### PR TITLE
Handle more special issues

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -84,7 +84,8 @@ export const ROUTING_SPECIAL_ISSUES = [
     stationOfJurisdiction: '355 - San Juan, Puerto Rico'
   },
   {
-    specialIssue: 'usTerritoryClaimAmericanSamoaGuamNorthernMarianaIslandsRotaSaipanTinian',
+    specialIssue: 'usTerritoryClaimAmericanSamoaGuamNorthern' +
+      'MarianaIslandsRotaSaipanTinian',
     stationOfJurisdiction: '459 - Honolulu, HI'
   }
 ];

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -56,7 +56,6 @@ export const UNHANDLED_SPECIAL_ISSUES = [
   'Pension - United States',
   'VAMC',
   'DIC - death, or accrued benefits - United States',
-  'Foreign claim - compensation claims, dual claims, appeals',
   'Education - GI Bill, dependents educational ' +
     'assistance, scholarship, transfer of entitlement',
   'Waiver of Overpayment',
@@ -71,6 +70,22 @@ export const ROUTING_SPECIAL_ISSUES = [
   {
     specialIssue: 'contaminatedWaterAtCampLejeune',
     stationOfJurisdiction: '327 - Louisville, KY'
+  },
+  {
+    specialIssue: 'foreignClaimCompensationClaimsDualClaimsAppeals',
+    stationOfJurisdiction: '311 - Pittsburgh, PA'
+  },
+  {
+    specialIssue: 'usTerritoryClaimPhilippines',
+    stationOfJurisdiction: '358 - Manila, Philippines'
+  },
+  {
+    specialIssue: 'usTerritoryClaimPuertoRicoAndVirginIslands',
+    stationOfJurisdiction: '355 - San Juan, Puerto Rico'
+  },
+  {
+    specialIssue: 'usTerritoryClaimAmericanSamoaGuamNorthernMarianaIslandsRotaSaipanTinian',
+    stationOfJurisdiction: '459 - Honolulu, HI'
   }
 ];
 


### PR DESCRIPTION
We now handle the following four special issues.

- Foreign claim - compensation claims, dual claims, appeals: Station 311 - Pittsburgh RO
- U.S. Territory (Philippines): Station 358 - Manila RO
- U.S. Territory - Puerto Rico and Virgin Islands: Station 355 - San Juan RO
- U.S. Territory - American Samoa, Guam, Northern Mariana Islands (Rota, Saipan & Tinian): Station 459 - Honolulu, RO

**Test plan**
- [ ] Test manually by selecting each of these four special issues and ensuring the station id is set correctly.
- [ ] Run test suite