### PR TITLE
location reset for partial grants

### DIFF
--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -163,7 +163,7 @@ class VACOLS::Case < VACOLS::Record
 
     conn = self.class.connection
 
-    # Note: we usee conn.quote here from ActiveRecord to deter SQL injection
+    # Note: we use conn.quote here from ActiveRecord to deter SQL injection
     location = conn.quote(location)
     user_db_id = conn.quote(RequestStore.store[:current_user].regional_office.upcase)
     case_id = conn.quote(bfkey)

--- a/app/services/test_data_service.rb
+++ b/app/services/test_data_service.rb
@@ -28,7 +28,6 @@ class TestDataService
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.prepare_claims_establishment!(vacols_id:, cancel_eps: false, decision_type: :partial)
     return false if ApplicationController.dependencies_faked?
     fail WrongEnvironmentError unless Rails.deploy_env?(:uat)
@@ -96,7 +95,6 @@ class TestDataService
               BFORGTIC = NULL
           WHERE BFKEY = #{case_id}
         SQL
-
         conn.execute(<<-SQL)
           UPDATE PRIORLOC
           SET LOCDIN = SYSDATE,
@@ -104,7 +102,6 @@ class TestDataService
               LOCEXCEP = 'Y'
           WHERE LOCKEY = #{case_id} and LOCDIN is NULL
         SQL
-
         conn.execute(<<-SQL)
           INSERT into PRIORLOC
             (LOCDOUT, LOCDTO, LOCSTTO, LOCSTOUT, LOCKEY)

--- a/app/services/test_data_service.rb
+++ b/app/services/test_data_service.rb
@@ -43,6 +43,7 @@ class TestDataService
       reset_outcoding_date(vacols_case)
     else
       vacols_case.update_attributes(bfddec: AppealRepository.dateshift_to_utc(10.days.ago))
+      reset_location(vacols_case)
     end
 
     # Upload decision document for the appeal if it isn't there
@@ -75,6 +76,39 @@ class TestDataService
           UPDATE FOLDER
           SET TIOCTIME = (SYSDATE-2)
           WHERE TICKNUM = #{case_id}
+        SQL
+      end
+    end
+  end
+
+  def self.reset_location(vacols_case)
+    conn = vacols_case.class.connection
+    # Note: we usee conn.quote here from ActiveRecord to deter SQL injection
+    case_id = conn.quote(vacols_case)
+    MetricsService.timer "VACOLS: reset decision date for #{case_id}" do
+      conn.transaction do
+        conn.execute(<<-SQL)
+          UPDATE BRIEFF
+          SET BFDLOCIN = SYSDATE,
+              BFCURLOC = '97',
+              BFDLOOUT = SYSDATE,
+              BFORGTIC = NULL
+          WHERE BFKEY = #{case_id}
+        SQL
+
+        conn.execute(<<-SQL)
+          UPDATE PRIORLOC
+          SET LOCDIN = SYSDATE,
+              LOCSTRCV = 'DSUSER',
+              LOCEXCEP = 'Y'
+          WHERE LOCKEY = #{case_id} and LOCDIN is NULL
+        SQL
+
+        conn.execute(<<-SQL)
+          INSERT into PRIORLOC
+            (LOCDOUT, LOCDTO, LOCSTTO, LOCSTOUT, LOCKEY)
+          VALUES
+           (SYSDATE, SYSDATE, '97', 'DSUSER', #{case_id})
         SQL
       end
     end

--- a/app/services/test_data_service.rb
+++ b/app/services/test_data_service.rb
@@ -28,12 +28,12 @@ class TestDataService
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def self.prepare_claims_establishment!(vacols_id:, cancel_eps: false, decision_type: :partial)
     return false if ApplicationController.dependencies_faked?
     fail WrongEnvironmentError unless Rails.deploy_env?(:uat)
 
     log "Preparing case with VACOLS id of #{vacols_id} for claims establishment"
-
     # Push the decision date to the current date in vacols
     # Update location to what it should be initially
     vacols_case = VACOLS::Case.find(vacols_id)
@@ -81,6 +81,7 @@ class TestDataService
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
   def self.reset_location(vacols_case)
     conn = vacols_case.class.connection
     # Note: we usee conn.quote here from ActiveRecord to deter SQL injection


### PR DESCRIPTION
connects [QA #29](https://github.com/department-of-veterans-affairs/appeals-qa/issues/29)

allows location reset in VACOLS so we can retest Partial/Remand appeals