### PR TITLE
Removing cf-btn-faux* class names. closes #431.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -396,7 +396,8 @@ textarea {
 // form buttons have high specificity.
 // Keep an eye on https://github.com/18F/web-design-standards/issues/891
 [type="submit"],
-[type="button"] {
+[type="button"],
+[class*="usa-button"] {
     margin: 0 !important;
 }
 
@@ -587,8 +588,4 @@ Certified success page
 
 .cf-login-input {
   display: inline !important;
-}
-
-.cf-button-no-margin {
-  margin: 0;
 }

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -588,3 +588,7 @@ Certified success page
 .cf-login-input {
   display: inline !important;
 }
+
+.cf-button-no-margin {
+  margin: 0;
+}

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -443,43 +443,6 @@ textarea {
     }
 }
 
-/* Make a link that looks like a button */
-.cf-btn-faux {
-    -webkit-font-smoothing: antialiased;
-    color: $color-white;
-    display: inline-block;
-    background: $color-primary;
-    border-radius: 0.3rem;
-    font-weight: bold;
-    line-height: 1;
-    padding: 1rem 2rem;
-    text-decoration: none;
-
-    &:active {
-        background: $color-primary-darkest;
-    }
-    &:hover {
-        background: $color-primary-darker;
-    }
-
-    &--secondary {
-        background: $color-secondary;
-
-        &:active {
-            background: $color-secondary-darkest;
-        }
-        &:hover {
-            background: $color-secondary-dark;
-        }
-    }
-
-    &:visited, &:hover, &:active {
-        color: $color-white;
-        text-decoration: none;
-    }
-}
-
-
 /*--- Alerts ---*/
 /* Overrides/fixes USA Web Design Guideline paths */
 .usa-alert-error {

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -397,7 +397,7 @@ textarea {
 // Keep an eye on https://github.com/18F/web-design-standards/issues/891
 [type="submit"],
 [type="button"],
-[class*="usa-button"] {
+.usa-button {
     margin: 0 !important;
 }
 

--- a/app/views/web/_cancel_cert_modal.html.erb
+++ b/app/views/web/_cancel_cert_modal.html.erb
@@ -6,7 +6,7 @@ modal_locals = {
     modal_text: "Are you sure you can't certify this case? Any changes you made in Caseflow will not be saved and the certification date will not be set in VACOLS.",
     modal_html: %Q{<div class="cf-push-row cf-modal-controls">
         <button type="button" class="usa-button-outline cf-action-close cf-push-left" data-controls="#confirm-cancel-certification">Go back</button>
-        <a href="#{url_for(controller: 'web', action: 'error')}" class="cf-push-right usa-button usa-button-secondary cf-button-no-margin">Yes, I\'m sure</a>
+        <a href="#{url_for(controller: 'web', action: 'error')}" class="cf-push-right usa-button usa-button-secondary">Yes, I\'m sure</a>
     </div>},
 }
 

--- a/app/views/web/_cancel_cert_modal.html.erb
+++ b/app/views/web/_cancel_cert_modal.html.erb
@@ -6,7 +6,7 @@ modal_locals = {
     modal_text: "Are you sure you can't certify this case? Any changes you made in Caseflow will not be saved and the certification date will not be set in VACOLS.",
     modal_html: %Q{<div class="cf-push-row cf-modal-controls">
         <button type="button" class="usa-button-outline cf-action-close cf-push-left" data-controls="#confirm-cancel-certification">Go back</button>
-        <a href="#{url_for(controller: 'web', action: 'error')}" class="cf-push-right cf-btn-faux cf-btn-faux--secondary" autofocus>Yes, I\'m sure</a>
+        <a href="#{url_for(controller: 'web', action: 'error')}" class="cf-push-right usa-button usa-button-secondary">Yes, I\'m sure</a>
     </div>},
 }
 

--- a/app/views/web/_cancel_cert_modal.html.erb
+++ b/app/views/web/_cancel_cert_modal.html.erb
@@ -6,7 +6,7 @@ modal_locals = {
     modal_text: "Are you sure you can't certify this case? Any changes you made in Caseflow will not be saved and the certification date will not be set in VACOLS.",
     modal_html: %Q{<div class="cf-push-row cf-modal-controls">
         <button type="button" class="usa-button-outline cf-action-close cf-push-left" data-controls="#confirm-cancel-certification">Go back</button>
-        <a href="#{url_for(controller: 'web', action: 'error')}" class="cf-push-right usa-button usa-button-secondary">Yes, I\'m sure</a>
+        <a href="#{url_for(controller: 'web', action: 'error')}" class="cf-push-right usa-button usa-button-secondary cf-button-no-margin">Yes, I\'m sure</a>
     </div>},
 }
 


### PR DESCRIPTION
Using usa-button and usa-button-secondary patterns/class names
from the USWDS. 