### PR TITLE
Cancel Link

### DIFF
--- a/app/views/certifications/mismatched_documents.html.erb
+++ b/app/views/certifications/mismatched_documents.html.erb
@@ -27,7 +27,7 @@
 
   <p>
     If you can’t find the document, click the
-    <strong>cancel certification</strong> link below.
+    <strong>cancel</strong> link below.
   </p>
 
   <div class="cf-table-wrap">
@@ -50,7 +50,7 @@
         <%= render partial: 'document_match', locals: { name: "SOC", match: appeal.soc_match?, date: appeal.soc_date } %>
 
         <% appeal.ssoc_dates.each_index do |i| %>
-          <%= render partial: 'document_match', 
+          <%= render partial: 'document_match',
                      locals: { name: "SSOC #{i+1}", match: appeal.ssoc_match?(appeal.ssoc_dates[i]), date: appeal.ssoc_dates[i] } %>
         <% end %>
 
@@ -61,8 +61,8 @@
 </div>
 
 <div class="cf-app-segment">
-  <!-- a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel certification</a>-->
+  <a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel</a>
   <button type="button" class="cf-push-right cf-action-refresh">Refresh Page</button>
 </div>
 
-<%#= render partial: 'cancel_cert_modal' %>
+<%= render partial: 'cancel_certification_modal' %>

--- a/app/views/certifications/new.html.erb
+++ b/app/views/certifications/new.html.erb
@@ -149,7 +149,7 @@
   <div class="cf-app-segment">
     <%= loading_indicator %>
 
-    <a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel certification</a>
+    <a href="#confirm-cancel-certification" class="cf-action-openmodal cf-btn-link">Cancel</a>
     <button type="submit" class="cf-push-right cf-submit">Preview Completed Form 8</button>
   </div>
 

--- a/spec/feature/cancel_certification_spec.rb
+++ b/spec/feature/cancel_certification_spec.rb
@@ -9,7 +9,22 @@ RSpec.feature "Cancel certification" do
     }
 
     visit "certifications/new/5555C"
-    click_on "Cancel certification"
+    click_on "Cancel"
+    expect(page).to have_content("Are you sure you can't certify this case?")
+    click_on "Yes, I'm sure"
+    expect(page).to have_content("Case not certified")
+  end
+
+  scenario "Click cancel when certification has mistmatched documents" do
+    User.authenticate!
+
+    Fakes::AppealRepository.records = {
+      "7777D" => Fakes::AppealRepository.appeal_mismatched_docs
+    }
+
+    visit "certifications/new/7777D"
+    expect(page).to have_content("No Matching Document")
+    click_on "Cancel"
     expect(page).to have_content("Are you sure you can't certify this case?")
     click_on "Yes, I'm sure"
     expect(page).to have_content("Case not certified")


### PR DESCRIPTION
connects #477 
connects #612
1. Add "Cancel" link to Mismatched Documents view
2. Change "Cancel certification" to "Cancel"

![image](https://cloud.githubusercontent.com/assets/3811786/21685223/b8808dfe-d32e-11e6-99ed-e22771cfce7d.png)

![image](https://cloud.githubusercontent.com/assets/3811786/21685225/bff76684-d32e-11e6-8ec6-2fc34fcfa7cc.png)


Testing:
* automated tests
