### PR TITLE
Standardize on single quotes

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -192,6 +192,7 @@ module.exports = {
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
+    "quotes": ["warn", "single", {"avoidEscape": true}],
     "radix": "error",
     "rest-spread-spacing": "error",
     "semi": "error",

--- a/client/app/certification/CancelCertificationModal.jsx
+++ b/client/app/certification/CancelCertificationModal.jsx
@@ -17,9 +17,9 @@ export default class CancelCertificationModal extends BaseForm {
     super(props);
     this.state = {
       shouldShowOtherReason: false,
-      cancellationReasonValue: '',
-      otherReasonValue: '',
-      emailValue: '',
+      cancellationReasonValue: "",
+      otherReasonValue: "",
+      emailValue: "",
       certificationCancellationForm: {
         cancellationReason: new FormField(
           '',
@@ -42,7 +42,7 @@ export default class CancelCertificationModal extends BaseForm {
       cancellationReasonValue: value
     });
 
-    if (value === 'Other') {
+    if (value === "Other") {
       this.setState({
         shouldShowOtherReason: true
       });
@@ -86,7 +86,7 @@ export default class CancelCertificationModal extends BaseForm {
   }
 
   validateForm = () => {
-    if (this.state.cancellationReasonValue === 'Other') {
+    if (this.state.cancellationReasonValue === "Other") {
       return this.validateFormAndSetErrors(this.state.certificationCancellationForm);
     }
 
@@ -115,7 +115,7 @@ export default class CancelCertificationModal extends BaseForm {
 
     let data = this.prepareData();
 
-    return ApiUtil.post('/certification_cancellations', { data }).
+    return ApiUtil.post(`/certification_cancellations`, { data }).
       then(() => {
         this.props.closeHandler();
 
@@ -133,22 +133,22 @@ export default class CancelCertificationModal extends BaseForm {
     let cancellationReasonOptions = [
       { displayText: "VBMS and VACOLS dates didn't match and couldn't be changed",
         value: "VBMS and VACOLS dates didn't match and couldn't be changed" },
-      { displayText: 'Missing document could not be found',
-        value: 'Missing document could not be found' },
-      { displayText: 'Pending FOIA request',
-        value: 'Pending FOIA request' },
-      { displayText: 'Other',
-        value: 'Other' }
+      { displayText: "Missing document could not be found",
+        value: "Missing document could not be found" },
+      { displayText: "Pending FOIA request",
+        value: "Pending FOIA request" },
+      { displayText: "Other",
+        value: "Other" }
     ];
 
     return <div>
       <Modal
             buttons={[
-              { classNames: ['cf-modal-link', 'cf-btn-link'],
+              { classNames: ["cf-modal-link", "cf-btn-link"],
                 name: '\u226A Go back',
                 onClick: closeHandler
               },
-              { classNames: ['usa-button', 'usa-button-secondary'],
+              { classNames: ["usa-button", "usa-button-secondary"],
                 name: 'Cancel certification',
                 onClick: this.submitForm
               }

--- a/client/app/certification/CancelCertificationModal.jsx
+++ b/client/app/certification/CancelCertificationModal.jsx
@@ -17,9 +17,9 @@ export default class CancelCertificationModal extends BaseForm {
     super(props);
     this.state = {
       shouldShowOtherReason: false,
-      cancellationReasonValue: "",
-      otherReasonValue: "",
-      emailValue: "",
+      cancellationReasonValue: '',
+      otherReasonValue: '',
+      emailValue: '',
       certificationCancellationForm: {
         cancellationReason: new FormField(
           '',
@@ -42,7 +42,7 @@ export default class CancelCertificationModal extends BaseForm {
       cancellationReasonValue: value
     });
 
-    if (value === "Other") {
+    if (value === 'Other') {
       this.setState({
         shouldShowOtherReason: true
       });
@@ -86,7 +86,7 @@ export default class CancelCertificationModal extends BaseForm {
   }
 
   validateForm = () => {
-    if (this.state.cancellationReasonValue === "Other") {
+    if (this.state.cancellationReasonValue === 'Other') {
       return this.validateFormAndSetErrors(this.state.certificationCancellationForm);
     }
 
@@ -115,7 +115,7 @@ export default class CancelCertificationModal extends BaseForm {
 
     let data = this.prepareData();
 
-    return ApiUtil.post(`/certification_cancellations`, { data }).
+    return ApiUtil.post('/certification_cancellations', { data }).
       then(() => {
         this.props.closeHandler();
 
@@ -133,22 +133,22 @@ export default class CancelCertificationModal extends BaseForm {
     let cancellationReasonOptions = [
       { displayText: "VBMS and VACOLS dates didn't match and couldn't be changed",
         value: "VBMS and VACOLS dates didn't match and couldn't be changed" },
-      { displayText: "Missing document could not be found",
-        value: "Missing document could not be found" },
-      { displayText: "Pending FOIA request",
-        value: "Pending FOIA request" },
-      { displayText: "Other",
-        value: "Other" }
+      { displayText: 'Missing document could not be found',
+        value: 'Missing document could not be found' },
+      { displayText: 'Pending FOIA request',
+        value: 'Pending FOIA request' },
+      { displayText: 'Other',
+        value: 'Other' }
     ];
 
     return <div>
       <Modal
             buttons={[
-              { classNames: ["cf-modal-link", "cf-btn-link"],
+              { classNames: ['cf-modal-link', 'cf-btn-link'],
                 name: '\u226A Go back',
                 onClick: closeHandler
               },
-              { classNames: ["usa-button", "usa-button-secondary"],
+              { classNames: ['usa-button', 'usa-button-secondary'],
                 name: 'Cancel certification',
                 onClick: this.submitForm
               }

--- a/client/app/certification/ConfirmCaseDetails.jsx
+++ b/client/app/certification/ConfirmCaseDetails.jsx
@@ -10,23 +10,23 @@ import Footer from './Footer';
 
 const representativeTypeOptions = [
   {
-    displayText: 'Attorney',
+    displayText: "Attorney",
     value: Constants.representativeTypes.ATTORNEY
   },
   {
-    displayText: 'Agent',
+    displayText: "Agent",
     value: Constants.representativeTypes.AGENT
   },
   {
-    displayText: 'Organization',
+    displayText: "Organization",
     value: Constants.representativeTypes.ORGANIZATION
   },
   {
-    displayText: 'None',
+    displayText: "None",
     value: Constants.representativeTypes.NONE
   },
   {
-    displayText: 'Other',
+    displayText: "Other",
     value: Constants.representativeTypes.OTHER
   }
 ];

--- a/client/app/certification/ConfirmCaseDetails.jsx
+++ b/client/app/certification/ConfirmCaseDetails.jsx
@@ -10,23 +10,23 @@ import Footer from './Footer';
 
 const representativeTypeOptions = [
   {
-    displayText: "Attorney",
+    displayText: 'Attorney',
     value: Constants.representativeTypes.ATTORNEY
   },
   {
-    displayText: "Agent",
+    displayText: 'Agent',
     value: Constants.representativeTypes.AGENT
   },
   {
-    displayText: "Organization",
+    displayText: 'Organization',
     value: Constants.representativeTypes.ORGANIZATION
   },
   {
-    displayText: "None",
+    displayText: 'None',
     value: Constants.representativeTypes.NONE
   },
   {
-    displayText: "Other",
+    displayText: 'Other',
     value: Constants.representativeTypes.OTHER
   }
 ];

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -32,10 +32,10 @@ class UnconnectedDocumentsCheck extends React.Component {
       certificationId
     } = this.props;
 
-    if (certificationStatus === "data_missing") {
+    if (certificationStatus === 'data_missing') {
       return <NotReady/>;
     }
-    if (certificationStatus === "already_certified") {
+    if (certificationStatus === 'already_certified') {
       return <AlreadyCertified/>;
     }
 

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -32,10 +32,10 @@ class UnconnectedDocumentsCheck extends React.Component {
       certificationId
     } = this.props;
 
-    if (certificationStatus === 'data_missing') {
+    if (certificationStatus === "data_missing") {
       return <NotReady/>;
     }
-    if (certificationStatus === 'already_certified') {
+    if (certificationStatus === "already_certified") {
       return <AlreadyCertified/>;
     }
 

--- a/client/app/certification/Footer.jsx
+++ b/client/app/certification/Footer.jsx
@@ -40,12 +40,12 @@ export default class Footer extends React.Component {
       <Button
             name="Cancel Certification"
             onClick={this.handleModalOpen}
-            classNames={['cf-btn-link']}
+            classNames={["cf-btn-link"]}
       />
       { !hideContinue && <Link to={nextPageUrl || '#'}>
         <Button type="button"
           name="Continue"
-          classNames={['cf-push-right']}
+          classNames={["cf-push-right"]}
           onClick={onClickContinue}
           loading={loading}
           disabled={disableContinue}>

--- a/client/app/certification/Footer.jsx
+++ b/client/app/certification/Footer.jsx
@@ -40,12 +40,12 @@ export default class Footer extends React.Component {
       <Button
             name="Cancel Certification"
             onClick={this.handleModalOpen}
-            classNames={["cf-btn-link"]}
+            classNames={['cf-btn-link']}
       />
       { !hideContinue && <Link to={nextPageUrl || '#'}>
         <Button type="button"
           name="Continue"
-          classNames={["cf-push-right"]}
+          classNames={['cf-push-right']}
           onClick={onClickContinue}
           loading={loading}
           disabled={disableContinue}>

--- a/client/app/components/Button.jsx
+++ b/client/app/components/Button.jsx
@@ -27,7 +27,7 @@ export default class Button extends React.Component {
     let LoadingIndicator = () => {
       app = app || 'default';
 
-      children = loadingText || "Loading...";
+      children = loadingText || 'Loading...';
 
       return <span>
         <button
@@ -58,7 +58,7 @@ export default class Button extends React.Component {
     return <span>
       <button
         id={id || `${type}-${name.replace(/\s/g, '-')}`}
-        className={classNames.join(' ') + (loading ? " hidden-field" : "")}
+        className={classNames.join(' ') + (loading ? ' hidden-field' : '')}
         type={type}
         disabled={disabled}
         onClick={onClick}

--- a/client/app/components/Button.jsx
+++ b/client/app/components/Button.jsx
@@ -27,7 +27,7 @@ export default class Button extends React.Component {
     let LoadingIndicator = () => {
       app = app || 'default';
 
-      children = loadingText || 'Loading...';
+      children = loadingText || "Loading...";
 
       return <span>
         <button
@@ -58,7 +58,7 @@ export default class Button extends React.Component {
     return <span>
       <button
         id={id || `${type}-${name.replace(/\s/g, '-')}`}
-        className={classNames.join(' ') + (loading ? ' hidden-field' : '')}
+        className={classNames.join(' ') + (loading ? " hidden-field" : "")}
         type={type}
         disabled={disabled}
         onClick={onClick}

--- a/client/app/components/CheckboxGroup.jsx
+++ b/client/app/components/CheckboxGroup.jsx
@@ -21,14 +21,14 @@ export default class CheckboxGroup extends React.Component {
     let fieldClasses = `checkbox-wrapper-${name} cf-form-checkboxes`;
 
     if (options.length <= this.MAX && !vertical) {
-      fieldClasses += '-inline';
+      fieldClasses += "-inline";
     }
 
     if (errorMessage) {
-      fieldClasses += ' usa-input-error';
+      fieldClasses += " usa-input-error";
     }
 
-    let legendClasses = (hideLabel) ? 'hidden-field' : '';
+    let legendClasses = (hideLabel) ? "hidden-field" : "";
 
     return <fieldset className={fieldClasses}>
       <legend className={legendClasses}>

--- a/client/app/components/CheckboxGroup.jsx
+++ b/client/app/components/CheckboxGroup.jsx
@@ -21,14 +21,14 @@ export default class CheckboxGroup extends React.Component {
     let fieldClasses = `checkbox-wrapper-${name} cf-form-checkboxes`;
 
     if (options.length <= this.MAX && !vertical) {
-      fieldClasses += "-inline";
+      fieldClasses += '-inline';
     }
 
     if (errorMessage) {
-      fieldClasses += " usa-input-error";
+      fieldClasses += ' usa-input-error';
     }
 
-    let legendClasses = (hideLabel) ? "hidden-field" : "";
+    let legendClasses = (hideLabel) ? 'hidden-field' : '';
 
     return <fieldset className={fieldClasses}>
       <legend className={legendClasses}>

--- a/client/app/components/Comment.jsx
+++ b/client/app/components/Comment.jsx
@@ -25,7 +25,7 @@ export default class Comment extends React.Component {
     return <div>
         <Button
           name="delete"
-          classNames={['cf-btn-link comment-control-button']}
+          classNames={["cf-btn-link comment-control-button"]}
           onClick={this.onDeleteComment}>
           Delete
         </Button>
@@ -34,7 +34,7 @@ export default class Comment extends React.Component {
         </span>
         <Button
           name="edit"
-          classNames={['cf-btn-link comment-control-button']}
+          classNames={["cf-btn-link comment-control-button"]}
           onClick={this.onEditComment}>
           Edit
         </Button>
@@ -53,7 +53,7 @@ export default class Comment extends React.Component {
     if (this.props.onJumpToComment) {
       jumpToSectionButton = <Button
           name="jumpToComment"
-          classNames={['cf-btn-link comment-control-button']}
+          classNames={["cf-btn-link comment-control-button"]}
           onClick={this.props.onJumpToComment}>
           Jump to Section
         </Button>;

--- a/client/app/components/Comment.jsx
+++ b/client/app/components/Comment.jsx
@@ -25,7 +25,7 @@ export default class Comment extends React.Component {
     return <div>
         <Button
           name="edit"
-          classNames={["cf-btn-link comment-control-button"]}
+          classNames={['cf-btn-link comment-control-button']}
           onClick={this.onEditComment}>
           Edit
         </Button>
@@ -34,7 +34,7 @@ export default class Comment extends React.Component {
         </span>
         <Button
           name="delete"
-          classNames={["cf-btn-link comment-control-button"]}
+          classNames={['cf-btn-link comment-control-button']}
           onClick={this.onDeleteComment}>
           Delete
         </Button>
@@ -53,7 +53,7 @@ export default class Comment extends React.Component {
     if (this.props.onJumpToComment) {
       jumpToSectionButton = <Button
           name="jumpToComment"
-          classNames={["cf-btn-link comment-control-button"]}
+          classNames={['cf-btn-link comment-control-button']}
           onClick={this.props.onJumpToComment}>
           Jump to Section
         </Button>;

--- a/client/app/components/Comment.jsx
+++ b/client/app/components/Comment.jsx
@@ -25,7 +25,7 @@ export default class Comment extends React.Component {
     return <div>
         <Button
           name="delete"
-          classNames={["cf-btn-link comment-control-button"]}
+          classNames={['cf-btn-link comment-control-button']}
           onClick={this.onDeleteComment}>
           Delete
         </Button>
@@ -34,7 +34,7 @@ export default class Comment extends React.Component {
         </span>
         <Button
           name="edit"
-          classNames={["cf-btn-link comment-control-button"]}
+          classNames={['cf-btn-link comment-control-button']}
           onClick={this.onEditComment}>
           Edit
         </Button>
@@ -53,7 +53,7 @@ export default class Comment extends React.Component {
     if (this.props.onJumpToComment) {
       jumpToSectionButton = <Button
           name="jumpToComment"
-          classNames={["cf-btn-link comment-control-button"]}
+          classNames={['cf-btn-link comment-control-button']}
           onClick={this.props.onJumpToComment}>
           Jump to Section
         </Button>;

--- a/client/app/components/EditComment.jsx
+++ b/client/app/components/EditComment.jsx
@@ -64,7 +64,7 @@ export default class EditComment extends React.Component {
           <span className="cf-right-side">
             <Button
               name="cancel"
-              classNames={['cf-btn-link']}
+              classNames={["cf-btn-link"]}
               onClick={this.cancelEdit}>
               Cancel
             </Button>

--- a/client/app/components/EditComment.jsx
+++ b/client/app/components/EditComment.jsx
@@ -72,7 +72,7 @@ export default class EditComment extends BaseForm {
           <span className="cf-right-side">
             <Button
               name="cancel"
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
               onClick={this.cancelEdit}>
               Cancel
             </Button>

--- a/client/app/components/EditComment.jsx
+++ b/client/app/components/EditComment.jsx
@@ -64,7 +64,7 @@ export default class EditComment extends React.Component {
           <span className="cf-right-side">
             <Button
               name="cancel"
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
               onClick={this.cancelEdit}>
               Cancel
             </Button>

--- a/client/app/components/Modal.jsx
+++ b/client/app/components/Modal.jsx
@@ -25,21 +25,21 @@ export default class Modal extends React.Component {
   }
 
   keyHandler = (event) => {
-    if (event.key === "Escape") {
+    if (event.key === 'Escape') {
       this.props.closeHandler();
     }
 
-    if (event.key === "Tab") {
+    if (event.key === 'Tab') {
       this.handleTab(event);
     }
   }
 
   componentWillUnmount() {
-    window.removeEventListener("keydown", this.keyHandler);
+    window.removeEventListener('keydown', this.keyHandler);
   }
 
   componentDidMount() {
-    window.addEventListener("keydown", this.keyHandler);
+    window.addEventListener('keydown', this.keyHandler);
   }
 
   generateButtons() {
@@ -47,10 +47,10 @@ export default class Modal extends React.Component {
       // If we have more than two buttons, push the
       // first left, and the rest right.
       // If we have just one button, push it right.
-      let classNames = ["cf-push-right"];
+      let classNames = ['cf-push-right'];
 
       if (i === 0 && this.props.buttons.length > 1) {
-        classNames = ["cf-push-left"];
+        classNames = ['cf-push-left'];
       }
 
       if (typeof object.classNames !== 'undefined') {

--- a/client/app/components/Modal.jsx
+++ b/client/app/components/Modal.jsx
@@ -25,21 +25,21 @@ export default class Modal extends React.Component {
   }
 
   keyHandler = (event) => {
-    if (event.key === 'Escape') {
+    if (event.key === "Escape") {
       this.props.closeHandler();
     }
 
-    if (event.key === 'Tab') {
+    if (event.key === "Tab") {
       this.handleTab(event);
     }
   }
 
   componentWillUnmount() {
-    window.removeEventListener('keydown', this.keyHandler);
+    window.removeEventListener("keydown", this.keyHandler);
   }
 
   componentDidMount() {
-    window.addEventListener('keydown', this.keyHandler);
+    window.addEventListener("keydown", this.keyHandler);
   }
 
   generateButtons() {
@@ -47,10 +47,10 @@ export default class Modal extends React.Component {
       // If we have more than two buttons, push the
       // first left, and the rest right.
       // If we have just one button, push it right.
-      let classNames = ['cf-push-right'];
+      let classNames = ["cf-push-right"];
 
       if (i === 0 && this.props.buttons.length > 1) {
-        classNames = ['cf-push-left'];
+        classNames = ["cf-push-left"];
       }
 
       if (typeof object.classNames !== 'undefined') {

--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -356,7 +356,7 @@ export class Pdf extends React.Component {
       }}>
         <div
           id={this.props.file}
-          className={`cf-pdf-page pdfViewer singlePageView`}>
+          className={'cf-pdf-page pdfViewer singlePageView'}>
           {pages}
         </div>
       </div>;

--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -356,7 +356,7 @@ export class Pdf extends React.Component {
       }}>
         <div
           id={this.props.file}
-          className={'cf-pdf-page pdfViewer singlePageView'}>
+          className={`cf-pdf-page pdfViewer singlePageView`}>
           {pages}
         </div>
       </div>;

--- a/client/app/components/PdfSidebar.jsx
+++ b/client/app/components/PdfSidebar.jsx
@@ -103,7 +103,7 @@ export default class PdfSidebar extends React.Component {
         <div className="cf-sidebar-header">
           <Button
             name="hide menu"
-            classNames={["cf-pdf-button"]}>
+            classNames={['cf-pdf-button']}>
             <strong>
               Hide Menu <i className="fa fa-chevron-right" aria-hidden="true"></i>
             </strong>
@@ -114,7 +114,7 @@ export default class PdfSidebar extends React.Component {
             <b>Document Type:</b> {this.props.doc.type}
             <Button
               name="download"
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
               ariaLabel="download"
             >
               <i className="cf-pdf-button fa fa-download" aria-hidden="true"></i>

--- a/client/app/components/PdfSidebar.jsx
+++ b/client/app/components/PdfSidebar.jsx
@@ -103,7 +103,7 @@ export default class PdfSidebar extends React.Component {
         <div className="cf-sidebar-header">
           <Button
             name="hide menu"
-            classNames={['cf-pdf-button']}>
+            classNames={["cf-pdf-button"]}>
             <strong>
               Hide Menu <i className="fa fa-chevron-right" aria-hidden="true"></i>
             </strong>
@@ -114,7 +114,7 @@ export default class PdfSidebar extends React.Component {
             <b>Document Type:</b> {this.props.doc.type}
             <Button
               name="download"
-              classNames={['cf-btn-link']}
+              classNames={["cf-btn-link"]}
               ariaLabel="download"
             >
               <i className="cf-pdf-button fa fa-download" aria-hidden="true"></i>

--- a/client/app/components/PdfUI.jsx
+++ b/client/app/components/PdfUI.jsx
@@ -73,7 +73,7 @@ export default class PdfUI extends React.Component {
           { this.props.onShowList &&
             <Button
               name="backToDocuments"
-              classNames={["cf-pdf-button"]}
+              classNames={['cf-pdf-button']}
               onClick={this.props.onShowList}>
               <i className="fa fa-chevron-left" aria-hidden="true"></i>
               &nbsp; View all documents
@@ -82,21 +82,21 @@ export default class PdfUI extends React.Component {
         <span className="usa-width-one-third cf-pdf-buttons-center">
           <Button
             name="zoomOut"
-            classNames={["cf-pdf-button cf-pdf-spaced-buttons"]}
+            classNames={['cf-pdf-button cf-pdf-spaced-buttons']}
             onClick={this.zoom(-ZOOM_RATE)}
             ariaLabel="zoom out">
             <i className="fa fa-minus" aria-hidden="true"></i>
           </Button>
           <Button
             name="fit"
-            classNames={["cf-pdf-button cf-pdf-spaced-buttons"]}
+            classNames={['cf-pdf-button cf-pdf-spaced-buttons']}
             onClick={this.fitToScreen}
             ariaLabel="fit to screen">
             <i className="fa fa-arrows-alt" aria-hidden="true"></i>
           </Button>
           <Button
             name="zoomIn"
-            classNames={["cf-pdf-button cf-pdf-spaced-buttons"]}
+            classNames={['cf-pdf-button cf-pdf-spaced-buttons']}
             onClick={this.zoom(ZOOM_RATE)}
             ariaLabel="zoom in">
             <i className="fa fa-plus" aria-hidden="true"></i>
@@ -107,7 +107,7 @@ export default class PdfUI extends React.Component {
             <DocumentCategoryIcons docId={this.props.doc.id} />
             <Button
               name="newTab"
-              classNames={["cf-pdf-button"]}
+              classNames={['cf-pdf-button']}
               ariaLabel="open document in new tab"
               onClick={() => window.open(
                 linkToSingleDocumentView(this.props.doc), '_blank')}>
@@ -121,7 +121,7 @@ export default class PdfUI extends React.Component {
           <span className="cf-pdf-buttons-left">
             <Button
               name="previous"
-              classNames={["cf-pdf-button"]}
+              classNames={['cf-pdf-button']}
               onClick={this.props.onPreviousPdf}
               ariaLabel="previous PDF">
               <i className="fa fa-arrow-circle-left fa-3x" aria-hidden="true"></i>
@@ -131,7 +131,7 @@ export default class PdfUI extends React.Component {
           <span className="cf-pdf-buttons-right">
             <Button
               name="next"
-              classNames={["cf-pdf-button cf-right-side"]}
+              classNames={['cf-pdf-button cf-right-side']}
               onClick={this.props.onNextPdf}
               ariaLabel="next PDF">
               <i className="fa fa-arrow-circle-right fa-3x" aria-hidden="true"></i>

--- a/client/app/components/PdfUI.jsx
+++ b/client/app/components/PdfUI.jsx
@@ -73,7 +73,7 @@ export default class PdfUI extends React.Component {
           { this.props.onShowList &&
             <Button
               name="backToDocuments"
-              classNames={['cf-pdf-button']}
+              classNames={["cf-pdf-button"]}
               onClick={this.props.onShowList}>
               <i className="fa fa-chevron-left" aria-hidden="true"></i>
               &nbsp; View all documents
@@ -82,21 +82,21 @@ export default class PdfUI extends React.Component {
         <span className="usa-width-one-third cf-pdf-buttons-center">
           <Button
             name="zoomOut"
-            classNames={['cf-pdf-button cf-pdf-spaced-buttons']}
+            classNames={["cf-pdf-button cf-pdf-spaced-buttons"]}
             onClick={this.zoom(-ZOOM_RATE)}
             ariaLabel="zoom out">
             <i className="fa fa-minus" aria-hidden="true"></i>
           </Button>
           <Button
             name="fit"
-            classNames={['cf-pdf-button cf-pdf-spaced-buttons']}
+            classNames={["cf-pdf-button cf-pdf-spaced-buttons"]}
             onClick={this.fitToScreen}
             ariaLabel="fit to screen">
             <i className="fa fa-arrows-alt" aria-hidden="true"></i>
           </Button>
           <Button
             name="zoomIn"
-            classNames={['cf-pdf-button cf-pdf-spaced-buttons']}
+            classNames={["cf-pdf-button cf-pdf-spaced-buttons"]}
             onClick={this.zoom(ZOOM_RATE)}
             ariaLabel="zoom in">
             <i className="fa fa-plus" aria-hidden="true"></i>
@@ -107,7 +107,7 @@ export default class PdfUI extends React.Component {
             <DocumentCategoryIcons docId={this.props.doc.id} />
             <Button
               name="newTab"
-              classNames={['cf-pdf-button']}
+              classNames={["cf-pdf-button"]}
               ariaLabel="open document in new tab"
               onClick={() => window.open(
                 linkToSingleDocumentView(this.props.doc), '_blank')}>
@@ -121,7 +121,7 @@ export default class PdfUI extends React.Component {
           <span className="cf-pdf-buttons-left">
             <Button
               name="previous"
-              classNames={['cf-pdf-button']}
+              classNames={["cf-pdf-button"]}
               onClick={this.props.onPreviousPdf}
               ariaLabel="previous PDF">
               <i className="fa fa-arrow-circle-left fa-3x" aria-hidden="true"></i>
@@ -131,7 +131,7 @@ export default class PdfUI extends React.Component {
           <span className="cf-pdf-buttons-right">
             <Button
               name="next"
-              classNames={['cf-pdf-button cf-right-side']}
+              classNames={["cf-pdf-button cf-right-side"]}
               onClick={this.props.onNextPdf}
               ariaLabel="next PDF">
               <i className="fa fa-arrow-circle-right fa-3x" aria-hidden="true"></i>

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -32,15 +32,15 @@ export default class RadioField extends React.Component {
     required = required || false;
 
     let radioClass = className.concat(
-      this.isVertical() ? "cf-form-radio" : "cf-form-radio-inline"
+      this.isVertical() ? 'cf-form-radio' : 'cf-form-radio-inline'
     ).concat(
-      errorMessage ? "usa-input-error" : ""
+      errorMessage ? 'usa-input-error' : ''
     );
 
-    let labelClass = "question-label";
+    let labelClass = 'question-label';
 
     if (hideLabel) {
-      labelClass += " hidden-field";
+      labelClass += ' hidden-field';
     }
 
     // Since HTML5 IDs should not contain spaces...
@@ -75,7 +75,7 @@ export default class RadioField extends React.Component {
 }
 
 RadioField.defaultProps = {
-  className: ["cf-form-showhide-radio"]
+  className: ['cf-form-showhide-radio']
 };
 
 RadioField.propTypes = {

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -32,15 +32,15 @@ export default class RadioField extends React.Component {
     required = required || false;
 
     let radioClass = className.concat(
-      this.isVertical() ? 'cf-form-radio' : 'cf-form-radio-inline'
+      this.isVertical() ? "cf-form-radio" : "cf-form-radio-inline"
     ).concat(
-      errorMessage ? 'usa-input-error' : ''
+      errorMessage ? "usa-input-error" : ""
     );
 
-    let labelClass = 'question-label';
+    let labelClass = "question-label";
 
     if (hideLabel) {
-      labelClass += ' hidden-field';
+      labelClass += " hidden-field";
     }
 
     // Since HTML5 IDs should not contain spaces...
@@ -75,7 +75,7 @@ export default class RadioField extends React.Component {
 }
 
 RadioField.defaultProps = {
-  className: ['cf-form-showhide-radio']
+  className: ["cf-form-showhide-radio"]
 };
 
 RadioField.propTypes = {

--- a/client/app/components/RenderFunctions.jsx
+++ b/client/app/components/RenderFunctions.jsx
@@ -18,7 +18,7 @@ export const loadingSymbolHtml = function(text = 'Loading', size = '30px', color
   if (!(/\D/).test(imgSize)) {
     imgSize += 'px';
     console.warn(
-      'loadingSymbolHtml() size argument', size, 'converted to', imgSize
+      "loadingSymbolHtml() size argument", size, "converted to", imgSize
     );
   }
 

--- a/client/app/components/RenderFunctions.jsx
+++ b/client/app/components/RenderFunctions.jsx
@@ -18,7 +18,7 @@ export const loadingSymbolHtml = function(text = 'Loading', size = '30px', color
   if (!(/\D/).test(imgSize)) {
     imgSize += 'px';
     console.warn(
-      "loadingSymbolHtml() size argument", size, "converted to", imgSize
+      'loadingSymbolHtml() size argument', size, 'converted to', imgSize
     );
   }
 

--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -51,7 +51,7 @@ class SearchableDropdown extends Component {
         value={this.state.value}
         options={options}
         onChange={this.onChange}
-        placeholder={placeholder ? placeholder : 'Select option'}
+        placeholder={placeholder ? placeholder : "Select option"}
         clearable={false}
         noResultsText="Not an option"
         disabled={readOnly}

--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -51,7 +51,7 @@ class SearchableDropdown extends Component {
         value={this.state.value}
         options={options}
         onChange={this.onChange}
-        placeholder={placeholder ? placeholder : "Select option"}
+        placeholder={placeholder ? placeholder : 'Select option'}
         clearable={false}
         noResultsText="Not an option"
         disabled={readOnly}

--- a/client/app/components/StyleGuideComponentTitle.jsx
+++ b/client/app/components/StyleGuideComponentTitle.jsx
@@ -12,7 +12,7 @@ export default class StyleGuideComponentTitle extends React.Component {
     let ViewSourceCodeLink = (props) => {
 
       /* eslint-disable max-len */
-      let baseUrl = 'https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/containers/StyleGuide/';
+      let baseUrl = "https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/containers/StyleGuide/";
 
       /* eslint-enable max-len */
 

--- a/client/app/components/StyleGuideComponentTitle.jsx
+++ b/client/app/components/StyleGuideComponentTitle.jsx
@@ -12,7 +12,7 @@ export default class StyleGuideComponentTitle extends React.Component {
     let ViewSourceCodeLink = (props) => {
 
       /* eslint-disable max-len */
-      let baseUrl = "https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/containers/StyleGuide/";
+      let baseUrl = 'https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/containers/StyleGuide/';
 
       /* eslint-enable max-len */
 

--- a/client/app/components/TabWindow.jsx
+++ b/client/app/components/TabWindow.jsx
@@ -38,7 +38,7 @@ export default class TabWindow extends React.Component {
   }
 
   getTabClassName = (index, currentPage, isTabDisabled) => {
-    let className = `cf-tab${index === currentPage ? ' cf-active' : ''}`;
+    let className = `cf-tab${index === currentPage ? " cf-active" : ""}`;
 
     className += isTabDisabled ? ' disabled' : '';
 
@@ -48,7 +48,7 @@ export default class TabWindow extends React.Component {
   // For pages with only one set of tabs or a non-specified tab group name
   // the name returns "undefined". This appends the word "main" to the tab group.
   getTabGroupName = (name) => {
-    return name ? name : 'main';
+    return name ? name : "main";
   }
 
   render() {
@@ -60,7 +60,7 @@ export default class TabWindow extends React.Component {
 
     return <div>
         <div className={
-          `cf-tab-navigation${fullPage ? ' cf-tab-navigation-full-screen' : ''}`
+          `cf-tab-navigation${fullPage ? " cf-tab-navigation-full-screen" : ""}`
         }>
           {tabs.map((tab, i) =>
             <button

--- a/client/app/components/TabWindow.jsx
+++ b/client/app/components/TabWindow.jsx
@@ -38,7 +38,7 @@ export default class TabWindow extends React.Component {
   }
 
   getTabClassName = (index, currentPage, isTabDisabled) => {
-    let className = `cf-tab${index === currentPage ? " cf-active" : ""}`;
+    let className = `cf-tab${index === currentPage ? ' cf-active' : ''}`;
 
     className += isTabDisabled ? ' disabled' : '';
 
@@ -48,7 +48,7 @@ export default class TabWindow extends React.Component {
   // For pages with only one set of tabs or a non-specified tab group name
   // the name returns "undefined". This appends the word "main" to the tab group.
   getTabGroupName = (name) => {
-    return name ? name : "main";
+    return name ? name : 'main';
   }
 
   render() {
@@ -60,7 +60,7 @@ export default class TabWindow extends React.Component {
 
     return <div>
         <div className={
-          `cf-tab-navigation${fullPage ? " cf-tab-navigation-full-screen" : ""}`
+          `cf-tab-navigation${fullPage ? ' cf-tab-navigation-full-screen' : ''}`
         }>
           {tabs.map((tab, i) =>
             <button

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -28,9 +28,9 @@ export default class Table extends React.Component {
     } = this.props;
 
     let alignmentClasses = {
-      'center': 'cf-txt-c',
-      'left': 'cf-txt-l',
-      'right': 'cf-txt-r'
+      "center": "cf-txt-c",
+      "left": "cf-txt-l",
+      "right": "cf-txt-r"
     };
 
     let cellClasses = (column) => {
@@ -47,7 +47,7 @@ export default class Table extends React.Component {
         <tr>
           {getColumns(props).map((column, columnNumber) =>
             <th scope="col" key={columnNumber} className={cellClasses(column)}>
-              {column.header || ''}
+              {column.header || ""}
             </th>
           )}
         </tr>
@@ -62,7 +62,7 @@ export default class Table extends React.Component {
         return rowObject[column.valueName];
       }
 
-      return '';
+      return "";
     };
 
     let getCellSpan = (rowObject, column) => {
@@ -74,7 +74,7 @@ export default class Table extends React.Component {
     };
 
     let Row = (props) => {
-      let rowId = props.footer ? 'footer' : props.rowNumber;
+      let rowId = props.footer ? "footer" : props.rowNumber;
 
       return <tr id={`table-row-${rowId}`}>
         {getColumns(props).map((column, columnNumber) =>

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -28,9 +28,9 @@ export default class Table extends React.Component {
     } = this.props;
 
     let alignmentClasses = {
-      "center": "cf-txt-c",
-      "left": "cf-txt-l",
-      "right": "cf-txt-r"
+      'center': 'cf-txt-c',
+      'left': 'cf-txt-l',
+      'right': 'cf-txt-r'
     };
 
     let cellClasses = (column) => {
@@ -47,7 +47,7 @@ export default class Table extends React.Component {
         <tr>
           {getColumns(props).map((column, columnNumber) =>
             <th scope="col" key={columnNumber} className={cellClasses(column)}>
-              {column.header || ""}
+              {column.header || ''}
             </th>
           )}
         </tr>
@@ -62,7 +62,7 @@ export default class Table extends React.Component {
         return rowObject[column.valueName];
       }
 
-      return "";
+      return '';
     };
 
     let getCellSpan = (rowObject, column) => {
@@ -74,7 +74,7 @@ export default class Table extends React.Component {
     };
 
     let Row = (props) => {
-      let rowId = props.footer ? "footer" : props.rowNumber;
+      let rowId = props.footer ? 'footer' : props.rowNumber;
 
       return <tr id={`table-row-${rowId}`}>
         {getColumns(props).map((column, columnNumber) =>

--- a/client/app/components/TextField.jsx
+++ b/client/app/components/TextField.jsx
@@ -20,9 +20,9 @@ export default class TextField extends React.Component {
     } = this.props;
 
     let textInputClass = className.concat(
-      invisible ? " cf-invisible" : ""
+      invisible ? ' cf-invisible' : ''
     ).concat(
-      errorMessage ? "usa-input-error" : ""
+      errorMessage ? 'usa-input-error' : ''
     );
 
     // Use empty string instead of null or undefined,
@@ -59,7 +59,7 @@ export default class TextField extends React.Component {
 TextField.defaultProps = {
   required: false,
   type: 'text',
-  className: ["cf-form-textinput"]
+  className: ['cf-form-textinput']
 };
 
 TextField.propTypes = {

--- a/client/app/components/TextField.jsx
+++ b/client/app/components/TextField.jsx
@@ -20,9 +20,9 @@ export default class TextField extends React.Component {
     } = this.props;
 
     let textInputClass = className.concat(
-      invisible ? ' cf-invisible' : ''
+      invisible ? " cf-invisible" : ""
     ).concat(
-      errorMessage ? 'usa-input-error' : ''
+      errorMessage ? "usa-input-error" : ""
     );
 
     // Use empty string instead of null or undefined,
@@ -59,7 +59,7 @@ export default class TextField extends React.Component {
 TextField.defaultProps = {
   required: false,
   type: 'text',
-  className: ['cf-form-textinput']
+  className: ["cf-form-textinput"]
 };
 
 TextField.propTypes = {

--- a/client/app/components/TextareaField.jsx
+++ b/client/app/components/TextareaField.jsx
@@ -17,8 +17,8 @@ export default class TextareaField extends React.Component {
       value
     } = this.props;
 
-    let className = 'cf-form-textarea' +
-          `${errorMessage ? ' usa-input-error' : ''}`;
+    let className = `cf-form-textarea` +
+          `${errorMessage ? " usa-input-error" : ""}`;
 
     return <div className={className}>
       <label className="question-label" htmlFor={name}>

--- a/client/app/components/TextareaField.jsx
+++ b/client/app/components/TextareaField.jsx
@@ -17,8 +17,8 @@ export default class TextareaField extends React.Component {
       value
     } = this.props;
 
-    let className = `cf-form-textarea` +
-          `${errorMessage ? " usa-input-error" : ""}`;
+    let className = 'cf-form-textarea' +
+          `${errorMessage ? ' usa-input-error' : ''}`;
 
     return <div className={className}>
       <label className="question-label" htmlFor={name}>

--- a/client/app/constants/SpecialIssues.js
+++ b/client/app/constants/SpecialIssues.js
@@ -20,10 +20,10 @@ const SPECIAL_ISSUES = [
     }
   },
   {
-    display: 'Education - GI Bill, dependents educational assistance, ' +
-      'scholarship, transfer of entitlement',
-    specialIssue: 'educationGiBillDependentsEducationalAssistanceScholarship' +
-      'TransferOfEntitlement',
+    display: `Education - GI Bill, dependents educational assistance, ` +
+      `scholarship, transfer of entitlement`,
+    specialIssue: `educationGiBillDependentsEducationalAssistanceScholarship` +
+      `TransferOfEntitlement`,
     stationOfJurisdiction: null,
     unhandled: {
       emailAddress: 'education',
@@ -153,10 +153,10 @@ const SPECIAL_ISSUES = [
     unhandled: null
   },
   {
-    display: 'U.S. Territory claim - American Samoa, Guam, Northern ' +
-      'Mariana Islands (Rota, Saipan & Tinian)',
-    specialIssue: 'usTerritoryClaimAmericanSamoaGuamNorthern' +
-      'MarianaIslandsRotaSaipanTinian',
+    display: `U.S. Territory claim - American Samoa, Guam, Northern ` +
+      `Mariana Islands (Rota, Saipan & Tinian)`,
+    specialIssue: `usTerritoryClaimAmericanSamoaGuamNorthern` +
+      `MarianaIslandsRotaSaipanTinian`,
     stationOfJurisdiction: {
       key: '459',
       location: 'Honolulu, HI'

--- a/client/app/constants/SpecialIssues.js
+++ b/client/app/constants/SpecialIssues.js
@@ -20,10 +20,10 @@ const SPECIAL_ISSUES = [
     }
   },
   {
-    display: `Education - GI Bill, dependents educational assistance, ` +
-      `scholarship, transfer of entitlement`,
-    specialIssue: `educationGiBillDependentsEducationalAssistanceScholarship` +
-      `TransferOfEntitlement`,
+    display: 'Education - GI Bill, dependents educational assistance, ' +
+      'scholarship, transfer of entitlement',
+    specialIssue: 'educationGiBillDependentsEducationalAssistanceScholarship' +
+      'TransferOfEntitlement',
     stationOfJurisdiction: null,
     unhandled: {
       emailAddress: 'education',
@@ -153,10 +153,10 @@ const SPECIAL_ISSUES = [
     unhandled: null
   },
   {
-    display: `U.S. Territory claim - American Samoa, Guam, Northern ` +
-      `Mariana Islands (Rota, Saipan & Tinian)`,
-    specialIssue: `usTerritoryClaimAmericanSamoaGuamNorthern` +
-      `MarianaIslandsRotaSaipanTinian`,
+    display: 'U.S. Territory claim - American Samoa, Guam, Northern ' +
+      'Mariana Islands (Rota, Saipan & Tinian)',
+    specialIssue: 'usTerritoryClaimAmericanSamoaGuamNorthern' +
+      'MarianaIslandsRotaSaipanTinian',
     stationOfJurisdiction: {
       key: '459',
       location: 'Honolulu, HI'

--- a/client/app/containers/BaseForm.jsx
+++ b/client/app/containers/BaseForm.jsx
@@ -56,7 +56,7 @@ export default class BaseForm extends React.Component {
 
   scrollToAndFocusFirstError = function() {
     let erroredForm = ReactDOM.findDOMNode(this.state.validating);
-    let errors = erroredForm.getElementsByClassName('usa-input-error-message');
+    let errors = erroredForm.getElementsByClassName("usa-input-error-message");
 
     if (errors.length > 0) {
       window.scrollBy(0, errors[0].parentElement.getBoundingClientRect().top);

--- a/client/app/containers/BaseForm.jsx
+++ b/client/app/containers/BaseForm.jsx
@@ -56,7 +56,7 @@ export default class BaseForm extends React.Component {
 
   scrollToAndFocusFirstError = function() {
     let erroredForm = ReactDOM.findDOMNode(this.state.validating);
-    let errors = erroredForm.getElementsByClassName("usa-input-error-message");
+    let errors = erroredForm.getElementsByClassName('usa-input-error-message');
 
     if (errors.length > 0) {
       window.scrollBy(0, errors[0].parentElement.getBoundingClientRect().top);

--- a/client/app/containers/CaseWorker/CaseWorkerIndex.jsx
+++ b/client/app/containers/CaseWorker/CaseWorkerIndex.jsx
@@ -20,7 +20,7 @@ export default class CaseWorkerIndex extends BaseForm {
       loading: true
     });
 
-    ApiUtil.patch('/dispatch/establish-claim/assign').then((response) => {
+    ApiUtil.patch(`/dispatch/establish-claim/assign`).then((response) => {
       window.location = `/dispatch/establish-claim/${response.body.next_task_id}`;
     }, () => {
       this.props.handleAlert(
@@ -70,7 +70,7 @@ export default class CaseWorkerIndex extends BaseForm {
                 this.props.completedCountToday} claims completed`
                 }
                 { !availableTasks &&
-                  'There are no more claims in your queue.'
+                  "There are no more claims in your queue."
                 }
               </span>
               { availableTasks &&
@@ -78,8 +78,8 @@ export default class CaseWorkerIndex extends BaseForm {
                 app="dispatch"
                 name={buttonText}
                 onClick={this.establishNextClaim}
-                classNames={['usa-button-primary', 'cf-push-right',
-                  'cf-button-aligned-with-textfield-right']}
+                classNames={["usa-button-primary", "cf-push-right",
+                  "cf-button-aligned-with-textfield-right"]}
                 disabled={!availableTasks}
                 loading={this.state.loading}
               />
@@ -87,8 +87,8 @@ export default class CaseWorkerIndex extends BaseForm {
               { !availableTasks &&
               <Button
                   name={buttonText}
-                  classNames={['usa-button-disabled', 'cf-push-right',
-                    'cf-button-aligned-with-textfield-right']}
+                  classNames={["usa-button-disabled", "cf-push-right",
+                    "cf-button-aligned-with-textfield-right"]}
                   disabled={true}
               />
               }

--- a/client/app/containers/CaseWorker/CaseWorkerIndex.jsx
+++ b/client/app/containers/CaseWorker/CaseWorkerIndex.jsx
@@ -20,7 +20,7 @@ export default class CaseWorkerIndex extends BaseForm {
       loading: true
     });
 
-    ApiUtil.patch(`/dispatch/establish-claim/assign`).then((response) => {
+    ApiUtil.patch('/dispatch/establish-claim/assign').then((response) => {
       window.location = `/dispatch/establish-claim/${response.body.next_task_id}`;
     }, () => {
       this.props.handleAlert(
@@ -70,7 +70,7 @@ export default class CaseWorkerIndex extends BaseForm {
                 this.props.completedCountToday} claims completed`
                 }
                 { !availableTasks &&
-                  "There are no more claims in your queue."
+                  'There are no more claims in your queue.'
                 }
               </span>
               { availableTasks &&
@@ -78,8 +78,8 @@ export default class CaseWorkerIndex extends BaseForm {
                 app="dispatch"
                 name={buttonText}
                 onClick={this.establishNextClaim}
-                classNames={["usa-button-primary", "cf-push-right",
-                  "cf-button-aligned-with-textfield-right"]}
+                classNames={['usa-button-primary', 'cf-push-right',
+                  'cf-button-aligned-with-textfield-right']}
                 disabled={!availableTasks}
                 loading={this.state.loading}
               />
@@ -87,8 +87,8 @@ export default class CaseWorkerIndex extends BaseForm {
               { !availableTasks &&
               <Button
                   name={buttonText}
-                  classNames={["usa-button-disabled", "cf-push-right",
-                    "cf-button-aligned-with-textfield-right"]}
+                  classNames={['usa-button-disabled', 'cf-push-right',
+                    'cf-button-aligned-with-textfield-right']}
                   disabled={true}
               />
               }

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -47,13 +47,13 @@ export const END_PRODUCT_INFO = {
 };
 
 const CREATE_EP_ERRORS = {
-  'duplicate_ep': {
+  "duplicate_ep": {
     header: 'At this time, we are unable to assign or create a new EP for this claim.',
     body: 'An EP with that modifier was previously created for this claim. ' +
           'Try a different modifier or select Cancel at the bottom of the ' +
           'page to release this claim and proceed to process it outside of Caseflow.'
   },
-  'task_already_completed': {
+  "task_already_completed": {
     header: 'This task was already completed.',
     body: <span>
             Please return
@@ -61,7 +61,7 @@ const CREATE_EP_ERRORS = {
             establish the next claim.
           </span>
   },
-  'missing_ssn': {
+  "missing_ssn": {
     header: 'The EP for this claim must be created outside Caseflow.',
     body: <span>
             This veteran does not have a social security number, so their
@@ -71,14 +71,14 @@ const CREATE_EP_ERRORS = {
             proceed to process it outside of Caseflow.
           </span>
   },
-  'default': {
+  "default": {
     header: 'System Error',
     body: 'Something went wrong on our end. We were not able to create an End Product. ' +
           'Please try again later.'
   }
 };
 
-const BACK_TO_DECISION_REVIEW_TEXT = '< Back to Review Decision';
+const BACK_TO_DECISION_REVIEW_TEXT = "< Back to Review Decision";
 
 // This page is used by AMC to establish claims. This is
 // the last step in the appeals process, and is after the decsion
@@ -228,7 +228,7 @@ export default class EstablishClaim extends BaseForm {
     let stationOfJurisdiction =
       this.store.getState().establishClaimForm.stationOfJurisdiction;
 
-    return stationOfJurisdiction === '397' ? 'ARC' : 'Routed';
+    return stationOfJurisdiction === '397' ? "ARC" : "Routed";
   }
 
   getClaimTypeFromDecision = () => {
@@ -236,7 +236,7 @@ export default class EstablishClaim extends BaseForm {
     let values = END_PRODUCT_INFO[this.getRoutingType()][decisionType];
 
     if (!values) {
-      throw new RangeError('Invalid decision type value');
+      throw new RangeError("Invalid decision type value");
     }
 
     return values;
@@ -696,11 +696,11 @@ export default class EstablishClaim extends BaseForm {
 
         {cancelModalDisplay && <Modal
           buttons={[
-            { classNames: ['cf-modal-link', 'cf-btn-link'],
+            { classNames: ["cf-modal-link", "cf-btn-link"],
               name: 'Close',
               onClick: this.handleModalClose('cancelModalDisplay')
             },
-            { classNames: ['usa-button', 'usa-button-secondary'],
+            { classNames: ["usa-button", "usa-button-secondary"],
               loading: modalSubmitLoading,
               name: 'Stop processing claim',
               onClick: this.handleFinishCancelTask

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -47,13 +47,13 @@ export const END_PRODUCT_INFO = {
 };
 
 const CREATE_EP_ERRORS = {
-  "duplicate_ep": {
+  'duplicate_ep': {
     header: 'At this time, we are unable to assign or create a new EP for this claim.',
     body: 'An EP with that modifier was previously created for this claim. ' +
           'Try a different modifier or select Cancel at the bottom of the ' +
           'page to release this claim and proceed to process it outside of Caseflow.'
   },
-  "task_already_completed": {
+  'task_already_completed': {
     header: 'This task was already completed.',
     body: <span>
             Please return
@@ -61,7 +61,7 @@ const CREATE_EP_ERRORS = {
             establish the next claim.
           </span>
   },
-  "missing_ssn": {
+  'missing_ssn': {
     header: 'The EP for this claim must be created outside Caseflow.',
     body: <span>
             This veteran does not have a social security number, so their
@@ -71,14 +71,14 @@ const CREATE_EP_ERRORS = {
             proceed to process it outside of Caseflow.
           </span>
   },
-  "default": {
+  'default': {
     header: 'System Error',
     body: 'Something went wrong on our end. We were not able to create an End Product. ' +
           'Please try again later.'
   }
 };
 
-const BACK_TO_DECISION_REVIEW_TEXT = "< Back to Review Decision";
+const BACK_TO_DECISION_REVIEW_TEXT = '< Back to Review Decision';
 
 // This page is used by AMC to establish claims. This is
 // the last step in the appeals process, and is after the decsion
@@ -228,7 +228,7 @@ export default class EstablishClaim extends BaseForm {
     let stationOfJurisdiction =
       this.store.getState().establishClaimForm.stationOfJurisdiction;
 
-    return stationOfJurisdiction === '397' ? "ARC" : "Routed";
+    return stationOfJurisdiction === '397' ? 'ARC' : 'Routed';
   }
 
   getClaimTypeFromDecision = () => {
@@ -236,7 +236,7 @@ export default class EstablishClaim extends BaseForm {
     let values = END_PRODUCT_INFO[this.getRoutingType()][decisionType];
 
     if (!values) {
-      throw new RangeError("Invalid decision type value");
+      throw new RangeError('Invalid decision type value');
     }
 
     return values;
@@ -696,11 +696,11 @@ export default class EstablishClaim extends BaseForm {
 
         {cancelModalDisplay && <Modal
           buttons={[
-            { classNames: ["cf-modal-link", "cf-btn-link"],
+            { classNames: ['cf-modal-link', 'cf-btn-link'],
               name: 'Close',
               onClick: this.handleModalClose('cancelModalDisplay')
             },
-            { classNames: ["usa-button", "usa-button-secondary"],
+            { classNames: ['usa-button', 'usa-button-secondary'],
               loading: modalSubmitLoading,
               name: 'Stop processing claim',
               onClick: this.handleFinishCancelTask

--- a/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
@@ -57,12 +57,12 @@ export class AssociatePage extends React.Component {
   ];
 
   getClassAssignButtonClasses = (loadingFlag, claimId) => {
-    let classes = ["usa-button-outline"];
+    let classes = ['usa-button-outline'];
 
     if (loadingFlag) {
-      classes.push("usa-button-disabled");
+      classes.push('usa-button-disabled');
       if (loadingFlag !== claimId) {
-        classes.push("cf-secondary-disabled");
+        classes.push('cf-secondary-disabled');
       }
     }
 
@@ -168,14 +168,14 @@ export class AssociatePage extends React.Component {
           <Button
             name={backToDecisionReviewText}
             onClick={handleBackToDecisionReview}
-            classNames={["cf-btn-link"]}
+            classNames={['cf-btn-link']}
           />
         </div>
         <div className="cf-push-right">
           <Button
             name="Cancel"
             onClick={handleCancelTask}
-            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
           />
           <Button
             app="dispatch"

--- a/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
@@ -57,12 +57,12 @@ export class AssociatePage extends React.Component {
   ];
 
   getClassAssignButtonClasses = (loadingFlag, claimId) => {
-    let classes = ['usa-button-outline'];
+    let classes = ["usa-button-outline"];
 
     if (loadingFlag) {
-      classes.push('usa-button-disabled');
+      classes.push("usa-button-disabled");
       if (loadingFlag !== claimId) {
-        classes.push('cf-secondary-disabled');
+        classes.push("cf-secondary-disabled");
       }
     }
 
@@ -168,14 +168,14 @@ export class AssociatePage extends React.Component {
           <Button
             name={backToDecisionReviewText}
             onClick={handleBackToDecisionReview}
-            classNames={['cf-btn-link']}
+            classNames={["cf-btn-link"]}
           />
         </div>
         <div className="cf-push-right">
           <Button
             name="Cancel"
             onClick={handleCancelTask}
-            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
+            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
           />
           <Button
             app="dispatch"

--- a/client/app/containers/EstablishClaimPage/EstablishClaimDecision.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimDecision.jsx
@@ -17,9 +17,9 @@ export class EstablishClaimDecision extends React.Component {
     let endProductButtonText;
 
     if (this.hasMultipleDecisions()) {
-      endProductButtonText = "Route claim for Decision 1";
+      endProductButtonText = 'Route claim for Decision 1';
     } else {
-      endProductButtonText = "Route claim";
+      endProductButtonText = 'Route claim';
     }
     this.state = {
       endProductButtonText
@@ -207,7 +207,7 @@ export class EstablishClaimDecision extends React.Component {
             <Button
                 name="Cancel"
                 onClick={handleCancelTask}
-                classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+                classNames={['cf-btn-link', 'cf-adjacent-buttons']}
             />
             <Button
               app="dispatch"

--- a/client/app/containers/EstablishClaimPage/EstablishClaimDecision.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimDecision.jsx
@@ -17,9 +17,9 @@ export class EstablishClaimDecision extends React.Component {
     let endProductButtonText;
 
     if (this.hasMultipleDecisions()) {
-      endProductButtonText = 'Route claim for Decision 1';
+      endProductButtonText = "Route claim for Decision 1";
     } else {
-      endProductButtonText = 'Route claim';
+      endProductButtonText = "Route claim";
     }
     this.state = {
       endProductButtonText
@@ -207,7 +207,7 @@ export class EstablishClaimDecision extends React.Component {
             <Button
                 name="Cancel"
                 onClick={handleCancelTask}
-                classNames={['cf-btn-link', 'cf-adjacent-buttons']}
+                classNames={["cf-btn-link", "cf-adjacent-buttons"]}
             />
             <Button
               app="dispatch"

--- a/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
@@ -32,16 +32,16 @@ export class EstablishClaimEmail extends BaseForm {
         `and ${selectedSpecialIssue[selectedSpecialIssue.length - 1]}`;
     }
 
-    let email = `The BVA Full Grant decision dated` +
+    let email = 'The BVA Full Grant decision dated' +
       ` ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name},` +
       ` ID #${appeal.sanitized_vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssue.join(', ')}` +
-      ` in your jurisdiction. Please proceed with control and implement this grant.`;
+      ' in your jurisdiction. Please proceed with control and implement this grant.';
 
     let note = `This claim for Vet ID #${appeal.sanitized_vbms_id}` +
       ` includes Special Issue(s): ${selectedSpecialIssue.join(', ')}` +
-      ` not handled by Caseflow`;
+      ' not handled by Caseflow';
 
     this.state = {
       emailForm: {
@@ -97,19 +97,19 @@ export class EstablishClaimEmail extends BaseForm {
             <Button
               name={this.props.backToDecisionReviewText}
               onClick={this.props.handleBackToDecisionReview}
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
             />
           </div>
           <div className="cf-push-right">
             <Button
             name="Cancel"
             onClick={this.props.handleCancelTask}
-            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
             />
             <Button
               app="dispatch"
               name="Finish routing claim"
-              classNames={["usa-button-primary"]}
+              classNames={['usa-button-primary']}
               disabled={!this.state.emailForm.confirmBox.value}
               onClick={this.props.handleEmailSubmit}
               loading={this.props.loading}
@@ -147,19 +147,19 @@ export class EstablishClaimEmail extends BaseForm {
               <Button
                 name={this.props.backToDecisionReviewText}
                 onClick={this.props.handleBackToDecisionReview}
-                classNames={["cf-btn-link"]}
+                classNames={['cf-btn-link']}
               />
             </div>
             <div className="cf-push-right">
               <Button
                   name="Cancel"
                   onClick={this.props.handleCancelTask}
-                  classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+                  classNames={['cf-btn-link', 'cf-adjacent-buttons']}
               />
               <Button
                   app="dispatch"
                   name="Release claim"
-                  classNames={["usa-button-secondary"]}
+                  classNames={['usa-button-secondary']}
                   disabled={!this.state.emailForm.confirmBox.value}
                   onClick={this.props.handleNoEmailSubmit}
                   loading={this.props.loading}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
@@ -33,16 +33,16 @@ export class EstablishClaimEmail extends BaseForm {
         `and ${selectedSpecialIssue[selectedSpecialIssue.length - 1]}`;
     }
 
-    let email = 'The BVA Full Grant decision dated' +
+    let email = `The BVA Full Grant decision dated` +
       ` ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name},` +
       ` ID #${appeal.sanitized_vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssue.join(', ')}` +
-      ' in your jurisdiction. Please proceed with control and implement this grant.';
+      ` in your jurisdiction. Please proceed with control and implement this grant.`;
 
     let note = `This claim for Vet ID #${appeal.sanitized_vbms_id}` +
       ` includes Special Issue(s): ${selectedSpecialIssue.join(', ')}` +
-      ' not handled by Caseflow';
+      ` not handled by Caseflow`;
 
     this.state = {
       emailForm: {
@@ -90,7 +90,7 @@ export class EstablishClaimEmail extends BaseForm {
                 <CopyToClipboard text={this.state.emailForm.emailField.value}>
                   <Button
                    name="copyNote"
-                   classNames={['usa-button-secondary usa-button-hover']}>
+                   classNames={["usa-button-outline usa-button-hover"]}>
                    <i className="fa fa-files-o" aria-hidden="true"></i>
                    Copy note
                   </Button>
@@ -113,19 +113,19 @@ export class EstablishClaimEmail extends BaseForm {
             <Button
               name={this.props.backToDecisionReviewText}
               onClick={this.props.handleBackToDecisionReview}
-              classNames={['cf-btn-link']}
+              classNames={["cf-btn-link"]}
             />
           </div>
           <div className="cf-push-right">
             <Button
             name="Cancel"
             onClick={this.props.handleCancelTask}
-            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
+            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
             />
             <Button
               app="dispatch"
               name="Finish routing claim"
-              classNames={['usa-button-primary']}
+              classNames={["usa-button-primary"]}
               disabled={!this.state.emailForm.confirmBox.value}
               onClick={this.props.handleEmailSubmit}
               loading={this.props.loading}
@@ -163,19 +163,19 @@ export class EstablishClaimEmail extends BaseForm {
               <Button
                 name={this.props.backToDecisionReviewText}
                 onClick={this.props.handleBackToDecisionReview}
-                classNames={['cf-btn-link']}
+                classNames={["cf-btn-link"]}
               />
             </div>
             <div className="cf-push-right">
               <Button
                   name="Cancel"
                   onClick={this.props.handleCancelTask}
-                  classNames={['cf-btn-link', 'cf-adjacent-buttons']}
+                  classNames={["cf-btn-link", "cf-adjacent-buttons"]}
               />
               <Button
                   app="dispatch"
                   name="Release claim"
-                  classNames={['usa-button-secondary']}
+                  classNames={["usa-button-secondary"]}
                   disabled={!this.state.emailForm.confirmBox.value}
                   onClick={this.props.handleNoEmailSubmit}
                   loading={this.props.loading}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimEmail.jsx
@@ -33,16 +33,16 @@ export class EstablishClaimEmail extends BaseForm {
         `and ${selectedSpecialIssue[selectedSpecialIssue.length - 1]}`;
     }
 
-    let email = `The BVA Full Grant decision dated` +
+    let email = 'The BVA Full Grant decision dated' +
       ` ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name},` +
       ` ID #${appeal.sanitized_vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssue.join(', ')}` +
-      ` in your jurisdiction. Please proceed with control and implement this grant.`;
+      ' in your jurisdiction. Please proceed with control and implement this grant.';
 
     let note = `This claim for Vet ID #${appeal.sanitized_vbms_id}` +
       ` includes Special Issue(s): ${selectedSpecialIssue.join(', ')}` +
-      ` not handled by Caseflow`;
+      ' not handled by Caseflow';
 
     this.state = {
       emailForm: {
@@ -90,7 +90,7 @@ export class EstablishClaimEmail extends BaseForm {
                 <CopyToClipboard text={this.state.emailForm.emailField.value}>
                   <Button
                    name="copyNote"
-                   classNames={["usa-button-outline usa-button-hover"]}>
+                   classNames={['usa-button-outline usa-button-hover']}>
                    <i className="fa fa-files-o" aria-hidden="true"></i>
                    Copy note
                   </Button>
@@ -113,19 +113,19 @@ export class EstablishClaimEmail extends BaseForm {
             <Button
               name={this.props.backToDecisionReviewText}
               onClick={this.props.handleBackToDecisionReview}
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
             />
           </div>
           <div className="cf-push-right">
             <Button
             name="Cancel"
             onClick={this.props.handleCancelTask}
-            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
             />
             <Button
               app="dispatch"
               name="Finish routing claim"
-              classNames={["usa-button-primary"]}
+              classNames={['usa-button-primary']}
               disabled={!this.state.emailForm.confirmBox.value}
               onClick={this.props.handleEmailSubmit}
               loading={this.props.loading}
@@ -163,19 +163,19 @@ export class EstablishClaimEmail extends BaseForm {
               <Button
                 name={this.props.backToDecisionReviewText}
                 onClick={this.props.handleBackToDecisionReview}
-                classNames={["cf-btn-link"]}
+                classNames={['cf-btn-link']}
               />
             </div>
             <div className="cf-push-right">
               <Button
                   name="Cancel"
                   onClick={this.props.handleCancelTask}
-                  classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+                  classNames={['cf-btn-link', 'cf-adjacent-buttons']}
               />
               <Button
                   app="dispatch"
                   name="Release claim"
-                  classNames={["usa-button-secondary"]}
+                  classNames={['usa-button-secondary']}
                   disabled={!this.state.emailForm.confirmBox.value}
                   onClick={this.props.handleNoEmailSubmit}
                   loading={this.props.loading}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
@@ -102,14 +102,14 @@ export class EstablishClaimForm extends React.Component {
           <Button
             name={backToDecisionReviewText}
             onClick={handleBackToDecisionReview}
-            classNames={["cf-btn-link"]}
+            classNames={['cf-btn-link']}
           />
         </div>
         <div className="cf-push-right">
           <Button
             name="Cancel"
             onClick={handleCancelTask}
-            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
+            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
           />
           <Button
             app="dispatch"

--- a/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
@@ -102,14 +102,14 @@ export class EstablishClaimForm extends React.Component {
           <Button
             name={backToDecisionReviewText}
             onClick={handleBackToDecisionReview}
-            classNames={['cf-btn-link']}
+            classNames={["cf-btn-link"]}
           />
         </div>
         <div className="cf-push-right">
           <Button
             name="Cancel"
             onClick={handleCancelTask}
-            classNames={['cf-btn-link', 'cf-adjacent-buttons']}
+            classNames={["cf-btn-link", "cf-adjacent-buttons"]}
           />
           <Button
             app="dispatch"

--- a/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
@@ -31,7 +31,7 @@ export class EstablishClaimNote extends BaseForm {
       ` dated ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name}, ID #${appeal.vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssues.join(', ')}` +
-      ' in your jurisdiction. Please proceed with control and implement this grant.';
+      ` in your jurisdiction. Please proceed with control and implement this grant.`;
 
     this.state = {
       noteForm: {
@@ -48,14 +48,14 @@ export class EstablishClaimNote extends BaseForm {
     let specialIssues = this.props.specialIssues;
 
     if (specialIssues.vamc) {
-      return '54';
+      return "54";
     } else if (specialIssues.nationalCemeteryAdministration) {
-      return '53';
+      return "53";
     } else if (!this.hasSelectedSpecialIssues()) {
-      return '98';
+      return "98";
     }
 
-    return '50';
+    return "50";
   }
 
   hasSelectedSpecialIssues() {
@@ -92,7 +92,7 @@ export class EstablishClaimNote extends BaseForm {
 
     return `The BVA ${this.props.decisionType} decision` +
       ` dated ${formatDate(this.props.appeal.serialized_decision_date)}` +
-      ' is being transfered from ARC as it contains: ' +
+      ` is being transfered from ARC as it contains: ` +
       `${this.selectedSpecialIssues().join(', ')} in your jurisdiction.`;
   }
 
@@ -139,7 +139,7 @@ export class EstablishClaimNote extends BaseForm {
               <Button
                 label = "Copy note"
                 name="copyNote"
-                classNames={['usa-button-secondary usa-button-hover']}>
+                classNames={["usa-button-outline usa-button-hover"]}>
                 <i className="fa fa-files-o" aria-hidden="true"></i>
                 Copy note
               </Button>
@@ -198,14 +198,14 @@ export class EstablishClaimNote extends BaseForm {
             <Button
               name={this.props.backToDecisionReviewText}
               onClick={this.props.handleBackToDecisionReview}
-              classNames={['cf-btn-link']}
+              classNames={["cf-btn-link"]}
             />
           </div>}
           <div className="cf-push-right">
             <Button
               app="dispatch"
               name="Finish routing claim"
-              classNames={['usa-button-primary']}
+              classNames={["usa-button-primary"]}
               disabled={!this.state.noteForm.confirmBox.value}
               onClick={this.handleSubmit}
               loading={this.props.loading}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
@@ -31,7 +31,7 @@ export class EstablishClaimNote extends BaseForm {
       ` dated ${formatDate(appeal.serialized_decision_date)}` +
       ` for ${appeal.veteran_name}, ID #${appeal.vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssues.join(', ')}` +
-      ` in your jurisdiction. Please proceed with control and implement this grant.`;
+      ' in your jurisdiction. Please proceed with control and implement this grant.';
 
     this.state = {
       noteForm: {
@@ -48,14 +48,14 @@ export class EstablishClaimNote extends BaseForm {
     let specialIssues = this.props.specialIssues;
 
     if (specialIssues.vamc) {
-      return "54";
+      return '54';
     } else if (specialIssues.nationalCemeteryAdministration) {
-      return "53";
+      return '53';
     } else if (!this.hasSelectedSpecialIssues()) {
-      return "98";
+      return '98';
     }
 
-    return "50";
+    return '50';
   }
 
   hasSelectedSpecialIssues() {
@@ -92,7 +92,7 @@ export class EstablishClaimNote extends BaseForm {
 
     return `The BVA ${this.props.decisionType} decision` +
       ` dated ${formatDate(this.props.appeal.serialized_decision_date)}` +
-      ` is being transfered from ARC as it contains: ` +
+      ' is being transfered from ARC as it contains: ' +
       `${this.selectedSpecialIssues().join(', ')} in your jurisdiction.`;
   }
 
@@ -139,7 +139,7 @@ export class EstablishClaimNote extends BaseForm {
               <Button
                 label = "Copy note"
                 name="copyNote"
-                classNames={["usa-button-outline usa-button-hover"]}>
+                classNames={['usa-button-outline usa-button-hover']}>
                 <i className="fa fa-files-o" aria-hidden="true"></i>
                 Copy note
               </Button>
@@ -198,14 +198,14 @@ export class EstablishClaimNote extends BaseForm {
             <Button
               name={this.props.backToDecisionReviewText}
               onClick={this.props.handleBackToDecisionReview}
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
             />
           </div>}
           <div className="cf-push-right">
             <Button
               app="dispatch"
               name="Finish routing claim"
-              classNames={["usa-button-primary"]}
+              classNames={['usa-button-primary']}
               disabled={!this.state.noteForm.confirmBox.value}
               onClick={this.handleSubmit}
               loading={this.props.loading}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimNote.jsx
@@ -31,7 +31,7 @@ export class EstablishClaimNote extends BaseForm {
       ` for ${appeal.veteran_name},` +
       ` ID #${appeal.sanitized_vbms_id}, was sent to the ARC but` +
       ` cannot be processed here, as it contains ${selectedSpecialIssues.join(', ')}` +
-      ` in your jurisdiction. Please proceed with control and implement this grant.`;
+      ' in your jurisdiction. Please proceed with control and implement this grant.';
 
     this.state = {
       noteForm: {
@@ -48,14 +48,14 @@ export class EstablishClaimNote extends BaseForm {
     let specialIssues = this.props.specialIssues;
 
     if (specialIssues.vamc) {
-      return "54";
+      return '54';
     } else if (specialIssues.nationalCemeteryAdministration) {
-      return "53";
+      return '53';
     } else if (!this.hasSelectedSpecialIssues()) {
-      return "98";
+      return '98';
     }
 
-    return "50";
+    return '50';
   }
 
   hasSelectedSpecialIssues() {
@@ -92,7 +92,7 @@ export class EstablishClaimNote extends BaseForm {
 
     return `The BVA ${this.props.decisionType} decision` +
       ` dated ${formatDate(this.props.appeal.serialized_decision_date)}` +
-      ` is being transfered from ARC as it contains: ` +
+      ' is being transfered from ARC as it contains: ' +
       `${this.selectedSpecialIssues().join(', ')} in your jurisdiction.`;
   }
 
@@ -180,14 +180,14 @@ export class EstablishClaimNote extends BaseForm {
             <Button
               name={this.props.backToDecisionReviewText}
               onClick={this.props.handleBackToDecisionReview}
-              classNames={["cf-btn-link"]}
+              classNames={['cf-btn-link']}
             />
           </div>}
           <div className="cf-push-right">
             <Button
               app="dispatch"
               name="Finish routing claim"
-              classNames={["usa-button-primary"]}
+              classNames={['usa-button-primary']}
               disabled={!this.state.noteForm.confirmBox.value}
               onClick={this.handleSubmit}
               loading={this.props.loading}

--- a/client/app/containers/EstablishClaimPage/EstablishClaimToolbar.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimToolbar.jsx
@@ -28,7 +28,7 @@ export default class EstablishClaimToolbar extends React.Component {
 
         <Button
           name={buttonText}
-          classNames={['cf-push-right']}
+          classNames={["cf-push-right"]}
           disabled={true}
         />
       </div>;
@@ -43,7 +43,7 @@ export default class EstablishClaimToolbar extends React.Component {
           app="dispatch"
           name={buttonText}
           onClick={this.establishNextClaim}
-          classNames={['usa-button-primary', 'cf-push-right']}
+          classNames={["usa-button-primary", "cf-push-right"]}
           loading={this.state.loading}
         />
       </div>;
@@ -66,7 +66,7 @@ export default class EstablishClaimToolbar extends React.Component {
       loading: true
     });
 
-    ApiUtil.patch('/dispatch/establish-claim/assign').
+    ApiUtil.patch(`/dispatch/establish-claim/assign`).
     then((response) => {
       window.location = `/dispatch/establish-claim/${response.body.next_task_id}`;
     }, () => {

--- a/client/app/containers/EstablishClaimPage/EstablishClaimToolbar.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimToolbar.jsx
@@ -28,7 +28,7 @@ export default class EstablishClaimToolbar extends React.Component {
 
         <Button
           name={buttonText}
-          classNames={["cf-push-right"]}
+          classNames={['cf-push-right']}
           disabled={true}
         />
       </div>;
@@ -43,7 +43,7 @@ export default class EstablishClaimToolbar extends React.Component {
           app="dispatch"
           name={buttonText}
           onClick={this.establishNextClaim}
-          classNames={["usa-button-primary", "cf-push-right"]}
+          classNames={['usa-button-primary', 'cf-push-right']}
           loading={this.state.loading}
         />
       </div>;
@@ -66,7 +66,7 @@ export default class EstablishClaimToolbar extends React.Component {
       loading: true
     });
 
-    ApiUtil.patch(`/dispatch/establish-claim/assign`).
+    ApiUtil.patch('/dispatch/establish-claim/assign').
     then((response) => {
       window.location = `/dispatch/establish-claim/${response.body.next_task_id}`;
     }, () => {

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example3.jsx
@@ -27,16 +27,16 @@ export default class Example3 extends React.Component {
   render = () => {
     let options = [
       {
-        id: 'checkboxExample31',
-        label: 'Yosemite National Park'
+        id: "checkboxExample31",
+        label: "Yosemite National Park"
       },
       {
-        id: 'checkboxExample32',
-        label: 'Grand Canyon National Park'
+        id: "checkboxExample32",
+        label: "Grand Canyon National Park"
       },
       {
-        id: 'checkboxExample33',
-        label: 'Disabled',
+        id: "checkboxExample33",
+        label: "Disabled",
         disabled: true
       }
     ];

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example3.jsx
@@ -27,16 +27,16 @@ export default class Example3 extends React.Component {
   render = () => {
     let options = [
       {
-        id: "checkboxExample31",
-        label: "Yosemite National Park"
+        id: 'checkboxExample31',
+        label: 'Yosemite National Park'
       },
       {
-        id: "checkboxExample32",
-        label: "Grand Canyon National Park"
+        id: 'checkboxExample32',
+        label: 'Grand Canyon National Park'
       },
       {
-        id: "checkboxExample33",
-        label: "Disabled",
+        id: 'checkboxExample33',
+        label: 'Disabled',
         disabled: true
       }
     ];

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example4.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example4.jsx
@@ -26,12 +26,12 @@ export default class Example4 extends React.Component {
   render = () => {
     let options = [
       {
-        id: 'checkboxExample41',
-        label: 'Option 1'
+        id: "checkboxExample41",
+        label: "Option 1"
       },
       {
-        id: 'checkboxExample42',
-        label: 'Option 2'
+        id: "checkboxExample42",
+        label: "Option 2"
       }
     ];
 

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example4.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example4.jsx
@@ -26,12 +26,12 @@ export default class Example4 extends React.Component {
   render = () => {
     let options = [
       {
-        id: "checkboxExample41",
-        label: "Option 1"
+        id: 'checkboxExample41',
+        label: 'Option 1'
       },
       {
-        id: "checkboxExample42",
-        label: "Option 2"
+        id: 'checkboxExample42',
+        label: 'Option 2'
       }
     ];
 

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example5.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example5.jsx
@@ -26,12 +26,12 @@ export default class Example5 extends React.Component {
   render = () => {
     let options = [
       {
-        id: 'checkboxExample51',
-        label: 'Option 1'
+        id: "checkboxExample51",
+        label: "Option 1"
       },
       {
-        id: 'checkboxExample52',
-        label: 'Option 2'
+        id: "checkboxExample52",
+        label: "Option 2"
       }
     ];
 

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example5.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example5.jsx
@@ -26,12 +26,12 @@ export default class Example5 extends React.Component {
   render = () => {
     let options = [
       {
-        id: "checkboxExample51",
-        label: "Option 1"
+        id: 'checkboxExample51',
+        label: 'Option 1'
       },
       {
-        id: "checkboxExample52",
-        label: "Option 2"
+        id: 'checkboxExample52',
+        label: 'Option 2'
       }
     ];
 

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example6.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example6.jsx
@@ -12,7 +12,7 @@ export default class Example6 extends React.Component {
         checkboxExample61: false,
         checkboxExample62: false
       },
-      errorMessage: 'You must choose an option'
+      errorMessage: "You must choose an option"
     };
   }
 
@@ -28,12 +28,12 @@ export default class Example6 extends React.Component {
   render = () => {
     let options = [
       {
-        id: 'checkboxExample61',
-        label: 'Option 1'
+        id: "checkboxExample61",
+        label: "Option 1"
       },
       {
-        id: 'checkboxExample62',
-        label: 'Option 2'
+        id: "checkboxExample62",
+        label: "Option 2"
       }
     ];
 

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example6.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example6.jsx
@@ -12,7 +12,7 @@ export default class Example6 extends React.Component {
         checkboxExample61: false,
         checkboxExample62: false
       },
-      errorMessage: "You must choose an option"
+      errorMessage: 'You must choose an option'
     };
   }
 
@@ -28,12 +28,12 @@ export default class Example6 extends React.Component {
   render = () => {
     let options = [
       {
-        id: "checkboxExample61",
-        label: "Option 1"
+        id: 'checkboxExample61',
+        label: 'Option 1'
       },
       {
-        id: "checkboxExample62",
-        label: "Option 2"
+        id: 'checkboxExample62',
+        label: 'Option 2'
       }
     ];
 

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example7.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example7.jsx
@@ -9,7 +9,7 @@ export default class Example7 extends React.Component {
 
     this.state = {
       value: null,
-      errorMessage: "You must acknowledge this."
+      errorMessage: 'You must acknowledge this.'
     };
   }
 
@@ -21,8 +21,8 @@ export default class Example7 extends React.Component {
   }
 
   render = () => {
-    let acknowledgement = "I acknowldge that this information is correct. " +
-      "I agree to follow the rules.";
+    let acknowledgement = 'I acknowldge that this information is correct. ' +
+      'I agree to follow the rules.';
 
     return <Checkbox
       label={acknowledgement}

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example7.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example7.jsx
@@ -9,7 +9,7 @@ export default class Example7 extends React.Component {
 
     this.state = {
       value: null,
-      errorMessage: 'You must acknowledge this.'
+      errorMessage: "You must acknowledge this."
     };
   }
 
@@ -21,8 +21,8 @@ export default class Example7 extends React.Component {
   }
 
   render = () => {
-    let acknowledgement = 'I acknowldge that this information is correct. ' +
-      'I agree to follow the rules.';
+    let acknowledgement = "I acknowldge that this information is correct. " +
+      "I agree to follow the rules.";
 
     return <Checkbox
       label={acknowledgement}

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
@@ -8,7 +8,7 @@ export default class Example1 extends React.Component {
     super(props);
 
     this.state = {
-      value: '1'
+      value: "1"
     };
   }
 
@@ -21,11 +21,11 @@ export default class Example1 extends React.Component {
   render = () => {
     let options = [
       { displayText: <span>Yosemite National Park</span>,
-        value: '1' },
-      { displayText: 'Grand Canyon National Park',
-        value: '2' },
-      { displayText: 'Yellowstone National Park and related services',
-        value: '3' }
+        value: "1" },
+      { displayText: "Grand Canyon National Park",
+        value: "2" },
+      { displayText: "Yellowstone National Park and related services",
+        value: "3" }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
@@ -8,7 +8,7 @@ export default class Example1 extends React.Component {
     super(props);
 
     this.state = {
-      value: "1"
+      value: '1'
     };
   }
 
@@ -21,11 +21,11 @@ export default class Example1 extends React.Component {
   render = () => {
     let options = [
       { displayText: <span>Yosemite National Park</span>,
-        value: "1" },
-      { displayText: "Grand Canyon National Park",
-        value: "2" },
-      { displayText: "Yellowstone National Park and related services",
-        value: "3" }
+        value: '1' },
+      { displayText: 'Grand Canyon National Park',
+        value: '2' },
+      { displayText: 'Yellowstone National Park and related services',
+        value: '3' }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
@@ -8,7 +8,7 @@ export default class Example2 extends React.Component {
     super(props);
 
     this.state = {
-      value: '1'
+      value: "1"
     };
   }
 
@@ -20,10 +20,10 @@ export default class Example2 extends React.Component {
 
   render = () => {
     let options = [
-      { displayText: 'Yes',
-        value: '1' },
-      { displayText: 'No',
-        value: '2' }
+      { displayText: "Yes",
+        value: "1" },
+      { displayText: "No",
+        value: "2" }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
@@ -8,7 +8,7 @@ export default class Example2 extends React.Component {
     super(props);
 
     this.state = {
-      value: "1"
+      value: '1'
     };
   }
 
@@ -20,10 +20,10 @@ export default class Example2 extends React.Component {
 
   render = () => {
     let options = [
-      { displayText: "Yes",
-        value: "1" },
-      { displayText: "No",
-        value: "2" }
+      { displayText: 'Yes',
+        value: '1' },
+      { displayText: 'No',
+        value: '2' }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
@@ -8,7 +8,7 @@ export default class Example3 extends React.Component {
     super(props);
 
     this.state = {
-      value: "2"
+      value: '2'
     };
   }
 
@@ -20,10 +20,10 @@ export default class Example3 extends React.Component {
 
   render = () => {
     let options = [
-      { displayText: "One",
-        value: "1" },
-      { displayText: "Two",
-        value: "2" }
+      { displayText: 'One',
+        value: '1' },
+      { displayText: 'Two',
+        value: '2' }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
@@ -8,7 +8,7 @@ export default class Example3 extends React.Component {
     super(props);
 
     this.state = {
-      value: '2'
+      value: "2"
     };
   }
 
@@ -20,10 +20,10 @@ export default class Example3 extends React.Component {
 
   render = () => {
     let options = [
-      { displayText: 'One',
-        value: '1' },
-      { displayText: 'Two',
-        value: '2' }
+      { displayText: "One",
+        value: "1" },
+      { displayText: "Two",
+        value: "2" }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example4.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example4.jsx
@@ -9,7 +9,7 @@ export default class Example4 extends React.Component {
 
     this.state = {
       value: null,
-      errorMessage: 'This field is required'
+      errorMessage: "This field is required"
     };
   }
 
@@ -22,10 +22,10 @@ export default class Example4 extends React.Component {
 
   render = () => {
     let options = [
-      { displayText: 'Furnished',
-        value: '1' },
-      { displayText: 'Not furnished',
-        value: '2' }
+      { displayText: "Furnished",
+        value: "1" },
+      { displayText: "Not furnished",
+        value: "2" }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example4.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example4.jsx
@@ -9,7 +9,7 @@ export default class Example4 extends React.Component {
 
     this.state = {
       value: null,
-      errorMessage: "This field is required"
+      errorMessage: 'This field is required'
     };
   }
 
@@ -22,10 +22,10 @@ export default class Example4 extends React.Component {
 
   render = () => {
     let options = [
-      { displayText: "Furnished",
-        value: "1" },
-      { displayText: "Not furnished",
-        value: "2" }
+      { displayText: 'Furnished',
+        value: '1' },
+      { displayText: 'Not furnished',
+        value: '2' }
     ];
 
     return <RadioField

--- a/client/app/containers/StyleGuide/StyleGuideLinkButton.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideLinkButton.jsx
@@ -15,12 +15,12 @@ let StyleGuideLinkButton = () => {
         <h3 className="styleguide-grey-header">Default</h3>
         <Button
           name="signup-1"
-          classNames={["usa-button-outline"]}>
+          classNames={['usa-button-outline']}>
           Signup
         </Button><br/><br/>
         <Button
           name="signup-2"
-          classNames={["cf-btn-link"]}>
+          classNames={['cf-btn-link']}>
           Signup
         </Button>
       </div>
@@ -28,12 +28,12 @@ let StyleGuideLinkButton = () => {
         <h3 className="styleguide-grey-header">Hover</h3>
         <Button
           name="signup-3"
-          classNames={["usa-button-outline usa-button-hover"]}>
+          classNames={['usa-button-outline usa-button-hover']}>
           Signup
         </Button><br/><br/>
         <Button
           name="signup-4"
-          classNames={["cf-btn-link button-hover"]}>
+          classNames={['cf-btn-link button-hover']}>
           Signup
         </Button>
       </div>
@@ -41,12 +41,12 @@ let StyleGuideLinkButton = () => {
         <h3 className="styleguide-grey-header">Active</h3>
         <Button
           name="signup-5"
-          classNames={["usa-button-outline usa-button-active"]}>
+          classNames={['usa-button-outline usa-button-active']}>
           Signup
         </Button><br/><br/>
         <Button
           name="signup-6"
-          classNames={["cf-btn-link button-active"]}>
+          classNames={['cf-btn-link button-active']}>
           Signup
         </Button>
       </div>

--- a/client/app/containers/StyleGuide/StyleGuideLinkButton.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideLinkButton.jsx
@@ -15,12 +15,12 @@ let StyleGuideLinkButton = () => {
         <h3 className="styleguide-grey-header">Default</h3>
         <Button
           name="signup-1"
-          classNames={['usa-button-outline']}>
+          classNames={["usa-button-outline"]}>
           Signup
         </Button><br/><br/>
         <Button
           name="signup-2"
-          classNames={['cf-btn-link']}>
+          classNames={["cf-btn-link"]}>
           Signup
         </Button>
       </div>
@@ -28,12 +28,12 @@ let StyleGuideLinkButton = () => {
         <h3 className="styleguide-grey-header">Hover</h3>
         <Button
           name="signup-3"
-          classNames={['usa-button-outline usa-button-hover']}>
+          classNames={["usa-button-outline usa-button-hover"]}>
           Signup
         </Button><br/><br/>
         <Button
           name="signup-4"
-          classNames={['cf-btn-link button-hover']}>
+          classNames={["cf-btn-link button-hover"]}>
           Signup
         </Button>
       </div>
@@ -41,12 +41,12 @@ let StyleGuideLinkButton = () => {
         <h3 className="styleguide-grey-header">Active</h3>
         <Button
           name="signup-5"
-          classNames={['usa-button-outline usa-button-active']}>
+          classNames={["usa-button-outline usa-button-active"]}>
           Signup
         </Button><br/><br/>
         <Button
           name="signup-6"
-          classNames={['cf-btn-link button-active']}>
+          classNames={["cf-btn-link button-active"]}>
           Signup
         </Button>
       </div>

--- a/client/app/containers/StyleGuide/StyleGuideLoadingButton.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideLoadingButton.jsx
@@ -21,14 +21,14 @@ export default class StyleGuideLoadingButton extends React.Component {
 
   toggle = (event) => {
     let state = this.state;
-    let attr = event.target.getAttribute("id").split("-")[1];
+    let attr = event.target.getAttribute('id').split('-')[1];
 
     state.loading[attr] = !state.loading[attr];
     this.setState(state);
   }
 
   render() {
-    let buttonName = "See it in action";
+    let buttonName = 'See it in action';
 
     return <div>
       <StyleGuideComponentTitle
@@ -51,9 +51,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-default"
-          name={"Reset"}
+          name={'Reset'}
           onClick={this.toggle}
-          classNames={["cf-btn-link"]}
+          classNames={['cf-btn-link']}
           disabled={!this.state.loading.default}
         />
       </p>
@@ -68,9 +68,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-dispatch"
-          name={"Reset"}
+          name={'Reset'}
           onClick={this.toggle}
-          classNames={["cf-btn-link"]}
+          classNames={['cf-btn-link']}
           disabled={!this.state.loading.dispatch}
         />
       </p>
@@ -85,9 +85,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-cert"
-          name={"Reset"}
+          name={'Reset'}
           onClick={this.toggle}
-          classNames={["cf-btn-link"]}
+          classNames={['cf-btn-link']}
           disabled={!this.state.loading.cert}
         />
       </p>
@@ -102,9 +102,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-efolder"
-          name={"Reset"}
+          name={'Reset'}
           onClick={this.toggle}
-          classNames={["cf-btn-link"]}
+          classNames={['cf-btn-link']}
           disabled={!this.state.loading.efolder}
         />
       </p>
@@ -119,9 +119,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-feedback"
-          name={"Reset"}
+          name={'Reset'}
           onClick={this.toggle}
-          classNames={["cf-btn-link"]}
+          classNames={['cf-btn-link']}
           disabled={!this.state.loading.feedback}
         />
       </p>

--- a/client/app/containers/StyleGuide/StyleGuideLoadingButton.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideLoadingButton.jsx
@@ -21,14 +21,14 @@ export default class StyleGuideLoadingButton extends React.Component {
 
   toggle = (event) => {
     let state = this.state;
-    let attr = event.target.getAttribute('id').split('-')[1];
+    let attr = event.target.getAttribute("id").split("-")[1];
 
     state.loading[attr] = !state.loading[attr];
     this.setState(state);
   }
 
   render() {
-    let buttonName = 'See it in action';
+    let buttonName = "See it in action";
 
     return <div>
       <StyleGuideComponentTitle
@@ -51,9 +51,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-default"
-          name={'Reset'}
+          name={"Reset"}
           onClick={this.toggle}
-          classNames={['cf-btn-link']}
+          classNames={["cf-btn-link"]}
           disabled={!this.state.loading.default}
         />
       </p>
@@ -68,9 +68,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-dispatch"
-          name={'Reset'}
+          name={"Reset"}
           onClick={this.toggle}
-          classNames={['cf-btn-link']}
+          classNames={["cf-btn-link"]}
           disabled={!this.state.loading.dispatch}
         />
       </p>
@@ -85,9 +85,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-cert"
-          name={'Reset'}
+          name={"Reset"}
           onClick={this.toggle}
-          classNames={['cf-btn-link']}
+          classNames={["cf-btn-link"]}
           disabled={!this.state.loading.cert}
         />
       </p>
@@ -102,9 +102,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-efolder"
-          name={'Reset'}
+          name={"Reset"}
           onClick={this.toggle}
-          classNames={['cf-btn-link']}
+          classNames={["cf-btn-link"]}
           disabled={!this.state.loading.efolder}
         />
       </p>
@@ -119,9 +119,9 @@ export default class StyleGuideLoadingButton extends React.Component {
         />
         <Button
           id="reset-feedback"
-          name={'Reset'}
+          name={"Reset"}
           onClick={this.toggle}
-          classNames={['cf-btn-link']}
+          classNames={["cf-btn-link"]}
           disabled={!this.state.loading.feedback}
         />
       </p>

--- a/client/app/containers/StyleGuide/StyleGuideModal.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideModal.jsx
@@ -39,15 +39,15 @@ export default class StyleGuideModal extends React.Component {
       <p><Button
           name="Launch modal"
           onClick={this.handleModalOpen}
-          classNames={['usa-button', 'usa-button-outline']}
+          classNames={["usa-button", "usa-button-outline"]}
       /></p>
       { styleGuideModal && <Modal
         buttons = {[
-          { classNames: ['cf-modal-link', 'cf-btn-link'],
+          { classNames: ["cf-modal-link", "cf-btn-link"],
             name: 'Close',
             onClick: this.handleModalClose
           },
-          { classNames: ['usa-button', 'usa-button-secondary'],
+          { classNames: ["usa-button", "usa-button-secondary"],
             name: 'Proceed with action',
             onClick: this.handleModalClose
           }

--- a/client/app/containers/StyleGuide/StyleGuideModal.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideModal.jsx
@@ -39,15 +39,15 @@ export default class StyleGuideModal extends React.Component {
       <p><Button
           name="Launch modal"
           onClick={this.handleModalOpen}
-          classNames={["usa-button", "usa-button-outline"]}
+          classNames={['usa-button', 'usa-button-outline']}
       /></p>
       { styleGuideModal && <Modal
         buttons = {[
-          { classNames: ["cf-modal-link", "cf-btn-link"],
+          { classNames: ['cf-modal-link', 'cf-btn-link'],
             name: 'Close',
             onClick: this.handleModalClose
           },
-          { classNames: ["usa-button", "usa-button-secondary"],
+          { classNames: ['usa-button', 'usa-button-secondary'],
             name: 'Proceed with action',
             onClick: this.handleModalClose
           }

--- a/client/app/containers/StyleGuide/StyleGuideNavigationBar.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideNavigationBar.jsx
@@ -38,7 +38,7 @@ export default class StyleGuideNavigationBar extends React.Component {
       name
     } = this.props;
 
-    name = "App Bar";
+    name = 'App Bar';
 
     return <div>
       <StyleGuideComponentTitle

--- a/client/app/containers/StyleGuide/StyleGuideNavigationBar.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideNavigationBar.jsx
@@ -38,7 +38,7 @@ export default class StyleGuideNavigationBar extends React.Component {
       name
     } = this.props;
 
-    name = 'App Bar';
+    name = "App Bar";
 
     return <div>
       <StyleGuideComponentTitle

--- a/client/app/containers/StyleGuide/StyleGuideTables.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideTables.jsx
@@ -8,50 +8,50 @@ import Table from '../../components/Table';
 export default function StyleGuideTables() {
   // List of objects which will be used to create each row
   let rowObjects = [
-    { name: "Shane",
-      spiritAnimal: "Hamster",
+    { name: 'Shane',
+      spiritAnimal: 'Hamster',
       likesSports: true },
-    { name: "Kavi",
-      spiritAnimal: "Koala Bear",
+    { name: 'Kavi',
+      spiritAnimal: 'Koala Bear',
       likesSports: false },
-    { name: "Gina",
-      spiritAnimal: "Otter",
+    { name: 'Gina',
+      spiritAnimal: 'Otter',
       likesSports: false }
   ];
 
   let columns = [
     {
-      header: "Name",
-      valueName: "name",
-      footer: "Totals"
+      header: 'Name',
+      valueName: 'name',
+      footer: 'Totals'
     },
     {
-      header: "Spirit Animal",
-      align: "center",
-      valueName: "spiritAnimal",
-      footer: "3"
+      header: 'Spirit Animal',
+      align: 'center',
+      valueName: 'spiritAnimal',
+      footer: '3'
     },
     {
-      header: "Likes sports?",
-      align: "center",
+      header: 'Likes sports?',
+      align: 'center',
       valueFunction: (person) => {
-        return person.likesSports ? "Yes" : "No";
+        return person.likesSports ? 'Yes' : 'No';
       },
-      footer: "1"
+      footer: '1'
     }
   ];
 
   let columnsWithAction = _.concat(columns, [
     {
-      header: "Poke",
-      align: "right",
+      header: 'Poke',
+      align: 'right',
       valueFunction: (person, rowNumber) => {
         return <a href={`#poke-${rowNumber}`}>Poke {person.name} »</a>;
       }
     }
   ]);
 
-  let summary = "Example styleguide table";
+  let summary = 'Example styleguide table';
 
   return <div>
     <StyleGuideComponentTitle

--- a/client/app/containers/StyleGuide/StyleGuideTables.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideTables.jsx
@@ -8,50 +8,50 @@ import Table from '../../components/Table';
 export default function StyleGuideTables() {
   // List of objects which will be used to create each row
   let rowObjects = [
-    { name: 'Shane',
-      spiritAnimal: 'Hamster',
+    { name: "Shane",
+      spiritAnimal: "Hamster",
       likesSports: true },
-    { name: 'Kavi',
-      spiritAnimal: 'Koala Bear',
+    { name: "Kavi",
+      spiritAnimal: "Koala Bear",
       likesSports: false },
-    { name: 'Gina',
-      spiritAnimal: 'Otter',
+    { name: "Gina",
+      spiritAnimal: "Otter",
       likesSports: false }
   ];
 
   let columns = [
     {
-      header: 'Name',
-      valueName: 'name',
-      footer: 'Totals'
+      header: "Name",
+      valueName: "name",
+      footer: "Totals"
     },
     {
-      header: 'Spirit Animal',
-      align: 'center',
-      valueName: 'spiritAnimal',
-      footer: '3'
+      header: "Spirit Animal",
+      align: "center",
+      valueName: "spiritAnimal",
+      footer: "3"
     },
     {
-      header: 'Likes sports?',
-      align: 'center',
+      header: "Likes sports?",
+      align: "center",
       valueFunction: (person) => {
-        return person.likesSports ? 'Yes' : 'No';
+        return person.likesSports ? "Yes" : "No";
       },
-      footer: '1'
+      footer: "1"
     }
   ];
 
   let columnsWithAction = _.concat(columns, [
     {
-      header: 'Poke',
-      align: 'right',
+      header: "Poke",
+      align: "right",
       valueFunction: (person, rowNumber) => {
         return <a href={`#poke-${rowNumber}`}>Poke {person.name} »</a>;
       }
     }
   ]);
 
-  let summary = 'Example styleguide table';
+  let summary = "Example styleguide table";
 
   return <div>
     <StyleGuideComponentTitle

--- a/client/app/containers/StyleGuide/StyleGuideTabs.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideTabs.jsx
@@ -15,34 +15,34 @@ export default class StyleGuideTabs extends React.Component {
 
     tabs = [
       {
-        label: 'Tab 1',
-        page: ' '
+        label: "Tab 1",
+        page: " "
       },
       {
-        label: 'Tab 2',
-        page: ' '
+        label: "Tab 2",
+        page: " "
       },
       {
-        label: 'Tab 3',
-        page: ' '
+        label: "Tab 3",
+        page: " "
       }
     ];
 
     tabsWithIcons = [{
       disable: false,
       icon: checkSymbolHtml(),
-      label: 'Active Tab',
-      page: ' '
+      label: "Active Tab",
+      page: " "
     }, {
       disable: false,
       icon: checkSymbolHtml(),
-      label: 'Enabled Tab',
-      page: ' '
+      label: "Enabled Tab",
+      page: " "
     }, {
       disable: true,
       icon: crossSymbolHtml(),
-      label: 'Disabled Tab',
-      page: ' '
+      label: "Disabled Tab",
+      page: " "
     }
     ];
 

--- a/client/app/containers/StyleGuide/StyleGuideTabs.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideTabs.jsx
@@ -15,34 +15,34 @@ export default class StyleGuideTabs extends React.Component {
 
     tabs = [
       {
-        label: "Tab 1",
-        page: " "
+        label: 'Tab 1',
+        page: ' '
       },
       {
-        label: "Tab 2",
-        page: " "
+        label: 'Tab 2',
+        page: ' '
       },
       {
-        label: "Tab 3",
-        page: " "
+        label: 'Tab 3',
+        page: ' '
       }
     ];
 
     tabsWithIcons = [{
       disable: false,
       icon: checkSymbolHtml(),
-      label: "Active Tab",
-      page: " "
+      label: 'Active Tab',
+      page: ' '
     }, {
       disable: false,
       icon: checkSymbolHtml(),
-      label: "Enabled Tab",
-      page: " "
+      label: 'Enabled Tab',
+      page: ' '
     }, {
       disable: true,
       icon: crossSymbolHtml(),
-      label: "Disabled Tab",
-      page: " "
+      label: 'Disabled Tab',
+      page: ' '
     }
     ];
 

--- a/client/app/containers/TasksManager/TasksManagerIndex.jsx
+++ b/client/app/containers/TasksManager/TasksManagerIndex.jsx
@@ -31,19 +31,19 @@ export default class TasksManagerIndex extends BaseForm {
       {
         header: 'Employee Name',
         valueName: 'name',
-        footer: noUsers ? "" : <b>Employee Total</b>
+        footer: noUsers ? '' : <b>Employee Total</b>
       },
       {
         header: 'Cases Assigned',
         valueFunction: () => this.state.assignedCases,
         footer: noUsers ?
-          "0" :
+          '0' :
           <b>{this.props.toCompleteCount + this.props.completedCountToday}</b>
       },
       {
         header: 'Cases Completed',
         valueName: 'numberOfTasks',
-        footer: noUsers ? "0" : <b>{this.props.completedCountToday}</b>
+        footer: noUsers ? '0' : <b>{this.props.completedCountToday}</b>
       },
       {
         header: 'Cases Remaining',

--- a/client/app/containers/TasksManager/TasksManagerIndex.jsx
+++ b/client/app/containers/TasksManager/TasksManagerIndex.jsx
@@ -31,19 +31,19 @@ export default class TasksManagerIndex extends BaseForm {
       {
         header: 'Employee Name',
         valueName: 'name',
-        footer: noUsers ? '' : <b>Employee Total</b>
+        footer: noUsers ? "" : <b>Employee Total</b>
       },
       {
         header: 'Cases Assigned',
         valueFunction: () => this.state.assignedCases,
         footer: noUsers ?
-          '0' :
+          "0" :
           <b>{this.props.toCompleteCount + this.props.completedCountToday}</b>
       },
       {
         header: 'Cases Completed',
         valueName: 'numberOfTasks',
-        footer: noUsers ? '0' : <b>{this.props.completedCountToday}</b>
+        footer: noUsers ? "0" : <b>{this.props.completedCountToday}</b>
       },
       {
         header: 'Cases Remaining',

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -21,9 +21,9 @@ export class PdfListView extends React.Component {
     let className;
 
     if (this.props.sortDirection === 'ascending') {
-      className = "fa-caret-down";
+      className = 'fa-caret-down';
     } else {
-      className = "fa-caret-up";
+      className = 'fa-caret-up';
     }
 
     let sortIcon = <i className={`fa fa-1 ${className} table-icon`}
@@ -131,7 +131,7 @@ export class PdfListView extends React.Component {
               {numberOfComments > 0 &&
                 <span>
                   <Button
-                    classNames={["cf-btn-link"]}
+                    classNames={['cf-btn-link']}
                     href="#"
                     ariaLabel={name}
                     name={name}

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -21,9 +21,9 @@ export class PdfListView extends React.Component {
     let className;
 
     if (this.props.sortDirection === 'ascending') {
-      className = 'fa-caret-down';
+      className = "fa-caret-down";
     } else {
-      className = 'fa-caret-up';
+      className = "fa-caret-up";
     }
 
     let sortIcon = <i className={`fa fa-1 ${className} table-icon`}
@@ -131,7 +131,7 @@ export class PdfListView extends React.Component {
               {numberOfComments > 0 &&
                 <span>
                   <Button
-                    classNames={['cf-btn-link']}
+                    classNames={["cf-btn-link"]}
                     href="#"
                     ariaLabel={name}
                     name={name}

--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -87,11 +87,11 @@ export default class PdfViewer extends React.Component {
   placeComment = (pageNumber, coordinates) => {
     if (this.state.isPlacingNote) {
       let annotation = {
-        class: 'Annotation',
+        class: "Annotation",
         page: pageNumber,
-        'type': 'point',
-        'x': coordinates.xPosition,
-        'y': coordinates.yPosition
+        "type": "point",
+        "x": coordinates.xPosition,
+        "y": coordinates.yPosition
       };
 
       this.setState({
@@ -231,11 +231,11 @@ export default class PdfViewer extends React.Component {
         </div>
         {this.state.onConfirmDelete && <Modal
           buttons={[
-            { classNames: ['cf-modal-link', 'cf-btn-link'],
+            { classNames: ["cf-modal-link", "cf-btn-link"],
               name: 'Cancel',
               onClick: this.closeConfirmDeleteModal
             },
-            { classNames: ['usa-button', 'usa-button-secondary'],
+            { classNames: ["usa-button", "usa-button-secondary"],
               name: 'Confirm delete',
               onClick: this.state.onConfirmDelete
             }

--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -87,11 +87,11 @@ export default class PdfViewer extends React.Component {
   placeComment = (pageNumber, coordinates) => {
     if (this.state.isPlacingNote) {
       let annotation = {
-        class: "Annotation",
+        class: 'Annotation',
         page: pageNumber,
-        "type": "point",
-        "x": coordinates.xPosition,
-        "y": coordinates.yPosition
+        'type': 'point',
+        'x': coordinates.xPosition,
+        'y': coordinates.yPosition
       };
 
       this.setState({
@@ -231,11 +231,11 @@ export default class PdfViewer extends React.Component {
         </div>
         {this.state.onConfirmDelete && <Modal
           buttons={[
-            { classNames: ["cf-modal-link", "cf-btn-link"],
+            { classNames: ['cf-modal-link', 'cf-btn-link'],
               name: 'Cancel',
               onClick: this.closeConfirmDeleteModal
             },
-            { classNames: ["usa-button", "usa-button-secondary"],
+            { classNames: ['usa-button', 'usa-button-secondary'],
               name: 'Confirm delete',
               onClick: this.state.onConfirmDelete
             }

--- a/client/app/util/AnnotationStorage.js
+++ b/client/app/util/AnnotationStorage.js
@@ -133,8 +133,8 @@ export default class AnnotationStorage {
     annotations.forEach((annotation) => {
       // We have to call it a uuid for the UI to properly use it
       annotation.uuid = annotation.id;
-      annotation.class = 'annotation';
-      annotation.type = 'point';
+      annotation.class = "annotation";
+      annotation.type = "point";
       annotation.documentId = annotation.document_id;
 
       if (!this.storedAnnotations[annotation.documentId]) {

--- a/client/app/util/AnnotationStorage.js
+++ b/client/app/util/AnnotationStorage.js
@@ -133,8 +133,8 @@ export default class AnnotationStorage {
     annotations.forEach((annotation) => {
       // We have to call it a uuid for the UI to properly use it
       annotation.uuid = annotation.id;
-      annotation.class = "annotation";
-      annotation.type = "point";
+      annotation.class = 'annotation';
+      annotation.type = 'point';
       annotation.documentId = annotation.document_id;
 
       if (!this.storedAnnotations[annotation.documentId]) {

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -21,10 +21,10 @@ const StringUtil = {
   convertToCamelCase(phrase = '') {
     // Code courtesy of Stack Overflow, Question 2970525
     return phrase.toLowerCase().
-        replace(/[^a-zA-Z ]/g, '').
+        replace(/[^a-zA-Z ]/g, "").
         replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => {
           if (Number(match) === 0) {
-            return '';
+            return "";
           }
 
           return index === 0 ? match.toLowerCase() : match.toUpperCase();
@@ -55,7 +55,7 @@ const StringUtil = {
   },
 
   html5CompliantId(str) {
-    return str.replace(/[^A-Za-z0-9-]/g, '-').replace(/-+/g, '-');
+    return str.replace(/[^A-Za-z0-9-]/g, "-").replace(/-+/g, "-");
   }
 };
 

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -21,10 +21,10 @@ const StringUtil = {
   convertToCamelCase(phrase = '') {
     // Code courtesy of Stack Overflow, Question 2970525
     return phrase.toLowerCase().
-        replace(/[^a-zA-Z ]/g, "").
+        replace(/[^a-zA-Z ]/g, '').
         replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, (match, index) => {
           if (Number(match) === 0) {
-            return "";
+            return '';
           }
 
           return index === 0 ? match.toLowerCase() : match.toUpperCase();
@@ -55,7 +55,7 @@ const StringUtil = {
   },
 
   html5CompliantId(str) {
-    return str.replace(/[^A-Za-z0-9-]/g, "-").replace(/-+/g, "-");
+    return str.replace(/[^A-Za-z0-9-]/g, '-').replace(/-+/g, '-');
   }
 };
 

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "test:karma": "NODE_ENV=test karma start",
     "test:karma:watch": "npm run test:karma -- --no-single-run",
     "test:legacy:watch": "npm run test:legacy -- --watch",
-    "lint": "eslint . --ext .jsx --ext .js",
+    "lint": "eslint . --ext .jsx --ext .js --max-warnings 0",
     "lint:fix": "npm run lint -- --fix",
     "build": "webpack --config webpack.config.js",
     "build:test": "NODE_ENV=test npm run build",

--- a/client/test/karma/components/Alert-test.js
+++ b/client/test/karma/components/Alert-test.js
@@ -10,8 +10,8 @@ describe('Alert', () => {
   let wrapper;
 
   beforeEach(() => {
-    title = "My Error";
-    message = "There was an error";
+    title = 'My Error';
+    message = 'There was an error';
   });
 
   context('role attribute', () => {

--- a/client/test/karma/components/Button-test.js
+++ b/client/test/karma/components/Button-test.js
@@ -21,7 +21,7 @@ describe('Button', () => {
     const wrapper = shallow(<Button
                               name="foo"
                               onChange={onChange}
-                              classNames={["usa-button-primary"]}
+                              classNames={['usa-button-primary']}
                               disabled={true} />);
 
     expect(wrapper.find('.usa-button-disabled')).to.have.length(1);

--- a/client/test/karma/components/Modal-test.js
+++ b/client/test/karma/components/Modal-test.js
@@ -10,7 +10,7 @@ describe('Modal', () => {
       let wrapper = mount(
         <Modal
         buttons={[
-          { classNames: ["test-class"],
+          { classNames: ['test-class'],
             name: 'first'
           }
         ]}
@@ -31,13 +31,13 @@ describe('Modal', () => {
       let wrapper = mount(
         <Modal
         buttons={[
-          { classNames: ["test-class"],
+          { classNames: ['test-class'],
             name: 'first'
           },
-          { classNames: ["test-class"],
+          { classNames: ['test-class'],
             name: 'second'
           },
-          { classNames: ["test-class"],
+          { classNames: ['test-class'],
             name: 'third'
           }
         ]}

--- a/client/test/karma/components/Table-test.js
+++ b/client/test/karma/components/Table-test.js
@@ -13,11 +13,11 @@ describe('Table', () => {
   beforeEach(() => {
     columns = [
       { header: 'First',
-        valueFunction: () => "fizz" },
+        valueFunction: () => 'fizz' },
       { header: 'Second',
-        valueFunction: () => "buzz" },
+        valueFunction: () => 'buzz' },
       { header: 'Second',
-        valueName: "type" }
+        valueName: 'type' }
     ];
 
     rowObjects = createTask(3);

--- a/client/test/karma/containers/EstablishClaim-test.js
+++ b/client/test/karma/containers/EstablishClaim-test.js
@@ -152,7 +152,7 @@ describe('EstablishClaim', () => {
         task={task}/>);
     });
 
-    context("when ARC EP", () => {
+    context('when ARC EP', () => {
       beforeEach(() => {
         wrapper.node.store.dispatch({
           type: Constants.CHANGE_ESTABLISH_CLAIM_FIELD,
@@ -182,7 +182,7 @@ describe('EstablishClaim', () => {
       });
     });
 
-    context("when Routed EP", () => {
+    context('when Routed EP', () => {
       it('returns 170RMDAMC - ARC-Remand for remand', () => {
         wrapper.setState({ reviewForm: { decisionType: { value: 'Remand' } } });
         expect(wrapper.instance().getClaimTypeFromDecision()).to.

--- a/client/test/node/components/Pdf-test.js
+++ b/client/test/node/components/Pdf-test.js
@@ -10,7 +10,7 @@ import { documents } from '../../data/documents';
 
 /* eslint-disable no-unused-expressions */
 describe('Pdf', () => {
-  let pdfId = "pdf";
+  let pdfId = 'pdf';
 
   // Note, these tests use mount rather than shallow.
   // In order to get that working, we must stub out
@@ -41,7 +41,7 @@ describe('Pdf', () => {
     });
 
     context('.render', () => {
-      it(`renders the staging div`, () => {
+      it('renders the staging div', () => {
         expect(wrapper.find('.cf-pdf-pdfjs-container')).
           to.have.length(PdfJsStub.numPages);
       });
@@ -59,7 +59,7 @@ describe('Pdf', () => {
         });
 
         it(`calls onPageChange with 1 and ${PdfJsStub.numPages}`, (done) => {
-          wrapper.instance().setupPdf("test.pdf").
+          wrapper.instance().setupPdf('test.pdf').
             then(() => {
               expect(onPageChange.calledWith(1, PdfJsStub.numPages)).to.be.true;
               done();

--- a/client/test/node/setup.js
+++ b/client/test/node/setup.js
@@ -1,4 +1,4 @@
-require("babel-polyfill");
+require('babel-polyfill');
 
 let jsdom = require('jsdom').jsdom;
 


### PR DESCRIPTION
This PR looks big, but it was generated entirely by `npm run lint:fix`.

It seems like it's nice to standardize on one quotes style. There were ~250 cases of double quotes and 2156 cases of single quotes, so I made everything single quotes.

If we would like to do this, I'd like to merge it quickly, to avoid merge conflicts.

Connect #1665.