### PR TITLE
Caching documents

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -39,7 +39,7 @@ class Appeal < ActiveRecord::Base
 
   attr_writer :documents
   def documents
-    @documents || fetch_documents!
+    @documents ||= fetch_documents!
   end
 
   def annotations_on_documents

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -28,12 +28,13 @@ class Document < ActiveRecord::Base
   end
 
   def self.from_vbms_document(vbms_document)
-    find_or_create_by(vbms_document_id: vbms_document.document_id).tap do |t|
-      t.type = TYPES[vbms_document.doc_type] || :other
-      t.alt_types = (vbms_document.alt_doc_types || []).map { |type| ALT_TYPES[type] }
-      t.received_at = vbms_document.received_at
-      t.filename = vbms_document.filename
-    end
+    new(
+      type: TYPES[vbms_document.doc_type] || :other,
+      alt_types: (vbms_document.alt_doc_types || []).map { |type| ALT_TYPES[type] },
+      received_at: vbms_document.received_at,
+      vbms_document_id: vbms_document.document_id,
+      filename: vbms_document.filename
+    )
   end
 
   def self.type_id(type)


### PR DESCRIPTION
Currently we don't cache the documents in an instance variable. This might force us to go to VBMS unnecessarily.

**Test Plan**
- [x] Test manually
- [x] Run test suite