### PR TITLE
Fix integration error where expecting Date to be TimeWithZone

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -110,7 +110,7 @@ class Appeal < ActiveRecord::Base
 
   def decision
     decisions = documents_with_type("BVA Decision").select do |decision|
-      (decision.received_at - decision_date).abs <= 1.day
+      (decision.received_at.to_time - decision_date).abs <= 1.day
     end
     fail(MultipleDecisionError) if decisions.size > 1
     decisions.first

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -110,7 +110,7 @@ class Appeal < ActiveRecord::Base
 
   def decision
     decisions = documents_with_type("BVA Decision").select do |decision|
-      (decision.received_at.to_time_in_current_zone - decision_date).abs <= 1.day
+      (decision.received_at.in_time_zone - decision_date).abs <= 1.day
     end
     fail(MultipleDecisionError) if decisions.size > 1
     decisions.first

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -110,7 +110,7 @@ class Appeal < ActiveRecord::Base
 
   def decision
     decisions = documents_with_type("BVA Decision").select do |decision|
-      (decision.received_at.to_time - decision_date).abs <= 1.day
+      (decision.received_at.to_time_in_current_zone - decision_date).abs <= 1.day
     end
     fail(MultipleDecisionError) if decisions.size > 1
     decisions.first

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Dispatch" do
       "123C" => Fakes::AppealRepository.appeal_remand_decided,
       "456D" => Fakes::AppealRepository.appeal_remand_decided,
       @vbms_id => { documents: [Document.new(
-        received_at: Time.current - 7.days, type: "BVA Decision",
+        received_at: (Time.current - 7.days).to_date, type: "BVA Decision",
         document_id: "123"
       )]
       }

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -234,13 +234,13 @@ describe Appeal do
   context "#decision" do
     let(:decision) do
       Document.new(
-        received_at: Time.current,
+        received_at: Date.today,
         type: "BVA Decision"
       )
     end
     let(:old_decision) do
       Document.new(
-        received_at: Time.current - 2.days,
+        received_at: 2.days.ago.to_date,
         type: "BVA Decision"
       )
     end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -234,7 +234,7 @@ describe Appeal do
   context "#decision" do
     let(:decision) do
       Document.new(
-        received_at: Date.zone.today,
+        received_at: Time.zone.now.to_date,
         type: "BVA Decision"
       )
     end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -234,7 +234,7 @@ describe Appeal do
   context "#decision" do
     let(:decision) do
       Document.new(
-        received_at: Date.today,
+        received_at: Date.zone.today,
         type: "BVA Decision"
       )
     end


### PR DESCRIPTION
The VBMS API returns a `Date` object for `Document#received_at`. Our fakes and code were expecting it to be a `Time`/`TimeWithZone`.

This fixes the tests and the part in the code which was returning the error below:
<img width="1194" alt="screen shot 2017-01-17 at 3 53 08 pm" src="https://cloud.githubusercontent.com/assets/1596259/22041550/4fd7a624-dcd5-11e6-8a94-98a4e238f6fb.png">
