### PR TITLE
Fixing pdf page z-index

### DIFF
--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -31,7 +31,7 @@ $bookmark-yellow: #efdf1a;
   right: 0;
   left: 0;
   min-height: 400px;
-  z-index: 1;
+  z-index: 0;
 }
 
 .cf-pdf-container {

--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -31,6 +31,7 @@ $bookmark-yellow: #efdf1a;
   right: 0;
   left: 0;
   min-height: 400px;
+  z-index: 1;
 }
 
 .cf-pdf-container {


### PR DESCRIPTION
A previous [merge](https://github.com/department-of-veterans-affairs/caseflow/commit/dbee510435895f211ce71185f72d559618fcb006) broke the delete modal. This re-adds the z-index to make the modal appear in front of the content of the page.

Connects: #1667 

**Test Plan**
- [ ] Manually try to delete a comment and ensure the modal appears in front of the content.