### PR TITLE
Clean DB within seeds.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'timecop'
   gem 'konacha'
+  gem 'database_cleaner'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
     concurrent-ruby (1.0.2)
     d3-rails (4.2.6)
       railties (>= 3.1)
+    database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
@@ -364,6 +365,7 @@ DEPENDENCIES
   capybara
   caseflow!
   connect_vbms!
+  database_cleaner
   guard-rspec
   jbuilder (~> 2.0)
   jquery-rails

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,8 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
+require 'database_cleaner'
+
 class SeedDB
   def initialize
     @appeals, @tasks, @users = [], [], []
@@ -66,7 +68,12 @@ class SeedDB
     @users.push(User.create(css_id: "ANNE MERICA", station_id: "283"))
   end
 
+  def clean_db
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
   def seed
+    clean_db
     create_default_user
     create_appeals(50)
     create_users(2)


### PR DESCRIPTION
This will truncate the DB (wipe all tables) right before loading the seeds data. This allows you to repeatedly run `rake db:seed` without running into errors:

Fixes: #437 

Testing:
- Run `rake db:seed` back to back locally, data exists in DB
- Run `rake db:setup` continues to work