### PR TITLE
Sharon stats routing

### DIFF
--- a/app/controllers/certification_stats_controller.rb
+++ b/app/controllers/certification_stats_controller.rb
@@ -1,6 +1,6 @@
 require "json"
 
-class StatsController < ApplicationController
+class CertificationStatsController < ApplicationController
   before_action :verify_authentication
   before_action :verify_access
 
@@ -10,7 +10,7 @@ class StatsController < ApplicationController
       daily: 0...30,
       weekly: 0...26,
       monthly: 0...24
-    }[interval].map { |i| Stats.offset(time: Stats.now, interval: interval, offset: i) }
+    }[interval].map { |i| CertificationStats.offset(time: CertificationStats.now, interval: interval, offset: i) }
   end
 
   private
@@ -25,7 +25,7 @@ class StatsController < ApplicationController
   helper_method :json
 
   def interval
-    @interval ||= Stats::INTERVALS.find { |i| i.to_s == params[:interval] } || :hourly
+    @interval ||= CertificationStats::INTERVALS.find { |i| i.to_s == params[:interval] } || :hourly
   end
   helper_method :interval
 

--- a/app/controllers/dispatch_stats_controller.rb
+++ b/app/controllers/dispatch_stats_controller.rb
@@ -1,0 +1,8 @@
+class DispatchStatsController < ApplicationController
+  before_action :verify_authentication
+  before_action :verify_access
+
+  def verify_access
+    verify_authorized_roles("System Admin")
+  end
+end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,0 +1,8 @@
+class StatsController < ApplicationController
+  before_action :verify_authentication
+  before_action :verify_access
+
+  def verify_access
+    verify_authorized_roles("System Admin")
+  end
+end

--- a/app/models/certification_stats.rb
+++ b/app/models/certification_stats.rb
@@ -1,8 +1,8 @@
 ##
-# Stats is an interface to quickly access statistics for Caseflow Certification
+# CertificationStats is an interface to quickly access statistics for Caseflow Certification
 # it is responsible for aggregating and caching statistics.
 #
-class Stats < Caseflow::Stats
+class CertificationStats < Caseflow::Stats
   CALCULATIONS = {
     certifications_started: lambda do |range|
       Certification.where(created_at: range).count
@@ -21,19 +21,19 @@ class Stats < Caseflow::Stats
     end,
 
     time_to_certify: lambda do |range|
-      Stats.percentile(:time_to_certify, Certification.where(completed_at: range), 95)
+      CertificationStats.percentile(:time_to_certify, Certification.where(completed_at: range), 95)
     end,
 
     missing_doc_time_to_certify: lambda do |range|
-      Stats.percentile(:time_to_certify, Certification.was_missing_doc.where(created_at: range), 95)
+      CertificationStats.percentile(:time_to_certify, Certification.was_missing_doc.where(created_at: range), 95)
     end,
 
     median_time_to_certify: lambda do |range|
-      Stats.percentile(:time_to_certify, Certification.where(completed_at: range), 50)
+      CertificationStats.percentile(:time_to_certify, Certification.where(completed_at: range), 50)
     end,
 
     median_missing_doc_time_to_certify: lambda do |range|
-      Stats.percentile(:time_to_certify, Certification.was_missing_doc.where(created_at: range), 50)
+      CertificationStats.percentile(:time_to_certify, Certification.was_missing_doc.where(created_at: range), 50)
     end,
 
     missing_doc: lambda do |range|

--- a/app/views/certification_stats/show.html.erb
+++ b/app/views/certification_stats/show.html.erb
@@ -15,11 +15,11 @@
 <div class="cf-app-segment cf-app-segment--alt">
   <div class="cf-stats">
     <ul class="cf-tab-navigation">
-      <% Stats::INTERVALS.each do |interval| %>
+      <% CertificationStats::INTERVALS.each do |interval| %>
         <li class="cf-tab <%= (@stats[0].interval == interval) && "cf-active" %>">
           <span>
             <span>
-              <%= link_to interval.to_s.capitalize, stats_path(interval) %>
+              <%= link_to interval.to_s.capitalize, certification_stats_path(interval) %>
             </span>
           </span>
         </li>

--- a/app/views/dispatch_stats/show.html.erb
+++ b/app/views/dispatch_stats/show.html.erb
@@ -1,0 +1,1 @@
+<% content_for :page_title do %>&nbsp &gt &nbspDispatch Dashboard<% end %>

--- a/app/views/stats/show.html.erb
+++ b/app/views/stats/show.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title do %>&nbsp &gt &nbspStats<% end %>
+
+<ul>
+  <li>
+    <%= link_to "Certification Stats", certification_stats_path %>
+  </li>
+  <li>
+    <%= link_to "Dispatch Stats", dispatch_stats_path %>
+  </li>
+</ul>

--- a/client/app/containers/DecisionReviewer.jsx
+++ b/client/app/containers/DecisionReviewer.jsx
@@ -128,15 +128,15 @@ export default class DecisionReviewer extends React.Component {
         return;
       }
 
-      ApiUtil.get(documentUrls[index])
-        .then(() => {
+      ApiUtil.get(documentUrls[index]).
+        then(() => {
           downloadDocuments(documentUrls, index + PARALLEL_DOCUMENT_REQUESTS);
         });
-    }
+    };
 
-    for (let i = 0; i < PARALLEL_DOCUMENT_REQUESTS; i++){
+    for (let i = 0; i < PARALLEL_DOCUMENT_REQUESTS; i++) {
       downloadDocuments(this.props.appealDocuments.map((doc) => {
-          return this.documentUrl(doc);
+        return this.documentUrl(doc);
       }), i);
     }
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,7 +83,7 @@ Rails.application.routes.draw do
   get 'whats-new' => 'whats_new#show'
 
   get 'certification/stats(/:interval)', to: 'certification_stats#show', as: 'certification_stats'
-  get 'dispatch/stats(/:interval)', to: 'dispatch_stats#show', as: 'dispatch_stats'
+  get 'dispatch/stats', to: 'dispatch_stats#show', as: 'dispatch_stats'
   get 'stats', to: 'stats#show'
 
   get "styleguide", to: "styleguide#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,7 +82,7 @@ Rails.application.routes.draw do
 
   get 'whats-new' => 'whats_new#show'
 
-  get 'stats(/:interval)', to: 'stats#show', as: 'stats'
+  get 'certification/stats(/:interval)', to: 'certification_stats#show', as: 'certification_stats'
 
   get "styleguide", to: "styleguide#show"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,8 @@ Rails.application.routes.draw do
   get 'whats-new' => 'whats_new#show'
 
   get 'certification/stats(/:interval)', to: 'certification_stats#show', as: 'certification_stats'
+  get 'dispatch/stats(/:interval)', to: 'dispatch_stats#show', as: 'dispatch_stats'
+  get 'stats', to: 'stats#show'
 
   get "styleguide", to: "styleguide#show"
 

--- a/spec/feature/certification_stats_spec.rb
+++ b/spec/feature/certification_stats_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Stats Dashboard" do
+RSpec.feature "Certification Stats Dashboard" do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 55, 0, rand(1000)))
 
@@ -47,14 +47,14 @@ RSpec.feature "Stats Dashboard" do
       created_at:          45.minutes.ago,
       completed_at:        30.minutes.ago
     )
-    Stats.calculate_all!
+    CertificationStats.calculate_all!
 
-    # Necessary role to view stats page
+    # Necessary role to view certification_stats page
     User.authenticate!(roles: ["System Admin"])
   end
 
   scenario "Switching tab intervals" do
-    visit "/stats"
+    visit "/certification/stats"
     expect(page).to have_content("Activity for 12:00–12:59 EST (so far)")
     expect(page).to have_content("Certifications Started 1")
     expect(page).to have_content("Certifications Completed 1")
@@ -101,8 +101,8 @@ RSpec.feature "Stats Dashboard" do
       created_at:          45.minutes.ago,
       completed_at:        nil
     )
-    Stats.calculate_all!
-    visit "/stats/daily"
+    CertificationStats.calculate_all!
+    visit "/certification/stats/daily"
     expect(page).to have_content("Activity for January 1 (so far)")
     expect(page).to have_content("Certifications Started 6")
     expect(page).to have_content("Certifications Completed 3")
@@ -119,7 +119,7 @@ RSpec.feature "Stats Dashboard" do
   end
 
   scenario "Toggle median to 95th percentile" do
-    visit "/stats"
+    visit "/certification/stats"
     click_on "Daily"
 
     find('*[role="button"]', text: "Overall (median)").trigger("click")
@@ -131,7 +131,7 @@ RSpec.feature "Stats Dashboard" do
   scenario "Navigate to past periods with arrow keys" do
     leftarrow = "d3.select(window).dispatch('keydown', { detail: { keyCode: 37 } })"
 
-    visit "/stats"
+    visit "/certification/stats"
     click_on "Monthly"
     expect(page).to have_content("Activity for January (so far)")
 
@@ -145,7 +145,7 @@ RSpec.feature "Stats Dashboard" do
   scenario "Unauthorized user access" do
     # Unauthenticated access
     User.unauthenticate!
-    visit "/stats"
+    visit "/certification/stats"
     expect(page).not_to have_content("Activity for")
     expect(page).not_to have_content("Certification Rate")
     expect(page).not_to have_content("Time to Certify")
@@ -153,7 +153,7 @@ RSpec.feature "Stats Dashboard" do
 
     # Authenticated access without System Admin role
     User.authenticate!
-    visit "/stats"
+    visit "/certification/stats"
     expect(page).not_to have_content("Activity for")
     expect(page).not_to have_content("Certification Rate")
     expect(page).not_to have_content("Time to Certify")

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -69,7 +69,7 @@ describe Certification do
         expect(certification.form8_started_at).to be_nil
       end
 
-      it "is included in the relevant stats" do
+      it "is included in the relevant certification_stats" do
         subject
 
         expect(Certification.was_missing_doc.count).to eq(1)
@@ -83,7 +83,7 @@ describe Certification do
     context "when ssocs are mismatched" do
       let(:appeal_hash) { Fakes::AppealRepository.appeal_mismatched_ssoc }
 
-      it "is included in the relevant stats" do
+      it "is included in the relevant certification_stats" do
         subject
 
         expect(Certification.was_missing_doc.count).to eq(1)
@@ -97,7 +97,7 @@ describe Certification do
     context "when multiple docs are mismatched" do
       let(:appeal_hash) { Fakes::AppealRepository.appeal_mismatched_docs }
 
-      it "is included in the relevant stats" do
+      it "is included in the relevant certification_stats" do
         subject
 
         expect(Certification.was_missing_doc.count).to eq(1)

--- a/spec/models/certification_stats_spec.rb
+++ b/spec/models/certification_stats_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Stats do
+describe CertificationStats do
   before do
     Timecop.freeze(Time.utc(2016, 2, 17, 20, 59, 0))
     Rails.cache.clear
@@ -13,14 +13,14 @@ describe Stats do
   let(:prev_weekly_stats) { Rails.cache.read("stats-2016-w06") }
 
   context ".calculate_all!" do
-    it "calculates and saves all calculated stats" do
+    it "calculates and saves all calculated certification_stats" do
       Certification.create(completed_at: 40.days.ago)
       Certification.create(completed_at: 7.days.ago)
       Certification.create(completed_at: 2.days.ago)
       Certification.create(completed_at: 4.hours.ago)
       Certification.create(completed_at: 30.minutes.ago)
 
-      Stats.calculate_all!
+      CertificationStats.calculate_all!
 
       expect(monthly_stats[:certifications_completed]).to eq(4)
       expect(weekly_stats[:certifications_completed]).to eq(3)
@@ -31,18 +31,18 @@ describe Stats do
 
     it "overwrites incomplete periods" do
       Certification.create(completed_at: 30.minutes.ago)
-      Stats.calculate_all!
+      CertificationStats.calculate_all!
       Certification.create(completed_at: 1.minute.ago)
-      Stats.calculate_all!
+      CertificationStats.calculate_all!
 
       expect(hourly_stats[:certifications_completed]).to eq(2)
     end
 
     it "does not recalculate complete periods" do
       Certification.create(completed_at: 7.days.ago)
-      Stats.calculate_all!
+      CertificationStats.calculate_all!
       Certification.create(completed_at: 7.days.ago)
-      Stats.calculate_all!
+      CertificationStats.calculate_all!
 
       expect(prev_weekly_stats[:certifications_completed]).to eq(1)
     end


### PR DESCRIPTION
This PR moves the certification stats page to /certification/stats, adds a new /dispatch/stats page, and adds a new /stats page that links to the other two pages. 

Connects #791 

- [ ] Confirmed in UI
- [ ] Unit tests pass

<img width="425" alt="screen shot 2017-03-13 at 3 00 00 pm" src="https://cloud.githubusercontent.com/assets/4306128/23870750/e40d8e14-07fd-11e7-8eb1-aaa6f84e08ed.png">
<img width="417" alt="screen shot 2017-03-13 at 3 00 30 pm" src="https://cloud.githubusercontent.com/assets/4306128/23870748/e407e07c-07fd-11e7-89e6-9c1d0c0e790b.png">
<img width="448" alt="screen shot 2017-03-13 at 3 00 42 pm" src="https://cloud.githubusercontent.com/assets/4306128/23870749/e40913de-07fd-11e7-93de-1e88466a1452.png">
