### PR TITLE
Better styleguide nav/content spacing when zoomed out

### DIFF
--- a/app/assets/stylesheets/_style_guide.scss
+++ b/app/assets/stylesheets/_style_guide.scss
@@ -25,6 +25,7 @@ div {
 
 .cf-sg-nav {
   margin-top: 35px;
+  width: 10em;
 
   .current-link {
     border-left: 4px solid $color-primary;
@@ -39,7 +40,7 @@ div {
 }
 
 .cf-sg-content {
-  padding-left: 190px;
+  padding-left: 12em;
 }
 
 .usa-accordion {


### PR DESCRIPTION
Connects #1827 

This issue got sent back from validation b/c the overlap still occurred when zoomed out far enough.  This should do the trick.
