### PR TITLE
Add error checking if user is not passed to FeatureToggle enabled method

### DIFF
--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,5 +1,4 @@
 class FeatureToggle
-
   class UserIsRequiredError < StandardError
     def message
       "User is required when regional offices are set on the feature"

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -57,7 +57,7 @@ class FeatureToggle
     # if regional_offices key is set, check if the feature
     # is enabled for the user's ro. Otherwise, it is enabled globally
     if regional_offices.present?
-      raise UserIsRequiredError unless user
+      fail UserIsRequiredError unless user
       return false unless regional_offices.include?(user.regional_office)
     end
     true

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,6 +1,6 @@
 class FeatureToggle
 
-  class UserIsRequired < StandardError
+  class UserIsRequiredError < StandardError
     def message
       "User is required when regional offices are set on the feature"
     end
@@ -58,7 +58,7 @@ class FeatureToggle
     # if regional_offices key is set, check if the feature
     # is enabled for the user's ro. Otherwise, it is enabled globally
     if regional_offices.present?
-      raise UserIsRequired unless user
+      raise UserIsRequiredError unless user
       return false unless regional_offices.include?(user.regional_office)
     end
     true

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,4 +1,11 @@
 class FeatureToggle
+
+  class UserIsRequired < StandardError
+    def message
+      "User is required when regional offices are set on the feature"
+    end
+  end
+
   # Keeps track of all enabled features
   FEATURE_LIST_KEY = :feature_list_key
 
@@ -47,12 +54,13 @@ class FeatureToggle
   def self.enabled?(feature, user: nil)
     return false unless features.include?(feature)
     regional_offices = get_subkey(feature, :regional_offices)
-    # if regional_offices key is set and a user is passed, check if the feature
-    # is enabled for the user's ro. Otherwise, it is enabled globally
-    if user && regional_offices.present? && !regional_offices.include?(user.regional_office)
-      return false
-    end
 
+    # if regional_offices key is set, check if the feature
+    # is enabled for the user's ro. Otherwise, it is enabled globally
+    if regional_offices.present?
+      raise UserIsRequired unless user
+      return false unless regional_offices.include?(user.regional_office)
+    end
     true
   end
 

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -180,6 +180,14 @@ describe FeatureToggle do
         let(:user) { User.new(regional_office: "RO09") }
         it { is_expected.to eq false }
       end
+
+      context "when user is not passed" do
+        let(:user) { nil }
+
+        it "throws an error" do
+          expect { subject }.to raise_error(FeatureToggle::UserIsRequired)
+        end
+      end
     end
   end
 end

--- a/spec/services/feature_toggle_spec.rb
+++ b/spec/services/feature_toggle_spec.rb
@@ -185,7 +185,7 @@ describe FeatureToggle do
         let(:user) { nil }
 
         it "throws an error" do
-          expect { subject }.to raise_error(FeatureToggle::UserIsRequired)
+          expect { subject }.to raise_error(FeatureToggle::UserIsRequiredError)
         end
       end
     end


### PR DESCRIPTION
If a feature has been restricted for a set of regional offices, `user` is required when checking if a feature is enabled.