### PR TITLE
Only run npm build command in development

### DIFF
--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -22,7 +22,7 @@ ReactOnRails.configure do |config|
 
   # This configures the script to run to build the production assets by webpack. Set this to nil
   # if you don't want react_on_rails building this file for you.
-  config.npm_build_production_command = "npm run build:production"
+  config.npm_build_production_command = Rails.env.deveopment? ? "npm run build:production" : ""
 
   ################################################################################
   # CLIENT RENDERING OPTIONS


### PR DESCRIPTION
In the interim (until deploy scripts are updated), we are not compiling React assets in non-development mode. This will skip attempting to run the npm compile, allowing `rake assets:precompile` to succeed