### PR TITLE
Removing bootstrap.min.js and extra call to jQuery 1.9. closes #210

### DIFF
--- a/app/views/layouts/basic.html.erb
+++ b/app/views/layouts/basic.html.erb
@@ -3,8 +3,6 @@
 <head>
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>Caseflow</title>
-  <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-  <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>


### PR DESCRIPTION
- Removing Bootstrap since we're not using it.
- Also removing jQuery 1.9 since we're using v1.11.3