### PR TITLE
Cache node modules on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ script:
   - bundle exec rake ci:other
   # Move our node modules, then do a production install & webpack build
   # This verifies our production webpack build step is working
-  - cd ./client && mv node_modules node_modules_bak && npm install --production --no-optional && npm run build:production
+  - mv node_modules node_modules_bak && npm install --production --no-optional && npm run build:production
   # Move the non-production node_modules back so that it's cached for next travis test run
-  - cd ./client && rm -rf node_modules && mv node_modules_bak node_modules
+  - rm -rf node_modules && mv node_modules_bak node_modules
 
 bundler_args: "--deployment --without development staging production"
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ bundler_args: "--deployment --without development staging production"
 cache:
   directories:
     - vendor/bundle
+    - client/node_modules
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,11 @@ before_script:
 script:
   - bundle exec rake spec
   - bundle exec rake ci:other
-  - rm -rf node_modules && npm install --production --no-optional && npm run build:production
+  # Move our node modules, then do a production install & webpack build
+  # This verifies our production webpack build step is working
+  - cd ./client && mv node_modules node_modules_bak && npm install --production --no-optional && npm run build:production
+  # Move the non-production node_modules back so that it's cached for next build
+  - cd ./client && rm -rf node_modules && mv node_modules_bak node_modules
 
 bundler_args: "--deployment --without development staging production"
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   # Move our node modules, then do a production install & webpack build
   # This verifies our production webpack build step is working
   - cd ./client && mv node_modules node_modules_bak && npm install --production --no-optional && npm run build:production
-  # Move the non-production node_modules back so that it's cached for next build
+  # Move the non-production node_modules back so that it's cached for next travis test run
   - cd ./client && rm -rf node_modules && mv node_modules_bak node_modules
 
 bundler_args: "--deployment --without development staging production"


### PR DESCRIPTION
This caches our `/node_modules` directory between builds. This will help:
- Reduce # of failed builds due to npm registry request failure
- Speed up our builds

### Before
`npm install` step is really slow on travis atm:
<img width="88" alt="screen shot 2017-05-02 at 5 47 39 pm" src="https://cloud.githubusercontent.com/assets/2256237/25641094/5ab20bf6-2f60-11e7-89ad-b9527bf4cc19.png">

### After
<img width="229" alt="screen shot 2017-05-02 at 5 55 57 pm" src="https://cloud.githubusercontent.com/assets/2256237/25641166/a6b90fa4-2f60-11e7-908c-1efe8565bc5e.png">




Test Plan:
- [x] Run two travis builds back-to-back, ensure they both work & pass