### PR TITLE
Updated link names for toolbar

### DIFF
--- a/app/views/tasks/_finished_toolbar.html.erb
+++ b/app/views/tasks/_finished_toolbar.html.erb
@@ -1,6 +1,6 @@
 <div class="cf-app-segment">
   <div class="cf-push-left">
-    <%= link_to('View History', establish_claims_path) %>
+    <%= link_to('View Work History', establish_claims_path) %>
   </div>
   <div class="cf-push-right">
     <% if current_user_next_task %>

--- a/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
@@ -34,7 +34,7 @@ export default class EstablishClaimComplete extends React.Component {
     </div>
     <div className="cf-app-segment">
       <div className="cf-push-left">
-        <a href="/dispatch/establish-claim">View History</a>
+        <a href="/dispatch/establish-claim">View Work History</a>
       </div>
       <div className="cf-push-right">
         { availableTasks &&


### PR DESCRIPTION
This PR updates the links in the toolbar to say 'View Work History' 

Connects #667 

- [ ] Confirm cancel page and completion page both have the correct links

<img width="613" alt="screen shot 2017-02-16 at 10 59 18 am" src="https://cloud.githubusercontent.com/assets/4306128/23028995/ff623406-f436-11e6-97db-5297652f4264.png">
