### PR TITLE
Include email and css_id to send to Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,7 +58,8 @@ class ApplicationController < ActionController::Base
     if current_user && ENV["SENTRY_DSN"]
       # Raven sends error info to Sentry.
       Raven.user_context(
-        email: current_user.username,
+        email: current_user.email,
+        css_id: current_user.css_id,
         regional_office: current_user.regional_office
       )
     end


### PR DESCRIPTION
Send email and css_id to Sentry.

Based on what I see in the code, we should have been sending user's username (which is css_id) and regional office data. I am not sure why it has not been showing up in Sentry.

connected #581 