### PR TITLE
Remove VBMSError. Centralize VBMS require statement.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   before_action :verify_authentication
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
-  rescue_from VBMSError, with: :on_vbms_error
+  rescue_from VBMS::ClientError, with: :on_vbms_error
 
   def unauthorized
     render status: 403

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -1,5 +1,3 @@
-require "vbms_error"
-
 class CertificationsController < ApplicationController
   before_action :verify_access
   before_action :set_application

--- a/app/models/tasks/establish_claim.rb
+++ b/app/models/tasks/establish_claim.rb
@@ -1,5 +1,3 @@
-require "vbms"
-
 class EstablishClaim < Task
   include CachedAttributes
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -52,7 +52,7 @@ class AppealRepository
     end
 
     fail ActiveRecord::RecordNotFound if case_records.empty?
-    fail MultipleAppealsByVBMSIDError if case_records.length > 1
+    fail Caseflow::Error::MultipleAppealsByVBMSID if case_records.length > 1
 
     appeal.vacols_id = case_records.first.bfkey
     set_vacols_values(appeal: appeal, case_record: case_records.first)

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -1,5 +1,3 @@
-require "vbms"
-
 # :nocov:
 class VBMSCaseflowLogger
   def log(event, data)
@@ -307,11 +305,11 @@ class AppealRepository
       @vbms_client.send_request(request)
     end
 
-  # rethrow as application-level error
   rescue VBMS::ClientError => e
     Raven.capture_exception(e)
     Rails.logger.error "#{e.message}\n#{e.backtrace.join("\n")}"
-    raise VBMSError
+
+    raise e
   end
 
   def self.fetch_documents_for(appeal)

--- a/app/services/create_establish_claim.rb
+++ b/app/services/create_establish_claim.rb
@@ -22,7 +22,7 @@ class CreateEstablishClaim
 
     establish_claim.prepare!
 
-  rescue MultipleAppealsByVBMSIDError
+  rescue Caseflow::Error::MultipleAppealsByVBMSID
     @error_message = "There were multiple appeals matching this VBMS ID."
   rescue ActiveRecord::RecordNotFound
     @error_message = "Appeal not found for that decision type." \

--- a/app/services/vbms_error.rb
+++ b/app/services/vbms_error.rb
@@ -1,6 +1,3 @@
-class VBMSError < StandardError
-end
-
 class MultipleAppealsByVBMSIDError < StandardError
 end
 

--- a/app/services/vbms_error.rb
+++ b/app/services/vbms_error.rb
@@ -1,5 +1,0 @@
-class MultipleAppealsByVBMSIDError < StandardError
-end
-
-class UnrecognizedDecisionTypeError < StandardError
-end

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# We need this because the autoload pathing to VBMS::HTTPError is messed up in connect_vbms
+require "vbms"
+
 module CaseflowCertification
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -1,0 +1,3 @@
+module Caseflow::Error
+  class MultipleAppealsByVBMSID < StandardError; end
+end

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -98,7 +98,7 @@ class Fakes::AppealRepository
     Rails.logger.info("Decision Type:\n#{decision_type}")
 
     # simulate VACOLS returning 2 appeals for a given vbms_id
-    fail MultipleAppealsByVBMSIDError if RASIE_MULTIPLE_APPEALS_ERROR_ID == appeal[:vbms_id]
+    fail Caseflow::Error::MultipleAppealsByVBMSID if RASIE_MULTIPLE_APPEALS_ERROR_ID == appeal[:vbms_id]
 
     # timing a hash access is unnecessary but this adds coverage to MetricsService in dev mode
     record = MetricsService.record "load appeal #{appeal.vacols_id}" do

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -83,7 +83,7 @@ class Fakes::AppealRepository
       @records[appeal.vacols_id] || fail(ActiveRecord::RecordNotFound)
     end
 
-    fail VBMSError if !record.nil? && RAISE_VBMS_ERROR_ID == record[:vbms_id]
+    fail VBMS::ClientError if !record.nil? && RAISE_VBMS_ERROR_ID == record[:vbms_id]
 
     # This is bad. I'm sorry
     record.delete(:vbms_id) if Rails.env.development?

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require "vbms"
 
 RSpec.feature "Establish Claim - ARC Dispatch" do
   before do


### PR DESCRIPTION
It's pointless and it caused a lot of headaches with debugging this issue: #1281

Change to putting app specific errors in `/lib/caseflow/error.rb` so the auto loader can find them

connects #1281