### PR TITLE
Adding modal closure on click, Esc feature. closes #364

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,13 @@ $.fn.extend({
     },
     clearField: function(){
         $(this).val('');
+    },
+    closeModal: function(event) {
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        if( $(event.target).hasClass('cf-modal') ) {
+            $(event.target).closeItem();
+        }
     }
 });
 
@@ -75,6 +82,17 @@ $(function() {
             window.location.hash = '';
         }
     });
+
+    $('.cf-modal').on('click', function(e){
+        $(this).closeModal(e);
+    });
+
+    $(window).on('keydown', function(e){
+        var escKey = (e.which == 27);
+        if(escKey) {
+            $('.cf-modal').trigger('click')
+        }
+    })
 });
 
 


### PR DESCRIPTION
I suggest merging #366 before this one. They work independently of each other. However #364 includes a small UX improvement that affects the behavior of this commit. 

Specifically, there's an invisible area on each side of the modal's content box that _looks like it should be_ clickable, but isn't. #364 eliminates those areas.