### PR TITLE
Show error pages for no decisions and multiple decisions.

### DIFF
--- a/app/views/tasks/multiple_decisions.html.erb
+++ b/app/views/tasks/multiple_decisions.html.erb
@@ -1,0 +1,12 @@
+<!-- TODO: Remove me when decisions are handled in task creation -->
+<% content_for :page_title do task.appeal.task_header end %>
+
+<div class="usa-alert usa-alert-error" role="alert">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Multiple Decisions</h3>
+    <p class="usa-alert-text">
+      There are multiple decision documents associated with this veteran.
+      Please  <%= link_to "cancel this claims establishment", cancel_task_path(task, feedback: "Multiple decisions", method: :patch %> and create the end product outside of Caseflow.
+    </p>
+  </div>
+</div>

--- a/app/views/tasks/no_decisions.html.erb
+++ b/app/views/tasks/no_decisions.html.erb
@@ -1,0 +1,13 @@
+<!-- TODO: Remove me when decisions are handled in task creation -->
+<% content_for :page_title do task.appeal.task_header end %>
+
+<div class="usa-alert usa-alert-error" role="alert">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">No Decision</h3>
+    <p class="usa-alert-text">
+      There are no decision documents associated with this veteran for the range of the decision date (<%= task.appeal.decision_date.to_formatted_s(:short_date) %>). 
+
+      Please make sure the decision document exists and try again or <%= link_to "cancel this claims establishment", cancel_task_path(task, feedback: "No decisions"), method: :patch %>.
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
This is a stop gap until we can get these errors worked out beforehand.