### PR TITLE
Making all special issues available regardless of grant type

### DIFF
--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -52,14 +52,31 @@ class EstablishClaimsController < TasksController
   end
 
   def special_issues_params
-    params.require(:specialIssues).permit(:rice_compliance, :private_attorney, :waiver_of_overpayment,
-                                          :pensions, :vamc, :incarcerated_veterans,
-                                          :dic_death_or_accrued_benefits, :education_or_vocational_rehab,
-                                          :foreign_claims, :manlincon_compliance,
-                                          :hearings_travel_board_video_conference, :home_loan_guaranty,
-                                          :insurance, :national_cemetery_administration, :spina_bifida,
-                                          :radiation, :nonrating_issues, :proposed_incompetency,
-                                          :manila_remand, :contaminated_water_at_camp_lejeune,
-                                          :mustard_gas, :dependencies)
+    params.require(:specialIssues).permit(
+      :contaminated_water_at_camp_lejeune,
+      :dic_death_or_accrued_benefits_united_states,
+      :education_gi_bill_dependents_educational_assistance_scholars,
+      :foreign_claim_compensation_claims_dual_claims_appeals,
+      :foreign_pension_dic_all_other_foreign_countries,
+      :foreign_pension_dic_mexico_central_and_south_american_caribb,
+      :hearing_including_travel_board_video_conference,
+      :home_loan_guarantee,
+      :incarcerated_veterans,
+      :insurance,
+      :manlincon_compliance,
+      :mustard_gas,
+      :national_cemetery_administration,
+      :nonrating_issue,
+      :pension_united_states,
+      :private_attorney_or_agent,
+      :radiation,
+      :rice_compliance,
+      :spina_bifida,
+      :us_territory_claim_american_samoa_guam_northern_mariana_isla,
+      :us_territory_claim_philippines,
+      :us_territory_claim_puerto_rico_and_virgin_islands,
+      :vamc,
+      :vocational_rehab,
+      :waiver_of_overpayment)
   end
 end

--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -52,31 +52,20 @@ class EstablishClaimsController < TasksController
   end
 
   def special_issues_params
-    params.require(:specialIssues).permit(
-      :contaminated_water_at_camp_lejeune,
-      :dic_death_or_accrued_benefits_united_states,
-      :education_gi_bill_dependents_educational_assistance_scholars,
-      :foreign_claim_compensation_claims_dual_claims_appeals,
-      :foreign_pension_dic_all_other_foreign_countries,
-      :foreign_pension_dic_mexico_central_and_south_american_caribb,
-      :hearing_including_travel_board_video_conference,
-      :home_loan_guarantee,
-      :incarcerated_veterans,
-      :insurance,
-      :manlincon_compliance,
-      :mustard_gas,
-      :national_cemetery_administration,
-      :nonrating_issue,
-      :pension_united_states,
-      :private_attorney_or_agent,
-      :radiation,
-      :rice_compliance,
-      :spina_bifida,
-      :us_territory_claim_american_samoa_guam_northern_mariana_isla,
-      :us_territory_claim_philippines,
-      :us_territory_claim_puerto_rico_and_virgin_islands,
-      :vamc,
-      :vocational_rehab,
-      :waiver_of_overpayment)
+    params.require(:specialIssues).permit(:contaminated_water_at_camp_lejeune,
+                                          :dic_death_or_accrued_benefits_united_states,
+                                          :education_gi_bill_dependents_educational_assistance_scholars,
+                                          :foreign_claim_compensation_claims_dual_claims_appeals,
+                                          :foreign_pension_dic_all_other_foreign_countries,
+                                          :foreign_pension_dic_mexico_central_and_south_american_caribb,
+                                          :hearing_including_travel_board_video_conference,
+                                          :home_loan_guarantee, :incarcerated_veterans, :insurance,
+                                          :manlincon_compliance, :mustard_gas, :national_cemetery_administration,
+                                          :nonrating_issue, :pension_united_states, :private_attorney_or_agent,
+                                          :radiation, :rice_compliance, :spina_bifida,
+                                          :us_territory_claim_american_samoa_guam_northern_mariana_isla,
+                                          :us_territory_claim_philippines,
+                                          :us_territory_claim_puerto_rico_and_virgin_islands,
+                                          :vamc, :vocational_rehab, :waiver_of_overpayment)
   end
 end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -24,13 +24,21 @@ class Appeal < ActiveRecord::Base
   vacols_attr_accessor :file_type
   vacols_attr_accessor :case_record
 
-  SPECIAL_ISSUE_COLUMNS = %i(rice_compliance private_attorney waiver_of_overpayment
-                             pensions vamc incarcerated_veterans dic_death_or_accrued_benefits
-                             education_or_vocational_rehab foreign_claims manlincon_compliance
-                             hearings_travel_board_video_conference home_loan_guaranty insurance
-                             national_cemetery_administration spina_bifida radiation
-                             nonrating_issues proposed_incompetency manila_remand
-                             contaminated_water_at_camp_lejeune mustard_gas dependencies).freeze
+  SPECIAL_ISSUE_COLUMNS = %i(contaminated_water_at_camp_lejeune
+                             dic_death_or_accrued_benefits_united_states
+                             education_gi_bill_dependents_educational_assistance_scholars
+                             foreign_claim_compensation_claims_dual_claims_appeals
+                             foreign_pension_dic_all_other_foreign_countries
+                             foreign_pension_dic_mexico_central_and_south_american_caribb
+                             hearing_including_travel_board_video_conference
+                             home_loan_guarantee incarcerated_veterans insurance
+                             manlincon_compliance mustard_gas national_cemetery_administration
+                             nonrating_issue pension_united_states private_attorney_or_agent
+                             radiation rice_compliance spina_bifida
+                             us_territory_claim_american_samoa_guam_northern_mariana_isla
+                             us_territory_claim_philippines
+                             us_territory_claim_puerto_rico_and_virgin_islands
+                             vamc vocational_rehab waiver_of_overpayment).freeze
 
   attr_writer :ssoc_dates
   def ssoc_dates

--- a/client/app/components/Checkbox.jsx
+++ b/client/app/components/Checkbox.jsx
@@ -29,7 +29,7 @@ export default class Checkbox extends React.Component {
 }
 
 Checkbox.propTypes = {
-  label: PropTypes.string,
+  label: PropTypes.node,
   name: PropTypes.string.isRequired,
   onChange: PropTypes.func,
   value: PropTypes.bool

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -332,6 +332,20 @@ export default class EstablishClaim extends BaseForm {
         this.props.regionalOfficeCities[regionalOfficeKey].state}`;
   }
 
+  prepareSpecialIssues() {
+    // The database column names must be less than 63 characters
+    // so we shorten all of the keys in our hash before we send
+    // them to the backend.
+    let shortenedObject = {};
+    let formValues = ApiUtil.convertToSnakeCase(
+      this.getFormValues(this.state.specialIssues));
+    Object.keys(formValues).forEach((key) => {
+      shortenedObject[key.substring(0,60)] = formValues[key];
+    });
+
+    return shortenedObject;
+  }
+
   prepareData() {
     let stateObject = this.state;
 
@@ -346,15 +360,13 @@ export default class EstablishClaim extends BaseForm {
     // the form value on the review page.
     let endProductInfo = this.getClaimTypeFromDecision();
 
-
     return {
       claim: ApiUtil.convertToSnakeCase({
         ...this.getFormValues(this.state.claimForm),
         endProductCode: endProductInfo[0],
         endProductLabel: endProductInfo[1]
       }),
-      specialIssues: ApiUtil.convertToSnakeCase(
-        this.getFormValues(this.state.specialIssues))
+      specialIssues: this.prepareSpecialIssues()
     };
   }
 

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -42,7 +42,7 @@ const PARTIAL_GRANT_MODIFIER_OPTIONS = [
   '179'
 ];
 
-const SPECIAL_ISSUES = Review.SPECIAL_ISSUE_FULL.concat(Review.SPECIAL_ISSUE_PARTIAL);
+const SPECIAL_ISSUES = Review.SPECIAL_ISSUES;
 
 // This page is used by AMC to establish claims. This is
 // the last step in the appeals process, and is after the decsion

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -339,8 +339,9 @@ export default class EstablishClaim extends BaseForm {
     let shortenedObject = {};
     let formValues = ApiUtil.convertToSnakeCase(
       this.getFormValues(this.state.specialIssues));
+
     Object.keys(formValues).forEach((key) => {
-      shortenedObject[key.substring(0,60)] = formValues[key];
+      shortenedObject[key.substring(0, 60)] = formValues[key];
     });
 
     return shortenedObject;

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -19,7 +19,8 @@ export const DECISION_TYPE = [
 export const SPECIAL_ISSUES = [
   'Contaminated Water at Camp LeJeune',
   'DIC - death, or accrued benefits - United States',
-  'Education - GI Bill, dependents educational assistance, scholarship, transfer of entitlement',
+  `Education - GI Bill, dependents educational ` +
+    `assistance, scholarship, transfer of entitlement`,
   'Foreign claim - compensation claims, dual claims, appeals',
   'Foreign pension, DIC - Mexico, Central and South American, Caribbean',
   'Foreign pension, DIC - all other foreign countries',
@@ -36,7 +37,8 @@ export const SPECIAL_ISSUES = [
   'Radiation',
   'Rice Compliance',
   'Spina Bifida',
-  'U.S. Territory claim - American Samoa, Guam, Northern Mariana Islands (Rota, Saipan & Tinian)',
+  `U.S. Territory claim - American Samoa, Guam, Northern ` +
+    `Mariana Islands (Rota, Saipan & Tinian)`,
   'U.S. Territory claim - Philippines',
   'U.S. Territory claim - Puerto Rico and Virgin Islands',
   'VAMC',
@@ -48,15 +50,15 @@ export const SPECIAL_ISSUES = [
 const SPECIAL_ISSUE_NODE_MAP = {
   'Manlincon Compliance': <span><i>Manlincon</i> Compliance</span>,
   'Rice Compliance': <span><i>Rice</i> Compliance</span>
-}
-
+};
 
 export const UNHANDLED_SPECIAL_ISSUES = [
-  'Pensions',
+  'Pension - United States',
   'VAMC',
-  'DIC - death, or accrued benefits',
-  'Foreign Claims',
-  'Education or Vocational Rehab',
+  'DIC - death, or accrued benefits - United States',,
+  'Foreign claim - compensation claims, dual claims, appeals',
+  `Education - GI Bill, dependents educational ` +
+    `assistance, scholarship, transfer of entitlement`,
   'Waiver of Overpayment',
   'National Cemetery Administration'
 ];
@@ -73,16 +75,14 @@ export const ROUTING_SPECIAL_ISSUES = [
 ];
 
 export const REGIONAL_OFFICE_SPECIAL_ISSUES = [
-  'dependencies',
-  'educationOrVocationalRehab',
-  'hearingsTravelBoardVideoConference',
-  'homeLoanGuaranty',
+  `educationGiBillDependentsEducational` +
+    `AssistanceScholarshipTransferOfEntitlement`,
+  'hearingIncludingTravelBoardVideoConference',
+  'homeLoanGuarantee',
   'incarceratedVeterans',
-  'manilaRemand',
   'manlinconCompliance',
-  'nonratingIssues',
-  'privateAttorney',
-  'proposedIncompetency',
+  'nonratingIssue',
+  'privateAttorneyOrAgent',
   'radiation',
   'riceCompliance',
   'spinaBifida'
@@ -242,19 +242,23 @@ export default class EstablishClaimReview extends React.Component {
            {...decisionType}
           />
 
-          <label>Special Issue Categories</label>
+          <label><b>Select Special Issue(s)</b></label>
           <div className="cf-multiple-columns">
-            {SPECIAL_ISSUES.map((issue, index) => {
-              let issueName = ApiUtil.convertToCamelCase(issue);
-              let node = SPECIAL_ISSUE_NODE_MAP[issue] || issue
-              return <Checkbox
-                id={issueName}
-                label={node}
-                name={issueName}
-                onChange={handleFieldChange('specialIssues', issueName)}
-                  key={index}
-                  {...specialIssues[issueName]}
-              />;})
+            {
+              SPECIAL_ISSUES.map((issue, index) => {
+                let issueName = ApiUtil.convertToCamelCase(issue);
+                let node = SPECIAL_ISSUE_NODE_MAP[issue] || issue;
+
+
+                return <Checkbox
+                  id={issueName}
+                  label={node}
+                  name={issueName}
+                  onChange={handleFieldChange('specialIssues', issueName)}
+                    key={index}
+                    {...specialIssues[issueName]}
+                />;
+              })
             }
           </div>
         </div>

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -55,10 +55,10 @@ const SPECIAL_ISSUE_NODE_MAP = {
 export const UNHANDLED_SPECIAL_ISSUES = [
   'Pension - United States',
   'VAMC',
-  'DIC - death, or accrued benefits - United States',,
+  'DIC - death, or accrued benefits - United States',
   'Foreign claim - compensation claims, dual claims, appeals',
-  `Education - GI Bill, dependents educational ` +
-    `assistance, scholarship, transfer of entitlement`,
+  'Education - GI Bill, dependents educational ' +
+    'assistance, scholarship, transfer of entitlement',
   'Waiver of Overpayment',
   'National Cemetery Administration'
 ];

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -16,41 +16,40 @@ export const DECISION_TYPE = [
   'Remand'
 ];
 
-export const SPECIAL_ISSUE_FULL = [
-  'Rice Compliance',
-  'Private Attorney',
-  'Waiver of Overpayment',
-  'Pensions',
-  'VAMC',
+export const SPECIAL_ISSUES = [
+  'Contaminated Water at Camp LeJeune',
+  'DIC - death, or accrued benefits - United States',
+  'Education - GI Bill, dependents educational assistance, scholarship, transfer of entitlement',
+  'Foreign claim - compensation claims, dual claims, appeals',
+  'Foreign pension, DIC - Mexico, Central and South American, Caribbean',
+  'Foreign pension, DIC - all other foreign countries',
+  'Hearing - including travel board & video conference',
+  'Home Loan Guarantee',
   'Incarcerated Veterans',
-  'DIC - death, or accrued benefits',
-  'Education or Vocational Rehab',
-  'Foreign Claims'
+  'Insurance',
+  'Manlincon Compliance',
+  'Mustard Gas',
+  'National Cemetery Administration',
+  'Non-rating issue',
+  'Pension - United States',
+  'Private Attorney or Agent',
+  'Radiation',
+  'Rice Compliance',
+  'Spina Bifida',
+  'U.S. Territory claim - American Samoa, Guam, Northern Mariana Islands (Rota, Saipan & Tinian)',
+  'U.S. Territory claim - Philippines',
+  'U.S. Territory claim - Puerto Rico and Virgin Islands',
+  'VAMC',
+  'Vocational Rehab',
+  'Waiver of Overpayment'
 ];
 
-export const SPECIAL_ISSUE_PARTIAL = [
-  'Manlincon Compliance',
-  'Rice Compliance',
-  'Private Attorney',
-  'Hearings - travel board & video conference',
-  'Contaminated Water at Camp Lejeune',
-  'Home Loan Guaranty',
-  'Waiver of Overpayment',
-  'Education or Vocational Rehab',
-  'VAMC',
-  'Insurance',
-  'National Cemetery Administration',
-  'Spina Bifida',
-  'Radiation',
-  'Non-rating Issues',
-  'Foreign Claims',
-  'Incarcerated Veterans',
-  'Proposed Incompetency',
-  'Manila Remand',
-  'Mustard Gas',
-  'Dependencies',
-  'DIC - death, or accrued benefits'
-];
+
+const SPECIAL_ISSUE_NODE_MAP = {
+  'Manlincon Compliance': <span><i>Manlincon</i> Compliance</span>,
+  'Rice Compliance': <span><i>Rice</i> Compliance</span>
+}
+
 
 export const UNHANDLED_SPECIAL_ISSUES = [
   'Pensions',
@@ -143,14 +142,6 @@ export default class EstablishClaimReview extends React.Component {
 
     let decisionDateStart = formatDate(addDays(new Date(task.appeal.decision_date), -3));
     let decisionDateEnd = formatDate(addDays(new Date(task.appeal.decision_date), 3));
-
-    let issueType = (() => {
-      if (decisionType.value === 'Remand' || decisionType.value === 'Partial Grant') {
-        return SPECIAL_ISSUE_PARTIAL;
-      }
-
-      return SPECIAL_ISSUE_FULL;
-    })();
 
     // Sort in reverse chronological order
     let decisions = task.appeal.decisions.sort((decision1, decision2) =>
@@ -253,16 +244,17 @@ export default class EstablishClaimReview extends React.Component {
 
           <label>Special Issue Categories</label>
           <div className="cf-multiple-columns">
-            {issueType.map((issue, index) =>
-              <Checkbox
-                id={ApiUtil.convertToCamelCase(issue)}
-                label={issue}
-                name={ApiUtil.convertToCamelCase(issue)}
-                onChange={handleFieldChange('specialIssues',
-                  ApiUtil.convertToCamelCase(issue))}
+            {SPECIAL_ISSUES.map((issue, index) => {
+              let issueName = ApiUtil.convertToCamelCase(issue);
+              let node = SPECIAL_ISSUE_NODE_MAP[issue] || issue
+              return <Checkbox
+                id={issueName}
+                label={node}
+                name={issueName}
+                onChange={handleFieldChange('specialIssues', issueName)}
                   key={index}
-                  {...specialIssues[ApiUtil.convertToCamelCase(issue)]}
-              />)
+                  {...specialIssues[issueName]}
+              />;})
             }
           </div>
         </div>

--- a/db/migrate/20170215190838_fix_special_issue_names.rb
+++ b/db/migrate/20170215190838_fix_special_issue_names.rb
@@ -1,0 +1,21 @@
+class FixSpecialIssueNames < ActiveRecord::Migration
+  def change
+    rename_column :appeals, :private_attorney, :private_attorney_or_agent
+    rename_column :appeals, :pensions, :pension_united_states
+    rename_column :appeals, :dic_death_or_accrued_benefits, :dic_death_or_accrued_benefits_united_states
+    rename_column :appeals, :education_or_vocational_rehab, :vocational_rehab
+    rename_column :appeals, :hearings_travel_board_video_conference, :hearing_including_travel_board_video_conference
+    rename_column :appeals, :home_loan_guaranty, :home_loan_guarantee
+    rename_column :appeals, :nonrating_issues, :nonrating_issue
+    rename_column :appeals, :foreign_claims, :foreign_claim_compensation_claims_dual_claims_appeals
+    rename_column :appeals, :manila_remand, :us_territory_claim_philippines
+    rename_column :appeals, :dependencies, :education_gi_bill_dependents_educational_assistance_scholars
+    
+    add_column :appeals, :foreign_pension_dic_all_other_foreign_countries, :boolean, default: false
+    add_column :appeals, :foreign_pension_dic_mexico_central_and_south_american_caribb, :boolean, default: false
+    add_column :appeals, :us_territory_claim_american_samoa_guam_northern_mariana_isla, :boolean, default: false
+    add_column :appeals, :us_territory_claim_puerto_rico_and_virgin_islands, :boolean, default: false
+
+    remove_column :appeals, :proposed_incompetency
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170206153412) do
+ActiveRecord::Schema.define(version: 20170215190838) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,30 +27,33 @@ ActiveRecord::Schema.define(version: 20170206153412) do
   add_index "annotations", ["document_id"], name: "index_annotations_on_document_id", using: :btree
 
   create_table "appeals", force: :cascade do |t|
-    t.string  "vacols_id",                                              null: false
+    t.string  "vacols_id",                                                                    null: false
     t.string  "vbms_id"
-    t.boolean "rice_compliance",                        default: false
-    t.boolean "private_attorney",                       default: false
-    t.boolean "waiver_of_overpayment",                  default: false
-    t.boolean "pensions",                               default: false
-    t.boolean "vamc",                                   default: false
-    t.boolean "incarcerated_veterans",                  default: false
-    t.boolean "dic_death_or_accrued_benefits",          default: false
-    t.boolean "education_or_vocational_rehab",          default: false
-    t.boolean "foreign_claims",                         default: false
-    t.boolean "manlincon_compliance",                   default: false
-    t.boolean "hearings_travel_board_video_conference", default: false
-    t.boolean "home_loan_guaranty",                     default: false
-    t.boolean "insurance",                              default: false
-    t.boolean "national_cemetery_administration",       default: false
-    t.boolean "spina_bifida",                           default: false
-    t.boolean "radiation",                              default: false
-    t.boolean "nonrating_issues",                       default: false
-    t.boolean "proposed_incompetency",                  default: false
-    t.boolean "manila_remand",                          default: false
-    t.boolean "contaminated_water_at_camp_lejeune",     default: false
-    t.boolean "mustard_gas",                            default: false
-    t.boolean "dependencies",                           default: false
+    t.boolean "rice_compliance",                                              default: false
+    t.boolean "private_attorney_or_agent",                                    default: false
+    t.boolean "waiver_of_overpayment",                                        default: false
+    t.boolean "pension_united_states",                                        default: false
+    t.boolean "vamc",                                                         default: false
+    t.boolean "incarcerated_veterans",                                        default: false
+    t.boolean "dic_death_or_accrued_benefits_united_states",                  default: false
+    t.boolean "vocational_rehab",                                             default: false
+    t.boolean "foreign_claim_compensation_claims_dual_claims_appeals",        default: false
+    t.boolean "manlincon_compliance",                                         default: false
+    t.boolean "hearing_including_travel_board_video_conference",              default: false
+    t.boolean "home_loan_guarantee",                                          default: false
+    t.boolean "insurance",                                                    default: false
+    t.boolean "national_cemetery_administration",                             default: false
+    t.boolean "spina_bifida",                                                 default: false
+    t.boolean "radiation",                                                    default: false
+    t.boolean "nonrating_issue",                                              default: false
+    t.boolean "us_territory_claim_philippines",                               default: false
+    t.boolean "contaminated_water_at_camp_lejeune",                           default: false
+    t.boolean "mustard_gas",                                                  default: false
+    t.boolean "education_gi_bill_dependents_educational_assistance_scholars", default: false
+    t.boolean "foreign_pension_dic_all_other_foreign_countries",              default: false
+    t.boolean "foreign_pension_dic_mexico_central_and_south_american_caribb", default: false
+    t.boolean "us_territory_claim_american_samoa_guam_northern_mariana_isla", default: false
+    t.boolean "us_territory_claim_puerto_rico_and_virgin_islands",            default: false
   end
 
   add_index "appeals", ["vacols_id"], name: "index_appeals_on_vacols_id", unique: true, using: :btree

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -368,7 +368,7 @@ RSpec.feature "Dispatch" do
     scenario "A regional office special issue routes correctly" do
       @task.assign!(:assigned, current_user)
       visit "/dispatch/establish-claim/#{@task.id}"
-      page.find("#privateAttorney").trigger("click")
+      page.find("#privateAttorneyOrAgent").trigger("click")
       click_on "Route Claim"
       click_on "Create New EP"
       expect(find_field("Station of Jurisdiction").value).to eq("313 - Baltimore, MD")

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -468,7 +468,7 @@ describe Appeal do
   end
 
   context "#special_issues?" do
-    let(:appeal) { Appeal.new(vacols_id: "123", dependencies: true) }
+    let(:appeal) { Appeal.new(vacols_id: "123", us_territory_claim_philippines: true) }
     subject { appeal.special_issues? }
 
     it "is true if any special issues exist" do
@@ -476,7 +476,7 @@ describe Appeal do
     end
 
     it "is false if no special issues exist" do
-      appeal.update!(dependencies: false)
+      appeal.update!(us_territory_claim_philippines: false)
       expect(subject).to be_falsy
     end
   end


### PR DESCRIPTION
Currently we show different special issue checkboxes depending on if a grant is a full or partial grant. Now we show all of them all the time. We also have added italics to Manlincon Compliance and Rice Compliance.

Connects: #715 

**Test Plan**
- [x] Make sure all checkboxes are visible manually
- [x] Run test suite

<img width="952" alt="screen shot 2017-02-15 at 11 13 04 am" src="https://cloud.githubusercontent.com/assets/3885236/22983331/c094ea06-f36f-11e6-8ee5-032b53035b6b.png">
