### PR TITLE
Add logging to PrepareEstablishClaimTasksJob

### DIFF
--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -2,6 +2,10 @@ class PrepareEstablishClaimTasksJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    EstablishClaim.unprepared.each(&:prepare_with_decision!)
+    @prepared_count = EstablishClaim.unprepared.inject(0) do |count, task|
+      count + (task.prepare_with_decision! == :success ? 1 : 0)
+    end
+
+    Rails.logger.info "Successfully prepared #{@prepared_count} tasks"
   end
 end

--- a/app/models/tasks/establish_claim.rb
+++ b/app/models/tasks/establish_claim.rb
@@ -86,8 +86,7 @@ class EstablishClaim < Task
 
   def prepare_with_decision!
     try_prepare_with_decision!.tap do |result|
-      Rails.logger.info "Prepared EstablishClaim (id = #{id}),\n" \
-                        "Result: #{result}"
+      Rails.logger.info "Prepared EstablishClaim (id = #{id}), Result: #{result}"
     end
   end
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -312,6 +312,8 @@ class AppealRepository
               end
     documents = send_and_log_request(sanitized_id, request)
 
+    Rails.logger.info("Document list length: #{documents.length}")
+
     documents.map do |vbms_document|
       Document.from_vbms_document(vbms_document)
     end


### PR DESCRIPTION
I'm thumped as to why there were no tasks prepared on a successful monday night job run, but when the job ran later that day 61 tasks were prepared...

- It doesn't seem to have to do with tasks that weren't created:
```
# Monday 2pm to tuesday
> EstablishClaim.where(created_at: 24.hours.ago..Time.now).count
=> 108

# Saturday 2pm to monday
> EstablishClaim.where(created_at: 3.days.ago..1.day.ago).count
=> 0

> # Friday 2pm to saturday
> EstablishClaim.where(created_at: 4.days.ago..3.day.ago).count
> 107

> # Only 2 tasks were prepared tuesday that were created on tuesday
> EstablishClaim.where(created_at: 48.hours.ago..Time.now).where.not(aasm_state: "unprepared").count
```
- There weren't any 500's or errors thrown during the job run.
- There doesn't seem to be any timezone issues in the logic.

My best guess at this point is that VBMS wasn't returning any documents for some reason, but still 200'ing. But I have no way to prove or disprove that.

Best I can do is add some logging to get more insight into what is happening during each job.

<img width="780" alt="screen shot 2017-04-18 at 3 11 06 pm" src="https://cloud.githubusercontent.com/assets/1596259/25149105/40380408-244b-11e7-9674-cc1aa53a36c8.png">

connects https://github.com/department-of-veterans-affairs/appeals-deployment/issues/586