### PR TITLE
Resizing text field and textarea widths. closes #390

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -503,12 +503,18 @@ textarea {
         display: inline-block;
         margin-right: 0;
     }
+
+    &-textarea-wrap {
+        max-width: rem(455px);
+    }
 }
 
 .form8-text-input {
     @include clearfix;
     clear: both;
+    max-width: rem(380px);
 }
+
 .form8-two-radio {
     &-item {
         display: inline-block;

--- a/app/views/web/_form8_date.html.erb
+++ b/app/views/web/_form8_date.html.erb
@@ -12,7 +12,7 @@ if defined?(div_id) && div_id
 end
 %>
 
-<p class="form8-date-input <%= div_class if defined?(div_class) %>" <%= div_id if defined?(div_id) %> <%= 'hidden' if defined?(hidden) && hidden %> <%= show_when if defined?(show_when) && show_when %>>
+<p class="form8-text-input <%= div_class if defined?(div_class) %>" <%= div_id if defined?(div_id) %> <%= 'hidden' if defined?(hidden) && hidden %> <%= show_when if defined?(show_when) && show_when %>>
     <label for="<%= input_id %>" <%= 'class=required' if defined?(required) && required %>>
         <strong><%= question_num %></strong>
         <%= question %>

--- a/app/views/web/_form8_textarea.html.erb
+++ b/app/views/web/_form8_textarea.html.erb
@@ -15,7 +15,7 @@
 
 %>
 
-<p class="row">
+<p class="cf-form-textarea-wrap">
     <label for="<%= input_name %>">
       <strong><%= question_num %></strong> <%= question %>
     </label>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -140,7 +140,6 @@
             } %>
 
         <%= render partial: 'form8_text', locals: {
-                div_class: 'cf-wrap-flex',
                 div_id: '8b-explanation',
                 question: '<em>Specify file if applicable</em>',
                 question_num: '',


### PR DESCRIPTION
- Adding max width for textarea wrappers and text input wrappers.
- Changing form8-date-input to form8-text-input. Why add an extra class?
- Changing row class to more descriptive cf-form-textarea-wrap
- Removing cf-wrap-flex because we're not using it.