### PR TITLE
Anya/1114 update vacols hearing request

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -8,7 +8,7 @@ class CertificationsController < ApplicationController
     status = certification.start!
     @form8 = certification.form8
 
-    if verify_certification_v2_access
+    if FeatureToggle.enabled?(:certification_v2)
       render "v2", layout: "application"
       return
     end
@@ -77,10 +77,6 @@ class CertificationsController < ApplicationController
 
   def verify_access
     verify_authorized_roles("Certify Appeal")
-  end
-
-  def verify_certification_v2_access
-    return true if current_user && current_user.can?("CertificationV2")
   end
 
   def certification

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -316,10 +316,10 @@ class Appeal < ActiveRecord::Base
 
     def certify(appeal)
       form8 = Form8.find_by(vacols_id: appeal.vacols_id)
+      certification = Certification.find_by(vacols_id: appeal.vacols_id)
 
       fail "No Form 8 found for appeal being certified" unless form8
-
-      repository.certify(appeal)
+      repository.certify(appeal: appeal, certification: certification)
       repository.upload_document_to_vbms(appeal, form8)
       repository.clean_document(form8.pdf_location)
     end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -319,6 +319,8 @@ class Appeal < ActiveRecord::Base
       certification = Certification.find_by(vacols_id: appeal.vacols_id)
 
       fail "No Form 8 found for appeal being certified" unless form8
+      fail "No Certification found for appeal being certified" unless certification
+
       repository.certify(appeal: appeal, certification: certification)
       repository.upload_document_to_vbms(appeal, form8)
       repository.clean_document(form8.pdf_location)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,6 +79,9 @@ class User < ActiveRecord::Base
 
   def toggle_admin_roles(role:, enable: true)
     return if role == "System Admin"
+    if role == "CertificationV2"
+      enable ? FeatureToggle.enable!(:certification_v2) : FeatureToggle.disable!(:certification_v2)
+    end
     enable ? admin_roles << role : admin_roles.delete(role)
   end
 

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -98,6 +98,15 @@ class VACOLS::Case < VACOLS::Record
     "5" => :none
   }.freeze
 
+  HEARING_PREFERENCE_TYPES_V2 = {
+    VIDEO: { vacols_value: "2", video_hearing: true },
+    TRAVEL_BOARD: { vacols_value: "2" },
+    WASHINGTON_DC: { vacols_value: "1" },
+    HEARING_TYPE_NOT_SPECIFIED: { vacols_value: "2", video_hearing: true },
+    NO_HEARING_DESIRED: { vacols_value: "5" },
+    HEARING_CANCELLED: { vacols_value: "5" }
+  }.freeze
+
   # NOTE(jd): This is a list of the valid locations that Caseflow
   # supports updating an appeal to. This is a subset of the overall locations
   # supported in VACOLS

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -207,7 +207,7 @@ class AppealRepository
     "98"
   end
 
-  def self.certify(appeal)
+  def self.certify(appeal:, certification:)
     certification_date = AppealRepository.dateshift_to_utc Time.zone.now
 
     # TODO(alex):
@@ -220,7 +220,13 @@ class AppealRepository
     appeal.case_record.bfdcertool = certification_date
     appeal.case_record.bf41stat = certification_date
 
-    appeal.case_record.bftbind = "X" if appeal.hearing_request_type == :travel_board
+    # Certification v2 - use the hearing preference that the user confirms.
+    if certification.hearing_preference
+      appeal.case_record.bfhr = VACOLS::Case::HEARING_REQUEST_TYPES.key(certification.hearing_preference)
+      appeal.case_record.bftbind = "X" if certification.hearing_preference == :travel_board
+    else
+      appeal.case_record.bftbind = "X" if appeal.hearing_request_type == :travel_board
+    end
 
     MetricsService.record("VACOLS: certify #{appeal.vacols_id}",
                           service: :vacols,

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -51,6 +51,7 @@ class Fakes::AppealRepository
   end
 
   def self.certify(appeal:, certification:)
+    @certification = certification
     @certified_appeal = appeal
     VBMSCaseflowLogger.log(:request, response_code: 500)
   end

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -50,7 +50,7 @@ class Fakes::AppealRepository
     appeal
   end
 
-  def self.certify(appeal)
+  def self.certify(appeal:, certification:)
     @certified_appeal = appeal
     VBMSCaseflowLogger.log(:request, response_code: 500)
   end

--- a/spec/feature/start_certification_spec.rb
+++ b/spec/feature/start_certification_spec.rb
@@ -81,6 +81,14 @@ RSpec.feature "Start Certification" do
   context "As an authorized user for Certification V2" do
     let!(:current_user) { User.authenticate!(roles: ["Certify Appeal", "CertificationV2"]) }
 
+    before(:all) do
+      FeatureToggle.enable!(:certification_v2)
+    end
+
+    after(:all) do
+      FeatureToggle.disable!(:certification_v2)
+    end
+
     scenario "Starting a Certification v2 with matching documents" do
       visit "certifications/new/#{appeal_ready.vacols_id}"
       expect(page).to have_current_path("/certifications/#{appeal_ready.vacols_id}/check_documents")

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -238,7 +238,10 @@ describe Appeal do
     subject { appeal.certify! }
 
     context "when form8 for appeal exists in the DB" do
-      before { @form8 = Form8.create(vacols_id: "765") }
+      before do
+        @form8 = Form8.create(vacols_id: "765")
+        @certification = Certification.create(vacols_id: "765")
+      end
 
       it "certifies the appeal using AppealRepository" do
         expect { subject }.to_not raise_error

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -112,6 +112,7 @@ User.prepend(StubbableUser)
 
 def reset_application!
   User.clear_stub!
+  FeatureToggle.disable!(:certification_v2)
   Fakes::AppealRepository.clean!
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -112,7 +112,6 @@ User.prepend(StubbableUser)
 
 def reset_application!
   User.clear_stub!
-  FeatureToggle.disable!(:certification_v2)
   Fakes::AppealRepository.clean!
 end
 


### PR DESCRIPTION
connects #1114 

Testing:
1. All existing tests pass 
2. Manual testing:
* Point to the integration environment locally and use appeal with vacols_id: 2765724
* Enable v2 role along with v1 role
* Uncertify the appeal, set `hearing_prefence` to "VIDEO" on the certification record in the DB that is associated with the appeal to certify 
* Certify the appeal and check Vacols that `case_record.bfhr` is equal to “2” and case_record.bftbind is equal to “X”
* Then uncertify the appeal, set `hearing_preference` to "WASHINGTON_DC"
* Certify the appeal again and check Vacols that `case_record.bfhr` is equal to “1” and case_record.bftbind is equal to nil
* Disable v2 role and ensure v1 works as expected
