### PR TITLE
Give routable special issues priority

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -145,6 +145,10 @@ class Appeal < ActiveRecord::Base
     decisions
   end
 
+  def serialized_decision_date
+    decision_date.to_formatted_s(:json_date)
+  end
+
   def certify!
     Appeal.certify(self)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -205,7 +205,7 @@ class Task < ActiveRecord::Base
   def to_hash
     serializable_hash(
       include: [:user, appeal: { methods:
-       [:decision_date,
+       [:serialized_decision_date,
         :veteran_name,
         :decision_type] }],
       methods: [:progress_status, :days_since_creation]
@@ -218,7 +218,7 @@ class Task < ActiveRecord::Base
         include:
           [decisions: { methods: :received_at }],
         methods:
-        [:decision_date,
+        [:serialized_decision_date,
          :decisions_hash,
          :disposition,
          :veteran_name,

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -440,8 +440,20 @@ export default class EstablishClaim extends BaseForm {
     });
   }
 
+  containsRoutingSpecialIssues(specialIssues)  {
+    return Boolean(Review.REGIONAL_OFFICE_SPECIAL_ISSUES.find((issue) => {
+      return specialIssues[issue].value;
+    }));
+  }
+
   validateReviewPageSubmit() {
     let validOutput = true;
+
+    // If it contains a routed special issue, allow EP creation even if it
+    // contains other unhandled special issues.
+    if (this.containsRoutingSpecialIssues(this.state.specialIssues)) {
+      return true;
+    }
 
     Review.UNHANDLED_SPECIAL_ISSUES.forEach((issue) => {
       if (this.state.specialIssues[StringUtil.convertToCamelCase(issue)].value) {

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -80,7 +80,7 @@ export default class EstablishClaim extends BaseForm {
       claimForm: {
         // This is the decision date that gets mapped to the claim's creation date
         date: new FormField(
-          formatDate(this.props.task.appeal.decision_date),
+          formatDate(this.props.task.appeal.serialized_decision_date),
           [
             requiredValidator('Please enter the Decision Date.'),
             dateValidator()

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines, require-jsdoc */
 
 import React, { PropTypes } from 'react';
 import ApiUtil from '../../util/ApiUtil';
@@ -46,6 +46,12 @@ const PARTIAL_GRANT_MODIFIER_OPTIONS = [
 ];
 
 const SPECIAL_ISSUES = Review.SPECIAL_ISSUES;
+
+let containsRoutingSpecialIssues = function(specialIssues) {
+  return Boolean(
+    Review.REGIONAL_OFFICE_SPECIAL_ISSUES.find((issue) => specialIssues[issue].value)
+  );
+};
 
 // This page is used by AMC to establish claims. This is
 // the last step in the appeals process, and is after the decsion
@@ -440,18 +446,12 @@ export default class EstablishClaim extends BaseForm {
     });
   }
 
-  containsRoutingSpecialIssues(specialIssues)  {
-    return Boolean(Review.REGIONAL_OFFICE_SPECIAL_ISSUES.find((issue) => {
-      return specialIssues[issue].value;
-    }));
-  }
-
   validateReviewPageSubmit() {
     let validOutput = true;
 
     // If it contains a routed special issue, allow EP creation even if it
     // contains other unhandled special issues.
-    if (this.containsRoutingSpecialIssues(this.state.specialIssues)) {
+    if (containsRoutingSpecialIssues(this.state.specialIssues)) {
       return true;
     }
 
@@ -574,4 +574,4 @@ EstablishClaim.propTypes = {
   task: PropTypes.object.isRequired
 };
 
-/* eslint-enable max-lines */
+/* eslint-enable max-lines, require-jsdoc */

--- a/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
@@ -26,7 +26,8 @@ export default class EstablishClaimNote extends BaseForm {
         `and ${selectedSpecialIssue[selectedSpecialIssue.length - 1]}`;
     }
 
-    let note = `The BVA Full Grant decision date ${formatDate(appeal.serialized_decision_date)}` +
+    let note = `The BVA Full Grant decision` +
+      ` date ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name}, ID #${appeal.vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssue.join(', ')}` +
       ` in your jurisdiction. Please proceed with control and implement this grant.`;

--- a/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
@@ -26,7 +26,7 @@ export default class EstablishClaimNote extends BaseForm {
         `and ${selectedSpecialIssue[selectedSpecialIssue.length - 1]}`;
     }
 
-    let note = `The BVA Full Grant decision date ${formatDate(appeal.decision_date)}` +
+    let note = `The BVA Full Grant decision date ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name}, ID #${appeal.vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssue.join(', ')}` +
       ` in your jurisdiction. Please proceed with control and implement this grant.`;

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -155,8 +155,13 @@ export default class EstablishClaimReview extends React.Component {
       task
     } = this.props;
 
-    let decisionDateStart = formatDate(addDays(new Date(task.appeal.serialized_decision_date), -3));
-    let decisionDateEnd = formatDate(addDays(new Date(task.appeal.serialized_decision_date), 3));
+    let decisionDateStart = formatDate(
+      addDays(new Date(task.appeal.serialized_decision_date), -3)
+    );
+
+    let decisionDateEnd = formatDate(
+      addDays(new Date(task.appeal.serialized_decision_date), 3)
+    );
 
     // Sort in reverse chronological order
     let decisions = task.appeal.decisions.sort((decision1, decision2) =>

--- a/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimReview.jsx
@@ -155,8 +155,8 @@ export default class EstablishClaimReview extends React.Component {
       task
     } = this.props;
 
-    let decisionDateStart = formatDate(addDays(new Date(task.appeal.decision_date), -3));
-    let decisionDateEnd = formatDate(addDays(new Date(task.appeal.decision_date), 3));
+    let decisionDateStart = formatDate(addDays(new Date(task.appeal.serialized_decision_date), -3));
+    let decisionDateEnd = formatDate(addDays(new Date(task.appeal.serialized_decision_date), 3));
 
     // Sort in reverse chronological order
     let decisions = task.appeal.decisions.sort((decision1, decision2) =>

--- a/client/app/containers/UnpreparedTasksIndex.jsx
+++ b/client/app/containers/UnpreparedTasksIndex.jsx
@@ -9,7 +9,7 @@ export default class UnpreparedTasksIndex extends React.Component {
   buildUnpreparedTaskRow = (task) => [
     `${task.appeal.veteran_name} (${task.appeal.vbms_id})`,
     task.appeal.decision_type,
-    formatDate(task.appeal.decision_date),
+    formatDate(task.appeal.serialized_decision_date),
     `${task.days_since_creation} days`
   ];
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,2 +1,5 @@
 DateTime::DATE_FORMATS[:short_date] =
 Time::DATE_FORMATS[:short_date] = "%m/%d/%Y"
+
+DateTime::DATE_FORMATS[:json_date] =
+Time::DATE_FORMATS[:json_date] = "%Y/%m/%d"

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -351,7 +351,7 @@ RSpec.feature "Dispatch" do
               payee_code: "00",
               predischarge: false,
               claim_type: "Claim",
-              date: @task.appeal.decision_date.to_date,
+              date: @task2.appeal.decision_date.to_date,
               end_product_modifier: "171",
               end_product_label: "AMC-Partial Grant",
               end_product_code: "170PGAMC",

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -455,6 +455,10 @@ RSpec.feature "Dispatch" do
       @task.assign!(:assigned, current_user)
       visit "/dispatch/establish-claim/#{@task.id}"
       page.find("#privateAttorneyOrAgent").trigger("click")
+
+      # It should also work even if a unsupported special issue is checked
+      page.find("#dicDeathOrAccruedBenefitsUnitedStates").trigger("click")
+
       click_on "Route Claim"
       click_on "Create New EP"
       expect(find_field("Station of Jurisdiction").value).to eq("313 - Baltimore, MD")

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Dispatch" do
   before do
+    # Set the time zone to the current user's time zone for proper date conversion
+    Time.zone = "America/New_York"
     Timecop.freeze(Time.utc(2017, 1, 1))
 
     @vbms_id = "VBMS_ID1"
@@ -123,10 +125,6 @@ RSpec.feature "Dispatch" do
       @other_task.start!
     end
 
-    let(:expected_decision_date) do
-      @task.appeal.decision_date.in_time_zone(current_user.timezone).to_date
-    end
-
     context "Skip the associate EP page" do
       before do
         BGSService.end_product_data = []
@@ -189,7 +187,7 @@ RSpec.feature "Dispatch" do
             predischarge: false,
             claim_type: "Claim",
             station_of_jurisdiction: "397",
-            date: expected_decision_date,
+            date: @task.appeal.decision_date.to_date,
             end_product_modifier: "172",
             end_product_label: "BVA Grant",
             end_product_code: "172BVAG",
@@ -353,7 +351,7 @@ RSpec.feature "Dispatch" do
               payee_code: "00",
               predischarge: false,
               claim_type: "Claim",
-              date: expected_decision_date,
+              date: @task.appeal.decision_date.to_date,
               end_product_modifier: "171",
               end_product_label: "AMC-Partial Grant",
               end_product_code: "170PGAMC",

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Dispatch" do
   before do
+    Timecop.freeze(Time.utc(2017, 1, 1))
+
     @vbms_id = "VBMS_ID1"
 
     BGSService.end_product_data = [
@@ -55,8 +57,6 @@ RSpec.feature "Dispatch" do
     )
     @task2 = EstablishClaim.create(appeal: appeal)
     @task2.prepare!
-
-    Timecop.freeze(Time.utc(2017, 1, 1))
 
     allow(Fakes::AppealRepository).to receive(:establish_claim!).and_call_original
   end
@@ -123,6 +123,10 @@ RSpec.feature "Dispatch" do
       @other_task.start!
     end
 
+    let(:expected_decision_date) do
+      @task.appeal.decision_date.in_time_zone(current_user.timezone).to_date
+    end
+
     context "Skip the associate EP page" do
       before do
         BGSService.end_product_data = []
@@ -185,7 +189,7 @@ RSpec.feature "Dispatch" do
             predischarge: false,
             claim_type: "Claim",
             station_of_jurisdiction: "397",
-            date: @task.appeal.decision_date.to_date,
+            date: expected_decision_date,
             end_product_modifier: "172",
             end_product_label: "BVA Grant",
             end_product_code: "172BVAG",
@@ -349,7 +353,7 @@ RSpec.feature "Dispatch" do
               payee_code: "00",
               predischarge: false,
               claim_type: "Claim",
-              date: @task2.appeal.decision_date.to_date,
+              date: expected_decision_date,
               end_product_modifier: "171",
               end_product_label: "AMC-Partial Grant",
               end_product_code: "170PGAMC",


### PR DESCRIPTION
Also fix some datetime issues with the tests:

`Date.new(timestring)` converts the `timestring` to the time zone local
to the browser and there is no way to change that without using moment.js.

This can cause an off-by-one error with the date if the timezone difference
between the RO and the browser timezone is larger than the time since the last
day or until the next day. This is particularly annoying in tests.

Instead of introducting moment.js right now, just pass the date (which
is what matters) without time and zone information. This guarantees that
the date is not switched because of weird timezone issues.

connects #911 