### PR TITLE
Raise error when too few tasks are prepared.

### DIFF
--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -6,6 +6,30 @@ class PrepareEstablishClaimTasksJob < ActiveJob::Base
       count + (task.prepare_with_decision! == :success ? 1 : 0)
     end
 
+    log_result
+  end
+
+  private
+
+  def log_result
     Rails.logger.info "Successfully prepared #{@prepared_count} tasks"
+
+    if workday? && (@prepared_count < expected_minimum)
+      raise Caseflow::Error::NotEnoughTasksPrepared
+    end
+  end
+
+  # TODO: This should include holidays, but don't have a great way to do that.
+  # So we're okay with an error firing on holidays
+  def workday?
+    !(next_workday.saturday? || next_workday.sunday?)
+  end
+
+  def next_workday
+    (Time.now + 12.hours).to_date
+  end
+
+  def expected_minimum
+    10
   end
 end

--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -14,8 +14,12 @@ class PrepareEstablishClaimTasksJob < ActiveJob::Base
   def log_result
     Rails.logger.info "Successfully prepared #{@prepared_count} tasks"
 
+    not_enough_prepared_check!
+  end
+
+  def not_enough_prepared_check!
     if workday? && (@prepared_count < expected_minimum)
-      raise Caseflow::Error::NotEnoughTasksPrepared
+      fail Caseflow::Error::NotEnoughTasksPrepared
     end
   end
 
@@ -26,7 +30,7 @@ class PrepareEstablishClaimTasksJob < ActiveJob::Base
   end
 
   def next_workday
-    (Time.now + 12.hours).to_date
+    (Time.zone.now + 12.hours).to_date
   end
 
   def expected_minimum

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -1,3 +1,4 @@
 module Caseflow::Error
   class MultipleAppealsByVBMSID < StandardError; end
+  class NotEnoughTasksPrepared < StandardError; end
 end

--- a/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
 describe PrepareEstablishClaimTasksJob do
-  before do
-    expect(Appeal.repository).to receive(:fetch_document_file) { "the decision file" }
-  end
-
   let!(:appeal_with_decision_document) do
     Generators::Appeal.create(
       vacols_record: { template: :remand_decided, decision_date: 7.days.ago },
@@ -19,25 +15,55 @@ describe PrepareEstablishClaimTasksJob do
     )
   end
 
-  let!(:preparable_task) do
-    EstablishClaim.create(appeal: appeal_with_decision_document)
-  end
-
   let!(:not_preparable_task) do
     EstablishClaim.create(appeal: appeal_without_decision_document)
   end
 
-  context ".perform" do
+  context ".perform", focus: true do
+    subject { PrepareEstablishClaimTasksJob.perform_now }
+
     let(:filename) { appeal_with_decision_document.decisions.first.file_name }
 
-    it "prepares the correct tasks" do
-      PrepareEstablishClaimTasksJob.perform_now
+    before do
+      allow_any_instance_of(PrepareEstablishClaimTasksJob).to receive(:expected_minimum).and_return(1)
+    end
 
-      expect(preparable_task.reload).to be_unassigned
-      expect(not_preparable_task.reload).to be_unprepared
+    context "when minimum number of tasks are prepared" do
+      let!(:preparable_task) do
+        EstablishClaim.create(appeal: appeal_with_decision_document)
+      end
 
-      # Validate that the decision content is cached in S3
-      expect(S3Service.files[filename]).to eq("the decision file")
+      before do
+        expect(Appeal.repository).to receive(:fetch_document_file) { "the decision file" }
+      end
+
+      it "prepares the correct tasks" do
+        subject
+
+        expect(preparable_task.reload).to be_unassigned
+        expect(not_preparable_task.reload).to be_unprepared
+
+        # Validate that the decision content is cached in S3
+        expect(S3Service.files[filename]).to eq("the decision file")
+      end
+    end
+
+    context "when minimun number of tasks are not prepared" do
+      context "it is the night before a weekend" do
+        before { Timecop.freeze(Time.utc(2017, 5, 12, 22)) }
+
+        it "it completes silently" do
+          expect { subject }.to_not raise_error
+        end
+      end
+
+      context "it is the night before a weekday" do
+        before { Timecop.freeze(Time.utc(2017, 5, 11, 22)) }
+
+        it "raises NotEnoughTasksPrepared" do
+          expect { subject }.to raise_error(Caseflow::Error::NotEnoughTasksPrepared)
+        end
+      end
     end
   end
 end

--- a/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
+++ b/spec/jobs/prepare_establish_claim_tasks_job_spec.rb
@@ -19,7 +19,7 @@ describe PrepareEstablishClaimTasksJob do
     EstablishClaim.create(appeal: appeal_without_decision_document)
   end
 
-  context ".perform", focus: true do
+  context ".perform" do
     subject { PrepareEstablishClaimTasksJob.perform_now }
 
     let(:filename) { appeal_with_decision_document.decisions.first.file_name }


### PR DESCRIPTION
This is an action item for https://github.com/department-of-veterans-affairs/appeals-deployment/issues/586

Testing via automated tests.