### PR TITLE
Refactors RadioField to pass `value` instead of `event` into onChange function, fixes inert radio buttons on Sign and Certify

### DIFF
--- a/client/app/certification/Certification.jsx
+++ b/client/app/certification/Certification.jsx
@@ -34,11 +34,9 @@ const UnconnectedEntryPointRedirect = ({ certificationStatus, match }) => {
   }
 };
 
-const mapStateToProps = (state) => {
-  return {
-    certificationStatus: state.certificationStatus
-  };
-};
+const mapStateToProps = (state) => ({
+  certificationStatus: state.certificationStatus
+});
 
 const EntryPointRedirect = connect(
   mapStateToProps

--- a/client/app/certification/CertificationProgressBar.jsx
+++ b/client/app/certification/CertificationProgressBar.jsx
@@ -43,11 +43,9 @@ class UnconnectedCertificationProgressBar extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    currentSection: state.currentSection
-  };
-};
+const mapStateToProps = (state) => ({
+  currentSection: state.currentSection
+});
 
 const CertificationProgressBar = connect(
   mapStateToProps

--- a/client/app/certification/ConfirmCaseDetails.jsx
+++ b/client/app/certification/ConfirmCaseDetails.jsx
@@ -121,11 +121,11 @@ const mapDispatchToProps = (dispatch) => ({
       }
     });
   },
-  onRepresentativeTypeChange: (event) => {
+  onRepresentativeTypeChange: (representativeType) => {
     dispatch({
       type: Constants.CHANGE_REPRESENTATIVE_TYPE,
       payload: {
-        representativeType: event.target.value
+        representativeType
       }
     });
   },

--- a/client/app/certification/ConfirmCaseDetails.jsx
+++ b/client/app/certification/ConfirmCaseDetails.jsx
@@ -104,50 +104,46 @@ class UnconnectedConfirmCaseDetails extends React.Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateProgressBar: () => {
-      dispatch({
-        type: Constants.UPDATE_PROGRESS_BAR,
-        payload: {
-          currentSection: Constants.progressBarSections.CONFIRM_CASE_DETAILS
-        }
-      });
-    },
-    onRepresentativeNameChange: (representativeName) => {
-      dispatch({
-        type: Constants.CHANGE_REPRESENTATIVE_NAME,
-        payload: {
-          representativeName
-        }
-      });
-    },
-    onRepresentativeTypeChange: (event) => {
-      dispatch({
-        type: Constants.CHANGE_REPRESENTATIVE_TYPE,
-        payload: {
-          representativeType: event.target.value
-        }
-      });
-    },
-    onOtherRepresentativeTypeChange: (otherRepresentativeType) => {
-      dispatch({
-        type: Constants.CHANGE_OTHER_REPRESENTATIVE_TYPE,
-        payload: {
-          otherRepresentativeType
-        }
-      });
-    }
-  };
-};
+const mapDispatchToProps = (dispatch) => ({
+  updateProgressBar: () => {
+    dispatch({
+      type: Constants.UPDATE_PROGRESS_BAR,
+      payload: {
+        currentSection: Constants.progressBarSections.CONFIRM_CASE_DETAILS
+      }
+    });
+  },
+  onRepresentativeNameChange: (representativeName) => {
+    dispatch({
+      type: Constants.CHANGE_REPRESENTATIVE_NAME,
+      payload: {
+        representativeName
+      }
+    });
+  },
+  onRepresentativeTypeChange: (event) => {
+    dispatch({
+      type: Constants.CHANGE_REPRESENTATIVE_TYPE,
+      payload: {
+        representativeType: event.target.value
+      }
+    });
+  },
+  onOtherRepresentativeTypeChange: (otherRepresentativeType) => {
+    dispatch({
+      type: Constants.CHANGE_OTHER_REPRESENTATIVE_TYPE,
+      payload: {
+        otherRepresentativeType
+      }
+    });
+  }
+});
 
-const mapStateToProps = (state) => {
-  return {
-    representativeType: state.representativeType,
-    representativeName: state.representativeName,
-    otherRepresentativeType: state.otherRepresentativeType
-  };
-};
+const mapStateToProps = (state) => ({
+  representativeType: state.representativeType,
+  representativeName: state.representativeName,
+  otherRepresentativeType: state.otherRepresentativeType
+});
 
 const ConfirmCaseDetails = connect(
   mapStateToProps,

--- a/client/app/certification/ConfirmHearing.jsx
+++ b/client/app/certification/ConfirmHearing.jsx
@@ -258,27 +258,27 @@ const mapDispatchToProps = (dispatch) => ({
       }
     });
   },
-  onHearingDocumentChange: (event) => {
+  onHearingDocumentChange: (hearingDocumentIsInVbms) => {
     dispatch({
       type: Constants.CHANGE_VBMS_HEARING_DOCUMENT,
       payload: {
-        hearingDocumentIsInVbms: event.target.value
+        hearingDocumentIsInVbms
       }
     });
   },
-  onTypeOfForm9Change: (event) => {
+  onTypeOfForm9Change: (form9Type) => {
     dispatch({
       type: Constants.CHANGE_TYPE_OF_FORM9,
       payload: {
-        form9Type: event.target.value
+        form9Type
       }
     });
   },
-  onHearingTypeChange: (event) => {
+  onHearingTypeChange: (hearingType) => {
     dispatch({
       type: Constants.CHANGE_TYPE_OF_HEARING,
       payload: {
-        hearingType: event.target.value
+        hearingType
       }
     });
   }

--- a/client/app/certification/ConfirmHearing.jsx
+++ b/client/app/certification/ConfirmHearing.jsx
@@ -291,15 +291,12 @@ const mapDispatchToProps = (dispatch) => {
  * application state should be passed in as props to
  * the rendered component.
  */
-const mapStateToProps = (state) => {
-  return {
-    hearingDocumentIsInVbms: state.hearingDocumentIsInVbms,
-    form9Type: state.form9Type,
-    form9Date: state.form9Date,
-    hearingType: state.hearingType
-  };
-};
-
+const mapStateToProps = (state) => ({
+  hearingDocumentIsInVbms: state.hearingDocumentIsInVbms,
+  form9Type: state.form9Type,
+  form9Date: state.form9Date,
+  hearingType: state.hearingType
+});
 
 /*
  * Creates a component that's connected to the Redux store

--- a/client/app/certification/ConfirmHearing.jsx
+++ b/client/app/certification/ConfirmHearing.jsx
@@ -249,42 +249,40 @@ class UnconnectedConfirmHearing extends React.Component {
  * that causes the reducer in reducers/index.js
  * to return a new state object.
  */
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateProgressBar: () => {
-      dispatch({
-        type: Constants.UPDATE_PROGRESS_BAR,
-        payload: {
-          currentSection: Constants.progressBarSections.CONFIRM_HEARING
-        }
-      });
-    },
-    onHearingDocumentChange: (event) => {
-      dispatch({
-        type: Constants.CHANGE_VBMS_HEARING_DOCUMENT,
-        payload: {
-          hearingDocumentIsInVbms: event.target.value
-        }
-      });
-    },
-    onTypeOfForm9Change: (event) => {
-      dispatch({
-        type: Constants.CHANGE_TYPE_OF_FORM9,
-        payload: {
-          form9Type: event.target.value
-        }
-      });
-    },
-    onHearingTypeChange: (event) => {
-      dispatch({
-        type: Constants.CHANGE_TYPE_OF_HEARING,
-        payload: {
-          hearingType: event.target.value
-        }
-      });
-    }
-  };
-};
+const mapDispatchToProps = (dispatch) => ({
+  updateProgressBar: () => {
+    dispatch({
+      type: Constants.UPDATE_PROGRESS_BAR,
+      payload: {
+        currentSection: Constants.progressBarSections.CONFIRM_HEARING
+      }
+    });
+  },
+  onHearingDocumentChange: (event) => {
+    dispatch({
+      type: Constants.CHANGE_VBMS_HEARING_DOCUMENT,
+      payload: {
+        hearingDocumentIsInVbms: event.target.value
+      }
+    });
+  },
+  onTypeOfForm9Change: (event) => {
+    dispatch({
+      type: Constants.CHANGE_TYPE_OF_FORM9,
+      payload: {
+        form9Type: event.target.value
+      }
+    });
+  },
+  onHearingTypeChange: (event) => {
+    dispatch({
+      type: Constants.CHANGE_TYPE_OF_HEARING,
+      payload: {
+        hearingType: event.target.value
+      }
+    });
+  }
+});
 
 /*
  * This function tells us which parts of the global

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -64,6 +64,7 @@ const mapStateToProps = (state) => ({
   socMatch: state.socMatch,
   socDate: state.socDate,
   documentsMatch: state.documentsMatch
+
     /* TODO: add ssoc_match and ssoc_dates */
 });
 

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -56,32 +56,27 @@ class UnconnectedDocumentsCheck extends React.Component {
   }
 }
 
-const mapStateToProps = (state) => {
-  return {
-    form9Match: state.form9Match,
-    form9Date: state.form9Date,
-    nodMatch: state.nodMatch,
-    nodDate: state.nodDate,
-    socMatch: state.socMatch,
-    socDate: state.socDate,
-    documentsMatch: state.documentsMatch
-
+const mapStateToProps = (state) => ({
+  form9Match: state.form9Match,
+  form9Date: state.form9Date,
+  nodMatch: state.nodMatch,
+  nodDate: state.nodDate,
+  socMatch: state.socMatch,
+  socDate: state.socDate,
+  documentsMatch: state.documentsMatch
     /* TODO: add ssoc_match and ssoc_dates */
-  };
-};
+});
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateProgressBar: () => {
-      dispatch({
-        type: Constants.UPDATE_PROGRESS_BAR,
-        payload: {
-          currentSection: Constants.progressBarSections.CHECK_DOCUMENTS
-        }
-      });
-    }
-  };
-};
+const mapDispatchToProps = (dispatch) => ({
+  updateProgressBar: () => {
+    dispatch({
+      type: Constants.UPDATE_PROGRESS_BAR,
+      payload: {
+        currentSection: Constants.progressBarSections.CHECK_DOCUMENTS
+      }
+    });
+  }
+});
 
 /*
  * Creates a component that's connected to the Redux store

--- a/client/app/certification/Header.jsx
+++ b/client/app/certification/Header.jsx
@@ -31,12 +31,10 @@ const UnconnectedHeader = ({
   </div>;
 };
 
-const mapStateToProps = (state) => {
-  return {
-    veteranName: state.veteranName,
-    vbmsId: state.vbmsId
-  };
-};
+const mapStateToProps = (state) => ({
+  veteranName: state.veteranName,
+  vbmsId: state.vbmsId
+});
 
 const Header = connect(
   mapStateToProps

--- a/client/app/certification/SignAndCertify.jsx
+++ b/client/app/certification/SignAndCertify.jsx
@@ -105,15 +105,13 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
-const mapStateToProps = (state) => {
-  return {
-    certifyingOffice: state.certifyingOffice,
-    certifyingUsername: state.certifyingUsername,
-    certifyingOfficialName: state.certifyingOfficialName,
-    certifyingOfficialTitle: state.certifyingOfficialTitle,
-    certificationDate: state.certificationDate
-  };
-};
+const mapStateToProps = (state) => ({
+  certifyingOffice: state.certifyingOffice,
+  certifyingUsername: state.certifyingUsername,
+  certifyingOfficialName: state.certifyingOfficialName,
+  certifyingOfficialTitle: state.certifyingOfficialTitle,
+  certificationDate: state.certificationDate
+});
 
 const SignAndCertify = connect(
   mapStateToProps,

--- a/client/app/certification/SignAndCertify.jsx
+++ b/client/app/certification/SignAndCertify.jsx
@@ -84,26 +84,24 @@ class UnconnectedSignAndCertify extends React.Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    updateProgressBar: () => {
-      dispatch({
-        type: Constants.UPDATE_PROGRESS_BAR,
-        payload: {
-          currentSection: Constants.progressBarSections.SIGN_AND_CERTIFY
-        }
-      });
-    },
-    onSignAndCertifyFormChange: (fieldName, value) => {
-      dispatch({
-        type: Constants.CHANGE_SIGN_AND_CERTIFY_FORM,
-        payload: {
-          [fieldName]: value
-        }
-      });
-    }
-  };
-};
+const mapDispatchToProps = (dispatch) => ({
+  updateProgressBar: () => {
+    dispatch({
+      type: Constants.UPDATE_PROGRESS_BAR,
+      payload: {
+        currentSection: Constants.progressBarSections.SIGN_AND_CERTIFY
+      }
+    });
+  },
+  onSignAndCertifyFormChange: (fieldName, value) => {
+    dispatch({
+      type: Constants.CHANGE_SIGN_AND_CERTIFY_FORM,
+      payload: {
+        [fieldName]: value
+      }
+    });
+  }
+});
 
 const mapStateToProps = (state) => ({
   certifyingOffice: state.certifyingOffice,

--- a/client/app/certification/SignAndCertify.jsx
+++ b/client/app/certification/SignAndCertify.jsx
@@ -43,7 +43,6 @@ class UnconnectedSignAndCertify extends React.Component {
       match
     } = this.props;
 
-
     return <div>
       <form>
         <div className="cf-app-segment cf-app-segment--alt">

--- a/client/app/certification/Success.jsx
+++ b/client/app/certification/Success.jsx
@@ -36,12 +36,10 @@ const UnconnectedSuccess = ({
   </div>;
 };
 
-const mapStateToProps = (state) => {
-  return {
-    veteranName: state.veteranName,
-    vbmsId: state.vbmsId
-  };
-};
+const mapStateToProps = (state) => ({
+  veteranName: state.veteranName,
+  vbmsId: state.vbmsId
+});
 
 const Success = connect(
   mapStateToProps

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -58,7 +58,9 @@ export default class RadioField extends React.Component {
           <div className="cf-form-radio-option" key={`${idPart}-${option.value}-${i}`}>
             <input
               name={name}
-              onChange={onChange}
+              onChange={(event) => {
+                onChange(event.target.value);
+              }}
               type="radio"
               id={`${idPart}_${option.value}`}
               value={option.value}

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
@@ -12,9 +12,9 @@ export default class Example1 extends React.Component {
     };
   }
 
-  onChange = (event) => {
+  onChange = (value) => {
     this.setState({
-      value: event.target.value
+      value
     });
   }
 

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
@@ -12,9 +12,9 @@ export default class Example2 extends React.Component {
     };
   }
 
-  onChange = (event) => {
+  onChange = (value) => {
     this.setState({
-      value: event.target.value
+      value
     });
   }
 

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
@@ -12,9 +12,9 @@ export default class Example3 extends React.Component {
     };
   }
 
-  onChange = (event) => {
+  onChange = (value) => {
     this.setState({
-      value: event.target.value
+      value
     });
   }
 


### PR DESCRIPTION
Refactors RadioField to pass `value` instead of `event` into onChange function. This matches the API of the rest of our React components. 

Also refactors the Redux functions to use slightly nicer and more concise syntax. We can use this syntax when writing any function where the only statement in the function body is returning a function.

Asking Shade and Ari to review since this changeset touches both of their work.

Testing:
![screen shot 2017-04-11 at 2 49 04 pm](https://cloud.githubusercontent.com/assets/3781835/24925373/0c3d0e9e-1ec6-11e7-93f0-34580eaa794d.png)
Sign and Certify radio button works.
All other radio buttons continue to work.