### PR TITLE
Move migration to production block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,7 @@ gem 'font-awesome-sass'
 
 gem 'redis-namespace'
 
+# catch problematic migrations at development/test time
 gem "zero_downtime_migrations"
 
 group :production, :staging do
@@ -124,7 +125,6 @@ group :development, :test do
   gem 'parallel_tests'
   # to save and open specific page in capybara tests
   gem 'launchy'
-  # catch problematic migrations at development/test time
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,8 @@ gem 'font-awesome-sass'
 
 gem 'redis-namespace'
 
+gem "zero_downtime_migrations"
+
 group :production, :staging do
   # Oracle DB
   gem 'activerecord-oracle_enhanced-adapter'
@@ -123,7 +125,6 @@ group :development, :test do
   # to save and open specific page in capybara tests
   gem 'launchy'
   # catch problematic migrations at development/test time
-  gem "zero_downtime_migrations"
 end
 
 group :development do


### PR DESCRIPTION
connects #1795 

We've added `safety_assured` to our migrations, but the gem (and method) doesn't exist in production