### PR TITLE
Fixing page title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 <head>
   <meta http-equiv='X-UA-Compatible' content='IE=edge'>
 
-  <title>Caseflow Certification</title>
+  <title>Caseflow <%= logo_name %></title>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Currently, the page title is always Caseflow Certification. Now it will be whatever the logo name is, and just Caseflow for pages without a specified logo_name.

connects: #651 

**Test Plan**
- [ ] Verify manually

![screen shot 2017-01-10 at 3 19 19 pm](https://cloud.githubusercontent.com/assets/3885236/21823255/4c67b6c4-d748-11e6-80f0-3bc83b0debb0.png)
