### PR TITLE
Linked form items

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,10 +6,8 @@
 
  (function () {
      "use strict";
-
      /* Copies appeals ID to clipboard */
      new Clipboard('[data-clipboard-text]');
-
  })();
 
 // For IE9
@@ -18,6 +16,23 @@ if (typeof String.prototype.trim !== 'function') {
         return this.replace(/^\s+|\s+$/g, '');
     }
 }
+
+
+/* --------------------------------
+Reusable open/close Item methods
+ -------------------------------- */
+
+$.fn.extend({
+    openItem: function() {
+        $(this).removeAttr('hidden');
+    },
+    toggleItem: function() {
+        $(this).toggleAttr('hidden','hidden');
+    },
+    closeItem: function(){
+        $(this).attr('hidden', 'hidden');
+    }
+});
 
 /*
 Extends jQuery to add a toggleAttr method
@@ -34,108 +49,44 @@ jQuery.fn.toggleAttr = function(attr) {
 // --- START: JS for questions.html.erb ---
 
 /**
- * Shows/hides an element (with a specified ID attribute) when a checked radio
- * button (with a specific name attribute) has a particular value.
- *
- * @param inputName The radio input element to check for value
- * @param divId The ID of the element to show/hide
- * @param showValue The value of the input element needed to show the element indicated by divId
- */
-function display_field(inputName, divId, showValue) {
-    var selectedOption = $("input[name='" + inputName + "']:checked")[0];
-    var div = $('#' + divId);
+* Show a linked text field when a particular checkbox or radio input is selected
+*
+* 1. Requires inputs and related text fields to be grouped within the same fieldset.
+* 2. Requires the revealed item to have a data-showwhen attribute. The value for this
+*    attribute should match that of the item that triggers the reveal.
+*/
 
-    if (selectedOption && selectedOption.value === showValue) {
-        div.removeClass("hidden");
-    }
-    else {
-        div.addClass("hidden");
-    }
-}
+/* Change event bubbles up, so we can wait until it hits fieldset */
+$('fieldset').on('change', function(e){
+    /*
+    If this is a checkbox, toggle the visibility of
+    its sibling.
+    */
 
-// -- Functions for display specific fields --
+    // TODO: Refactor this to use openItem/closeItem/toggleItem
 
-var display_8b_explanation = function () {
-    display_field("8B_POWER_OF_ATTORNEY", "8b-explanation", "8B_CERTIFICATION_THAT_VALID_POWER_OF_ATTORNEY_IS_IN_ANOTHER_VA_FILE");
-}
-
-var display_9b = function () {
-    display_field("9A_IF_REPRESENTATIVE_IS_SERVICE_ORGANIZATION_IS_VA_FORM_646", "9b", "no");
-}
-var display_10c = function () {
-    display_field("10B_IF_HELD_IS_TRANSCRIPT_IN_FILE", "10c", "no");
-}
-var display_11b = function () {
-    display_field("11A_ARE_CONTESTED_CLAIMS_PROCEDURES_APPLICABLE_IN_THIS_CASE", "11b", "yes");
-}
-
-var display_13_other = function () {
-    var isChecked = $("input[name='13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER']")[0].checked;
-    var div = $('#13');
-    if (isChecked) {
-        div.removeClass("hidden");
-    }
-    else {
-        div.addClass("hidden");
-    }
-}
-
-function requiredFieldsComplete() {
-    var a17Val = $('#17A_SIGNATURE_OF_CERTIFYING_OFFICIAL_input_id').val();
-    var b17Val = $('#17B_TITLE_input_id').val();
-
-    if (!a17Val.trim() || !b17Val.trim()) {
-        return false;
+    if( $(e.target).attr('type') == 'checkbox' ) {
+        $(this).find('[data-showwhen]').toggleClass('hidden');
     }
 
-    return true;
-}
+    /*
+    Otherwise, assume it's a radio button. Find the element that should be
+    triggered when that value is selected. If the value of showwhen matches
+    the value of the selected item, show that item.
+    */
 
-var questionsSubmit = function (event) {
-    if (!requiredFieldsComplete()) {
-        alert("Please fill in 17A and 17B");
-        return event.preventDefault();
+    else if(
+        $(this).find('[data-showwhen]').length &&
+        $(this).find('[data-showwhen]').data('showwhen') == $(e.target).attr('value')
+    ) {
+        $(this).find('[data-showwhen]').removeClass('hidden');
+    } else {
+        $(this).find('[data-showwhen]').addClass('hidden');
     }
-}
 
-// -- Add listeners and other on page load behavior --
-
-$(function () {
-    if(!!$("#question-form").length) {
-        $("input[name='8B_POWER_OF_ATTORNEY']").change(display_8b_explanation);
-        $("input[name='9A_IF_REPRESENTATIVE_IS_SERVICE_ORGANIZATION_IS_VA_FORM_646']").change(display_9b);
-        $("input[name='10B_IF_HELD_IS_TRANSCRIPT_IN_FILE']").change(display_10c);
-        $("input[name='11A_ARE_CONTESTED_CLAIMS_PROCEDURES_APPLICABLE_IN_THIS_CASE']").change(display_11b);
-        $("input[name='13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER']").change(display_13_other);
-        $("#question-form").submit(questionsSubmit);
-
-        // Restore the hidden fields that should be displayed, used when back button is used
-        display_8b_explanation();
-        display_9b();
-        display_10c();
-        display_11b();
-        display_13_other();
-    }
 });
 
 // --- END: JS for questions.html.erb ---
-
-/* --------------------------------
-Reusable open/close Item methods
- -------------------------------- */
-
-$.fn.extend({
-    openItem: function() {
-        $(this).removeAttr('hidden');
-    },
-    toggleItem: function() {
-        $(this).toggleAttr('hidden','hidden');
-    },
-    closeItem: function(){
-        $(this).attr('hidden', 'hidden');
-    }
-})
-
 
 $(function(){
     $(".dropdown-trigger").on('click', function(e) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,14 +10,6 @@
      new Clipboard('[data-clipboard-text]');
  })();
 
-// For IE9
-if (typeof String.prototype.trim !== 'function') {
-    String.prototype.trim = function () {
-        return this.replace(/^\s+|\s+$/g, '');
-    }
-}
-
-
 /* --------------------------------
 Reusable open/close Item methods
  -------------------------------- */
@@ -45,15 +37,16 @@ jQuery.fn.toggleAttr = function(attr) {
  });
 };
 
-
 // --- START: JS for questions.html.erb ---
 
 /**
 * Show a linked text field when a particular checkbox or radio input is selected
 *
-* 1. Requires inputs and related text fields to be grouped within the same fieldset.
+* 1. Requires inputs and related text fields to be grouped within the same fieldset
+     (which is the best way to mark it up anyway).
 * 2. Requires the revealed item to have a data-showwhen attribute. The value for this
-*    attribute should match that of the item that triggers the reveal.
+*    attribute should match that of the item that triggers the reveal. I.e., if the
+*    element should be triggered on when 'Yes' is selected, use data-showwhen="yes".
 */
 
 /* Change event bubbles up, so we can wait until it hits fieldset */
@@ -63,10 +56,8 @@ $('fieldset').on('change', function(e){
     its sibling.
     */
 
-    // TODO: Refactor this to use openItem/closeItem/toggleItem
-
     if( $(e.target).attr('type') == 'checkbox' ) {
-        $(this).find('[data-showwhen]').toggleClass('hidden');
+        $(this).find('[data-showwhen]').toggleItem();
     }
 
     /*
@@ -79,9 +70,9 @@ $('fieldset').on('change', function(e){
         $(this).find('[data-showwhen]').length &&
         $(this).find('[data-showwhen]').data('showwhen') == $(e.target).attr('value')
     ) {
-        $(this).find('[data-showwhen]').removeClass('hidden');
+        $(this).find('[data-showwhen]').openItem('hidden');
     } else {
-        $(this).find('[data-showwhen]').addClass('hidden');
+        $(this).find('[data-showwhen]').closeItem('hidden', 'hidden');
     }
 
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,18 @@
      new Clipboard('[data-clipboard-text]');
  })();
 
+/*
+Extends jQuery to add a toggleAttr method
+https://gist.github.com/mathiasbynens/298591
+*/
+jQuery.fn.toggleAttr = function(attr) {
+ return this.each(function() {
+  var $this = $(this);
+  $this.attr(attr) ? $this.removeAttr(attr) : $this.attr(attr, attr);
+ });
+};
+
+
 /* --------------------------------
 Reusable open/close Item methods
  -------------------------------- */
@@ -26,60 +38,50 @@ $.fn.extend({
     }
 });
 
-/*
-Extends jQuery to add a toggleAttr method
-https://gist.github.com/mathiasbynens/298591
-*/
-jQuery.fn.toggleAttr = function(attr) {
- return this.each(function() {
-  var $this = $(this);
-  $this.attr(attr) ? $this.removeAttr(attr) : $this.attr(attr, attr);
- });
-};
-
-// --- START: JS for questions.html.erb ---
-
-/**
-* Show a linked text field when a particular checkbox or radio input is selected
-*
-* 1. Requires inputs and related text fields to be grouped within the same fieldset
-     (which is the best way to mark it up anyway).
-* 2. Requires the revealed item to have a data-showwhen attribute. The value for this
-*    attribute should match that of the item that triggers the reveal. I.e., if the
-*    element should be triggered on when 'Yes' is selected, use data-showwhen="yes".
-*/
-
-/* Change event bubbles up, so we can wait until it hits fieldset */
-$('fieldset').on('change', function(e){
-    /*
-    If this is a checkbox, toggle the visibility of
-    its sibling.
-    */
-
-    if( $(e.target).attr('type') == 'checkbox' ) {
-        $(this).find('[data-showwhen]').toggleItem();
-    }
-
-    /*
-    Otherwise, assume it's a radio button. Find the element that should be
-    triggered when that value is selected. If the value of showwhen matches
-    the value of the selected item, show that item.
-    */
-
-    else if(
-        $(this).find('[data-showwhen]').length &&
-        $(this).find('[data-showwhen]').data('showwhen') == $(e.target).attr('value')
-    ) {
-        $(this).find('[data-showwhen]').openItem('hidden');
-    } else {
-        $(this).find('[data-showwhen]').closeItem('hidden', 'hidden');
-    }
-
-});
-
-// --- END: JS for questions.html.erb ---
-
 $(function(){
+
+    // --- START: JS for questions.html.erb ---
+
+    /**
+    * Show a linked text field when a particular checkbox or radio input is selected
+    *
+    * 1. Requires inputs and related text fields to be grouped within the same fieldset
+         (which is the best way to mark it up anyway).
+    * 2. Requires the revealed item to have a data-showwhen attribute. The value for this
+    *    attribute should match that of the item that triggers the reveal. I.e., if the
+    *    element should be triggered on when 'Yes' is selected, use data-showwhen="yes".
+    */
+
+    /* Change event bubbles up, so we can wait until it hits fieldset */
+    $('fieldset').on('change', function(e){
+        /*
+        If this is a checkbox, toggle the visibility of
+        its sibling.
+        */
+
+        if( $(e.target).attr('type') == 'checkbox' ) {
+            $(this).find('[data-showwhen]').toggleItem();
+        }
+
+        /*
+        Otherwise, assume it's a radio button. Find the element that should be
+        triggered when that value is selected. If the value of showwhen matches
+        the value of the selected item, show that item.
+        */
+
+        else if(
+            $(this).find('[data-showwhen]').length &&
+            $(this).find('[data-showwhen]').data('showwhen') == $(e.target).attr('value')
+        ) {
+            $(this).find('[data-showwhen]').openItem('hidden');
+        } else {
+            $(this).find('[data-showwhen]').closeItem('hidden', 'hidden');
+        }
+
+    });
+
+    // --- END: JS for questions.html.erb ---
+
     $(".dropdown-trigger").on('click', function(e) {
          e.preventDefault(); // Prevent page jump
          var dropdownMenu = $(this).attr('href');

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -49,10 +49,6 @@ body {
   border-bottom: 1px solid #eee;
 }
 
-.hidden {
-  display: none;
-}
-
 .success {
   color: #009245;
 }

--- a/app/views/web/_form8_text.html.erb
+++ b/app/views/web/_form8_text.html.erb
@@ -16,8 +16,10 @@
 %>
 
 <% input_id = "#{input_name}_input_id" %>
+<% show_when = "data-showwhen=#{show_when}" %>
 
-<p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>">
+
+<p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= show_when if defined?(show_when) && show_when %>>
     <label for="<%= input_id %>">
         <strong <%= 'class=required' if defined?(required) && required %>><%= question_num %></strong>
         <%= question %>

--- a/app/views/web/_form8_text.html.erb
+++ b/app/views/web/_form8_text.html.erb
@@ -18,7 +18,7 @@
 <% input_id = "#{input_name}_input_id" %>
 <% show_when = "data-showwhen=#{show_when}" %>
 
-<p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= show_when if defined?(show_when) && show_when %>>
+<p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= hidden if defined?(hidden) && hidden %> <%= show_when if defined?(show_when) && show_when %>>
     <label for="<%= input_id %>">
         <strong <%= 'class=required' if defined?(required) && required %>><%= question_num %></strong>
         <%= question %>

--- a/app/views/web/_form8_text.html.erb
+++ b/app/views/web/_form8_text.html.erb
@@ -12,7 +12,7 @@
     - max_length: The number of characters a response can maximally include. 45 is default.
     - closing_hr: true/false, show a horizontal rules at the end (default: true)
     - required: true/false, if a field is required (default: false)
-    - is_linked: Whether this field is linked to radio button fields
+    - close_fieldset: Whether this fieldset should be closed
 %>
 
 <% input_id = "#{input_name}_input_id" %>
@@ -24,6 +24,6 @@
     </label>
     <input text="text" name="<%= input_name %>" maxlength="<%= defined?(max_length) ? max_length : 45 %>" class="form-control" <%= 'required' if defined?(required) && required %> id="<%= input_id %>">
 </p>
-<% if defined?(is_linked) && is_linked %>
+<% if defined?(close_fieldset) && close_fieldset %>
 </fieldset>
 <% end %>

--- a/app/views/web/_form8_text.html.erb
+++ b/app/views/web/_form8_text.html.erb
@@ -18,7 +18,7 @@
 <% input_id = "#{input_name}_input_id" %>
 <% show_when = "data-showwhen=#{show_when}" %>
 
-<p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= hidden if defined?(hidden) && hidden %> <%= show_when if defined?(show_when) && show_when %>>
+<p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= 'hidden' if defined?(hidden) && hidden %> <%= show_when if defined?(show_when) && show_when %>>
     <label for="<%= input_id %>">
         <strong <%= 'class=required' if defined?(required) && required %>><%= question_num %></strong>
         <%= question %>

--- a/app/views/web/_form8_text.html.erb
+++ b/app/views/web/_form8_text.html.erb
@@ -18,7 +18,6 @@
 <% input_id = "#{input_name}_input_id" %>
 <% show_when = "data-showwhen=#{show_when}" %>
 
-
 <p class="form8-text-input <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= show_when if defined?(show_when) && show_when %>>
     <label for="<%= input_id %>">
         <strong <%= 'class=required' if defined?(required) && required %>><%= question_num %></strong>

--- a/app/views/web/_form8_two_radio.html.erb
+++ b/app/views/web/_form8_two_radio.html.erb
@@ -24,7 +24,7 @@ end
 %>
 
 
-<fieldset class="form8-two-radio <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= show_when if defined?(show_when) && show_when %>>
+<fieldset class="form8-two-radio <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= hidden if defined?(hidden) && hidden %> <%= show_when if defined?(show_when) && show_when %>>
   <legend>
       <strong<%= ' class=required' if defined?(required) && required %>><%= question_num %></strong>
       <%= question %>

--- a/app/views/web/_form8_two_radio.html.erb
+++ b/app/views/web/_form8_two_radio.html.erb
@@ -17,7 +17,14 @@
     - div_class: The class attribute of the containing div
 %>
 
-<fieldset class="form8-two-radio <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>">
+<%
+if defined?(show_when)
+  show_when = "data-showwhen=#{show_when}"
+end
+%>
+
+
+<fieldset class="form8-two-radio <%= div_class if defined?(div_class) %>" id="<%= div_id if defined?(div_id) %>" <%= show_when if defined?(show_when) && show_when %>>
   <legend>
       <strong<%= ' class=required' if defined?(required) && required %>><%= question_num %></strong>
       <%= question %>

--- a/app/views/web/_form8_yes_no_radio.html.erb
+++ b/app/views/web/_form8_yes_no_radio.html.erb
@@ -21,7 +21,8 @@
   # Fill in local varialbes passed to this partial
   question: question,
   question_num: question_num,
-  input_name: input_name, }
+  input_name: input_name,
+}
 
    # Optional arguments
    if defined?(div_id)
@@ -34,5 +35,11 @@
    if defined?(required)
      yes_no_locals[:required] = required
    end
+
+   if defined?(show_when)
+     yes_no_locals[:show_when] = show_when
+   end
+
+
 %>
 <%= render partial: 'form8_two_radio', locals: yes_no_locals %>

--- a/app/views/web/_form8_yes_no_radio.html.erb
+++ b/app/views/web/_form8_yes_no_radio.html.erb
@@ -40,6 +40,10 @@
      yes_no_locals[:show_when] = show_when
    end
 
+   if defined?(hidden)
+     yes_no_locals[:hidden] = hidden
+   end
+
 
 %>
 <%= render partial: 'form8_two_radio', locals: yes_no_locals %>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -27,7 +27,7 @@
                 question: 'Please specify location of the veteran\'s power of attorney',
                 question_num: '8B EXPLANATION',
                 input_name: '8B_REMARKS',
-                is_linked: true,
+                close_fieldset: true,
             } %>
       <% end %>
 
@@ -52,7 +52,7 @@
                 question: 'If VA form 646 is not of record, explain',
                 question_num: '9B',
                 input_name: '9B_IF_VA_FORM_646_IS_NOT_OF_RECORD_EXPLAIN',
-                is_linked: true,
+                close_fieldset: true,
             } %>
       <% end %>
 
@@ -71,7 +71,7 @@
                   question: 'If not held, explain',
                   question_num: '10C',
                   input_name: '10C_IF_REQUESTED_BUT_NOT_HELD_EXPLAIN',
-                  is_linked: true,
+                  close_fieldset: true,
               } %>
         <% end %>
 
@@ -91,7 +91,7 @@
               input_name: '11B_HAVE_THE_REQUIREMENTS_OF_38_USC_BEEN_FOLLOWED',
               div_id: '11b',
               div_class: 'hidden',
-              is_linked: true
+              close_fieldset: true
           } %>
 
       </fieldset><%# Closes nested fieldset for question 11b %>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -158,7 +158,7 @@
                   input_name: '13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER_REMARKS',
                   div_id: '13',
                   div_class: 'hidden',
-                  closing_hr: false
+                  show_when: '13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER'
               } %>
           </div>
     </fieldset>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -28,6 +28,7 @@
                 question_num: '8B EXPLANATION',
                 input_name: '8B_REMARKS',
                 close_fieldset: true,
+                show_when: '8B_CERTIFICATION_THAT_VALID_POWER_OF_ATTORNEY_IS_IN_ANOTHER_VA_FILE',
             } %>
       <% end %>
 
@@ -53,6 +54,7 @@
                 question_num: '9B',
                 input_name: '9B_IF_VA_FORM_646_IS_NOT_OF_RECORD_EXPLAIN',
                 close_fieldset: true,
+                show_when: 'no',
             } %>
       <% end %>
 
@@ -72,6 +74,7 @@
                   question_num: '10C',
                   input_name: '10C_IF_REQUESTED_BUT_NOT_HELD_EXPLAIN',
                   close_fieldset: true,
+                  show_when: 'no',
               } %>
         <% end %>
 
@@ -91,7 +94,8 @@
               input_name: '11B_HAVE_THE_REQUIREMENTS_OF_38_USC_BEEN_FOLLOWED',
               div_id: '11b',
               div_class: 'hidden',
-              close_fieldset: true
+              close_fieldset: true,
+              show_when: 'yes'
           } %>
 
       </fieldset><%# Closes nested fieldset for question 11b %>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -23,7 +23,7 @@
 
         <%= render partial: 'form8_text', locals: {
                 div_id: '8b-explanation',
-                hidden: 'hidden',
+                hidden: true,
                 question: 'Please specify location of the veteran\'s power of attorney',
                 question_num: '8B EXPLANATION',
                 input_name: '8B_REMARKS',
@@ -49,7 +49,7 @@
             } %>
         <%= render partial: 'form8_text', locals: {
                 div_id: '9b',
-                hidden: 'hidden',
+                hidden: true,
                 question: 'If VA form 646 is not of record, explain',
                 question_num: '9B',
                 input_name: '9B_IF_VA_FORM_646_IS_NOT_OF_RECORD_EXPLAIN',
@@ -69,7 +69,7 @@
         <% if @kase.required_fields[:show_10c] %>
           <%= render partial: 'form8_text', locals: {
                   div_id: '10c',
-                  hidden: 'hidden',
+                  hidden: true,
                   question: 'If not held, explain',
                   question_num: '10C',
                   input_name: '10C_IF_REQUESTED_BUT_NOT_HELD_EXPLAIN',
@@ -93,7 +93,7 @@
               question_num: '11B',
               input_name: '11B_HAVE_THE_REQUIREMENTS_OF_38_USC_BEEN_FOLLOWED',
               div_id: '11b',
-              hidden: 'hidden',
+              hidden: true,
               close_fieldset: true,
               show_when: 'yes'
           } %>
@@ -157,7 +157,7 @@
                   question_num: '',
                   input_name: '13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER_REMARKS',
                   div_id: '13',
-                  hidden: 'hidden',
+                  hidden: true,
                   show_when: '13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER'
               } %>
           </div>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -23,7 +23,7 @@
 
         <%= render partial: 'form8_text', locals: {
                 div_id: '8b-explanation',
-                div_class: 'hidden',
+                hidden: 'hidden',
                 question: 'Please specify location of the veteran\'s power of attorney',
                 question_num: '8B EXPLANATION',
                 input_name: '8B_REMARKS',
@@ -49,7 +49,7 @@
             } %>
         <%= render partial: 'form8_text', locals: {
                 div_id: '9b',
-                div_class: 'hidden',
+                hidden: 'hidden',
                 question: 'If VA form 646 is not of record, explain',
                 question_num: '9B',
                 input_name: '9B_IF_VA_FORM_646_IS_NOT_OF_RECORD_EXPLAIN',
@@ -69,7 +69,7 @@
         <% if @kase.required_fields[:show_10c] %>
           <%= render partial: 'form8_text', locals: {
                   div_id: '10c',
-                  div_class: 'hidden',
+                  hidden: 'hidden',
                   question: 'If not held, explain',
                   question_num: '10C',
                   input_name: '10C_IF_REQUESTED_BUT_NOT_HELD_EXPLAIN',
@@ -93,7 +93,7 @@
               question_num: '11B',
               input_name: '11B_HAVE_THE_REQUIREMENTS_OF_38_USC_BEEN_FOLLOWED',
               div_id: '11b',
-              div_class: 'hidden',
+              hidden: 'hidden',
               close_fieldset: true,
               show_when: 'yes'
           } %>
@@ -157,7 +157,7 @@
                   question_num: '',
                   input_name: '13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER_REMARKS',
                   div_id: '13',
-                  div_class: 'hidden',
+                  hidden: 'hidden',
                   show_when: '13_RECORDS_TO_BE_FORWARDED_TO_BOARD_OF_VETERANS_APPEALS_OTHER'
               } %>
           </div>


### PR DESCRIPTION
Simplifying javascript that shows related field based on the selected option.

- Listens for change events on `fieldset` elements
- Uses a `data-showwhen` attribute to form fields
- Uses `hidden` attribute (with CSS for older browsers) for more consistent behavior with assistive tech