### PR TITLE
Add can't certify link to start, questions, and generate pages. Fixes #256.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -454,3 +454,7 @@ Certified success page
         margin-right: 1.8rem;
     }
 }
+
+.space-left {
+  margin-left: 20px;
+}

--- a/app/views/web/error.html.erb
+++ b/app/views/web/error.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title do %>Not Certified<% end %>
 
 <div id="certifications-error" class="usa-cf_app-segment usa-cf_app-segment--alt">
-    <h1>This case has not been certified!</h1>
-    <p>The AOJ will be notified and asked to follow up with the Veteran.</p>
-    <p>You can now close this page and open another case in VACOLS.</p>
+    <h1>This case was not certified</h1>
+    <p>Certification date was not set and any changes you made were not saved.</p>
+    <p>You can close this page and open another case in VACOLS.</p>
 </div>

--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -6,9 +6,8 @@
       <h2>Review Form 8 Before Upload</h2>
       <p>
         Review the completed Form 8 below and verify all fields are accurate.
-        If the form looks correct, click the <strong>Upload and Certify</strong>
-        button and the Form 8 will automatically be uploaded to VBMS. If there
-        are any mistakes, <button type="button" class="cf-btn-link cf-btn-link--inline cf-action-back">go back to fix any errors</button>.
+        If the form looks correct, click the Upload and Certify
+        button and the Form 8 will automatically be uploaded to VBMS.
       </p>
 
       <embed class="embedded-document usa-cf_app-segment" src="/caseflow/files/forms/<%= @file_name %>"></embed>

--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -17,7 +17,8 @@
     <input type="hidden" value="<%= @file_name %>" name="file_name">
     <input type="hidden" value="<%= @certification_date %>" name="certification_date">
 
-    <button type="button" class="cf-btn-link cf-action-back pull-left">Go back to fix any errors</a>
+    <button type="button" class="cf-btn-link cf-action-back pull-left">Go back and make edits</button>
+    <%= link_to "Can't certify", :not_certified, class: 'cf-btn-link pull-left' %>
     <button type="submit" class="btn btn-primary push-right">Upload and Certify</button>
 
 <% end %>

--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -17,8 +17,8 @@
     <input type="hidden" value="<%= @file_name %>" name="file_name">
     <input type="hidden" value="<%= @certification_date %>" name="certification_date">
 
-    <button type="button" class="cf-btn-link cf-action-back pull-left">Go back and make edits</button>
-    <%= link_to "Can't certify", :not_certified, class: 'cf-btn-link pull-left' %>
+    <button type="button" class="usa-button-gray cf-action-back pull-left">&laquo; Go back and make edits</button>
+    <%= link_to "Can't certify", :not_certified, class: 'cf-btn-link space-left pull-left' %><!-- TODO: Make this more responsive friendly later -->
     <button type="submit" class="btn btn-primary push-right">Upload and Certify</button>
 
 <% end %>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -184,6 +184,7 @@
   </div>
 
   <div class="usa-cf_app-segment">
-      <button type="submit" class="btn btn-primary usa-cf_app-btn-forward">Preview Completed Form 8</button>
+      <%= link_to "Can't certify", :not_certified, class: 'cf-btn-link pull-left' %>
+      <button type="submit" class="btn btn-primary usa-cf_app-btn-forward push-right">Preview Completed Form 8</button>
   </div>
 <% end %>

--- a/app/views/web/start.html.erb
+++ b/app/views/web/start.html.erb
@@ -58,14 +58,13 @@
   </div>
 
     <div class="usa-cf_app-segment">
-  <%= form_tag(action: :error) do %>
 
-            <button type="submit" class="cf-btn-link push-left">This case cannot be certified</button>
-            <button type="button" class="btn btn-primary push-right cf-action-refresh">
-                Refresh Page
-            </button>
 
-  <% end %>
+    <%= link_to "Can't certify", :not_certified, class: 'cf-btn-link pull-left' %>
+    <button type="button" class="btn btn-primary push-right cf-action-refresh">
+        Refresh Page
+    </button>
+
 </div>
 
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
     post '/certifications/:id/questions', to: 'web#questions_submit'
     get '/certifications/:id/generate', to: 'web#generate'
     post '/certifications/:id/certify', to: 'web#certify'
+    get '/certifications/:id/error', to: 'web#error', as: :not_certified
     post '/certifications/:id/error', to: 'web#error'
 
     get '/files/forms/:id', to: 'web#show_form'


### PR DESCRIPTION
For #256 

Start:
![image](https://cloud.githubusercontent.com/assets/950486/11569139/292ee3da-99be-11e5-98c6-70cef7733d02.png)

Questions:
![image](https://cloud.githubusercontent.com/assets/950486/11569147/3097aad0-99be-11e5-97d8-5a1af7f4b99c.png)

Generate:
![image](https://cloud.githubusercontent.com/assets/950486/11569331/58ece9ae-99bf-11e5-98d6-f6afecf9185f.png)


Known issue: On generate, the buttons and link get split across lines in a wonky way when the screen width is shrunk, but everything is still readable and clickable. Can fix this later if a priority.

@KHarshawat or @maryannbrody : Can one of you review for design?

@webinista or @paultag : Can one of you review code?
