### PR TITLE
Ensure decision_date exists in decisions method

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -157,6 +157,8 @@ class Appeal < ActiveRecord::Base
   end
 
   def decisions
+    return [] unless decision_date
+
     decisions = documents_with_type("BVA Decision").select do |decision|
       (decision.received_at.in_time_zone - decision_date).abs <= 3.days
     end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -358,6 +358,14 @@ describe Appeal do
       it { is_expected.to eq([]) }
     end
 
+    context "returns nil when no decision_date" do
+      before do
+        appeal.decision_date = nil
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
     context "returns multiple decisions when there are two decisions" do
       let(:documents) { [decision, decision.clone] }
 


### PR DESCRIPTION
This bug was causing our PrepareEstablishClaimJob to fail in production

Testing:
- [x] Added a test
- [x] Existing tests pass