### PR TITLE
Load fakes on app initialize

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,6 @@ class ApplicationController < ActionController::Base
   before_action :strict_transport_security
 
   before_action :set_timezone,
-                :setup_fakes,
                 :check_whats_new_cookie
   before_action :set_raven_user
   before_action :verify_authentication
@@ -95,10 +94,6 @@ class ApplicationController < ActionController::Base
 
   def set_timezone
     Time.zone = current_user.timezone if current_user
-  end
-
-  def setup_fakes
-    Fakes::Initializer.development! if Rails.env.development? || Rails.env.demo?
   end
 
   def test_user?

--- a/config/initializers/fake_dependencies.rb
+++ b/config/initializers/fake_dependencies.rb
@@ -1,0 +1,1 @@
+Fakes::Initializer.development! if Rails.env.development? || Rails.env.demo?


### PR DESCRIPTION
- Rather than within a request lifecycle. Load fakes on app initialize so
they exist for rake tasks too

Testing:
- [x] running dev server locally works
- [x] running rake db:seed locally works