### PR TITLE
Anya/836 toggle features ro

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,8 @@ gem 'aasm'
 
 gem 'font-awesome-sass'
 
+gem 'redis-namespace'
+
 group :production, :staging do
   # Oracle DB
   gem 'activerecord-oracle_enhanced-adapter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,6 +484,7 @@ DEPENDENCIES
   rainbow
   rb-readline
   react_on_rails (~> 6)
+  redis-namespace
   redis-rails
   request_store
   rspec

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ For parallelized tests:
 
 ### Feature Toggle
 
-You can turn on and turn off features using `rails c`. Example usage:
+To enable and disable features using `rails c`. Example usage:
 
 ```
 # users

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ sudo ln -s libclntsh.so.12.1 libclntsh.so
 Now you'll be able to install the gems required to run the app connected to VBMS and VACOLS:
 `$ bundle install --with staging`
 
-Set the development VACOLS credentials as environment variables.  
+Set the development VACOLS credentials as environment variables.
 (ask a team member for them)
 ```
 export VACOLS_USERNAME=username
@@ -181,3 +181,44 @@ For parallelized tests:
 `$ rake parallel:setup[4]`
 
 `$ rake ci:all`
+
+### Feature Toggle
+
+You can turn on and turn off features using `rails c`. Example usage:
+
+```
+# users
+user1 = User.new(regional_office: "RO03")
+user2 = User.new(regional_office: "RO04")
+
+# enable for everyone
+FeatureToggle.enable!(:apple)
+=> true
+FeatureToggle.enabled?(:apple, user1)
+=> true
+
+# enable for a list of regional offices
+FeatureToggle.enable!(:apple, regional_offices: ["RO03", "RO08"])
+=> true
+
+# add more regional offices to the same feature
+FeatureToggle.enable!(:apple, regional_offices: ["RO03", "RO09"])
+=> true
+
+# view the details
+FeatureToggle.details_for(:apple)
+=> { :regional_offices => ["RO03", "RO08", "RO09"] }
+
+# check if the feature is enabled for a given user
+FeatureToggle.enabled?(:apple, user1)
+=> true
+FeatureToggle.enabled?(:apple, user2)
+=> false
+
+# disable a few regional offices
+FeatureToggle.disable!(:apple, regional_offices: ["RO03", "RO09"])
+=> true
+FeatureToggle.details_for(:apple)
+=> { :regional_offices =>["RO08"] }
+```
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,6 +55,11 @@ class ApplicationController < ActionController::Base
   end
   helper_method :current_user
 
+  def feature_enabled?(feature)
+    FeatureToggle.enabled?(feature, current_user)
+  end
+  helper_method :feature_enabled?
+
   def logo_class
     return "cf-logo-image-default" if logo_name.nil?
     "cf-logo-image-#{logo_name.downcase.tr(' ', '-')}"

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,83 +1,93 @@
 class FeatureToggle
-  class FeatureIsNotEnabledError < StandardError
-    def message
-      "Feature is not enabled"
-    end
-  end
-
-  class FeatureIsAlreadyEnabledError < StandardError
-    def message
-      "Feature is already enabled"
-    end
-  end
 
   # Keeps track of all enabled features
-  FEATURES = :features
+  FEATURE_LIST_KEY = :feature_list_key
 
-  # Adds a feature to the set of known features.
-  def self.enable_feature(feature)
-    fail FeatureIsAlreadyEnabledError if feature_enabled?(feature)
-    client.sadd FEATURES, feature
+  def self.features
+    client.smembers(FEATURE_LIST_KEY)
+  end
+
+  # Method to enable a feature globally or for a specfic set of regional offices
+  # Examples:
+  # FeatureToggle.enable!(:foo)
+  # FeatureToggle.enable!(:bar, regional_offices: ["RO01", "RO02"])
+  def self.enable!(feature, regional_offices: [])
+    # redis method: sadd (add item to a set)
+    client.sadd FEATURE_LIST_KEY, feature unless features.include?(feature.to_s)
+
+    enable_group(feature: feature,
+                  key: :regional_offices,
+                  value: regional_offices) if regional_offices.present?
     true
   end
 
-  # Removes a feature from the set of known features.
-  def self.disable_feature(feature)
-    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
+
+  # Method to disable a feature globally or for a specfic set of regional offices
+  # Examples:
+  # FeatureToggle.disable!(:foo)
+  # FeatureToggle.disable!(:bar, regional_offices: ["RO01", "RO02"])
+  def self.disable!(feature, regional_offices: [])
     client.multi do
-      client.srem FEATURES, feature
+      # redis method: srem (remove item from a set)
+      client.srem FEATURE_LIST_KEY, feature
       client.del feature
+    end unless regional_offices.present?
+
+    disable_group(feature: feature,
+                  key: :regional_offices,
+                  value: regional_offices) if regional_offices.present?
+    true
+  end
+
+  # Method to check if a given feature is enabled for a user
+  def self.enabled?(feature, current_user)
+    return false unless features.include?(feature.to_s)
+
+    data = details_for(feature)
+    if data && data["regional_offices"].present?
+      return false unless data["regional_offices"].include?(current_user.regional_office)
     end
     true
   end
 
-  def self.feature_enabled?(feature)
-    features.include?(feature.to_s)
-  end
-
-  # The set of known features.
-  def self.features
-    client.smembers(FEATURES)
-  end
-
-  # Adds a group to a given feature
-  def self.enable_group(feature, group)
-    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
-    client.sadd feature, group
-    true
-  end
-
-  # Removes a group from a given feature
-  def self.disable_group(feature, group)
-    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
-    client.srem feature, group
-    true
-  end
-
-  # Lists all groups for a given feature
-  def self.list_groups(feature)
-    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
-    client.smembers(feature)
-  end
-
-  # Removes all groups from a given feature
-  def self.clear_all_groups(feature)
-    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
-    client.del(feature)
-    true
-  end
-
-  # Checks if a given feature is enabled for a specific group
-  def self.enabled_for_group?(feature, group)
-    client.sismember(feature, group)
-  end
-
-  # Checks if a given feature is disabled for a specific group
-  def self.disabled_for_group?(feature, group)
-    !enabled_for_group?(feature, group)
+  # Returns a hash result for a given feature
+  def self.details_for(feature)
+    get_data_for_feature(feature) || {} if features.include?(feature.to_s)
   end
 
   def self.client
-    @client ||= Redis.new(url: Rails.application.secrets.redis_url_cache)
+    @client ||= Redis::Namespace.new(:feature_toggle, redis: Redis.new(url: Rails.application.secrets.redis_url_cache))
+  end
+
+  class << self
+
+    private
+
+    def enable_group(feature:, key:, value:)
+      data = get_data_for_subkey(feature, key.to_s)
+      data = data.present? ? data + value : value
+      set_data_for_subkey(feature, key, data)
+    end
+
+    def disable_group(feature:, key:, value:)
+      data = get_data_for_subkey(feature, key.to_s)
+      return unless data
+      data = data - value
+      set_data_for_subkey(feature, key, data)
+    end
+
+    def get_data_for_feature(feature)
+      data = client.get(feature)
+      JSON.parse(data) if data
+    end
+
+    def get_data_for_subkey(feature, key)
+      data = get_data_for_feature(feature)
+      data[key] if data
+    end
+
+    def set_data_for_subkey(feature, key, data)
+      client.set(feature, { key => data.uniq }.to_json)
+    end
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,58 +1,61 @@
 class FeatureToggle
-
   # Keeps track of all enabled features
   FEATURE_LIST_KEY = :feature_list_key
 
   def self.features
-    client.smembers(FEATURE_LIST_KEY)
+    client.smembers(FEATURE_LIST_KEY).map(&:to_sym)
   end
 
   # Method to enable a feature globally or for a specfic set of regional offices
   # Examples:
   # FeatureToggle.enable!(:foo)
   # FeatureToggle.enable!(:bar, regional_offices: ["RO01", "RO02"])
-  def self.enable!(feature, regional_offices: [])
+  def self.enable!(feature, regional_offices: nil)
     # redis method: sadd (add item to a set)
-    client.sadd FEATURE_LIST_KEY, feature unless features.include?(feature.to_s)
+    client.sadd FEATURE_LIST_KEY, feature unless features.include?(feature)
 
-    enable_group(feature: feature,
-                  key: :regional_offices,
-                  value: regional_offices) if regional_offices.present?
+    if regional_offices.present?
+      enable(feature: feature,
+             key: :regional_offices,
+             value: regional_offices)
+    end
     true
   end
-
 
   # Method to disable a feature globally or for a specfic set of regional offices
   # Examples:
   # FeatureToggle.disable!(:foo)
   # FeatureToggle.disable!(:bar, regional_offices: ["RO01", "RO02"])
-  def self.disable!(feature, regional_offices: [])
-    client.multi do
-      # redis method: srem (remove item from a set)
-      client.srem FEATURE_LIST_KEY, feature
-      client.del feature
-    end unless regional_offices.present?
+  def self.disable!(feature, regional_offices: nil)
+    unless regional_offices
+      client.multi do
+        # redis method: srem (remove item from a set)
+        client.srem FEATURE_LIST_KEY, feature
+        client.del feature
+      end
+      return true
+    end
 
-    disable_group(feature: feature,
-                  key: :regional_offices,
-                  value: regional_offices) if regional_offices.present?
+    disable(feature: feature,
+            key: :regional_offices,
+            value: regional_offices)
+
     true
   end
 
   # Method to check if a given feature is enabled for a user
   def self.enabled?(feature, current_user)
-    return false unless features.include?(feature.to_s)
-
-    data = details_for(feature)
-    if data && data["regional_offices"].present?
-      return false unless data["regional_offices"].include?(current_user.regional_office)
-    end
+    return false unless features.include?(feature)
+    regional_offices = get_subkey(feature, :regional_offices)
+    # if regional_offices key is set, check if the feature is enabled for the user's ro
+    # otherwise, it is enabled globally
+    return false if regional_offices.present? && !regional_offices.include?(current_user.regional_office)
     true
   end
 
   # Returns a hash result for a given feature
   def self.details_for(feature)
-    get_data_for_feature(feature) || {} if features.include?(feature.to_s)
+    feature_hash(feature) || {} if features.include?(feature)
   end
 
   def self.client
@@ -60,33 +63,31 @@ class FeatureToggle
   end
 
   class << self
-
     private
 
-    def enable_group(feature:, key:, value:)
-      data = get_data_for_subkey(feature, key.to_s)
+    def enable(feature:, key:, value:)
+      data = get_subkey(feature, key)
       data = data.present? ? data + value : value
-      set_data_for_subkey(feature, key, data)
+      set_subkey(feature, key, data)
     end
 
-    def disable_group(feature:, key:, value:)
-      data = get_data_for_subkey(feature, key.to_s)
+    def disable(feature:, key:, value:)
+      data = get_subkey(feature, key)
       return unless data
-      data = data - value
-      set_data_for_subkey(feature, key, data)
+      set_subkey(feature, key, data - value)
     end
 
-    def get_data_for_feature(feature)
+    def feature_hash(feature)
       data = client.get(feature)
-      JSON.parse(data) if data
+      JSON.parse(data).symbolize_keys if data
     end
 
-    def get_data_for_subkey(feature, key)
-      data = get_data_for_feature(feature)
+    def get_subkey(feature, key)
+      data = feature_hash(feature)
       data[key] if data
     end
 
-    def set_data_for_subkey(feature, key, data)
+    def set_subkey(feature, key, data)
       client.set(feature, { key => data.uniq }.to_json)
     end
   end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,0 +1,83 @@
+class FeatureToggle
+  class FeatureIsNotEnabledError < StandardError
+    def message
+      "Feature is not enabled"
+    end
+  end
+
+  class FeatureIsAlreadyEnabledError < StandardError
+    def message
+      "Feature is already enabled"
+    end
+  end
+
+  # Keeps track of all enabled features
+  FEATURES = :features
+
+  # Adds a feature to the set of known features.
+  def self.enable_feature(feature)
+    fail FeatureIsAlreadyEnabledError if feature_enabled?(feature)
+    client.sadd FEATURES, feature
+    true
+  end
+
+  # Removes a feature from the set of known features.
+  def self.disable_feature(feature)
+    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
+    client.multi do
+      client.srem FEATURES, feature
+      client.del feature
+    end
+    true
+  end
+
+  def self.feature_enabled?(feature)
+    features.include?(feature.to_s)
+  end
+
+  # The set of known features.
+  def self.features
+    client.smembers(FEATURES)
+  end
+
+  # Adds a group to a given feature
+  def self.enable_group(feature, group)
+    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
+    client.sadd feature, group
+    true
+  end
+
+  # Removes a group from a given feature
+  def self.disable_group(feature, group)
+    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
+    client.srem feature, group
+    true
+  end
+
+  # Lists all groups for a given feature
+  def self.list_groups(feature)
+    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
+    client.smembers(feature)
+  end
+
+  # Removes all groups from a given feature
+  def self.clear_all_groups(feature)
+    fail FeatureIsNotEnabledError unless feature_enabled?(feature)
+    client.del(feature)
+    true
+  end
+
+  # Checks if a given feature is enabled for a specific group
+  def self.enabled_for_group?(feature, group)
+    client.sismember(feature, group)
+  end
+
+  # Checks if a given feature is disabled for a specific group
+  def self.disabled_for_group?(feature, group)
+    !enabled_for_group?(feature, group)
+  end
+
+  def self.client
+    @client ||= Redis.new(url: Rails.application.secrets.redis_url_cache)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,6 +35,7 @@ module CaseflowCertification
     config.google_analytics_account = nil
     config.google_analytics_host = nil
 
-     config.bgs_environment = ENV["BGS_ENVIRONMENT"] || "beplinktest"
+    config.bgs_environment = ENV["BGS_ENVIRONMENT"] || "beplinktest"
+
   end
 end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -1,0 +1,59 @@
+describe FeatureToggle do
+  before :each do
+    FeatureToggle.client.flushall
+  end
+
+  it "should enable a feature" do
+    FeatureToggle.enable_feature(:test)
+    FeatureToggle.enable_feature(:search)
+    expect(FeatureToggle.client.sismember(FeatureToggle::FEATURES, :test)).to eq true
+    expect(FeatureToggle.features).to eq %w(test search)
+  end
+
+  it "should return error if feature is already enabled" do
+    FeatureToggle.enable_feature(:test)
+    expect { FeatureToggle.enable_feature(:test) }.to raise_error(FeatureToggle::FeatureIsAlreadyEnabledError)
+  end
+
+  it "should disable a feature" do
+    FeatureToggle.enable_feature(:test)
+    FeatureToggle.disable_feature(:test)
+    expect(FeatureToggle.client.sismember(FeatureToggle::FEATURES, :test)).to eq false
+  end
+
+  it "should enable/disable a feature for a regional office" do
+    FeatureToggle.enable_feature(:stats)
+    FeatureToggle.enable_group(:stats, "RO01")
+    FeatureToggle.enable_group(:stats, "RO02")
+    FeatureToggle.enable_group(:stats, "RO03")
+    FeatureToggle.disable_group(:stats, "RO02")
+    expect(FeatureToggle.list_groups(:stats).sort).to eq %w(RO01 RO03)
+  end
+
+  it "should return error if feature is not enabled" do
+    expect { FeatureToggle.disable_feature(:absent) }.to raise_error
+    [:enable_group, :disable_group].each do |m|
+      expect { FeatureToggle.send(m, :absent, "RO03") }.to raise_error(FeatureToggle::FeatureIsNotEnabledError)
+    end
+    [:list_groups, :clear_all_groups].each do |m|
+      expect { FeatureToggle.send(m, :absent) }.to raise_error(FeatureToggle::FeatureIsNotEnabledError)
+    end
+  end
+
+  it "should check if a feature is enabled/disabled for a regional office" do
+    FeatureToggle.enable_feature(:search)
+    FeatureToggle.enable_group(:search, "RO01")
+    expect(FeatureToggle.enabled_for_group?(:search, "RO01")).to eq true
+    expect(FeatureToggle.enabled_for_group?(:search, "RO03")).to eq false
+    expect(FeatureToggle.disabled_for_group?(:search, "RO03")).to eq true
+    expect(FeatureToggle.disabled_for_group?(:thing, "RO01")).to eq true
+  end
+
+  it "should clear all regional offices for a feature" do
+    FeatureToggle.enable_feature(:stats)
+    FeatureToggle.enable_group(:stats, "RO01")
+    FeatureToggle.enable_group(:stats, "RO02")
+    FeatureToggle.clear_all_groups(:stats)
+    expect(FeatureToggle.list_groups(:stats)).to eq []
+  end
+end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -108,7 +108,6 @@ describe FeatureToggle do
   end
 
   context ".features" do
-
     context "when features exist" do
       before do
         FeatureToggle.enable!(:test)
@@ -128,7 +127,6 @@ describe FeatureToggle do
   end
 
   context ".details_for" do
-
     subject { FeatureToggle.details_for(:banana) }
 
     context "when enabled globally" do

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -1,5 +1,4 @@
 describe FeatureToggle do
-
   let(:user1) { User.new(regional_office: "RO03") }
   let(:user2) { User.new(regional_office: "RO07") }
 
@@ -7,56 +6,182 @@ describe FeatureToggle do
     FeatureToggle.client.flushall
   end
 
-  it "should enable a feature" do
-    FeatureToggle.enable!(:test)
-    # should enable only once
-    FeatureToggle.enable!(:test)
-    FeatureToggle.enable!(:search)
-    expect(FeatureToggle.features.sort).to eq %w(search test)
-    expect(FeatureToggle.enabled?(:search, user1)).to eq true
+  context ".enable!" do
+    context "for everyone" do
+      subject { FeatureToggle.enable!(:search) }
+
+      it "feature is enabled for everyone" do
+        subject
+        expect(FeatureToggle.enabled?(:search, user1)).to eq true
+        expect(FeatureToggle.enabled?(:search, user2)).to eq true
+      end
+    end
+
+    context "for a set of regional_offices" do
+      subject { FeatureToggle.enable!(:test, regional_offices: %w(RO01 RO02 RO03)) }
+
+      it "feature is enabled for users who belong to the regional offices" do
+        subject
+        expect(FeatureToggle.enabled?(:test, user1)).to eq true
+        expect(FeatureToggle.enabled?(:test, user2)).to eq false
+      end
+
+      it "enable for more users" do
+        subject
+        FeatureToggle.enable!(:test, regional_offices: ["RO07"])
+        expect(FeatureToggle.enabled?(:test, user1)).to eq true
+        expect(FeatureToggle.enabled?(:test, user2)).to eq true
+      end
+    end
   end
 
-  it "should disable a feature" do
-    FeatureToggle.enable!(:test)
-    FeatureToggle.enable!(:search)
-    FeatureToggle.disable!(:test)
-    expect(FeatureToggle.features).to eq %w(search)
-    expect(FeatureToggle.enabled?(:test, user1)).to eq false
-    expect(FeatureToggle.enabled?(:search, user1)).to eq true
+  context ".disable!" do
+    context "globally" do
+      before do
+        FeatureToggle.enable!(:search)
+      end
+      subject { FeatureToggle.disable!(:search) }
+
+      it "feature is disabled for everyone" do
+        subject
+        expect(FeatureToggle.enabled?(:search, user1)).to eq false
+        expect(FeatureToggle.enabled?(:search, user2)).to eq false
+      end
+    end
+
+    context "for a set of regional offices" do
+      before do
+        FeatureToggle.enable!(:test, regional_offices: %w(RO07 RO03))
+      end
+      subject { FeatureToggle.disable!(:test, regional_offices: ["RO03"]) }
+
+      it "users who belong to the regional offices can no longer access the feature" do
+        subject
+        expect(FeatureToggle.enabled?(:test, user1)).to eq false
+        expect(FeatureToggle.enabled?(:test, user2)).to eq true
+      end
+    end
+
+    context "when regional_offices becomes an empty array" do
+      before do
+        FeatureToggle.enable!(:test, regional_offices: %w(RO03 RO02 RO09))
+      end
+      subject { FeatureToggle.disable!(:test, regional_offices: %w(RO03 RO02 RO09)) }
+
+      it "feature becomes enabled for everyone" do
+        subject
+        expect(FeatureToggle.enabled?(:test, user1)).to eq true
+        expect(FeatureToggle.enabled?(:test, user2)).to eq true
+      end
+
+      it "feature can be disabled globally" do
+        subject
+        FeatureToggle.disable!(:test)
+        expect(FeatureToggle.enabled?(:test, user1)).to eq false
+        expect(FeatureToggle.enabled?(:test, user2)).to eq false
+      end
+    end
+
+    context "when sending an empty array" do
+      before do
+        FeatureToggle.enable!(:test, regional_offices: %w(RO03 RO02 RO09))
+      end
+      subject { FeatureToggle.disable!(:test, regional_offices: []) }
+
+      it "no regional offices are disabled" do
+        subject
+        expect(FeatureToggle.details_for(:test)[:regional_offices]).to eq %w(RO03 RO02 RO09)
+      end
+    end
+
+    context "when sending incorrect regional offices" do
+      before do
+        FeatureToggle.enable!(:test, regional_offices: %w(RO03 RO02 RO09))
+      end
+      subject { FeatureToggle.disable!(:test, regional_offices: ["RO01"]) }
+
+      it "no regional offices are disabled" do
+        subject
+        expect(FeatureToggle.details_for(:test)[:regional_offices]).to eq %w(RO03 RO02 RO09)
+      end
+    end
   end
 
-  it "should return details for a feature" do
-    FeatureToggle.enable!(:test)
-    expect(FeatureToggle.details_for(:test)).to be {}
-    FeatureToggle.enable!(:test, regional_offices: ["RO08", "RO01"])
-    expect(FeatureToggle.details_for(:test).keys).to eq ["regional_offices"]
+  context ".features" do
+
+    context "when features exist" do
+      before do
+        FeatureToggle.enable!(:test)
+        FeatureToggle.enable!(:test)
+        FeatureToggle.enable!(:search)
+      end
+      subject { FeatureToggle.features.sort }
+
+      it { is_expected.to eq [:search, :test] }
+    end
+
+    context "when features do not exist" do
+      subject { FeatureToggle.features }
+
+      it { is_expected.to eq [] }
+    end
   end
 
-  it "should enable/disable a feature for multiple regional offices" do
-    FeatureToggle.enable!(:test, regional_offices: ["RO01", "RO02", "RO03"])
-    expect(FeatureToggle.details_for(:test)["regional_offices"].sort).to eq ["RO01", "RO02", "RO03"]
-    expect(FeatureToggle.enabled?(:test, user1)).to eq true
-    expect(FeatureToggle.enabled?(:test, user2)).to eq false
+  context ".details_for" do
 
-    # disable RO03
-    FeatureToggle.disable!(:test, regional_offices: ["RO03"])
-    expect(FeatureToggle.details_for(:test)["regional_offices"].sort).to eq ["RO01", "RO02"]
-    expect(FeatureToggle.enabled?(:test, user1)).to eq false
-    expect(FeatureToggle.enabled?(:test, user2)).to eq false
+    subject { FeatureToggle.details_for(:banana) }
 
-    # enable RO07
-    FeatureToggle.enable!(:test, regional_offices: ["RO07"])
-    expect(FeatureToggle.details_for(:test)["regional_offices"].sort).to eq ["RO01", "RO02", "RO07"]
-    expect(FeatureToggle.enabled?(:test, user1)).to eq false
-    expect(FeatureToggle.enabled?(:test, user2)).to eq true
+    context "when enabled globally" do
+      before do
+        FeatureToggle.enable!(:banana)
+      end
+      it { is_expected.to be {} }
+    end
 
-    # feature doesn't exist
-    expect(FeatureToggle.enabled?(:foo, user2)).to eq false
+    context "when not enabled" do
+      it { is_expected.to be nil }
+    end
 
-    # disable the entire feature
-    FeatureToggle.disable!(:test)
-    expect(FeatureToggle.details_for(:test)).to eq nil
-    expect(FeatureToggle.enabled?(:test, user1)).to eq false
-    expect(FeatureToggle.enabled?(:test, user2)).to eq false
+    context "when enabled for a list of regional offices" do
+      before do
+        FeatureToggle.enable!(:banana, regional_offices: %w(RO03 RO02 RO09))
+      end
+      it { is_expected.to eq(regional_offices: %w(RO03 RO02 RO09)) }
+    end
+  end
+
+  context ".enabled?" do
+    context "when enabled for everyone" do
+      before do
+        FeatureToggle.enable!(:search)
+      end
+      subject { FeatureToggle.enabled?(:search, user1) }
+
+      it { is_expected.to eq true }
+    end
+
+    context "when a feature does not exist in redis" do
+      subject { FeatureToggle.enabled?(:foo, user1) }
+
+      it { is_expected.to eq false }
+    end
+
+    context "when enabled for a set of regional_offices" do
+      subject { FeatureToggle.enabled?(:search, user) }
+
+      before do
+        FeatureToggle.enable!(:search, regional_offices: %w(RO01 RO02 RO03))
+      end
+
+      context "if a user is associated with a regional office" do
+        let(:user) { User.new(regional_office: "RO02") }
+        it { is_expected.to eq true }
+      end
+
+      context "if a user is not associated with a regional office" do
+        let(:user) { User.new(regional_office: "RO09") }
+        it { is_expected.to eq false }
+      end
+    end
   end
 end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -1,59 +1,62 @@
 describe FeatureToggle do
+
+  let(:user1) { User.new(regional_office: "RO03") }
+  let(:user2) { User.new(regional_office: "RO07") }
+
   before :each do
     FeatureToggle.client.flushall
   end
 
   it "should enable a feature" do
-    FeatureToggle.enable_feature(:test)
-    FeatureToggle.enable_feature(:search)
-    expect(FeatureToggle.client.sismember(FeatureToggle::FEATURES, :test)).to eq true
-    expect(FeatureToggle.features).to eq %w(test search)
-  end
-
-  it "should return error if feature is already enabled" do
-    FeatureToggle.enable_feature(:test)
-    expect { FeatureToggle.enable_feature(:test) }.to raise_error(FeatureToggle::FeatureIsAlreadyEnabledError)
+    FeatureToggle.enable!(:test)
+    # should enable only once
+    FeatureToggle.enable!(:test)
+    FeatureToggle.enable!(:search)
+    expect(FeatureToggle.features.sort).to eq %w(search test)
+    expect(FeatureToggle.enabled?(:search, user1)).to eq true
   end
 
   it "should disable a feature" do
-    FeatureToggle.enable_feature(:test)
-    FeatureToggle.disable_feature(:test)
-    expect(FeatureToggle.client.sismember(FeatureToggle::FEATURES, :test)).to eq false
+    FeatureToggle.enable!(:test)
+    FeatureToggle.enable!(:search)
+    FeatureToggle.disable!(:test)
+    expect(FeatureToggle.features).to eq %w(search)
+    expect(FeatureToggle.enabled?(:test, user1)).to eq false
+    expect(FeatureToggle.enabled?(:search, user1)).to eq true
   end
 
-  it "should enable/disable a feature for a regional office" do
-    FeatureToggle.enable_feature(:stats)
-    FeatureToggle.enable_group(:stats, "RO01")
-    FeatureToggle.enable_group(:stats, "RO02")
-    FeatureToggle.enable_group(:stats, "RO03")
-    FeatureToggle.disable_group(:stats, "RO02")
-    expect(FeatureToggle.list_groups(:stats).sort).to eq %w(RO01 RO03)
+  it "should return details for a feature" do
+    FeatureToggle.enable!(:test)
+    expect(FeatureToggle.details_for(:test)).to be {}
+    FeatureToggle.enable!(:test, regional_offices: ["RO08", "RO01"])
+    expect(FeatureToggle.details_for(:test).keys).to eq ["regional_offices"]
   end
 
-  it "should return error if feature is not enabled" do
-    expect { FeatureToggle.disable_feature(:absent) }.to raise_error
-    [:enable_group, :disable_group].each do |m|
-      expect { FeatureToggle.send(m, :absent, "RO03") }.to raise_error(FeatureToggle::FeatureIsNotEnabledError)
-    end
-    [:list_groups, :clear_all_groups].each do |m|
-      expect { FeatureToggle.send(m, :absent) }.to raise_error(FeatureToggle::FeatureIsNotEnabledError)
-    end
-  end
+  it "should enable/disable a feature for multiple regional offices" do
+    FeatureToggle.enable!(:test, regional_offices: ["RO01", "RO02", "RO03"])
+    expect(FeatureToggle.details_for(:test)["regional_offices"].sort).to eq ["RO01", "RO02", "RO03"]
+    expect(FeatureToggle.enabled?(:test, user1)).to eq true
+    expect(FeatureToggle.enabled?(:test, user2)).to eq false
 
-  it "should check if a feature is enabled/disabled for a regional office" do
-    FeatureToggle.enable_feature(:search)
-    FeatureToggle.enable_group(:search, "RO01")
-    expect(FeatureToggle.enabled_for_group?(:search, "RO01")).to eq true
-    expect(FeatureToggle.enabled_for_group?(:search, "RO03")).to eq false
-    expect(FeatureToggle.disabled_for_group?(:search, "RO03")).to eq true
-    expect(FeatureToggle.disabled_for_group?(:thing, "RO01")).to eq true
-  end
+    # disable RO03
+    FeatureToggle.disable!(:test, regional_offices: ["RO03"])
+    expect(FeatureToggle.details_for(:test)["regional_offices"].sort).to eq ["RO01", "RO02"]
+    expect(FeatureToggle.enabled?(:test, user1)).to eq false
+    expect(FeatureToggle.enabled?(:test, user2)).to eq false
 
-  it "should clear all regional offices for a feature" do
-    FeatureToggle.enable_feature(:stats)
-    FeatureToggle.enable_group(:stats, "RO01")
-    FeatureToggle.enable_group(:stats, "RO02")
-    FeatureToggle.clear_all_groups(:stats)
-    expect(FeatureToggle.list_groups(:stats)).to eq []
+    # enable RO07
+    FeatureToggle.enable!(:test, regional_offices: ["RO07"])
+    expect(FeatureToggle.details_for(:test)["regional_offices"].sort).to eq ["RO01", "RO02", "RO07"]
+    expect(FeatureToggle.enabled?(:test, user1)).to eq false
+    expect(FeatureToggle.enabled?(:test, user2)).to eq true
+
+    # feature doesn't exist
+    expect(FeatureToggle.enabled?(:foo, user2)).to eq false
+
+    # disable the entire feature
+    FeatureToggle.disable!(:test)
+    expect(FeatureToggle.details_for(:test)).to eq nil
+    expect(FeatureToggle.enabled?(:test, user1)).to eq false
+    expect(FeatureToggle.enabled?(:test, user2)).to eq false
   end
 end


### PR DESCRIPTION
connects #836 

1. Create FeatureToggle Service
2. Store features in Redis cache
3. Added instructions to README

Example Usage:

```
# users
user1 = User.new(regional_office: "RO03")
user2 = User.new(regional_office: "RO04")

# enable for everyone
FeatureToggle.enable!(:apple)
=> true
FeatureToggle.enabled?(:apple, user1)
=> true

# enable for a list of regional offices
FeatureToggle.enable!(:apple, regional_offices: ["RO03", "RO08"])
=> true

# add more regional offices to the same feature
FeatureToggle.enable!(:apple, regional_offices: ["RO03", "RO09"])
=> true

# view the details
FeatureToggle.details_for(:apple)
=> { :regional_offices => ["RO03", "RO08", "RO09"] }

# check if the feature is enabled for a given user
FeatureToggle.enabled?(:apple, user1)
=> true
FeatureToggle.enabled?(:apple, user2)
=> false

# disable a few regional offices
FeatureToggle.disable!(:apple, regional_offices: ["RO03", "RO09"])
=> true
FeatureToggle.details_for(:apple)
=> { :regional_offices =>["RO08"] }
```

     
