### PR TITLE
Support demo env

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,7 +51,7 @@ class ApplicationController < ActionController::Base
   end
 
   def setup_fakes
-    Fakes::Initializer.development! if Rails.env.development?
+    Fakes::Initializer.development! if Rails.env.development? || Rails.env.demo?
   end
 
   def check_whats_new_cookie

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,17 @@ development_vacols:
   timeout: 5000
   database: db/development-vacols.sqlite3
 
+demo:
+  <<: *default
+  username: <%= `whoami` %>
+  database: caseflow_certification_demo
+
+demo_vacols:
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+  database: db/demo-vacols.sqlite3
+
 staging:
   <<: *default
   username: <%= `whoami` %>

--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -1,0 +1,79 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Enable Rack::Cache to put a simple HTTP cache in front of your application
+  # Add `rack-cache` to your Gemfile before enabling this.
+  # For large-scale production use, consider using a caching reverse proxy like
+  # NGINX, varnish or squid.
+  # config.action_dispatch.rack_cache = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  # config.log_tags = [ :subdomain, :uuid ]
+
+  # Use a different logger for distributed setups.
+  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+
+  # TODO(jd): Get GA account for demo environment
+  # config.google_analytics_account = "UA-74789258-1"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   patch "certifications" => "certifications#create"
 
   # :nocov:
-  if Rails.env.development? || Rails.env.test?
+  if Rails.env.development? || Rails.env.test? || Rails.env.demo?
     scope "/dev" do
       get '/users', to: "dev_users#index"
       post '/set-user/:id', to: "dev#set_user", as: 'set_user'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,6 +15,10 @@ development:
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
   redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
 
+demo:
+  secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
+  redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
+  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] %>
 
 test:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862


### PR DESCRIPTION
This PR adds support for a `demo` environment, to be used on the current "hosted dev".  This gives us the benefits of a production-like setup with precompiled assets but with the faked out integrations.

Testing:
- Setting up demo database:
<img width="625" alt="screen shot 2016-11-18 at 5 58 52 pm" src="https://cloud.githubusercontent.com/assets/2256237/20449672/d1536bb2-adb8-11e6-81f1-af8dc0c4b85d.png">

- Running app in demo mode:
<img width="771" alt="screen shot 2016-11-18 at 5 56 52 pm" src="https://cloud.githubusercontent.com/assets/2256237/20449659/b7e3859a-adb8-11e6-8812-fcfed2369320.png">
<img width="528" alt="screen shot 2016-11-18 at 6 01 26 pm" src="https://cloud.githubusercontent.com/assets/2256237/20449765/68c2aeae-adb9-11e6-949a-8e5b3b280a08.png">
