### PR TITLE
Scope new Establish Claim Task creation to decision type

### DIFF
--- a/app/controllers/admin/establish_claims_controller.rb
+++ b/app/controllers/admin/establish_claims_controller.rb
@@ -10,7 +10,7 @@ class Admin::EstablishClaimsController < ApplicationController
     @create_establish_claim = CreateEstablishClaim.new(create_establish_claim_params)
 
     if @create_establish_claim.perform!
-      flash[:success] = "Task created or already existed"
+      flash[:success] = "Task created 😎"
     else
       flash[:error] = @create_establish_claim.error_message
     end

--- a/app/controllers/admin/establish_claims_controller.rb
+++ b/app/controllers/admin/establish_claims_controller.rb
@@ -2,22 +2,23 @@ class Admin::EstablishClaimsController < ApplicationController
   before_action :verify_system_admin
 
   def show
-    @appeal = Appeal.new
+    @create_establish_claim = CreateEstablishClaim.new
     @existing_tasks = EstablishClaim.newest_first.limit(100)
   end
 
   def create
-    vbms_id = params[:appeal][:vbms_id]
-    appeal = Appeal.find_or_create_by_vbms_id(vbms_id)
-    establish_claim = EstablishClaim.find_or_create_by(appeal: appeal)
-    # Admin has to confirm appeal has a decision document
-    establish_claim.prepare! if establish_claim.may_prepare?
+    @create_establish_claim = CreateEstablishClaim.new(create_establish_claim_params)
 
-    flash[:success] = "Task created or already existed"
-    redirect_to admin_establish_claim_path
+    if @create_establish_claim.perform!
+      flash[:success] = "Task created or already existed"
+    else
+      flash[:error] = @create_establish_claim.error_message
+    end
 
-  rescue MultipleAppealsByVBMSIDError
-    flash[:error] = "Multiple appeals detected. Please try another VBMS ID"
     redirect_to admin_establish_claim_path
+  end
+
+  def create_establish_claim_params
+    params.require(:create_establish_claim).permit(:vbms_id, :decision_type)
   end
 end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -199,14 +199,6 @@ class Appeal < ActiveRecord::Base
       appeal
     end
 
-    def find_or_create_by_vbms_id(vbms_id)
-      appeal = find_or_initialize_by(vbms_id: vbms_id)
-      repository.load_vacols_data_by_vbms_id(appeal)
-      appeal.save
-
-      appeal
-    end
-
     def repository
       @repository ||= AppealRepository
     end

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -40,7 +40,7 @@ class AppealRepository
                  when "Partial Grant or Remand"
                    VACOLS::Case.remands_ready_for_claims_establishment
                  else
-                   fail UnrecognizedDecisionTypeError
+                   VACOLS::Case.includes(:folder, :correspondent)
                  end
 
     case_records = MetricsService.timer "loaded VACOLS case #{appeal.vbms_id}" do

--- a/app/services/create_establish_claim.rb
+++ b/app/services/create_establish_claim.rb
@@ -1,0 +1,45 @@
+# Service object used by Caseflow System Admins
+# to manually create Establish Claims tasks
+class CreateEstablishClaim
+  include ActiveModel::Model
+
+  DECISION_TYPES = ["Full Grant", "Partial Grant or Remand"].freeze
+
+  attr_accessor :vbms_id, :decision_type
+  attr_accessor :error_message
+
+  def perform!
+    perform_create_establish_claim
+
+    !error_message
+  end
+
+  private
+
+  def perform_create_establish_claim
+    establish_claim = EstablishClaim.find_or_create_by(appeal: create_appeal)
+
+    # Admin has to confirm appeal has a decision document
+    if establish_claim.may_prepare?
+      establish_claim.prepare!
+    else
+      @error_message = "This appeal did not have a decision document in VBMS."
+    end
+
+  rescue MultipleAppealsByVBMSIDError
+    @error_message = "There were multiple appeals matching this VBMS ID."
+  rescue ActiveRecord::RecordNotFound
+    @error_message = "Appeal not found for that decision type." \
+      "Make sure to add the 'S' or 'C' to the end of the file number."
+  rescue UnrecognizedDecisionTypeError
+    @error_message = "You must select a decision type"
+  end
+
+  def create_appeal
+    appeal = Appeal.find_or_initialize_by(vbms_id: vbms_id)
+    Appeal.repository.load_vacols_data_by_vbms_id(appeal: appeal, decision_type: decision_type)
+    appeal.save!
+
+    appeal
+  end
+end

--- a/app/services/vbms_error.rb
+++ b/app/services/vbms_error.rb
@@ -3,3 +3,6 @@ end
 
 class MultipleAppealsByVBMSIDError < StandardError
 end
+
+class UnrecognizedDecisionTypeError < StandardError
+end

--- a/app/views/admin/establish_claims/show.html.erb
+++ b/app/views/admin/establish_claims/show.html.erb
@@ -13,14 +13,16 @@
     uploaded before creating a task.
   </div>
 
-  <%= form_for @appeal, url: admin_establish_claim_path, method: "POST",
+  <%= form_for @create_establish_claim, url: admin_establish_claim_path, method: "POST",
     html: { id: "establish-claim-form", class: "cf-form" },
     builder: CaseflowFormBuilder do |f| %>
-
       <%= f.text_field :vbms_id, label: "VBMS ID", question_name: "vbms_id" %>
+      <%= f.radio_buttons_field :decision_type, label: "Decision Type", question_name: "decision_type",
+            values: CreateEstablishClaim::DECISION_TYPES, inline: true %>
 
       <button type="submit" class="cf-submit">Create Task</button>
   <% end %>
+
   <hr class="cf-section-break"/>
   <h2>Existing Tasks</h2>
   <div class="usa-width-one-whole">

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -58,8 +58,11 @@ class Fakes::AppealRepository
     appeal.assign_from_vacols(record)
   end
 
-  def self.load_vacols_data_by_vbms_id(appeal)
+  def self.load_vacols_data_by_vbms_id(appeal:, decision_type:)
     return unless @records
+
+    # Require decision type to be set, don't bother with more detailed checks
+    fail UnrecognizedDecisionTypeError unless decision_type
 
     # simulate VACOLS returning 2 appeals for a given vbms_id
     fail MultipleAppealsByVBMSIDError if RASIE_MULTIPLE_APPEALS_ERROR_ID == appeal[:vbms_id]
@@ -69,6 +72,8 @@ class Fakes::AppealRepository
       # TODO(jd): create a more dynamic setup
       @records.find { |_, r| r[:vbms_id] == appeal.vbms_id } || fail(ActiveRecord::RecordNotFound)
     end
+
+    fail ActiveRecord::RecordNotFound unless record
 
     appeal.vacols_id = record[0]
     appeal.assign_from_vacols(record[1])

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -61,8 +61,8 @@ class Fakes::AppealRepository
   def self.load_vacols_data_by_vbms_id(appeal:, decision_type:)
     return unless @records
 
-    # Require decision type to be set, don't bother with more detailed checks
-    fail UnrecognizedDecisionTypeError unless decision_type
+    p "Load faked VACOLS data for appeal VBMS ID: #{appeal.vbms_id}"
+    p "Decision Type:\n", decision_type
 
     # simulate VACOLS returning 2 appeals for a given vbms_id
     fail MultipleAppealsByVBMSIDError if RASIE_MULTIPLE_APPEALS_ERROR_ID == appeal[:vbms_id]
@@ -237,9 +237,9 @@ class Fakes::AppealRepository
     }
   end
 
-  def self.appeal_partial_grant_decided
+  def self.appeal_partial_grant_decided(vbms_id: "REMAND_VBMS_ID", missing_decision: false)
     {
-      vbms_id: "REMAND_VBMS_ID",
+      vbms_id: vbms_id,
       type: "Original",
       status: "Remand",
       disposition: "Allowed",
@@ -248,7 +248,8 @@ class Fakes::AppealRepository
       veteran_last_name: "Crockett",
       appellant_first_name: "Susie",
       appellant_last_name: "Crockett",
-      appellant_relationship: "Daughter"
+      appellant_relationship: "Daughter",
+      documents: missing_decision ? [] : [decision_document]
     }
   end
 

--- a/spec/feature/admin_spec.rb
+++ b/spec/feature/admin_spec.rb
@@ -4,16 +4,18 @@ RSpec.feature "Admin" do
   before do
     User.authenticate!(roles: ["System Admin"])
     Fakes::AppealRepository.records = {
-      "123C" => Fakes::AppealRepository.appeal_remand_decided,
-      "456D" => Fakes::AppealRepository.appeal_full_grant_decided
+      "123C" => Fakes::AppealRepository.appeal_partial_grant_decided,
+      "456D" => Fakes::AppealRepository.appeal_full_grant_decided,
+      "789E" => Fakes::AppealRepository.appeal_partial_grant_decided(vbms_id: "789E", missing_decision: true)
     }
-    @vbms_id = "7777"
+    @vbms_id = "REMAND_VBMS_ID"
 
     appeal = Appeal.create(
       vacols_id: "123C",
       vbms_id: @vbms_id
     )
     @task = EstablishClaim.create(appeal: appeal)
+    @task.prepare!
   end
 
   scenario "Establish Claim page" do
@@ -21,13 +23,28 @@ RSpec.feature "Admin" do
 
     # view existing tasks
     expect(Task.count).to eq(1)
-    expect(Task.to_complete.count).to eq(0)
     expect(page).to have_css("#task-#{@task.id}")
 
     # attempt to create a task without clicking on a decision
     page.fill_in "VBMS ID", with: "FULLGRANT_VBMS_ID"
     page.click_on "Create Task"
     expect(page).to have_content "You must select a decision type"
+
+    # attempt to create a task for an appeal that exists
+    page.fill_in "VBMS ID", with: @vbms_id
+    within_fieldset("Decision Type") do
+      find("label", text: "Partial Grant or Remand").click
+    end
+    page.click_on "Create Task"
+    expect(page).to have_content "A task already exists for this appeal"
+
+    # attempt to create a task with no decision
+    page.fill_in "VBMS ID", with: "789E"
+    within_fieldset("Decision Type") do
+      find("label", text: "Partial Grant or Remand").click
+    end
+    page.click_on "Create Task"
+    expect(page).to have_content "This appeal did not have a decision document in VBMS"
 
     # attempt to create a task for a file number with multiple appeals
     page.fill_in "VBMS ID", with: "raise_multiple_appeals_error"
@@ -55,9 +72,9 @@ RSpec.feature "Admin" do
     # ensure new task is created
     expect(page).to have_current_path("/admin/establish_claim")
     expect(page).to have_content "Task created"
-    expect(Task.count).to eq(2)
+    expect(Task.count).to eq(3)
 
     # ensure that the task is unassigned
-    expect(Task.to_complete.count).to eq(1)
+    expect(Task.to_complete.count).to eq(2)
   end
 end

--- a/spec/feature/admin_spec.rb
+++ b/spec/feature/admin_spec.rb
@@ -24,13 +24,32 @@ RSpec.feature "Admin" do
     expect(Task.to_complete.count).to eq(0)
     expect(page).to have_css("#task-#{@task.id}")
 
-    # attempt to create a task for an existing vbms_id
-    page.fill_in "VBMS ID", with: "raise_multiple_appeals_error"
+    # attempt to create a task without clicking on a decision
+    page.fill_in "VBMS ID", with: "FULLGRANT_VBMS_ID"
     page.click_on "Create Task"
-    expect(page).to have_content "Multiple appeals detected"
+    expect(page).to have_content "You must select a decision type"
+
+    # attempt to create a task for a file number with multiple appeals
+    page.fill_in "VBMS ID", with: "raise_multiple_appeals_error"
+    within_fieldset("Decision Type") do
+      find("label", text: "Full Grant").click
+    end
+    page.click_on "Create Task"
+    expect(page).to have_content "There were multiple appeals matching this VBMS ID"
+
+    # attempt to create a task for a file number with multiple appeals
+    page.fill_in "VBMS ID", with: "not found waaaah"
+    within_fieldset("Decision Type") do
+      find("label", text: "Full Grant").click
+    end
+    page.click_on "Create Task"
+    expect(page).to have_content "Appeal not found for that decision type."
 
     # create a new task
     page.fill_in "VBMS ID", with: "FULLGRANT_VBMS_ID"
+    within_fieldset("Decision Type") do
+      find("label", text: "Full Grant").click
+    end
     page.click_on "Create Task"
 
     # ensure new task is created


### PR DESCRIPTION
Every Establish Claim Task we tried to create today had multiple
appeals for the file number, which is annoying. The way to fix this
is to scope it to the type of decision.

Also, added refactored a little bit and added some better error
messaging.