### PR TITLE
close index&column warmup connection

### DIFF
--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -49,4 +49,5 @@ def warmup_pool(pool, initial_pool_size)
     conn.indexes(table_name)
     conn.columns(table_name)
   end
+  conn.close
 end


### PR DESCRIPTION
Before this PR we were leaking 1 VACOLS connection per application. Not a big deal but it meant we effectively had `DB_CONN_POOL_INITIAL_SIZE - 1` connections actually available in the pool because 1 was never returned. 