### PR TITLE
New endpoint and methods for uncertifying in UAT

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -46,6 +46,17 @@ class CertificationsController < ApplicationController
     render layout: "application"
   end
 
+  # ONLY FOR TEST USER
+  def uncertify
+    if current_user.id == ENV["TEST_USER_ID"]
+      @certification = Certification.find_by(vacols_id: vacols_id)
+      @certification.decertify!(current_user.id)
+      @certification.destroy
+    end
+
+    redirect_to new_certification_path(vacols_id: ENV["TEST_APPEAL_ID"])
+  end
+
   private
 
   def verify_access

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -50,7 +50,7 @@ class CertificationsController < ApplicationController
   def uncertify
     if current_user.id == ENV["TEST_USER_ID"]
       @certification = Certification.find_by(vacols_id: vacols_id)
-      @certification.decertify!(current_user.id)
+      @certification.uncertify!(current_user.id)
       @certification.destroy
     end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -122,7 +122,7 @@ class Appeal < ActiveRecord::Base
 
   def uncertify!(user_id)
     return unless user_id == ENV["TEST_USER_ID"]
-    Appeal.uncertify(self){}
+    Appeal.uncertify(self)
   end
 
   def fetch_documents!

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -120,6 +120,11 @@ class Appeal < ActiveRecord::Base
     Appeal.certify(self)
   end
 
+  def uncertify!(user_id)
+    return unless user_id == ENV["TEST_USER_ID"]
+    Appeal.uncertify(self){}
+  end
+
   def fetch_documents!
     self.class.repository.fetch_documents_for(self)
     @documents
@@ -165,6 +170,15 @@ class Appeal < ActiveRecord::Base
 
       repository.certify(appeal)
       repository.upload_form8(appeal, form8)
+    end
+
+    # ONLY FOR TEST USER and for TEST_APPEAL_ID
+    def uncertify!(appeal)
+      return unless appeal.vacols_id == ENV["TEST_APPEAL_ID"]
+
+      Form8.find_by(vacols_id: appeal.vacols_id).destroy
+      File.delete(form8.pdf_location) unless File.exist?(form8.pdf_location)
+      repository.uncertify(appeal)
     end
 
     def map_end_product_value(code, mapping)

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -83,6 +83,13 @@ class Certification < ActiveRecord::Base
     where(ssocs_required: true)
   end
 
+  # ONLY FOR TEST USER
+  def uncertify!(user_id)
+    # YEAH, I KNOW THIS IS REDUNDANT! -Artem
+    return unless user_id == ENV["TEST_USER_ID"]
+    appeal.uncertify!(user_id)
+  end
+
   private
 
   def now

--- a/app/views/certifications/confirm.html.erb
+++ b/app/views/certifications/confirm.html.erb
@@ -10,4 +10,8 @@
   </ul>
 
   <p class="cf-msg-screen-text">Way to go! You can now close this browser window and open another case in VACOLS.</p>
+  <% if current_user.css_id == ENV['TEST_USER_ID'] && params[:id] == ENV["TEST_APPEAL_ID"] %>
+      <%= link_to "Uncertify Appeal", uncertify_certification_path(params[:id]), method: :post %>
+  <% end %>
+
 </div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,4 +56,8 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
   #
   ENV["CASEFLOW_FEEDBACK_URL"] = "test.feedback.url"
+
+  # For testing uncertification methods
+  ENV["TEST_USER_ID"] = "Certify Appeal"
+  ENV["TEST_APPEAL_ID"] = "123C"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,12 @@ Rails.application.routes.draw do
     get 'pdf', on: :member
     post 'confirm', on: :member
     get 'cancel', on: :member
+
+    # ONLY FOR UAT TESTING
+    if ENV["TEST_USER_ID"]
+      post 'uncertify', on: :member
+    end
+
   end
 
   scope path: "/dispatch" do

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -83,6 +83,8 @@ RSpec.feature "Confirm Certification" do
       certification = Certification.find_or_create_by_vacols_id("123C")
       expect(certification.reload.completed_at).to eq(Time.zone.now)
       expect(page).to have_content("Uncertify Appeal")
+      click_link("Uncertify Appeal")
+      expect(certification.appeal.certified?).to be_falsey
     end
   end
 end

--- a/spec/models/concerns/associated_vacols_model_spec.rb
+++ b/spec/models/concerns/associated_vacols_model_spec.rb
@@ -48,7 +48,7 @@ describe AssociatedVacolsModel do
 
   context "#check_and_load_vacols_data!" do
     it do
-      TestVacolsModelRepository.should_receive(:load_vacols_data).exactly(1).times
+      expect(TestVacolsModelRepository).to receive(:load_vacols_data).exactly(1).times
       model.check_and_load_vacols_data!
       model.check_and_load_vacols_data!
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,16 @@ module StubbableUser
         }, OpenStruct.new(remote_ip: "127.0.0.1"))
     end
 
+    def tester!(roles: nil)
+      self.stub = User.from_session(
+        { "user" =>
+          { "id" => ENV["TEST_USER_ID"],
+            "station_id" => "283",
+            "email" => "test@example.com",
+            "roles" => roles || ["Certify Appeal"] }
+        }, OpenStruct.new(remote_ip: "127.0.0.1"))
+    end
+
     def current_user
       @stub
     end


### PR DESCRIPTION
connects [#16 from appeals-qa](https://github.com/department-of-veterans-affairs/appeals-qa/issues/16)
and [#342 from appeals-deployment](https://github.com/department-of-veterans-affairs/appeals-deployment/issues/342)

- added a route to uncertify an appeal
- added methods to the controller and models to use the existing `uncertify` method from that endpoint
- tests that check basic access to the methods; unable to fully test the integration at the moment

#