### PR TITLE
Changing .embedded-document class name to .cf-doc-embed. closes #421

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -66,7 +66,7 @@ label {
   background-color: #ffffff;
 }
 
-.embedded-document {
+.cf-doc-embed {
   width: 100%;
   height: 80vh;
 }

--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -9,7 +9,7 @@
       </p>
   </div>
 
-  <iframe class="embedded-document cf-app-segment" src="<%= pdfjs.full_path(file: "/caseflow/files/forms/" + @file_name); =%>"></iframe>
+  <iframe class="cf-doc-embed cf-app-segment" src="<%= pdfjs.full_path(file: "/caseflow/files/forms/" + @file_name); =%>"></iframe>
 
 
 <%= form_tag({action: :certify}, {class: 'cf-form cf-app-segment'}) do %>


### PR DESCRIPTION
Bringing class name in line with new naming convention.