### PR TITLE
Fix linting issues

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "mocha test/setup.js test/* --compilers js:babel-core/register",
     "test:watch": "mocha test/setup.js test/* --watch --compilers js:babel-core/register",
-    "lint": "eslint . --fix --ext .jsx --ext .js",
+    "lint": "eslint . --ext .jsx --ext .js",
+    "lint:fix": "eslint . --fix --ext .jsx --ext .js",
     "build:test": "webpack --config webpack.config.js",
     "build:production": "NODE_ENV=production webpack --config webpack.config.js",
     "build:development": "webpack -w --config webpack.config.js"

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -2,6 +2,7 @@ require "open3"
 require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
+task(:lint).clear
 task :lint do
   puts "running scss-lint..."
   scss_result = ShellCommand.run("scss-lint --color")
@@ -19,7 +20,8 @@ task :lint do
   end
 
   puts "\nrunning eslint..."
-  eslint_result = ShellCommand.run("npm run lint")
+  eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"
+  eslint_result = ShellCommand.run("npm run #{eslint_cmd}")
 
   puts "\n"
   if scss_result && rubocop_result && jshint_result && eslint_result

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "postinstall": "cd client && npm install --no-optional",
     "dev": "rm app/assets/webpack/* || true && cd client && npm run build:development",
     "test": "cd client && npm test",
-    "lint": "cd client && npm run lint"
+    "lint": "cd client && npm run lint",
+    "lint:fix": "cd client && npm run lint:fix"
   },
   "devDependencies": {
   }


### PR DESCRIPTION
- Only run eslint --fix locally. On travis we want to skip this option
so we properly error when linting has not passed
- Clear out the `rake lint` so that it does not double run rubocop

connects #1148 

Testing:
- [x] running `rake lint` locally