### PR TITLE
Remove .only from master

### DIFF
--- a/client/test/util/ApiUtil-test.js
+++ b/client/test/util/ApiUtil-test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import ApiUtil from '../../app/util/ApiUtil';
 
-describe.only('ApiUtil', () => {
+describe('ApiUtil', () => {
   context('.headers', () => {
     it('returns default headers', () => {
       let headers = ApiUtil.headers();


### PR DESCRIPTION
- Not all npm tests are running on master atm :(

We need to be more careful during code review. Committing any `focus: true` or `.only()` breaks the tests