### PR TITLE
Generators Everywhere!

### DIFF
--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -57,10 +57,7 @@ class Certification < ActiveRecord::Base
 
   # VACOLS attributes
   def appeal
-    @appeal ||= begin
-      appeal = Appeal.find_or_create_by_vacols_id(vacols_id)
-      appeal
-    end
+    @appeal ||= Appeal.find_or_create_by_vacols_id(vacols_id)
   end
 
   def form8

--- a/app/views/test/users/index.html.erb
+++ b/app/views/test/users/index.html.erb
@@ -16,8 +16,6 @@
       <p><a href="/certifications/new/123C">Ready to Certify</a></p>
       <p><a href="/certifications/new/456C">Mismatched Documents</a></p>
       <p><a href="/certifications/new/789C">Already Certified</a></p>
-      <p><a href="/certifications/new/321C">Remands Decided</a></p>
-      <p><a href="/certifications/new/654C">Full Grant Decided</a></p>
       <p><a href="/certifications/new/000ERR">VBMS Error</a></p>
       <p><a href="/certifications/new/001ERR">Unable to Certify</a></p>
       <h2>Misc.</h2>

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -234,7 +234,7 @@ class Fakes::AppealRepository
 
   def self.seed_appeal_already_certified!
     Generators::Appeal.build(
-      vacols_id: "456C",
+      vacols_id: "789C",
       vacols_record: :certified
     )
   end

--- a/lib/generators/appeal.rb
+++ b/lib/generators/appeal.rb
@@ -29,6 +29,9 @@ class Generators::Appeal
       }
     end
 
+    # This is a method and not a constant because Datetime values need
+    # to be evaluated lazily. Would be nice to have a better solution
+    # rubocop:disable Metrics/MethodLength
     def vacols_record_templates
       {
         ready_to_certify: {
@@ -62,6 +65,7 @@ class Generators::Appeal
         }
       }
     end
+    # rubocop:enable Metrics/MethodLength
 
     # Build an appeal and set up the correct faked data in AppealRepository
     # @attrs - the hash of arguments passed into `Appeal#new` with a few exceptions:

--- a/lib/generators/appeal.rb
+++ b/lib/generators/appeal.rb
@@ -1,6 +1,26 @@
 class Generators::Appeal
   extend Generators::Base
 
+  VACOLS_RECORD_TEMPLATES = {
+    remand_decided: {
+      status: "Remand",
+      disposition: "Remanded",
+      decision_date: 7.days.ago
+    },
+    partial_grant_decided: {
+      status: "Remand",
+      disposition: "Allowed",
+      decision_date: 7.days.ago
+    },
+    full_grant_decided: {
+      type: "Post Remand",
+      status: "Complete",
+      disposition: "Allowed",
+      outcoding_date: 2.days.ago,
+      decision_date: 7.days.ago
+    }
+  }
+
   class << self
     def default_attrs
       {
@@ -9,20 +29,42 @@ class Generators::Appeal
       }
     end
 
-    def default_vacols_record
+    def vacols_record_default_attrs
+      last_name = generate_last_name
+
       {
-        veteran_first_name: "Davy",
-        veteran_last_name: "Crockett",
+        type: "Original",
+        veteran_first_name: generate_first_name,
+        veteran_last_name: last_name,
+        appellant_first_name: generate_first_name,
+        appellant_last_name: last_name,
+        appellant_relationship: "Child",
+        regional_office_key: "RO13",
         decision_date: 7.days.ago
       }
     end
 
     # Build an appeal and set up the correct faked data in AppealRepository
     # @attrs - the hash of arguments passed into `Appeal#new` with a few exceptions:
-    #   - :vacols_record [Hash] - Hash of the parsed values returned from AppealRepository from VACOLS
+    #   - :vacols_record [Hash or Array] - 
+    #       Hash of the parsed values returned from AppealRepository from VACOLS or
+    #       a symbol identifying the template used.
     #   - :documents [Array] - Array of `Document` objects returned from AppealsRepository from VBMS
+    #
+    # Examples
+    #
+    # # Sets vacols_record to the :remand_decided template + defaults
+    # Generators::Appeal.build(vacols_record: :remand_decided)
+    #
+    # # Sets vacols_record with a custom first name + the defaults
+    # Generators::Appeal.build({veteran_first_name: "Marky"})
+    # 
+    # # Sets vacols_record with a custom decision_date + :remand_decided template + defaults
+    # Generators::Appeal.build(vacols_record: {template: :remand_decided, decision_date: 1.day.ago})
+    #
     def build(attrs = {})
-      vacols_record = (attrs.delete(:vacols_record) || default_vacols_record).clone
+      vacols_record = extract_vacols_record(attrs)
+
       documents = attrs.delete(:documents)
       appeal = Appeal.new(default_attrs.merge(attrs))
 
@@ -33,7 +75,24 @@ class Generators::Appeal
 
       Fakes::AppealRepository.document_records ||= {}
       Fakes::AppealRepository.document_records[appeal.vbms_id] = documents
+
       appeal
+    end
+
+    private
+
+    def extract_vacols_record(attrs)
+      vacols_record = attrs.delete(:vacols_record)
+
+      template_key, vacols_record = if vacols_record.is_a?(Hash)
+        [vacols_record.delete(:template), vacols_record]
+      else
+        [vacols_record, {}]
+      end
+
+      template = VACOLS_RECORD_TEMPLATES[template_key] || {}
+
+      vacols_record_default_attrs.merge(template).merge(vacols_record)
     end
   end
 end

--- a/lib/generators/base.rb
+++ b/lib/generators/base.rb
@@ -17,6 +17,14 @@ module Generators::Base
     SecureRandom.hex[0..8]
   end
 
+  def generate_first_name
+    %w(George John Thomas James Andrew Martin Susan Barack Grace Anne).sample
+  end
+
+  def generate_last_name
+    %w(Washington King Jefferson Anthony Madison Jackson VanBuren Merica).sample
+  end
+
   def build(*)
     fail "#{self.class.name} must implement .build(attrs)"
   end

--- a/lib/generators/document.rb
+++ b/lib/generators/document.rb
@@ -2,11 +2,19 @@ class Generators::Document
   extend Generators::Base
 
   class << self
-    def build(attrs)
-      attrs[:vbms_document_id] ||= generate_external_id
+    def default_attrs
+      {
+        vbms_document_id: generate_external_id,
+        filename: "filename.pdf",
+        received_at: 3.days.ago
+      }
+    end
+
+    def build(attrs = {})
+      attrs = default_attrs.merge(attrs)
 
       # received_at is always a Date when coming from VBMS
-      attrs[:received_at] = (attrs[:received_at] || Time.zone.now).to_date
+      attrs[:received_at] = attrs[:received_at].to_date
 
       Document.new(attrs || {})
     end

--- a/spec/feature/admin_spec.rb
+++ b/spec/feature/admin_spec.rb
@@ -1,22 +1,15 @@
 require "rails_helper"
 
 RSpec.feature "Admin" do
-  let(:full_grant_vacols_record) { Fakes::AppealRepository.appeal_full_grant_decided }
-  let(:vacols_record) { Fakes::AppealRepository.appeal_partial_grant_decided }
-
   let!(:current_user) { User.authenticate!(roles: ["System Admin"]) }
 
-  let(:existing_task_vacols_record) { Fakes::AppealRepository.appeal_partial_grant_decided }
-  let!(:appeal_with_existing_task) { Generators::Appeal.create(vacols_record: vacols_record) }
+  let!(:appeal_missing_decision) { Generators::Appeal.create(documents: []) }
+  let!(:appeal_with_existing_task) { Generators::Appeal.create }
   let!(:existing_task) { EstablishClaim.create(appeal: appeal_with_existing_task, aasm_state: :unassigned) }
-
-  let!(:appeal_missing_decision) do
-    Generators::Appeal.create(vacols_record: vacols_record, documents: [])
-  end
 
   let!(:appeal) do
     Generators::Appeal.create(
-      vacols_record: full_grant_vacols_record,
+      vacols_record: :full_grant_decided,
       documents: [Generators::Document.build(type: "BVA Decision", received_at: 7.days.ago)]
     )
   end

--- a/spec/feature/cancel_certification_spec.rb
+++ b/spec/feature/cancel_certification_spec.rb
@@ -1,149 +1,162 @@
 require "rails_helper"
 
 RSpec.feature "Cancel certification" do
-  context "Cancellation certification" do
-    before do
-      User.authenticate!
+  let!(:current_user) { User.authenticate! }
 
-      Fakes::AppealRepository.records = {
-        "5555C" => Fakes::AppealRepository.appeal_ready_to_certify
-      }
-      Certification.create!(vacols_id: "FIRST")
+  let(:nod) { Generators::Document.build(type: "NOD") }
+  let(:soc) { Generators::Document.build(type: "SOC") }
+  let(:form9) { Generators::Document.build(type: "Form 9") }
+
+  let(:appeal) do
+    Generators::Appeal.build(
+      vacols_record: {
+        template: :ready_to_certify,
+        nod_date: nod.received_at,
+        soc_date: soc.received_at,
+        form9_date: form9.received_at
+      },
+      documents: [nod, soc, form9]
+    )
+  end
+
+  let(:appeal_mismatched_docs) do
+    Generators::Appeal.build(
+      vacols_record: {
+        template: :ready_to_certify,
+        nod_date: nod.received_at,
+        soc_date: soc.received_at,
+        form9_date: form9.received_at
+      },
+      documents: []
+    )
+  end
+
+  scenario "Validate Input Fields" do
+    visit "certifications/new/#{appeal.vacols_id}"
+    click_on "Cancel Certification"
+    expect(page).to have_content("Please explain why this case cannot be certified with Caseflow.")
+
+    # Test validation errors
+    within(".modal-container") do
+      click_on "Cancel certification"
     end
+    expect(page).to have_content("Make sure you've selected an option below.")
+    expect(page).to have_content("Make sure you’ve entered a valid email address below.")
 
-    scenario "Validate Input Fields" do
-      visit "certifications/new/5555C"
-      click_on "Cancel Certification"
-      expect(page).to have_content("Please explain why this case cannot be certified with Caseflow.")
-
-      # Test validation errors
-      within(".modal-container") do
-        click_on "Cancel certification"
-      end
-      expect(page).to have_content("Make sure you've selected an option below.")
-      expect(page).to have_content("Make sure you’ve entered a valid email address below.")
-
-      within_fieldset("Why can't be this case certified in Caseflow") do
-        find("label", text: "Other").click
-      end
-      fill_in "What's your VA email address?", with: "fk@va.gov"
-      expect(page).to_not have_css(".usa-input-error")
-      fill_in "What's your VA email address?", with: "fk@va"
-      within(".modal-container") do
-        click_on "Cancel certification"
-      end
-      expect(page).to have_content("Make sure you’ve filled out the comment box below.")
-      expect(page).to have_content("Make sure you’ve entered a valid email address below.")
-
-      within_fieldset("Why can't be this case certified in Caseflow") do
-        find("label", text: "Other").click
-      end
-      fill_in "Tell us more about your situation.", with: " "
-      within(".modal-container") do
-        click_on "Cancel certification"
-      end
-      expect(page).to have_content("Make sure you’ve filled out the comment box below.")
-
-      within_fieldset("Why can't be this case certified in Caseflow") do
-        find("label", text: "Other").click
-      end
-      fill_in "Tell us more about your situation.", with: "Test"
-      fill_in "What's your VA email address?", with: "fk@va.gov"
-      expect(page).to_not have_css(".usa-input-error")
-      within(".modal-container") do
-        click_on "Cancel certification"
-      end
-      expect(page).to_not have_css(".usa-input-error")
-
-      # Test resulting page
-      expect(page).to have_content("The certification has been cancelled")
-
-      # Test CertificationCancellation resulting record
-      expect(CertificationCancellation.last.certification_id).to eq(Certification.last.id)
-      expect(CertificationCancellation.last.cancellation_reason).to eq("Other")
-      expect(CertificationCancellation.last.other_reason).to eq("Test")
-      expect(CertificationCancellation.last.email).to eq("fk@va.gov")
+    within_fieldset("Why can't be this case certified in Caseflow") do
+      find("label", text: "Other").click
     end
-
-    scenario "Test Characters remaining" do
-      visit "certifications/new/5555C"
-      click_on "Cancel Certification"
-      within_fieldset("Why can't be this case certified in Caseflow") do
-        find("label", text: "Other").click
-      end
-      fill_in "Tell us more about your situation.", with: "Test"
-      expect(page).to have_content("1996 characters remaining")
-      fill_in "Tell us more about your situation.", with:
-          "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget
-          dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
-          ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
-          consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.
-          In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede
-          mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean
-          vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
-          enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra
-          nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel
-          augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
-          tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque
-          sedipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec
-          odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis
-          ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit
-          amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue
-          velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien.
-          Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan
-          lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum
-          primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi
-          consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget,
-          imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu,
-          accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus
-          ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestib"
-      expect(page).to have_content("0 characters remaining")
-      fill_in "Tell us more about your situation.", with:
-          "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget
-          dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
-          ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
-          consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.
-          In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede
-          mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean
-          vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
-          enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra
-          nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel
-          augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
-          tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque
-          sedipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec
-          odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis
-          ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit
-          amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue
-          velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien.
-          Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan
-          lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum
-          primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi
-          consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget,
-          imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu,
-          accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus
-          ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestib{"
-      expect(page).to have_content("0 characters remaining")
+    fill_in "What's your VA email address?", with: "fk@va.gov"
+    expect(page).to_not have_css(".usa-input-error")
+    fill_in "What's your VA email address?", with: "fk@va"
+    within(".modal-container") do
+      click_on "Cancel certification"
     end
+    expect(page).to have_content("Make sure you’ve filled out the comment box below.")
+    expect(page).to have_content("Make sure you’ve entered a valid email address below.")
 
-    scenario "Click cancel when certification has mistmatched documents" do
-      User.authenticate!
-
-      Fakes::AppealRepository.records = {
-        "7777D" => Fakes::AppealRepository.appeal_mismatched_docs
-      }
-
-      visit "certifications/new/7777D"
-      expect(page).to have_content("Not found")
-      click_on "Cancel Certification"
-      expect(page).to have_content("Please explain why this case cannot be certified with Caseflow.")
-      within_fieldset("Why can't be this case certified in Caseflow") do
-        find("label", text: "Missing document could not be found").click
-      end
-      fill_in "What's your VA email address?", with: "fk@va.gov"
-      within(".modal-container") do
-        click_on "Cancel certification"
-      end
-      expect(page).to have_content("The certification has been cancelled")
+    within_fieldset("Why can't be this case certified in Caseflow") do
+      find("label", text: "Other").click
     end
+    fill_in "Tell us more about your situation.", with: " "
+    within(".modal-container") do
+      click_on "Cancel certification"
+    end
+    expect(page).to have_content("Make sure you’ve filled out the comment box below.")
+
+    within_fieldset("Why can't be this case certified in Caseflow") do
+      find("label", text: "Other").click
+    end
+    fill_in "Tell us more about your situation.", with: "Test"
+    fill_in "What's your VA email address?", with: "fk@va.gov"
+    expect(page).to_not have_css(".usa-input-error")
+    within(".modal-container") do
+      click_on "Cancel certification"
+    end
+    expect(page).to_not have_css(".usa-input-error")
+
+    # Test resulting page
+    expect(page).to have_content("The certification has been cancelled")
+
+    # Test CertificationCancellation resulting record
+    expect(CertificationCancellation.last.certification_id).to eq(Certification.last.id)
+    expect(CertificationCancellation.last.cancellation_reason).to eq("Other")
+    expect(CertificationCancellation.last.other_reason).to eq("Test")
+    expect(CertificationCancellation.last.email).to eq("fk@va.gov")
+  end
+
+  scenario "Test Characters remaining" do
+    visit "certifications/new/#{appeal.vacols_id}"
+    click_on "Cancel Certification"
+    within_fieldset("Why can't be this case certified in Caseflow") do
+      find("label", text: "Other").click
+    end
+    fill_in "Tell us more about your situation.", with: "Test"
+    expect(page).to have_content("1996 characters remaining")
+    fill_in "Tell us more about your situation.", with:
+        "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget
+        dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+        ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
+        consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.
+        In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede
+        mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean
+        vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
+        enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra
+        nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel
+        augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
+        tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque
+        sedipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec
+        odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis
+        ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit
+        amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue
+        velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien.
+        Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan
+        lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum
+        primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi
+        consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget,
+        imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu,
+        accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus
+        ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestib"
+    expect(page).to have_content("0 characters remaining")
+    fill_in "Tell us more about your situation.", with:
+        "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget
+        dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur
+        ridiculus mus. Donec quam felis, ultricies nec, pellentesque eu, pretium quis, sem. Nulla
+        consequat massa quis enim. Donec pede justo, fringilla vel, aliquet nec, vulputate eget, arcu.
+        In enim justo, rhoncus ut, imperdiet a, venenatis vitae, justo. Nullam dictum felis eu pede
+        mollis pretium. Integer tincidunt. Cras dapibus. Vivamus elementum semper nisi. Aenean
+        vulputate eleifend tellus. Aenean leo ligula, porttitor eu, consequat vitae, eleifend ac,
+        enim. Aliquam lorem ante, dapibus in, viverra quis, feugiat a, tellus. Phasellus viverra
+        nulla ut metus varius laoreet. Quisque rutrum. Aenean imperdiet. Etiam ultricies nisi vel
+        augue. Curabitur ullamcorper ultricies nisi. Nam eget dui. Etiam rhoncus. Maecenas tempus,
+        tellus eget condimentum rhoncus, sem quam semper libero, sit amet adipiscing sem neque
+        sedipsum. Nam quam nunc, blandit vel, luctus pulvinar, hendrerit id, lorem. Maecenas nec
+        odio et ante tincidunt tempus. Donec vitae sapien ut libero venenatis faucibus. Nullam quis
+        ante. Etiam sit amet orci eget eros faucibus tincidunt. Duis leo. Sed fringilla mauris sit
+        amet nibh. Donec sodales sagittis magna. Sed consequat, leo eget bibendum sodales, augue
+        velit cursus nunc, quis gravida magna mi a libero. Fusce vulputate eleifend sapien.
+        Vestibulum purus quam, scelerisque ut, mollis sed, nonummy id, metus. Nullam accumsan
+        lorem in dui. Cras ultricies mi eu turpis hendrerit fringilla. Vestibulum ante ipsum
+        primis in faucibus orci luctus et ultrices posuere cubilia Curae; In ac dui quis mi
+        consectetuer lacinia. Nam pretium turpis et arcu. Duis arcu tortor, suscipit eget,
+        imperdiet nec, imperdiet iaculis, ipsum. Sed aliquam ultrices mauris. Integer ante arcu,
+        accumsan a, consectetuer eget, posuere ut, mauris. Praesent adipiscing. Phasellus
+        ullamcorper ipsum rutrum nunc. Nunc nonummy metus. Vestib{"
+    expect(page).to have_content("0 characters remaining")
+  end
+
+  scenario "Click cancel when certification has mistmatched documents" do
+    visit "certifications/new/#{appeal_mismatched_docs.vacols_id}"
+    expect(page).to have_content("Not found")
+    click_on "Cancel Certification"
+    expect(page).to have_content("Please explain why this case cannot be certified with Caseflow.")
+    within_fieldset("Why can't be this case certified in Caseflow") do
+      find("label", text: "Missing document could not be found").click
+    end
+    fill_in "What's your VA email address?", with: "fk@va.gov"
+    within(".modal-container") do
+      click_on "Cancel certification"
+    end
+    expect(page).to have_content("The certification has been cancelled")
   end
 end

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Confirm Certification", focus: true do
+RSpec.feature "Confirm Certification" do
   let!(:current_user) { User.authenticate! }
 
   before do

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Confirm Certification" do
+RSpec.feature "Confirm Certification", focus: true do
   let!(:current_user) { User.authenticate! }
 
   before do
@@ -47,6 +47,7 @@ RSpec.feature "Confirm Certification" do
   end
 
   scenario "Successful confirmation" do
+    puts Fakes::AppealRepository.records.inspect
     visit "certifications/#{appeal.vacols_id}"
     expect(page).to have_content("Review Form 8")
     click_on "Upload and certify"

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Confirm Certification", focus: true do
+RSpec.feature "Confirm Certification" do
   let!(:current_user) { User.authenticate! }
 
   before do
@@ -47,7 +47,6 @@ RSpec.feature "Confirm Certification", focus: true do
   end
 
   scenario "Successful confirmation" do
-    puts Fakes::AppealRepository.records.inspect
     visit "certifications/#{appeal.vacols_id}"
     expect(page).to have_content("Review Form 8")
     click_on "Upload and certify"

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Confirm Certification" do
+RSpec.feature "Confirm Certification", focus: true do
   let!(:current_user) { User.authenticate! }
 
   before do

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -1,25 +1,38 @@
 require "rails_helper"
 
 RSpec.feature "Confirm Certification" do
+  let!(:current_user) { User.authenticate! }
+
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-    User.authenticate!
     Form8.pdf_service = FakePdfService
 
-    Fakes::AppealRepository.records = {
-      "5555C" => Fakes::AppealRepository.appeal_ready_to_certify,
-      ENV["TEST_APPEAL_ID"] => Fakes::AppealRepository.appeal_ready_to_certify
-    }
-
-    certification = Certification.create!(vacols_id: "5555C")
+    # Put the Certification in the state to be confirmed
+    certification = Certification.create!(vacols_id: appeal.vacols_id)
     form8 = Form8.create!(certification_id: certification.id)
     form8.assign_attributes_from_appeal(certification.appeal)
     form8.save
     certification.form8.save_pdf!
   end
 
+  let(:nod) { Generators::Document.build(type: "NOD") }
+  let(:soc) { Generators::Document.build(type: "SOC", received_at: Date.new(1987, 9, 6)) }
+  let(:form9) { Generators::Document.build(type: "Form 9") }
+  let(:vacols_record) do
+    {
+      template: :ready_to_certify,
+      nod_date: nod.received_at,
+      soc_date: soc.received_at,
+      form9_date: form9.received_at
+    }
+  end
+
+  let(:appeal) do
+    Generators::Appeal.build(vacols_record: vacols_record, documents: [nod, soc, form9])
+  end
+
   scenario "Screen reader user visits pdf link" do
-    visit "certifications/5555C"
+    visit "certifications/#{appeal.vacols_id}"
 
     # We want this content to only appear for screen reader users, so
     # it will not be visible, but it **should** be in the DOM.
@@ -30,22 +43,22 @@ RSpec.feature "Confirm Certification" do
     # so let's find the hidden link's href and visit it manually to check that the pdf can be
     # found there.
     pdf_href = page.find("#sr-download-link", visible: false)[:href]
-    expect(pdf_href).to include("/5555C/pdf")
+    expect(pdf_href).to include("/#{appeal.vacols_id}/pdf")
   end
 
   scenario "Successful confirmation" do
-    visit "certifications/5555C"
+    visit "certifications/#{appeal.vacols_id}"
     expect(page).to have_content("Review Form 8")
     click_on "Upload and certify"
 
     expect(Fakes::AppealRepository.certified_appeal).to_not be_nil
-    expect(Fakes::AppealRepository.certified_appeal.vacols_id).to eq("5555C")
-    expect(Fakes::AppealRepository.uploaded_form8.vacols_id).to eq("5555C")
-    expect(Fakes::AppealRepository.uploaded_form8_appeal.vacols_id).to eq("5555C")
+    expect(Fakes::AppealRepository.certified_appeal.vacols_id).to eq(appeal.vacols_id)
+    expect(Fakes::AppealRepository.uploaded_form8.vacols_id).to eq(appeal.vacols_id)
+    expect(Fakes::AppealRepository.uploaded_form8_appeal.vacols_id).to eq(appeal.vacols_id)
 
     expect(page).to have_content("Congratulations!")
 
-    certification = Certification.find_or_create_by_vacols_id("5555C")
+    certification = Certification.find_or_create_by_vacols_id(appeal.vacols_id)
     expect(certification.reload.completed_at).to eq(Time.zone.now)
   end
 end

--- a/spec/feature/dropdown_spec.rb
+++ b/spec/feature/dropdown_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 RSpec.feature "Dropdown" do
+  let!(:current_user) { User.authenticate! }
+  let(:appeal) { Generators::Appeal.build(vacols_record: :ready_to_certify) }
+
   scenario "What's new indicator is reset after visiting /whats-new" do
-    Fakes::AppealRepository.records = { "1234C" => Fakes::AppealRepository.appeal_mismatched_docs }
     User.authenticate!
 
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
     expect(page).to have_css("#whats-new-item.cf-nav-whatsnew", visible: false)
     visit "/whats-new"
     expect(page).to_not have_css("#whats-new-item.cf-nav-whatsnew", visible: false)
@@ -14,7 +16,7 @@ RSpec.feature "Dropdown" do
   scenario "Dropdown works on both erb and react pages" do
     User.authenticate!
 
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
     click_on "DSUSER (DSUSER)"
     expect(page).to have_content("Sign out")
 

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
     [Generators::Document.build(type: "BVA Decision", received_at: 7.days.ago)]
   end
 
-  let(:vacols_record) { Fakes::AppealRepository.appeal_remand_decided }
+  let(:vacols_record) { :remand_decided }
 
   context "As a manager" do
     let!(:current_user) do
@@ -230,10 +230,8 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
 
     context "For a full grant" do
       let(:vacols_record) do
-        Fakes::AppealRepository.appeal_full_grant_decided.merge(
-          # Specify RO to test ROJ routing
-          regional_office_key: "RO21"
-        )
+        # Specify RO to test ROJ routing
+        { template: :full_grant_decided, regional_office_key: "RO21" }
       end
 
       scenario "Establish a new claim with special issue routed to national office" do
@@ -360,7 +358,7 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
     end
 
     context "For a partial grant" do
-      let(:vacols_record) { Fakes::AppealRepository.appeal_partial_grant_decided }
+      let(:vacols_record) { :partial_grant_decided }
 
       scenario "Establish a new claim routed to ARC" do
         # Mock the claim_id returned by VBMS's create end product

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "vbms"
 
-RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
+RSpec.feature "Establish Claim - ARC Dispatch" do
   before do
     # Set the time zone to the current user's time zone for proper date conversion
     Time.zone = "America/New_York"
@@ -122,7 +122,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
     end
 
     scenario "Go back and forward in the browser" do
-      puts Fakes::AppealRepository.records.inspect
       task.assign!(:assigned, current_user)
 
       visit "/dispatch/establish-claim/#{task.id}"
@@ -225,7 +224,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
 
         expect(page).to have_content("Multiple Decision Documents")
         safe_click_on "Route claim for Decision 1"
-        safe_click_on "< Back to Decision Review"
+        safe_click_on "< Back to Review Decision"
         expect(page).to have_content("Multiple Decision Documents")
       end
     end
@@ -542,7 +541,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
           expect(page).to have_content("Existing EP")
 
           # Validate the Back link takes you back to the Review Decision page
-          safe_click_on "< Back to Decision Review"
+          safe_click_on "< Back to Review Decision"
 
           expect(page).to have_content("Review Decision")
 

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -225,7 +225,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
 
         expect(page).to have_content("Multiple Decision Documents")
         safe_click_on "Route claim for Decision 1"
-        safe_click_on "< Back to Review Decision"
+        safe_click_on "< Back to Decision Review"
         expect(page).to have_content("Multiple Decision Documents")
       end
     end
@@ -542,7 +542,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
           expect(page).to have_content("Existing EP")
 
           # Validate the Back link takes you back to the Review Decision page
-          safe_click_on "< Back to Review Decision"
+          safe_click_on "< Back to Decision Review"
 
           expect(page).to have_content("Review Decision")
 

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -122,12 +122,11 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
     end
 
     scenario "Go back and forward in the browser" do
+      puts Fakes::AppealRepository.records.inspect
       task.assign!(:assigned, current_user)
 
       visit "/dispatch/establish-claim/#{task.id}"
 
-      puts page.current_path
-      puts page.html
       safe_click_on "Route claim"
 
       find_label_for("gulfWarRegistry").click

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "vbms"
 
-RSpec.feature "Establish Claim - ARC Dispatch" do
+RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
   before do
     # Set the time zone to the current user's time zone for proper date conversion
     Time.zone = "America/New_York"
@@ -11,6 +11,8 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
 
     allow(Fakes::AppealRepository).to receive(:establish_claim!).and_call_original
     allow(Fakes::AppealRepository).to receive(:update_vacols_after_dispatch!).and_call_original
+
+    Capybara.current_driver = :poltergeist
   end
 
   let(:case_worker) do
@@ -125,6 +127,9 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       task.assign!(:assigned, current_user)
 
       visit "/dispatch/establish-claim/#{task.id}"
+
+      puts page.current_path
+      puts page.html
       safe_click_on "Route claim"
 
       find_label_for("gulfWarRegistry").click

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -11,8 +11,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", focus: true do
 
     allow(Fakes::AppealRepository).to receive(:establish_claim!).and_call_original
     allow(Fakes::AppealRepository).to receive(:update_vacols_after_dispatch!).and_call_original
-
-    Capybara.current_driver = :poltergeist
   end
 
   let(:case_worker) do

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -1,11 +1,9 @@
 require "rails_helper"
 
 RSpec.feature "Login" do
-  before do
-    Fakes::AppealRepository.records = {
-      "1234C" => Fakes::AppealRepository.appeal_ready_to_certify
-    }
+  let(:appeal) { Generators::Appeal.build(vacols_record: :ready_to_certify) }
 
+  before do
     Fakes::AuthenticationService.vacols_regional_offices = { "DSUSER" => "pa55word!" }
     Fakes::AuthenticationService.user_session = {
       "id" => "ANNE MERICA", "roles" => ["Certify Appeal"], "station_id" => "405", "email" => "test@example.com"
@@ -21,26 +19,26 @@ RSpec.feature "Login" do
     Fakes::AuthenticationService.user_session = {
       "id" => "ANNE MERICA", "roles" => ["Certify Appeal"], "station_id" => "314", "email" => "world@example.com"
     }
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
 
-    expect(page).to have_current_path(new_certification_path(vacols_id: "1234C"))
+    expect(page).to have_current_path(new_certification_path(vacols_id: appeal.vacols_id))
     expect(find("#menu-trigger")).to have_content("ANNE MERICA (RO14)")
     expect(user.reload.email).to eq "world@example.com"
   end
 
   scenario "with valid credentials" do
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
     # vacols login
     expect(page).to have_content("VACOLS credentials")
     fill_in "VACOLS Login ID", with: "DSUSER"
     fill_in "VACOLS Password", with: "pa55word!"
     click_on "Login"
-    expect(page).to have_current_path(new_certification_path(vacols_id: "1234C"))
+    expect(page).to have_current_path(new_certification_path(vacols_id: appeal.vacols_id))
     expect(find("#menu-trigger")).to have_content("ANNE MERICA (DSUSER)")
   end
 
   scenario "with invalid credentials" do
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
 
     # vacols login
     fill_in "VACOLS Login ID", with: "DSUSER"
@@ -50,12 +48,12 @@ RSpec.feature "Login" do
     expect(page).to have_current_path(login_path)
     expect(find(".usa-alert-body")).to have_content("The username and password you entered don't match")
 
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
     expect(page).to have_current_path(login_path)
   end
 
   scenario "logging out redirects to home page" do
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
 
     # vacols login
     expect(page).to have_content("VACOLS credentials")
@@ -65,13 +63,13 @@ RSpec.feature "Login" do
 
     click_on "ANNE MERICA (DSUSER)"
     click_on "Sign out"
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
     expect(page).to have_current_path("/login")
   end
 
   scenario "email should be set on login" do
     user = User.create(css_id: "ANNE MERICA", station_id: "405")
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
     fill_in "VACOLS Login ID", with: "DSUSER"
     fill_in "VACOLS Password", with: "pa55word!"
     click_on "Login"
@@ -80,7 +78,7 @@ RSpec.feature "Login" do
 
   scenario "Single Sign On is down" do
     Rails.application.config.sso_service_disabled = true
-    visit "certifications/new/1234C"
+    visit "certifications/new/#{appeal.vacols_id}"
 
     expect(page).to have_content("Login Service Unavailable")
   end

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -9,7 +9,7 @@ def scroll_to(value)
 end
 
 RSpec.feature "Reader" do
-  let(:vacols_record) { Fakes::AppealRepository.appeal_remand_decided }
+  let(:vacols_record) { :remand_decided }
 
   # Currently the vbms_document_ids need to be set since they correspond to specific
   # files to load when we fetch content.

--- a/spec/feature/send_feedback_spec.rb
+++ b/spec/feature/send_feedback_spec.rb
@@ -1,14 +1,11 @@
 require "rails_helper"
 
 RSpec.feature "Send feedback" do
-  before do
-    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-    Fakes::AppealRepository.records = { "ABCD" => Fakes::AppealRepository.appeal_ready_to_certify }
-  end
+  let!(:current_user) { User.authenticate! }
+  let(:appeal) { Generators::Appeal.build(vacols_record: :ready_to_certify) }
 
   scenario "Sending feedback about Caseflow Certification" do
-    User.authenticate!
-    visit "certifications/new/ABCD"
+    visit "certifications/new/#{appeal.vacols_id}"
 
     expect(page).to have_link("Send feedback")
 

--- a/spec/feature/start_certification_spec.rb
+++ b/spec/feature/start_certification_spec.rb
@@ -5,170 +5,195 @@ RSpec.feature "Start Certification" do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end
 
-  scenario "Starting a certification before logging in redirects to login page" do
-    Fakes::AppealRepository.records = { "ABCD" => Fakes::AppealRepository.appeal_ready_to_certify }
+  let(:nod) { Generators::Document.build(type: "NOD") }
+  let(:soc) { Generators::Document.build(type: "SOC", received_at: Date.new(1987, 9, 6)) }
+  let(:form9) { Generators::Document.build(type: "Form 9") }
+  let(:mismatched_nod) { Generators::Document.build(type: "NOD", received_at: 100.days.ago) }
 
-    visit "certifications/new/ABCD"
-    expect(page).to have_current_path("/login")
-  end
+  let(:documents) { [nod, soc, form9] }
+  let(:mismatched_documents) { [mismatched_nod, soc] }
 
-  scenario "Starting a certification when user isn't assigned 'Certify Appeal' function" do
-    User.authenticate!(roles: ["Download eFolder"])
-    visit "certifications/new/ABCD"
-
-    expect(page).to have_current_path("/unauthorized")
-  end
-
-  scenario "Starting a Certification v2" do
-    User.authenticate!(roles: ["Certify Appeal", "CertificationV2"])
-    Fakes::AppealRepository.records = { "ABCD" => Fakes::AppealRepository.appeal_ready_to_certify }
-
-    visit "certifications/new/ABCD"
-    expect(page).to have_current_path("/certifications/ABCD/check_documents")
-    expect(page).to have_content("All documents detected!")
-    click_button("Continue")
-    expect(page).to have_content("Review data from BGS about the appellant's representative")
-    click_button("Continue")
-    expect(page).to have_content("Check the appellant's eFolder for a hearing cancellation")
-    page.find(".cf-form-radio-option", text: "Yes").click
-    expect(page).to have_content("What did the appellant request in the document you found")
-    page.find(".cf-form-radio-option", text: "No").click
-    expect(page).to have_content("Caseflow found the document below, labeled as a Form 9")
-    page.find(".cf-form-radio-option", text: "Statement in lieu of Form 9").click
-    expect(page).to have_content("What optional board hearing preference, if any")
-  end
-
-  scenario "Starting a certification with missing documents" do
-    User.authenticate!(roles: ["Certify Appeal"])
-
-    appeal_hash = {
+  let(:vacols_record) do
+    {
+      template: :ready_to_certify,
       type: "Original",
       file_type: "VVA",
       representative: "The American Legion",
-      nod_date: 1.day.ago,
-      soc_date: Date.new(1987, 9, 6),
-      form9_date: 1.day.ago,
-      ssoc_dates: [6.days.from_now, 7.days.from_now],
-      documents: [Fakes::AppealRepository.nod_document, Fakes::AppealRepository.soc_document],
-      veteran_first_name: "Davy",
-      veteran_last_name: "Crockett",
-      regional_office_key: "DSUSER"
-    }
-    Fakes::AppealRepository.records = { "1234C" => appeal_hash }
-
-    visit "certifications/new/1234C"
-
-    expect(find("#correspondent-name")).to have_content("Crockett, Davy")
-    expect(find("#appeal-type-header")).to have_content("Original")
-    expect(find("#file-type-header")).to have_content("VVA")
-    expect(find("#vso-header")).to have_content("The American Legion")
-
-    expect(find("#page-title")).to have_content "Mismatched Documents"
-    expect(find("#nod-match")).to have_content "Not found"
-    expect(find("#soc-match")).to_not have_content "Not found"
-    expect(find("#soc-match")).to have_content "09/06/1987"
-    expect(find("#form-9-match")).to have_content "Not found"
-    expect(find("#ssoc-1-match")).to have_content "Not found"
-    expect(find("#ssoc-2-match")).to have_content "SSOC 2"
-    expect(find("#ssoc-2-match")).to have_content "Not found"
-
-    certification = Certification.last
-    expect(certification.vacols_id).to eq("1234C")
-    expect(certification.nod_matching_at).to be_nil
-    expect(certification.soc_matching_at).to eq(Time.zone.now)
-    expect(certification.form9_matching_at).to be_nil
-    expect(certification.ssocs_required).to be_truthy
-    expect(certification.ssocs_matching_at).to be_nil
-    expect(certification.form8_started_at).to be_nil
-  end
-
-  scenario "Clicking the refresh button" do
-    User.authenticate!
-
-    Fakes::AppealRepository.records = { "1234C" => Fakes::AppealRepository.appeal_mismatched_docs }
-    visit "certifications/new/1234C"
-
-    Fakes::AppealRepository.records = { "1234C" => Fakes::AppealRepository.appeal_ready_to_certify }
-    click_on "Refresh page"
-    expect(page).to have_content "Complete Electronic Form 8"
-  end
-
-  scenario "Starting a certifications with all documents matching" do
-    User.authenticate!
-
-    appeal_hash = {
-      type: "Original",
-      file_type: "VBMS",
-      vbms_id: "VBMS-ID",
-      representative: "Military Order of the Purple Heart",
-      nod_date: 3.days.ago,
-      soc_date: Date.new(1987, 9, 6),
-      form9_date: 1.day.ago,
-      documents: [
-        Document.new(type: "NOD", received_at: 3.days.ago),
-        Document.new(type: "SOC", received_at: Date.new(1987, 9, 6)),
-        Document.new(type: "Form 9", received_at: 1.day.ago)
-      ],
       veteran_first_name: "Davy",
       veteran_last_name: "Crockett",
       veteran_middle_initial: "X",
       appellant_first_name: "Susie",
+      appellant_middle_initial: nil,
       appellant_last_name: "Crockett",
       appellant_relationship: "Daughter",
-      regional_office_key: "DSUSER"
+      nod_date: nod.received_at,
+      soc_date: soc.received_at,
+      form9_date: form9.received_at
     }
-    Fakes::AppealRepository.records = { "5678C" => appeal_hash }
-
-    visit "certifications/new/5678C"
-
-    expect(page).to have_content "Complete Electronic Form 8"
-
-    expect(page).to have_field "Name of Appellant", with: "Susie, Crockett"
-    expect(page).to have_field "Relationship to Veteran", with: "Daughter"
-    expect(page).to have_field "File Number", with: "VBMS-ID"
-    expect(page).to have_field "Full Veteran Name", with: "Crockett, Davy, X"
-    expect(page).to have_selector("#question5B.hidden-field", visible: false)
-    expect(page).to have_selector("#question6B.hidden-field", visible: false)
-    expect(page).to have_selector("#question7B.hidden-field", visible: false)
-
-    certification = Certification.last
-    expect(certification.vacols_id).to eq("5678C")
-    expect(certification.form8_started_at).to eq(Time.zone.now)
   end
 
-  scenario "404's if appeal doesn't exist in VACOLS" do
-    User.authenticate!
-    Fakes::AppealRepository.records = {}
-
-    visit "certifications/new/4444NNNN"
-    expect(page).to have_content("Page not found")
+  let(:vacols_record_with_ssocs) do
+    vacols_record.merge(ssoc_dates: [6.days.from_now, 7.days.from_now])
   end
 
-  scenario "VBMS-specific 500 on vbms error" do
-    User.authenticate!
-    appeal = Fakes::AppealRepository.appeal_raises_vbms_error
-    Fakes::AppealRepository.records = { "ABCD" => appeal }
-
-    visit "certifications/new/ABCD"
-    expect(page).to have_content("Unable to communicate with the VBMS system at this time.")
+  let(:appeal_ready) do
+    Generators::Appeal.build(vacols_record: vacols_record, documents: documents)
   end
 
-  scenario "Appeal missing data" do
-    User.authenticate!
-    appeal = Fakes::AppealRepository.appeal_missing_data
-    Fakes::AppealRepository.records = { "ABCD" => appeal }
-
-    visit "certifications/new/ABCD"
-    expect(page).to have_content("Appeal is not ready for certification.")
+  let(:appeal_mismatched_documents) do
+    Generators::Appeal.build(vacols_record: vacols_record_with_ssocs, documents: mismatched_documents)
   end
 
-  scenario "Appeal is already certified" do
-    User.authenticate!
-    appeal = Fakes::AppealRepository.appeal_already_certified
-    Fakes::AppealRepository.records = { "1234" => appeal }
+  let(:appeal_not_ready) do
+    Generators::Appeal.build(vacols_record: :not_ready_to_certify, documents: documents)
+  end
 
-    visit "certifications/new/1234"
-    expect(find("#page-title")).to have_content "Already Certified"
-    expect(page).to have_content "Appeal has already been Certified"
+  # Fakes::AppealRepository is stubbed to raise an error with this id
+  let(:appeal_vbms_error) do
+    Generators::Appeal.build(
+      vbms_id: Fakes::AppealRepository::RAISE_VBMS_ERROR_ID,
+      vacols_record: vacols_record,
+      documents: documents
+    )
+  end
+
+  let(:appeal_already_certified) do
+    Generators::Appeal.build(vacols_record: :certified, documents: documents)
+  end
+
+  context "As a user who's not logged in" do
+    scenario "Starting a certification redirects to login page" do
+      visit "certifications/new/#{appeal_ready.vacols_id}"
+      expect(page).to have_current_path("/login")
+    end
+  end
+
+  context "As a user who isn't authorized" do
+    let!(:current_user) { User.authenticate!(roles: ["Download eFolder"]) }
+
+    scenario "Starting a certification when user isn't assigned 'Certify Appeal' function" do
+      visit "certifications/new/#{appeal_ready.vacols_id}"
+
+      expect(page).to have_current_path("/unauthorized")
+    end
+  end
+
+  context "As an authorized user for Certification V2" do
+    let!(:current_user) { User.authenticate!(roles: ["Certify Appeal", "CertificationV2"]) }
+
+    scenario "Starting a Certification v2" do
+      visit "certifications/new/#{appeal_ready.vacols_id}"
+      expect(page).to have_current_path("/certifications/#{appeal_ready.vacols_id}/check_documents")
+      expect(page).to have_content("All documents detected!")
+
+      click_button("Continue")
+      expect(page).to have_content("Review data from BGS about the appellant's representative")
+
+      click_button("Continue")
+      expect(page).to have_content("Check the appellant's eFolder for a hearing cancellation")
+
+      within_fieldset("Was a hearing cancellation or request added after #{form9.received_at}?") do
+        find("label", text: "Yes").click
+      end
+      expect(page).to have_content("What did the appellant request in the document you found")
+
+      within_fieldset("Was a hearing cancellation or request added after #{form9.received_at}?") do
+        find("label", text: "No").click
+      end
+      within_fieldset("Caseflow found the document below, labeled as a Form 9") do
+        find("label", text: "Statement in lieu of Form 9").click
+      end
+      expect(page).to have_content("What optional board hearing preference, if any")
+    end
+  end
+
+  context "As an authorized user to Certify Appeal" do
+    let!(:current_user) { User.authenticate!(roles: ["Certify Appeal"]) }
+
+    scenario "When some documents aren't matching shows missing documents page" do
+      visit "certifications/new/#{appeal_mismatched_documents.vacols_id}"
+
+      expect(find("#correspondent-name")).to have_content("Crockett, Davy")
+      expect(find("#appeal-type-header")).to have_content("Original")
+      expect(find("#file-type-header")).to have_content("VVA")
+      expect(find("#vso-header")).to have_content("The American Legion")
+
+      expect(find("#page-title")).to have_content "Mismatched Documents"
+      expect(find("#nod-match")).to have_content "Not found"
+      expect(find("#soc-match")).to_not have_content "Not found"
+      expect(find("#soc-match")).to have_content "09/06/1987"
+      expect(find("#form-9-match")).to have_content "Not found"
+      expect(find("#ssoc-1-match")).to have_content "Not found"
+      expect(find("#ssoc-2-match")).to have_content "SSOC 2"
+      expect(find("#ssoc-2-match")).to have_content "Not found"
+
+      expect(Certification.last).to have_attributes(
+        vacols_id: appeal_mismatched_documents.vacols_id,
+        nod_matching_at: nil,
+        soc_matching_at: Time.zone.now,
+        form9_matching_at: nil,
+        ssocs_required: true,
+        ssocs_matching_at: nil,
+        form8_started_at: nil
+      )
+    end
+
+    scenario "When appeal is not ready for certificaition" do
+      visit "certifications/new/#{appeal_not_ready.vacols_id}"
+      expect(page).to have_content("Appeal is not ready for certification.")
+    end
+
+    scenario "Clicking the refresh button" do
+      visit "certifications/new/#{appeal_mismatched_documents.vacols_id}"
+
+      # Overwrite AppealRepository data with an appeal with matching documents
+      Generators::Appeal.build(
+        vacols_id: appeal_mismatched_documents.vacols_id,
+        vbms_id: appeal_mismatched_documents.vbms_id,
+        vacols_record: vacols_record,
+        documents: documents
+      )
+
+      click_on "Refresh page"
+      expect(page).to have_content "Complete Electronic Form 8"
+    end
+
+    scenario "Starting a certifications with all documents matching" do
+      visit "certifications/new/#{appeal_ready.vacols_id}"
+
+      expect(page).to have_content "Complete Electronic Form 8"
+
+      expect(page).to have_field "Name of Appellant", with: "Susie, Crockett"
+      expect(page).to have_field "Relationship to Veteran", with: "Daughter"
+      expect(page).to have_field "File Number", with: appeal_ready.vbms_id
+      expect(page).to have_field "Full Veteran Name", with: "Crockett, Davy, X"
+      expect(page).to have_selector("#question5B.hidden-field", visible: false)
+      expect(page).to have_selector("#question6B.hidden-field", visible: false)
+      expect(page).to have_selector("#question7B.hidden-field", visible: false)
+
+      expect(Certification.last).to have_attributes(
+        vacols_id: appeal_ready.vacols_id,
+        form8_started_at: Time.zone.now
+      )
+    end
+
+    scenario "VBMS-specific 500 on vbms error" do
+      visit "certifications/new/#{appeal_vbms_error.vacols_id}"
+      expect(page).to have_content("Unable to communicate with the VBMS system at this time.")
+    end
+
+    scenario "404's if appeal doesn't exist in VACOLS" do
+      # It's awkward that we have to do this in order to trigger a RecordNotFound
+      Fakes::AppealRepository.records = {}
+
+      visit "certifications/new/4444NNNN"
+      expect(page).to have_content("Page not found")
+    end
+
+    scenario "Appeal is already certified" do
+      visit "certifications/new/#{appeal_already_certified.vacols_id}"
+      expect(find("#page-title")).to have_content "Already Certified"
+      expect(page).to have_content "Appeal has already been Certified"
+    end
   end
 end

--- a/spec/jobs/create_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/create_establish_claim_tasks_job_spec.rb
@@ -8,12 +8,10 @@ describe CreateEstablishClaimTasksJob do
     FeatureToggle.enable!(:dispatch_partial_grants_remands)
   end
 
-  let!(:remand) { Generators::Appeal.build({vacols_record: :remand_decided}) }
+  let!(:remand) { Generators::Appeal.build(vacols_record: :remand_decided) }
 
   let!(:full_grant) do
-    Generators::Appeal.build({
-      vacols_record: {template: :full_grant_decided, decision_date: 1.day.ago}
-    })
+    Generators::Appeal.build(vacols_record: { template: :full_grant_decided, decision_date: 1.day.ago })
   end
 
   context ".perform" do

--- a/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
@@ -7,14 +7,14 @@ describe PrepareEstablishClaimTasksJob do
 
   let!(:appeal_with_decision_document) do
     Generators::Appeal.create(
-      vacols_record: Fakes::AppealRepository.appeal_remand_decided,
+      vacols_record: {template: :remand_decided, decision_date: 7.days.ago},
       documents: [Generators::Document.build(type: "BVA Decision", received_at: 7.days.ago)]
     )
   end
 
   let!(:appeal_without_decision_document) do
     Generators::Appeal.create(
-      vacols_record: Fakes::AppealRepository.appeal_remand_decided,
+      vacols_record: :remand_decided,
       documents: [Generators::Document.build(type: "BVA Decision", received_at: 31.days.ago)]
     )
   end

--- a/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
@@ -7,7 +7,7 @@ describe PrepareEstablishClaimTasksJob do
 
   let!(:appeal_with_decision_document) do
     Generators::Appeal.create(
-      vacols_record: {template: :remand_decided, decision_date: 7.days.ago},
+      vacols_record: { template: :remand_decided, decision_date: 7.days.ago },
       documents: [Generators::Document.build(type: "BVA Decision", received_at: 7.days.ago)]
     )
   end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -82,7 +82,7 @@ describe Appeal do
 
   context "#fetch_documents!" do
     let(:documents) do
-      [Fakes::AppealRepository.nod_document, Fakes::AppealRepository.soc_document]
+      [Generators::Document.build(type: "NOD"), Generators::Document.build(type: "SOC")]
     end
 
     let(:appeal) do

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -1,44 +1,45 @@
 describe Certification do
   let(:certification_date) { nil }
-  let(:certification) { Certification.new(vacols_id: "4949") }
-  let(:appeal_hash) { { vacols_id: "4949", vbms_id: "VB12", certification_date: certification_date } }
-  let(:appeal) do
-    Appeal.new(appeal_hash)
+  let(:nod) { Generators::Document.build(type: "NOD") }
+  let(:soc) { Generators::Document.build(type: "SOC", received_at: Date.new(1987, 9, 6)) }
+  let(:form9) { Generators::Document.build(type: "Form 9") }
+  let(:documents) { [nod, soc, form9] }
+
+  let(:vacols_record_template) { :ready_to_certify }
+  let(:ssoc_date) { nil }
+  let(:vacols_record) do
+    {
+      template: vacols_record_template,
+      nod_date: nod.received_at,
+      soc_date: soc.received_at,
+      ssoc_dates: ssoc_date ? [ssoc_date] : nil,
+      form9_date: form9.received_at
+    }
   end
+
+  let(:appeal) do
+    Generators::Appeal.build(vacols_record: vacols_record, documents: documents)
+  end
+
+  let(:certification_completed_at) { nil }
+  let(:certification) do
+    Certification.new(
+      vacols_id: appeal.vacols_id,
+      completed_at: certification_completed_at
+    )
+  end
+
   let(:user) { User.find_or_create_by(station_id: 456, css_id: 124) }
 
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
-    Fakes::AppealRepository.records = { "4949" => appeal_hash }
-    allow(Appeal).to receive(:find_or_create_by_vacols_id) { appeal }
-
-    allow(Appeal.repository).to receive(:load_vacols_data) {}
-  end
-
-  after do
-    Fakes::AppealRepository.documents = nil
-  end
-
-  context "#appeal" do
-    subject { certification.appeal }
-    before do
-      Fakes::AppealRepository.set_vbms_documents!
-    end
-
-    it "includes documents" do
-      expect(subject.documents).to_not be_empty
-
-      expect_any_instance_of(Appeal).to_not receive(:fetch_documents!).at_least(1).times
-      # test it doesn't fetch documents a 2nd time
-      subject
-    end
   end
 
   context "#start!" do
     subject { certification.start! }
 
     context "when appeal has already been certified" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_already_certified }
+      let(:vacols_record_template) { :certified }
 
       it "returns already_certified and sets the flag" do
         expect(subject).to eq(:already_certified)
@@ -48,7 +49,9 @@ describe Certification do
     end
 
     context "when appeal is missing certification data" do
-      it "returns already_certified and sets the flag" do
+      let(:vacols_record) { {} }
+
+      it "returns data_missing and sets the flag" do
         expect(subject).to eq(:data_missing)
         expect(certification.reload.vacols_data_missing).to be_truthy
         expect(certification.form8_started_at).to be_nil
@@ -56,7 +59,7 @@ describe Certification do
     end
 
     context "when a document is mismatched" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_mismatched_nod }
+      let(:documents) { [soc, form9] }
 
       it "returns mismatched_documents and sets the flag" do
         expect(subject).to eq(:mismatched_documents)
@@ -81,7 +84,7 @@ describe Certification do
     end
 
     context "when ssocs are mismatched" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_mismatched_ssoc }
+      let(:ssoc_date) { 1.day.ago }
 
       it "is included in the relevant certification_stats" do
         subject
@@ -95,7 +98,8 @@ describe Certification do
     end
 
     context "when multiple docs are mismatched" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_mismatched_docs }
+      let(:documents) { [] }
+      let(:ssoc_date) { 1.day.ago }
 
       it "is included in the relevant certification_stats" do
         subject
@@ -109,8 +113,6 @@ describe Certification do
     end
 
     context "when appeal is ready to start" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_ready_to_certify }
-
       it "returns success and sets timestamps" do
         expect(subject).to eq(:started)
 
@@ -124,15 +126,13 @@ describe Certification do
 
       it "no ssoc does not trip missing ssoc stat" do
         subject
-
         expect(Certification.was_missing_ssoc.count).to eq(0)
       end
 
       context "when appeal has ssoc" do
-        before do
-          appeal.ssoc_dates = [10.days.ago]
-          appeal.documents << Document.new(type: "SSOC", received_at: 10.days.ago)
-        end
+        let(:ssoc_date) { 4.days.ago }
+        let(:ssoc) { Generators::Document.build(type: "SSOC", received_at: 4.days.ago) }
+        let(:documents) { [nod, soc, form9, ssoc] }
 
         it "returns success and sets ssoc_required" do
           expect(subject).to eq(:started)
@@ -141,75 +141,58 @@ describe Certification do
         end
       end
 
-      context "when fetching form8 data for a new certification" do
-        let(:appeal_hash) { { vacols_id: "4949" } }
+      context "when matching form8 exists" do
+        context "when matching form8 is recent" do
+          let!(:form8) { Form8.create(certification_id: certification.id) }
+          let(:new_date) { Time.utc(2016, 7, 7, 12, 0, 0) }
 
-        it "populates a form8 with appeal data when form8 data is not present" do
-          cert = Certification.create(vacols_id: "4949")
-          allow(cert).to receive(:form8).and_return(nil)
+          it "updates the form8's certification date" do
+            Timecop.freeze(new_date)
+            subject
 
-          cert.start!
+            expect(form8.reload.certification_date).to eq(new_date.to_date)
+          end
+        end
 
-          form = Form8.find_by(certification_id: cert.id)
-          expect(form.vacols_id).to eq(cert.vacols_id)
+        context "when matching form8 is stale (> 48 hrs old)" do
+          let!(:form8) do
+            Form8.create(certification_id: certification.id, updated_at: 3.days.ago)
+          end
+
+          it "updates the form8's values from appeal" do
+            subject
+            expect(form8.reload.file_number).to eq(appeal.vbms_id)
+          end
         end
       end
 
-      context "when resuming a certification" do
-        it "does not update a form8's appeal data if form8 has been updated less than 48 hours ago" do
-          cert = Certification.new(vacols_id: "4949")
-          form = double
-          # TODO(alex): these tests are too mocked out. refactor them to be more realistic!
-          allow(cert).to receive(:form8).and_return(nil, form)
-          allow(form).to receive(:update_certification_date)
-          allow(form).to receive(:updated_at).and_return(Time.zone.now)
+      context "when matching form8 doesn't exist" do
+        # Save the certification so it has an id
+        before { certification.save! }
 
-          cert.start!
-          cert.start!
+        it "creates a new form8" do
+          subject
 
-          expect(form).to have_received(:update_certification_date).once
-          expect(form).to have_received(:update_certification_date).at_most(:once)
-        end
-
-        it "updates a form8's appeal data if form8 has been updated more than 48 hours ago" do
-          cert = Certification.new(vacols_id: "4949")
-          form = double
-          allow(cert).to receive(:form8).and_return(form)
-          allow(form).to receive(:update_certification_date)
-          allow(form).to receive(:updated_at).and_return(49.hours.ago)
-
-          cert.start!
-          cert.start!
-
-          expect(form).to have_received(:update_certification_date).at_most(0).times
-        end
-
-        it "updates the certification_date on the form8 to the current day" do
-          cert = Certification.create!
-          Form8.create!(vacols_id: "9999", certification_id: cert.id, certification_date: 1.day.ago.to_date)
-          cert.start!
-          expect(cert.form8.certification_date).to eq(Time.zone.now.to_date)
+          expect(Form8.find_by(certification_id: certification.id)).to have_attributes(
+            vacols_id: certification.vacols_id,
+            certification_date: Time.zone.now.to_date
+          )
         end
       end
     end
   end
 
   context "#form8" do
+    subject { certification.form8 }
+
     context "when a form8 exists in the db for that certification" do
-      it "returns the saved form8" do
-        cert = Certification.create!
-        form8 = Form8.create(vacols_id: "9999", certification_id: cert.id)
-        expect(cert.form8.id).to eq(form8.id)
-        expect(cert.form8.vacols_id).to eq("9999")
-      end
+      before { certification.save! }
+      let!(:existing_form8) { Form8.create(certification_id: certification.id) }
+      it { is_expected.to eq(existing_form8) }
     end
+
     context "when no saved form8 exists" do
-      it "returns a new form8" do
-        cert = Certification.create!
-        expect(Form8.exists?(certification_id: cert.id)).to eq(false)
-        cert.start!
-        expect(cert.form8.class).to eq(Form8)
-      end
+      it { is_expected.to be_nil }
     end
   end
 
@@ -224,36 +207,23 @@ describe Certification do
   context "#time_to_certify" do
     subject { certification.time_to_certify }
 
-    before do
-      certification.start!
+    context "when not completed" do
+      it { is_expected.to be_nil }
     end
 
-    context "when appeal has already been certified" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_already_certified }
+    context "when completed" do
+      let(:certification_completed_at) { 1.hour.from_now }
 
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
-    end
-
-    context "when appeal has yet to be certified" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_ready_to_certify }
-
-      it "returns nil" do
-        expect(subject).to be_nil
-      end
-    end
-
-    context "when appeal has been certified using Caseflow" do
-      let(:appeal_hash) { Fakes::AppealRepository.appeal_ready_to_certify }
-
-      before do
-        Timecop.freeze(Time.utc(2015, 1, 1, 13, 0, 0))
-        certification.complete!(user.id)
+      context "when not created" do
+        it { is_expected.to be_nil }
       end
 
-      it "returns the time since certification started" do
-        expect(subject).to eq(1.hour)
+      context "when created" do
+        before { certification.save! }
+
+        it "returns the time since certification started" do
+          expect(subject).to eq(1.hour)
+        end
       end
     end
   end

--- a/spec/models/claim_establishment_spec.rb
+++ b/spec/models/claim_establishment_spec.rb
@@ -1,10 +1,10 @@
 describe ClaimEstablishment do
   let(:appeal_remand) do
-    Generators::Appeal.build(vacols_record: Fakes::AppealRepository.appeal_remand_decided)
+    Generators::Appeal.build(vacols_record: :remand_decided)
   end
 
   let(:appeal_full_grant) do
-    Generators::Appeal.build(vacols_record: Fakes::AppealRepository.appeal_full_grant_decided)
+    Generators::Appeal.build(vacols_record: :full_grant_decided)
   end
 
   context ".get_decision_type" do

--- a/spec/models/establish_claim_spec.rb
+++ b/spec/models/establish_claim_spec.rb
@@ -27,7 +27,7 @@ describe EstablishClaim do
     )
   end
 
-  let(:vacols_record) { Fakes::AppealRepository.appeal_remand_decided }
+  let(:vacols_record) { :remand_decided }
   let(:dispatched_to_station) { "RO98" }
   let(:aasm_state) { :unassigned }
   let(:completion_status) { nil }
@@ -132,7 +132,7 @@ describe EstablishClaim do
       let(:completion_status) { :completed }
 
       context "when appeal is a Remand or Partial Grant" do
-        let(:vacols_record) { Fakes::AppealRepository.appeal_remand_decided }
+        let(:vacols_record) { :remand_decided }
 
         it { is_expected.to include("Reviewed Remand decision") }
         it { is_expected.to include("VACOLS Updated: Changed Location to 98") }
@@ -154,7 +154,7 @@ describe EstablishClaim do
       end
 
       context "when appeal is a Full Grant" do
-        let(:vacols_record) { Fakes::AppealRepository.appeal_full_grant_decided }
+        let(:vacols_record) { :full_grant_decided }
 
         it { is_expected.to include("Reviewed Full Grant decision") }
         it { is_expected.to_not include(/VACOLS Updated/) }

--- a/spec/models/form8_spec.rb
+++ b/spec/models/form8_spec.rb
@@ -37,7 +37,7 @@ describe Form8 do
 
   context "#update_from_appeal" do
     let(:form8) { Form8.new }
-    appeal = Appeal.new(Fakes::AppealRepository.appeal_ready_to_certify)
+    let(:appeal) { Generators::Appeal.build(vacols_record: :ready_to_certify) }
 
     it "populates _initial_ fields with the same values as their counterparts" do
       form8.assign_attributes_from_appeal(appeal)
@@ -52,7 +52,7 @@ describe Form8 do
 
   context "#attributes" do
     let(:form8) { Form8.new }
-    appeal = Appeal.new(Fakes::AppealRepository.appeal_ready_to_certify)
+    let(:appeal) { Generators::Appeal.build(vacols_record: :ready_to_certify) }
 
     it "does not return initial attributes" do
       form8.assign_attributes_from_appeal(appeal)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -328,9 +328,13 @@ describe Task do
   context "#prepare_with_decision!" do
     subject { task.prepare_with_decision! }
 
+    let(:appeal) do
+      Generators::Appeal.create(
+        vacols_record: {template: :partial_grant_decided, decision_date: 7.days.ago},
+        documents: documents
+      )
+    end
     let(:task) { EstablishClaim.create(appeal: appeal) }
-    let(:appeal) { Generators::Appeal.create(vacols_record: vacols_record, documents: documents) }
-    let(:vacols_record) { Fakes::AppealRepository.appeal_partial_grant_decided }
 
     context "if the task's appeal has no decisions" do
       let(:documents) { [] }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -330,7 +330,7 @@ describe Task do
 
     let(:appeal) do
       Generators::Appeal.create(
-        vacols_record: {template: :partial_grant_decided, decision_date: 7.days.ago},
+        vacols_record: { template: :partial_grant_decided, decision_date: 7.days.ago },
         documents: documents
       )
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -131,7 +131,9 @@ RSpec.configure do |config|
   if Dir["#{::Rails.root}/app/assets/webpack/*"].empty?
     ReactOnRails::TestHelper.ensure_assets_compiled
   end
-  config.before(:all) { User.unauthenticate! }
+  config.before(:all) do
+    User.unauthenticate!
+  end
 
   config.after(:each) do
     Timecop.return

--- a/spec/services/appeals_repository_spec.rb
+++ b/spec/services/appeals_repository_spec.rb
@@ -95,7 +95,6 @@ describe AppealRepository do
       allow_any_instance_of(Appeal).to receive(:check_and_load_vacols_data!).and_return(nil)
     end
 
-
     subject do
       appeal = Appeal.new
       AppealRepository.set_vacols_values(
@@ -179,7 +178,7 @@ describe AppealRepository do
     before { Appeal.repository = Fakes::AppealRepository }
 
     let(:appeal) do
-      Generators::Appeal.build({vacols_record: vacols_record}.merge(special_issues))
+      Generators::Appeal.build({ vacols_record: vacols_record }.merge(special_issues))
     end
 
     let(:special_issues) { {} }

--- a/spec/services/appeals_repository_spec.rb
+++ b/spec/services/appeals_repository_spec.rb
@@ -3,7 +3,6 @@ describe AppealRepository do
     @old_repo = Appeal.repository
     Appeal.repository = AppealRepository
 
-    allow_any_instance_of(Appeal).to receive(:check_and_load_vacols_data!).and_return(nil)
     allow_any_instance_of(VACOLS::Case::ActiveRecord_Relation).to receive(:find).and_return(nil)
   end
   after { Appeal.repository = @old_repo }
@@ -55,6 +54,10 @@ describe AppealRepository do
   end
 
   context ".build_appeal" do
+    before do
+      allow_any_instance_of(Appeal).to receive(:check_and_load_vacols_data!).and_return(nil)
+    end
+
     subject { AppealRepository.build_appeal(case_record) }
 
     it "returns a new appeal" do
@@ -87,7 +90,11 @@ describe AppealRepository do
   end
 
   context ".set_vacols_values" do
-    before { Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0)) }
+    before do
+      Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+      allow_any_instance_of(Appeal).to receive(:check_and_load_vacols_data!).and_return(nil)
+    end
+
 
     subject do
       appeal = Appeal.new
@@ -169,63 +176,49 @@ describe AppealRepository do
   end
 
   context "#location_after_dispatch" do
-    before do
-      Appeal.repository = Fakes::AppealRepository
+    before { Appeal.repository = Fakes::AppealRepository }
 
-      Fakes::AppealRepository.records = {
-        "123" => Fakes::AppealRepository.appeal_remand_decided,
-        "456" => Fakes::AppealRepository.appeal_partial_grant_decided,
-        "789" => Fakes::AppealRepository.appeal_full_grant_decided
-      }
-
-      # Clear the mock set for Appeal used in all the other AppealRepository tests
-      allow_any_instance_of(Appeal).to receive(:check_and_load_vacols_data!).and_call_original
+    let(:appeal) do
+      Generators::Appeal.build({vacols_record: vacols_record}.merge(special_issues))
     end
+
+    let(:special_issues) { {} }
+
     subject { AppealRepository.location_after_dispatch(appeal: appeal) }
 
-    context "full grant" do
-      let(:appeal) { Appeal.create(vacols_id: "789") }
-
-      it "returns nil" do
-        expect(subject).to eq(nil)
-      end
+    context "when appeal is a full grant" do
+      let(:vacols_record) { :full_grant_decided }
+      it { is_expected.to be_nil }
     end
 
-    context "partial grant" do
-      let(:appeal) { Appeal.create(vacols_id: "456") }
+    context "when appeal is a partial grant" do
+      let(:vacols_record) { :partial_grant_decided }
 
-      it "handles vamc special issue" do
-        expect(appeal.partial_grant?).to eq(true)
-        appeal.vamc = true
-        expect(subject).to eq("54")
+      context "when no special issues" do
+        it { is_expected.to eq("98") }
       end
 
-      it "handles appeal.national_cemetery_administration special issue" do
-        expect(appeal.partial_grant?).to eq(true)
-        appeal.update!(national_cemetery_administration: true)
-        expect(subject).to eq("53")
+      context "when vamc is true" do
+        let(:special_issues) { { vamc: true } }
+        it { is_expected.to eq("54") }
       end
 
-      it "handles no special issue" do
-        expect(appeal.partial_grant?).to eq(true)
-        expect(appeal.special_issues?).to eq(false)
-        expect(subject).to eq("98")
+      context "when national_cemetery_administration is true" do
+        let(:special_issues) { { national_cemetery_administration: true } }
+        it { is_expected.to eq("53") }
       end
 
-      it "handles special issues" do
-        expect(appeal.partial_grant?).to eq(true)
-        appeal.radiation = true
-        expect(subject).to eq "50"
+      context "when a special issue besides vamc and national_cemetery_administration is true" do
+        let(:special_issues) { { radiation: true } }
+        it { is_expected.to eq("50") }
       end
     end
 
     context "remand" do
-      let(:appeal) { Appeal.create(vacols_id: "123") }
+      let(:vacols_record) { :remand }
 
-      it "mirrors partial grant" do
-        expect(appeal.remand?).to eq(true)
-        expect(appeal.special_issues?).to eq(false)
-        expect(subject).to eq("98")
+      context "when no special issues" do
+        it { is_expected.to eq("98") }
       end
     end
   end


### PR DESCRIPTION
Allow VACOLS data to be setup via templates through a flexible API in `Generators::Appeal.build`.

This allowed me to remove all data template methods from Fakes::AppealRepository. Any setup of data is done through Generators in the tests.

Also refactor some of the tests as I went along because I couldn't help it.

connects #1064