### PR TITLE
Update npm-shrinkwrap and readme

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -14,11 +14,17 @@ The frontend code is compiled using [Webpack](https://webpack.github.io/) & [Bab
 
 Caseflow's frontend uses npm (Node Package Manager) to manage its JS dependencies. Similar to Rail's Gemfile, the frontend manages its dependencies via a `package.json` file located in `/client`. You can search for JS libraries on [NPM's website](https://www.npmjs.com/). To add a new dependency:
 
-> $ npm install new-library --save
+> $ npm install <new-library> --save
 
-This will add information about the library to the `package.json`. Then to install the new dependency:
+Ensure the dependency management file  (npm-shrinkwrap.json) is updated:
 
-> $ npm install
+> $ npm shrinkwrap
+
+If you run into any errors with extraneous files run:
+
+> $ npm prune
+
+Please make sure to commit changes to the package.json and npm-shrinkwrap.json together.
 
 ## Styling
 

--- a/client/README.md
+++ b/client/README.md
@@ -16,7 +16,7 @@ Caseflow's frontend uses npm (Node Package Manager) to manage its JS dependencie
 
 > $ npm install <new-library> --save
 
-Ensure the dependency management file  (npm-shrinkwrap.json) is updated:
+The above command will update the package.json and install the module to the `/node_modules` directory. However, this does not guarantee a deterministic install, especially when multiple modules have the same dependency module. To ensure consist installation of npm modules, we use [npm shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap). After installing a new package (updating package.json) you must also ensure the dependency management file (`npm-shrinkwrap.json`) is updated:
 
 > $ npm shrinkwrap
 
@@ -24,6 +24,7 @@ If you run into any errors with extraneous files run:
 
 > $ npm prune
 
+When doing a fresh `npm install` of all packages, if a valid `npm-shrinkwrap.json` file exists, it will be used to deterministically install packaged.
 Please make sure to commit changes to the package.json and npm-shrinkwrap.json together.
 
 ## Styling

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -2274,15 +2274,15 @@
           "from": "combined-stream@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
         },
-        "commander": {
-          "version": "2.9.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
-        },
         "concat-map": {
           "version": "0.0.1",
           "from": "concat-map@0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -2449,15 +2449,15 @@
           "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
-        "is-property": {
-          "version": "1.0.2",
-          "from": "is-property@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-        },
         "is-my-json-valid": {
           "version": "2.13.1",
           "from": "is-my-json-valid@>=2.12.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "from": "is-property@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -5164,11 +5164,6 @@
       "version": "3.0.0",
       "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-    },
-    "strip-json-comments": {
-      "version": "1.0.4",
-      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "superagent": {
       "version": "3.0.0",

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -4,116 +4,99 @@
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
-      "from": "abbrev@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
     },
     "acorn": {
       "version": "4.0.4",
-      "from": "acorn@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.4.tgz"
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "dev": true,
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "from": "acorn@>=3.0.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         }
       }
     },
     "ajv": {
       "version": "4.10.0",
-      "from": "ajv@>=4.7.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ajv/-/ajv-4.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.10.0.tgz"
     },
     "ajv-keywords": {
       "version": "1.3.0",
-      "from": "ajv-keywords@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.3.0.tgz"
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "from": "ansi-escapes@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
     },
     "ansi-regex": {
       "version": "2.0.0",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
     },
     "ansicolors": {
       "version": "0.2.1",
-      "from": "ansicolors@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
     },
     "argparse": {
       "version": "1.0.9",
-      "from": "argparse@>=1.0.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
     },
     "array-find": {
       "version": "0.1.1",
-      "from": "array-find@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/array-find/-/array-find-0.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/array-find/-/array-find-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-0.1.1.tgz"
     },
     "array-flatten": {
       "version": "2.1.0",
-      "from": "array-flatten@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.0.tgz"
     },
     "array-union": {
       "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz"
     },
     "array-uniq": {
       "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
     },
     "assertion-error": {
       "version": "1.0.2",
-      "from": "assertion-error@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
     },
     "babel": {
       "version": "6.5.2",
-      "from": "babel@>=6.5.2 <7.0.0",
+      "from": "https://registry.npmjs.org/babel/-/babel-6.5.2.tgz",
       "resolved": "https://registry.npmjs.org/babel/-/babel-6.5.2.tgz"
     },
     "babel-cli": {
       "version": "6.18.0",
-      "from": "babel-cli@>=6.6.5 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.18.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.18.0.tgz",
       "dependencies": {
         "babel-register": {
@@ -121,21 +104,11 @@
           "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
           "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
             "home-or-tmp": {
               "version": "2.0.0",
               "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
               "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
                 "os-tmpdir": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -143,400 +116,10 @@
                 }
               }
             },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
             "source-map-support": {
               "version": "0.4.6",
               "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz",
               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.6.tgz"
-            }
-          }
-        },
-        "chokidar": {
-          "version": "1.6.1",
-          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
-          "optional": true,
-          "dependencies": {
-            "anymatch": {
-              "version": "1.3.0",
-              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-              "optional": true,
-              "dependencies": {
-                "arrify": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                  "optional": true
-                },
-                "micromatch": {
-                  "version": "2.3.11",
-                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                  "optional": true,
-                  "dependencies": {
-                    "arr-diff": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "arr-flatten": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
-                          "optional": true
-                        }
-                      }
-                    },
-                    "array-unique": {
-                      "version": "0.2.1",
-                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-                      "optional": true
-                    },
-                    "braces": {
-                      "version": "1.8.5",
-                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "expand-range": {
-                          "version": "1.8.2",
-                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                          "optional": true,
-                          "dependencies": {
-                            "fill-range": {
-                              "version": "2.2.3",
-                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                              "optional": true,
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "2.1.0",
-                                  "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-                                },
-                                "isobject": {
-                                  "version": "2.1.0",
-                                  "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                  "optional": true,
-                                  "dependencies": {
-                                    "isarray": {
-                                      "version": "1.0.0",
-                                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                      "optional": true
-                                    }
-                                  }
-                                },
-                                "randomatic": {
-                                  "version": "1.1.5",
-                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
-                                  "optional": true
-                                },
-                                "repeat-string": {
-                                  "version": "1.6.1",
-                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-                                  "optional": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "preserve": {
-                          "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-                          "optional": true
-                        },
-                        "repeat-element": {
-                          "version": "1.1.2",
-                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                        }
-                      }
-                    },
-                    "expand-brackets": {
-                      "version": "0.1.5",
-                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "is-posix-bracket": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-                          "optional": true
-                        }
-                      }
-                    },
-                    "extglob": {
-                      "version": "0.3.2",
-                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-                      "optional": true
-                    },
-                    "filename-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
-                      "optional": true
-                    },
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    },
-                    "kind-of": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
-                      "dependencies": {
-                        "is-buffer": {
-                          "version": "1.1.4",
-                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
-                        }
-                      }
-                    },
-                    "normalize-path": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
-                      "optional": true
-                    },
-                    "object.omit": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "for-own": {
-                          "version": "0.1.4",
-                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
-                          "optional": true,
-                          "dependencies": {
-                            "for-in": {
-                              "version": "0.1.6",
-                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
-                              "optional": true
-                            }
-                          }
-                        },
-                        "is-extendable": {
-                          "version": "0.1.1",
-                          "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-                          "optional": true
-                        }
-                      }
-                    },
-                    "parse-glob": {
-                      "version": "3.0.4",
-                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "glob-base": {
-                          "version": "0.3.0",
-                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                          "optional": true
-                        },
-                        "is-dotfile": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
-                          "optional": true
-                        }
-                      }
-                    },
-                    "regex-cache": {
-                      "version": "0.4.3",
-                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "is-equal-shallow": {
-                          "version": "0.1.3",
-                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-                          "optional": true
-                        },
-                        "is-primitive": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "async-each": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-              "optional": true
-            },
-            "glob-parent": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "is-binary-path": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-              "optional": true,
-              "dependencies": {
-                "binary-extensions": {
-                  "version": "1.7.0",
-                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz",
-                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz",
-                  "optional": true
-                }
-              }
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                }
-              }
-            },
-            "readdirp": {
-              "version": "2.1.0",
-              "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-              "optional": true,
-              "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                  "optional": true
-                },
-                "minimatch": {
-                  "version": "3.0.3",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "optional": true,
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.6",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "optional": true,
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "0.4.2",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "optional": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "optional": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                  "optional": true,
-                  "dependencies": {
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                      "optional": true
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "optional": true
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "optional": true
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "optional": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "optional": true
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "optional": true
-                    }
-                  }
-                },
-                "set-immediate-shim": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-                  "optional": true
-                }
-              }
-            }
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
             }
           }
         },
@@ -553,101 +136,12 @@
         "glob": {
           "version": "5.0.15",
           "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "dependencies": {
-            "inflight": {
-              "version": "1.0.6",
-              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.3",
-              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.6",
-                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "lodash": {
-          "version": "4.17.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
         },
         "output-file-sync": {
           "version": "1.1.2",
           "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
-          "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz"
         },
         "slash": {
           "version": "1.0.0",
@@ -670,82 +164,260 @@
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
+        },
+        "chokidar": {
+          "version": "1.6.1",
+          "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "dependencies": {
+                "micromatch": {
+                  "version": "2.3.11",
+                  "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                      "dependencies": {
+                        "arr-flatten": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "array-unique": {
+                      "version": "0.2.1",
+                      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                    },
+                    "braces": {
+                      "version": "1.8.5",
+                      "from": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.2",
+                          "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.3",
+                              "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "2.1.0",
+                                  "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                },
+                                "isobject": {
+                                  "version": "2.1.0",
+                                  "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+                                },
+                                "randomatic": {
+                                  "version": "1.1.5",
+                                  "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                      "dependencies": {
+                        "is-posix-bracket": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "extglob": {
+                      "version": "0.3.2",
+                      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz",
+                      "dependencies": {
+                        "is-buffer": {
+                          "version": "1.1.4",
+                          "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                        }
+                      }
+                    },
+                    "normalize-path": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
+                    },
+                    "object.omit": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.4",
+                          "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.4.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.6",
+                              "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.6.tgz"
+                            }
+                          }
+                        },
+                        "is-extendable": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.4",
+                      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.3.0",
+                          "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.2",
+                          "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.3",
+                      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "async-each": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+            },
+            "glob-parent": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.7.0",
+                  "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.7.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                }
+              }
+            },
+            "readdirp": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+              "dependencies": {
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                }
+              }
+            }
+          }
         }
       }
     },
     "babel-code-frame": {
       "version": "6.20.0",
-      "from": "babel-code-frame@>=6.20.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.20.0.tgz"
     },
     "babel-core": {
       "version": "6.18.2",
-      "from": "babel-core@>=6.7.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.18.2.tgz",
       "dependencies": {
         "babel-code-frame": {
           "version": "6.16.0",
           "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "js-tokens": {
-              "version": "2.0.0",
-              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
         },
         "babel-generator": {
           "version": "6.19.0",
@@ -765,14 +437,7 @@
                     "is-finite": {
                       "version": "1.0.2",
                       "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
                     }
                   }
                 }
@@ -790,47 +455,25 @@
           "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.16.0.tgz"
         },
-        "babel-messages": {
-          "version": "6.8.0",
-          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+        "babel-template": {
+          "version": "6.16.0",
+          "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
         },
         "babel-register": {
           "version": "6.18.0",
           "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.18.0.tgz",
           "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
             "home-or-tmp": {
               "version": "2.0.0",
               "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
               "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
                 "os-tmpdir": {
                   "version": "1.0.2",
                   "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
@@ -841,63 +484,15 @@
             }
           }
         },
-        "babel-template": {
-          "version": "6.16.0",
-          "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
-        },
         "babel-traverse": {
           "version": "6.19.0",
           "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-          "dependencies": {
-            "globals": {
-              "version": "9.14.0",
-              "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-              "dependencies": {
-                "loose-envify": {
-                  "version": "1.3.0",
-                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                  "dependencies": {
-                    "js-tokens": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz"
         },
         "babel-types": {
           "version": "6.19.0",
           "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-          "dependencies": {
-            "esutils": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "to-fast-properties": {
-              "version": "1.0.2",
-              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-            }
-          }
-        },
-        "babylon": {
-          "version": "6.14.1",
-          "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
         },
         "convert-source-map": {
           "version": "1.3.0",
@@ -907,53 +502,12 @@
         "debug": {
           "version": "2.3.3",
           "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.2",
-              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-            }
-          }
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
         },
         "json5": {
           "version": "0.5.0",
           "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
-        },
-        "lodash": {
-          "version": "4.17.2",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.3",
-          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.6",
-              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "0.4.2",
-                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
         },
         "private": {
           "version": "0.1.6",
@@ -972,15 +526,9 @@
         }
       }
     },
-    "babel-eslint": {
-      "version": "6.1.2",
-      "from": "babel-eslint@>=6.1.2 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
-      "dev": true
-    },
     "babel-loader": {
       "version": "6.2.8",
-      "from": "babel-loader@>=6.2.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.8.tgz",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.2.8.tgz",
       "dependencies": {
         "find-cache-dir": {
@@ -1007,18 +555,6 @@
                       "version": "2.1.0",
                       "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                        }
-                      }
                     }
                   }
                 }
@@ -1047,42 +583,19 @@
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
             }
           }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         }
       }
     },
     "babel-messages": {
       "version": "6.8.0",
-      "from": "babel-messages@>=6.8.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
     },
     "babel-polyfill": {
       "version": "6.16.0",
-      "from": "babel-polyfill@>=6.7.4 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.16.0.tgz",
       "dependencies": {
-        "core-js": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-        },
         "regenerator-runtime": {
           "version": "0.9.6",
           "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
@@ -1092,7 +605,7 @@
     },
     "babel-preset-es2015": {
       "version": "6.18.0",
-      "from": "babel-preset-es2015@>=6.6.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz",
       "dependencies": {
         "babel-plugin-check-es2015-constants": {
@@ -1115,18 +628,6 @@
           "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz",
           "dependencies": {
-            "babel-template": {
-              "version": "6.16.0",
-              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                }
-              }
-            },
             "babel-traverse": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
@@ -1135,135 +636,24 @@
                 "babel-code-frame": {
                   "version": "6.16.0",
                   "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.8.0",
-                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                 },
                 "debug": {
                   "version": "2.3.3",
                   "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.14.0",
-                  "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             },
-            "lodash": {
-              "version": "4.17.2",
-              "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+            "babel-template": {
+              "version": "6.16.0",
+              "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
             }
           }
         },
@@ -1272,17 +662,10 @@
           "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.18.0.tgz",
           "dependencies": {
-            "babel-helper-define-map": {
+            "babel-helper-optimise-call-expression": {
               "version": "6.18.0",
-              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                }
-              }
+              "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
             },
             "babel-helper-function-name": {
               "version": "6.18.0",
@@ -1296,37 +679,15 @@
                 }
               }
             },
-            "babel-helper-optimise-call-expression": {
-              "version": "6.18.0",
-              "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
-            },
             "babel-helper-replace-supers": {
               "version": "6.18.0",
               "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.18.0.tgz"
             },
-            "babel-messages": {
-              "version": "6.8.0",
-              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-            },
             "babel-template": {
               "version": "6.16.0",
               "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
             },
             "babel-traverse": {
               "version": "6.19.0",
@@ -1336,135 +697,24 @@
                 "babel-code-frame": {
                   "version": "6.16.0",
                   "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                 },
                 "debug": {
                   "version": "2.3.3",
                   "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.14.0",
-                  "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                 }
               }
+            },
+            "babel-helper-define-map": {
+              "version": "6.18.0",
+              "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz"
             },
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             }
           }
         },
@@ -1478,16 +728,16 @@
               "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
               "dependencies": {
+                "babel-types": {
+                  "version": "6.19.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
+                },
                 "babel-helper-function-name": {
                   "version": "6.18.0",
                   "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                   "dependencies": {
-                    "babel-helper-get-function-arity": {
-                      "version": "6.18.0",
-                      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
-                    },
                     "babel-traverse": {
                       "version": "6.19.0",
                       "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
@@ -1496,137 +746,21 @@
                         "babel-code-frame": {
                           "version": "6.16.0",
                           "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.8.0",
-                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.14.1",
-                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                         },
                         "debug": {
                           "version": "2.3.3",
                           "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.2",
-                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "9.14.0",
-                          "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.2",
-                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.3.0",
-                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                         }
                       }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.19.0",
-                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
                     },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+                    "babel-helper-get-function-arity": {
+                      "version": "6.18.0",
+                      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
                     }
                   }
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
                 }
               }
             },
@@ -1643,135 +777,19 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             }
@@ -1790,24 +808,7 @@
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             }
           }
         },
@@ -1826,28 +827,6 @@
               "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
               "dependencies": {
-                "babel-helper-get-function-arity": {
-                  "version": "6.18.0",
-                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
-                },
-                "babel-template": {
-                  "version": "6.16.0",
-                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.14.1",
-                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                    }
-                  }
-                },
                 "babel-traverse": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
@@ -1856,142 +835,31 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.14.1",
-                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.18.0",
+                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
+                },
+                "babel-template": {
+                  "version": "6.16.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
                 }
               }
             },
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             }
           }
         },
@@ -2018,135 +886,19 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             }
@@ -2157,10 +909,10 @@
           "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.18.0.tgz",
           "dependencies": {
-            "babel-plugin-transform-strict-mode": {
-              "version": "6.18.0",
-              "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz"
+            "babel-types": {
+              "version": "6.19.0",
+              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             },
             "babel-template": {
               "version": "6.16.0",
@@ -2175,142 +927,21 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
                 }
               }
             },
-            "babel-types": {
-              "version": "6.19.0",
-              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.18.0",
+              "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.18.0.tgz"
             }
           }
         },
@@ -2319,35 +950,6 @@
           "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.19.0.tgz",
           "dependencies": {
-            "babel-helper-hoist-variables": {
-              "version": "6.18.0",
-              "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
-              "dependencies": {
-                "babel-types": {
-                  "version": "6.19.0",
-                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
             "babel-template": {
               "version": "6.16.0",
               "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
@@ -2361,135 +963,31 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
+                }
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.18.0",
+              "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.18.0.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.19.0",
+                  "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             }
@@ -2513,135 +1011,19 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.8.0",
-                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
                 },
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             }
@@ -2662,28 +1044,6 @@
                   "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.18.0.tgz"
                 },
-                "babel-messages": {
-                  "version": "6.8.0",
-                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                },
-                "babel-template": {
-                  "version": "6.16.0",
-                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.14.1",
-                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                    }
-                  }
-                },
                 "babel-traverse": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
@@ -2692,135 +1052,24 @@
                     "babel-code-frame": {
                       "version": "6.16.0",
                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "babylon": {
-                      "version": "6.14.1",
-                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                     },
                     "debug": {
                       "version": "2.3.3",
                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "0.7.2",
-                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.14.0",
-                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.0",
-                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                     }
                   }
+                },
+                "babel-template": {
+                  "version": "6.16.0",
+                  "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
                 },
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             }
@@ -2831,6 +1080,23 @@
           "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.18.0.tgz",
           "dependencies": {
+            "babel-traverse": {
+              "version": "6.19.0",
+              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.16.0",
+                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
+                },
+                "debug": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+                }
+              }
+            },
             "babel-helper-call-delegate": {
               "version": "6.18.0",
               "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.18.0.tgz",
@@ -2851,162 +1117,12 @@
             "babel-template": {
               "version": "6.16.0",
               "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                }
-              }
-            },
-            "babel-traverse": {
-              "version": "6.19.0",
-              "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.16.0",
-                  "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.8.0",
-                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                },
-                "babylon": {
-                  "version": "6.14.1",
-                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                },
-                "debug": {
-                  "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "0.7.2",
-                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.14.0",
-                  "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.0",
-                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
             },
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             }
           }
         },
@@ -3018,24 +1134,7 @@
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             }
           }
         },
@@ -3052,36 +1151,12 @@
             "babel-helper-regex": {
               "version": "6.18.0",
               "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz",
-              "dependencies": {
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.18.0.tgz"
             },
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             }
           }
         },
@@ -3108,24 +1183,7 @@
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             },
@@ -3168,24 +1226,7 @@
             "babel-types": {
               "version": "6.19.0",
               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                }
-              }
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
             },
             "private": {
               "version": "0.1.6",
@@ -3198,7 +1239,7 @@
     },
     "babel-preset-react": {
       "version": "6.16.0",
-      "from": "babel-preset-react@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
       "dependencies": {
         "babel-plugin-syntax-flow": {
@@ -3234,44 +1275,27 @@
                 "babel-types": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                  "dependencies": {
-                    "to-fast-properties": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "lodash": {
-                  "version": "4.17.2",
-                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                 }
               }
             }
           }
         },
-        "babel-plugin-transform-react-jsx-self": {
-          "version": "6.11.0",
-          "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
-          "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz"
-        },
         "babel-plugin-transform-react-jsx-source": {
           "version": "6.9.0",
           "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.9.0.tgz"
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.11.0",
+          "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.11.0.tgz"
         }
       }
     },
     "babel-preset-stage-0": {
       "version": "6.16.0",
-      "from": "babel-preset-stage-0@>=6.5.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.16.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.16.0.tgz",
       "dependencies": {
         "babel-plugin-transform-do-expressions": {
@@ -3308,11 +1332,6 @@
               "from": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.18.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.18.0.tgz",
               "dependencies": {
-                "babel-plugin-syntax-class-constructor-call": {
-                  "version": "6.18.0",
-                  "from": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz"
-                },
                 "babel-template": {
                   "version": "6.16.0",
                   "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
@@ -3326,137 +1345,26 @@
                         "babel-code-frame": {
                           "version": "6.16.0",
                           "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "2.0.0",
-                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.8.0",
-                          "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                         },
                         "debug": {
                           "version": "2.3.3",
                           "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "0.7.2",
-                              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "9.14.0",
-                          "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                          "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.2",
-                          "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.3.0",
-                              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                         }
                       }
                     },
                     "babel-types": {
                       "version": "6.19.0",
                       "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                      "dependencies": {
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babylon": {
-                      "version": "6.14.1",
-                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                    },
-                    "lodash": {
-                      "version": "4.17.2",
-                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                     }
                   }
+                },
+                "babel-plugin-syntax-class-constructor-call": {
+                  "version": "6.18.0",
+                  "from": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz"
                 }
               }
             },
@@ -3477,11 +1385,6 @@
               "from": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.18.0.tgz",
               "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.18.0.tgz",
               "dependencies": {
-                "babel-plugin-syntax-dynamic-import": {
-                  "version": "6.18.0",
-                  "from": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
-                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz"
-                },
                 "babel-plugin-transform-class-properties": {
                   "version": "6.19.0",
                   "from": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.19.0.tgz",
@@ -3492,10 +1395,10 @@
                       "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                       "dependencies": {
-                        "babel-helper-get-function-arity": {
-                          "version": "6.18.0",
-                          "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
+                        "babel-types": {
+                          "version": "6.19.0",
+                          "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                         },
                         "babel-traverse": {
                           "version": "6.19.0",
@@ -3505,140 +1408,19 @@
                             "babel-code-frame": {
                               "version": "6.16.0",
                               "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.2.1",
-                                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.5",
-                                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.1",
-                                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.8.0",
-                              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.14.1",
-                              "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                             },
                             "debug": {
                               "version": "2.3.3",
                               "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.2",
-                                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "9.14.0",
-                              "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash": {
-                              "version": "4.17.2",
-                              "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                             }
                           }
                         },
-                        "babel-types": {
-                          "version": "6.19.0",
-                          "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "lodash": {
-                              "version": "4.17.2",
-                              "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                            }
-                          }
+                        "babel-helper-get-function-arity": {
+                          "version": "6.18.0",
+                          "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+                          "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
                         }
                       }
                     },
@@ -3660,135 +1442,19 @@
                             "babel-code-frame": {
                               "version": "6.16.0",
                               "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.2.1",
-                                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.5",
-                                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.1",
-                                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.8.0",
-                              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                             },
                             "debug": {
                               "version": "2.3.3",
                               "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.2",
-                                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "9.14.0",
-                              "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                             }
                           }
                         },
                         "babel-types": {
                           "version": "6.19.0",
                           "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "babylon": {
-                          "version": "6.14.1",
-                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                        },
-                        "lodash": {
-                          "version": "4.17.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                         }
                       }
                     }
@@ -3799,6 +1465,11 @@
                   "from": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.13.0.tgz",
                   "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.13.0.tgz",
                   "dependencies": {
+                    "babel-types": {
+                      "version": "6.19.0",
+                      "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
+                    },
                     "babel-helper-define-map": {
                       "version": "6.18.0",
                       "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.18.0.tgz",
@@ -3809,11 +1480,6 @@
                           "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                           "dependencies": {
-                            "babel-helper-get-function-arity": {
-                              "version": "6.18.0",
-                              "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
-                            },
                             "babel-traverse": {
                               "version": "6.19.0",
                               "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
@@ -3822,251 +1488,19 @@
                                 "babel-code-frame": {
                                   "version": "6.16.0",
                                   "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.3",
-                                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.2.1",
-                                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.5",
-                                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.1",
-                                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.8.0",
-                                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.14.1",
-                                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                                 },
                                 "debug": {
                                   "version": "2.3.3",
                                   "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.2",
-                                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "9.14.0",
-                                  "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.2",
-                                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.3.0",
-                                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "lodash": {
-                          "version": "4.17.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-helper-explode-class": {
-                      "version": "6.18.0",
-                      "from": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz",
-                      "dependencies": {
-                        "babel-helper-bindify-decorators": {
-                          "version": "6.18.0",
-                          "from": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz"
-                        },
-                        "babel-traverse": {
-                          "version": "6.19.0",
-                          "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.16.0",
-                              "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.2.1",
-                                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.5",
-                                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.1",
-                                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                                 }
                               }
                             },
-                            "babel-messages": {
-                              "version": "6.8.0",
-                              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.14.1",
-                              "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                            },
-                            "debug": {
-                              "version": "2.3.3",
-                              "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.2",
-                                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "9.14.0",
-                              "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "lodash": {
-                              "version": "4.17.2",
-                              "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                            "babel-helper-get-function-arity": {
+                              "version": "6.18.0",
+                              "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+                              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
                             }
                           }
                         }
@@ -4076,6 +1510,35 @@
                       "version": "6.13.0",
                       "from": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz"
+                    },
+                    "babel-helper-explode-class": {
+                      "version": "6.18.0",
+                      "from": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz",
+                      "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.18.0.tgz",
+                      "dependencies": {
+                        "babel-traverse": {
+                          "version": "6.19.0",
+                          "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+                          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.19.0.tgz",
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.16.0",
+                              "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
+                            },
+                            "debug": {
+                              "version": "2.3.3",
+                              "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
+                            }
+                          }
+                        },
+                        "babel-helper-bindify-decorators": {
+                          "version": "6.18.0",
+                          "from": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz",
+                          "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.18.0.tgz"
+                        }
+                      }
                     },
                     "babel-template": {
                       "version": "6.16.0",
@@ -4090,144 +1553,23 @@
                             "babel-code-frame": {
                               "version": "6.16.0",
                               "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.3",
-                                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.2.1",
-                                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.5",
-                                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.1",
-                                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "2.0.0",
-                                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.8.0",
-                              "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
+                              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                             },
                             "debug": {
                               "version": "2.3.3",
                               "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "0.7.2",
-                                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "9.14.0",
-                              "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                              "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.2",
-                              "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.3.0",
-                                  "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                             }
                           }
-                        },
-                        "babylon": {
-                          "version": "6.14.1",
-                          "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                        },
-                        "lodash": {
-                          "version": "4.17.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-types": {
-                      "version": "6.19.0",
-                      "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                      "dependencies": {
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "lodash": {
-                          "version": "4.17.2",
-                          "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
                         }
                       }
                     }
                   }
+                },
+                "babel-plugin-syntax-dynamic-import": {
+                  "version": "6.18.0",
+                  "from": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+                  "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz"
                 },
                 "babel-preset-stage-3": {
                   "version": "6.17.0",
@@ -4249,34 +1591,15 @@
                           "from": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz",
                           "dependencies": {
-                            "babel-helper-function-name": {
-                              "version": "6.18.0",
-                              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-                              "dependencies": {
-                                "babel-helper-get-function-arity": {
-                                  "version": "6.18.0",
-                                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
-                                }
-                              }
-                            },
                             "babel-template": {
                               "version": "6.16.0",
                               "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                              "dependencies": {
-                                "babylon": {
-                                  "version": "6.14.1",
-                                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+                            },
+                            "babel-types": {
+                              "version": "6.19.0",
+                              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                             },
                             "babel-traverse": {
                               "version": "6.19.0",
@@ -4286,138 +1609,24 @@
                                 "babel-code-frame": {
                                   "version": "6.16.0",
                                   "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.3",
-                                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.2.1",
-                                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.5",
-                                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.1",
-                                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.8.0",
-                                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.14.1",
-                                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                                 },
                                 "debug": {
                                   "version": "2.3.3",
                                   "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.2",
-                                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "9.14.0",
-                                  "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.2",
-                                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.3.0",
-                                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                                 }
                               }
                             },
-                            "babel-types": {
-                              "version": "6.19.0",
-                              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                            "babel-helper-function-name": {
+                              "version": "6.18.0",
+                              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                               "dependencies": {
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                                },
-                                "to-fast-properties": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+                                "babel-helper-get-function-arity": {
+                                  "version": "6.18.0",
+                                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
                                 }
                               }
                             }
@@ -4440,34 +1649,15 @@
                           "from": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz",
                           "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz",
                           "dependencies": {
-                            "babel-helper-function-name": {
-                              "version": "6.18.0",
-                              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
-                              "dependencies": {
-                                "babel-helper-get-function-arity": {
-                                  "version": "6.18.0",
-                                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
-                                }
-                              }
-                            },
                             "babel-template": {
                               "version": "6.16.0",
                               "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz",
-                              "dependencies": {
-                                "babylon": {
-                                  "version": "6.14.1",
-                                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.16.0.tgz"
+                            },
+                            "babel-types": {
+                              "version": "6.19.0",
+                              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                             },
                             "babel-traverse": {
                               "version": "6.19.0",
@@ -4477,138 +1667,24 @@
                                 "babel-code-frame": {
                                   "version": "6.16.0",
                                   "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.3",
-                                      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.2.1",
-                                          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.5",
-                                          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.1",
-                                          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "2.0.0",
-                                      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.8.0",
-                                  "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.14.1",
-                                  "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                                 },
                                 "debug": {
                                   "version": "2.3.3",
                                   "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "0.7.2",
-                                      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "9.14.0",
-                                  "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                                  "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.2",
-                                  "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.3.0",
-                                      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                                 }
                               }
                             },
-                            "babel-types": {
-                              "version": "6.19.0",
-                              "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
+                            "babel-helper-function-name": {
+                              "version": "6.18.0",
+                              "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
+                              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.18.0.tgz",
                               "dependencies": {
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                                },
-                                "to-fast-properties": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+                                "babel-helper-get-function-arity": {
+                                  "version": "6.18.0",
+                                  "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.18.0.tgz"
                                 }
                               }
                             }
@@ -4626,6 +1702,11 @@
                       "from": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz",
                       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.8.0.tgz",
                       "dependencies": {
+                        "babel-plugin-syntax-exponentiation-operator": {
+                          "version": "6.13.0",
+                          "from": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+                        },
                         "babel-helper-builder-binary-assignment-operator-visitor": {
                           "version": "6.18.0",
                           "from": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.18.0.tgz",
@@ -4644,116 +1725,12 @@
                                     "babel-code-frame": {
                                       "version": "6.16.0",
                                       "from": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz",
-                                      "dependencies": {
-                                        "chalk": {
-                                          "version": "1.1.3",
-                                          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                          "dependencies": {
-                                            "ansi-styles": {
-                                              "version": "2.2.1",
-                                              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                            },
-                                            "escape-string-regexp": {
-                                              "version": "1.0.5",
-                                              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                            },
-                                            "has-ansi": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                              "dependencies": {
-                                                "ansi-regex": {
-                                                  "version": "2.0.0",
-                                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                                }
-                                              }
-                                            },
-                                            "strip-ansi": {
-                                              "version": "3.0.1",
-                                              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                              "dependencies": {
-                                                "ansi-regex": {
-                                                  "version": "2.0.0",
-                                                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                                                }
-                                              }
-                                            },
-                                            "supports-color": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                            }
-                                          }
-                                        },
-                                        "esutils": {
-                                          "version": "2.0.2",
-                                          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                        },
-                                        "js-tokens": {
-                                          "version": "2.0.0",
-                                          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "babel-messages": {
-                                      "version": "6.8.0",
-                                      "from": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.8.0.tgz"
-                                    },
-                                    "babylon": {
-                                      "version": "6.14.1",
-                                      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-                                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.16.0.tgz"
                                     },
                                     "debug": {
                                       "version": "2.3.3",
                                       "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-                                      "dependencies": {
-                                        "ms": {
-                                          "version": "0.7.2",
-                                          "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-                                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-                                        }
-                                      }
-                                    },
-                                    "globals": {
-                                      "version": "9.14.0",
-                                      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
-                                    },
-                                    "invariant": {
-                                      "version": "2.2.2",
-                                      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                      "dependencies": {
-                                        "loose-envify": {
-                                          "version": "1.3.0",
-                                          "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-                                          "dependencies": {
-                                            "js-tokens": {
-                                              "version": "2.0.0",
-                                              "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "lodash": {
-                                      "version": "4.17.2",
-                                      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
+                                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
                                     }
                                   }
                                 }
@@ -4762,31 +1739,9 @@
                             "babel-types": {
                               "version": "6.19.0",
                               "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz",
-                              "dependencies": {
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "lodash": {
-                                  "version": "4.17.2",
-                                  "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
-                                },
-                                "to-fast-properties": {
-                                  "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
-                                }
-                              }
+                              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.19.0.tgz"
                             }
                           }
-                        },
-                        "babel-plugin-syntax-exponentiation-operator": {
-                          "version": "6.13.0",
-                          "from": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-                          "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
                         }
                       }
                     },
@@ -4812,14 +1767,9 @@
     },
     "babel-runtime": {
       "version": "6.18.0",
-      "from": "babel-runtime@>=6.6.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.18.0.tgz",
       "dependencies": {
-        "core-js": {
-          "version": "2.4.1",
-          "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-        },
         "regenerator-runtime": {
           "version": "0.9.6",
           "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz",
@@ -4829,498 +1779,410 @@
     },
     "babel-traverse": {
       "version": "6.21.0",
-      "from": "babel-traverse@>=6.0.20 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.21.0.tgz",
-      "dev": true,
       "dependencies": {
         "babel-runtime": {
           "version": "6.20.0",
-          "from": "babel-runtime@>=6.20.0 <7.0.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
         }
       }
     },
     "babel-types": {
       "version": "6.21.0",
-      "from": "babel-types@>=6.0.19 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.21.0.tgz",
-      "dev": true,
       "dependencies": {
         "babel-runtime": {
           "version": "6.20.0",
-          "from": "babel-runtime@^6.20.0",
-          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.20.0.tgz"
         }
       }
     },
     "babylon": {
       "version": "6.14.1",
-      "from": "babylon@>=6.11.0 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.14.1.tgz"
     },
     "balanced-match": {
       "version": "0.4.2",
-      "from": "balanced-match@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "boolbase": {
       "version": "1.0.0",
-      "from": "boolbase@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
     },
     "brace-expansion": {
       "version": "1.1.6",
-      "from": "brace-expansion@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
     },
     "browser-stdout": {
       "version": "1.3.0",
-      "from": "browser-stdout@1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
     },
     "caller-path": {
       "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz"
     },
     "callsites": {
       "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
     },
     "camelize": {
       "version": "1.0.0",
-      "from": "camelize@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.0.tgz"
     },
     "cardinal": {
       "version": "0.5.0",
-      "from": "cardinal@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
-      "dev": true
-    },
-    "chai": {
-      "version": "3.5.0",
-      "from": "chai@>=3.5.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.5.0.tgz"
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
     },
     "cheerio": {
       "version": "0.22.0",
-      "from": "cheerio@>=0.22.0 <0.23.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz"
     },
     "circular-json": {
       "version": "0.3.1",
-      "from": "circular-json@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz"
     },
     "cli-color": {
       "version": "0.1.7",
-      "from": "cli-color@>=0.1.6 <0.2.0",
+      "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.1.7.tgz",
-      "dev": true,
       "dependencies": {
         "es5-ext": {
           "version": "0.8.2",
-          "from": "es5-ext@>=0.8.0 <0.9.0",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.8.2.tgz"
         }
       }
     },
     "cli-cursor": {
       "version": "1.0.2",
-      "from": "cli-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz"
     },
     "cli-width": {
       "version": "2.1.0",
-      "from": "cli-width@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
     },
     "code-point-at": {
       "version": "1.1.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
     },
     "commander": {
       "version": "2.9.0",
-      "from": "commander@>=2.8.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "concat-stream": {
       "version": "1.6.0",
-      "from": "concat-stream@>=1.4.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz"
     },
     "core-js": {
       "version": "2.4.1",
-      "from": "core-js@>=2.4.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
     "create-stylesheet": {
       "version": "0.3.0",
-      "from": "create-stylesheet@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/create-stylesheet/-/create-stylesheet-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/create-stylesheet/-/create-stylesheet-0.3.0.tgz"
     },
     "css-select": {
       "version": "1.2.0",
-      "from": "css-select@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz"
     },
     "css-what": {
       "version": "2.1.0",
-      "from": "css-what@>=2.1.0 <2.2.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
     },
     "d": {
       "version": "0.1.1",
-      "from": "d@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
     },
     "debug": {
       "version": "2.5.1",
-      "from": "debug@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.5.1.tgz"
     },
     "deep-eql": {
       "version": "0.1.3",
-      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "dev": true,
       "dependencies": {
         "type-detect": {
           "version": "0.1.1",
-          "from": "type-detect@0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
         }
       }
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
     },
     "define-properties": {
       "version": "1.1.2",
-      "from": "define-properties@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz"
     },
     "del": {
       "version": "2.2.2",
-      "from": "del@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz"
     },
     "diff": {
       "version": "1.4.0",
-      "from": "diff@1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
     },
     "difflib": {
       "version": "0.2.4",
-      "from": "difflib@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz"
     },
     "doctrine": {
       "version": "1.5.0",
-      "from": "doctrine@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz"
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
         }
       }
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
     },
     "domhandler": {
       "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
     },
     "domutils": {
       "version": "1.5.1",
-      "from": "domutils@1.5.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
     },
     "dreamopt": {
       "version": "0.6.0",
-      "from": "dreamopt@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.6.0.tgz"
     },
     "entities": {
       "version": "1.1.1",
-      "from": "entities@>=1.1.1 <1.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "dev": true
-    },
-    "enzyme": {
-      "version": "2.7.0",
-      "from": "enzyme@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.7.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
     },
     "error": {
       "version": "4.4.0",
-      "from": "error@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/error/-/error-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/error/-/error-4.4.0.tgz"
     },
     "es-abstract": {
       "version": "1.6.1",
-      "from": "es-abstract@>=1.3.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.6.1.tgz"
     },
     "es-to-primitive": {
       "version": "1.1.1",
-      "from": "es-to-primitive@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz"
     },
     "es5-ext": {
       "version": "0.10.12",
-      "from": "es5-ext@>=0.10.11 <0.11.0",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz"
     },
     "es5-shim": {
       "version": "4.5.9",
-      "from": "es5-shim@>=4.5.7 <5.0.0",
+      "from": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.5.9.tgz"
     },
     "es6-iterator": {
       "version": "2.0.0",
-      "from": "es6-iterator@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
     },
     "es6-map": {
       "version": "0.1.4",
-      "from": "es6-map@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.4.tgz"
     },
     "es6-set": {
       "version": "0.1.4",
-      "from": "es6-set@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.4.tgz"
     },
     "es6-symbol": {
       "version": "3.1.0",
-      "from": "es6-symbol@>=3.1.0 <3.2.0",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz"
     },
     "es6-weak-map": {
       "version": "2.0.1",
-      "from": "es6-weak-map@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.1.tgz"
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escope": {
       "version": "3.6.0",
-      "from": "escope@>=3.6.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "dev": true
-    },
-    "eslint": {
-      "version": "3.12.2",
-      "from": "eslint@>=3.10.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.12.2.tgz",
-      "dev": true
-    },
-    "eslint-plugin-react": {
-      "version": "6.8.0",
-      "from": "eslint-plugin-react@>=6.7.1 <7.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.8.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz"
     },
     "espree": {
       "version": "3.3.2",
-      "from": "espree@>=3.3.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.3.2.tgz"
     },
     "esprima": {
       "version": "2.7.3",
-      "from": "esprima@>=2.6.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
     },
     "esrecurse": {
       "version": "4.1.0",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "dev": true,
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
-          "from": "estraverse@>=4.1.0 <4.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz"
         }
       }
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
     },
     "event-emitter": {
       "version": "0.3.4",
-      "from": "event-emitter@>=0.3.4 <0.4.0",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.4.tgz"
     },
     "exit-hook": {
       "version": "1.1.1",
-      "from": "exit-hook@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
     },
     "expose-loader": {
       "version": "0.7.1",
-      "from": "expose-loader@>=0.7.1 <0.8.0",
+      "from": "https://registry.npmjs.org/expose-loader/-/expose-loader-0.7.1.tgz",
       "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-0.7.1.tgz"
     },
     "fast-levenshtein": {
       "version": "2.0.5",
-      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz"
     },
     "figures": {
       "version": "1.7.0",
-      "from": "figures@>=1.3.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz"
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "from": "file-entry-cache@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz"
     },
     "flat-cache": {
       "version": "1.2.2",
-      "from": "flat-cache@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz"
     },
     "foreach": {
       "version": "2.0.5",
-      "from": "foreach@>=2.0.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
     },
     "fsevents": {
       "version": "1.0.15",
-      "from": "fsevents@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.15.tgz",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.0.15.tgz",
-      "optional": true,
       "dependencies": {
+        "nan": {
+          "version": "2.4.0",
+          "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz"
+        },
+        "node-pre-gyp": {
+          "version": "0.6.29",
+          "from": "node-pre-gyp@>=0.6.29 <0.7.0",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz"
+        },
         "abbrev": {
           "version": "1.0.9",
           "from": "abbrev@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
         },
         "ansi-regex": {
           "version": "2.0.0",
@@ -5330,69 +2192,47 @@
         "ansi-styles": {
           "version": "2.2.1",
           "from": "ansi-styles@>=2.2.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
         },
         "aproba": {
           "version": "1.0.4",
           "from": "aproba@>=1.0.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.0.4.tgz"
         },
         "are-we-there-yet": {
           "version": "1.1.2",
           "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz"
         },
         "asn1": {
           "version": "0.2.3",
           "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
         },
         "assert-plus": {
           "version": "0.2.0",
           "from": "assert-plus@>=0.2.0 <0.3.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
         },
         "async": {
           "version": "1.5.2",
           "from": "async@>=1.5.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
         },
         "aws-sign2": {
           "version": "0.6.0",
           "from": "aws-sign2@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.4.1",
           "from": "aws4@>=1.2.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
         },
         "balanced-match": {
           "version": "0.4.2",
           "from": "balanced-match@>=0.4.1 <0.5.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-        },
-        "bl": {
-          "version": "1.1.2",
-          "from": "bl@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-          "optional": true,
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "from": "readable-stream@>=2.0.5 <2.1.0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "optional": true
-            }
-          }
         },
         "block-stream": {
           "version": "0.0.9",
@@ -5417,14 +2257,12 @@
         "caseless": {
           "version": "0.11.0",
           "from": "caseless@>=0.11.0 <0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
         },
         "chalk": {
           "version": "1.1.3",
           "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
         },
         "code-point-at": {
           "version": "1.0.0",
@@ -5439,8 +2277,7 @@
         "commander": {
           "version": "2.9.0",
           "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
         },
         "concat-map": {
           "version": "0.0.1",
@@ -5460,34 +2297,17 @@
         "cryptiles": {
           "version": "2.0.5",
           "from": "cryptiles@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "optional": true
-        },
-        "dashdash": {
-          "version": "1.14.0",
-          "from": "dashdash@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
         },
         "debug": {
           "version": "2.2.0",
           "from": "debug@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
         },
         "deep-extend": {
           "version": "0.4.1",
           "from": "deep-extend@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz"
         },
         "delayed-stream": {
           "version": "1.0.0",
@@ -5497,26 +2317,22 @@
         "delegates": {
           "version": "1.0.0",
           "from": "delegates@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
         },
         "ecc-jsbn": {
           "version": "0.1.1",
           "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
         },
         "extend": {
           "version": "3.0.0",
           "from": "extend@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "extsprintf": {
           "version": "1.0.2",
@@ -5526,14 +2342,12 @@
         "forever-agent": {
           "version": "0.6.1",
           "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "1.0.0-rc4",
           "from": "form-data@>=1.0.0-rc4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz"
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -5548,40 +2362,22 @@
         "fstream-ignore": {
           "version": "1.0.5",
           "from": "fstream-ignore@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
         },
         "gauge": {
           "version": "2.6.0",
           "from": "gauge@>=2.6.0 <2.7.0",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.6.0.tgz"
         },
         "generate-function": {
           "version": "2.0.0",
           "from": "generate-function@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
         },
         "generate-object-property": {
           "version": "1.2.0",
           "from": "generate-object-property@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-          "optional": true
-        },
-        "getpass": {
-          "version": "0.1.6",
-          "from": "getpass@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
+          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
         },
         "glob": {
           "version": "7.0.5",
@@ -5596,38 +2392,32 @@
         "graceful-readlink": {
           "version": "1.0.1",
           "from": "graceful-readlink@>=1.0.0",
-          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
         },
         "har-validator": {
           "version": "2.0.6",
           "from": "har-validator@>=2.0.6 <2.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
         },
         "has-ansi": {
           "version": "2.0.0",
           "from": "has-ansi@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
         },
         "has-color": {
           "version": "0.1.7",
           "from": "has-color@>=0.1.7 <0.2.0",
-          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
         },
         "has-unicode": {
           "version": "2.0.1",
           "from": "has-unicode@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
         },
         "hawk": {
           "version": "3.1.3",
           "from": "hawk@>=3.1.3 <3.2.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
         },
         "hoek": {
           "version": "2.16.3",
@@ -5637,8 +2427,7 @@
         "http-signature": {
           "version": "1.1.1",
           "from": "http-signature@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
         },
         "inflight": {
           "version": "1.0.5",
@@ -5653,31 +2442,27 @@
         "ini": {
           "version": "1.3.4",
           "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
         },
-        "is-my-json-valid": {
-          "version": "2.13.1",
-          "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-          "optional": true
-        },
         "is-property": {
           "version": "1.0.2",
           "from": "is-property@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+        },
+        "is-my-json-valid": {
+          "version": "2.13.1",
+          "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+          "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz"
         },
         "is-typedarray": {
           "version": "1.0.0",
           "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isarray": {
           "version": "1.0.0",
@@ -5687,44 +2472,37 @@
         "isstream": {
           "version": "0.1.2",
           "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "jodid25519": {
           "version": "1.0.2",
           "from": "jodid25519@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
         },
         "jsbn": {
           "version": "0.1.0",
           "from": "jsbn@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
         },
         "json-schema": {
           "version": "0.2.2",
           "from": "json-schema@0.2.2",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
           "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "jsonpointer": {
           "version": "2.0.0",
           "from": "jsonpointer@2.0.0",
-          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
         },
         "jsprim": {
           "version": "1.3.0",
           "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz"
         },
         "mime-db": {
           "version": "1.23.0",
@@ -5754,38 +2532,22 @@
         "ms": {
           "version": "0.7.1",
           "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "optional": true
-        },
-        "nan": {
-          "version": "2.4.0",
-          "from": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.29",
-          "from": "node-pre-gyp@>=0.6.29 <0.7.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.29.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
         },
         "node-uuid": {
           "version": "1.4.7",
           "from": "node-uuid@>=1.4.7 <1.5.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
         },
         "nopt": {
           "version": "3.0.6",
           "from": "nopt@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
         },
         "npmlog": {
           "version": "3.1.2",
           "from": "npmlog@>=3.1.2 <3.2.0",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-3.1.2.tgz"
         },
         "number-is-nan": {
           "version": "1.0.0",
@@ -5795,14 +2557,12 @@
         "oauth-sign": {
           "version": "0.8.2",
           "from": "oauth-sign@>=0.8.1 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "object-assign": {
           "version": "4.1.0",
           "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
         },
         "once": {
           "version": "1.3.3",
@@ -5817,14 +2577,12 @@
         "pinkie": {
           "version": "2.0.4",
           "from": "pinkie@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
         },
         "pinkie-promise": {
           "version": "2.0.1",
           "from": "pinkie-promise@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
         },
         "process-nextick-args": {
           "version": "1.0.7",
@@ -5834,22 +2592,7 @@
         "qs": {
           "version": "6.2.0",
           "from": "qs@>=6.2.0 <6.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz",
-          "optional": true
-        },
-        "rc": {
-          "version": "1.1.6",
-          "from": "rc@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-          "optional": true,
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.2.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "optional": true
-            }
-          }
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
         },
         "readable-stream": {
           "version": "2.1.4",
@@ -5859,8 +2602,7 @@
         "request": {
           "version": "2.73.0",
           "from": "request@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/request/-/request-2.73.0.tgz"
         },
         "rimraf": {
           "version": "2.5.3",
@@ -5870,56 +2612,37 @@
         "semver": {
           "version": "5.2.0",
           "from": "semver@>=5.2.0 <5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.2.0.tgz"
         },
         "set-blocking": {
           "version": "2.0.0",
           "from": "set-blocking@>=2.0.0 <2.1.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
         },
         "signal-exit": {
           "version": "3.0.0",
           "from": "signal-exit@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.0.tgz"
         },
         "sntp": {
           "version": "1.0.9",
           "from": "sntp@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "optional": true
-        },
-        "sshpk": {
-          "version": "1.8.3",
-          "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
-          "optional": true,
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "from": "assert-plus@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
         },
         "string-width": {
           "version": "1.0.1",
           "from": "string-width@>=1.0.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.1.tgz"
         },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
         "stringstream": {
           "version": "0.0.5",
           "from": "stringstream@>=0.0.4 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -5929,14 +2652,12 @@
         "strip-json-comments": {
           "version": "1.0.4",
           "from": "strip-json-comments@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "supports-color": {
           "version": "2.0.0",
           "from": "supports-color@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
         },
         "tar": {
           "version": "2.2.1",
@@ -5946,32 +2667,27 @@
         "tar-pack": {
           "version": "3.1.4",
           "from": "tar-pack@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.1.4.tgz"
         },
         "tough-cookie": {
           "version": "2.2.2",
           "from": "tough-cookie@>=2.2.0 <2.3.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.2.tgz"
         },
         "tunnel-agent": {
           "version": "0.4.3",
           "from": "tunnel-agent@>=0.4.1 <0.5.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
         },
         "tweetnacl": {
           "version": "0.13.3",
           "from": "tweetnacl@>=0.13.0 <0.14.0",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
         },
         "uid-number": {
           "version": "0.0.6",
           "from": "uid-number@>=0.0.6 <0.1.0",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -5981,14 +2697,12 @@
         "verror": {
           "version": "1.3.6",
           "from": "verror@1.3.6",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
         },
         "wide-align": {
           "version": "1.1.0",
           "from": "wide-align@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
         },
         "wrappy": {
           "version": "1.0.2",
@@ -5998,116 +2712,158 @@
         "xtend": {
           "version": "4.0.1",
           "from": "xtend@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "optional": true
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+        },
+        "bl": {
+          "version": "1.1.2",
+          "from": "bl@>=1.1.2 <1.2.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "from": "readable-stream@>=2.0.5 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+            }
+          }
+        },
+        "dashdash": {
+          "version": "1.14.0",
+          "from": "dashdash@>=1.12.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            }
+          }
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "from": "getpass@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            }
+          }
+        },
+        "rc": {
+          "version": "1.1.6",
+          "from": "rc@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            }
+          }
+        },
+        "sshpk": {
+          "version": "1.8.3",
+          "from": "sshpk@>=1.7.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+            }
+          }
         }
       }
     },
     "function-bind": {
       "version": "1.1.0",
-      "from": "function-bind@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
     },
     "function.prototype.name": {
       "version": "1.0.0",
-      "from": "function.prototype.name@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz"
     },
     "generate-function": {
       "version": "2.0.0",
-      "from": "generate-function@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
     },
     "generate-object-property": {
       "version": "1.2.0",
-      "from": "generate-object-property@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "glob": {
       "version": "7.1.1",
-      "from": "glob@>=7.0.3 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
     },
     "globals": {
       "version": "9.14.0",
-      "from": "globals@>=9.0.0 <10.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.14.0.tgz"
     },
     "globby": {
       "version": "5.0.0",
-      "from": "globby@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz"
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
     },
     "graceful-readlink": {
       "version": "1.0.1",
-      "from": "graceful-readlink@>=1.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
     },
     "growl": {
       "version": "1.9.2",
-      "from": "growl@1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
     },
     "has": {
       "version": "1.0.1",
-      "from": "has@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
     },
     "has-color": {
       "version": "0.1.7",
-      "from": "has-color@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
     },
     "has-flag": {
       "version": "1.0.0",
-      "from": "has-flag@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "heap": {
       "version": "0.2.6",
-      "from": "heap@>=0.2.0",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz"
     },
     "htmlparser2": {
       "version": "3.9.2",
-      "from": "htmlparser2@>=3.9.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz"
     },
     "ignore": {
       "version": "3.2.0",
-      "from": "ignore@>=3.2.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.2.0.tgz"
     },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "imports-loader@>=0.6.5 <0.7.0",
+      "from": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "dependencies": {
         "loader-utils": {
@@ -6129,17 +2885,12 @@
               "version": "0.5.0",
               "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
@@ -6153,133 +2904,112 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
     },
     "inquirer": {
       "version": "0.12.0",
-      "from": "inquirer@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz"
     },
     "interpret": {
       "version": "1.0.1",
-      "from": "interpret@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz"
     },
     "invariant": {
       "version": "2.2.2",
-      "from": "invariant@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
     },
     "is-callable": {
       "version": "1.1.3",
-      "from": "is-callable@>=1.1.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
     },
     "is-date-object": {
       "version": "1.0.1",
-      "from": "is-date-object@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
     },
     "is-my-json-valid": {
       "version": "2.15.0",
-      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
     },
     "is-path-in-cwd": {
       "version": "1.0.0",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz"
     },
     "is-path-inside": {
       "version": "1.0.0",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
     },
     "is-property": {
       "version": "1.0.2",
-      "from": "is-property@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
     },
     "is-regex": {
       "version": "1.0.3",
-      "from": "is-regex@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.3.tgz"
     },
     "is-resolvable": {
       "version": "1.0.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz"
     },
     "is-subset": {
       "version": "0.1.1",
-      "from": "is-subset@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
     },
     "is-symbol": {
       "version": "1.0.1",
-      "from": "is-symbol@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
     },
     "js-tokens": {
       "version": "2.0.0",
-      "from": "js-tokens@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
     },
     "js-yaml": {
       "version": "3.7.0",
-      "from": "js-yaml@>=3.5.1 <4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz"
     },
     "jsdom": {
       "version": "9.8.3",
-      "from": "jsdom@latest",
+      "from": "https://registry.npmjs.org/jsdom/-/jsdom-9.8.3.tgz",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.8.3.tgz",
       "dependencies": {
         "abab": {
@@ -6289,7 +3019,7 @@
         },
         "acorn": {
           "version": "2.7.0",
-          "from": "acorn@>=2.4.0 <3.0.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
         },
         "acorn-globals": {
@@ -6322,69 +3052,20 @@
           "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
           "dependencies": {
-            "esprima": {
-              "version": "2.7.3",
-              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-            },
             "estraverse": {
               "version": "1.9.3",
               "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
               "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
             },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "dependencies": {
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "fast-levenshtein": {
-                  "version": "2.0.5",
-                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
-                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz"
-                },
-                "levn": {
-                  "version": "0.3.0",
-                  "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-                },
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-                }
-              }
-            },
             "source-map": {
               "version": "0.2.0",
               "from": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "optional": true,
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-                  "optional": true
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
                 }
               }
             }
@@ -6467,119 +3148,18 @@
             "har-validator": {
               "version": "2.0.6",
               "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.15.0",
-                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "4.0.0",
-                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    }
-                  }
-                }
-              }
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
             },
             "hawk": {
               "version": "3.1.3",
               "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
               "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
                 "boom": {
                   "version": "2.10.1",
                   "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
@@ -6589,11 +3169,6 @@
                   "version": "2.0.5",
                   "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
@@ -6649,45 +3224,40 @@
                       "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "optional": true
-                    },
                     "dashdash": {
                       "version": "1.14.1",
                       "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "optional": true
                     },
                     "getpass": {
                       "version": "0.1.6",
                       "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                     },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "optional": true
-                    },
                     "jsbn": {
                       "version": "0.1.0",
                       "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.14.3",
                       "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
                     }
                   }
                 }
@@ -6807,417 +3377,318 @@
     },
     "json-diff": {
       "version": "0.3.1",
-      "from": "json-diff@>=0.3.1 <0.4.0",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.3.1.tgz"
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
     },
     "json3": {
       "version": "3.3.2",
-      "from": "json3@3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
     },
     "jsonpointer": {
       "version": "4.0.1",
-      "from": "jsonpointer@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
     },
     "jsx-ast-utils": {
       "version": "1.3.5",
-      "from": "jsx-ast-utils@>=1.3.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.3.5.tgz"
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
     },
     "lodash": {
       "version": "4.17.2",
-      "from": "lodash@>=4.2.0 <5.0.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz"
     },
     "lodash._baseassign": {
       "version": "3.2.0",
-      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
     },
     "lodash._basecopy": {
       "version": "3.0.1",
-      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
     },
     "lodash._basecreate": {
       "version": "3.0.3",
-      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
     },
     "lodash._getnative": {
       "version": "3.9.1",
-      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
-      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "from": "lodash.assign@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
     },
     "lodash.assignin": {
       "version": "4.2.0",
-      "from": "lodash.assignin@>=4.0.9 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz"
     },
     "lodash.bind": {
       "version": "4.2.1",
-      "from": "lodash.bind@>=4.1.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz"
     },
     "lodash.create": {
       "version": "3.1.1",
-      "from": "lodash.create@3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz"
     },
     "lodash.defaults": {
       "version": "4.2.0",
-      "from": "lodash.defaults@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
     },
     "lodash.filter": {
       "version": "4.6.0",
-      "from": "lodash.filter@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz"
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "from": "lodash.flatten@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
     },
     "lodash.foreach": {
       "version": "4.5.0",
-      "from": "lodash.foreach@>=4.3.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz"
     },
     "lodash.isarguments": {
       "version": "3.1.0",
-      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
     },
     "lodash.isarray": {
       "version": "3.0.4",
-      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
     },
     "lodash.keys": {
       "version": "3.1.2",
-      "from": "lodash.keys@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
     },
     "lodash.map": {
       "version": "4.6.0",
-      "from": "lodash.map@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz"
     },
     "lodash.merge": {
       "version": "4.6.0",
-      "from": "lodash.merge@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz"
     },
     "lodash.pick": {
       "version": "4.4.0",
-      "from": "lodash.pick@>=4.2.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
     },
     "lodash.pickby": {
       "version": "4.6.0",
-      "from": "lodash.pickby@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz"
     },
     "lodash.reduce": {
       "version": "4.6.0",
-      "from": "lodash.reduce@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz"
     },
     "lodash.reject": {
       "version": "4.6.0",
-      "from": "lodash.reject@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz"
     },
     "lodash.some": {
       "version": "4.6.0",
-      "from": "lodash.some@>=4.4.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
     },
     "loose-envify": {
       "version": "1.3.0",
-      "from": "loose-envify@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz"
     },
     "marked": {
       "version": "0.3.6",
-      "from": "marked@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz"
     },
     "minimatch": {
       "version": "3.0.3",
-      "from": "minimatch@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "dev": true
-    },
-    "mocha": {
-      "version": "3.2.0",
-      "from": "mocha@>=3.1.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.0.5",
-          "from": "glob@7.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.1.2",
-          "from": "supports-color@3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "dev": true
-        }
-      }
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
     "ms": {
       "version": "0.7.2",
-      "from": "ms@0.7.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
     },
     "msee": {
       "version": "0.1.2",
-      "from": "msee@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/msee/-/msee-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/msee/-/msee-0.1.2.tgz",
-      "dev": true,
       "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "from": "ansi-styles@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "dev": true
-        },
         "chalk": {
           "version": "0.4.0",
-          "from": "chalk@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "from": "object-keys@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "from": "strip-ansi@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz"
         },
         "xtend": {
           "version": "2.1.2",
-          "from": "xtend@>=2.1.1 <2.2.0",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+        },
+        "ansi-styles": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
         }
       }
     },
     "mute-stream": {
       "version": "0.0.5",
-      "from": "mute-stream@0.0.5",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
     },
     "natural-compare": {
       "version": "1.4.0",
-      "from": "natural-compare@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
     },
     "node-ensure": {
       "version": "0.0.0",
-      "from": "node-ensure@>=0.0.0 <0.0.1",
+      "from": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz"
     },
     "nopt": {
       "version": "2.1.2",
-      "from": "nopt@>=2.1.1 <2.2.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.1.2.tgz"
     },
     "npm": {
       "version": "2.15.11",
-      "from": "npm@>=2.15.10 <3.0.0",
+      "from": "https://registry.npmjs.org/npm/-/npm-2.15.11.tgz",
       "resolved": "https://registry.npmjs.org/npm/-/npm-2.15.11.tgz",
-      "dev": true,
       "dependencies": {
         "abbrev": {
           "version": "1.0.9",
           "from": "abbrev@>=1.0.9 <1.1.0",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
         },
         "ansi": {
           "version": "0.3.1",
           "from": "ansi@latest",
-          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.0.0",
-          "from": "ansi-regex@2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz"
         },
         "ansicolors": {
           "version": "0.3.2",
-          "from": "ansicolors@latest",
-          "dev": true
+          "from": "ansicolors@latest"
         },
         "ansistyles": {
           "version": "0.1.3",
           "from": "ansistyles@0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz"
         },
         "archy": {
           "version": "1.0.0",
           "from": "archy@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
         },
         "async-some": {
           "version": "1.0.2",
-          "from": "async-some@>=1.0.2 <1.1.0",
-          "dev": true
+          "from": "async-some@>=1.0.2 <1.1.0"
         },
         "block-stream": {
           "version": "0.0.9",
           "from": "block-stream@0.0.9",
-          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
         },
         "char-spinner": {
           "version": "1.0.1",
           "from": "char-spinner@latest",
-          "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz"
         },
         "chmodr": {
           "version": "1.0.2",
           "from": "chmodr@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-1.0.2.tgz"
         },
         "chownr": {
           "version": "1.0.1",
           "from": "chownr@1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz"
         },
         "cmd-shim": {
           "version": "2.0.2",
           "from": "cmd-shim@2.0.2",
-          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz"
         },
         "columnify": {
           "version": "1.5.4",
           "from": "columnify@latest",
           "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "dev": true,
           "dependencies": {
             "wcwidth": {
               "version": "1.0.0",
               "from": "wcwidth@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "defaults": {
                   "version": "1.0.3",
                   "from": "defaults@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "clone": {
                       "version": "1.0.2",
                       "from": "clone@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                     }
                   }
                 }
@@ -7229,192 +3700,157 @@
           "version": "1.1.10",
           "from": "config-chain@latest",
           "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.10.tgz",
-          "dev": true,
           "dependencies": {
             "proto-list": {
               "version": "1.2.4",
               "from": "proto-list@>=1.2.1 <1.3.0",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
             }
           }
         },
         "dezalgo": {
           "version": "1.0.3",
           "from": "dezalgo@>=1.0.3 <1.1.0",
-          "dev": true,
           "dependencies": {
             "asap": {
               "version": "2.0.3",
               "from": "asap@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.3.tgz"
             }
           }
         },
         "editor": {
           "version": "1.0.0",
           "from": "editor@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz"
         },
         "fs-vacuum": {
           "version": "1.2.9",
           "from": "fs-vacuum@1.2.9",
-          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz"
         },
         "fs-write-stream-atomic": {
           "version": "1.0.8",
           "from": "fs-write-stream-atomic@>=1.0.5 <1.1.0",
           "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.8.tgz",
-          "dev": true,
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
               "from": "iferr@>=0.1.5 <0.2.0",
-              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz"
             }
           }
         },
         "fstream": {
           "version": "1.0.10",
-          "from": "fstream@>=1.0.10 <1.1.0",
-          "dev": true
+          "from": "fstream@>=1.0.10 <1.1.0"
         },
         "fstream-npm": {
           "version": "1.1.1",
           "from": "fstream-npm@1.1.1",
           "resolved": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.1.1.tgz",
-          "dev": true,
           "dependencies": {
             "fstream-ignore": {
               "version": "1.0.5",
               "from": "fstream-ignore@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
             }
           }
         },
         "github-url-from-git": {
           "version": "1.4.0",
           "from": "github-url-from-git@>=1.4.0-0 <2.0.0-0",
-          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.4.0.tgz"
         },
         "github-url-from-username-repo": {
           "version": "1.0.2",
-          "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0",
-          "dev": true
+          "from": "github-url-from-username-repo@>=1.0.2-0 <2.0.0-0"
         },
         "glob": {
           "version": "7.0.6",
           "from": "glob@7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
-          "dev": true,
           "dependencies": {
             "fs.realpath": {
               "version": "1.0.0",
               "from": "fs.realpath@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
             },
             "path-is-absolute": {
               "version": "1.0.0",
               "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "4.1.6",
           "from": "graceful-fs@>=4.1.5 <4.2.0",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.6.tgz"
         },
         "hosted-git-info": {
           "version": "2.1.5",
           "from": "hosted-git-info@>=2.1.4 <2.2.0",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "from": "imurmurhash@0.1.4",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
         },
         "inflight": {
           "version": "1.0.5",
           "from": "inflight@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz"
         },
         "inherits": {
           "version": "2.0.3",
           "from": "inherits@2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
         },
         "ini": {
           "version": "1.3.4",
           "from": "ini@latest",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
         },
         "init-package-json": {
           "version": "1.9.4",
           "from": "init-package-json@>=1.9.4 <1.10.0",
           "resolved": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
-          "dev": true,
           "dependencies": {
             "glob": {
               "version": "6.0.4",
               "from": "glob@>=6.0.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "dev": true,
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
             "promzard": {
               "version": "0.3.0",
               "from": "promzard@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz"
             }
           }
         },
         "lockfile": {
           "version": "1.0.1",
           "from": "lockfile@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
         },
         "lru-cache": {
           "version": "4.0.1",
           "from": "lru-cache@4.0.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.1.tgz",
-          "dev": true,
           "dependencies": {
             "pseudomap": {
               "version": "1.0.2",
               "from": "pseudomap@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
             },
             "yallist": {
               "version": "2.0.0",
               "from": "yallist@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz"
             }
           }
         },
@@ -7422,25 +3858,21 @@
           "version": "3.0.3",
           "from": "minimatch@3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-          "dev": true,
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.6",
               "from": "brace-expansion@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-              "dev": true,
               "dependencies": {
                 "balanced-match": {
                   "version": "0.4.2",
                   "from": "balanced-match@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
                   "from": "concat-map@0.0.1",
-                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
             }
@@ -7450,13 +3882,11 @@
           "version": "0.5.1",
           "from": "mkdirp@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dev": true,
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
               "from": "minimist@0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
@@ -7464,31 +3894,26 @@
           "version": "3.4.0",
           "from": "node-gyp@3.4.0",
           "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.4.0.tgz",
-          "dev": true,
           "dependencies": {
             "path-array": {
               "version": "1.0.1",
               "from": "path-array@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/path-array/-/path-array-1.0.1.tgz",
-              "dev": true,
               "dependencies": {
                 "array-index": {
                   "version": "1.0.0",
                   "from": "array-index@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/array-index/-/array-index-1.0.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "debug": {
                       "version": "2.2.0",
                       "from": "debug@>=2.2.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "ms": {
                           "version": "0.7.1",
                           "from": "ms@0.7.1",
-                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                         }
                       }
                     },
@@ -7496,25 +3921,21 @@
                       "version": "3.1.0",
                       "from": "es6-symbol@>=3.0.2 <4.0.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "d": {
                           "version": "0.1.1",
                           "from": "d@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
                         },
                         "es5-ext": {
                           "version": "0.10.12",
                           "from": "es5-ext@>=0.10.11 <0.11.0",
                           "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.12.tgz",
-                          "dev": true,
                           "dependencies": {
                             "es6-iterator": {
                               "version": "2.0.0",
                               "from": "es6-iterator@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz",
-                              "dev": true
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.0.tgz"
                             }
                           }
                         }
@@ -7528,32 +3949,27 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.6 <3.1.0",
-          "dev": true
+          "from": "nopt@>=3.0.6 <3.1.0"
         },
         "normalize-git-url": {
           "version": "3.0.2",
           "from": "normalize-git-url@3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz"
         },
         "normalize-package-data": {
           "version": "2.3.5",
           "from": "normalize-package-data@>=2.3.5 <2.4.0",
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "dev": true,
           "dependencies": {
             "is-builtin-module": {
               "version": "1.0.0",
               "from": "is-builtin-module@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "dev": true,
               "dependencies": {
                 "builtin-modules": {
                   "version": "1.1.0",
                   "from": "builtin-modules@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                 }
               }
             }
@@ -7562,110 +3978,93 @@
         "npm-cache-filename": {
           "version": "1.0.2",
           "from": "npm-cache-filename@1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz"
         },
         "npm-install-checks": {
           "version": "1.0.7",
           "from": "npm-install-checks@1.0.7",
-          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-1.0.7.tgz"
         },
         "npm-package-arg": {
           "version": "4.1.0",
           "from": "npm-package-arg@>=4.1.0 <4.2.0",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.1.0.tgz"
         },
         "npm-registry-client": {
           "version": "7.2.1",
           "from": "npm-registry-client@7.2.1",
           "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.2.1.tgz",
-          "dev": true,
           "dependencies": {
             "concat-stream": {
               "version": "1.5.2",
               "from": "concat-stream@>=1.5.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-              "dev": true,
               "dependencies": {
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "typedarray@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
                 "readable-stream": {
                   "version": "2.0.6",
                   "from": "readable-stream@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "from": "typedarray@>=0.0.5 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "dev": true
                 }
               }
             },
             "retry": {
               "version": "0.10.0",
               "from": "retry@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz"
             }
           }
         },
         "npm-user-validate": {
           "version": "0.1.5",
           "from": "npm-user-validate@0.1.5",
-          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz"
         },
         "npmlog": {
           "version": "2.0.4",
           "from": "npmlog@>=2.0.4 <2.1.0",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
-          "dev": true,
           "dependencies": {
             "are-we-there-yet": {
               "version": "1.1.2",
               "from": "are-we-there-yet@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-              "dev": true,
               "dependencies": {
                 "delegates": {
                   "version": "1.0.0",
                   "from": "delegates@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
                 }
               }
             },
@@ -7673,49 +4072,41 @@
               "version": "1.2.7",
               "from": "gauge@>=1.2.5 <1.3.0",
               "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-              "dev": true,
               "dependencies": {
                 "has-unicode": {
                   "version": "2.0.0",
                   "from": "has-unicode@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz",
-                  "dev": true
-                },
-                "lodash._baseslice": {
-                  "version": "4.0.0",
-                  "from": "lodash._baseslice@4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz",
-                  "dev": true
-                },
-                "lodash._basetostring": {
-                  "version": "4.12.0",
-                  "from": "lodash._basetostring@4.12.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.0.tgz"
                 },
                 "lodash.pad": {
                   "version": "4.4.0",
                   "from": "lodash.pad@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.4.0.tgz"
                 },
                 "lodash.padend": {
                   "version": "4.5.0",
                   "from": "lodash.padend@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.5.0.tgz"
                 },
                 "lodash.padstart": {
                   "version": "4.5.0",
                   "from": "lodash.padstart@>=4.1.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.5.0.tgz"
+                },
+                "lodash._baseslice": {
+                  "version": "4.0.0",
+                  "from": "lodash._baseslice@4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseslice/-/lodash._baseslice-4.0.0.tgz"
+                },
+                "lodash._basetostring": {
+                  "version": "4.12.0",
+                  "from": "lodash._basetostring@4.12.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-4.12.0.tgz"
                 },
                 "lodash.tostring": {
                   "version": "4.1.4",
                   "from": "lodash.tostring@4.1.4",
-                  "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz"
                 }
               }
             }
@@ -7724,76 +4115,64 @@
         "once": {
           "version": "1.4.0",
           "from": "once@1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
         },
         "opener": {
           "version": "1.4.1",
           "from": "opener@>=1.4.1 <1.5.0",
-          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/opener/-/opener-1.4.1.tgz"
         },
         "osenv": {
           "version": "0.1.3",
           "from": "osenv@0.1.3",
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-          "dev": true,
           "dependencies": {
             "os-homedir": {
               "version": "1.0.0",
               "from": "os-homedir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
             },
             "os-tmpdir": {
               "version": "1.0.1",
               "from": "os-tmpdir@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
             }
           }
         },
         "path-is-inside": {
           "version": "1.0.1",
           "from": "path-is-inside@1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
         },
         "read": {
           "version": "1.0.7",
           "from": "read@1.0.7",
           "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "dev": true,
           "dependencies": {
             "mute-stream": {
               "version": "0.0.5",
               "from": "mute-stream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
             }
           }
         },
         "read-installed": {
           "version": "4.0.3",
           "from": "read-installed@4.0.3",
-          "dev": true,
           "dependencies": {
             "debuglog": {
               "version": "1.0.1",
               "from": "debuglog@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz"
             },
             "readdir-scoped-modules": {
               "version": "1.0.2",
-              "from": "readdir-scoped-modules@>=1.0.0 <2.0.0",
-              "dev": true
+              "from": "readdir-scoped-modules@>=1.0.0 <2.0.0"
             },
             "util-extend": {
               "version": "1.0.1",
               "from": "util-extend@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.1.tgz"
             }
           }
         },
@@ -7801,19 +4180,16 @@
           "version": "2.0.4",
           "from": "read-package-json@2.0.4",
           "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
-          "dev": true,
           "dependencies": {
             "glob": {
               "version": "6.0.4",
               "from": "glob@>=6.0.0 <7.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "dev": true,
               "dependencies": {
                 "path-is-absolute": {
                   "version": "1.0.0",
                   "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
@@ -7821,13 +4197,11 @@
               "version": "1.0.3",
               "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
               "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-              "dev": true,
               "dependencies": {
                 "jju": {
                   "version": "1.3.0",
                   "from": "jju@>=1.1.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
                 }
               }
             }
@@ -7837,111 +4211,93 @@
           "version": "2.1.5",
           "from": "readable-stream@2.1.5",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-          "dev": true,
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
               "from": "buffer-shims@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             },
             "core-util-is": {
               "version": "1.0.2",
               "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "1.0.0",
               "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
               "from": "process-nextick-args@>=1.0.6 <1.1.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
               "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
               "from": "util-deprecate@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         },
         "realize-package-specifier": {
           "version": "3.0.1",
           "from": "realize-package-specifier@>=3.0.0 <3.1.0",
-          "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.1.tgz"
         },
         "request": {
           "version": "2.74.0",
           "from": "request@2.74.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.74.0.tgz",
-          "dev": true,
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
               "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "aws4": {
               "version": "1.4.1",
               "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.4.1.tgz"
             },
             "bl": {
               "version": "1.1.2",
               "from": "bl@>=1.1.2 <1.2.0",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
-              "dev": true,
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.6",
                   "from": "readable-stream@>=2.0.5 <2.1.0",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "dev": true,
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "1.0.0",
                       "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
                       "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
                       "from": "string_decoder@>=0.10.0 <0.11.0",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
                       "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
                 }
@@ -7950,46 +4306,39 @@
             "caseless": {
               "version": "0.11.0",
               "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
               "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dev": true,
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
                   "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
               "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
               "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc4",
               "from": "form-data@>=1.0.0-rc4 <1.1.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-              "dev": true,
               "dependencies": {
                 "async": {
                   "version": "1.5.2",
                   "from": "async@>=1.5.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
                 }
               }
             },
@@ -7997,37 +4346,31 @@
               "version": "2.0.6",
               "from": "har-validator@>=2.0.6 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "dev": true,
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
                   "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dev": true,
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
                       "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
                       "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
                       "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
                     },
                     "supports-color": {
                       "version": "2.0.0",
                       "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
@@ -8035,13 +4378,11 @@
                   "version": "2.9.0",
                   "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
                       "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
@@ -8049,39 +4390,33 @@
                   "version": "2.13.1",
                   "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.13.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
                       "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
                       "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dev": true,
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
                           "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "dev": true
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
                       "from": "jsonpointer@2.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
                       "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
@@ -8089,13 +4424,11 @@
                   "version": "2.0.1",
                   "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "dev": true,
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
                       "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
                     }
                   }
                 }
@@ -8105,31 +4438,26 @@
               "version": "3.1.3",
               "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dev": true,
               "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
                 "boom": {
                   "version": "2.10.1",
                   "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
                   "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "dev": true
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
                   "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
@@ -8137,37 +4465,31 @@
               "version": "1.1.1",
               "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dev": true,
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
                   "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                 },
                 "jsprim": {
                   "version": "1.3.0",
                   "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
-                  "dev": true,
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
                       "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
                       "from": "json-schema@0.2.2",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
                       "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
@@ -8175,59 +4497,46 @@
                   "version": "1.9.2",
                   "from": "sshpk@>=1.7.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
-                  "dev": true,
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
                       "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "1.0.0",
                       "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "dev": true
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                     },
                     "dashdash": {
                       "version": "1.14.0",
                       "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
-                      "dev": true
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
                     },
                     "getpass": {
                       "version": "0.1.6",
                       "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                      "dev": true
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                     },
                     "jsbn": {
                       "version": "0.1.0",
                       "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.3",
                       "from": "tweetnacl@>=0.13.0 <0.14.0",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
-                      "dev": true,
-                      "optional": true
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     }
                   }
                 }
@@ -8236,132 +4545,111 @@
             "is-typedarray": {
               "version": "1.0.0",
               "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "isstream": {
               "version": "0.1.2",
               "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "json-stringify-safe": {
               "version": "5.0.1",
               "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.11",
               "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.11.tgz",
-              "dev": true,
               "dependencies": {
                 "mime-db": {
                   "version": "1.23.0",
                   "from": "mime-db@>=1.23.0 <1.24.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.23.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
               "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "oauth-sign": {
               "version": "0.8.2",
               "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
             },
             "qs": {
               "version": "6.2.1",
               "from": "qs@>=6.2.0 <6.3.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.1.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
               "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "tough-cookie": {
               "version": "2.3.1",
               "from": "tough-cookie@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.3",
               "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
             }
           }
         },
         "retry": {
           "version": "0.10.0",
           "from": "retry@0.10.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.0.tgz"
         },
         "rimraf": {
           "version": "2.5.4",
           "from": "rimraf@latest",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
         },
         "semver": {
           "version": "5.1.0",
           "from": "semver@>=5.1.0 <5.2.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
         },
         "sha": {
           "version": "2.0.1",
           "from": "sha@2.0.1",
           "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "dev": true,
           "dependencies": {
             "readable-stream": {
               "version": "2.0.2",
               "from": "readable-stream@>=2.0.2 <3.0.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
-              "dev": true,
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
                   "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.3",
                   "from": "process-nextick-args@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
                   "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.1",
                   "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
             }
@@ -8370,72 +4658,60 @@
         "slide": {
           "version": "1.1.6",
           "from": "slide@>=1.1.6 <1.2.0",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz"
         },
         "sorted-object": {
           "version": "2.0.0",
           "from": "sorted-object@2.0.0",
-          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.0.tgz"
         },
         "spdx-license-ids": {
           "version": "1.2.2",
           "from": "spdx-license-ids@1.2.2",
-          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
         },
         "strip-ansi": {
           "version": "3.0.1",
           "from": "strip-ansi@*",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@2.2.1",
-          "dev": true
+          "from": "tar@2.2.1"
         },
         "text-table": {
           "version": "0.2.0",
-          "from": "text-table@~0.2.0",
-          "dev": true
+          "from": "text-table@~0.2.0"
         },
         "uid-number": {
           "version": "0.0.6",
           "from": "uid-number@>=0.0.6 <0.1.0",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
         },
         "umask": {
           "version": "1.1.0",
           "from": "umask@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz"
         },
         "validate-npm-package-license": {
           "version": "3.0.1",
           "from": "validate-npm-package-license@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "dev": true,
           "dependencies": {
             "spdx-correct": {
               "version": "1.0.2",
               "from": "spdx-correct@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
             },
             "spdx-expression-parse": {
               "version": "1.0.2",
               "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-              "dev": true,
               "dependencies": {
                 "spdx-exceptions": {
                   "version": "1.0.4",
                   "from": "spdx-exceptions@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                  "dev": true
+                  "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                 }
               }
             }
@@ -8444,12 +4720,10 @@
         "validate-npm-package-name": {
           "version": "2.2.2",
           "from": "validate-npm-package-name@2.2.2",
-          "dev": true,
           "dependencies": {
             "builtins": {
               "version": "0.0.7",
-              "from": "builtins@0.0.7",
-              "dev": true
+              "from": "builtins@0.0.7"
             }
           }
         },
@@ -8457,129 +4731,108 @@
           "version": "1.2.11",
           "from": "which@1.2.11",
           "resolved": "https://registry.npmjs.org/which/-/which-1.2.11.tgz",
-          "dev": true,
           "dependencies": {
             "isexe": {
               "version": "1.1.2",
               "from": "isexe@>=1.1.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-              "dev": true
+              "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
           "from": "wrappy@>=1.0.2 <1.1.0",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "dev": true
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
         },
         "write-file-atomic": {
           "version": "1.1.4",
-          "from": "write-file-atomic@>=1.1.4 <1.2.0",
-          "dev": true
-        }
-      }
-    },
-    "npm-shrinkwrap": {
-      "version": "6.0.2",
-      "from": "npm-shrinkwrap@>=6.0.2 <7.0.0",
-      "resolved": "https://registry.npmjs.org/npm-shrinkwrap/-/npm-shrinkwrap-6.0.2.tgz",
-      "dev": true,
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "dev": true
+          "from": "write-file-atomic@>=1.1.4 <1.2.0"
+        },
+        "ansi-regex": {
+          "version": "2.0.0",
+          "from": "ansi-regex@2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "from": "imurmurhash@0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
         }
       }
     },
     "nth-check": {
       "version": "1.0.1",
-      "from": "nth-check@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
     },
     "object-assign": {
       "version": "4.1.0",
-      "from": "object-assign@>=4.1.0 <5.0.0",
+      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
     },
     "object-is": {
       "version": "1.0.1",
-      "from": "object-is@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
     },
     "object-keys": {
       "version": "1.0.11",
-      "from": "object-keys@>=1.0.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
     },
     "object.assign": {
       "version": "4.0.4",
-      "from": "object.assign@>=4.0.4 <5.0.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz"
     },
     "object.entries": {
       "version": "1.0.4",
-      "from": "object.entries@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz"
     },
     "object.values": {
       "version": "1.0.4",
-      "from": "object.values@>=1.0.3 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz"
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
     },
     "onetime": {
       "version": "1.1.0",
-      "from": "onetime@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.2 <0.9.0",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz"
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "from": "path-is-inside@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
     },
     "pdf-annotate.js": {
       "version": "1.0.0",
-      "from": "pdf-annotate.js@latest",
+      "from": "https://registry.npmjs.org/pdf-annotate.js/-/pdf-annotate.js-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pdf-annotate.js/-/pdf-annotate.js-1.0.0.tgz"
     },
     "pdfjs-dist": {
@@ -8589,45 +4842,38 @@
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
     },
     "pluralize": {
       "version": "1.2.1",
-      "from": "pluralize@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
     },
     "process-nextick-args": {
       "version": "1.0.7",
-      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
     },
     "react": {
       "version": "0.14.8",
@@ -8654,18 +4900,6 @@
                   "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
                   "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
                   "dependencies": {
-                    "commander": {
-                      "version": "2.9.0",
-                      "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                        }
-                      }
-                    },
                     "detective": {
                       "version": "4.3.2",
                       "from": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
@@ -8686,89 +4920,12 @@
                     "glob": {
                       "version": "5.0.15",
                       "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.6",
-                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        },
-                        "minimatch": {
-                          "version": "3.0.3",
-                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.6",
-                              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.4.2",
-                                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "once": {
-                          "version": "1.4.0",
-                          "from": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.1",
-                          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz"
                     },
                     "iconv-lite": {
                       "version": "0.4.15",
                       "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
                       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
                     },
                     "private": {
                       "version": "0.1.6",
@@ -8827,11 +4984,6 @@
                   }
                 }
               }
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
@@ -8844,18 +4996,6 @@
               "version": "1.2.7",
               "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
               "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "loose-envify": {
-              "version": "1.3.0",
-              "from": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.0.tgz",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "2.0.0",
-                  "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-2.0.0.tgz"
-                }
-              }
             },
             "promise": {
               "version": "7.1.1",
@@ -8883,12 +5023,6 @@
         }
       }
     },
-    "react-addons-test-utils": {
-      "version": "0.14.8",
-      "from": "react-addons-test-utils@>=0.14.8 <0.15.0",
-      "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-0.14.8.tgz",
-      "dev": true
-    },
     "react-dom": {
       "version": "0.14.8",
       "from": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.8.tgz",
@@ -8896,247 +5030,201 @@
     },
     "react-on-rails": {
       "version": "6.1.2",
-      "from": "react-on-rails@6.1.2",
+      "from": "https://registry.npmjs.org/react-on-rails/-/react-on-rails-6.1.2.tgz",
       "resolved": "https://registry.npmjs.org/react-on-rails/-/react-on-rails-6.1.2.tgz"
-    },
-    "react-pdf-js": {
-      "version": "1.0.32",
-      "from": "react-pdf-js@latest",
-      "resolved": "https://registry.npmjs.org/react-pdf-js/-/react-pdf-js-1.0.32.tgz",
-      "dependencies": {
-        "pdfjs-dist": {
-          "version": "1.6.361",
-          "from": "pdfjs-dist@1.6.361",
-          "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-1.6.361.tgz"
-        }
-      }
     },
     "readable-stream": {
       "version": "2.2.2",
-      "from": "readable-stream@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
     },
     "readline2": {
       "version": "1.0.1",
-      "from": "readline2@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
     },
     "rechoir": {
       "version": "0.6.2",
-      "from": "rechoir@>=0.6.2 <0.7.0",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
     },
     "redeyed": {
       "version": "0.5.0",
-      "from": "redeyed@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.5.0.tgz",
-      "dev": true,
       "dependencies": {
         "esprima-fb": {
           "version": "12001.1.0-dev-harmony-fb",
-          "from": "esprima-fb@>=12001.1.0-dev-harmony-fb <12001.2.0",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-12001.1.0-dev-harmony-fb.tgz"
         }
       }
     },
     "regenerator-runtime": {
       "version": "0.10.1",
-      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz"
     },
     "require-uncached": {
       "version": "1.0.3",
-      "from": "require-uncached@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz"
     },
     "resolve": {
       "version": "1.2.0",
-      "from": "resolve@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.2.0.tgz"
     },
     "resolve-from": {
       "version": "1.0.1",
-      "from": "resolve-from@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
     },
     "restore-cursor": {
       "version": "1.0.1",
-      "from": "restore-cursor@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz"
     },
     "rimraf": {
       "version": "2.5.4",
-      "from": "rimraf@>=2.2.8 <3.0.0",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
     },
     "run-async": {
       "version": "0.1.0",
-      "from": "run-async@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz"
     },
     "run-parallel": {
       "version": "1.1.6",
-      "from": "run-parallel@>=1.1.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.6.tgz"
     },
     "run-series": {
       "version": "1.1.4",
-      "from": "run-series@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.4.tgz"
     },
     "rx-lite": {
       "version": "3.1.2",
-      "from": "rx-lite@>=3.1.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
     },
     "safe-json-parse": {
       "version": "2.0.0",
-      "from": "safe-json-parse@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-2.0.0.tgz"
     },
     "semver": {
       "version": "4.3.6",
-      "from": "semver@>=4.0.3 <5.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
     },
     "shelljs": {
       "version": "0.7.5",
-      "from": "shelljs@>=0.7.5 <0.8.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.5.tgz"
     },
     "slice-ansi": {
       "version": "0.0.4",
-      "from": "slice-ansi@0.0.4",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
     },
     "sorted-object": {
       "version": "1.0.0",
-      "from": "sorted-object@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/sorted-object/-/sorted-object-1.0.0.tgz"
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "from": "sprintf-js@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "dev": true
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
     },
     "string-template": {
       "version": "0.2.1",
-      "from": "string-template@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz"
     },
     "string-width": {
       "version": "1.0.2",
-      "from": "string-width@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
     },
     "strip-bom": {
       "version": "3.0.0",
-      "from": "strip-bom@>=3.0.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
     },
     "superagent": {
       "version": "3.0.0",
-      "from": "superagent@*",
+      "from": "https://registry.npmjs.org/superagent/-/superagent-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.0.0.tgz",
       "dependencies": {
         "component-emitter": {
           "version": "1.2.1",
-          "from": "component-emitter@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz"
         },
         "cookiejar": {
           "version": "2.1.0",
-          "from": "cookiejar@>=2.0.6 <3.0.0",
+          "from": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.0.tgz"
         },
         "debug": {
           "version": "2.3.3",
-          "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.2",
-              "from": "ms@0.7.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-            }
-          }
+          "from": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz"
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "form-data": {
           "version": "2.1.2",
-          "from": "form-data@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
           "dependencies": {
             "asynckit": {
               "version": "0.4.0",
-              "from": "asynckit@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <2.0.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "mime-types": {
               "version": "2.1.13",
-              "from": "mime-types@>=2.1.12 <3.0.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.25.0",
-                  "from": "mime-db@>=1.25.0 <1.26.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz"
                 }
               }
@@ -9145,176 +5233,115 @@
         },
         "formidable": {
           "version": "1.0.17",
-          "from": "formidable@>=1.0.17 <2.0.0",
+          "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz",
           "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
         },
         "methods": {
           "version": "1.1.2",
-          "from": "methods@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.3.4 <2.0.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "qs": {
           "version": "6.3.0",
-          "from": "qs@>=6.1.0 <7.0.0",
+          "from": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
-        },
-        "readable-stream": {
-          "version": "2.2.2",
-          "from": "readable-stream@>=2.0.5 <3.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-          "dependencies": {
-            "buffer-shims": {
-              "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-            },
-            "core-util-is": {
-              "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            },
-            "process-nextick-args": {
-              "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0",
-              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-            }
-          }
         }
       }
     },
     "superagent-no-cache": {
       "version": "0.1.0",
-      "from": "superagent-no-cache@*",
+      "from": "https://registry.npmjs.org/superagent-no-cache/-/superagent-no-cache-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/superagent-no-cache/-/superagent-no-cache-0.1.0.tgz",
       "dependencies": {
         "component-ie": {
           "version": "1.0.0",
-          "from": "component-ie@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/component-ie/-/component-ie-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/component-ie/-/component-ie-1.0.0.tgz"
         }
       }
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
     },
     "table": {
       "version": "3.8.3",
-      "from": "table@>=3.7.8 <4.0.0",
+      "from": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
-      "dev": true,
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "dev": true
-        },
         "string-width": {
           "version": "2.0.0",
-          "from": "string-width@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "dev": true
+          "from": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz"
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
         }
       }
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
     },
     "to-fast-properties": {
       "version": "1.0.2",
-      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
     },
     "tryit": {
       "version": "1.0.3",
-      "from": "tryit@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
     },
     "type-detect": {
       "version": "1.0.0",
-      "from": "type-detect@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
     "user-home": {
       "version": "2.0.0",
-      "from": "user-home@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz"
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
     },
     "uuid": {
       "version": "2.0.3",
-      "from": "uuid@>=2.0.3 <3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
     },
     "webpack": {
       "version": "1.13.3",
-      "from": "webpack@>=1.12.14 <2.0.0",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-1.13.3.tgz",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.13.3.tgz",
       "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-        },
         "async": {
           "version": "1.5.2",
           "from": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -9330,17 +5357,17 @@
           "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "dependencies": {
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            },
             "memory-fs": {
               "version": "0.2.0",
               "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
             }
           }
+        },
+        "acorn": {
+          "version": "3.3.0",
+          "from": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
         },
         "interpret": {
           "version": "0.6.6",
@@ -9366,11 +5393,6 @@
               "version": "0.5.0",
               "from": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.0.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.0",
-              "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
             }
           }
         },
@@ -9390,60 +5412,6 @@
                   "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
                 }
               }
-            },
-            "readable-stream": {
-              "version": "2.2.2",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-              "dependencies": {
-                "buffer-shims": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
@@ -9483,11 +5451,6 @@
                   "version": "1.1.8",
                   "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
                   "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 }
               }
             },
@@ -9549,11 +5512,6 @@
                   "version": "0.2.1",
                   "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 }
               }
             },
@@ -9592,16 +5550,6 @@
               "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
                 "isarray": {
                   "version": "0.0.1",
                   "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -9612,19 +5560,7 @@
             "stream-browserify": {
               "version": "1.0.0",
               "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+              "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz"
             },
             "timers-browserify": {
               "version": "1.4.2",
@@ -9684,29 +5620,22 @@
           "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
-            "minimist": {
-              "version": "0.0.10",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            },
             "wordwrap": {
               "version": "0.0.3",
               "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
         },
         "tapable": {
           "version": "0.1.10",
@@ -9866,11 +5795,6 @@
                   "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
                   "dependencies": {
-                    "arrify": {
-                      "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                    },
                     "micromatch": {
                       "version": "2.3.11",
                       "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -9916,14 +5840,7 @@
                                     "isobject": {
                                       "version": "2.1.0",
                                       "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                      "dependencies": {
-                                        "isarray": {
-                                          "version": "1.0.0",
-                                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                                        }
-                                      }
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
                                     },
                                     "randomatic": {
                                       "version": "1.1.5",
@@ -10067,11 +5984,6 @@
                   "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
                 },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
                 "is-binary-path": {
                   "version": "1.0.1",
                   "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -10096,77 +6008,11 @@
                     }
                   }
                 },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                },
                 "readdirp": {
                   "version": "2.1.0",
                   "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
                   "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.3",
-                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.6",
-                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.2.2",
-                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
-                      "dependencies": {
-                        "buffer-shims": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                        },
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    },
                     "set-immediate-shim": {
                       "version": "1.0.1",
                       "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -10175,11 +6021,6 @@
                   }
                 }
               }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
             }
           }
         },
@@ -10188,11 +6029,6 @@
           "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "dependencies": {
-            "source-list-map": {
-              "version": "0.1.6",
-              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
-              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
-            },
             "source-map": {
               "version": "0.4.4",
               "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
@@ -10204,6 +6040,11 @@
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
                 }
               }
+            },
+            "source-list-map": {
+              "version": "0.1.6",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.6.tgz"
             }
           }
         }
@@ -10211,27 +6052,23 @@
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz"
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "dev": true
+      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
     }
   }
 }


### PR DESCRIPTION
Fixes an issue where `npm shrinkwrap` would fail. This was an oversight of mine in the client/README. Should now be an official step to npm shrinkwrap when adding new modules.

Test:
- [x] Deleted `/node_modules` , did a fresh `npm install` and it worked
- [x] Verified `npm shrinkwrap` works