### PR TITLE
Change e-reader to use vacols id vs vbms id

### DIFF
--- a/app/controllers/review_controller.rb
+++ b/app/controllers/review_controller.rb
@@ -2,8 +2,8 @@ class ReviewController < ApplicationController
   before_action :verify_system_admin
 
   def index
-    vbms_id = params[:vbms_id]
-    @appeal = Appeal.find_or_create_by_vbms_id(vbms_id)
+    vacols_id = params[:vacols_id]
+    @appeal = Appeal.find_or_create_by_vacols_id(vacols_id)
   end
 
   def logo_name

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -250,7 +250,8 @@ class Fakes::AppealRepository
         description: "Service Connection New & Material 5062 Arthritis and Rheumatoid",
         disposition: "Granted",
         program: "Compensation"
-      }]
+      }],
+      documents: [nod_document, soc_document, form9_document, decision_document]
     }
   end
 


### PR DESCRIPTION
Currently we look up the documents from the vbms_id. However, the code is better setup to look things up by vacols_id.

**Test Plan**
- [ ] Test manually in UAT