### PR TITLE
Specify a pool size for VACOLS connections

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -57,6 +57,7 @@ production_vacols:
   host: <%= ENV["VACOLS_HOST"] %>
   port: <%= ENV["VACOLS_PORT"] %>
   database: <%= ENV["VACOLS_DATABASE"] %>
+  pool: <%= ENV["DB_CONN_POOL_MAX_SIZE"] || 5 %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
Otherwise the RAILS default is 5.