### PR TITLE
configure socket timeouts

### DIFF
--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -1,11 +1,13 @@
 # VACOLS throttles the rate of new connections, create up front to prevent
 # blocking as pool grows under load
 
-# configure timeouts, in seconds, for underlying socket
-OCI8.properties[:tcp_connect_timeout] = 10
-OCI8.properties[:connect_timeout] = 10
-OCI8.properties[:send_timeout] = 10
-OCI8.properties[:recv_timeout] = 20
+# configure timeouts, in seconds, for underlying socket in environments that use Oracle
+if defined? OCI8
+  OCI8.properties[:tcp_connect_timeout] = 10
+  OCI8.properties[:connect_timeout] = 10
+  OCI8.properties[:send_timeout] = 10
+  OCI8.properties[:recv_timeout] = 20
+end
 
 WARMUP_TABLES = ["vacols.brieff", "vacols.corres", "vacols.folder"]
 

--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -1,6 +1,12 @@
 # VACOLS throttles the rate of new connections, create up front to prevent
 # blocking as pool grows under load
 
+# configure timeouts, in seconds, for underlying socket
+OCI8.properties[:tcp_connect_timeout] = 10
+OCI8.properties[:connect_timeout] = 10
+OCI8.properties[:send_timeout] = 10
+OCI8.properties[:recv_timeout] = 20
+
 WARMUP_TABLES = ["vacols.brieff", "vacols.corres", "vacols.folder"]
 
 ActiveSupport.on_load(:active_record_vacols) do


### PR DESCRIPTION
Before this PR, if a socket hung in the [synchronized](https://github.com/rails/rails/blob/v4.2.7.1/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L348-L351) pool-verification [`ping`](https://github.com/rsim/oracle-enhanced/blob/v1.6.7/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb#L401) query, it could deadlock the whole application (block the connection pool).

After this PR, requests will hang for 20 seconds and then the client will see a 500 internal server error. But at least the application can recover from stuck sockets to VACOLS.

Addresses https://github.com/department-of-veterans-affairs/appeals-deployment/issues/156