### PR TITLE
Reduce methods passed to task to_hash

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -179,19 +179,26 @@ class Task < ActiveRecord::Base
     super.merge(type: type)
   end
 
-  def to_hash
+  def to_hash(full: false)
+    appeal_methods = [:veteran_name]
+
+    if full
+      appeal_methods.push(
+        :decision_date,
+        :decisions,
+        :disposition,
+        :veteran_name,
+        :decision_type,
+        :station_key,
+        :non_canceled_end_products_within_30_days,
+        :pending_eps,
+        :issues,
+        :days_since_decision
+      )
+    end
+
     serializable_hash(
-      include: [:user, appeal: { methods:
-        [:decision_date,
-         :decisions,
-         :disposition,
-         :veteran_name,
-         :decision_type,
-         :station_key,
-         :non_canceled_end_products_within_30_days,
-         :pending_eps,
-         :issues,
-         :days_since_decision] }],
+      include: [:user, appeal: { methods: appeal_methods }],
       methods: [:progress_status]
     )
   end

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title do task.appeal.task_header end %>
 <%= react_component("BaseContainer", props: {
-  task: task.to_hash,
+  task: task.to_hash(full: true),
   pdfLink: pdf_establish_claim_path(id: task.id, time: Time.now.to_i),
   pdfjsLink: pdfjs.full_path(file: pdf_establish_claim_path(id: task.id, time: Time.now.to_i)),
   page: "EstablishClaim",


### PR DESCRIPTION
- This removes many methods that are often unnecessary for task-related
  pages. In particular, non_canceled_end_products_within_30_days &
  pending_eps were making calls to BGS for each task/appeal though the
data is unused on index pages

connects https://github.com/department-of-veterans-affairs/appeals-deployment/issues/429

For the Manager task index view, we were calling these 2 BGS-related methods for each appeal. This resulted in 20-30 requests to BGS per page load

Testing:
- [x] locally, both the index and show page for tasks still render
- [ ] all tests pass