### PR TITLE
Update VACOLS location when assigning existing EP

### DIFF
--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -21,12 +21,9 @@ class EstablishClaimsController < TasksController
   end
 
   def assign_existing_end_product
-    Task.transaction do
-      task.appeal.update!(special_issues_params)
-      Dispatch.new(task: task)
-              .assign_existing_end_product!(end_product_id: params[:end_product_id])
-      task.assign_existing_end_product!(params[:end_product_id])
-    end
+    Dispatch.new(task: task)
+            .assign_existing_end_product!(end_product_id: params[:end_product_id],
+                                          special_issues: special_issues_params)
     render json: {}
   end
 

--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -21,7 +21,8 @@ class EstablishClaimsController < TasksController
   end
 
   def assign_existing_end_product
-    task.assign_existing_end_product!(params[:end_product_id])
+    Dispatch.new(task: task)
+            .assign_existing_end_product!(end_product_id: params[:end_product_id])
     render json: {}
   end
 

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -155,7 +155,7 @@ class VACOLS::Case < VACOLS::Record
   end
 
   # rubocop:disable Metrics/MethodLength
-  def update_vacols_location!(location)
+  def update_vacols_location!(appeal:, location:)
     return unless location
 
     fail(InvalidLocationError) unless VALID_UPDATE_LOCATIONS.include?(location)

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -155,7 +155,7 @@ class VACOLS::Case < VACOLS::Record
   end
 
   # rubocop:disable Metrics/MethodLength
-  def update_vacols_location!(appeal:, location:)
+  def update_vacols_location!(location)
     return unless location
 
     fail(InvalidLocationError) unless VALID_UPDATE_LOCATIONS.include?(location)
@@ -167,7 +167,7 @@ class VACOLS::Case < VACOLS::Record
     user_db_id = conn.quote(RequestStore.store[:current_user].regional_office.upcase)
     case_id = conn.quote(bfkey)
 
-    MetricsService.timer "VACOLS: update_vacols_location! #{appeal.vacols_id}" do
+    MetricsService.timer "VACOLS: update_vacols_location! #{bfkey}" do
       conn.transaction do
         conn.execute(<<-SQL)
           UPDATE BRIEFF

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -155,7 +155,7 @@ class VACOLS::Case < VACOLS::Record
   end
 
   # rubocop:disable Metrics/MethodLength
-  def update_vacols_location(location)
+  def update_vacols_location!(location)
     return unless location
 
     fail(InvalidLocationError) unless VALID_UPDATE_LOCATIONS.include?(location)
@@ -167,7 +167,7 @@ class VACOLS::Case < VACOLS::Record
     user_db_id = conn.quote(RequestStore.store[:current_user].regional_office.upcase)
     case_id = conn.quote(bfkey)
 
-    MetricsService.timer "VACOLS: update_vacols_location #{appeal.vacols_id}" do
+    MetricsService.timer "VACOLS: update_vacols_location! #{appeal.vacols_id}" do
       conn.transaction do
         conn.execute(<<-SQL)
           UPDATE BRIEFF

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -165,16 +165,21 @@ class AppealRepository
     veteran_record = parse_veteran_establish_claim_info(raw_veteran_record)
 
     end_product = Appeal.transaction do
-      location = location_after_dispatch(appeal: appeal,
-                                         station: claim[:station_of_jurisdiction])
-
-      appeal.case_record.update_vacols_location(location)
+      update_location_after_dispatch!(appeal: appeal,
+                                     station: claim[:station_of_jurisdiction])
 
       request = VBMS::Requests::EstablishClaim.new(veteran_record, claim)
       send_and_log_request(sanitized_id, request)
     end
 
     end_product
+  end
+
+  def self.update_location_after_dispatch!(appeal:, station:)
+    location = location_after_dispatch(appeal: appeal,
+                                       station: station)
+
+    appeal.case_record.update_vacols_location!(location)
   end
 
   # Determine VACOLS location desired after dispatching a decision

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -179,8 +179,7 @@ class AppealRepository
     location = location_after_dispatch(appeal: appeal,
                                        station: station)
 
-    appeal.case_record.update_vacols_location!(appeal: appeal,
-                                               location: location)
+    appeal.case_record.update_vacols_location!(location)
   end
 
   # Determine VACOLS location desired after dispatching a decision

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -166,7 +166,7 @@ class AppealRepository
 
     end_product = Appeal.transaction do
       update_location_after_dispatch!(appeal: appeal,
-                                     station: claim[:station_of_jurisdiction])
+                                      station: claim[:station_of_jurisdiction])
 
       request = VBMS::Requests::EstablishClaim.new(veteran_record, claim)
       send_and_log_request(sanitized_id, request)

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -179,7 +179,8 @@ class AppealRepository
     location = location_after_dispatch(appeal: appeal,
                                        station: station)
 
-    appeal.case_record.update_vacols_location!(location)
+    appeal.case_record.update_vacols_location!(appeal: appeal,
+                                               location: location)
   end
 
   # Determine VACOLS location desired after dispatching a decision

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -175,7 +175,7 @@ class AppealRepository
     end_product
   end
 
-  def self.update_location_after_dispatch!(appeal:, station:)
+  def self.update_location_after_dispatch!(appeal:, station: nil)
     location = location_after_dispatch(appeal: appeal,
                                        station: station)
 

--- a/app/services/dispatch.rb
+++ b/app/services/dispatch.rb
@@ -44,7 +44,7 @@ class Dispatch
     end
   end
 
-  def initialize(claim:, task:)
+  def initialize(task:, claim: {})
     # TODO(jd): If we permanently keep the decision date a non-editable field,
     # we should instead pass that value from the taks.appeal.decision date, rather
     # than use the value passed from the front end

--- a/app/services/dispatch.rb
+++ b/app/services/dispatch.rb
@@ -67,8 +67,9 @@ class Dispatch
     task.review!(outgoing_reference_id: end_product.claim_id)
   end
 
-  def assign_existing_end_product!(end_product_id:)
+  def assign_existing_end_product!(end_product_id:, special_issues:)
     task.transaction do
+      task.appeal.update!(special_issues)
       task.assign_existing_end_product!(end_product_id)
       Appeal.repository.update_location_after_dispatch!(appeal: task.appeal)
     end

--- a/app/services/dispatch.rb
+++ b/app/services/dispatch.rb
@@ -67,6 +67,13 @@ class Dispatch
     task.review!(outgoing_reference_id: end_product.claim_id)
   end
 
+  def assign_existing_end_product!(end_product_id:)
+    task.transaction do
+      task.assign_existing_end_product!(end_product_id)
+      Appeal.repository.update_location_after_dispatch!(appeal: task.appeal)
+    end
+  end
+
   # Class used for validating the claim object
   class Claim
     include ActiveModel::Validations

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -36,7 +36,7 @@ class Fakes::AppealRepository
     OpenStruct.new(claim_id: @end_product_claim_id)
   end
 
-  def self.update_location_after_dispatch!(appeal:, station:)
+  def self.update_location_after_dispatch!(*)
   end
 
   def self.upload_and_clean_document(appeal, form8)

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -36,6 +36,9 @@ class Fakes::AppealRepository
     OpenStruct.new(claim_id: @end_product_claim_id)
   end
 
+  def self.update_location_after_dispatch!(appeal:, station:)
+  end
+
   def self.upload_and_clean_document(appeal, form8)
     @uploaded_form8 = form8
     @uploaded_form8_appeal = appeal


### PR DESCRIPTION
This moves the update vacols location to a shared method that can be used when establishing a claim and when assigning an existing EP

connects #930 
connects #955

Testing:
- [x] Test suite passes
- [x] Manually tested against UAT