### PR TITLE
Updating header to have the name of the app

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,9 +37,15 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def logo_class
-    "cf-logo-image-default"
+    return "cf-logo-image-default" unless !logo_name.nil?
+    "cf-logo-image-#{logo_name.downcase.gsub(" ", "-")}"
   end
   helper_method :logo_class
+
+  def logo_name
+    nil
+  end
+  helper_method :logo_name
 
   def set_raven_user
     if current_user && ENV["SENTRY_DSN"]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,8 +38,8 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
 
   def logo_class
-    return "cf-logo-image-default" unless !logo_name.nil?
-    "cf-logo-image-#{logo_name.downcase.gsub(" ", "-")}"
+    return "cf-logo-image-default" if logo_name.nil?
+    "cf-logo-image-#{logo_name.downcase.tr(' ', '-')}"
   end
   helper_method :logo_class
 

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -79,7 +79,7 @@ class CertificationsController < ApplicationController
     params[:id] || params[:vacols_id] || params[:form8][:vacols_id]
   end
 
-  def logo_class
-    "cf-logo-image-certification"
+  def logo_name
+    "Certification"
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -99,7 +99,7 @@ class TasksController < ApplicationController
     verify_user(task.user)
   end
 
-  def logo_class
-    "cf-logo-image-dispatch"
+  def logo_name
+    "Dispatch"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,7 @@
     <nav class="cf-nav">
       <div class="usa-grid-full">
         <a href="/">
-          <h1 class="cf-logo"><%= content_tag(:span, nil, :class => "cf-logo-image #{logo_class}") %>Caseflow</h1>
+          <h1 class="cf-logo"><%= content_tag(:span, nil, :class => "cf-logo-image #{logo_class}") %>Caseflow <%= logo_name %></h1>
         </a>
         <h2 id="page-title" class="cf-application-title"><%= yield :page_title %></h2>
 


### PR DESCRIPTION
The header is currently missing "dispatch" or "certification". Adds that in a reusable way.

**Test Plan**
![screen shot 2016-12-02 at 1 24 07 pm](https://cloud.githubusercontent.com/assets/3885236/20845351/a1219466-b892-11e6-8785-3f5b6846d41d.png)

- [ ] Manually check
- [ ] Run test suite