### PR TITLE
Ensure that values for 8A, 8B, 10B are captured. closes #504

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -124,10 +124,13 @@ $.fn.extend({
         $(hideThese).find('[type=radio], [type=checkbox]').prop('checked', false);
 
         /* Clear other text fields */
-        $(hideThese).find('input').val('');
+        $(hideThese).find('[type=text], textarea').val('');
+
+        /* Unset radio buttons and checkboxes */
+        $(hideThese).find('[type=checkbox], [type=radio]').prop('checked', false);
 
         $(showThis).openItem();
-        
+
         if( $(showThis).data('requiredifshown') !== undefined ) {
             $(showThis).addClass('required');
             $(showThis).find('input').filter(':visible').each(function(){

--- a/app/views/web/_form8_radio_inputs.html.erb
+++ b/app/views/web/_form8_radio_inputs.html.erb
@@ -1,4 +1,4 @@
-<%#
+    <%#
     Use for radio button inputs.
 
     Required variables:
@@ -26,13 +26,13 @@
       fieldset should be closed. Default is false.
 %>
 
-<fieldset class="<%= parent_class.join(' ') if defined?(parent_class) %>"<%=raw %Q( id="#{parent_id}") if defined?(parent_id) %><%=' hidden=hidden' if defined?(hidden) && hidden %><%=raw %Q( data-showwhen="#{show_when}") if defined?(show_when) && show_when %><%=raw %Q( data-linkedto="#{linked}") if defined?(linked) && linked %><%= 'data-requiredifshown' if defined?(requiredifshown) && requiredifshown %>>
+<fieldset class="<%= parent_class.join(' ') if defined?(parent_class) %>"<%=raw %Q( id="#{parent_id}") if defined?(parent_id) %><%=' hidden=hidden' if defined?(hidden) && hidden %><%=raw %Q( data-showwhen="#{show_when}") if defined?(show_when) && show_when %><%=raw %Q( data-linkedto="#{linked}") if defined?(linked) && linked %><%= ' data-requiredifshown' if defined?(requiredifshown) && requiredifshown %>>
     <legend<%= ' class=required' if defined?(required) && required %>>
         <strong><%= question_num %></strong>
         <%= question %>
     </legend>
 
-<div class="cf-form-radio-options">    
+<div class="cf-form-radio-options">
 <% for option in options %>
     <div class="cf-form-radio-option">
         <input type="radio" name="<%=input_name%>" id="<%=option[:id]%>"

--- a/app/views/web/_form8_radio_inputs.html.erb
+++ b/app/views/web/_form8_radio_inputs.html.erb
@@ -1,4 +1,4 @@
-    <%#
+<%#
     Use for radio button inputs.
 
     Required variables:

--- a/app/views/web/_form8_radio_inputs.html.erb
+++ b/app/views/web/_form8_radio_inputs.html.erb
@@ -26,7 +26,7 @@
       fieldset should be closed. Default is false.
 %>
 
-<fieldset class="<%= parent_class.join(' ') if defined?(parent_class) %>"<%= %Q( id=#{parent_id}) if defined?(parent_id) %><%=' hidden=hidden' if defined?(hidden) && hidden %><%=raw %Q( data-showwhen="#{show_when}") if defined?(show_when) && show_when %><%=raw %Q( data-linkedto="#{linked}") if defined?(linked) && linked %> <%= 'data-requiredifshown' if defined?(requiredifshown) && requiredifshown %>>
+<fieldset class="<%= parent_class.join(' ') if defined?(parent_class) %>"<%=raw %Q( id="#{parent_id}") if defined?(parent_id) %><%=' hidden=hidden' if defined?(hidden) && hidden %><%=raw %Q( data-showwhen="#{show_when}") if defined?(show_when) && show_when %><%=raw %Q( data-linkedto="#{linked}") if defined?(linked) && linked %><%= 'data-requiredifshown' if defined?(requiredifshown) && requiredifshown %>>
     <legend<%= ' class=required' if defined?(required) && required %>>
         <strong><%= question_num %></strong>
         <%= question %>

--- a/app/views/web/questions.html.erb
+++ b/app/views/web/questions.html.erb
@@ -134,29 +134,34 @@
          options: [{
              label: 'Power of attorney',
              input_name: '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_POWER_OF_ATTORNEY',
-             id:'8A_POWER_OF_ATTORNEY',
+             id: '8A_POWER_OF_ATTORNEY',
+             value: '8A_POWER_OF_ATTORNEY',
              hidden: true,
              showthese: '#Q8B',
              hidethese: '#Q8C, #Q9A',
+           
          },
          {
              label: 'Agent',
              input_name: '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_AGENT',
-             id:'8A_AGENT',
+             id: '8A_AGENT',
+             value: '8A_AGENT',
              showthese: '#Q8C',
              hidethese: '#Q8B, #Q9A',
          },
          {
              label: 'Service organization',
              input_name: '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_SERVICE_ORGANIZATION',
-             id:'8A_SERVICE_ORGANIZATION',
+             id: '8A_SERVICE_ORGANIZATION',
+             value: '8A_SERVICE_ORGANIZATION',
              showthese: '#Q9A',
              hidethese: '#Q8B,#Q8C',
          },
          {
              label: 'No representative',
              input_name: '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_NO_REPRESENTATIVE',
-             id:'8A_NO_REPRESENTATIVE',
+             id: '8A_NO_REPRESENTATIVE',
+             value: '8A_NO_REPRESENTATIVE',
              hidethese: '#Q8B,#Q8C,#Q9A'
          }
         ]
@@ -172,8 +177,8 @@
                 requiredifshown: true,
                 options: [{
                     label: 'Located in the veteran\'s appeal file',
-                    value: '8B_POWER_OF_ATTORNEY',
-                    id: '8B_POWER_OF_ATTORNEY',
+                    value: '8B_VETERANS_APPEAL_FILE',
+                    id: '8B_VETERANS_APPEAL_FILE',
                     hidethese: '#8B-Explanation',
                 },
                 {
@@ -207,7 +212,7 @@
        } %>
 
 
-     <%= render partial: 'form8_radio_inputs', locals: {
+     <%= render partial: 'form8_yes_no_radio', locals: {
             question: 'Representative is service organization, is VA Form 646, or equivalent, of record?',
             question_num: '9A',
             input_name: '9A_IF_REPRESENTATIVE_IS_SERVICE_ORGANIZATION_IS_VA_FORM_646',
@@ -215,18 +220,6 @@
             parent_id: 'Q9A',
             hidden: true,
             requiredifshown: true,
-            options: [{
-                label: 'Yes',
-                value: 'yes',
-                id: '9A_YES',
-                hidethese: '#Q9B'
-            },
-            {
-                label: 'No',
-                value: 'no',
-                id: '9A_NO',
-                showthese: '#Q9B',
-            }]
 
      } %>
 


### PR DESCRIPTION
Fixed a bug that cleared the `value` attribute for all inputs.
Changed that to clear the value for text, textarea inputs, and
uncheck the radio button and checkboxes.