### PR TITLE
Added back options to generate page, fixes #86

### DIFF
--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -6,7 +6,7 @@
         Review the completed Form 8 below and verify all fields are accurate.
         If the form looks correct, click the <strong>Upload and Certify</strong>
         button and the Form 8 will automatically be uploaded to VBMS. If there
-        are any mistakes, <a onlick="window.history.back();">go back the errors</a>.
+        are any mistakes, <a onlick="window.history.back();">go back to fix any errors</a>.
       </p>
       <hr/>
 
@@ -21,7 +21,7 @@
       <%= form_tag({action: :certify}) do %>
         <input type="hidden" value="<%= @file_name %>" name="file_name"/>
         <input type="hidden" value="<%= @certification_date %>" name="certification_date"/>
-        <a href="#">Go back to fix an error</a>
+        <a href="#">Go back to fix any errors</a>
         <input type="submit" value="Upload and Certify" class="btn btn-primary pull-right"/>
       <% end %>
     </div>

--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -6,7 +6,7 @@
         Review the completed Form 8 below and verify all fields are accurate.
         If the form looks correct, click the <strong>Upload and Certify</strong>
         button and the Form 8 will automatically be uploaded to VBMS. If there
-        are any mistakes, <a onlick="window.history.back();">go back to fix any errors</a>.
+        are any mistakes, <a onclick="javascript:history.back()">go back to fix any errors</a>.
       </p>
       <hr/>
 
@@ -21,7 +21,7 @@
       <%= form_tag({action: :certify}) do %>
         <input type="hidden" value="<%= @file_name %>" name="file_name"/>
         <input type="hidden" value="<%= @certification_date %>" name="certification_date"/>
-        <a href="#">Go back to fix any errors</a>
+        <a onclick="javascript:history.back()">Go back to fix any errors</a>
         <input type="submit" value="Upload and Certify" class="btn btn-primary pull-right"/>
       <% end %>
     </div>

--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -6,8 +6,7 @@
         Review the completed Form 8 below and verify all fields are accurate.
         If the form looks correct, click the <strong>Upload and Certify</strong>
         button and the Form 8 will automatically be uploaded to VBMS. If there
-        are any mistakes, use your browser's back button to go back and correct
-        them.
+        are any mistakes, <a onlick="window.history.back();">go back the errors</a>.
       </p>
       <hr/>
 
@@ -15,13 +14,16 @@
 
       <hr/>
 
-      <div class="input-group">
-        <%= form_tag(action: :certify) do %>
-          <input type="hidden" value="<%= @file_name %>" name="file_name"/>
-          <input type="hidden" value="<%= @certification_date %>" name="certification_date"/>
-          <input type="submit" value="Upload and Certify" class="btn btn-primary"/>
-        <% end %>
-      </div>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col col-md-10 col-md-offset-1">
+      <%= form_tag({action: :certify}) do %>
+        <input type="hidden" value="<%= @file_name %>" name="file_name"/>
+        <input type="hidden" value="<%= @certification_date %>" name="certification_date"/>
+        <a href="#">Go back to fix an error</a>
+        <input type="submit" value="Upload and Certify" class="btn btn-primary pull-right"/>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #86

![image](https://cloud.githubusercontent.com/assets/950486/10944777/c5dde024-82e8-11e5-8cb8-b37b60a49d51.png)

Highlights
- Go back text in initial description
- Go back text at botton
- Right alignment of upload button