### PR TITLE
Save sorted order of EPs

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
@@ -13,7 +13,8 @@ export default class AssociatePage extends React.Component {
     super(props);
 
     this.state = {
-      loading: null
+      loading: null,
+      sortedEndProducts: this.props.endProducts.sort(this.sortEndProduct)
     };
   }
 
@@ -75,8 +76,6 @@ export default class AssociatePage extends React.Component {
       hasAvailableModifers
     } = this.props;
 
-    let endProducts = this.props.endProducts.sort(this.sortEndProduct);
-
     let alert;
 
     if (this.props.hasAvailableModifers) {
@@ -114,7 +113,7 @@ export default class AssociatePage extends React.Component {
           <Table
             headers={TABLE_HEADERS}
             buildRowValues={this.buildEndProductRow}
-            values={endProducts}
+            values={this.state.sortedEndProducts}
           />
         </div>
       </div>


### PR DESCRIPTION
EPs on the associate EP page are sorted by their received_by date. When these dates are the same, (like with test data) there is not a stable order, and so on resorting the order can change. This means when someone clicks a button, the loading indicator display will trigger a resort and may change the order of the EPs. While unlikely to happen in production, it's best to just sort the data once anyway.

**Test Plan**
- [ ] Run test suite