### PR TITLE
Fixing the button loading styling

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -100,10 +100,14 @@
   margin-right: 10px;
   line-height: 0;
   position: relative;
-  top: -9px;
 }
 
 .cf-loading-button-symbol {
+  display: inline-block;
+}
+
+.cf-loading-indicator {
+  text-align: center;
   display: inline-block;
 }
 
@@ -174,4 +178,9 @@ select {
   &[id="decisionType"] {
     margin-bottom: 30px;
   }
+}
+
+// TODO: unify this with the styling in caseflow commons once all buttons are using React
+.icon-loading-back {
+  margin-left: -30px;
 }

--- a/client/app/components/Button.jsx
+++ b/client/app/components/Button.jsx
@@ -24,6 +24,7 @@ export default class Button extends React.Component {
 
     if (loading) {
       classNames = classNames.filter((className) => !className.includes('usa-button'));
+
       return <span className={classNames.join(' ')}>
         <span className="cf-loading-indicator">{loadingSymbolHtml()}</span>
       </span>;

--- a/client/app/components/Button.jsx
+++ b/client/app/components/Button.jsx
@@ -21,15 +21,16 @@ export default class Button extends React.Component {
       onClick,
       type
     } = this.props;
-    // Disabled the button when loading
+
+    if (loading) {
+      classNames = classNames.filter((className) => !className.includes('usa-button'));
+      return <span className={classNames.join(' ')}>
+        <span className="cf-loading-indicator">{loadingSymbolHtml()}</span>
+      </span>;
+    }
 
     if (!children) {
       children = name;
-    }
-
-    if (loading) {
-      disabled = loading;
-      children = loadingSymbolHtml();
     }
 
     if (disabled) {

--- a/client/test/components/Button-test.js
+++ b/client/test/components/Button-test.js
@@ -4,12 +4,18 @@ import { shallow, mount } from 'enzyme';
 import Button from '../../app/components/Button';
 
 describe('Button', () => {
-  it('renders as disabled with loading indicator when loading', () => {
+  it('renders loading icon instead of button when loading', () => {
     let onChange = () => true;
-    const wrapper = shallow(<Button name="foo" onChange={onChange} loading={true} />);
+    const wrapper = shallow(<Button
+                              id="test-button"
+                              classNames={['usa-button-primary']}
+                              name="foo"
+                              onChange={onChange}
+                              loading={true} />);
 
-    expect(wrapper.find('.usa-button-disabled')).to.have.length(1);
-    expect(wrapper.find('.cf-loading-button-text')).to.have.length(1);
+    expect(wrapper.find('.usa-button-primary')).to.have.length(0);
+    expect(wrapper.find('#test-button')).to.have.length(0);
+    expect(wrapper.find('.cf-loading-indicator')).to.have.length(1);
   });
 
   it('removes other button classes when disabled', () => {


### PR DESCRIPTION
The button loading styling is not consistent between certification and dispatch. Made some change to make the React button's loading state look like the certification loading button.

Connects: #686 #716

**Test Plan**
- [x] Verify manually
- [x] Run test suite

![screen shot 2017-02-07 at 11 21 40 am](https://cloud.githubusercontent.com/assets/3885236/22700146/a0349aa2-ed27-11e6-9fb5-b24330afdccd.png)
