### PR TITLE
Button's loading state is no longer separate markup

### DIFF
--- a/client/app/components/Button.jsx
+++ b/client/app/components/Button.jsx
@@ -9,6 +9,16 @@ export default class Button extends React.Component {
     }
   }
 
+  loadingClasses = (app, loading) => {
+    let classes = ` cf-${app}`;
+
+    if (loading) {
+      classes += " cf-loading";
+    }
+
+    return classes;
+  }
+
   render() {
     let {
       app,
@@ -23,29 +33,13 @@ export default class Button extends React.Component {
       type
     } = this.props;
 
-    let LoadingIndicator = () => {
-      app = app || 'dispatch';
+    if (!children) {
+      children = name;
+    }
 
+    if (loading) {
       children = loadingText || "Loading...";
-
-      return <span>
-        <button
-          id={`${id || `${type}-${name.replace(/\s/g, '-')}`}-loading`}
-          className={`${classNames.join(' ')} cf-${app} cf-loading`}
-          type={type}
-          disabled={true}>
-          <span className="cf-loading-icon-container">
-            <span className="cf-loading-icon-front">
-              <span className="cf-loading-icon-back">
-                {children}
-              </span>
-            </span>
-          </span>
-        </button>
-      </span>;
-    };
-
-    children = children || name;
+    }
 
     if (disabled || loading) {
       // remove any usa-button styling and then add disabled styling
@@ -56,14 +50,18 @@ export default class Button extends React.Component {
     return <span>
       <button
         id={id || `${type}-${name.replace(/\s/g, '-')}`}
-        className={classNames.join(' ') + (loading ? " hidden-field" : "")}
+        className={classNames.join(' ') + this.loadingClasses(app, loading)}
         type={type}
         disabled={disabled}
         onClick={onClick}>
-          {children}
+        <span className="cf-loading-icon-container">
+          <span className="cf-loading-icon-front">
+            <span className="cf-loading-icon-back">
+              {children}
+            </span>
+          </span>
+        </span>
       </button>
-
-      { loading && <LoadingIndicator /> }
     </span>;
   }
 }
@@ -74,6 +72,7 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
+  app: PropTypes.string,
   children: PropTypes.node,
   classNames: PropTypes.arrayOf(PropTypes.string),
   disabled: PropTypes.bool,

--- a/client/test/components/Button-test.js
+++ b/client/test/components/Button-test.js
@@ -13,7 +13,7 @@ describe('Button', () => {
                               onChange={onChange}
                               loading={true} />);
 
-    expect(wrapper.find('#test-button.hidden-field')).to.have.length(1);
+    expect(wrapper.find('#test-button.cf-loading')).to.have.length(1);
   });
 
   it('removes other button classes when disabled', () => {


### PR DESCRIPTION
Connects #711 

In struggling with the intermittent PhantomJS crashes, we originally thought the problem was with the button being quickly replaced by ReactJS, so the code was modified to simply hide the original button and append a loading indicator component.  It worked for quite a while.

But PhantomJS eventually crashed again, so more investigation took place, resulting in a fix unrelated to the button altogether.

This PR removes the appended loading component - instead the original button is enhanced with SPANs whose loading styles kick in when the `cf-loading` class is applied to the topmost element.  Much simpler and easier to maintain.