### PR TITLE
add styles for inline code snippets

### DIFF
--- a/app/assets/stylesheets/_style_guide.scss
+++ b/app/assets/stylesheets/_style_guide.scss
@@ -71,3 +71,14 @@ i {
   font-weight: 700;
   border-bottom: 7px solid $color-gray-light;
 }
+
+//Inline Code Text
+code, pre {
+  background-color: $color-gray-lightest;
+  color: $color-base;
+
+  &::before, &::after {
+    letter-spacing: -0.2em;
+    content: '\00a0';
+  }
+}

--- a/app/assets/stylesheets/_style_guide.scss
+++ b/app/assets/stylesheets/_style_guide.scss
@@ -73,11 +73,13 @@ i {
 }
 
 //Inline Code Text
-code, pre {
+code,
+pre {
   background-color: $color-gray-lightest;
   color: $color-base;
 
-  &::before, &::after {
+  &::before,
+  &::after {
     letter-spacing: -0.2em;
     content: '\00a0';
   }


### PR DESCRIPTION
This adds basic styles for code text inline with copy, `like this`.

References #1009 