### PR TITLE
Sign and Certify migration fix

### DIFF
--- a/db/migrate/20170502144719_add_sign_and_certify_fields.rb
+++ b/db/migrate/20170502144719_add_sign_and_certify_fields.rb
@@ -1,4 +1,5 @@
 class AddSignAndCertifyFields < ActiveRecord::Migration
+  # this migration was mistakenly merged while empty, disregard
   def change
   end
 end

--- a/db/migrate/20170502213808_add_certification_sign_and_certify_fields.rb
+++ b/db/migrate/20170502213808_add_certification_sign_and_certify_fields.rb
@@ -1,0 +1,9 @@
+class AddCertificationV2Fields2 < ActiveRecord::Migration
+  def change
+    add_column :certifications, :certifying_office, :string
+    add_column :certifications, :certifying_username, :string
+    add_column :certifications, :certifying_official_name, :string
+    add_column :certifications, :certifying_official_title, :string
+    add_column :certifications, :certification_date, :string
+  end
+end

--- a/db/migrate/20170502213808_add_certification_sign_and_certify_fields.rb
+++ b/db/migrate/20170502213808_add_certification_sign_and_certify_fields.rb
@@ -1,4 +1,4 @@
-class AddCertificationV2Fields2 < ActiveRecord::Migration
+class AddCertificationSignAndCertifyFields < ActiveRecord::Migration
   def change
     add_column :certifications, :certifying_office, :string
     add_column :certifications, :certifying_username, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170502144719) do
+ActiveRecord::Schema.define(version: 20170502213808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/caseflow/pull/1778 was mistakenly merged with an empty migration. This adds the correct migration.