### PR TITLE
Make :visited state for action links in app body blue. closes #378

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -403,6 +403,9 @@ textarea {
     padding-top: 1rem !important;
     padding-bottom: 1rem !important;
 
+    &:visited {
+        color: $color-primary;
+    }
     // Removes padding, so that these links can be placed inline.
     &--inline {
         padding: 0 !important;

--- a/app/views/layouts/basic.html.erb
+++ b/app/views/layouts/basic.html.erb
@@ -49,12 +49,12 @@
   </main>
 
     <footer class="cf-text-center usa-grid cf-app-footer">
-        <p class="cf-push-left">
+        <div class="cf-push-left">
             Built with <abbr title="love">&#9825;</abbr> by the <a href="http://www.va.gov/ds/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>.
-        </p>
-        <p class="cf-push-right">
+        </div>
+        <div class="cf-push-right">
             <a target="_blank" href="https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx">Send feedback</a>
-        </p>
+        </div>
     </footer>
 
   <%= javascript_include_tag 'application' %>


### PR DESCRIPTION
Footer links retain `:visited` state added by the USWDS. Also changes `p` to `div` because the USWDS automatically adds an underline to every `a` within a `p` element.