### PR TITLE
Mdbenjam add user info to comment

### DIFF
--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -31,6 +31,7 @@ $bookmark-yellow: #efdf1a;
   right: 0;
   left: 0;
   min-height: 400px;
+  z-index: 1;
 }
 
 .cf-pdf-container {

--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -31,7 +31,6 @@ $bookmark-yellow: #efdf1a;
   right: 0;
   left: 0;
   min-height: 400px;
-  z-index: 1;
 }
 
 .cf-pdf-container {

--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -4,7 +4,7 @@ class AnnotationController < ApplicationController
   ANNOTATION_AUTHORIZED_ROLES = ["Reader"].freeze
 
   def create
-    annotation = Annotation.create!(annotation_params)
+    annotation = Annotation.create!(annotation_params.merge(user_id: current_user.id))
     render json: { id: annotation.id }
   end
 

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,5 +1,6 @@
 class Annotation < ActiveRecord::Base
   belongs_to :document
+  belongs_to :user
 
   def to_hash
     serializable_hash(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   has_many :tasks
   has_many :document_views
+  has_many :annotations
 
   # Ephemeral values obtained from CSS on auth. Stored in user's session
   attr_accessor :ip_address, :admin_roles

--- a/db/migrate/20170424151347_add_user_ref_to_annotations.rb
+++ b/db/migrate/20170424151347_add_user_ref_to_annotations.rb
@@ -1,0 +1,5 @@
+class AddUserRefToAnnotations < ActiveRecord::Migration
+  def change
+    add_reference :annotations, :user, index: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170413191800) do
+ActiveRecord::Schema.define(version: 20170424151347) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,9 +22,11 @@ ActiveRecord::Schema.define(version: 20170413191800) do
     t.integer "page"
     t.integer "x"
     t.integer "y"
+    t.integer "user_id"
   end
 
   add_index "annotations", ["document_id"], name: "index_annotations_on_document_id", using: :btree
+  add_index "annotations", ["user_id"], name: "index_annotations_on_user_id", using: :btree
 
   create_table "appeals", force: :cascade do |t|
     t.string  "vacols_id",                                                                    null: false
@@ -220,5 +222,6 @@ ActiveRecord::Schema.define(version: 20170413191800) do
 
   add_index "users", ["station_id", "css_id"], name: "index_users_on_station_id_and_css_id", unique: true, using: :btree
 
+  add_foreign_key "annotations", "users"
   add_foreign_key "certifications", "users"
 end

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -69,7 +69,9 @@ RSpec.feature "Reader" do
     expect(page).to have_content("Foo")
 
     # Expect comment to be in database
-    expect(documents[0].reload.annotations.first.comment).to eq("Foo")
+    annotation = documents[0].reload.annotations.first
+    expect(annotation.comment).to eq("Foo")
+    expect(annotation.user_id).to eq(current_user.id)
 
     # Edit the comment
     click_on "Edit"
@@ -91,7 +93,7 @@ RSpec.feature "Reader" do
     # Expect the comment to be removed from the page
     expect(page).to_not have_content("FooBar")
 
-    # Expect the comment to be removed from teh database
+    # Expect the comment to be removed from the database
     expect(documents[0].reload.annotations.count).to eq(0)
   end
 


### PR DESCRIPTION
We currently do not track which user creates which comment. We want to have that data for future analysis.

Connects: #1265 

**Test Plan**
- [x] Add a comment, make sure the Annotation table has the correct user_id for that comment.