### PR TITLE
Adding a bunch of associated EPs to make testing easier

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -27,6 +27,84 @@ class Fakes::BGSService
         claim_receive_date: Time.zone.now - 200.days,
         claim_type_code: "172BVAG",
         status_type_code: "CLR"
+      },
+      {
+        benefit_claim_id: "5",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "170APPACT",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "6",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "170APPACTPMC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "7",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "170PGAMC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "8",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "170RMD",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "9",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "170RMDAMC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "10",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "170RMDPMC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "11",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "172GRANT",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "12",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "172BVAG",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "13",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "172BVAGPMC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "14",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "400CORRC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "15",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "400CORRCPMC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "16",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "930RC",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "17",
+        claim_receive_date: Time.zone.now - 10.days,
+        claim_type_code: "930RCPMC",
+        status_type_code: "PEND"
       }
     ].freeze
 


### PR DESCRIPTION
Adding all of the types of EPs to the Associate EP page to make validation easier.

**Test Plan**
- [ ] Verify manually
<img width="840" alt="screen shot 2017-01-13 at 10 50 09 am" src="https://cloud.githubusercontent.com/assets/3885236/21936129/137f802a-d97e-11e6-840f-3bd356dfc240.png">
