### PR TITLE
Sharon manager view

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -107,7 +107,7 @@ class TasksController < ApplicationController
   end
 
   def verify_access
-    verify_authorized_roles(task_roles[:employee])
+    manager? or verify_authorized_roles(task_roles[:employee])
   end
 
   def verify_assigned_to_current_user

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -107,7 +107,7 @@ class TasksController < ApplicationController
   end
 
   def verify_access
-    manager? or verify_authorized_roles(task_roles[:employee])
+    manager? || verify_authorized_roles(task_roles[:employee])
   end
 
   def verify_assigned_to_current_user

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -74,7 +74,7 @@ class SeedDB
     @users.push(User.create(css_id: "Establish Claim", station_id: "283", full_name: "Jane Smith"))
     @users.push(User.create(css_id: "Establish Claim", station_id: "284", full_name: "Bob Contoso"))
     @users.push(User.create(css_id: "Establish Claim", station_id: "285", full_name: "Carole Johnson"))
-    @users.push(User.create(css_id: "Establish Claim, Manage Claim Establishment", station_id: "283", full_name: "John Doe"))
+    @users.push(User.create(css_id: "Manage Claim Establishment", station_id: "283", full_name: "John Doe"))
     @users.push(User.create(css_id: "Certify Appeal", station_id: "283", full_name: "John Smith"))
     @users.push(User.create(css_id: "System Admin", station_id: "283", full_name: "Angelina Smith"))
   end


### PR DESCRIPTION
This PR allows users with just the 'Manager' role to see the manager page. 

Connects #859 

- [ ] User with 'Manager' role sees the manager index page
- [ ] User with 'Employee' role sees the employee index page
- [ ] Other manager pages work as expected
- [ ] Unit tests pass