### PR TITLE
Fixes for loading users in dev environment

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,8 @@ class SeedDB
       station_index = deterministic ? (i % length) : (rand(length))
       User.create(
         station_id: VACOLS::RegionalOffice::STATIONS.keys[station_index],
-        css_id: "css_#{i}"
+        css_id: "css_#{i}",
+        full_name: "name_#{i}"
         )
     end
 

--- a/lib/fakes/authentication_service.rb
+++ b/lib/fakes/authentication_service.rb
@@ -13,7 +13,8 @@ class Fakes::AuthenticationService
     {
       "id" => user.css_id,
       "roles" => roles,
-      "station_id" => user.station_id
+      "station_id" => user.station_id,
+      "name" => user.full_name
     }
   end
 

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -10,7 +10,7 @@ class Fakes::Initializer
       "id" => "ANNE MERICA",
       "roles" => ["Certify Appeal", "Establish Claim", "Manage Claim Establishment"],
       "station_id" => "283",
-      "full_name" => "Anne Merica"
+      "name" => "Anne Merica"
     }
 
     Appeal.repository = Fakes::AppealRepository


### PR DESCRIPTION
This PR fixes a dev environment sessions bug where we were overwriting users' full names on page loads. It now sets the correct session variables so that doesn't happen. 

- [x] Unit tests pass
- [x] Users aren't being overwritten in the console on page loads
- [x] All users' names are showing up correctly on the manager page view 