### PR TITLE
Changing document_id to use vbms_document_id

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -273,7 +273,7 @@ class AppealRepository
   def self.fetch_document_file(document)
     @vbms_client ||= init_vbms_client
 
-    request = VBMS::Requests::FetchDocumentById.new(document.document_id)
+    request = VBMS::Requests::FetchDocumentById.new(document.vbms_document_id)
     result = @vbms_client.send_request(request)
     result && result.content
   rescue => e


### PR DESCRIPTION
When ripping out the code that saved the documents in the database, we accidentally still referenced document_id in appeals repository.

Connects: #951 

**Test Plan**
- [ ] Work with Artem to validate in UAT