### PR TITLE
Don't clobber vbms_ids in dev mode

### DIFF
--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -83,6 +83,8 @@ class Fakes::AppealRepository
     # RAISE_VACOLS_NOT_FOUND_ID == record[:vacols_id]
     fail VBMSError if !record.nil? && RAISE_VBMS_ERROR_ID == record[:vbms_id]
 
+    # This is bad. I'm sorry
+    record.delete(:vbms_id) if Rails.env.development?
     appeal.assign_from_vacols(record)
   end
 


### PR DESCRIPTION
- This is a temporary hack to get dev mode working again. We were
previously clobbering vmbs_ids when we fetch the data from VACOLS. In
the future we should refactor and use generators in dev mode