### PR TITLE
Mdbenjam fixing unassigned but completed

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -43,7 +43,7 @@ class TasksController < ApplicationController
   helper_method :current_user_historical_tasks
 
   def next_unassigned_task
-    @next_unassigned_task ||= scoped_tasks.unassigned.first
+    @next_unassigned_task ||= scoped_tasks.unassigned.to_complete.first
   end
   helper_method :next_unassigned_task
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -71,6 +71,8 @@ class Task < ActiveRecord::Base
   def assign!(user)
     before_assign
     fail(AlreadyAssignedError) if self.user
+    fail(AlreadyStartedError) if started?
+    fail(AlreadyCompleteError) if complete?
 
     return if user.tasks.to_complete.where(type: type).count > 0
 
@@ -98,6 +100,8 @@ class Task < ActiveRecord::Base
 
   def start!
     fail(NotAssignedError) unless assigned?
+    fail(AlreadyStartedError) if started?
+    fail(AlreadyCompleteError) if complete?
     return if started?
 
     update!(started_at: Time.now.utc)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -69,6 +69,7 @@ class Task < ActiveRecord::Base
   end
 
   def assign!(user)
+    print user
     before_assign
     fail(AlreadyAssignedError) if self.user
     fail(AlreadyStartedError) if started?

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -69,7 +69,6 @@ class Task < ActiveRecord::Base
   end
 
   def assign!(user)
-    print user
     before_assign
     fail(AlreadyAssignedError) if self.user
     fail(AlreadyStartedError) if started?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,21 +44,6 @@ class SeedDB
       establish_claim = EstablishClaim.create(
         appeal: @appeals[i % num_appeals]
         )
-      if i % 4 > 0
-        establish_claim.assign!(@users[i % num_users])
-      end
-
-      if i % 4 > 1
-        establish_claim.started_at = 1.day.ago
-      end
-
-      if i % 4 > 2
-        establish_claim.completed_at = 0.day.ago
-        if i % 3 == 0
-          establish_claim.completion_status = 1
-        end
-      end
-      establish_claim.save
     end
 
     @tasks.push(*tasks)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -46,6 +46,16 @@ class SeedDB
         )
     end
 
+    # Give each user a task in a different state
+    tasks[0].assign!(@users[0])
+
+    tasks[1].assign!(@users[1])
+    tasks[1].start!
+    
+    tasks[2].assign!(@users[2])
+    tasks[2].start!
+    tasks[2].complete!(0)
+
     @tasks.push(*tasks)
   end
 
@@ -64,7 +74,7 @@ class SeedDB
     clean_db
     create_default_users
     create_appeals(50)
-    create_users(2)
+    create_users(3)
     create_tasks(50)
   end
 end


### PR DESCRIPTION
Currently we can hit a bug where we try to establish a claim and rails crashes. This happens when a task is completed but not assigned. When you click the next claim button, we query for unassigned tasks, assign it to ourselves, then try to find it by looking for tasks still needed to complete. We now also make sure that we query for non-completed tasks before assigning.

Also added some error checks to avoid moving into invalid task states. Some more thinking needs to be done here to better reason about task states.

Also removed creating bad data in the seeds file. All taks should be unassigned, unstarted, and uncompleted.

**Test Plan**
- [ ] Run test suite