### PR TITLE
Ensure tasks are started when first loaded

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,9 +19,6 @@ class TasksController < ApplicationController
   def assign
     next_unassigned_task.assign!(current_user)
     redirect_to url_for(next_unassigned_task)
-  rescue ActiveRecord::StaleObjectError, Task::AlreadyAssignedError => e
-    Raven.capture_exception(e)
-    not_found
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,6 +11,9 @@ class TasksController < ApplicationController
   end
 
   def show
+    # Future safeguard for when we give managers a show view
+    # for a given task
+    task.start! if current_user == task.user
   end
 
   def assign

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -19,6 +19,9 @@ class TasksController < ApplicationController
   def assign
     next_unassigned_task.assign!(current_user)
     redirect_to url_for(next_unassigned_task)
+  rescue ActiveRecord::StaleObjectError, Task::AlreadyAssignedError => e
+    Raven.capture_exception(e)
+    not_found
   end
 
   private

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ActiveRecord::Base
   belongs_to :appeal
 
   class AlreadyAssignedError < StandardError; end
+  class NotAssignedError < StandardError; end
 
   COMPLETION_STATUS_MAPPING = {
     0 => "Completed",
@@ -41,10 +42,21 @@ class Task < ActiveRecord::Base
   def assign!(user)
     return AlreadyAssignedError if self.user
 
-    update_attributes!(
+    update!(
       user: user,
       assigned_at: Time.now.utc
     )
+  end
+
+  def start!
+    return NotAssignedError unless assigned?
+    return if started?
+
+    update!(started_at: Time.now.utc)
+  end
+
+  def started?
+    started_at
   end
 
   def assigned?
@@ -69,7 +81,7 @@ class Task < ActiveRecord::Base
 
   # completion_status is 0 for success, or non-zero to specify another completed case
   def completed(status)
-    update_attributes!(
+    update!(
       completed_at: Time.now.utc,
       completion_status: status
     )

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -39,7 +39,12 @@ class Task < ActiveRecord::Base
     type.titlecase
   end
 
+  def before_assign
+    # Test hook for testing race conditions
+  end
+
   def assign!(user)
+    before_assign
     fail(AlreadyAssignedError) if self.user
 
     update!(

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,7 +40,7 @@ class Task < ActiveRecord::Base
   end
 
   def assign!(user)
-    return AlreadyAssignedError if self.user
+    fail(AlreadyAssignedError) if self.user
 
     update!(
       user: user,
@@ -49,7 +49,7 @@ class Task < ActiveRecord::Base
   end
 
   def start!
-    return NotAssignedError unless assigned?
+    fail(NotAssignedError) unless assigned?
     return if started?
 
     update!(started_at: Time.now.utc)

--- a/db/migrate/20161121140139_add_lock_version_to_appeals.rb
+++ b/db/migrate/20161121140139_add_lock_version_to_appeals.rb
@@ -1,0 +1,5 @@
+class AddLockVersionToAppeals < ActiveRecord::Migration
+  def change
+    add_column :tasks, :lock_version, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161109182923) do
+ActiveRecord::Schema.define(version: 20161121140139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 20161109182923) do
     t.integer  "completion_status"
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.integer  "lock_version"
   end
 
   add_index "tasks", ["appeal_id", "type"], name: "index_tasks_on_appeal_id_and_type", unique: true, using: :btree

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -62,11 +62,12 @@ RSpec.feature "Dispatch" do
       expect(page).to have_css("tr#task-#{@completed_task.id}")
     end
 
-    scenario "Assign the next task to me" do
+    scenario "Assign the next task to me and starts it" do
       visit "/dispatch/establish-claim"
       click_on @completed_task.start_text
       expect(page).to have_current_path("/dispatch/establish-claim/#{@task.id}")
       expect(@task.reload.user).to eq(current_user)
+      expect(@task.started?).to be_truthy
     end
 
     scenario "Visit an Establish Claim task that is assigned to another user" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -51,6 +51,10 @@ describe Task do
         expect(subject.user.id).to eq(@user.id)
         expect(subject.assigned_at).not_to be_nil
       end
+
+      it "raises erorr if already assigned" do
+        expect { @task.assign!(@user) }.to raise_error(Task::AlreadyAssignedError)
+      end
     end
 
     context ".assigned?" do
@@ -100,14 +104,14 @@ describe Task do
     end
   end
 
-  context ".start!", focus: true do
+  context ".start!" do
     it "errors if no one is assigned" do
-      expect(@task.user).to be_falsey
-      @task.start!
-      expect { @task.start! }.to raise_error
+      expect(@task.user).to be_nil
+      expect { @task.start! }.to raise_error(Task::NotAssignedError)
     end
 
     it "sets started_at value to current timestamp" do
+      @task.assign!(@user)
       expect(@task.started_at).to be_falsey
       @task.start!
       expect(@task.started_at).to eq(Time.now.utc)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -5,6 +5,8 @@ describe Task do
   # Clear the task from the DB before every test
   before do
     reset_application!
+    Timecop.freeze(Time.utc(2016, 2, 17, 20, 59, 0))
+
     @user = User.create(station_id: "ABC", css_id: "123")
     @appeal = Appeal.create(vacols_id: "123C")
     @appeal2 = Appeal.create(vacols_id: "456D")
@@ -95,6 +97,34 @@ describe Task do
       end
 
       it { is_expected.to eq("Complete") }
+    end
+  end
+
+  context ".start!", focus: true do
+    it "errors if no one is assigned" do
+      expect(@task.user).to be_falsey
+      @task.start!
+      expect { @task.start! }.to raise_error
+    end
+
+    it "sets started_at value to current timestamp" do
+      expect(@task.started_at).to be_falsey
+      @task.start!
+      expect(@task.started_at).to eq(Time.now.utc)
+    end
+  end
+
+  context ".started?" do
+    subject { @task.started? }
+    before { @task.assign!(@user) }
+
+    context "not started" do
+      it { is_expected.to be_falsey }
+    end
+
+    context "was started" do
+      before { @task.start! }
+      it { is_expected.to be_truthy }
     end
   end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -45,15 +45,22 @@ describe Task do
     subject { @task }
 
     context ".assign!" do
-      before { @task.assign!(@user) }
-
       it "correctly assigns a task to a user" do
+        @task.assign!(@user)
         expect(subject.user.id).to eq(@user.id)
         expect(subject.assigned_at).not_to be_nil
       end
 
-      it "raises erorr if already assigned" do
+      it "raises error if already assigned" do
+        @task.assign!(@user)
         expect { @task.assign!(@user) }.to raise_error(Task::AlreadyAssignedError)
+      end
+
+      it "raises error if object stale" do
+        expect(@task).to receive(:before_assign) do
+          Task.find(@task.id).update!(started_at: Time.now.utc)
+        end
+        expect { @task.assign!(@user) }.to raise_error(ActiveRecord::StaleObjectError)
       end
     end
 


### PR DESCRIPTION
Ties up a few loose ends we didn't catch in other PRs so far:
- Ensures tasks get assigned a `started_at` value. This value is the first time the specific task page is loaded
- Fix bug when we weren't throwing Errors properly in task "action" methods


Testing:
- Manually tested loading the show page in the browser. Data is updated as expected (and only once)
- Added unit tests, they pass
- All existing tests pass