### PR TITLE
Fixes whitespace bug for cancel feedback

### DIFF
--- a/client/app/util/validators/RequiredValidator.js
+++ b/client/app/util/validators/RequiredValidator.js
@@ -1,5 +1,5 @@
 const requiredValidator = (message) => function(value) {
-  if (value === '') {
+  if (value.trim() === '') {
     return message;
   }
 


### PR DESCRIPTION
There is a bug where a user can enter only whitespace on the cancel modal, get past the form validation, but not pass the database validation. This PR will fail a whitespace only response in the form validation. 

Fixes #600 

![whitespace_bug](https://cloud.githubusercontent.com/assets/4306128/21403349/6a59002a-c78a-11e6-9a11-0106969041eb.gif)

- [ ] Unit tests pass
- [ ] Tested in the UI