### PR TITLE
Re-styling VBMS Failure page. closes #253

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -541,7 +541,7 @@ textarea {
 
 .cf-form-radio-inline {
     clear: both;
-    
+
     .cf-form-radio-option {
         float: left;
         padding-right: rem(30px);
@@ -588,6 +588,13 @@ Certified success page
     margin-bottom: rem(65px) !important;
     margin-top: rem(15px) !important;
     width: 65%;
+}
+
+.cf-msg-screen-text {
+    width: 65%;
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .cf-list-checklist {

--- a/app/views/web/404.html.erb
+++ b/app/views/web/404.html.erb
@@ -4,6 +4,6 @@
 <div class="cf-app-msg-screen cf-app-segment cf-app-segment--alt">
   <h1 class="cf-msg-screen-heading">Page not found</h1>
   <h2 class="cf-msg-screen-deck">Oops! It looks like the page you're looking for does not exist</h2>
-  <p class="cf-text-center">You might want to double check the URL for errors.</p>
+  <p class="cf-msg-screen-text">You might want to double check the URL for errors.</p>
 </div>
 <% end %>

--- a/app/views/web/certify.html.erb
+++ b/app/views/web/certify.html.erb
@@ -9,5 +9,5 @@
      <!-- <li><i class="cf-icon-success--bg cf-success"></i> Dispatched the appeal to <abbr title="Board of Veteran's Appeals">BVA</abbr></li> -->
   </ul>
 
-  <p class="cf-text-center">Way to go! You can now close this browser window and open another case in VACOLS.</p>
+  <p class="cf-msg-screen-text">Way to go! You can now close this browser window and open another case in VACOLS.</p>
 </div>

--- a/app/views/web/error.html.erb
+++ b/app/views/web/error.html.erb
@@ -4,6 +4,6 @@
 <div id="certifications-error" class="cf-text-center cf-app-segment cf-app-segment--alt">
     <h1 class="cf-error cf-msg-screen-heading">Case not certified</h1>
     <h2 class="cf-msg-screen-deck">The certification date was not set and any changes made in Caseflow were not saved.</h2>
-    <p>You can close this page and open another case in VACOLS.</p>
+    <p class="cf-msg-screen-text">You can close this page and open another case in VACOLS.</p>
 </div>
 <% end %>

--- a/app/views/web/not_found.html.erb
+++ b/app/views/web/not_found.html.erb
@@ -4,6 +4,6 @@
 <div class="cf-app-msg-screen cf-app-segment cf-app-segment--alt">
     <h1 class="cf-msg-screen-heading">Case not found</h1>
     <h2 class="cf-msg-screen-deck">There is no case in VACOLS with the ID you provided.</h2>
-    <p class="cf-text-center">You can close this page and open another case in VACOLS.</p>
+    <p class="cf-msg-screen-text">You can close this page and open another case in VACOLS.</p>
 </div>
 <% end %>

--- a/app/views/web/vbms_failure.html.erb
+++ b/app/views/web/vbms_failure.html.erb
@@ -6,15 +6,14 @@
 %>
 <% content_for :page_title do %>VBMS Error<% end %>
 
-<div id="certifications-error">
-  <div class="row">
-    <div class="col-sm-6 col-sm-offset-3">
-      <h1>VBMS Failure</h1>
-      <p>The VBMS system is not replying to requests, and we're unable to
-          check on the status of the files for this case in VBMS. Please
-          give VBMS a few moments to come back online, and
-          <a href="<%= url_for :controller => 'web', :action => 'start' %>">Restart the certification process</a>.
-      </p>
-    </div>
-  </div>
+<div class="cf-app-msg-screen cf-app-segment cf-app-segment--alt">
+    <h1 class="cf-msg-screen-heading">VBMS Failure</h1>
+    <h2 class="cf-msg-screen-deck">The VBMS system is not replying to requests</h2>
+
+
+    <p class="cf-text-center">We're unable to
+     check on the status of the files for this case in VBMS. Please
+     give VBMS a few moments to come back online, and
+     <a href="<%= url_for :controller => 'web', :action => 'start' %>">Restart the certification process</a>.
+    </p>
 </div>

--- a/app/views/web/vbms_failure.html.erb
+++ b/app/views/web/vbms_failure.html.erb
@@ -10,8 +10,7 @@
     <h1 class="cf-msg-screen-heading">VBMS Failure</h1>
     <h2 class="cf-msg-screen-deck">The VBMS system is not replying to requests</h2>
 
-
-    <p class="cf-text-center">We're unable to
+    <p class="cf-msg-screen-text">We're unable to
      check on the status of the files for this case in VBMS. Please
      give VBMS a few moments to come back online, and
      <a href="<%= url_for :controller => 'web', :action => 'start' %>">Restart the certification process</a>.


### PR DESCRIPTION
    - Changed vbms_failure.html.erb template.
    - Added .cf-msg-screen-text class to CSS.
    - Changed cf-text-center class to .cf-msg-screen-text in other templates.

    Changes to be committed:
        modified:   app/assets/stylesheets/application.css.scss
        modified:   app/views/web/404.html.erb
        modified:   app/views/web/certify.html.erb
        modified:   app/views/web/error.html.erb
        modified:   app/views/web/not_found.html.erb
        modified:   app/views/web/vbms_failure.html.erb