### PR TITLE
Sharon create task bug

### DIFF
--- a/app/controllers/admin/establish_claims_controller.rb
+++ b/app/controllers/admin/establish_claims_controller.rb
@@ -9,7 +9,9 @@ class Admin::EstablishClaimsController < ApplicationController
   def create
     vbms_id = params[:appeal][:vbms_id]
     appeal = Appeal.find_or_create_by_vbms_id(vbms_id)
-    EstablishClaim.find_or_create_by(appeal: appeal)
+    establish_claim = EstablishClaim.find_or_create_by(appeal: appeal)
+    # Admin has to confirm appeal has a decision document
+    establish_claim.prepare! if establish_claim.may_prepare?
 
     flash[:success] = "Task created or already existed"
     redirect_to admin_establish_claim_path

--- a/app/views/admin/establish_claims/show.html.erb
+++ b/app/views/admin/establish_claims/show.html.erb
@@ -8,6 +8,11 @@
     </div>
   <% end %>
 
+  <div class="usa-alert-body usa-alert">
+    Please remember to ensure a decision PDF has been
+    uploaded before creating a task.
+  </div>
+
   <%= form_for @appeal, url: admin_establish_claim_path, method: "POST",
     html: { id: "establish-claim-form", class: "cf-form" },
     builder: CaseflowFormBuilder do |f| %>

--- a/spec/feature/admin_spec.rb
+++ b/spec/feature/admin_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Admin", focus: true do
+RSpec.feature "Admin" do
   before do
     User.authenticate!(roles: ["System Admin"])
     Fakes::AppealRepository.records = {

--- a/spec/feature/admin_spec.rb
+++ b/spec/feature/admin_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Admin" do
+RSpec.feature "Admin", focus: true do
   before do
     User.authenticate!(roles: ["System Admin"])
     Fakes::AppealRepository.records = {
@@ -21,6 +21,7 @@ RSpec.feature "Admin" do
 
     # view existing tasks
     expect(Task.count).to eq(1)
+    expect(Task.to_complete.count).to eq(0)
     expect(page).to have_css("#task-#{@task.id}")
 
     # attempt to create a task for an existing vbms_id
@@ -36,5 +37,8 @@ RSpec.feature "Admin" do
     expect(page).to have_current_path("/admin/establish_claim")
     expect(page).to have_content "Task created"
     expect(Task.count).to eq(2)
+
+    # ensure that the task is unassigned
+    expect(Task.to_complete.count).to eq(1)
   end
 end


### PR DESCRIPTION
This PR allows admins to create tasks that automatically go to the 'unassigned' state. Admins will have to confirm that the appeal has a decision document before manually creating the task. 

Fixes #841

- [ ] Updated unit tests to confirm newly created task is in correct state