### PR TITLE
Removing `btn` and `btn-primary` classes. closes #455

### DIFF
--- a/app/views/web/generate.html.erb
+++ b/app/views/web/generate.html.erb
@@ -18,7 +18,7 @@
 
     <button type="button" class="usa-button-gray cf-action-back cf-push-left">&laquo; Go back and make edits</button>
     <a href="#confirm-cancel-certification" class="cf-action-openmodal space-left cf-btn-link">Cancel certification</a>
-    <button type="submit" class="btn btn-primary cf-push-right">Upload and Certify</button>
+    <button type="submit" class="cf-push-right">Upload and Certify</button>
 <% end %>
 
 <%= render partial: 'cancel_cert_modal' %>

--- a/app/views/web/start.html.erb
+++ b/app/views/web/start.html.erb
@@ -61,6 +61,6 @@
 
     <div class="cf-app-segment">
         <a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel certification</a>
-        <button type="button" class="btn btn-primary cf-push-right cf-action-refresh">Refresh Page</button>
+        <button type="button" class="cf-push-right cf-action-refresh">Refresh Page</button>
     </div>
     <%= render partial: 'cancel_cert_modal' %>


### PR DESCRIPTION
Removing `btn` and `btn-primary` classes from generate, start views that were leftover from Bootstrap.