### PR TITLE
Removing an RVM reference since we're using rbenv

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -91,10 +91,9 @@ For *production* (you may need to uncomment them):
 
 ## Everytime Setup
 
-Make sure you're using the correct JRuby and environment variables.
+Make sure you're using the correct environment variables. 
 
 ```
-> rvm use jruby-1.7.22
 > source env.sh
 ```
 


### PR DESCRIPTION
Changing 

> rvm use jruby-1.7.22
> source env.sh

to 

> source env.sh

And modifying sentence before it to remove RVM-related language.