### PR TITLE
warmup VACOLS connection pool on startup

### DIFF
--- a/app/models/vacols/record.rb
+++ b/app/models/vacols/record.rb
@@ -2,4 +2,5 @@ class VACOLS::Record < ActiveRecord::Base
   self.abstract_class = true
 
   establish_connection "#{Rails.env}_vacols".to_sym
+  ActiveSupport.run_load_hooks(:active_record_vacols, VACOLS::Record)
 end

--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -6,8 +6,15 @@ ActiveSupport.on_load(:active_record_vacols) do
 
   # use specified initial pool size, default to half the maximum size
   initial_pool_size = (ENV['DB_CONN_POOL_INITIAL_SIZE'] || db_config['pool'] / 2).to_i
+  Rails.logger.info("creating #{initial_pool_size} initial connections...")
+
+  MetricsService.timer "created #{initial_pool_size} connections" do
+    warmup_pool(VACOLS::Record.connection_pool, initial_pool_size)
+  end
+end
+
+def warmup_pool(pool, initial_pool_size)
   threads = []
-  pool = VACOLS::Record.connection_pool
 
   initial_pool_size.times do |i|
     threads << Thread.new do

--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -1,0 +1,20 @@
+
+# VACOLS throttles the rate of new connections, create up front to prevent 
+# blocking as pool grows under load
+ActiveSupport.on_load(:active_record_vacols) do
+  db_config =  Rails.application.config.database_configuration[Rails.env]
+
+  # use specified initial pool size, default to half the maximum size
+  initial_pool_size = (ENV['DB_CONN_POOL_INITIAL_SIZE'] || db_config['pool'] / 2).to_i
+  threads = []
+  pool = VACOLS::Record.connection_pool
+
+  initial_pool_size.times do |i|
+    threads << Thread.new do
+      conn = pool.connection
+      conn.close
+    end
+  end
+
+  threads.each(&:join)
+end


### PR DESCRIPTION
Most database pools allow a configurable initial size. `ActiveRecord` does not.

VACOLS server limits the rate at which new connections can be established. So the pool cannot grow fast enough to accommodate even moderate traffic on startup. 

This PR forces the creation of `DB_CONN_POOL_INITIAL_SIZE` VACOLS connections on application startup (defaults to half the maximum value).

Fixes #801