### PR TITLE
Removing <div> that caused spacing issue on start. Closes #393

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -263,7 +263,13 @@ body {
     width: 90%;
 }
 
+/*
+.cf-app-segment represents a chunk of an application's
+page Should be an immediate child of .cf-app. Avoid
+making .cf-app-segment a grandchild element of .cf-app.
+*/
 .cf-app-segment {
+    // Clearfix
     &::before, &::after {
         content: ' ';
         display: block;
@@ -277,10 +283,14 @@ body {
     }
 }
 
+// Adds top margin when .cf-app-segment
+// is preceded by an element
 * + .cf-app-segment {
     margin-top: rem(30px);
 }
 
+// Make the top margin larger whenever
+// cf-app-segment is the first-child
 .cf-app-segment {
     &:first-child {
         margin-top: rem(40px);

--- a/app/views/web/start.html.erb
+++ b/app/views/web/start.html.erb
@@ -4,8 +4,6 @@
 %>
 <% content_for :page_title do %>Mismatched Documents<% end %>
 
-<div id="certifications-start">
-
     <div class="usa-alert usa-alert-error cf-app-segment" role="alert">
       <div class="usa-alert-body">
         <h3 class="usa-alert-heading">Cannot find documents in VBMS</h3>
@@ -14,37 +12,38 @@
     </div>
 
 
-  <div class="cf-app-segment cf-app-segment--alt">
-      <h2>Find missing documents</h2>
+    <div class="cf-app-segment cf-app-segment--alt">
+        <h2>Find missing documents</h2>
 
-      <p>
-          Caseflow could not find the documents marked with an <svg width="55" height="55" class="cf-icon-missing" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 55 55"><title>missing icon</title><path d="M52.6 46.9l-6 6c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-13-13-13 13c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-6-6c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l13-13-13-13c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l6-6c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l13 13 13-13c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l6 6c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3l-13 13 13 13c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3z"/></svg>
-      </svg> in the appellant's eFolder. This usually happens when something doesn't match up. Try checking:</p>
+        <p>
+            Caseflow could not find the documents marked with an <svg width="55" height="55" class="cf-icon-missing" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 55 55"><title>missing icon</title><path d="M52.6 46.9l-6 6c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-13-13-13 13c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-6-6c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l13-13-13-13c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l6-6c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l13 13 13-13c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l6 6c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3l-13 13 13 13c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3z"/></svg>
+        </svg> in the appellant's eFolder. This usually happens when something doesn't match up. Try checking:
+        </p>
 
-          <ul>
-                <li>The <strong>document type</strong> in VBMS to make sure it's labeled correctly</li>
-                <li>The <strong>document date</strong> &#8212; the date in VBMS must match the date in VACOLS</li>
-          </ul>
+        <ul>
+            <li>The <strong>document type</strong> in VBMS to make sure it's labeled correctly</li>
+            <li>The <strong>document date</strong> &#8212; the date in VBMS must match the date in VACOLS</li>
+        </ul>
 
-      <p>Once you've made corrections, <button type="button" class="cf-action-refresh cf-btn-link cf-btn-link--inline">refresh this page</button>.</p>
+        <p>Once you've made corrections, <button type="button" class="cf-action-refresh cf-btn-link cf-btn-link--inline">refresh this page</button>.</p>
 
-       <p>
-        If you can’t find the document, click the
-        <strong>This case cannot be certified</strong> link below.
-      </p>
+        <p>
+            If you can’t find the document, click the
+            <strong>This case cannot be certified</strong> link below.
+        </p>
 
-      <div class="cf-table-wrap">
-          <table class="usa-table-borderless cf-table-borderless">
+        <div class="cf-table-wrap">
+        <table class="usa-table-borderless cf-table-borderless">
             <caption class="usa-sr-only">
-              This table compares received dates for forms stored in VACOLS and VBMS.
+                This table compares received dates for forms stored in VACOLS and VBMS.
             </caption>
             <thead>
                 <tr>
-                  <th></th>
-                  <th>Document</th>
-                  <th>VACOLS</th>
-                  <th>VBMS</th>
-              </tr>
+                    <th></th>
+                    <th>Document</th>
+                    <th>VACOLS</th>
+                    <th>VBMS</th>
+                </tr>
             </thead>
             <tbody>
                 <%= render partial: 'table_row', locals: {field_name: 'NOD', vacols_field: @kase.bfdnod_date, vbms_field: @kase.efolder_nod_date} %>
@@ -56,19 +55,15 @@
                 <%= render partial: 'table_row', locals: {field_name: 'SSOC 5', vacols_field: @kase.bfssoc5_date, vbms_field: @kase.efolder_ssoc5_date} %>
                 <%= render partial: 'table_row', locals: {field_name: 'Form 9', vacols_field: @kase.bfd19_date, vbms_field: @kase.efolder_form9_date} %>
             </tbody>
-          </table>
-      </div>
-  </div>
+        </table>
+        </div>
+    </div>
 
     <div class="cf-app-segment">
+        <a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel certification</a>
+        <button type="button" class="btn btn-primary cf-push-right cf-action-refresh">Refresh Page</button>
+    </div>
 
-    <a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel certification</a>
-    <button type="button" class="btn btn-primary cf-push-right cf-action-refresh">
-        Refresh Page
-    </button>
-
-</div>
-</div>
 
 <%= render partial: 'modal', locals: {
         modal_id: 'confirm-cancel-certification',


### PR DESCRIPTION
- Also adding some usage notes re: class names.

Most of these line changes are spacing-related. Key deletions are line 7 (`-<div id="certifications-start">`) and 71 of `app/views/web/start.html.erb`