### PR TITLE
Populate question 10B with the hearing held value

### DIFF
--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -60,6 +60,7 @@ class Form8 < ActiveRecord::Base
       representative_name: appeal.representative_name,
       representative_type: appeal.representative_type,
       hearing_requested: appeal.hearing_type ? "Yes" : "No",
+      hearing_held: appeal.hearing_held ? "Yes" : "No",
       ssoc_required: appeal.ssoc_dates.empty? ? "Not required" : "Required and furnished",
       certifying_office: appeal.regional_office_name,
       certifying_username: appeal.regional_office_key,

--- a/spec/feature/save_certification_spec.rb
+++ b/spec/feature/save_certification_spec.rb
@@ -59,6 +59,12 @@ RSpec.feature "Save Certification" do
       find("label", text: "Attorney").click
     end
     within_fieldset("10A Was BVA hearing requested?") do
+      find("label", text: "Yes").click
+    end
+    within_fieldset("10B Was the hearing held?") do
+      find("label", text: "Yes").click
+    end
+    within_fieldset("Is the hearing transcript on file?") do
       find("label", text: "No").click
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
@@ -79,7 +85,10 @@ RSpec.feature "Save Certification" do
       expect(find_field("Attorney", visible: false)).to be_checked
     end
     within_fieldset("10A Was BVA hearing requested?") do
-      expect(find_field("No", visible: false)).to be_checked
+      expect(find_field("Yes", visible: false)).to be_checked
+    end
+    within_fieldset("10B Was the hearing held?") do
+      expect(find_field("Yes", visible: false)).to be_checked
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
       expect(find_field("No", visible: false)).to be_checked


### PR DESCRIPTION
Form 8:  Question 10B:  pre-populate hearing held value

Connects #435 

Testing:
1. Tested manually. Pre-populates with "No" for the appeal with the hearing held set to 'No". See screenshot:
![image](https://cloud.githubusercontent.com/assets/3811786/21400528/8d03dbf6-c77e-11e6-9a77-187f618b8b9a.png)
2. Included automated test

