### PR TITLE
Change the criteria for the seam report:

### DIFF
--- a/lib/sources/caseflow/reports.rb
+++ b/lib/sources/caseflow/reports.rb
@@ -67,6 +67,15 @@ module Caseflow
         "RO99",
       ]
 
+      # VBMS document types which are appeals related documents
+      APPEALS_DOCUMENT_TYPES = [
+        EFolder::Case::SOC_DOC_TYPE_ID,
+        EFolder::Case::NOD_DOC_TYPE_ID,
+        EFolder::Case::SSOC_DOC_TYPE_ID,
+        EFolder::Case::FORM_9_DOC_TYPE_ID,
+        EFolder::Case::FORM_8_DOC_TYPE_ID,
+      ]
+
       def find_vacols_cases
         return Case.joins(:folder).where(
           "bf41stat < ? AND bfmpro = ? AND (folder.tivbms IS NULL OR folder.tivbms NOT IN (?)) AND bfregoff NOT IN (?)",
@@ -75,7 +84,11 @@ module Caseflow
       end
 
       def should_include(vacols_case)
-        vacols_case.efolder_case.documents.length >= 1
+        # Include cases in the report which have an appeals related document in
+        # their eFolder
+        vacols_case.efolder_case.documents.any? do |doc|
+          APPEALS_DOCUMENT_TYPES.include?(doc.doc_type.try(:to_i))
+        end
       end
 
       def spreadsheet_columns

--- a/lib/sources/caseflow/reports.rb
+++ b/lib/sources/caseflow/reports.rb
@@ -67,14 +67,16 @@ module Caseflow
         "RO99",
       ]
 
-      # VBMS document types which are appeals related documents
-      APPEALS_DOCUMENT_TYPES = [
-        EFolder::Case::SOC_DOC_TYPE_ID,
-        EFolder::Case::NOD_DOC_TYPE_ID,
-        EFolder::Case::SSOC_DOC_TYPE_ID,
-        EFolder::Case::FORM_9_DOC_TYPE_ID,
-        EFolder::Case::FORM_8_DOC_TYPE_ID,
-      ]
+      def initialize
+        # VBMS document types which are appeals related documents
+        @appeals_document_types = [
+          EFolder::Case::SOC_DOC_TYPE_ID,
+          EFolder::Case::NOD_DOC_TYPE_ID,
+          EFolder::Case::SSOC_DOC_TYPE_ID,
+          EFolder::Case::FORM_9_DOC_TYPE_ID,
+          EFolder::Case::FORM_8_DOC_TYPE_ID,
+        ]
+      end
 
       def find_vacols_cases
         return Case.joins(:folder).where(
@@ -87,7 +89,7 @@ module Caseflow
         # Include cases in the report which have an appeals related document in
         # their eFolder
         vacols_case.efolder_case.documents.any? do |doc|
-          APPEALS_DOCUMENT_TYPES.include?(doc.doc_type.try(:to_i))
+          @appeals_document_types.include?(doc.doc_type.try(:to_i))
         end
       end
 


### PR DESCRIPTION
Previously we included a case if their eFoler contained any documents at all. With this change we include a case if they have an eFolder _and_ it contains at least one appeals related document (NOD, SOC, SSOC, Form8, Form9)