### PR TITLE
Upgrade connect_vbms version, for establishing claims

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'therubyracer', platforms: :ruby
 
 gem 'pg', platforms: :ruby
 
-gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "d71251eb3d066748b395d58633af5bd5863ef928"
+gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "0b275309ea58399a79e8ed9d6e99aa703cdd687c"
 
 gem 'redis-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: d71251eb3d066748b395d58633af5bd5863ef928
-  ref: d71251eb3d066748b395d58633af5bd5863ef928
+  revision: 0b275309ea58399a79e8ed9d6e99aa703cdd687c
+  ref: 0b275309ea58399a79e8ed9d6e99aa703cdd687c
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.6.0.1)


### PR DESCRIPTION
Requires `CONNECT_VBMS_BASE_URL` set, which was added to deployment in
https://github.com/department-of-veterans-affairs/appeals-deployment/pull/322

Tested locally and works.