### PR TITLE
Add assign functionality to employee task list

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,4 +72,12 @@ class ApplicationController < ActionController::Base
     session["return_to"] = request.original_url
     redirect_to "/unauthorized"
   end
+
+  # Verifies the passed user matches the current user
+  def verify_user(user)
+    return true if current_user == user
+
+    session["return_to"] = request.original_url
+    redirect_to "/unauthorized"
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,7 +10,11 @@ class TasksController < ApplicationController
   end
 
   def show
-    @task = Task.find(task_id)
+  end
+
+  def assign
+    task.assign!(current_user)
+    redirect_to task_path(task)
   end
 
   private
@@ -30,12 +34,17 @@ class TasksController < ApplicationController
   end
 
   def type
-    params[:task_type]
+    params[:task_type] || (task && task.type.to_sym)
   end
 
   def task_id
     params[:id]
   end
+
+  def task
+    @task ||= Task.find(task_id)
+  end
+  helper_method :task
 
   def completed_tasks
     @completed_tasks ||= Task.where.not(completed_at: nil).order(created_at: :desc).limit(5)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,6 @@
 class TasksController < ApplicationController
   before_action :verify_access
+  before_action :verify_assigned_to_current_user, only: [:show]
 
   class TaskTypeMissingError < StandardError; end
 
@@ -66,12 +67,14 @@ class TasksController < ApplicationController
   end
 
   def manager?
-    # TODO(jd): Determine real CSS role to be used
     current_user.can?(task_roles[:manager])
   end
 
   def verify_access
-    # TODO(jd): Determine real CSS role to be used
     verify_authorized_roles(task_roles[:employee])
+  end
+
+  def verify_assigned_to_current_user
+    verify_user(task.user)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,7 @@ class TasksController < ApplicationController
 
   def assign
     task.assign!(current_user)
-    redirect_to task_path(task)
+    redirect_to task.show_path
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,7 @@ class TasksController < ApplicationController
 
   def assign
     task.assign!(current_user)
-    redirect_to task.show_path
+    redirect_to task.url_path
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,6 +33,9 @@ class TasksController < ApplicationController
     Task.where(type: type).newest_first
   end
 
+  # If a task_type is explicitly passed via the router, use that.
+  # Otherwise look up the task type from the task itself
+  # Ex:  PATCH /tasks/:id/assign will look up the task type from the task
   def type
     params[:task_type] || (task && task.type.to_sym)
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,9 +33,6 @@ class TasksController < ApplicationController
     Task.where(type: type).newest_first
   end
 
-  # If a task_type is explicitly passed via the router, use that.
-  # Otherwise look up the task type from the task itself
-  # Ex:  PATCH /tasks/:id/assign will look up the task type from the task
   def type
     params[:task_type]
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -13,8 +13,8 @@ class TasksController < ApplicationController
   end
 
   def assign
-    task.assign!(current_user)
-    redirect_to task.url_path
+    next_unassigned_task.assign!(current_user)
+    redirect_to next_unassigned_task.url_path
   end
 
   private
@@ -37,7 +37,7 @@ class TasksController < ApplicationController
   # Otherwise look up the task type from the task itself
   # Ex:  PATCH /tasks/:id/assign will look up the task type from the task
   def type
-    params[:task_type] || (task && task.type.to_sym)
+    params[:task_type]
   end
 
   def task_id

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,7 +14,7 @@ class TasksController < ApplicationController
 
   def assign
     next_unassigned_task.assign!(current_user)
-    redirect_to next_unassigned_task.url_path
+    redirect_to url_for(next_unassigned_task)
   end
 
   private

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,8 @@ class Task < ActiveRecord::Base
   belongs_to :user
   belongs_to :appeal
 
+  class AlreadyAssignedError < StandardError; end
+
   DEPARTMENT_MAPPING = {
     EstablishClaim: :dispatch
   }.freeze
@@ -46,6 +48,8 @@ class Task < ActiveRecord::Base
   end
 
   def assign!(user)
+    return AlreadyAssignedError if self.user
+
     update_attributes!(
       user: user,
       assigned_at: Time.now.utc

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -36,7 +36,7 @@ class Task < ActiveRecord::Base
     type.titlecase
   end
 
-  def assign(user)
+  def assign!(user)
     update_attributes!(
       user: user,
       assigned_at: Time.now.utc

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,7 +4,7 @@ class Task < ActiveRecord::Base
 
   DEPARTMENT_MAPPING = {
     EstablishClaim: :dispatch
-  }
+  }.freeze
 
   COMPLETION_STATUS_MAPPING = {
     0 => "Completed",

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,10 +4,6 @@ class Task < ActiveRecord::Base
 
   class AlreadyAssignedError < StandardError; end
 
-  DEPARTMENT_MAPPING = {
-    EstablishClaim: :dispatch
-  }.freeze
-
   COMPLETION_STATUS_MAPPING = {
     0 => "Completed",
     1 => "Cancelled",
@@ -40,11 +36,6 @@ class Task < ActiveRecord::Base
 
   def start_text
     type.titlecase
-  end
-
-  def url_path
-    department = DEPARTMENT_MAPPING[type.to_sym]
-    "/#{department}/#{type.underscore.dasherize}/#{id}"
   end
 
   def assign!(user)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,10 @@ class Task < ActiveRecord::Base
   belongs_to :user
   belongs_to :appeal
 
+  DEPARTMENT_MAPPING = {
+    EstablishClaim: :dispatch
+  }
+
   COMPLETION_STATUS_MAPPING = {
     0 => "Completed",
     1 => "Cancelled",
@@ -34,6 +38,11 @@ class Task < ActiveRecord::Base
 
   def start_text
     type.titlecase
+  end
+
+  def show_path
+    department = DEPARTMENT_MAPPING(task.type.to_sym)
+    "#{department}/#{type.underscore.dasherize}/#{task.id}"
   end
 
   def assign!(user)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,9 +40,9 @@ class Task < ActiveRecord::Base
     type.titlecase
   end
 
-  def show_path
-    department = DEPARTMENT_MAPPING(task.type.to_sym)
-    "#{department}/#{type.underscore.dasherize}/#{task.id}"
+  def url_path
+    department = DEPARTMENT_MAPPING[type.to_sym]
+    "/#{department}/#{type.underscore.dasherize}/#{id}"
   end
 
   def assign!(user)

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,5 +1,5 @@
 <h1>Dispatch Show WIP</h1>
-<p>Type: <%= @task.type %></p>
-<p>user: <%= @task.user.display_name %></p>
-<p>vacols_id: <%= @task.appeal.vacols_id %></p>
+<p>Type: <%= task.type %></p>
+<p>user: <%= task.user.display_name %></p>
+<p>vacols_id: <%= task.appeal.vacols_id %></p>
 

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,4 +1,5 @@
 <h1>Dispatch Show WIP</h1>
 <p>Type: <%= @task.type %></p>
+<p>user: <%= @task.user.display_name %></p>
 <p>vacols_id: <%= @task.appeal.vacols_id %></p>
 

--- a/app/views/tasks/worker_index.html.erb
+++ b/app/views/tasks/worker_index.html.erb
@@ -2,9 +2,8 @@
   <div class="usa-width-one-whole task-start-wrapper">
     <% if next_unassigned_task %>
       <div class="task-start-cta">
-        <button type="button" class="usa-button-primary">
-          <%= next_unassigned_task.start_text %>
-        </button>
+        <%= link_to(next_unassigned_task.start_text, assign_task_path(next_unassigned_task),
+          class: "usa-button-primary", method: 'patch') %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/worker_index.html.erb
+++ b/app/views/tasks/worker_index.html.erb
@@ -2,7 +2,7 @@
   <div class="usa-width-one-whole task-start-wrapper">
     <% if next_unassigned_task %>
       <div class="task-start-cta">
-        <%= link_to(next_unassigned_task.start_text, assign_task_path(next_unassigned_task),
+        <%= link_to("Establish Claim", assign_path,
           class: "usa-button-primary", method: 'patch') %>
       </div>
     <% end %>

--- a/app/views/tasks/worker_index.html.erb
+++ b/app/views/tasks/worker_index.html.erb
@@ -2,7 +2,7 @@
   <div class="usa-width-one-whole task-start-wrapper">
     <% if next_unassigned_task %>
       <div class="task-start-cta">
-        <%= link_to("Establish Claim", assign_path,
+        <%= link_to("Establish Claim", assign_establish_claims_path,
           class: "usa-button-primary", method: 'patch') %>
       </div>
     <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,13 @@ Rails.application.configure do
   silence_warnings do
     begin
       require 'pry'
-      IRB = Pry
+      config.console = Pry
+      unless defined? Pry::ExtendCommandBundle
+        Pry::ExtendCommandBundle = Module.new
+      end
+      require "rails/console/app"
+      require "rails/console/helpers"
+      TOPLEVEL_BINDING.eval('self').extend ::Rails::ConsoleMethods
     rescue LoadError
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
   #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
 
   # Example resource route (maps HTTP verbs to controller actions automatically):
-  
+
   resources :sessions, only: [:new, :create]
   resources :certifications, path_names: { new: "new/:vacols_id" } do
     get 'pdf', on: :member
@@ -18,9 +18,15 @@ Rails.application.routes.draw do
     get 'cancel', on: :member
   end
 
-  scope "/dispatch/establish-claim", task_type: :EstablishClaim do
-    get '/', to: "tasks#index"
-    get '/:task_id', to: "tasks#show"
+  scope "/dispatch" do
+    # TODO(jd): Make this its own controller action that looks at the user's roles
+    # and redirects accordingly
+    get "/", to: redirect("/dispatch/establish-claim")
+
+    scope "/establish-claim", task_type: :EstablishClaim do
+      get "/", to: "tasks#index"
+      get "/:id", to: "tasks#show"
+    end
   end
 
   resources :tasks, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,15 +18,17 @@ Rails.application.routes.draw do
     get 'cancel', on: :member
   end
 
-  scope "/dispatch" do
+  scope path: "/dispatch" do
     # TODO(jd): Make this its own controller action that looks at the user's roles
     # and redirects accordingly
     get "/", to: redirect("/dispatch/establish-claim")
 
-    scope "/establish-claim", task_type: :EstablishClaim do
-      get "/", to: "tasks#index"
-      patch "/assign", to: "tasks#assign"
-      get "/:id", to: "tasks#show"
+    resources :establish_claims,
+              path: "/establish-claim",
+              controller: "tasks",
+              task_type: :EstablishClaim,
+              only: [:show, :index] do
+      patch 'assign', on: :collection
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,10 @@ Rails.application.routes.draw do
     get '/', to: "tasks#index"
   end
 
+  resources :tasks, only: [:show] do
+    patch 'assign', on: :member
+  end
+
   resources :offices, only: :index
 
   get "health-check", to: "health_checks#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,12 +25,9 @@ Rails.application.routes.draw do
 
     scope "/establish-claim", task_type: :EstablishClaim do
       get "/", to: "tasks#index"
+      patch "/assign", to: "tasks#assign"
       get "/:id", to: "tasks#show"
     end
-  end
-
-  resources :tasks, only: [] do
-    patch 'assign', on: :member
   end
 
   patch "certifications" => "certifications#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,9 +20,10 @@ Rails.application.routes.draw do
 
   scope "/dispatch/establish-claim", task_type: :EstablishClaim do
     get '/', to: "tasks#index"
+    get '/:task_id', to: "tasks#show"
   end
 
-  resources :tasks, only: [:show] do
+  resources :tasks, only: [] do
     patch 'assign', on: :member
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,7 @@ class SeedDB
         appeal: @appeals[i % num_appeals]
         )
       if i % 4 > 0
-        establish_claim.assign(@users[i % num_users])
+        establish_claim.assign!(@users[i % num_users])
       end
 
       if i % 4 > 1

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Dispatch", focus: true do
+RSpec.feature "Dispatch" do
   before do
     reset_application!
     Fakes::AppealRepository.records = {

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -60,6 +60,7 @@ RSpec.feature "Dispatch" do
 
         click_on "Establish Claim"
         expect(page).to have_current_path("/dispatch/establish-claim/#{@task.id}")
+        expect(@task.user).to eq(current_user)
       end
     end
   end

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Dispatch" do
+RSpec.feature "Dispatch", focus: true do
   before do
     reset_application!
     Fakes::AppealRepository.records = {
@@ -7,7 +7,7 @@ RSpec.feature "Dispatch" do
     }
     @vbms_id = "VBMS_ID1"
     appeal = Appeal.create(vacols_id: "123C", vbms_id: @vbms_id)
-    @end_product = EstablishClaim.create(appeal: appeal)
+    @task = EstablishClaim.create(appeal: appeal)
   end
 
   context "manager" do
@@ -25,8 +25,8 @@ RSpec.feature "Dispatch" do
 
     context "task completed" do
       before do
-        @end_product.assign(User.create(station_id: "123", css_id: "ABC"))
-        @end_product.update(started_at: Time.now.utc, completed_at: Time.now.utc)
+        @task.assign!(User.create(station_id: "123", css_id: "ABC"))
+        @task.update(started_at: Time.now.utc, completed_at: Time.now.utc)
       end
 
       scenario "Case Worker" do
@@ -57,6 +57,9 @@ RSpec.feature "Dispatch" do
 
         expect(page).to have_content("Establish Claim")
         expect(page).to have_css("tr#task-#{@completed_task.id}")
+
+        click_on "Establish Claim"
+        expect(page).to have_current_path("/dispatch/establish-claim/#{@task.id}")
       end
     end
   end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -114,4 +114,9 @@ describe Task do
   context "#to_complete" do
     it { expect { Task.to_complete.find(@task.id) }.not_to raise_error }
   end
+
+  context "#url_path" do
+    subject { @task.url_path }
+    it { is_expected.to eq("/dispatch/establish-claim/#{@task.id}") }
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -42,8 +42,8 @@ describe Task do
   context "Assigning user methods" do
     subject { @task }
 
-    context ".assign" do
-      before { @task.assign(@user) }
+    context ".assign!" do
+      before { @task.assign!(@user) }
 
       it "correctly assigns a task to a user" do
         expect(subject.user.id).to eq(@user.id)
@@ -57,7 +57,7 @@ describe Task do
       end
 
       it "assigned is true after assignment" do
-        @task.assign(@user)
+        @task.assign!(@user)
         expect(subject.assigned?).to be_truthy
       end
     end
@@ -74,7 +74,7 @@ describe Task do
 
     context "task is assigned" do
       before do
-        @task.assign(@user)
+        @task.assign!(@user)
       end
 
       it { is_expected.to eq("Not Started") }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -114,9 +114,4 @@ describe Task do
   context "#to_complete" do
     it { expect { Task.to_complete.find(@task.id) }.not_to raise_error }
   end
-
-  context "#url_path" do
-    subject { @task.url_path }
-    it { is_expected.to eq("/dispatch/establish-claim/#{@task.id}") }
-  end
 end


### PR DESCRIPTION
This PR makes the "Establish Claim" button assign the claim to the current user and redirect to the show page.

Fixes #438 


Test plan:
- [x] Existing teste suite passes
- [x] Added new feature test
- [x] Manually tested in browser:
![establish_claim](https://cloud.githubusercontent.com/assets/2256237/20318033/9ac009ea-ab36-11e6-8e97-37b0c40226da.gif)
