### PR TITLE
Anya/660 admin change roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,9 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
 gem "puma", "~> 2.16.0"
 
+# use to_b method to convert string to boolean
+gem 'wannabe_bool'
+
 # Style
 gem 'us_web_design_standards', git: 'https://github.com/harrisj/us_web_design_standards_gem.git', branch: 'rails-assets-fixes'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,6 +418,7 @@ GEM
       tzinfo (>= 1.0.0)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    wannabe_bool (0.6.0)
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
@@ -495,6 +496,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   us_web_design_standards!
+  wannabe_bool
   web-console (~> 2.0)
   where-or
 

--- a/app/controllers/functions_controller.rb
+++ b/app/controllers/functions_controller.rb
@@ -1,4 +1,4 @@
-require 'wannabe_bool'
+require "wannabe_bool"
 
 class FunctionsController < ApplicationController
   before_action :verify_access

--- a/app/controllers/functions_controller.rb
+++ b/app/controllers/functions_controller.rb
@@ -1,0 +1,20 @@
+require 'wannabe_bool'
+
+class FunctionsController < ApplicationController
+  before_action :verify_access
+
+  def index
+    @functions = current_user.functions
+  end
+
+  def change
+    current_user.toggle_admin_roles(role: params[:function], enable: params[:enable].to_b)
+    redirect_to "/functions"
+  end
+
+  private
+
+  def verify_access
+    verify_authorized_roles("System Admin")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,12 +2,14 @@ class User < ActiveRecord::Base
   has_many :tasks
 
   # Ephemeral values obtained from CSS on auth. Stored in user's session
-  attr_accessor :roles, :ip_address
+  attr_accessor :roles, :ip_address, :admin_roles
   attr_writer :regional_office
 
   TASK_TYPE_TO_ROLES = {
     EstablishClaim: { employee: "Establish Claim", manager: "Manage Claim Establishment" }
   }.freeze
+
+  FUNCTIONS = ["Establish Claim", "Manage Claim Establishment", "Certify Appeal"].freeze
 
   def username
     css_id
@@ -33,9 +35,13 @@ class User < ActiveRecord::Base
     end
   end
 
+  def admin?
+    roles.include?("System Admin")
+  end
+
   def can?(thing)
     return false if roles.nil?
-    return true if roles.include? "System Admin"
+    return true if admin? && admin_roles.include?(thing)
     roles.include? thing
   end
 
@@ -54,6 +60,18 @@ class User < ActiveRecord::Base
     super.merge(display_name: display_name)
   end
 
+  def functions
+    User::FUNCTIONS.each_with_object({}) do |function, result|
+      result[function] ||= {}
+      result[function][:enabled] = admin_roles.include?(function)
+    end
+  end
+
+  def toggle_admin_roles(role:, enable: true)
+    return if role == "System Admin"
+    enable ? admin_roles << role : admin_roles.delete(role)
+  end
+
   private
 
   def station_offices
@@ -69,11 +87,14 @@ class User < ActiveRecord::Base
 
       return nil if user.nil?
 
+      user["admin_roles"] ||= user["roles"] && user["roles"].include?("System Admin") ? ["System Admin"] : []
+
       find_or_create_by(css_id: user["id"], station_id: user["station_id"]).tap do |u|
         u.full_name = user["name"]
         u.email = user["email"]
         u.roles = user["roles"]
         u.ip_address = request.remote_ip
+        u.admin_roles = user["admin_roles"]
         u.regional_office = session[:regional_office]
         u.save
       end

--- a/app/views/functions/index.html.erb
+++ b/app/views/functions/index.html.erb
@@ -1,0 +1,17 @@
+<div class="cf-app-segment cf-app-segment--alt">
+  <div class="usa-grid-full">
+    <h1>Change Functions</h1>
+    <% @functions.each do |name, value| %>
+      <p>
+        <% if value[:enabled]  %>
+            &#9989; <%= name %> (Enabled)
+            <%= link_to "Disable", functions_change_url(function: name, enable: false), method: :patch, id: name.gsub(/\s+/, "_").downcase  %>
+        <% else %>
+            &#10060; <%= name %> (Disabled)
+            <%= link_to "Enable", functions_change_url(function: name, enable: true), method: :patch, id: name.gsub(/\s+/, "_").downcase %>
+        <% end %>
+      </p>
+    <% end %>
+</div>
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
       </script>
 
   <%= favicon_link_tag %>
-  
+
 </head>
 <body>
   <header>
@@ -86,6 +86,12 @@
               <% if ApplicationController.dependencies_faked? %>
                 <li>
                   <a href="<%= url_for controller: 'dev_users', action: 'index'%>">Switch User</a>
+                </li>
+              <% end %>
+
+              <% if current_user.admin? %>
+                <li>
+                  <a href="<%= url_for controller: 'functions', action: 'index'%>">Change Functions</a>
                 </li>
               <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,9 @@ Rails.application.routes.draw do
   end
   # :nocov:
 
+  resources :functions, only: :index
+  patch '/functions/change', to: 'functions#change'
+
   resources :offices, only: :index
 
   get "health-check", to: "health_checks#show"

--- a/lib/fakes/authentication_service.rb
+++ b/lib/fakes/authentication_service.rb
@@ -10,11 +10,13 @@ class Fakes::AuthenticationService
     user = User.find(user_id)
     # Take the roles from the User's css_id
     roles = user.css_id.split(",").map(&:strip)
+    admin_roles = roles.include?("System Admin") ? ["System Admin"] : []
     {
       "id" => user.css_id,
       "roles" => roles,
       "station_id" => user.station_id,
-      "name" => user.full_name
+      "name" => user.full_name,
+      "admin_roles" => admin_roles
     }
   end
 

--- a/spec/feature/functions_spec.rb
+++ b/spec/feature/functions_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "Change Functions" do
+  scenario "As a system admin" do
+    User.authenticate!(roles: ["System Admin"])
+    visit "/"
+    click_on "DSUSER (DSUSER)"
+    click_on "Change Functions"
+    expect(page).to have_content "Establish Claim (Disabled)"
+    expect(page).to have_content "Manage Claim Establishment (Disabled)"
+    expect(page).to have_content "Certify Appeal (Disabled)"
+
+    find("#establish_claim", "Enable").click
+    find("#certify_appeal", "Enable").click
+
+    expect(page).to have_content "Establish Claim (Enabled)"
+    expect(page).to have_content "Manage Claim Establishment (Disabled)"
+    expect(page).to have_content "Certify Appeal (Enabled)"
+
+    find("#establish_claim", "Disable").click
+    expect(page).to have_content "Establish Claim (Disabled)"
+    find("#certify_appeal", "Disable").click
+
+    visit "/certifications/new/123C"
+    expect(page).to have_content("You aren't authorized to use this part of Caseflow yet.")
+  end
+
+  scenario "As a non system admin" do
+    User.authenticate!(roles: ["Certify Appeal"])
+    visit "/"
+    click_on "DSUSER (DSUSER)"
+    expect(page).to_not have_content "Change Functions"
+    visit "/functions"
+    expect(page).to have_content("You aren't authorized to use this part of Caseflow yet.")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,12 +63,14 @@ module StubbableUser
     end
 
     def authenticate!(roles: nil)
+      admin_roles = roles && roles.include?("System Admin") ? ["System Admin"] : []
       self.stub = User.from_session(
         { "user" =>
           { "id" => "DSUSER",
             "station_id" => "283",
             "email" => "test@example.com",
-            "roles" => roles || ["Certify Appeal"] }
+            "roles" => roles || ["Certify Appeal"],
+            "admin_roles" => admin_roles }
         }, OpenStruct.new(remote_ip: "127.0.0.1"))
     end
 


### PR DESCRIPTION
Add ability for system admins to change functions.

![image](https://cloud.githubusercontent.com/assets/3811786/21910578/a41c652e-d8ea-11e6-9b31-1838bb893324.png)


connects #660 