### PR TITLE
Fix modifiers

### DIFF
--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -6,13 +6,13 @@ class DevController < ApplicationController
 
   def set_end_products
     case params[:type]
-    when 'full'
+    when "full"
       BGSService.end_product_data = BGSService.existing_full_grants
-    when 'partial'
+    when "partial"
       BGSService.end_product_data = BGSService.existing_partial_grants
-    when 'none'
+    when "none"
       BGSService.end_product_data = BGSService.no_grants
-    when 'all'
+    when "all"
       BGSService.end_product_data = BGSService.all_grants
     end
 

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -3,4 +3,19 @@ class DevController < ApplicationController
     session["user"] = User.authentication_service.get_user_session(params[:id])
     redirect_to "/dev/users"
   end
+
+  def set_end_products
+    case params[:type]
+    when 'full'
+      BGSService.end_product_data = BGSService.existing_full_grants
+    when 'partial'
+      BGSService.end_product_data = BGSService.existing_partial_grants
+    when 'none'
+      BGSService.end_product_data = BGSService.no_grants
+    when 'all'
+      BGSService.end_product_data = BGSService.all_grants
+    end
+
+    redirect_to "/dev/users"
+  end
 end

--- a/app/controllers/dev_controller.rb
+++ b/app/controllers/dev_controller.rb
@@ -1,4 +1,5 @@
 class DevController < ApplicationController
+  # :nocov:
   def set_user
     session["user"] = User.authentication_service.get_user_session(params[:id])
     redirect_to "/dev/users"
@@ -18,4 +19,5 @@ class DevController < ApplicationController
 
     redirect_to "/dev/users"
   end
+  # :nocov:
 end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -223,8 +223,11 @@ class Appeal < ActiveRecord::Base
     end
   end
 
+  def bgs
+    @bgs ||= BGSService.new
+  end
+
   def pending_eps
-    bgs = BGSService.new
     end_products = Dispatch.filter_dispatch_end_products(
       bgs.get_end_products(sanitized_vbms_id))
 
@@ -232,7 +235,6 @@ class Appeal < ActiveRecord::Base
   end
 
   def non_canceled_end_products_within_30_days
-    bgs = BGSService.new
     end_products = Dispatch.filter_dispatch_end_products(
       bgs.get_end_products(sanitized_vbms_id))
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -207,19 +207,6 @@ class Appeal < ActiveRecord::Base
     @documents_by_type = {}
   end
 
-  def map_ep_values(end_products)
-    end_products.map do |end_product|
-      new_end_product = end_product.clone
-      new_end_product[:claim_type_code] = Appeal.map_end_product_value(
-        new_end_product[:claim_type_code],
-        Dispatch::END_PRODUCT_CODES)
-      new_end_product[:status_type_code] = Appeal.map_end_product_value(
-        new_end_product[:status_type_code],
-        Dispatch::END_PRODUCT_STATUS)
-      new_end_product
-    end
-  end
-
   def select_non_canceled_end_products_within_30_days(end_products)
     # Find all EPs with relevant type codes that are not canceled.
     end_products.select do |end_product|
@@ -241,7 +228,7 @@ class Appeal < ActiveRecord::Base
     end_products = Dispatch.filter_dispatch_end_products(
       bgs.get_end_products(sanitized_vbms_id))
 
-    map_ep_values(select_pending_eps(end_products))
+    Dispatch.map_ep_values(select_pending_eps(end_products))
   end
 
   def non_canceled_end_products_within_30_days
@@ -249,7 +236,7 @@ class Appeal < ActiveRecord::Base
     end_products = Dispatch.filter_dispatch_end_products(
       bgs.get_end_products(sanitized_vbms_id))
 
-    map_ep_values(select_non_canceled_end_products_within_30_days(end_products))
+    Dispatch.map_ep_values(select_non_canceled_end_products_within_30_days(end_products))
   end
 
   def sanitized_vbms_id

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -202,6 +202,19 @@ class Appeal < ActiveRecord::Base
     @documents_by_type = {}
   end
 
+  def map_ep_values(end_products)
+    end_products.map do |end_product|
+      new_end_product = end_product.clone
+      new_end_product[:claim_type_code] = Appeal.map_end_product_value(
+        new_end_product[:claim_type_code],
+        Dispatch::END_PRODUCT_CODES)
+      new_end_product[:status_type_code] = Appeal.map_end_product_value(
+        new_end_product[:status_type_code],
+        Dispatch::END_PRODUCT_STATUS)
+      new_end_product
+    end
+  end
+
   def select_non_canceled_end_products_within_30_days(end_products)
     # Find all EPs with relevant type codes that are not canceled.
     end_products.select do |end_product|
@@ -210,22 +223,27 @@ class Appeal < ActiveRecord::Base
     end
   end
 
+  def select_pending_eps(end_products)
+    # Find all pending EPs
+    end_products.select do |end_product|
+      end_product[:status_type_code] == "PEND"
+    end
+  end
+
+  def pending_eps
+    bgs = BGSService.new
+    end_products = Dispatch.filter_dispatch_end_products(
+      bgs.get_end_products(sanitized_vbms_id))
+
+    map_ep_values(select_pending_eps(end_products))
+  end
+
   def non_canceled_end_products_within_30_days
     bgs = BGSService.new
     end_products = Dispatch.filter_dispatch_end_products(
       bgs.get_end_products(sanitized_vbms_id))
 
-    select_non_canceled_end_products_within_30_days(end_products)
-      .map do |end_product|
-        new_end_product = end_product.clone
-        new_end_product[:claim_type_code] = Appeal.map_end_product_value(
-          new_end_product[:claim_type_code],
-          Dispatch::END_PRODUCT_CODES)
-        new_end_product[:status_type_code] = Appeal.map_end_product_value(
-          new_end_product[:status_type_code],
-          Dispatch::END_PRODUCT_STATUS)
-        new_end_product
-      end
+    map_ep_values(select_non_canceled_end_products_within_30_days(end_products))
   end
 
   def sanitized_vbms_id

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -185,7 +185,8 @@ class Task < ActiveRecord::Base
          :veteran_name,
          :decision_type,
          :regional_office_key,
-         :non_canceled_end_products_within_30_days] }],
+         :non_canceled_end_products_within_30_days,
+         :pending_eps] }],
       methods: [:progress_status]
     )
   end

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -149,13 +149,13 @@ class AppealRepository
   def self.establish_claim!(appeal:, claim:)
     @vbms_client ||= init_vbms_client
 
-    raw_veteran_record = BGSService.new.fetch_veteran_info(appeal.vbms_id)
+    sanitized_id = appeal.sanitized_vbms_id
+    raw_veteran_record = BGSService.new.fetch_veteran_info(sanitized_id)
 
     # Reduce keys in raw response down to what we specifically need for
     # establish claim
     veteran_record = parse_veteran_establish_claim_info(raw_veteran_record)
 
-    sanitized_id = appeal.sanitized_vbms_id
     request = VBMS::Requests::EstablishClaim.new(veteran_record, claim)
     end_product = send_and_log_request(sanitized_id, request)
 

--- a/app/services/dispatch.rb
+++ b/app/services/dispatch.rb
@@ -31,6 +31,19 @@ class Dispatch
     end
   end
 
+  def self.map_ep_values(end_products)
+    end_products.map do |end_product|
+      new_end_product = end_product.clone
+      new_end_product[:claim_type_code] = Appeal.map_end_product_value(
+        new_end_product[:claim_type_code],
+        Dispatch::END_PRODUCT_CODES)
+      new_end_product[:status_type_code] = Appeal.map_end_product_value(
+        new_end_product[:status_type_code],
+        Dispatch::END_PRODUCT_STATUS)
+      new_end_product
+    end
+  end
+
   def initialize(claim:, task:)
     @claim = Claim.new(claim)
     @task = task

--- a/app/views/dev_users/index.html.erb
+++ b/app/views/dev_users/index.html.erb
@@ -9,8 +9,8 @@
     </div>
     
     <div class="usa-width-one-half">
-	<h1>Page Links</h1>
-	<h2>Dispatch</h2>
+      <h1>Page Links</h1>
+      <h2>Dispatch</h2>
       <p><a href="/dispatch/establish-claim">Establish Claim</a></p>
       <h2>Certification</h2>
       <p><a href="/certifications/new/123C">Ready to Certify</a></p>
@@ -21,5 +21,16 @@
       <p><a href="/certifications/new/000ERR">VBMS Error</a></p>
       <p><a href="/certifications/new/001ERR">Ready to Certify</a></p>
     </div>
-  </div>  
+  </div>
+  <div class="usa-grid-full">
+    <div class="usa-width-one-half">
+      <h1>End Product Seed Data</h1>
+      <p><a href="/dev/set-end-products/?type=all">All Grants</a></p>
+      <p><a href="/dev/set-end-products/?type=none">No Grants</a></p>
+      <p><a href="/dev/set-end-products/?type=partial">Partial Grants</a></p>
+      <p><a href="/dev/set-end-products/?type=full">Full Grants</a></p>
+    </div>
+    <div class="usa-width-one-half">
+    </div>
+  </div>
 </div>

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -260,7 +260,7 @@ export default class EstablishClaim extends BaseForm {
    */
   validModifiers = () => {
     let modifiers = [];
-    let endProducts = this.props.task.appeal.non_canceled_end_products_within_30_days;
+    let endProducts = this.props.task.appeal.pending_eps;
 
     if (this.state.reviewForm.decisionType.value === 'Full Grant') {
       modifiers = FULL_GRANT_MODIFIER_OPTIONS;

--- a/client/test/containers/EstablishClaim-test.js
+++ b/client/test/containers/EstablishClaim-test.js
@@ -14,7 +14,8 @@ describe('EstablishClaim', () => {
       const task = {
         appeal: {
           decision_type: 'Remand',
-          non_canceled_end_products_within_30_days: []
+          non_canceled_end_products_within_30_days: [],
+          pending_eps: []
         },
         user: 'a'
       };

--- a/client/test/containers/EstablishClaim-test.js
+++ b/client/test/containers/EstablishClaim-test.js
@@ -53,7 +53,8 @@ describe('EstablishClaim', () => {
       const task = {
         appeal: {
           decision_type: 'Remand',
-          non_canceled_end_products_within_30_days: []
+          non_canceled_end_products_within_30_days: [],
+          pending_eps: []
         },
         user: 'a'
       };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     scope "/dev" do
       get '/users', to: "dev_users#index"
       post '/set-user/:id', to: "dev#set_user", as: 'set_user'
+      get '/set-end-products', to: "dev#set_end_products", as: 'set_end_products'
     end
   end
   # :nocov:

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -2,7 +2,7 @@ class Fakes::BGSService
   cattr_accessor :end_product_data
   attr_accessor :client
 
-  END_PRODUCTS =
+  def self.all_grants
     [
       {
         benefit_claim_id: "1",
@@ -36,89 +36,141 @@ class Fakes::BGSService
         benefit_claim_id: "5",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "170APPACT",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "6",
-        claim_receive_date: Time.zone.now - 10.days,
+        claim_receive_date: Time.zone.now - 200.days,
         claim_type_code: "170APPACTPMC",
+        end_product_type_code: "171",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "7",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "170PGAMC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "8",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "170RMD",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "9",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "170RMDAMC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "10",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "170RMDPMC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "11",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "172GRANT",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "12",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "172BVAG",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "13",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "172BVAGPMC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "14",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "400CORRC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "15",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "400CORRCPMC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "16",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "930RC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "17",
         claim_receive_date: Time.zone.now - 10.days,
         claim_type_code: "930RCPMC",
+        end_product_type_code: "170",
         status_type_code: "PEND"
       }
-    ].freeze
-
-  def get_end_products(_veteran_id)
-    end_product_data || END_PRODUCTS
+    ]
   end
 
-  # def get_eps(veteran_id)
-  #   # What is the endpoint?
-  # end
+  def self.existing_full_grants
+    [
+      {
+        benefit_claim_id: "1",
+        claim_receive_date: Time.zone.now - 20.days,
+        claim_type_code: "172GRANT",
+        end_product_type_code: "172",
+        status_type_code: "PEND"
+      }
+    ]
+  end
+
+  def self.existing_partial_grants
+    [
+      {
+        benefit_claim_id: "1",
+        claim_receive_date: Time.zone.now + 10.days,
+        claim_type_code: "170RMD",
+        end_product_type_code: "170",
+        status_type_code: "PEND"
+      },
+      {
+        benefit_claim_id: "2",
+        claim_receive_date: Time.zone.now + 10.days,
+        claim_type_code: "170RMD",
+        end_product_type_code: "171",
+        status_type_code: "CLR"
+      },
+      {
+        benefit_claim_id: "3",
+        claim_receive_date: Time.zone.now - 200.days,
+        claim_type_code: "170RMD",
+        end_product_type_code: "175",
+        status_type_code: "PEND"
+      }
+    ]
+  end
+
+  def self.no_grants
+    []
+  end
+
+  def get_end_products(_veteran_id)
+    end_product_data || all_grants
+  end
 
   # rubocop:disable Metrics/MethodLength
   def fetch_veteran_info(_)

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -169,7 +169,7 @@ class Fakes::BGSService
   end
 
   def get_end_products(_veteran_id)
-    end_product_data || all_grants
+    end_product_data || no_grants
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -132,7 +132,7 @@ class Fakes::BGSService
     [
       {
         benefit_claim_id: "1",
-        claim_receive_date: Time.zone.now - 20.days,
+        claim_receive_date: 20.days.ago.to_formatted_s(:short_date),
         claim_type_code: "172GRANT",
         end_product_type_code: "172",
         status_type_code: "PEND"
@@ -144,21 +144,21 @@ class Fakes::BGSService
     [
       {
         benefit_claim_id: "1",
-        claim_receive_date: Time.zone.now + 10.days,
+        claim_receive_date: 10.days.ago.to_formatted_s(:short_date),
         claim_type_code: "170RMD",
         end_product_type_code: "170",
         status_type_code: "PEND"
       },
       {
         benefit_claim_id: "2",
-        claim_receive_date: Time.zone.now + 10.days,
+        claim_receive_date: 10.days.ago.to_formatted_s(:short_date),
         claim_type_code: "170RMD",
         end_product_type_code: "171",
         status_type_code: "CLR"
       },
       {
         benefit_claim_id: "3",
-        claim_receive_date: Time.zone.now - 200.days,
+        claim_receive_date: 200.days.ago.to_formatted_s(:short_date),
         claim_type_code: "170RMD",
         end_product_type_code: "175",
         status_type_code: "PEND"
@@ -171,7 +171,7 @@ class Fakes::BGSService
   end
 
   def get_end_products(_veteran_id)
-    end_product_data || no_grants
+    end_product_data || self.class.no_grants
   end
 
   def fetch_veteran_info(_)

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -193,7 +193,7 @@ RSpec.feature "Dispatch" do
       end
     end
 
-    context "Add existing Full Grant & Partial Grant EPs", focus: true do
+    context "Add existing Full Grant & Partial Grant EPs" do
       before do
         BGSService.end_product_data =
           [

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -193,7 +193,7 @@ RSpec.feature "Dispatch" do
       end
     end
 
-    context "Add existing Full Grant & Partial Grant EPs" do
+    context "Add existing Full Grant & Partial Grant EPs", focus: true do
       before do
         BGSService.end_product_data =
           [
@@ -209,7 +209,7 @@ RSpec.feature "Dispatch" do
               claim_receive_date: 10.days.from_now.to_formatted_s(:short_date),
               claim_type_code: "170RMD",
               end_product_type_code: "170",
-              status_type_code: "CLR"
+              status_type_code: "PEND"
             }
           ]
       end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1,4 +1,4 @@
-describe Appeal, focus: true do
+describe Appeal do
   let(:yesterday) { 1.day.ago.to_formatted_s(:short_date) }
   let(:twenty_days_ago) { 20.days.ago.to_formatted_s(:short_date) }
   let(:last_year) { 365.days.ago.to_formatted_s(:short_date) }
@@ -459,7 +459,7 @@ describe Appeal, focus: true do
         }
       ]
     end
-    it do
+    it "filters eps that are not canceled and were created within 30 days" do
       expect(appeal.non_canceled_end_products_within_30_days)
         .to eq(end_products.slice(0, 2))
     end
@@ -512,7 +512,7 @@ describe Appeal, focus: true do
         }
       ]
     end
-    it do
+    it "filters onlying pending eps" do
       expect(appeal.pending_eps)
         .to eq(end_products.slice(0, 2))
     end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1,4 +1,4 @@
-describe Appeal do
+describe Appeal, focus: true do
   let(:yesterday) { 1.day.ago.to_formatted_s(:short_date) }
   let(:twenty_days_ago) { 20.days.ago.to_formatted_s(:short_date) }
   let(:last_year) { 365.days.ago.to_formatted_s(:short_date) }

--- a/spec/services/dispatch_spec.rb
+++ b/spec/services/dispatch_spec.rb
@@ -1,5 +1,8 @@
 describe Dispatch do
-  context "#filter_dispatch_end_products" do
+  let(:twenty_days_ago) { 20.days.ago.to_formatted_s(:short_date) }
+  let(:last_year) { 365.days.ago.to_formatted_s(:short_date) }
+
+  context ".filter_dispatch_end_products" do
     let(:end_products) do
       [{ claim_type_code: "170APPACT" },
        { claim_type_code: "170APPACTPMC" },
@@ -24,6 +27,43 @@ describe Dispatch do
 
     it "filters out non-dispatch end products" do
       is_expected.to eq(end_products)
+    end
+  end
+
+  context ".map_ep_values" do
+    let(:end_products_output) do
+      [
+        {
+          claim_receive_date: twenty_days_ago,
+          claim_type_code: "PMC-BVA Grant",
+          status_type_code: "Pending"
+        },
+        {
+          claim_receive_date: last_year,
+          claim_type_code: "Rating Control",
+          status_type_code: "Canceled"
+        }
+      ]
+    end
+    subject { Dispatch.map_ep_values(end_products_input) }
+
+    let(:end_products_input) do
+      [
+        {
+          claim_receive_date: twenty_days_ago,
+          claim_type_code: "172BVAGPMC",
+          status_type_code: "PEND"
+        },
+        {
+          claim_receive_date: last_year,
+          claim_type_code: "930RC",
+          status_type_code: "CAN"
+        }
+      ]
+    end
+
+    it "correctly maps abbreviations to strings" do
+      is_expected.to eq(end_products_output)
     end
   end
 end


### PR DESCRIPTION
Currently modifiers are restricted by cleared EPs, and not restricted by pending EPs created outside the past thirty days. This PR selects the available modifiers by looking at all pending EPs. Also, adding links to the dev/set-users page to modify EP data.

**Test Plan**
- [ ] Verify manually by using EP data that contains a cleared EP, and an old pending EP and making sure they effect the available modifiers.
- [ ] Run test suite