### PR TITLE
Add a hacky workaround for incoming 8A data

### DIFF
--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -101,11 +101,11 @@ class WebController < ApplicationController
     poa_name = 'Unknown'
     if poa == '8A_POWER_OF_ATTORNEY'
         poa_name = 'Power of attorney'
-    elsif poa == '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_AGENT'
+    elsif poa == '8A_AGENT'
         poa_name = 'Agent'
-    elsif poa == '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_SERVICE_ORGANIZATION'
+    elsif poa == '8A_SERVICE_ORGANIZATION'
         poa_name = 'Service organization'
-    elsif poa = '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_NO_REPRESENTATIVE'
+    elsif poa = '8A_NO_REPRESENTATIVE'
         poa_name = 'No representative'
     end
     fields['8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY'] = poa_name

--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -97,6 +97,21 @@ class WebController < ApplicationController
     ## Clear not applicable fields
     fields = fields.each{|key, value| fields.delete(key) if value == 'NOT_APPLICABLE' }
 
+    poa = fields['8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY']
+    poa_name = ""
+    if poa == '8A_POWER_OF_ATTORNEY'
+        poa_name = 'Power of attorney'
+    elsif poa == '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_AGENT'
+        poa_name = 'Agent'
+    elsif poa == '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_SERVICE_ORGANIZATION'
+        poa_name = 'Service organization'
+    elsif poa = '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_NO_REPRESENTATIVE'
+        poa_name = 'No representative'
+    else
+        poa_name = 'Unknown'
+    end
+    fields['8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY'] = poa_name
+
 
     ## Ensure that values are not set when a dependent question makes the answer not applicable
     if fields['8B_POWER_OF_ATTORNEY'] == '8B_POWER_OF_ATTORNEY'

--- a/app/controllers/web_controller.rb
+++ b/app/controllers/web_controller.rb
@@ -98,7 +98,7 @@ class WebController < ApplicationController
     fields = fields.each{|key, value| fields.delete(key) if value == 'NOT_APPLICABLE' }
 
     poa = fields['8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY']
-    poa_name = ""
+    poa_name = 'Unknown'
     if poa == '8A_POWER_OF_ATTORNEY'
         poa_name = 'Power of attorney'
     elsif poa == '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_AGENT'
@@ -107,8 +107,6 @@ class WebController < ApplicationController
         poa_name = 'Service organization'
     elsif poa = '8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY_NO_REPRESENTATIVE'
         poa_name = 'No representative'
-    else
-        poa_name = 'Unknown'
     end
     fields['8A_APPELLANT_REPRESENTED_IN_THIS_APPEAL_BY'] = poa_name
 


### PR DESCRIPTION
My guess is this changed in bc2c50e88c12076d9463fdaa2741636188ba565c and we never updated the front-end.

Wild guess, though.

This is a massive hack and adds tech debt. We need to refactor this. We're now defining this on the labels on the front-end and also on the backend before sending to the Form 8.