### PR TITLE
Sets a default station in case the user navigates backwards in the form

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -304,6 +304,9 @@ export default class EstablishClaim extends BaseForm {
   setStationState() {
     let stateObject = this.state;
 
+    // default needs to be reset in case the user has navigated back in the form
+    stateObject.claimForm.stationOfJurisdiction.value = '397 - AMC';
+
     Review.REGIONAL_OFFICE_SPECIAL_ISSUES.forEach((issue) => {
       if (this.state.specialIssues[issue].value) {
         stateObject.claimForm.stationOfJurisdiction.value =


### PR DESCRIPTION
This PR fixes a bug where the user could navigate backwards in the form, uncheck special issues that route to specific station, but the station of jurisdiction wouldn't update to the default. Now it updates to the default station. 

Fixes #717 

- [ ] Check 'Private Attorney', move on to next page, click back, uncheck 'Private Attorney', move on to next page, confirm station of jurisdiction is '397 - AMC'
- [ ] Confirmed other special issues are still routed correctly 
- [ ] Unit tests pass