### PR TITLE
Fixing EP & Claim Label and Decision Date editable

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
@@ -47,7 +47,7 @@ export const render = function() {
          readOnly={true}
         />
         <DropDown
-         label="Claim Label"
+         label="EP & Claim Label"
          name="claimLabel"
          options={CLAIM_LABEL_OPTIONS}
          onChange={this.handleFieldChange('form', 'claimLabel')}
@@ -63,7 +63,7 @@ export const render = function() {
         <DateSelector
          label="Decision Date"
          name="decisionDate"
-         readOnly={true}
+         readOnly={false}
          value={appeal.decision_date}
         />
         <DropDown


### PR DESCRIPTION
Changing a label on the form from "Claim Label" to "EP & Claim Label" and make the Decision Date field editable.

Fixes #577 and #578 
<img width="641" alt="screen shot 2016-12-19 at 10 25 49 am" src="https://cloud.githubusercontent.com/assets/3885236/21318024/8ae42330-c5d5-11e6-9346-a37610a77b3d.png">


**Test Plan**
- [ ] Run test suite
- [ ] Test manually