### PR TITLE
Fix Dispatch vacols_note integration

### DIFF
--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -93,7 +93,7 @@ class EstablishClaimsController < TasksController
   end
 
   def vacols_note_params
-    params.permit(:vacols_note)
+    params[:vacols_note]
   end
 
   def establish_claim_params

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -6,6 +6,7 @@ class VACOLS::Case < VACOLS::Record
   has_one    :folder,        foreign_key: :ticknum
   belongs_to :correspondent, foreign_key: :bfcorkey, primary_key: :stafkey
   has_many   :issues,        foreign_key: :isskey
+  has_many   :notes,         foreign_key: :tsktknm
 
   class InvalidLocationError < StandardError; end
 

--- a/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
@@ -52,8 +52,6 @@ export default class EstablishClaimNote extends BaseForm {
     }
 
     return "50";
-
-
   }
 
   hasSelectedSpecialIssues() {


### PR DESCRIPTION
connects #884 #894 

Testing:
- [x] Locally completed the dispatch flow, confirmed the `vacols_note` was properly filled when it arrived at the Dispatch service