### PR TITLE
Add system admin user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,6 +66,7 @@ class SeedDB
     @users.push(User.create(css_id: "Establish Claim", station_id: "283", full_name: "Jane Smith"))
     @users.push(User.create(css_id: "Establish Claim, Manage Claim Establishment", station_id: "283", full_name: "John Doe"))
     @users.push(User.create(css_id: "Certify Appeal", station_id: "283", full_name: "John Smith"))
+    @users.push(User.create(css_id: "System Admin", station_id: "283", full_name: "Angelina Smith"))
   end
 
   def clean_db


### PR DESCRIPTION
Add system admin user to seeds.


Testing:
1. Ran `db:reset` and ensured the user was created in the DB
2. Logged in as that user and ensured the user had system admin role

connected #606 