### PR TITLE
Changing name of pilot-warning class to cf-notice. closes #389

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -75,7 +75,7 @@ label {
   padding-right: 0px;
 }
 
-.pilot-warning {
+.cf-notice {
   padding: 8px 20px 8px;
   text-align: center;
   background-color: $color-primary;

--- a/app/views/layouts/basic.html.erb
+++ b/app/views/layouts/basic.html.erb
@@ -10,7 +10,7 @@
 
 <body>
       <header>
-          <div class="pilot-warning">
+          <div class="cf-notice">
               <strong>Caseflow is a pilot stage project.</strong>
               Have a question, feature improvement, or problem?
               <a target="_blank" href="https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx">Send feedback</a>


### PR DESCRIPTION
Making the name less-specific for two reasons:

1. Trying to create a naming system with a cf- prefix
2. Provides a base class and styles that we can build on to for
   a `cf-notice--maintenance`, etc. if necessary