### PR TITLE
Anya/762 migration record other explanation

### DIFF
--- a/db/migrate/20170127165539_update_blank_record_other_explanation.rb
+++ b/db/migrate/20170127165539_update_blank_record_other_explanation.rb
@@ -1,0 +1,7 @@
+class UpdateBlankRecordOtherExplanation < ActiveRecord::Migration
+  def change
+    Form8.find_each do |form8|
+      form8.update(record_other_explanation: "Unknown") if form8.record_other_explanation == "{}"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170127155914) do
+ActiveRecord::Schema.define(version: 20170127165539) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Initially in form8, `record_other_explanation` data type was set to be an array, however, in the UI it is a text field and it has always been saved as a plain text which resulted in an empty array. The previous migration changed the data type to "text" which changed record_other_explanation to have values: `"{}"`. As a result we needed to create a migration to update `record_other_explanation` field with "Unknown" if record_other_explanation was set to `"{}"`. 

connects #762 

Testing:
* Tested this migration locally