### PR TITLE
Removing 'Send to RO' button, moving Cancel button to its position

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -389,9 +389,11 @@ export default class EstablishClaim extends BaseForm {
 
         <div className="cf-app-segment" id="establish-claim-buttons">
           <div className="cf-push-right">
-            <a href="#send_to_ro" className="cf-btn-link cf-adjacent-buttons">
-              Send to RO
-            </a>
+            <Button
+                name="Cancel"
+                onClick={this.handleCancelTask}
+                classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+            />
             <Button
               name={this.isAssociatePage() ? "Create New EP" : "Create End Product"}
               loading={loading}
@@ -410,11 +412,6 @@ export default class EstablishClaim extends BaseForm {
               />
             </div>
           }
-          <Button
-            name="Cancel"
-            onClick={this.handleCancelTask}
-            classNames={["cf-btn-link"]}
-          />
         </div>
         {cancelModalDisplay && <Modal
           buttons={[


### PR DESCRIPTION
This PR removes the 'Send to RO' button, and moves the 'Cancel' button to the right side of the screen on all of the dispatch form pages. 

Fixes #690 
Fixes #674 

- [ ] Unit tests pass
- [ ] Confirmed buttons are in the correct location on each page of the dispatch form