### PR TITLE
Replace old group authentication with SAML SSO

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,15 @@ gem 'httpi'
 # gem 'libxml-jruby'
 gem 'nokogiri', '~> 1.6.6.2'
 
+# For SAML SSO
+
+# TODO: Waiting on PR https://github.com/onelogin/ruby-saml/pull/271
+gem 'ruby-saml', git: 'https://github.com/alex/ruby-saml', :branch => 'patch-1'
+# TODO: Waiting on PR https://github.com/PracticallyGreen/omniauth-saml/pull/50
+gem 'omniauth-saml', git: 'https://github.com/Vodeclic/omniauth-saml', :ref => '62c8e1cc5a9db7af62218aaaefa527e3d9058331'
+
+gem 'omniauth-saml-va', git: 'https://github.com/department-of-veterans-affairs/omniauth-saml-va'
+
 gem 'connect_vbms', path: './vendor/gems/connect_vbms'
 
 # Use Capistrano for deployment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,29 @@
+GIT
+  remote: https://github.com/Vodeclic/omniauth-saml
+  revision: 62c8e1cc5a9db7af62218aaaefa527e3d9058331
+  ref: 62c8e1cc5a9db7af62218aaaefa527e3d9058331
+  specs:
+    omniauth-saml (1.4.1)
+      omniauth (~> 1.1)
+      ruby-saml (~> 1.0.0)
+
+GIT
+  remote: https://github.com/alex/ruby-saml
+  revision: d08193c36b4186278f3d1ef0d18c435dd0180c44
+  branch: patch-1
+  specs:
+    ruby-saml (1.0.1)
+      jruby-openssl (>= 0.9.8)
+      nokogiri (>= 1.6.0)
+      uuid (~> 2.3)
+
+GIT
+  remote: https://github.com/department-of-veterans-affairs/omniauth-saml-va
+  revision: 0118479e466d2c67540e36e53812f79cd21c0d29
+  specs:
+    omniauth-saml-va (0.1)
+      omniauth-saml (~> 1.4.0)
+
 PATH
   remote: ./vendor/gems/connect_vbms
   specs:
@@ -59,6 +85,7 @@ GEM
     ffi (1.9.10-java)
     haml (4.0.7)
       tilt
+    hashie (3.4.2)
     highline (1.7.8)
     hike (1.2.3)
     httpi (2.4.1)
@@ -67,8 +94,11 @@ GEM
     jbuilder (2.3.1)
       activesupport (>= 3.0.0, < 5)
       multi_json (~> 1.2)
+    jruby-openssl (0.9.12-java)
     json (1.8.3-java)
     kramdown (1.8.0)
+    macaddr (1.7.1)
+      systemu (~> 2.6.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
     method_source (0.8.2)
@@ -76,6 +106,9 @@ GEM
     minitest (5.8.1)
     multi_json (1.11.2)
     nokogiri (1.6.6.2-java)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
     parallel (1.6.1)
     pdf-forms (0.6.0)
     polyamorous (1.1.0)
@@ -143,6 +176,7 @@ GEM
       activerecord (>= 3.0)
       activesupport (>= 3.0)
       polyamorous (~> 1.1.0)
+    systemu (2.6.5)
     temple (0.7.6)
     terminal-table (1.5.2)
     therubyrhino (2.0.4)
@@ -156,6 +190,8 @@ GEM
     uglifier (2.7.2)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    uuid (2.3.8)
+      macaddr (~> 1.0)
     xmlenc (0.2.1)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -173,12 +209,15 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   kramdown
   nokogiri (~> 1.6.6.2)
+  omniauth-saml!
+  omniauth-saml-va!
   parallel (~> 1.6.1)
   pdf-forms (= 0.6.0)
   pry
   pry-rails
   puma
   rails (~> 4.1.8)
+  ruby-saml!
   sass-rails (~> 4.0.3)
   sdoc (~> 0.4.0)
   squeel

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,22 +16,6 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def is_valid_user?(username, password)
-    db_url = Rails.application.config.database_configuration[Rails.env]['url']
-
-    # Attempt to login to the database
-    connection = nil
-    begin
-      connection = DriverManager.getConnection(db_url, username, password) # throws exception if login fails
-    rescue
-      return false
-    ensure
-      connection.close unless connection.nil?
-    end
-
-    true
-  end
-
   def is_unauthorized?(kase, username)
     ro = kase.bfregoff.try('upcase')
     return ro != username

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,15 @@
+# By default, OmniAuth will configure the path /auth/:provider. It is
+# created by OmniAuth automatically for you, and you will start the auth
+# process by going to that path.
+
+if not ENV.has_key? 'SSOI_SAML_XML_LOCATION' or not ENV.has_key? 'SSOI_SAML_PRIVATE_KEY_LOCATION'
+  raise 'SSOI_SAML_XML_LOCATION or SSOI_SAML_PRIVATE_KEY_LOCATION is not set'
+end
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :samlva, 'CASEFLOW', ENV['SSOI_SAML_PRIVATE_KEY_LOCATION'], ENV['SSOI_SAML_XML_LOCATION'],
+    :callback_path => '/caseflow/users/auth/saml/callback',
+    :path_prefix => '/caseflow/auth'
+end
+
+Rails.application.config.login_url = "/caseflow/auth/samlva"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,7 @@ Rails.application.routes.draw do
     get '/login', to: 'web#login'
     post '/login', to: 'web#login_submit'
     get '/logout', to: 'web#logout'
+
+    post '/users/auth/saml/callback', to: 'web#ssoi_saml_callback'
   end
 end

--- a/env.sh
+++ b/env.sh
@@ -10,3 +10,7 @@ export CONNECT_VBMS_KEYPASS="importkey"
 export CONNECT_VBMS_KEY="caseflow_uat_keyfile"
 export CONNECT_VBMS_CACERT="caseflow_uat_ca_cert"
 export CONNECT_VBMS_CERT="caseflow_uat_client_cert"
+
+# SAML information
+export SSOI_SAML_XML_LOCATION="${HOME}/Downloads/CASEFLOWmetadata-DEV_signed.xml"
+export SSOI_SAML_PRIVATE_KEY_LOCATION="${HOME}/Downloads/key.pem"


### PR DESCRIPTION
In particular, this will change our login endpoints to bounce users to
SAML SSO, in order to grab some basic information about the user.

This is the most basic integration, we only store the locally unique
identifier off the response hash, from the OmniAuth schema.

More information on the response hash we're passed can be found on the
OmniAuth wiki[1]

This requires that the configuration XML file be present locally, and
that the location of that file is set in the `SAML_XML_LOCATION` envvar.

[1]: https://github.com/intridea/omniauth/wiki/Auth-Hash-Schema