### PR TITLE
Add job for creating Establish Claim tasks

### DIFF
--- a/app/jobs/create_establish_claim_tasks_job.rb
+++ b/app/jobs/create_establish_claim_tasks_job.rb
@@ -1,0 +1,13 @@
+class CreateEstablishClaimTasksJob # < ActiveJob::Base
+  def perform(full_grant_decided_after)
+    # fetch all partial grants
+    AppealRepository.remands_ready_for_claims_establishment.each do |appeal|
+      CreateEndProduct.find_or_create_by(appeal: appeal)
+    end
+
+    # fetch all full grants
+    AppealRepository.amc_full_grants(decided_after: full_grant_decided_after).each do |appeal|
+      CreateEndProduct.find_or_create_by(appeal: appeal)
+    end
+  end
+end

--- a/app/jobs/create_establish_claim_tasks_job.rb
+++ b/app/jobs/create_establish_claim_tasks_job.rb
@@ -17,7 +17,7 @@ class CreateEstablishClaimTasksJob < ActiveJob::Base
     Time.utc(
       time.year,
       time.month,
-      (time.day - 3)
+      time.day - 2
     )
   end
 end

--- a/app/jobs/create_establish_claim_tasks_job.rb
+++ b/app/jobs/create_establish_claim_tasks_job.rb
@@ -1,5 +1,5 @@
-class CreateEstablishClaimTasksJob # < ActiveJob::Base
-  def perform(full_grant_decided_after)
+class CreateEstablishClaimTasksJob < ActiveJob::Base
+  def perform
     # fetch all partial grants
     AppealRepository.remands_ready_for_claims_establishment.each do |appeal|
       CreateEndProduct.find_or_create_by(appeal: appeal)
@@ -9,5 +9,15 @@ class CreateEstablishClaimTasksJob # < ActiveJob::Base
     AppealRepository.amc_full_grants(decided_after: full_grant_decided_after).each do |appeal|
       CreateEndProduct.find_or_create_by(appeal: appeal)
     end
+  end
+
+  # Grab all historical full grants within the last 3 days
+  def full_grant_decided_after
+    time = Time.now
+    Time.utc(
+      time.year,
+      time.month,
+      (time.day - 3)
+    )
   end
 end

--- a/app/jobs/create_establish_claim_tasks_job.rb
+++ b/app/jobs/create_establish_claim_tasks_job.rb
@@ -1,4 +1,6 @@
 class CreateEstablishClaimTasksJob < ActiveJob::Base
+  queue_as :default
+
   def perform
     # fetch all partial grants
     AppealRepository.remands_ready_for_claims_establishment.each do |appeal|

--- a/app/jobs/create_establish_claim_tasks_job.rb
+++ b/app/jobs/create_establish_claim_tasks_job.rb
@@ -2,18 +2,18 @@ class CreateEstablishClaimTasksJob < ActiveJob::Base
   def perform
     # fetch all partial grants
     AppealRepository.remands_ready_for_claims_establishment.each do |appeal|
-      CreateEndProduct.find_or_create_by(appeal: appeal)
+      EstablishClaim.find_or_create_by(appeal: appeal)
     end
 
     # fetch all full grants
     AppealRepository.amc_full_grants(decided_after: full_grant_decided_after).each do |appeal|
-      CreateEndProduct.find_or_create_by(appeal: appeal)
+      EstablishClaim.find_or_create_by(appeal: appeal)
     end
   end
 
   # Grab all historical full grants within the last 3 days
   def full_grant_decided_after
-    time = Time.now
+    time = Time.now.utc
     Time.utc(
       time.year,
       time.month,

--- a/app/jobs/create_establish_claim_tasks_job.rb
+++ b/app/jobs/create_establish_claim_tasks_job.rb
@@ -13,11 +13,12 @@ class CreateEstablishClaimTasksJob < ActiveJob::Base
 
   # Grab all historical full grants within the last 3 days
   def full_grant_decided_after
-    time = Time.now.utc
-    Time.utc(
-      time.year,
-      time.month,
-      time.day - 2
+    Time.zone = "Eastern Time (US & Canada)"
+    current_time = Time.zone.now
+    Time.zone.local(
+      current_time.year,
+      current_time.month,
+      current_time.day - 3
     )
   end
 end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -132,9 +132,7 @@ class Appeal < ActiveRecord::Base
      delegate :certify, to: :repository
 
      def find_or_create_by_vacols_id(vacols_id)
-       appeal = find_by(vacols_id: vacols_id) ||
-                new(vacols_id: vacols_id)
-
+       appeal = find_or_initialize_by(vacols_id: vacols_id)
        repository.load_vacols_data(appeal)
        appeal.save
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -31,7 +31,7 @@ class AppealRepository
 
   # TODO: consider persisting these records
   def self.build_appeal(case_record)
-    appeal = Appeal.find_or_create_by(vacols_id: case_record.bfkey)
+    appeal = Appeal.find_or_initialize_by(vacols_id: case_record.bfkey)
     set_vacols_values(appeal: appeal, case_record: case_record)
   end
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -75,7 +75,7 @@ class AppealRepository
   # :nocov:
   def self.remands_ready_for_claims_establishment
     remands = MetricsService.timer "loaded remands in loc 97 from VACOLS" do
-      VACOLS::CASE.remands_ready_for_claims_establishment
+      VACOLS::Case.remands_ready_for_claims_establishment
     end
 
     remands.map { |case_record| build_appeal(case_record) }
@@ -83,7 +83,7 @@ class AppealRepository
 
   def self.amc_full_grants(decided_after:)
     full_grants = MetricsService.timer "loaded AMC full grants decided after #{decided_after} from VACOLS" do
-      VACOLS::CASE.amc_full_grants(decided_after)
+      VACOLS::Case.amc_full_grants(decided_after)
     end
 
     full_grants.map { |case_record| build_appeal(case_record) }

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -31,7 +31,8 @@ class AppealRepository
 
   # TODO: consider persisting these records
   def self.build_appeal(case_record)
-    AppealRepository.set_vacols_values(appeal: Appeal.new, case_record: case_record)
+    appeal = Appeal.find_or_create_by(vacols_id: case_record.bfkey)
+    set_vacols_values(appeal: appeal, case_record: case_record)
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -1,6 +1,6 @@
 # Create establish claim tasks every night at midnight
 create_establish_claim_tasks_job:
- cron: "0 0 * * * America/New_York"
+ cron: "1 0 * * * America/New_York"
  class: "CreateEstablishClaimTasksJob"
  queue: default
  active_job: false

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -1,0 +1,6 @@
+# Create establish claim tasks every night at midnight
+create_establish_claim_tasks_job:
+ cron: "0 0 * * * America/New_York"
+ class: "CreateEstablishClaimTasksJob"
+ queue: default
+ active_job: false

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -6,10 +6,10 @@ class Fakes::AppealRepository
     attr_accessor :certified_appeal
   end
 
-  def self.create(vacols_id, default_attrs_method_name, overrides = {})
+  def self.new(vacols_id, default_attrs_method_name, overrides = {})
     # Dynamically call the specified class method name to obtain
     # the hash of defualt values eg:
-    #   AppealRepository.create("123C", :appeal_ready_to_certify)
+    #   AppealRepository.new("123C", :appeal_ready_to_certify)
     default_attrs = send(default_attrs_method_name)
     attrs = default_attrs.merge(overrides) # merge in overrides
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -7,6 +7,9 @@ class Fakes::AppealRepository
   end
 
   def self.create(vacols_id, default_attrs_method_name, overrides = {})
+    # Dynamically call the specified class method name to obtain
+    # the hash of defualt values eg:
+    #   AppealRepository.create("123C", :appeal_ready_to_certify)
     default_attrs = send(default_attrs_method_name)
     attrs = default_attrs.merge(overrides) # merge in overrides
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -6,6 +6,15 @@ class Fakes::AppealRepository
     attr_accessor :certified_appeal
   end
 
+  def self.create(vacols_id, default_attrs_method_name, overrides = {})
+    default_attrs = send(default_attrs_method_name)
+    attrs = default_attrs.merge(overrides) # merge in overrides
+
+    appeal = Appeal.new(vacols_id: vacols_id)
+    appeal.assign_from_vacols(attrs)
+    appeal
+  end
+
   def self.certify(appeal)
     @certified_appeal = appeal
   end

--- a/spec/jobs/create_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/create_establish_claim_tasks_job_spec.rb
@@ -7,7 +7,7 @@ describe CreateEstablishClaimTasksJob do
 
     allow(AppealRepository).to receive(:remands_ready_for_claims_establishment).and_return([@partial_grant])
     allow(AppealRepository).to receive(:amc_full_grants).and_return([@full_grant])
-    Timecop.freeze(Time.utc(2015, 1, 10, 12, 8, 0))
+    Timecop.freeze(Time.zone.local(2015, 1, 10, 12, 8, 0))
   end
 
   after { Timecop.return }
@@ -23,7 +23,7 @@ describe CreateEstablishClaimTasksJob do
   context ".full_grant_decided_after" do
     subject { CreateEstablishClaimTasksJob.new.full_grant_decided_after }
     it "returns a date 3 days earlier at midnight" do
-      is_expected.to eq(Time.utc(2015, 1, 7, 0))
+      is_expected.to eq(Time.zone.local(2015, 1, 7, 0))
     end
   end
 end

--- a/spec/jobs/create_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/create_establish_claim_tasks_job_spec.rb
@@ -2,8 +2,8 @@ describe CreateEstablishClaimTasksJob do
   before do
     reset_application!
 
-    @partial_grant = Fakes::AppealRepository.create("123C", :appeal_remand_decided)
-    @full_grant = Fakes::AppealRepository.create("456D", :appeal_full_grant_decided, decision_date: 1.day.ago)
+    @partial_grant = Fakes::AppealRepository.new("123C", :appeal_remand_decided)
+    @full_grant = Fakes::AppealRepository.new("456D", :appeal_full_grant_decided, decision_date: 1.day.ago)
 
     allow(AppealRepository).to receive(:remands_ready_for_claims_establishment).and_return([@partial_grant])
     allow(AppealRepository).to receive(:amc_full_grants).and_return([@full_grant])

--- a/spec/jobs/create_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/create_establish_claim_tasks_job_spec.rb
@@ -1,0 +1,41 @@
+describe CreateEstablishClaimTasksJob do
+  before do
+    reset_application!
+
+    @partial_grant = Fakes::AppealRepository.create("123C", :appeal_remand_decided)
+    @full_grant = Fakes::AppealRepository.create("456D", :appeal_full_grant_decided, decision_date: 1.day.ago)
+
+    allow(AppealRepository).to receive(:remands_ready_for_claims_establishment).and_return([@partial_grant])
+    allow(AppealRepository).to receive(:amc_full_grants).and_return([@full_grant])
+    Timecop.freeze(Time.utc(2015, 1, 10, 12, 8, 0))
+  end
+
+  after { Timecop.return }
+
+  context ".perform" do
+    it "creates tasks" do
+      expect(Task.count).to eq(0)
+      CreateEstablishClaimTasksJob.perform_now
+      expect(Task.count).to eq(2)
+    end
+
+    context "full grants beyond 3 days" do
+      before do
+        @full_grant.update(decision_date: 10.days.ago)
+      end
+
+      it "filters them out" do
+        expect(Task.count).to eq(0)
+        CreateEstablishClaimTasksJob.perform_now
+        expect(Task.count).to eq(2)
+      end
+    end
+  end
+
+  context ".full_grant_decided_after" do
+    subject { CreateEstablishClaimTasksJob.new.full_grant_decided_after }
+    it "returns a date 3 days earlier at midnight" do
+      is_expected.to eq(Time.utc(2015, 1, 7, 0))
+    end
+  end
+end

--- a/spec/jobs/create_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/create_establish_claim_tasks_job_spec.rb
@@ -14,21 +14,9 @@ describe CreateEstablishClaimTasksJob do
 
   context ".perform" do
     it "creates tasks" do
-      expect(Task.count).to eq(0)
+      expect(EstablishClaim.count).to eq(0)
       CreateEstablishClaimTasksJob.perform_now
-      expect(Task.count).to eq(2)
-    end
-
-    context "full grants beyond 3 days" do
-      before do
-        @full_grant.update(decision_date: 10.days.ago)
-      end
-
-      it "filters them out" do
-        expect(Task.count).to eq(0)
-        CreateEstablishClaimTasksJob.perform_now
-        expect(Task.count).to eq(2)
-      end
+      expect(EstablishClaim.count).to eq(2)
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,7 @@ def reset_application!
   User.clear_stub!
   User.delete_all
   Certification.delete_all
+  Fakes::AppealRepository.records = nil
 end
 
 def current_user

--- a/spec/services/appeals_repository_spec.rb
+++ b/spec/services/appeals_repository_spec.rb
@@ -28,6 +28,7 @@ describe AppealRepository do
 
   let(:case_record) do
     OpenStruct.new(
+      bfkey: "123C",
       bfcorlid: "VBMS-ID",
       bfac: "4",
       bfso: "Q",


### PR DESCRIPTION
- Check for partial and full grant appeals, create establish claim tasks
   for both
- Add cron to run job every night at midnight


Testing:
- Added new unit tests for the job. They pass
- Existing unit tests pass