### PR TITLE
Update commons

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "3341005efa746c998e662c24bd5b9e1aab17420a"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "9b7bbe5719557f25a49709bb1c7fc82d99084885"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 3341005efa746c998e662c24bd5b9e1aab17420a
-  ref: 3341005efa746c998e662c24bd5b9e1aab17420a
+  revision: 9b7bbe5719557f25a49709bb1c7fc82d99084885
+  ref: 9b7bbe5719557f25a49709bb1c7fc82d99084885
   specs:
     caseflow (0.1.6)
       aws-sdk (~> 2)
@@ -107,13 +107,13 @@ GEM
       nokogiri
     arel (6.0.4)
     ast (2.3.0)
-    aws-sdk (2.9.9)
-      aws-sdk-resources (= 2.9.9)
-    aws-sdk-core (2.9.9)
+    aws-sdk (2.9.12)
+      aws-sdk-resources (= 2.9.12)
+    aws-sdk-core (2.9.12)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.9.9)
-      aws-sdk-core (= 2.9.9)
+    aws-sdk-resources (2.9.12)
+      aws-sdk-core (= 2.9.12)
     aws-sigv4 (1.0.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)


### PR DESCRIPTION
This will point to the latest `caseflow-commons` commit that adds TEST env to the Redis namespace in FeatureToggle to avoid conflicts between test and deb envs.