### PR TITLE
Sharon job for reassigning tasks

### DIFF
--- a/app/jobs/reassign_old_tasks_job.rb
+++ b/app/jobs/reassign_old_tasks_job.rb
@@ -2,6 +2,7 @@ class ReassignOldTasksJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    EstablishClaim.assigned_not_completed.each(&:duplicate_and_mark_complete!)
+    Task.assigned_not_completed.where(type: Task::REASSIGN_OLD_TASKS).each(&:duplicate_and_mark_complete!)
   end
+
 end

--- a/app/jobs/reassign_old_tasks_job.rb
+++ b/app/jobs/reassign_old_tasks_job.rb
@@ -2,9 +2,6 @@ class ReassignOldTasksJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    EstablishClaim.assigned_not_completed.each do | task |
-      task.duplicate_and_mark_complete! 
-    end
+    EstablishClaim.assigned_not_completed.each(&:duplicate_and_mark_complete!)
   end
-
 end

--- a/app/jobs/reassign_old_tasks_job.rb
+++ b/app/jobs/reassign_old_tasks_job.rb
@@ -1,0 +1,10 @@
+class ReassignOldTasksJob < ActiveJob::Base
+  queue_as :default
+
+  def perform
+    EstablishClaim.assigned_not_completed.each do | task |
+      task.duplicate_and_mark_complete! 
+    end
+  end
+
+end

--- a/app/jobs/reassign_old_tasks_job.rb
+++ b/app/jobs/reassign_old_tasks_job.rb
@@ -2,6 +2,6 @@ class ReassignOldTasksJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    Task.assigned_not_completed.where(type: Task::REASSIGN_OLD_TASKS).each(&:duplicate_and_mark_complete!)
+    Task.assigned_not_completed.where(type: Task::REASSIGN_OLD_TASKS).each(&:expire!)
   end
 end

--- a/app/jobs/reassign_old_tasks_job.rb
+++ b/app/jobs/reassign_old_tasks_job.rb
@@ -4,5 +4,4 @@ class ReassignOldTasksJob < ActiveJob::Base
   def perform
     Task.assigned_not_completed.where(type: Task::REASSIGN_OLD_TASKS).each(&:duplicate_and_mark_complete!)
   end
-
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,6 +9,8 @@ class Task < ActiveRecord::Base
     routed_to_ro: 3
   }.freeze
 
+  REASSIGN_OLD_TASKS = [:EstablishClaim]
+
   class << self
     def unassigned
       where(user_id: nil)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,7 +40,7 @@ class Task < ActiveRecord::Base
       where.not(completed_at: nil)
     end
 
-    def uncompleted_task_for_appeal(appeal)
+    def to_complete_task_for_appeal(appeal)
       where(completed_at: nil, appeal: appeal)
     end
 
@@ -103,7 +103,7 @@ class Task < ActiveRecord::Base
   end
 
   def no_open_tasks_for_appeal
-    if self.class.uncompleted_task_for_appeal(appeal).count > 0
+    if self.class.to_complete_task_for_appeal(appeal).count > 0
       errors.add(:appeal, "Uncompleted task already exists for this appeal")
     end
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -57,7 +57,7 @@ class Task < ActiveRecord::Base
     self
   end
 
-  def duplicate_and_mark_complete!
+  def expire!
     transaction do
       EstablishClaim.create!(appeal_id: appeal_id)
       completed!(self.class.completion_status_code("Expired"))

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -34,8 +34,8 @@ class Task < ActiveRecord::Base
       where.not(completed_at: nil)
     end
 
-    def completion_status_code(code)
-      COMPLETION_STATUS_MAPPING.key(code)
+    def completion_status_code(text)
+      COMPLETION_STATUS_MAPPING.key(text)
     end
   end
 
@@ -49,14 +49,6 @@ class Task < ActiveRecord::Base
       assigned_at: Time.now.utc
     )
     self
-  end
-
-  def unassign!
-    update_attributes!(
-      user: nil,
-      assigned_at: nil,
-      started_at: nil
-    )
   end
 
   def duplicate_and_mark_complete!

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,8 @@ class Task < ActiveRecord::Base
   belongs_to :user
   belongs_to :appeal
 
+  validates :appeal, uniqueness: { scope: :}
+
   class AlreadyAssignedError < StandardError; end
 
   COMPLETION_STATUS_MAPPING = {
@@ -60,7 +62,7 @@ class Task < ActiveRecord::Base
   def expire!
     transaction do
       self.class.create!(appeal_id: appeal_id, type: type)
-      completed!(self.class.completion_status_code(:expired))
+      complete!(self.class.completion_status_code(:expired))
     end
   end
 
@@ -85,7 +87,7 @@ class Task < ActiveRecord::Base
   end
 
   # completion_status is 0 for success, or non-zero to specify another completed case
-  def completed!(status)
+  def complete!(status)
     update_attributes!(
       completed_at: Time.now.utc,
       completion_status: status

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,7 +9,7 @@ class Task < ActiveRecord::Base
     routed_to_ro: 3
   }.freeze
 
-  REASSIGN_OLD_TASKS = [:EstablishClaim]
+  REASSIGN_OLD_TASKS = [:EstablishClaim].freeze
 
   class << self
     def unassigned

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -39,7 +39,7 @@ class Task < ActiveRecord::Base
     end
 
     def completion_status_code(text)
-      COMPLETION_STATUS_MAPPING.key(text)
+      COMPLETION_STATUS_MAPPING[text]
     end
   end
 
@@ -59,8 +59,8 @@ class Task < ActiveRecord::Base
 
   def expire!
     transaction do
-      EstablishClaim.create!(appeal_id: appeal_id)
-      completed!(self.class.completion_status_code("Expired"))
+      self.class.create!(appeal_id: appeal_id, type: type)
+      completed!(self.class.completion_status_code(:expired))
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -44,7 +44,7 @@ class Task < ActiveRecord::Base
     type.titlecase
   end
 
-  def assign!(user)
+  def assign(user)
     update_attributes!(
       user: user,
       assigned_at: Time.now.utc

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,22 +2,21 @@ class Task < ActiveRecord::Base
   belongs_to :user
   belongs_to :appeal
 
+  COMPLETION_STATUS_MAPPING = {
+    0 => "Completed",
+    1 => "Cancelled by User",
+    2 => "Cancelled by System",
+    3 => "Routed to RO"
+  }.freeze
+
   class << self
-
-    COMPLETION_STATUS_MAPPING = {
-      0 => "Completed",
-      1 => "Cancelled by User",
-      2 => "Cancelled by System",
-      3 => "Routed to RO"
-    }.freeze
-
     def unassigned
       where(user_id: nil)
     end
 
     def assigned_not_completed
       to_complete.where.not(assigned_at: nil)
-    end 
+    end
 
     def newest_first
       order(created_at: :desc)
@@ -56,7 +55,7 @@ class Task < ActiveRecord::Base
     update_attributes!(
       user: nil,
       assigned_at: nil,
-      started_at: nil,
+      started_at: nil
     )
   end
 

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -4,3 +4,9 @@ create_establish_claim_tasks_job:
  class: "CreateEstablishClaimTasksJob"
  queue: default
  active_job: false
+
+reassign_old_tasks:
+ cron: "1 0 * * * America/New_York"
+ class: "ReassignOldTasksJob"
+ queue: default
+ active_job: false

--- a/db/migrate/20161115191744_remove_unique_constraint_tasks.rb
+++ b/db/migrate/20161115191744_remove_unique_constraint_tasks.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueConstraintTasks < ActiveRecord::Migration
+  def change
+  	remove_index(:tasks, column: [:appeal_id, :type])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102170128) do
+ActiveRecord::Schema.define(version: 20161115191744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,8 +49,6 @@ ActiveRecord::Schema.define(version: 20161102170128) do
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
   end
-
-  add_index "tasks", ["appeal_id", "type"], name: "index_tasks_on_appeal_id_and_type", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string "station_id", null: false

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Dispatch" do
                                                 completed_at: Time.now.utc)
       end
 
-      scenario "Case Worker" do
+      scenario "Case Worker", focus: true do
         visit "/dispatch/establish-claim"
 
         expect(page).to have_content("Establish Claim")

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Dispatch" do
                                                 completed_at: Time.now.utc)
       end
 
-      scenario "Case Worker", focus: true do
+      scenario "Case Worker" do
         visit "/dispatch/establish-claim"
 
         expect(page).to have_content("Establish Claim")

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -1,0 +1,19 @@
+describe ReassignOldTasksJob do
+  before do
+    reset_application!
+    @appeal = Appeal.create(vacols_id: '1')
+    @user = User.create(station_id: '123', css_id: 'abc')
+    @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign(@user)
+    #@finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(2)
+  end
+
+  context ".perform" do
+    it "closes unfinished tasks", focus: true do
+      expect(EstablishClaim.count).to eq(1)
+      ReassignOldTasksJob.perform_now
+      expect(EstablishClaim.count).to eq(2)
+      expect(@unfinished_task.complete?).to be_truthy 
+    end
+  end
+
+end

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -4,7 +4,7 @@ describe ReassignOldTasksJob do
     @appeal = Appeal.create(vacols_id: "1")
     @user = User.create(station_id: "123", css_id: "abc")
     @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign(@user)
-    status_code = Task.completion_status_code("Cancelled by System")
+    status_code = Task.completion_status_code("Expired")
     @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(status_code)
   end
 

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -3,16 +3,16 @@ describe ReassignOldTasksJob do
     reset_application!
     @appeal = Appeal.create(vacols_id: '1')
     @user = User.create(station_id: '123', css_id: 'abc')
-    @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign(@user)
-    #@finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(2)
+    @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign!(@user)
+    @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(Task.completion_status_code("Cancelled by System"))
   end
 
   context ".perform" do
-    it "closes unfinished tasks", focus: true do
-      expect(EstablishClaim.count).to eq(1)
-      ReassignOldTasksJob.perform_now
+    it "closes unfinished tasks" do
       expect(EstablishClaim.count).to eq(2)
-      expect(@unfinished_task.complete?).to be_truthy 
+      ReassignOldTasksJob.perform_now
+      expect(EstablishClaim.count).to eq(3)
+      expect(@unfinished_task.reload.complete?).to be_truthy 
     end
   end
 

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -8,7 +8,7 @@ describe ReassignOldTasksJob do
     @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(status_code)
   end
 
-  context ".perform" do
+  context ".perform", focus: true do
     it "closes unfinished tasks" do
       expect(EstablishClaim.count).to eq(2)
       ReassignOldTasksJob.perform_now

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -1,10 +1,11 @@
 describe ReassignOldTasksJob do
   before do
     reset_application!
-    @appeal = Appeal.create(vacols_id: '1')
-    @user = User.create(station_id: '123', css_id: 'abc')
+    @appeal = Appeal.create(vacols_id: "1")
+    @user = User.create(station_id: "123", css_id: "abc")
     @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign(@user)
-    @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(Task.completion_status_code("Cancelled by System"))
+    status_code = Task.completion_status_code("Cancelled by System")
+    @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(status_code)
   end
 
   context ".perform" do
@@ -12,8 +13,7 @@ describe ReassignOldTasksJob do
       expect(EstablishClaim.count).to eq(2)
       ReassignOldTasksJob.perform_now
       expect(EstablishClaim.count).to eq(3)
-      expect(@unfinished_task.reload.complete?).to be_truthy 
+      expect(@unfinished_task.reload.complete?).to be_truthy
     end
   end
-
 end

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -8,7 +8,7 @@ describe ReassignOldTasksJob do
   let!(:status_code) { Task.completion_status_code(:expired) }
   let!(:finished_task) do
     EstablishClaim.create(appeal_id:
-    appeal.id).completed!(status_code)
+    appeal.id).complete!(status_code)
   end
 
   context ".perform" do

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -8,7 +8,7 @@ describe ReassignOldTasksJob do
     @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(status_code)
   end
 
-  context ".perform", focus: true do
+  context ".perform" do
     it "closes unfinished tasks" do
       expect(EstablishClaim.count).to eq(2)
       ReassignOldTasksJob.perform_now

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -2,13 +2,14 @@ describe ReassignOldTasksJob do
   before do
     reset_application!
   end
-  let!(:appeal) { Appeal.create(vacols_id: "1") }
-  let!(:user)   { User.create(station_id: "123", css_id: "abc") }
-  let!(:unfinished_task) { EstablishClaim.create(appeal_id: appeal.id).assign!(user) }
+  let!(:appeal1) { Appeal.create(vacols_id: "1") }
+  let!(:appeal2) { Appeal.create(vacols_id: "2") }
+  let!(:user) { User.create(station_id: "123", css_id: "abc") }
+  let!(:unfinished_task) { EstablishClaim.create(appeal_id: appeal1.id).assign!(user) }
   let!(:status_code) { Task.completion_status_code(:expired) }
   let!(:finished_task) do
     EstablishClaim.create(appeal_id:
-    appeal.id).complete!(status_code)
+    appeal2.id).complete!(status_code)
   end
 
   context ".perform" do

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -3,7 +3,7 @@ describe ReassignOldTasksJob do
     reset_application!
     @appeal = Appeal.create(vacols_id: '1')
     @user = User.create(station_id: '123', css_id: 'abc')
-    @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign!(@user)
+    @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign(@user)
     @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(Task.completion_status_code("Cancelled by System"))
   end
 

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -1,11 +1,14 @@
 describe ReassignOldTasksJob do
   before do
     reset_application!
-    @appeal = Appeal.create(vacols_id: "1")
-    @user = User.create(station_id: "123", css_id: "abc")
-    @unfinished_task = EstablishClaim.create(appeal_id: @appeal.id).assign(@user)
-    status_code = Task.completion_status_code("Expired")
-    @finished_task = EstablishClaim.create(appeal_id: @appeal.id).completed!(status_code)
+  end
+  let!(:appeal) { Appeal.create(vacols_id: "1") }
+  let!(:user)   { User.create(station_id: "123", css_id: "abc") }
+  let!(:unfinished_task) { EstablishClaim.create(appeal_id: appeal.id).assign!(user) }
+  let!(:status_code) { Task.completion_status_code("Expired") }
+  let!(:finished_task) do
+    EstablishClaim.create(appeal_id:
+    appeal.id).completed!(status_code)
   end
 
   context ".perform" do
@@ -13,7 +16,7 @@ describe ReassignOldTasksJob do
       expect(EstablishClaim.count).to eq(2)
       ReassignOldTasksJob.perform_now
       expect(EstablishClaim.count).to eq(3)
-      expect(@unfinished_task.reload.complete?).to be_truthy
+      expect(unfinished_task.reload.complete?).to be_truthy
     end
   end
 end

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -5,7 +5,7 @@ describe ReassignOldTasksJob do
   let!(:appeal) { Appeal.create(vacols_id: "1") }
   let!(:user)   { User.create(station_id: "123", css_id: "abc") }
   let!(:unfinished_task) { EstablishClaim.create(appeal_id: appeal.id).assign!(user) }
-  let!(:status_code) { Task.completion_status_code("Expired") }
+  let!(:status_code) { Task.completion_status_code(:expired) }
   let!(:finished_task) do
     EstablishClaim.create(appeal_id:
     appeal.id).completed!(status_code)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -8,6 +8,8 @@ describe Task do
     @user = User.create(station_id: "ABC", css_id: "123")
     @appeal = Appeal.create(vacols_id: "123C")
     @appeal2 = Appeal.create(vacols_id: "456D")
+    @appeal3 = Appeal.create(vacols_id: "789E")
+    @appeal4 = Appeal.create(vacols_id: "123F")
     @task = EstablishClaim.create(appeal: @appeal)
     @task2 = EstablishClaim.create(appeal: @appeal2)
   end
@@ -113,5 +115,27 @@ describe Task do
 
   context "#to_complete" do
     it { expect { Task.to_complete.find(@task.id) }.not_to raise_error }
+  end
+
+  context "duplicate and mark complete" do
+    before do
+      @task3 = EstablishClaim.create(appeal: @appeal3)
+      @task4 = EstablishClaim.create(appeal: @appeal4)
+    end
+    it "closes unfinished tasks" do
+      initial_sum = EstablishClaim.count
+      @task4.duplicate_and_mark_complete!
+      expect(EstablishClaim.count).to eq(initial_sum + 1)
+      expect(@task4.reload.complete?).to be_truthy
+    end
+  end
+
+  context "assigned not completed" do
+    before do
+      @task3 = EstablishClaim.create(appeal: @appeal3)
+      @task4 = EstablishClaim.create(appeal: @appeal4)
+      @task3.assign(@user)
+    end
+    it { expect { Task.assigned_not_completed.find(@task3.id) }.not_to raise_error }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -126,7 +126,7 @@ describe Task do
       task4.expire!
       expect(EstablishClaim.count).to eq(initial_sum + 1)
       expect(task4.reload.complete?).to be_truthy
-      expect(task4.reload.completion_status).to eq(Task.completion_status_code("expired"))
+      expect(task4.reload.completion_status).to eq(Task.completion_status_code(:expired))
     end
   end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -117,25 +117,25 @@ describe Task do
     it { expect { Task.to_complete.find(@task.id) }.not_to raise_error }
   end
 
-  context "duplicate and mark complete" do
-    before do
-      @task3 = EstablishClaim.create(appeal: @appeal3)
-      @task4 = EstablishClaim.create(appeal: @appeal4)
-    end
+  context "#expire!" do
+    let!(:task3) { EstablishClaim.create(appeal: @appeal3) }
+    let!(:task4) { EstablishClaim.create(appeal: @appeal4) }
+
     it "closes unfinished tasks" do
       initial_sum = EstablishClaim.count
-      @task4.duplicate_and_mark_complete!
+      task4.expire!
       expect(EstablishClaim.count).to eq(initial_sum + 1)
-      expect(@task4.reload.complete?).to be_truthy
+      expect(task4.reload.complete?).to be_truthy
+      expect(task4.reload.completion_status).to eq(Task.completion_status_code("expired"))
     end
   end
 
-  context "assigned not completed" do
+  context "#assigned_not_completed" do
+    let!(:task3) { EstablishClaim.create(appeal: @appeal3) }
+    let!(:task4) { EstablishClaim.create(appeal: @appeal4) }
     before do
-      @task3 = EstablishClaim.create(appeal: @appeal3)
-      @task4 = EstablishClaim.create(appeal: @appeal4)
-      @task3.assign(@user)
+      task3.assign!(@user)
     end
-    it { expect { Task.assigned_not_completed.find(@task3.id) }.not_to raise_error }
+    it { expect { Task.assigned_not_completed.find(task3.id) }.not_to raise_error }
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,46 +6,50 @@ describe Task do
   before do
     reset_application!
     @user = User.create(station_id: "ABC", css_id: "123")
-    @appeal = Appeal.create(vacols_id: "123C")
-    @appeal2 = Appeal.create(vacols_id: "456D")
-    @appeal3 = Appeal.create(vacols_id: "789E")
-    @appeal4 = Appeal.create(vacols_id: "123F")
-    @task = EstablishClaim.create(appeal: @appeal)
-    @task2 = EstablishClaim.create(appeal: @appeal2)
   end
 
   context ".newest_first" do
+    let!(:appeal1) { Appeal.create(vacols_id: "123C") }
+    let!(:task1) { EstablishClaim.create(appeal: appeal1) }
+    let!(:appeal2) { Appeal.create(vacols_id: "456D") }
+    let!(:task2) { EstablishClaim.create(appeal: appeal2) }
     subject { Task.newest_first }
     before do
-      @task.update(created_at: 10.days.ago)
-      @task2.update(created_at: 1.day.ago)
+      task1.update(created_at: 10.days.ago)
+      task2.update(created_at: 1.day.ago)
     end
 
     it "orders correctly" do
       expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
-      expect(subject.first).to eq(@task2)
-      expect(subject.last).to eq(@task)
+      expect(subject.first).to eq(task2)
+      expect(subject.last).to eq(task1)
     end
   end
 
   context ".unassigned" do
+    let!(:appeal1) { Appeal.create(vacols_id: "123C") }
+    let!(:task1) { EstablishClaim.create(appeal: appeal1) }
+    let!(:appeal2) { Appeal.create(vacols_id: "456D") }
+    let!(:task2) { EstablishClaim.create(appeal: appeal2) }
     before do
-      @task.update(user: User.create(css_id: "111", station_id: "abc"))
+      task1.update(user: User.create(css_id: "111", station_id: "abc"))
     end
     subject { Task.unassigned }
 
     it "filters by nil user_id" do
       expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
       expect(subject.count).to eq(1)
-      expect(subject.first).to eq(@task2)
+      expect(subject.first).to eq(task2)
     end
   end
 
   context "Assigning user methods" do
-    subject { @task }
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
+    subject { task }
 
     context ".assign!" do
-      before { @task.assign!(@user) }
+      before { task.assign!(@user) }
 
       it "correctly assigns a task to a user" do
         expect(subject.user.id).to eq(@user.id)
@@ -59,14 +63,16 @@ describe Task do
       end
 
       it "assigned is true after assignment" do
-        @task.assign!(@user)
+        task.assign!(@user)
         expect(subject.assigned?).to be_truthy
       end
     end
   end
 
   context ".progress_status" do
-    subject { @task.progress_status }
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
+    subject { task.progress_status }
 
     # We start with a blank task and move it task through the various states
 
@@ -76,16 +82,18 @@ describe Task do
 
     context "task is assigned" do
       before do
-        @task.assign!(@user)
+        task.assign!(@user)
       end
 
       it { is_expected.to eq("Not Started") }
     end
 
     context "task is started" do
+      let!(:appeal) { Appeal.create(vacols_id: "123C") }
+      let!(:task) { EstablishClaim.create(appeal: appeal) }
       before do
         # TODO(Mark): When we have a method to start a task, this should be updated
-        @task.started_at = Time.now.utc
+        task.started_at = Time.now.utc
       end
       it { is_expected.to eq("In Progress") }
     end
@@ -93,7 +101,7 @@ describe Task do
     context "task is completed" do
       before do
         # TODO(Mark): When we have a method to complete a task, this should be updated
-        @task.completed_at = Time.now.utc
+        task.completed_at = Time.now.utc
       end
 
       it { is_expected.to eq("Complete") }
@@ -101,41 +109,47 @@ describe Task do
   end
 
   context ".completed?" do
-    subject { @task }
-    before { @task.completed_at = Time.now.utc }
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
+    subject { task }
+    before { task.completed_at = Time.now.utc }
     it { expect(subject.completed_at).to be_truthy }
   end
 
   context "#completed_today" do
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
     before do
-      @task.update_attributes!(completed_at: Time.now.utc)
+      task.update_attributes!(completed_at: Time.now.utc)
     end
-    it { expect { Task.completed_today.find(@task.id) }.not_to raise_error }
+    it { expect { Task.completed_today.find(task.id) }.not_to raise_error }
   end
 
   context "#to_complete" do
-    it { expect { Task.to_complete.find(@task.id) }.not_to raise_error }
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
+    it { expect { Task.to_complete.find(task.id) }.not_to raise_error }
   end
 
   context "#expire!" do
-    let!(:task3) { EstablishClaim.create(appeal: @appeal3) }
-    let!(:task4) { EstablishClaim.create(appeal: @appeal4) }
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
 
     it "closes unfinished tasks" do
       initial_sum = EstablishClaim.count
-      task4.expire!
+      task.expire!
       expect(EstablishClaim.count).to eq(initial_sum + 1)
-      expect(task4.reload.complete?).to be_truthy
-      expect(task4.reload.completion_status).to eq(Task.completion_status_code(:expired))
+      expect(task.reload.complete?).to be_truthy
+      expect(task.reload.completion_status).to eq(Task.completion_status_code(:expired))
     end
   end
 
   context "#assigned_not_completed" do
-    let!(:task3) { EstablishClaim.create(appeal: @appeal3) }
-    let!(:task4) { EstablishClaim.create(appeal: @appeal4) }
+    let!(:appeal) { Appeal.create(vacols_id: "123C") }
+    let!(:task) { EstablishClaim.create(appeal: appeal) }
     before do
-      task3.assign!(@user)
+      task.assign!(@user)
     end
-    it { expect { Task.assigned_not_completed.find(task3.id) }.not_to raise_error }
+    it { expect { Task.assigned_not_completed.find(task.id) }.not_to raise_error }
   end
 end


### PR DESCRIPTION
This PR adds a job for reassigning tasks. A cron job runs at midnight, and for each unfinished task that's been assigned, it sets the original task to 'cancelled by system', and creates a new task that's unassigned. 

Finishes: #400 

Test plan:

- [ ] Existing unit tests pass
- [ ] Added new unit test

@joofsh @mdbenjam 