### PR TITLE
Anyar/342 fix missing doc stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'redis-rails'
 gem 'sidekiq'
 gem "sidekiq-cron", "~> 0.4.0"
 
+# remove when upgrading to rails 5
+gem 'where-or'
+
 group :production, :staging do
   # Oracle DB
   gem 'activerecord-oracle_enhanced-adapter'
@@ -90,6 +93,8 @@ group :development, :test do
   gem 'timecop'
   gem 'konacha'
   gem 'database_cleaner'
+  # to save and open specific page in capybara tests
+  gem 'launchy'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,8 @@ GEM
       sprockets (>= 2, < 4)
       sprockets-rails (>= 2, < 4)
       tilt
+    launchy (2.4.3)
+      addressable (~> 2.3)
     libv8 (3.16.14.15)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -384,6 +386,7 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    where-or (0.1.5)
     xmldsig (0.3.2)
       nokogiri
     xmlenc (0.5.0)
@@ -412,6 +415,7 @@ DEPENDENCIES
   jquery-rails
   jshint
   konacha
+  launchy
   moment_timezone-rails
   parallel
   pdf-forms
@@ -442,6 +446,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   us_web_design_standards!
   web-console (~> 2.0)
+  where-or
 
 BUNDLED WITH
    1.13.6

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -62,8 +62,6 @@ class Certification < ActiveRecord::Base
   end
 
   def self.was_missing_nod
-    # Find certifications where 'nod_matching_at' is not set OR where NOD document was
-    # matched after the appeal was created in Caseflow.
     # Allow 1 second lag just in case 'nod_matching_at' timestamp is a few milliseconds
     # greater than 'created_at' timestamp
     where(nod_matching_at: nil).or(where("nod_matching_at > created_at + INTERVAL '1 second'"))

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -56,37 +56,33 @@ class Certification < ActiveRecord::Base
   end
 
   def self.was_missing_doc
-    # Once we switch to Rails 5:
-    #
-    # self.was_missing_nod
-    #   .or(self.was_missing_soc)
-    #   .or(self.was_missing_ssoc)
-    #   .or(self.was_missing_form9)
-
-    where("(nod_matching_at IS NULL or nod_matching_at > form8_started_at) " \
-          "or (soc_matching_at IS NULL or soc_matching_at > form8_started_at) " \
-          "or (ssocs_required = 't' and (ssocs_matching_at IS NULL or ssocs_matching_at > form8_started_at)) " \
-          "or (form9_matching_at IS NULL or form9_matching_at > form8_started_at)")
+    was_missing_nod.or(was_missing_soc)
+                   .or(was_missing_ssoc)
+                   .or(was_missing_form9)
   end
 
   def self.was_missing_nod
-    where("nod_matching_at IS NULL or nod_matching_at > form8_started_at")
+    # Find certifications where 'nod_matching_at' is not set OR where NOD document was
+    # matched after the appeal was created in Caseflow.
+    # Allow 1 second lag just in case 'nod_matching_at' timestamp is a few milliseconds
+    # greater than 'created_at' timestamp
+    where(nod_matching_at: nil).or(where("nod_matching_at > created_at + INTERVAL '1 second'"))
   end
 
   def self.was_missing_soc
-    where("soc_matching_at IS NULL or soc_matching_at > form8_started_at")
+    where(soc_matching_at: nil).or(where("soc_matching_at > created_at + INTERVAL '1 second'"))
+  end
+
+  def self.was_missing_ssoc
+    ssoc_required.where(ssocs_matching_at: nil).or(where("ssocs_matching_at > created_at + INTERVAL '1 second'"))
+  end
+
+  def self.was_missing_form9
+    where(form9_matching_at: nil).or(where("form9_matching_at > created_at + INTERVAL '1 second'"))
   end
 
   def self.ssoc_required
     where(ssocs_required: true)
-  end
-
-  def self.was_missing_ssoc
-    ssoc_required.where("ssocs_matching_at IS NULL or ssocs_matching_at > form8_started_at")
-  end
-
-  def self.was_missing_form9
-    where("form9_matching_at IS NULL or form9_matching_at > form8_started_at")
   end
 
   private

--- a/app/models/stats.rb
+++ b/app/models/stats.rb
@@ -4,11 +4,8 @@
 #
 class Stats < Caseflow::Stats
   CALCULATIONS = {
-    # active_users: lambda do |range|
-    # end,
-
     certifications_started: lambda do |range|
-      Certification.where(form8_started_at: range).count
+      Certification.where(created_at: range).count
     end,
 
     certifications_completed: lambda do |range|
@@ -16,11 +13,11 @@ class Stats < Caseflow::Stats
     end,
 
     same_period_completions: lambda do |range|
-      Certification.completed.where(form8_started_at: range).count
+      Certification.completed.where(created_at: range).count
     end,
 
     missing_doc_same_period_completions: lambda do |range|
-      Certification.was_missing_doc.merge(Certification.completed).where(form8_started_at: range).count
+      Certification.was_missing_doc.merge(Certification.completed).where(created_at: range).count
     end,
 
     time_to_certify: lambda do |range|
@@ -28,7 +25,7 @@ class Stats < Caseflow::Stats
     end,
 
     missing_doc_time_to_certify: lambda do |range|
-      Stats.percentile(:time_to_certify, Certification.was_missing_doc.where(form8_started_at: range), 95)
+      Stats.percentile(:time_to_certify, Certification.was_missing_doc.where(created_at: range), 95)
     end,
 
     median_time_to_certify: lambda do |range|
@@ -36,31 +33,31 @@ class Stats < Caseflow::Stats
     end,
 
     median_missing_doc_time_to_certify: lambda do |range|
-      Stats.percentile(:time_to_certify, Certification.was_missing_doc.where(form8_started_at: range), 50)
+      Stats.percentile(:time_to_certify, Certification.was_missing_doc.where(created_at: range), 50)
     end,
 
     missing_doc: lambda do |range|
-      Certification.was_missing_doc.where(form8_started_at: range).count
+      Certification.was_missing_doc.where(created_at: range).count
     end,
 
     missing_nod: lambda do |range|
-      Certification.was_missing_nod.where(form8_started_at: range).count
+      Certification.was_missing_nod.where(created_at: range).count
     end,
 
     missing_soc: lambda do |range|
-      Certification.was_missing_soc.where(form8_started_at: range).count
+      Certification.was_missing_soc.where(created_at: range).count
     end,
 
     missing_ssoc: lambda do |range|
-      Certification.was_missing_ssoc.where(form8_started_at: range).count
+      Certification.was_missing_ssoc.where(created_at: range).count
     end,
 
     ssoc_required: lambda do |range|
-      Certification.ssoc_required.where(form8_started_at: range).count
+      Certification.ssoc_required.where(created_at: range).count
     end,
 
     missing_form9: lambda do |range|
-      Certification.was_missing_form9.where(form8_started_at: range).count
+      Certification.was_missing_form9.where(created_at: range).count
     end
   }.freeze
 end

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -3,8 +3,6 @@ require "rails_helper"
 RSpec.feature "Confirm Certification" do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-
-    Certification.delete_all
     User.authenticate!
     Form8.pdf_service = FakePdfService
 
@@ -39,13 +37,13 @@ RSpec.feature "Confirm Certification" do
 
   scenario "Successful confirmation" do
     visit "certifications/5555C"
-    expect(page).to have_content("Review Form 8")
     click_on "Upload and certify"
 
     expect(Fakes::AppealRepository.certified_appeal).to_not be_nil
     expect(Fakes::AppealRepository.certified_appeal.vacols_id).to eq("5555C")
     expect(Fakes::AppealRepository.uploaded_form8.vacols_id).to eq("5555C")
     expect(Fakes::AppealRepository.uploaded_form8_appeal.vacols_id).to eq("5555C")
+
     expect(page).to have_content("Congratulations! The case has been certified.")
 
     certification = Certification.find_or_create_by_vacols_id("5555C")

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Confirm Certification" do
     # Sending click or keypress events to elements that are not in the DOM doesn't seem to work,
     # so let's find the hidden link's href and visit it manually to check that the pdf can be
     # found there.
-    pdf_href = page.find('#sr-download-link')["href"]
+    pdf_href = page.find("#sr-download-link")["href"]
     visit(pdf_href)
     content_header = page.response_headers["Content-Disposition"]
 
@@ -37,6 +37,7 @@ RSpec.feature "Confirm Certification" do
 
   scenario "Successful confirmation" do
     visit "certifications/5555C"
+    expect(page).to have_content("Review Form 8")
     click_on "Upload and certify"
 
     expect(Fakes::AppealRepository.certified_appeal).to_not be_nil

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -1,6 +1,5 @@
 RSpec.feature "Dispatch" do
   before do
-    reset_application!
     Fakes::AppealRepository.records = {
       "123C" => Fakes::AppealRepository.appeal_remand_decided,
       "456D" => Fakes::AppealRepository.appeal_remand_decided

--- a/spec/feature/save_certification_spec.rb
+++ b/spec/feature/save_certification_spec.rb
@@ -23,20 +23,24 @@ RSpec.feature "Save Certification" do
     expect(page).to have_current_path(new_certification_path(vacols_id: "1234C"))
 
     expect(find("#question3 .usa-input-error-message")).to(
-      have_content("Please enter the veteran's full name."))
+      have_content("Please enter the veteran's full name.")
+    )
 
     fill_in "Full Veteran Name", with: "Paul Joe"
     expect(find("#question3 .usa-input-error-message")).to_not(
-      have_content("Please enter the veteran's full name."))
+      have_content("Please enter the veteran's full name.")
+    )
 
     expect(find("#question11A .usa-input-error-message")).to(
-      have_content("Oops! Looks like you missed one!"))
+      have_content("Oops! Looks like you missed one!")
+    )
 
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
       find("label", text: "No").click
     end
     expect(find("#question10A .usa-input-error-message")).to_not(
-      have_content("Oops! Looks like you missed one!"))
+      have_content("Oops! Looks like you missed one!")
+    )
 
     expect(page).to have_css("#question8A3.usa-input-error")
   end

--- a/spec/feature/send_feedback_spec.rb
+++ b/spec/feature/send_feedback_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.feature "Send feedback" do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-    reset_application!
     Fakes::AppealRepository.records = { "ABCD" => Fakes::AppealRepository.appeal_ready_to_certify }
   end
   after { Timecop.return }

--- a/spec/feature/start_certification_spec.rb
+++ b/spec/feature/start_certification_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.feature "Start Certification" do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-    reset_application!
   end
   after { Timecop.return }
 

--- a/spec/feature/stats_spec.rb
+++ b/spec/feature/stats_spec.rb
@@ -81,7 +81,6 @@ RSpec.feature "Stats Dashboard" do
   end
 
   scenario "Check missing documents" do
-
     Certification.create(
       nod_matching_at:     45.minutes.ago,
       form9_matching_at:   45.minutes.ago,

--- a/spec/feature/stats_spec.rb
+++ b/spec/feature/stats_spec.rb
@@ -2,9 +2,7 @@ require "rails_helper"
 
 RSpec.feature "Stats Dashboard" do
   before do
-    Timecop.freeze(Time.utc(2015, 1, 1, 17, 55, 0))
-
-    Certification.delete_all
+    Timecop.freeze(Time.utc(2015, 1, 1, 17, 55, 0, rand(1000)))
 
     Certification.create(
       nod_matching_at:     5.hours.ago,
@@ -13,6 +11,7 @@ RSpec.feature "Stats Dashboard" do
       ssocs_required:      false,
       ssocs_matching_at:   nil,
       form8_started_at:    5.hours.ago,
+      created_at:          5.hours.ago,
       completed_at:        4.hours.ago
     )
 
@@ -23,6 +22,7 @@ RSpec.feature "Stats Dashboard" do
       ssocs_required:      true,
       ssocs_matching_at:   4.hours.ago,
       form8_started_at:    5.hours.ago,
+      created_at:          5.hours.ago,
       completed_at:        nil
     )
 
@@ -33,6 +33,7 @@ RSpec.feature "Stats Dashboard" do
       ssocs_required:      true,
       ssocs_matching_at:   5.hours.ago,
       form8_started_at:    5.hours.ago,
+      created_at:          5.hours.ago,
       completed_at:        3.hours.ago
     )
 
@@ -43,8 +44,10 @@ RSpec.feature "Stats Dashboard" do
       ssocs_required:      true,
       ssocs_matching_at:   45.minutes.ago,
       form8_started_at:    45.minutes.ago,
+      created_at:          45.minutes.ago,
       completed_at:        30.minutes.ago
     )
+    Stats.calculate_all!
 
     User.authenticate!
   end
@@ -74,6 +77,46 @@ RSpec.feature "Stats Dashboard" do
     expect(page).to have_content("NOD 50 %")
     expect(page).to have_content("SOC 0 %")
     expect(page).to have_content("SSOC 33 %")
+    expect(page).to have_content("Form 9 0 %")
+  end
+
+  scenario "Check missing documents" do
+
+    Certification.create(
+      nod_matching_at:     45.minutes.ago,
+      form9_matching_at:   45.minutes.ago,
+      soc_matching_at:     45.minutes.ago,
+      ssocs_required:      true,
+      ssocs_matching_at:   43.minutes.ago,
+      form8_started_at:    nil,
+      created_at:          45.minutes.ago,
+      completed_at:        nil
+    )
+
+    Certification.create(
+      nod_matching_at:     45.minutes.ago,
+      form9_matching_at:   45.minutes.ago,
+      soc_matching_at:     nil,
+      ssocs_required:      true,
+      ssocs_matching_at:   45.minutes.ago,
+      form8_started_at:    nil,
+      created_at:          45.minutes.ago,
+      completed_at:        nil
+    )
+    Stats.calculate_all!
+    visit "/stats/daily"
+    expect(page).to have_content("Activity for January 1 (so far)")
+    expect(page).to have_content("Certifications Started 6")
+    expect(page).to have_content("Certifications Completed 3")
+    expect(page).to have_content("Overall 50 %")
+    expect(page).to have_content("Missing Document 25 %")
+    expect(page).to have_content("Overall (median) 60.00 min")
+    expect(page).to have_content("Missing Document (median) 120.00 min")
+
+    expect(page).to have_content("Any Document 67 %")
+    expect(page).to have_content("NOD 33 %")
+    expect(page).to have_content("SOC 17 %")
+    expect(page).to have_content("SSOC 40 %")
     expect(page).to have_content("Form 9 0 %")
   end
 

--- a/spec/feature/switch_user_spec.rb
+++ b/spec/feature/switch_user_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.feature "Switch User" do
   before do
-    reset_application!
     User.create(station_id: "283", css_id: "123")
     User.create(station_id: "ABC", css_id: "456")
     User.create(station_id: "283", css_id: "ANNE MERICA")

--- a/spec/jobs/create_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/create_establish_claim_tasks_job_spec.rb
@@ -1,7 +1,5 @@
 describe CreateEstablishClaimTasksJob do
   before do
-    reset_application!
-
     @partial_grant = Fakes::AppealRepository.new("123C", :appeal_remand_decided)
     @full_grant = Fakes::AppealRepository.new("456D", :appeal_full_grant_decided, decision_date: 1.day.ago)
 

--- a/spec/jobs/reassign_old_tasks_job_spec.rb
+++ b/spec/jobs/reassign_old_tasks_job_spec.rb
@@ -1,12 +1,10 @@
 describe ReassignOldTasksJob do
-  before do
-    reset_application!
-  end
   let!(:appeal1) { Appeal.create(vacols_id: "1") }
   let!(:appeal2) { Appeal.create(vacols_id: "2") }
   let!(:user) { User.create(station_id: "123", css_id: "abc") }
   let!(:unfinished_task) { EstablishClaim.create(appeal_id: appeal1.id).assign!(user) }
   let!(:status_code) { Task.completion_status_code(:expired) }
+
   let!(:finished_task) do
     EstablishClaim.create(appeal_id:
     appeal2.id).complete!(status_code)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -94,7 +94,6 @@ describe Appeal do
   end
 
   context "#certify!" do
-    before { Form8.delete_all }
     let(:appeal) { Appeal.new(vacols_id: "765") }
     subject { appeal.certify! }
 

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -10,9 +10,6 @@ describe Certification do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
     Fakes::AppealRepository.records = { "4949" => appeal_hash }
-    Certification.delete_all
-    Task.delete_all
-    Appeal.delete_all
     Appeal.stub(:find_or_create_by_vacols_id) do |_vacols_id|
       appeal
     end

--- a/spec/models/stats_spec.rb
+++ b/spec/models/stats_spec.rb
@@ -1,7 +1,6 @@
 describe Stats do
   before do
     Timecop.freeze(Time.utc(2016, 2, 17, 20, 59, 0))
-    Certification.delete_all
     Rails.cache.clear
   end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -4,7 +4,6 @@ end
 describe Task do
   # Clear the task from the DB before every test
   before do
-    reset_application!
     Timecop.freeze(Time.utc(2016, 2, 17, 20, 59, 0))
 
     @user = User.create(station_id: "ABC", css_id: "123")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,7 @@ require "rspec/rails"
 require "react_on_rails"
 require_relative "support/fake_pdf_service"
 require_relative "support/sauce_driver"
+require_relative "support/database_cleaner"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,8 +82,6 @@ User.prepend(StubbableUser)
 
 def reset_application!
   User.clear_stub!
-  # database cleaner is set up to ignore users table so clean users here
-  User.delete_all
   Fakes::AppealRepository.records = nil
 end
 
@@ -118,7 +116,6 @@ RSpec.configure do |config|
   if Dir["#{::Rails.root}/app/assets/webpack/*"].empty?
     ReactOnRails::TestHelper.ensure_assets_compiled
   end
-
   config.before(:all) { User.unauthenticate! }
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -81,11 +81,9 @@ end
 User.prepend(StubbableUser)
 
 def reset_application!
-  Task.delete_all
-  Appeal.delete_all
   User.clear_stub!
+  # database cleaner is set up to ignore users table so clean users here
   User.delete_all
-  Certification.delete_all
   Fakes::AppealRepository.records = nil
 end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,0 +1,48 @@
+require 'capybara/rspec'
+
+RSpec.configure do |config|
+
+  config.use_transactional_fixtures = false
+
+  config.before(:suite) do
+    if config.use_transactional_fixtures?
+      raise(<<-MSG)
+        Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
+        (or set it to false) to prevent uncommitted transactions being used in
+        JavaScript-dependent specs.
+
+        During testing, the app-under-test that the browser driver connects to
+        uses a different database connection to the database connection used by
+        the spec. The app's database connection would not be able to access
+        uncommitted transaction data setup over the spec's database connection.
+      MSG
+    end
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.strategy = :transaction
+  end
+
+  config.before(:each, type: :feature) do
+    # :rack_test driver's Rack app under test shares database connection
+    # with the specs, so continue to use transaction strategy for speed.
+    driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
+
+    unless driver_shares_db_connection_with_specs
+      # Driver is probably for an external browser with an app
+      # under test that does *not* share a database connection with the
+      # specs, so use truncation strategy.
+      DatabaseCleaner.strategy = :truncation
+    end
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.append_after(:each) do
+    DatabaseCleaner.clean
+  end
+
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -5,7 +5,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     if config.use_transactional_fixtures?
-      raise(<<-MSG)
+      fail(<<-MSG)
         Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
         (or set it to false) to prevent uncommitted transactions being used in
         JavaScript-dependent specs.

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -33,7 +33,9 @@ RSpec.configure do |config|
       # Driver is probably for an external browser with an app
       # under test that does *not* share a database connection with the
       # specs, so use truncation strategy.
-      DatabaseCleaner.strategy = :truncation
+
+      # do not truncate users table
+      DatabaseCleaner.strategy = :truncation, { except: %w(users) }
     end
   end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,7 +1,6 @@
-require 'capybara/rspec'
+require "capybara/rspec"
 
 RSpec.configure do |config|
-
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
@@ -33,9 +32,7 @@ RSpec.configure do |config|
       # Driver is probably for an external browser with an app
       # under test that does *not* share a database connection with the
       # specs, so use truncation strategy.
-
-      # do not truncate users table
-      DatabaseCleaner.strategy = :truncation, { except: %w(users) }
+      DatabaseCleaner.strategy = :truncation
     end
   end
 
@@ -45,6 +42,6 @@ RSpec.configure do |config|
 
   config.append_after(:each) do
     DatabaseCleaner.clean
+    reset_application!
   end
-
 end


### PR DESCRIPTION
1. Fixes a bug around stats page. It uses `created_at` timestamp instead of `form8_started_at` timestamp to find `certifications` records. 
2. Add database_cleaner to tests

Testing:
1. Go to `/stats` page and test all tabs.
2. Reference this document: https://github.com/department-of-veterans-affairs/appeals-pm/blob/master/administration/requests/GAO%20100666.md#dashboard-metrics-for-caseflow-certification 
@astewarttistatech 