### PR TITLE
Fix the styling on the sidebar

### DIFF
--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -77,7 +77,8 @@ svg[aria-hidden=true],
 // scss-lint:enable QualifyingElement
 
 .cf-sidebar-wrapper {
-  float: right;
+  display: flex;
+  flex-direction: column;
   width: 380px;
   top: 0;
   bottom: 0;
@@ -103,9 +104,6 @@ svg[aria-hidden=true],
 
 .cf-comment-wrapper {
   padding: 0 30px;
-  position: absolute;
-  top: 328px;
-  bottom: 0;
   width: 380px;
   overflow-y: scroll;
 }


### PR DESCRIPTION
Currently the comment wrapper in the sidebar is absolutely positioned... Which makes editing the sidebar very difficult. We're moving to a flex layout.

**Test Plan**
- [x] Make sure you can still scroll comments without scrolling the sidebar.