### PR TITLE
Update pdfjs_viewer-rails to the latest version to not have warnings …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 
 # PDF Tools
 gem 'pdf-forms'
-gem 'pdfjs_viewer-rails'
+#
+gem 'pdfjs_viewer-rails', git: "https://github.com/senny/pdfjs_viewer-rails.git", ref: 'a4249eacbf70175db63b57e9f364d0a9a79e2b43'
 
 # Error reporting to Sentry
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,15 @@ GIT
       railties
       sass (~> 3.4)
 
+GIT
+  remote: https://github.com/senny/pdfjs_viewer-rails.git
+  revision: a4249eacbf70175db63b57e9f364d0a9a79e2b43
+  ref: a4249eacbf70175db63b57e9f364d0a9a79e2b43
+  specs:
+    pdfjs_viewer-rails (0.0.9)
+      rails (> 4.2.0)
+      sass-rails (~> 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -97,7 +106,7 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    arel (6.0.3)
+    arel (6.0.4)
     ast (2.3.0)
     aws-sdk (2.6.46)
       aws-sdk-resources (= 2.6.46)
@@ -113,7 +122,7 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     brakeman (3.3.1)
-    builder (3.2.2)
+    builder (3.2.3)
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -130,7 +139,7 @@ GEM
     cliver (0.3.2)
     coderay (1.1.1)
     colorize (0.7.7)
-    concurrent-ruby (1.0.2)
+    concurrent-ruby (1.0.4)
     connection_pool (2.2.1)
     d3-rails (4.3.0)
       railties (>= 3.1)
@@ -184,7 +193,7 @@ GEM
       execjs (>= 1.4.0)
       multi_json (~> 1.0)
       therubyracer (~> 0.12.1)
-    json (1.8.3)
+    json (1.8.6)
     konacha (4.0.0)
       actionpack (>= 4.1, < 5)
       capybara
@@ -210,7 +219,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.10.1)
     moment_timezone-rails (0.5.0)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
@@ -220,12 +229,10 @@ GEM
       sass (>= 3.3)
       thor (~> 0.19)
     nenv (0.3.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    nokogiri (1.6.8-x64-mingw32)
+    nokogiri (1.6.8.1-x64-mingw32)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
     nori (2.6.0)
     notiffany (0.1.0)
       nenv (~> 0.1)
@@ -238,11 +245,7 @@ GEM
     pdf-forms (1.0.0)
       cliver (~> 0.3.2)
       safe_shell (>= 1.0.3, < 2.0)
-    pdfjs_viewer-rails (0.0.8)
-      rails (> 4.2.0)
-      sass-rails (~> 5.0)
     pg (0.18.4)
-    pkg-config (1.1.7)
     poltergeist (1.10.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -256,7 +259,7 @@ GEM
       slop (~> 3.4)
     puma (2.16.0)
     quantile (0.2.0)
-    rack (1.6.4)
+    rack (1.6.5)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
@@ -274,9 +277,9 @@ GEM
       sprockets-rails
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
-    rails-dom-testing (1.0.7)
+    rails-dom-testing (1.0.8)
       activesupport (>= 4.2.0.beta, < 5.0)
-      nokogiri (~> 1.6.0)
+      nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
@@ -287,7 +290,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.2.2)
+    rake (11.3.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
@@ -355,7 +358,7 @@ GEM
     rubyzip (1.2.0)
     rufus-scheduler (3.2.2)
     safe_shell (1.0.3)
-    sass (3.4.22)
+    sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
@@ -399,10 +402,10 @@ GEM
     simplecov-html (0.10.0)
     slop (3.6.0)
     socksify (1.7.0)
-    sprockets (3.7.0)
+    sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.1.1)
+    sprockets-rails (3.2.0)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -411,9 +414,9 @@ GEM
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
-    tilt (2.0.5)
+    tilt (2.0.6)
     timecop (0.8.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -470,7 +473,7 @@ DEPENDENCIES
   parallel
   parallel_tests
   pdf-forms
-  pdfjs_viewer-rails
+  pdfjs_viewer-rails!
   pg
   prometheus-client
   pry


### PR DESCRIPTION
…by default

Do not display warnings (default) for PDF JS

Note: it doesn't remove messages around PDF (ex: `PDF 8249cfa1b29ffd18fdc43ff03c76af68 [1.7 itext-paulo-155 (itextpdf.sf.net-lowagie.com) / pdftk 2.02 - www.pdftk.com] (PDF.js: 1.3.91)`)

![image](https://cloud.githubusercontent.com/assets/3811786/22467159/81eb9c3a-e791-11e6-91a3-467ed08dd429.png)

connect #748 