### PR TITLE
Add linter to client tests

### DIFF
--- a/client/.eslintignore
+++ b/client/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/
+webpack.config.js
+.eslintrc.js

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -2,7 +2,8 @@ module.exports = {
   "env": {
     "browser": true,
     "commonjs": true,
-    "es6": true
+    "es6": true,
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "parser": "babel-eslint",
@@ -51,10 +52,9 @@ module.exports = {
     "guard-for-in": "error",
     "handle-callback-err": "error",
     "id-blacklist": "error",
-    "id-length": "error",
+    "id-length": ["error", { "exceptions": ["i"] }],
     "id-match": "error",
     "indent": ["error", 2],
-    "init-declarations": "error",
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "jsx-quotes": "error",
@@ -128,7 +128,7 @@ module.exports = {
     "no-octal-escape": "error",
     "no-param-reassign": "error",
     "no-path-concat": "error",
-    "no-plusplus": "error",
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-process-env": "error",
     "no-process-exit": "error",
     "no-proto": "error",

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -14,7 +14,8 @@ module.exports = {
     "sourceType": "module"
   },
   "plugins": [
-    "react"
+    "react",
+    "mocha"
   ],
   "rules": {
     "accessor-pairs": "error",
@@ -73,6 +74,7 @@ module.exports = {
     "max-params": "error",
     "max-statements": "error",
     "max-statements-per-line": "error",
+    "mocha/no-exclusive-tests": "error",
     "new-cap": "error",
     "new-parens": "error",
     "newline-after-var": "error",

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -4699,15 +4699,15 @@
           "from": "ansi-styles@>=2.2.1 <3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
-        "aproba": {
-          "version": "1.0.4",
-          "from": "aproba@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
-        },
         "are-we-there-yet": {
           "version": "1.1.2",
           "from": "are-we-there-yet@>=1.1.2 <1.2.0",
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
+        },
+        "aproba": {
+          "version": "1.0.4",
+          "from": "aproba@>=1.0.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
         },
         "asn1": {
           "version": "0.2.3",
@@ -4749,15 +4749,15 @@
           "from": "boom@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
         },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "from": "buffer-shims@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-        },
         "brace-expansion": {
           "version": "1.1.5",
           "from": "brace-expansion@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz"
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "from": "buffer-shims@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
         },
         "caseless": {
           "version": "0.11.0",
@@ -4789,30 +4789,30 @@
           "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
         },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "from": "console-control-strings@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-        },
         "core-util-is": {
           "version": "1.0.2",
           "from": "core-util-is@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "from": "console-control-strings@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
         },
         "cryptiles": {
           "version": "2.0.5",
           "from": "cryptiles@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
         "deep-extend": {
           "version": "0.4.1",
           "from": "deep-extend@>=0.4.0 <0.5.0",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -4859,30 +4859,30 @@
           "from": "fs.realpath@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
         },
-        "fstream": {
-          "version": "1.0.10",
-          "from": "fstream@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
-        },
         "fstream-ignore": {
           "version": "1.0.5",
           "from": "fstream-ignore@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "from": "fstream@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz"
         },
         "gauge": {
           "version": "2.6.0",
           "from": "gauge@>=2.6.0 <2.7.0",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
         },
-        "generate-function": {
-          "version": "2.0.0",
-          "from": "generate-function@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-        },
         "generate-object-property": {
           "version": "1.2.0",
           "from": "generate-object-property@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "from": "generate-function@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
         },
         "glob": {
           "version": "7.0.5",
@@ -4894,15 +4894,15 @@
           "from": "graceful-fs@>=4.1.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
         },
-        "graceful-readlink": {
-          "version": "1.0.1",
-          "from": "graceful-readlink@>=1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-        },
         "har-validator": {
           "version": "2.0.6",
           "from": "har-validator@>=2.0.6 <2.1.0",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "from": "graceful-readlink@>=1.0.0",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
@@ -4984,15 +4984,15 @@
           "from": "jodid25519@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
         },
-        "jsbn": {
-          "version": "0.1.0",
-          "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
-        },
         "json-schema": {
           "version": "0.2.2",
           "from": "json-schema@0.2.2",
           "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
+        },
+        "jsbn": {
+          "version": "0.1.0",
+          "from": "jsbn@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -5084,11 +5084,6 @@
           "from": "pinkie@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
         },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-        },
         "process-nextick-args": {
           "version": "1.0.7",
           "from": "process-nextick-args@>=1.0.6 <1.1.0",
@@ -5099,15 +5094,20 @@
           "from": "qs@>=6.2.0 <6.3.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
-        "readable-stream": {
-          "version": "2.1.4",
-          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
         },
         "request": {
           "version": "2.73.0",
           "from": "request@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
+        },
+        "readable-stream": {
+          "version": "2.1.4",
+          "from": "readable-stream@>=2.0.0 <3.0.0||>=1.1.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.4.tgz"
         },
         "rimraf": {
           "version": "2.5.3",
@@ -5194,30 +5194,30 @@
           "from": "uid-number@>=0.0.6 <0.1.0",
           "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
         },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "from": "util-deprecate@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-        },
         "verror": {
           "version": "1.3.6",
           "from": "verror@1.3.6",
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "from": "util-deprecate@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
         },
         "wide-align": {
           "version": "1.1.0",
           "from": "wide-align@>=1.1.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
         },
-        "wrappy": {
-          "version": "1.0.2",
-          "from": "wrappy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-        },
         "xtend": {
           "version": "4.0.1",
           "from": "xtend@>=4.0.0 <5.0.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "from": "wrappy@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
         },
         "bl": {
           "version": "1.1.2",

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "mocha test/setup.js test/* --compilers js:babel-core/register",
     "test:watch": "mocha test/setup.js test/* --watch --compilers js:babel-core/register",
-    "lint": "eslint --fix --ext .jsx --ext .js app",
+    "lint": "eslint . --fix --ext .jsx --ext .js",
     "build:test": "webpack --config webpack.config.js",
     "build:production": "NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "webpack -w --config webpack.config.js"

--- a/client/test/components/Alert-test.js
+++ b/client/test/components/Alert-test.js
@@ -27,7 +27,7 @@ describe('Alert', () => {
       wrapper = shallow(
         <Alert type="success" title={title} message={message}/>
       );
-      expect(wrapper.find('.usa-alert').prop('role')).to.eq(undefined);
+      expect(wrapper.find('.usa-alert').prop('role')).to.not.eq('alert');
     });
   });
 });

--- a/client/test/components/DateSelector-test.js
+++ b/client/test/components/DateSelector-test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import DateSelector from '../../app/components/DateSelector';
 
 describe('DateSelector', () => {
@@ -10,18 +10,23 @@ describe('DateSelector', () => {
     let backspace;
 
     beforeEach(() => {
-      wrapper = mount(<DateSelector name='test'/>);
+      wrapper = mount(<DateSelector name="test"/>);
       let input = wrapper.find('input');
-      type = function(str) {
+
+      type = (str) => {
         for (let i = 0; i < str.length; i++) {
           let value = wrapper.state().value;
-          input.simulate('change', {target: {value: (value + str.charAt(i))}});
+
+          input.simulate('change', { target: { value: value + str.charAt(i) } });
         }
-      }
-      backspace = function() {
+      };
+      backspace = () => {
         let value = wrapper.state().value;
-        input.simulate('change', {target: {value: value.substr(0, value.length - 1)}});
-      }
+
+        input.simulate('change', {
+          target: { value: value.substr(0, value.length - 1) }
+        });
+      };
     });
     context('month', () => {
       it('valid', () => {
@@ -45,7 +50,7 @@ describe('DateSelector', () => {
         backspace();
         expect(wrapper.state().value).to.be.eq('0');
       });
-    })
+    });
     context('date', () => {
       it('valid', () => {
         type('12/11');
@@ -68,7 +73,7 @@ describe('DateSelector', () => {
         backspace();
         expect(wrapper.state().value).to.be.eq('09/1');
       });
-    })
+    });
     context('year', () => {
       it('valid', () => {
         type('12/11/1994');
@@ -78,6 +83,6 @@ describe('DateSelector', () => {
         type('12/01/a1b9c9d1');
         expect(wrapper.state().value).to.be.eq('12/01/1991');
       });
-    })
+    });
   });
 });

--- a/client/test/components/TextField-test.js
+++ b/client/test/components/TextField-test.js
@@ -5,8 +5,9 @@ import TextField from '../../app/components/TextField';
 
 describe('TextField', () => {
   it('renders', () => {
-    let onChange = () => {};
+    let onChange = () => true;
     const wrapper = shallow(<TextField name="foo" onChange={onChange} />);
+
     expect(wrapper.find('input')).to.have.length(1);
   });
 });

--- a/client/test/containers/BaseContainer-test.js
+++ b/client/test/containers/BaseContainer-test.js
@@ -6,6 +6,7 @@ import BaseContainer from '../../app/containers/BaseContainer';
 
 describe('BaseContainer', () => {
   let wrapper;
+
   beforeEach(() => {
     wrapper = mount(<BaseContainer page="TestPage" otherProp="foo"/>);
   });
@@ -18,22 +19,22 @@ describe('BaseContainer', () => {
 
   context('renders alerts', () => {
     it('hides alert if none in state', () => {
-      expect(wrapper.state().alert).to.eq(null)
+      expect(wrapper.state().alert).to.eq(null);
       expect(wrapper.find('.usa-alert')).to.have.length(0);
     });
 
     it('shows alert if alert in state', () => {
-      expect(wrapper.state().alert).to.eq(null)
+      expect(wrapper.state().alert).to.eq(null);
       wrapper.find('.handleAlert').simulate('click');
-      expect(wrapper.state().alert).to.not.eq(null)
+      expect(wrapper.state().alert).to.not.eq(null);
       expect(wrapper.find('.usa-alert')).to.have.length(1);
     });
 
     it('clears alert when triggered', () => {
       wrapper.find('.handleAlert').simulate('click');
-      expect(wrapper.state().alert).to.not.eq(null)
+      expect(wrapper.state().alert).to.not.eq(null);
       wrapper.find('.handleAlertClear').simulate('click');
-      expect(wrapper.state().alert).to.eq(null)
+      expect(wrapper.state().alert).to.eq(null);
     });
   });
 });

--- a/client/test/containers/EstablishClaim-test.js
+++ b/client/test/containers/EstablishClaim-test.js
@@ -1,13 +1,18 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import EstablishClaim from '../../app/containers/EstablishClaim';
 
 describe('EstablishClaim', () => {
   context('.render', () => {
     let wrapper;
+
     beforeEach(() => {
-      const task = {user: 'a', appeal: 'b'};
+      const task = {
+        appeal: 'b',
+        user: 'a'
+      };
+
       wrapper = mount(<EstablishClaim task={task}/>);
     });
 

--- a/client/test/setup.js
+++ b/client/test/setup.js
@@ -1,4 +1,4 @@
-var jsdom = require('jsdom').jsdom;
+let jsdom = require('jsdom').jsdom;
 
 global.document = jsdom('');
 global.window = document.defaultView;

--- a/client/test/util/ApiUtil-test.js
+++ b/client/test/util/ApiUtil-test.js
@@ -5,9 +5,10 @@ describe('ApiUtil', () => {
   context('.headers', () => {
     it('returns default headers', () => {
       let headers = ApiUtil.headers();
-      expect(headers['Accept']).to.eq('application/json')
-      expect(headers['Content-Type']).to.eq('application/json')
-      expect(Object.keys(headers)).to.include('X-CSRF-Token')
+
+      expect(headers.Accept).to.eq('application/json');
+      expect(headers['Content-Type']).to.eq('application/json');
+      expect(Object.keys(headers)).to.include('X-CSRF-Token');
     });
   });
 
@@ -15,9 +16,9 @@ describe('ApiUtil', () => {
     it('returns Request object', () => {
       let req = ApiUtil.patch('/foo');
 
-      expect(req.url).to.eq('/foo')
-      expect(req.header['X-HTTP-METHOD-OVERRIDE']).to.eq('patch')
-      expect(req.header['Cache-Control']).to.include('no-cache')
+      expect(req.url).to.eq('/foo');
+      expect(req.header['X-HTTP-METHOD-OVERRIDE']).to.eq('patch');
+      expect(req.header['Cache-Control']).to.include('no-cache');
     });
   });
 
@@ -25,23 +26,28 @@ describe('ApiUtil', () => {
     it('returns Request object', () => {
       let req = ApiUtil.post('/bar');
 
-      expect(req.url).to.eq('/bar')
-      expect(req.header['Cache-Control']).to.include('no-cache')
+      expect(req.url).to.eq('/bar');
+      expect(req.header['Cache-Control']).to.include('no-cache');
     });
   });
 
   context('.convertToSnakeCase', () => {
     let obj;
+
     beforeEach(() => {
-      obj = { camelCaseKey: 'val', secondKey: 'val2' };
+      obj = {
+        camelCaseKey: 'val',
+        secondKey: 'val2'
+      };
     });
 
     it('converts object keys', () => {
       let result = ApiUtil.convertToSnakeCase(obj);
+      let length = 2;
 
-      expect(Object.keys(result).length).to.eq(2);
-      expect(result['camel_case_key']).to.eq('val');
-      expect(result['second_key']).to.eq('val2');
+      expect(Object.keys(result).length).to.eq(length);
+      expect(result.camel_case_key).to.eq('val');
+      expect(result.second_key).to.eq('val2');
     });
   });
 });

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -9,12 +9,12 @@ const config = {
     'es5-shim/es5-shim',
     'es5-shim/es5-sham',
     'babel-polyfill',
-    './app/index',
+    './app/index'
   ],
 
   output: {
     filename: 'webpack-bundle.js',
-    path: '../app/assets/webpack',
+    path: '../app/assets/webpack'
   },
 
   resolve: {
@@ -28,23 +28,23 @@ const config = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify(nodeEnv),
-      },
-    }),
+        NODE_ENV: JSON.stringify(nodeEnv)
+      }
+    })
   ],
   module: {
     loaders: [
       {
         test: require.resolve('react'),
-        loader: 'imports?shim=es5-shim/es5-shim&sham=es5-shim/es5-sham',
+        loader: 'imports?shim=es5-shim/es5-shim&sham=es5-shim/es5-sham'
       },
       {
         test: /\.jsx?$/,
         loader: 'babel-loader',
-        exclude: /node_modules/,
-      },
-    ],
-  },
+        exclude: /node_modules/
+      }
+    ]
+  }
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "dev": "rm app/assets/webpack/* || true && cd client && npm run build:development",
     "test": "cd client && npm test",
     "lint": "cd client && npm run lint"
+  },
+  "devDependencies": {
+    "eslint": "^3.11.1",
+    "eslint-plugin-mocha": "^4.7.0"
   }
 }


### PR DESCRIPTION
This PR:
- Adds support for eslint to our /test directory (Note: All the test code changes in this PR are merely to resolve linting errors)
- Adds a mocha rule that prevents `.only()` in our tests. Ex:
<img width="611" alt="screen shot 2016-12-02 at 5 50 36 pm" src="https://cloud.githubusercontent.com/assets/2256237/20853105/dee6c634-b8b7-11e6-8bf0-ff351ff6c554.png">

