### PR TITLE
Refactor verify_authentication before filter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,7 @@ class ApplicationController < ActionController::Base
                 :setup_fakes,
                 :check_whats_new_cookie
   before_action :set_raven_user
+  before_action :verify_authentication
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from VBMSError, with: :on_vbms_error

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -1,7 +1,6 @@
 require "vbms_error"
 
 class CertificationsController < ApplicationController
-  before_action :verify_authentication
   before_action :verify_access
 
   def new

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authentication
+
   def show
     status_code = params[:status_code]
     template_name = status_code == "404" ? "errors/404" : "errors/500"

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,6 +1,5 @@
 class HealthChecksController < ApplicationController
-  skip_before_action :authenticate
-  skip_before_action :authorize
+  skip_before_action :verify_authentication
 
   def show
     render json: { healthy: true }.merge(Rails.application.config.build_version || {})

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,2 +1,3 @@
 class HelpController < ApplicationController
+  skip_before_action :verify_authentication
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,5 @@
 class SessionsController < ApplicationController
+  skip_before_action :verify_authentication,
   def new
     if Rails.application.config.sso_service_disabled
       @error_title = "Login Service Unavailable"

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
-  skip_before_action :verify_authentication,
+  skip_before_action :verify_authentication
+
   def new
     if Rails.application.config.sso_service_disabled
       @error_title = "Login Service Unavailable"

--- a/app/controllers/test/setup_controller.rb
+++ b/app/controllers/test/setup_controller.rb
@@ -28,6 +28,8 @@ class Test::SetupController < ApplicationController
 
   # Set current user in DEMO
   def set_user
+    User.before_set_user # for testing only
+
     session["user"] = User.authentication_service.get_user_session(params[:id])
     redirect_to "/test/users"
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,9 @@ class User < ActiveRecord::Base
   def display_name
     # fully authenticated
     if authenticated?
-      "#{username} (#{regional_office})"
+    name = "#{username} (#{regional_office})"
+    p "DISPLAY NAME: #{name}"
+    name
 
     # just SSOI, not yet vacols authenticated
     else
@@ -82,6 +84,11 @@ class User < ActiveRecord::Base
   class << self
     attr_writer :authentication_service
     delegate :authenticate_vacols, to: :authentication_service
+
+
+    # Empty method used for testing purposes
+    def before_set_user
+    end
 
     def from_session(session, request)
       user = session["user"] ||= authentication_service.default_user_session

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,9 +27,7 @@ class User < ActiveRecord::Base
   def display_name
     # fully authenticated
     if authenticated?
-    name = "#{username} (#{regional_office})"
-    p "DISPLAY NAME: #{name}"
-    name
+      "#{username} (#{regional_office})"
 
     # just SSOI, not yet vacols authenticated
     else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,6 @@ class User < ActiveRecord::Base
     attr_writer :authentication_service
     delegate :authenticate_vacols, to: :authentication_service
 
-
     # Empty method used for testing purposes
     def before_set_user
     end

--- a/spec/feature/switch_user_spec.rb
+++ b/spec/feature/switch_user_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Switch User" do
     User.create(station_id: "283", css_id: "123")
     User.create(station_id: "ABC", css_id: "456")
     User.create(station_id: "283", css_id: "ANNE MERICA")
+    User.authenticate!
   end
 
   scenario "We can switch between users in the database in dev mode" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,6 +88,10 @@ module StubbableUser
       @stub
     end
 
+    def before_set_user
+      clear_stub!
+    end
+
     def unauthenticate!
       self.stub = nil
     end


### PR DESCRIPTION
- Add before_filter to application_controller.
Force specific routes opt out instead for security's sake

connects #719 

### Testing
- [x] Fixed tests that did not properly test auth
- [x] Manually testing in browser, the expected routes still require auth (dispatch, certification)
- [x] Manually testing in browser, the expected routes do *not* require auth (homepage FAQ, errors, sessions)
