### PR TITLE
Refactor EstablishClaimReview into react component

### DIFF
--- a/client/app/containers/BaseForm.jsx
+++ b/client/app/containers/BaseForm.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 
 export default class BaseForm extends React.Component {
 
-  handleFieldChange = function (form, field) {
+  handleFieldChange = (form, field) => {
     return (value) => {
       let stateObject = {};
 

--- a/client/app/containers/BaseForm.jsx
+++ b/client/app/containers/BaseForm.jsx
@@ -3,14 +3,12 @@ import ReactDOM from 'react-dom';
 
 export default class BaseForm extends React.Component {
 
-  handleFieldChange = (form, field) => {
-    return (value) => {
-      let stateObject = {};
+  handleFieldChange = (form, field) => (value) => {
+    let stateObject = {};
 
-      stateObject[form] = { ...this.state[form] };
-      stateObject[form][field].value = value;
-      this.setState(stateObject);
-    };
+    stateObject[form] = { ...this.state[form] };
+    stateObject[form][field].value = value;
+    this.setState(stateObject);
   };
 
   validateFormAndSetErrors = function(form) {

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -173,7 +173,7 @@ export default class EstablishClaim extends BaseForm {
     });
   }
 
-  handleModalClose = function (modal) {
+  handleModalClose = (modal) => {
     return () => {
       let stateObject = {};
 
@@ -358,8 +358,15 @@ export default class EstablishClaim extends BaseForm {
     let {
       loading,
       cancelModalDisplay,
-      modalSubmitLoading
+      modalSubmitLoading,
+      specialIssueModalDisplay,
+      specialIssues
     } = this.state;
+
+    let {
+      pdfLink,
+      pdfjsLink
+    } = this.props;
 
     return (
       <div>
@@ -367,11 +374,13 @@ export default class EstablishClaim extends BaseForm {
           <EstablishClaimReview
             decisionType={this.state.reviewForm.decisionType}
             handleDecisionTypeChange={this.handleDecisionTypeChange}
-            specialIssues={this.state.specialIssues}
             handleCancelTaskForSpecialIssue={this.handleCancelTaskForSpecialIssue}
             handleFieldChange={this.handleFieldChange}
             handleModalClose={this.handleModalClose}
-            specialIssueModalDisplay={this.state.specialIssueModalDisplay}
+            pdfLink={pdfLink}
+            pdfjsLink={pdfjsLink}
+            specialIssueModalDisplay={specialIssueModalDisplay}
+            specialIssues={specialIssues}
           />
         }
         { this.isAssociatePage() &&

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -13,7 +13,7 @@ import requiredValidator from '../../util/validators/RequiredValidator';
 import dateValidator from '../../util/validators/DateValidator';
 import { formatDate } from '../../util/DateUtil';
 import EstablishClaimReview, * as Review from './EstablishClaimReview';
-import EstablishClaimForm, * as Form from './EstablishClaimForm';
+import * as Form from './EstablishClaimForm';
 import AssociatePage from './EstablishClaimAssociateEP';
 
 export const REVIEW_PAGE = 0;

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -12,8 +12,8 @@ import FormField from '../../util/FormField';
 import requiredValidator from '../../util/validators/RequiredValidator';
 import dateValidator from '../../util/validators/DateValidator';
 import { formatDate } from '../../util/DateUtil';
-import * as Review from './EstablishClaimReview';
-import * as Form from './EstablishClaimForm';
+import EstablishClaimReview, * as Review from './EstablishClaimReview';
+import EstablishClaimForm, * as Form from './EstablishClaimForm';
 import AssociatePage from './EstablishClaimAssociateEP';
 
 export const REVIEW_PAGE = 0;
@@ -363,15 +363,25 @@ export default class EstablishClaim extends BaseForm {
 
     return (
       <div>
-        { this.isReviewPage() && Review.render.call(this) }
+        { this.isReviewPage() &&
+          <EstablishClaimReview
+            decisionType={this.state.reviewForm.decisionType}
+            handleDecisionTypeChange={this.handleDecisionTypeChange}
+            specialIssues={this.state.specialIssues}
+            handleCancelTaskForSpecialIssue={this.handleCancelTaskForSpecialIssue}
+            handleFieldChange={this.handleFieldChange}
+            handleModalClose={this.handleModalClose}
+            specialIssueModalDisplay={this.state.specialIssueModalDisplay}
+          />
+        }
         { this.isAssociatePage() &&
           <AssociatePage
             endProducts={this.props.task.appeal.non_canceled_end_products_within_30_days}
-            task = {this.props.task}
-            decisionType = {this.state.reviewForm.decisionType.value}
-            handleAlert = {this.props.handleAlert}
-            handleAlertClear = {this.props.handleAlertClear}
-            hasAvailableModifers = {this.hasAvailableModifers()}
+            task={this.props.task}
+            decisionType={this.state.reviewForm.decisionType.value}
+            handleAlert={this.props.handleAlert}
+            handleAlertClear={this.props.handleAlertClear}
+            hasAvailableModifers={this.hasAvailableModifers()}
           />
         }
         { this.isFormPage() && Form.render.call(this) }

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -173,13 +173,11 @@ export default class EstablishClaim extends BaseForm {
     });
   }
 
-  handleModalClose = (modal) => {
-    return () => {
-      let stateObject = {};
+  handleModalClose = (modal) => () => {
+    let stateObject = {};
 
-      stateObject[modal] = false;
-      this.setState(stateObject);
-    };
+    stateObject[modal] = false;
+    this.setState(stateObject);
   };
 
   handleCancelTask = () => {

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -80,107 +80,118 @@ export const REGIONAL_OFFICE_SPECIAL_ISSUES = [
   'spinaBifida'
 ];
 
-export const render = function() {
-  let { pdfLink, pdfjsLink } = this.props;
+export default class EstablishClaimReview extends React.Component {
+  render() {
+    let {
+      decisionType,
+      handleCancelTaskForSpecialIssue,
+      handleDecisionTypeChange,
+      handleFieldChange,
+      handleModalClose,
+      pdfLink,
+      pdfjsLink,
+      specialIssueModalDisplay,
+      specialIssues
+    } = this.props;
 
-  let count = 0;
+    let count = 0;
 
-  let issueType = '';
+    let issueType = '';
 
-  if (this.state.reviewForm.decisionType.value === 'Remand' ||
-  this.state.reviewForm.decisionType.value === 'Partial Grant') {
-    issueType = SPECIAL_ISSUE_PARTIAL;
-  } else {
-    issueType = SPECIAL_ISSUE_FULL;
-  }
+    if (decisionType.value === 'Remand' || decisionType.value === 'Partial Grant') {
+      issueType = SPECIAL_ISSUE_PARTIAL;
+    } else {
+      issueType = SPECIAL_ISSUE_FULL;
+    }
 
-  return (
-    <div>
-      <div className="cf-app-segment cf-app-segment--alt">
-        <h2>Review Decision</h2>
-        Review the final decision from VBMS below to determine the next step.
-      </div>
-      {
+    return (
+      <div>
+        <div className="cf-app-segment cf-app-segment--alt">
+          <h2>Review Decision</h2>
+          Review the final decision from VBMS below to determine the next step.
+        </div>
+        {
 
-      /* This link is here for 508 compliance, and shouldn't be visible to sighted
-       users. We need to allow non-sighted users to preview the Decision. Adobe Acrobat
-       is the accessibility standard and is used across gov't, so we'll recommend it
-       for now. The usa-sr-only class will place an element off screen without
-       affecting its placement in tab order, thus making it invisible onscreen
-       but read out by screen readers. */
-      }
-      <a
-        className="usa-sr-only"
-        id="sr-download-link"
-        href={pdfLink}
-        download
-        target="_blank">
-        The PDF viewer in your browser may not be accessible. Click to download
-        the Decision PDF so you can preview it in a reader with accessibility features
-        such as Adobe Acrobat.
-      </a>
-      <a className="usa-sr-only" href="#establish-claim-buttons">
-        If you are using a screen reader and have downloaded and verified the Decision
-        PDF, click this link to skip past the browser PDF viewer to the
-        establish-claim buttons.
-      </a>
-
-      <iframe
-        aria-label="The PDF embedded here is not accessible. Please use the above
-          link to download the PDF and view it in a PDF reader. Then use the buttons
-          below to go back and make edits or upload and certify the document."
-        className="cf-doc-embed cf-app-segment"
-        title="Form8 PDF"
-        src={pdfjsLink}>
-      </iframe>
-      <div className="cf-app-segment cf-app-segment--alt">
-      <DropDown
-       label="Decision Type"
-       name="decisionType"
-       options={DECISION_TYPE}
-       onChange={this.handleDecisionTypeChange}
-       {...this.state.reviewForm.decisionType}
-      />
-
-    <label>Special Issue Categories</label>
-      {
-
-        /* eslint-disable no-return-assign */
-        issueType.map((issue) =>
-        <Checkbox
-            id={ApiUtil.convertToCamelCase(issue)}
-            label={issue}
-            name={ApiUtil.convertToCamelCase(issue)}
-            {...this.state.specialIssues[issue]}
-            onChange={this.handleFieldChange('specialIssues',
-                ApiUtil.convertToCamelCase(issue))}
-            key={count += 1}
-          />)
-
-          /* eslint-enable no-return-assign */
-      }
-    </div>
-    {this.state.specialIssueModalDisplay && <Modal
-      buttons={[
-        { classNames: ["cf-btn-link"],
-          name: '\u00AB Close',
-          onClick: this.handleModalClose('specialIssueModalDisplay')
-        },
-        { classNames: ["usa-button", "usa-button-secondary"],
-          name: 'Cancel Claim Establishment',
-          onClick: this.handleCancelTaskForSpecialIssue
+        /* This link is here for 508 compliance, and shouldn't be visible to sighted
+         users. We need to allow non-sighted users to preview the Decision. Adobe Acrobat
+         is the accessibility standard and is used across gov't, so we'll recommend it
+         for now. The usa-sr-only class will place an element off screen without
+         affecting its placement in tab order, thus making it invisible onscreen
+         but read out by screen readers. */
         }
-      ]}
-      visible={true}
-      closeHandler={this.handleModalClose('specialIssueModalDisplay')}
-      title="Special Issue Grant">
-      <p>
-        You selected a special issue category not handled by AMO. Special
-        issue cases cannot be processed in caseflow at this time. Please
-        select <b>Cancel Claim Establishment</b> and proceed to process
-        this case manually in VBMS.
-      </p>
-    </Modal>}
-  </div>
-  );
+        <a
+          className="usa-sr-only"
+          id="sr-download-link"
+          href={pdfLink}
+          download
+          target="_blank">
+          The PDF viewer in your browser may not be accessible. Click to download
+          the Decision PDF so you can preview it in a reader with accessibility features
+          such as Adobe Acrobat.
+        </a>
+        <a className="usa-sr-only" href="#establish-claim-buttons">
+          If you are using a screen reader and have downloaded and verified the Decision
+          PDF, click this link to skip past the browser PDF viewer to the
+          establish-claim buttons.
+        </a>
+
+        <iframe
+          aria-label="The PDF embedded here is not accessible. Please use the above
+            link to download the PDF and view it in a PDF reader. Then use the buttons
+            below to go back and make edits or upload and certify the document."
+          className="cf-doc-embed cf-app-segment"
+          title="Form8 PDF"
+          src={pdfjsLink}>
+        </iframe>
+        <div className="cf-app-segment cf-app-segment--alt">
+        <DropDown
+         label="Decision Type"
+         name="decisionType"
+         options={DECISION_TYPE}
+         onChange={handleDecisionTypeChange}
+         {...decisionType}
+        />
+
+      <label>Special Issue Categories</label>
+        {
+
+          /* eslint-disable no-return-assign */
+          issueType.map((issue) =>
+          <Checkbox
+              id={ApiUtil.convertToCamelCase(issue)}
+              label={issue}
+              name={ApiUtil.convertToCamelCase(issue)}
+              {...specialIssues[issue]}
+              onChange={handleFieldChange('specialIssues',
+                  ApiUtil.convertToCamelCase(issue))}
+              key={count += 1}
+            />)
+
+            /* eslint-enable no-return-assign */
+        }
+      </div>
+      {specialIssueModalDisplay && <Modal
+        buttons={[
+          { classNames: ["cf-btn-link"],
+            name: '\u00AB Close',
+            onClick: handleModalClose('specialIssueModalDisplay')
+          },
+          { classNames: ["usa-button", "usa-button-secondary"],
+            name: 'Cancel Claim Establishment',
+            onClick: handleCancelTaskForSpecialIssue
+          }
+        ]}
+        visible={true}
+        closeHandler={handleModalClose('specialIssueModalDisplay')}
+        title="Special Issue Grant">
+        <p>
+          You selected a special issue category not handled by AMO. Special
+          issue cases cannot be processed in caseflow at this time. Please
+          select <b>Cancel Claim Establishment</b> and proceed to process
+          this case manually in VBMS.
+        </p>
+      </Modal>}
+    </div>
+    );
+  }
 };

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -194,4 +194,4 @@ export default class EstablishClaimReview extends React.Component {
     </div>
     );
   }
-};
+}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -1,4 +1,4 @@
-import React, { PropTypes }  from 'react';
+import React, { PropTypes } from 'react';
 import DropDown from '../../components/DropDown';
 import Checkbox from '../../components/Checkbox';
 import Modal from '../../components/Modal';

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -198,8 +198,8 @@ export default class EstablishClaimReview extends React.Component {
 
 EstablishClaimReview.propTypes = {
   decisionType: PropTypes.object.isRequired,
-  handleDecisionTypeChange: PropTypes.func.isRequired,
   handleCancelTaskForSpecialIssue: PropTypes.func.isRequired,
+  handleDecisionTypeChange: PropTypes.func.isRequired,
   handleFieldChange: PropTypes.func.isRequired,
   handleModalClose: PropTypes.func.isRequired,
   pdfLink: PropTypes.string.isRequired,

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes }  from 'react';
 import DropDown from '../../components/DropDown';
 import Checkbox from '../../components/Checkbox';
 import Modal from '../../components/Modal';
@@ -195,3 +195,15 @@ export default class EstablishClaimReview extends React.Component {
     );
   }
 }
+
+EstablishClaimReview.propTypes = {
+  decisionType: PropTypes.object.isRequired,
+  handleDecisionTypeChange: PropTypes.func.isRequired,
+  handleCancelTaskForSpecialIssue: PropTypes.func.isRequired,
+  handleFieldChange: PropTypes.func.isRequired,
+  handleModalClose: PropTypes.func.isRequired,
+  pdfLink: PropTypes.string.isRequired,
+  pdfjsLink: PropTypes.string.isRequired,
+  specialIssueModalDisplay: PropTypes.bool.isRequired,
+  specialIssues: PropTypes.object.isRequired
+};

--- a/client/test/containers/EstablishClaim-test.js
+++ b/client/test/containers/EstablishClaim-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import EstablishClaim, { FORM_PAGE } from
+import EstablishClaim, { FORM_PAGE, REVIEW_PAGE } from
   '../../app/containers/EstablishClaimPage/EstablishClaim';
 
 describe('EstablishClaim', () => {
@@ -23,12 +23,12 @@ describe('EstablishClaim', () => {
 
       wrapper = mount(<EstablishClaim task={task}/>);
 
-      // Force component to Form page
-      wrapper.setState({ page: FORM_PAGE });
     });
 
     context('when task is canceled', () => {
       beforeEach(() => {
+        // Force component to Form page
+        wrapper.setState({ page: FORM_PAGE });
         wrapper.find('#button-Cancel').simulate('click');
       });
 
@@ -39,6 +39,35 @@ describe('EstablishClaim', () => {
       it('modal can be closed', () => {
         wrapper.find('#Cancel-EP-Establishment-button-id-0').simulate('click');
         expect(wrapper.find('.cf-modal')).to.have.length(0);
+      });
+    });
+
+    context('EstablishClaimReview', () => {
+      beforeEach(() => {
+        wrapper.setState({ page: REVIEW_PAGE });
+      });
+
+      it('shows special issues modal if special issue selected', () => {
+        expect(wrapper.find('.cf-modal-body')).to.have.length(0);
+
+        // Click VAMC special issue checkbox
+        wrapper.find('#vamc').simulate('change', { target: {checked: true }});
+
+        // Click to create end product
+        wrapper.find('#button-Create-End-Product').simulate('click');
+        expect(wrapper.find('.cf-modal-body')).to.have.length(1);
+      });
+
+      it('shows cancel model', () => {
+        expect(wrapper.find('.cf-modal-body')).to.have.length(0);
+
+        // click cancel to open modal
+        wrapper.find('#button-Cancel').simulate('click');
+        expect(wrapper.find('.cf-modal-body')).to.have.length(1);
+
+        // Click go back and close modal
+        wrapper.find('#Cancel-EP-Establishment-button-id-0').simulate('click');
+        expect(wrapper.find('.cf-modal-body')).to.have.length(0);
       });
     });
   });

--- a/client/test/containers/EstablishClaim-test.js
+++ b/client/test/containers/EstablishClaim-test.js
@@ -51,7 +51,7 @@ describe('EstablishClaim', () => {
         expect(wrapper.find('.cf-modal-body')).to.have.length(0);
 
         // Click VAMC special issue checkbox
-        wrapper.find('#vamc').simulate('change', { target: {checked: true }});
+        wrapper.find('#vamc').simulate('change', { target: { checked: true } });
 
         // Click to create end product
         wrapper.find('#button-Create-End-Product').simulate('click');


### PR DESCRIPTION
PR 1 refactoring EstablishClaim code. Converts EstablishClaimReview into a true react component

connects #733 

Testing:
- [x] Existing tests pass
- [x] webpack build succeeds
- [x] manual testing in browser, page still works