### PR TITLE
Use the recorded Regional Office key instead of trying to infer it

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -250,6 +250,7 @@ class Task < ActiveRecord::Base
          :veteran_name,
          :decision_type,
          :station_key,
+         :regional_office_key,
          :non_canceled_end_products_within_30_days,
          :pending_eps,
          :issues,

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -502,7 +502,7 @@ export default class EstablishClaim extends BaseForm {
 
   getStationOfJurisdiction() {
     let stationKey = this.props.task.appeal.station_key;
-    let regionalOfficeKey = this.props.regionalOfficeStations[stationKey];
+    let regionalOfficeKey = this.props.task.appeal.regional_office_key;
 
     return `${stationKey} - ${
         this.props.regionalOfficeCities[regionalOfficeKey].city}, ${

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -249,6 +249,7 @@ class Fakes::AppealRepository
       appellant_first_name: "Susie",
       appellant_last_name: "Crockett",
       appellant_relationship: "Daughter",
+      regional_office_key: "RO13",
       documents: missing_decision ? [] : [decision_document]
     }
   end


### PR DESCRIPTION
Infering it can produce arrays of Regional Offices which case the
bug in #1040

connects #1040