### PR TITLE
Warmup activerecord for vacols fetching columns & indexes

### DIFF
--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -1,5 +1,8 @@
 # VACOLS throttles the rate of new connections, create up front to prevent
 # blocking as pool grows under load
+
+WARMUP_TABLES = ["vacols.brieff", "vacols.corres", "vacols.folder"]
+
 ActiveSupport.on_load(:active_record_vacols) do
   db_config =  Rails.application.config.database_configuration[Rails.env]
 
@@ -21,11 +24,10 @@ def warmup_pool(pool, initial_pool_size)
       conn = pool.connection
       Rails.logger.info("taking connection #{i}; db pool size: #{pool.connections.size}")
 
-      [VACOLS::Case, VACOLS::Correspondent, VACOLS::Folder].each do |vacols_class|
-        name = vacols_class.table_name
-        Rails.logger.info("fetching indexes & columns for #{name} on connection #{i}")
-        conn.indexes(name)
-        conn.columns(name)
+      WARMUP_TABLES.each do |table_name|
+        Rails.logger.info("fetching indexes & columns for #{table_name} on connection #{i}")
+        conn.indexes(table_name)
+        conn.columns(table_name)
       end
 
 

--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -10,8 +10,10 @@ ActiveSupport.on_load(:active_record_vacols) do
   initial_pool_size = (ENV['DB_CONN_POOL_INITIAL_SIZE'] || db_config['pool'] / 2).to_i
   Rails.logger.info("creating #{initial_pool_size} initial connections...")
 
-  MetricsService.timer "created #{initial_pool_size} connections" do
-    warmup_pool(VACOLS::Record.connection_pool, initial_pool_size)
+  unless ApplicationController.dependencies_faked?
+    MetricsService.timer "created #{initial_pool_size} connections" do
+      warmup_pool(VACOLS::Record.connection_pool, initial_pool_size)
+    end
   end
 end
 


### PR DESCRIPTION
This PR warms up active record for vacols, caching the columns & indexes for the 3 relevant tables that we use. 

connects https://github.com/department-of-veterans-affairs/appeals-deployment/issues/156

CC @amprokop @shanear for awareness

Testing:
- [x] Ran this code manually on my toy preprod instance. First request to `/dispatch/establish-claim` was fast and did not do the slow lookups