### PR TITLE
Using serialized date so it shows up correctly in the note

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
@@ -26,7 +26,8 @@ export default class EstablishClaimEmail extends BaseForm {
         `and ${selectedSpecialIssue[selectedSpecialIssue.length - 1]}`;
     }
 
-    let email = `The BVA Full Grant decision dated ${formatDate(appeal.decision_date)}` +
+    let email = `The BVA Full Grant decision dated` +
+      ` ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name}, ID #${appeal.vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssue.join(', ')}` +
       ` in your jurisdiction. Please proceed with control and implement this grant.`;


### PR DESCRIPTION
This PR fixes the date in the email on the email special issues page. 

Connects #722 

<img width="1157" alt="screen shot 2017-02-21 at 5 36 57 pm" src="https://cloud.githubusercontent.com/assets/4306128/23188352/6556bdda-f85c-11e6-8a3b-40d5a2de7046.png">
