### PR TITLE
Fix Fakes::BGSService to return correctly formatted dates

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -2,6 +2,7 @@ class Fakes::BGSService
   cattr_accessor :end_product_data
   attr_accessor :client
 
+  # rubocop:disable Metrics/MethodLength
   def end_product_defaults
     default_date = 10.days.ago.to_formatted_s(:short_date)
     [
@@ -122,7 +123,6 @@ class Fakes::BGSService
   #   # What is the endpoint?
   # end
 
-  # rubocop:disable Metrics/MethodLength
   def fetch_veteran_info(_)
     {
       address_line1: "1234 FAKE ST",

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -2,9 +2,8 @@ class Fakes::BGSService
   cattr_accessor :end_product_data
   attr_accessor :client
 
-  DEFAULT_CLAIM_RECEIVE_DATE = 10.days.ago.to_formatted_s(:short_date)
-
-  END_PRODUCTS =
+  def end_product_defaults
+    default_date = 10.days.ago.to_formatted_s(:short_date)
     [
       {
         benefit_claim_id: "1",
@@ -15,7 +14,7 @@ class Fakes::BGSService
       },
       {
         benefit_claim_id: "2",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170RMD",
         end_product_type_code: "170",
         status_type_code: "CLR"
@@ -36,86 +35,87 @@ class Fakes::BGSService
       },
       {
         benefit_claim_id: "5",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170APPACT",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "6",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170APPACTPMC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "7",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170PGAMC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "8",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170RMD",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "9",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170RMDAMC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "10",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "170RMDPMC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "11",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "172GRANT",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "12",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "172BVAG",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "13",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "172BVAGPMC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "14",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "400CORRC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "15",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "400CORRCPMC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "16",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "930RC",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "17",
-        claim_receive_date: DEFAULT_CLAIM_RECEIVE_DATE,
+        claim_receive_date: default_date,
         claim_type_code: "930RCPMC",
         status_type_code: "PEND"
       }
-    ].freeze
+    ]
+  end
 
   def get_end_products(_veteran_id)
-    end_product_data || END_PRODUCTS
+    end_product_data || end_product_defaults
   end
 
   # def get_eps(veteran_id)


### PR DESCRIPTION
When defining constants, the date_formats.rb file is not yet loaded,
which causes `to_formatted_s` to not use the proper format.

Solution was to create methods instead of constants to created the
test data in time.