### PR TITLE
Set PG statement timeout

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -9,6 +9,8 @@ default: &default
   encoding: unicode
   pool: <%= ENV["DB_CONN_POOL_MAX_SIZE"] || 5 %>
   timeout: 5000
+  variables:
+    statement_timeout: 30_000 # 30 seconds
 
 development:
   <<: *default


### PR DESCRIPTION
This PR adds a statement timeout to postgres, ensuring no query takes over 30 seconds. For now this is very conservative. We should potentially lower the timeout later as we fine tune our system.

CC @shanear @askldjd for awareness

Testing:
- [x] Manually ran long query, verified it timed out as expected:

Setting the time out to 10 ms and doing a regular query
<img width="782" alt="screen shot 2017-03-14 at 1 15 50 pm" src="https://cloud.githubusercontent.com/assets/2256237/23913340/04eec45c-08b9-11e7-917a-79ecb5200510.png">

Setting the time out to the real 30 seconds and doing a fake slow query
<img width="898" alt="screen shot 2017-03-14 at 1 19 02 pm" src="https://cloud.githubusercontent.com/assets/2256237/23913341/0510f054-08b9-11e7-808e-354c4f604537.png">
