### PR TITLE
Fixing placement of toolbar buttons on complete page

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -49,11 +49,6 @@
   color: $color-secondary;
 }
 
-.cf-centered-buttons {
-  width: 50%;
-  margin: auto;
-}
-
 .cf-associated-header {
   color: $color-primary;
   font-size: 20px;

--- a/app/views/tasks/_finished_toolbar.html.erb
+++ b/app/views/tasks/_finished_toolbar.html.erb
@@ -1,11 +1,15 @@
-<div class="cf-centered-buttons">
-  <%= link_to('View History', establish_claims_path) %>
-  <% if current_user_next_task %>
-      <%= link_to(start_text, assign_establish_claims_path,
-                  class: "usa-button-primary cf-push-right", method: 'patch') %>
-  <% else %>
-      <button class="usa-button-disabled cf-push-right" disabled>
-        <%= start_text %>
-      </button>
-  <% end %>
+<div class="cf-app-segment">
+  <div class="cf-push-left">
+    <%= link_to('View History', establish_claims_path) %>
+  </div>
+  <div class="cf-push-right">
+    <% if current_user_next_task %>
+        <%= link_to(start_text, assign_establish_claims_path,
+                    class: "usa-button-primary cf-push-right", method: 'patch') %>
+    <% else %>
+        <button class="usa-button-disabled cf-push-right" disabled>
+          <%= start_text %>
+        </button>
+    <% end %>
+  </div>
 </div>

--- a/app/views/tasks/canceled.html.erb
+++ b/app/views/tasks/canceled.html.erb
@@ -8,7 +8,5 @@
       Caseflow Dispatch.</li>
     <li> You may establish another claim or view your Work History.</li>
   </ul>
-
-  <%= render 'finished_toolbar' %>
-
 </div>
+<%= render 'finished_toolbar' %>

--- a/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
@@ -15,7 +15,8 @@ export default class EstablishClaimComplete extends React.Component {
       secondHeader
     } = this.props;
 
-    return <div
+    return <div>
+      <div
         id="certifications-generate"
         className="cf-app-msg-screen cf-app-segment cf-app-segment--alt">
       <h1 className="cf-success cf-msg-screen-heading">{firstHeader}</h1>
@@ -30,8 +31,12 @@ export default class EstablishClaimComplete extends React.Component {
             {content}
         </ul>
       }
-      <div className="cf-centered-buttons">
+    </div>
+    <div className="cf-app-segment">
+      <div className="cf-push-left">
         <a href="/dispatch/establish-claim">View History</a>
+      </div>
+      <div className="cf-push-right">
         { availableTasks &&
         <Button
           name={buttonText}
@@ -48,6 +53,7 @@ export default class EstablishClaimComplete extends React.Component {
         />
         }
       </div>
+    </div>
     </div>;
   }
 


### PR DESCRIPTION
This PR moves the buttons on the complete page out of the centered box and lower on the page. 

Fixes #667 

<img width="891" alt="screen shot 2017-02-08 at 3 25 36 pm" src="https://cloud.githubusercontent.com/assets/4306128/22756245/788cc8f6-ee14-11e6-8ea3-7c49bb92c7e7.png">
<img width="990" alt="screen shot 2017-02-08 at 3 26 04 pm" src="https://cloud.githubusercontent.com/assets/4306128/22756244/788b3a40-ee14-11e6-95ba-3f70380f1cc7.png">
<img width="987" alt="screen shot 2017-02-08 at 3 26 28 pm" src="https://cloud.githubusercontent.com/assets/4306128/22756246/788e4f28-ee14-11e6-8407-67fbdfdced8e.png">
