### PR TITLE
Fix rake db:setup script

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,9 +97,9 @@ class ApplicationController < ActionController::Base
     Time.zone = current_user.timezone if current_user
   end
 
-  # This is essentially only used for development mode
-  # The config/initialized/fake_dependencies runs on app boot and covers production scenarios
-  # However, in dev mode with class reloading the initializer gets wiped away
+  # Used is used in development mode to:
+  # - Ensure the fakes are loaded (reset in dev mode on file save & class reload)
+  # - Setup the default authenticated user
   def setup_fakes
     Fakes::Initializer.development! if Rails.env.development? || Rails.env.demo?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,7 +97,7 @@ class ApplicationController < ActionController::Base
     Time.zone = current_user.timezone if current_user
   end
 
-  # Used is used in development mode to:
+  # This is used in development mode to:
   # - Ensure the fakes are loaded (reset in dev mode on file save & class reload)
   # - Setup the default authenticated user
   def setup_fakes

--- a/config/initializers/fake_dependencies.rb
+++ b/config/initializers/fake_dependencies.rb
@@ -1,1 +1,1 @@
-Fakes::Initializer.development! if Rails.env.development? || Rails.env.demo?
+Fakes::Initializer.load! if Rails.env.development? || Rails.env.demo?

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -1,6 +1,12 @@
 class Fakes::Initializer
-  def self.development!
+  def self.load!
     User.authentication_service = Fakes::AuthenticationService
+    Appeal.repository = Fakes::AppealRepository
+  end
+
+  def self.development!
+    load!
+
     User.authentication_service.vacols_regional_offices = {
       "DSUSER" => "DSUSER",
       "RO13" => "RO13"
@@ -14,7 +20,6 @@ class Fakes::Initializer
       "name" => "Cave Johnson"
     }
 
-    Appeal.repository = Fakes::AppealRepository
     Fakes::AppealRepository.seed!
   end
 end


### PR DESCRIPTION
- When we run `rake db:migrate` we were loading
  `Fakes::Initializer.development!` , this loads generators but will fail
because the tables are not yet defined. Instead we only want to load the
fake dependencies (load!)