### PR TITLE
Adding routing for contaminated water

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -65,7 +65,11 @@ export const UNHANDLED_SPECIAL_ISSUES = [
 export const ROUTING_SPECIAL_ISSUES = [
   {
     specialIssue: 'mustardGas',
-    stationOfJurisdiction: '351 - Muskogee'
+    stationOfJurisdiction: '351 - Muskogee, OK'
+  },
+  {
+    specialIssue: 'contaminatedWaterAtCampLejeune',
+    stationOfJurisdiction: '327 - Louisville, KY'
   }
 ];
 

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -391,7 +391,7 @@ RSpec.feature "Dispatch" do
       page.find("#mustardGas").trigger("click")
       click_on "Create End Product"
       click_on "Create New EP"
-      expect(find_field("Station of Jurisdiction").value).to eq("351 - Muskogee")
+      expect(find_field("Station of Jurisdiction").value).to eq("351 - Muskogee, OK")
     end
 
     scenario "A special issue is chosen and saved in database" do


### PR DESCRIPTION
This PR routes the contaminated water special issue to the correct RO. I confirmed with Abby that if somebody selects two special issues that each have their own routing, we can just pick one of the locations. 

Fixes #721 

- [ ] Confirmed contaminated water routes to the correct RO in the UI
- [ ] Confirmed other special issues still route to the correct RO in the UI
- [ ]  Unit tests pass