### PR TITLE
More linting: object key quotes

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -193,6 +193,7 @@ module.exports = {
     "prefer-spread": "error",
     "prefer-template": "error",
     "quotes": ["warn", "single", {"avoidEscape": true}],
+    "quote-props": ["warn", "as-needed"],
     "radix": "error",
     "rest-spread-spacing": "error",
     "semi": "error",

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -29,7 +29,7 @@ module.exports = {
     "block-spacing": "error",
     "brace-style": "error",
     "callback-return": "error",
-    "camelcase": "error",
+    "camelcase": ["warn", {"properties": "never"}],
     "class-methods-use-this": "error",
     "comma-dangle": "error",
     "comma-spacing": "error",

--- a/client/app/components/RenderFunctions.jsx
+++ b/client/app/components/RenderFunctions.jsx
@@ -22,7 +22,7 @@ export const loadingSymbolHtml = function(text = 'Loading', size = '30px', color
     );
   }
 
-  const style = { 'marginLeft': `-${imgSize}` };
+  const style = { marginLeft: `-${imgSize}` };
 
   return (
       <div>

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -28,9 +28,9 @@ export default class Table extends React.Component {
     } = this.props;
 
     let alignmentClasses = {
-      'center': 'cf-txt-c',
-      'left': 'cf-txt-l',
-      'right': 'cf-txt-r'
+      center: 'cf-txt-c',
+      left: 'cf-txt-l',
+      right: 'cf-txt-r'
     };
 
     let cellClasses = (column) => {

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -34,26 +34,26 @@ export const EMAIL_PAGE = 'email';
 
 
 export const END_PRODUCT_INFO = {
-  'ARC': {
+  ARC: {
     'Full Grant': ['172BVAG', 'BVA Grant'],
     'Partial Grant': ['170PGAMC', 'ARC-Partial Grant'],
-    'Remand': ['170RMDAMC', 'ARC-Remand']
+    Remand: ['170RMDAMC', 'ARC-Remand']
   },
-  'Routed': {
+  Routed: {
     'Full Grant': ['172BVAG', 'BVA Grant'],
     'Partial Grant': ['170RBVAG', 'Remand with BVA Grant'],
-    'Remand': ['170RMD', 'Remand']
+    Remand: ['170RMD', 'Remand']
   }
 };
 
 const CREATE_EP_ERRORS = {
-  'duplicate_ep': {
+  duplicate_ep: {
     header: 'At this time, we are unable to assign or create a new EP for this claim.',
     body: 'An EP with that modifier was previously created for this claim. ' +
           'Try a different modifier or select Cancel at the bottom of the ' +
           'page to release this claim and proceed to process it outside of Caseflow.'
   },
-  'task_already_completed': {
+  task_already_completed: {
     header: 'This task was already completed.',
     body: <span>
             Please return
@@ -61,7 +61,7 @@ const CREATE_EP_ERRORS = {
             establish the next claim.
           </span>
   },
-  'missing_ssn': {
+  missing_ssn: {
     header: 'The EP for this claim must be created outside Caseflow.',
     body: <span>
             This veteran does not have a social security number, so their
@@ -71,7 +71,7 @@ const CREATE_EP_ERRORS = {
             proceed to process it outside of Caseflow.
           </span>
   },
-  'default': {
+  default: {
     header: 'System Error',
     body: 'Something went wrong on our end. We were not able to create an End Product. ' +
           'Please try again later.'

--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -89,9 +89,9 @@ export default class PdfViewer extends React.Component {
       let annotation = {
         class: 'Annotation',
         page: pageNumber,
-        'type': 'point',
-        'x': coordinates.xPosition,
-        'y': coordinates.yPosition
+        type: 'point',
+        x: coordinates.xPosition,
+        y: coordinates.yPosition
       };
 
       this.setState({

--- a/client/app/util/ApiUtil.js
+++ b/client/app/util/ApiUtil.js
@@ -52,7 +52,7 @@ const ApiUtil = {
   headers(options = {}) {
     let headers = Object.assign({},
       {
-        'Accept': 'application/json',
+        Accept: 'application/json',
         'Content-Type': 'application/json'
       },
       ReactOnRails.authenticityHeaders(),

--- a/client/test/karma/establishClaim/util/index-test.js
+++ b/client/test/karma/establishClaim/util/index-test.js
@@ -21,7 +21,7 @@ context('establishClaimUtil', () => {
 
     beforeEach(() => {
       regionalOfficeCities = {
-        'RO01': {
+        RO01: {
           city: 'Boston',
           state: 'MA',
           timezone: 'America/New_York'
@@ -72,7 +72,7 @@ context('establishClaimUtil', () => {
       result = validModifiers(
         [
           {
-            'end_product_type_code': '170'
+            end_product_type_code: '170'
           }
         ],
         'partial grants'


### PR DESCRIPTION
Same PR description for #1668 applies here.

Connecct #1665.

I loosened up the `camelcase` rule for object property keys, because we don't always control those keys. 