### PR TITLE
When appeal is already certified, display Certification title

### DIFF
--- a/app/views/certifications/already_certified.html.erb
+++ b/app/views/certifications/already_certified.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title do %>Mismatched Documents<% end %>
+<% content_for :page_title do %>Certification<% end %>
 
 <div class="usa-alert usa-alert-info cf-app-segment" role="alert">
   <div class="usa-alert-body">

--- a/spec/feature/start_certification_spec.rb
+++ b/spec/feature/start_certification_spec.rb
@@ -144,4 +144,14 @@ RSpec.feature "Start Certification" do
     visit "certifications/new/ABCD"
     expect(page).to have_content("Appeal is not ready for certification.")
   end
+
+  scenario "Appeal is already certified" do
+    User.authenticate!
+    appeal = Fakes::AppealRepository.appeal_already_certified
+    Fakes::AppealRepository.records = { "1234" => appeal }
+
+    visit "certifications/new/1234"
+    expect(find("#page-title")).to have_content "Certification"
+    expect(page).to have_content "Appeal has already been Certified"
+  end
 end


### PR DESCRIPTION
Fix the bug on the "Already Certified" page, for the header to say "Certification".