### PR TITLE
adding test for style guide

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -103,8 +103,8 @@
 }
 
 * + .cf-form-dropdown {
-  margin-top: 2rem;
-  margin-bottom: 2rem;
+  margin-top: 1.6rem;
+  margin-bottom: 1.6rem;
 }
 
 .cf-form-textinput[readonly] {

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example3.jsx
@@ -42,12 +42,11 @@ export default class Example3 extends React.Component {
     ];
 
     return <CheckboxGroup
-      label="Vertical Checkboxes:"
+      label={<h3>Vertical Checkboxes</h3>}
       name="checkbox_example_3"
       options={options}
       onChange={this.onChange}
       values={this.state.values}
-      hideLabel={true}
     ></CheckboxGroup>;
   }
 }

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example4.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example4.jsx
@@ -36,12 +36,11 @@ export default class Example4 extends React.Component {
     ];
 
     return <CheckboxGroup
-      label="Horizontal Checkboxes:"
+      label={<h3>Horizontal Checkboxes:</h3>}
       name="checkbox_example_4"
       options={options}
       onChange={this.onChange}
       values={this.state.values}
-      hideLabel={true}
     ></CheckboxGroup>;
   }
 }

--- a/client/app/containers/StyleGuide/CheckboxExamples/Example5.jsx
+++ b/client/app/containers/StyleGuide/CheckboxExamples/Example5.jsx
@@ -36,12 +36,11 @@ export default class Example5 extends React.Component {
     ];
 
     return <CheckboxGroup
-      label="Horizontal checkboxes forced vertically:"
+      label={<h3>Forced Vertical Checkboxes</h3>}
       name="checkbox_example_5"
       options={options}
       onChange={this.onChange}
       values={this.state.values}
-      hideLabel={true}
       vertical={true}
     ></CheckboxGroup>;
   }

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example1.jsx
@@ -29,8 +29,7 @@ export default class Example1 extends React.Component {
     ];
 
     return <RadioField
-      label="Vertical Radio Button"
-      hideLabel={true}
+      label={<h3>Vertical Radio Button</h3>}
       name="radio_example_1"
       options={options}
       value={this.state.value}

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example2.jsx
@@ -27,8 +27,7 @@ export default class Example2 extends React.Component {
     ];
 
     return <RadioField
-      label={<span><strong>Horizontal Radio Button</strong></span>}
-      hideLabel={true}
+      label={<h3>Horizontal Radio Button</h3>}
       name="radio_example_2"
       options={options}
       value={this.state.value}

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example3.jsx
@@ -27,8 +27,7 @@ export default class Example3 extends React.Component {
     ];
 
     return <RadioField
-      label="Forced Vertical Layout"
-      hideLabel={true}
+      label={<h3>Horizontal Radio Button Forced Into Vertical Layout</h3>}
       name="radio_example_3"
       options={options}
       vertical={true}

--- a/client/app/containers/StyleGuide/StyleGuideCheckboxes.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideCheckboxes.jsx
@@ -27,11 +27,8 @@ export default class StyleGuideCheckboxes extends React.Component {
       <Example1 />
       <h3>Single Checkbox with value set</h3>
       <Example2 />
-      <h3>Vertical Checkboxes</h3>
       <Example3 />
-      <h3>Horizontal Checkboxes</h3>
       <Example4 />
-      <h3>Forced Vertical Checkboxes</h3>
       <Example5 />
       <h3>Required Checkboxes</h3>
       <Example6 />

--- a/client/app/containers/StyleGuide/StyleGuideRadioField.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideRadioField.jsx
@@ -20,11 +20,8 @@ export default class StyleGuideRadioField extends React.Component {
       <p>Radio buttons largely follow the same design as those in the
         US Web Design Standards but we also include horizontal radio buttons.
         This layout is used when there are at most 2 options.</p>
-      <h3>Vertical Radio Button</h3>
       <Example1 />
-      <h3>Horizontal Radio Button</h3>
       <Example2 />
-      <h3>Horizontal Radio Button Forced Into Vertical Layout</h3>
       <Example3 />
       <h3>Required Radio Button Errors</h3>
       <Example4 />

--- a/client/app/containers/StyleGuide/StyleGuideSearchableDropdown.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearchableDropdown.jsx
@@ -45,7 +45,7 @@ class StyleGuideSearchableDropdown extends Component {
         <h3>Single Select Searchable Dropdown</h3>
         <SearchableDropdown
           label="Searchable dropdown"
-          name="countries"
+          name="single-select-countries"
           options={options}
           onChange={this.onChange}
           required={true}
@@ -54,7 +54,7 @@ class StyleGuideSearchableDropdown extends Component {
         <SearchableDropdown
           creatable={true}
           label="Click in the box below to select, type, or add issue(s)"
-          name="countries"
+          name="multi-select-countries"
           options={options}
           required={true}
           multi={true}

--- a/spec/feature/styleguide_spec.rb
+++ b/spec/feature/styleguide_spec.rb
@@ -1,11 +1,8 @@
 require "rails_helper"
 
-# Future Style Guide Test...remove skip after fixing accessibility errors
-# :nocov:
 RSpec.feature "Style Guide" do
-  skip "renders and is accessible" do
+  scenario "renders and is accessible" do
     visit "/styleguide"
     expect(page).to have_content("Caseflow Commons")
   end
 end
-# :nocov:


### PR DESCRIPTION
This adds a test for style guide and fixes label issues with the checkboxes/radio buttons on the style guide:
<img width="756" alt="screen shot 2017-05-01 at 10 13 42 am" src="https://cloud.githubusercontent.com/assets/4773320/25581646/0ea1f47e-2e57-11e7-8265-b5084d085987.png">
<img width="323" alt="screen shot 2017-05-01 at 10 14 00 am" src="https://cloud.githubusercontent.com/assets/4773320/25581647/0eae19a2-2e57-11e7-868a-54834917f517.png">

Also adds a different ID to each of the searchable dropdowns:
<img width="757" alt="screen shot 2017-05-01 at 10 14 21 am" src="https://cloud.githubusercontent.com/assets/4773320/25581648/0eb4c5a4-2e57-11e7-806b-6af4051e4042.png">
