### PR TITLE
Increase TTL on employee count

### DIFF
--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -64,7 +64,7 @@ class EstablishClaimsController < TasksController
   end
 
   def update_employee_count
-    Rails.cache.write("employee_count", params[:count])
+    Rails.cache.write("employee_count", params[:count], expires_in: 48.hours)
     render json: {}
   end
 

--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -64,7 +64,7 @@ class EstablishClaimsController < TasksController
   end
 
   def update_employee_count
-    Rails.cache.write("employee_count", params[:count], expires_in: 48.hours)
+    Rails.cache.write("employee_count", params[:count], expires_in: nil)
     render json: {}
   end
 

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -49,6 +49,12 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       # two tasks assigned to her, has completed one, and has one remaining.
       expect(page).to have_content("Jane Smith 3 1 2")
       expect(page).to have_content("Employee Total 5 1 4")
+
+      # Employee count should be 0 after 48 hours
+      Timecop.freeze((48 * 60 * 60 + 1).seconds.from_now) do
+        visit "/dispatch/establish-claim"
+        expect(find_field("the number of people").value).to have_content("0")
+      end
     end
 
     scenario "View unprepared tasks page" do

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -49,12 +49,6 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       # two tasks assigned to her, has completed one, and has one remaining.
       expect(page).to have_content("Jane Smith 3 1 2")
       expect(page).to have_content("Employee Total 5 1 4")
-
-      # Employee count should be 0 after 48 hours
-      Timecop.freeze((48 * 60 * 60 + 1).seconds.from_now) do
-        visit "/dispatch/establish-claim"
-        expect(find_field("the number of people").value).to have_content("0")
-      end
     end
 
     scenario "View unprepared tasks page" do


### PR DESCRIPTION
Connects #1206 

Trying to keep the employee count in cache an additional 24 hours to see if the number is what the manager expects on the next visit.