### PR TITLE
quick touches to confirmation page

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -136,7 +136,7 @@
 
 .cf-button-associated-text-right {
   color: $color-gray;
-  margin-right: 10px;
+  margin-right: 30px;
   line-height: 35px;
 }
 

--- a/app/views/establish_claims/assigned_existing_ep.html.erb
+++ b/app/views/establish_claims/assigned_existing_ep.html.erb
@@ -1,12 +1,15 @@
 <% content_for :page_title do task.appeal.task_header end %>
+
+<% veteran_name = task.appeal.veteran_full_name %>
+
 <%= react_component('BaseContainer', props: {
     availableTasks: tasks.any_assignable_to?(current_user),
     buttonText: start_text,
     checklist: ['Reviewed decision', 'Assigned existing EP to claim'],
-    firstHeader: 'Congratulations!',
+    firstHeader: 'Success!',
     page: 'EstablishClaimComplete',
     totalCasesCompleted: user_quota.tasks_completed_count,
     employeeCount: team_quota.user_count,
     totalCasesToComplete: to_complete_count,
-    secondHeader: task.appeal.veteran_full_name + "'s claim (" + task.appeal.sanitized_vbms_id + ') has been assigned an EP.'
+    veteranName: veteran_name
 }) %>

--- a/app/views/establish_claims/assigned_existing_ep.html.erb
+++ b/app/views/establish_claims/assigned_existing_ep.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do task.appeal.task_header end %>
 
-<% veteran_name = task.appeal.veteran_full_name %>
-
 <%= react_component('BaseContainer', props: {
     availableTasks: tasks.any_assignable_to?(current_user),
     buttonText: start_text,
@@ -11,5 +9,5 @@
     totalCasesCompleted: user_quota.tasks_completed_count,
     employeeCount: team_quota.user_count,
     totalCasesToComplete: to_complete_count,
-    veteranName: veteran_name
+    veteranName: task.appeal.veteran_full_name
 }) %>

--- a/app/views/establish_claims/complete.html.erb
+++ b/app/views/establish_claims/complete.html.erb
@@ -1,7 +1,6 @@
 <% content_for :page_title do task.appeal.task_header end %>
 
-<% second_header = task.appeal.veteran_full_name + "'s End Product (" + task.appeal.sanitized_vbms_id + ') has been created.'
-   second_header = task.appeal.veteran_full_name + "'s claim (" + task.appeal.sanitized_vbms_id + ') has been processed' if task.special_issue_emailed? or task.special_issue_not_emailed? %>
+<% veteran_name = task.appeal.veteran_full_name %>
 
 <%= react_component("BaseContainer", props: {
     availableTasks: tasks.any_assignable_to?(current_user),
@@ -12,5 +11,5 @@
     totalCasesCompleted: user_quota.tasks_completed_count,
     employeeCount: team_quota.user_count,
     totalCasesToComplete: to_complete_count,
-    secondHeader: second_header
+    veteranName: veteran_name
 }) %>

--- a/app/views/establish_claims/complete.html.erb
+++ b/app/views/establish_claims/complete.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title do task.appeal.task_header end %>
 
-<% veteran_name = task.appeal.veteran_full_name %>
-
 <%= react_component("BaseContainer", props: {
     availableTasks: tasks.any_assignable_to?(current_user),
     buttonText: start_text,
@@ -11,5 +9,5 @@
     totalCasesCompleted: user_quota.tasks_completed_count,
     employeeCount: team_quota.user_count,
     totalCasesToComplete: to_complete_count,
-    veteranName: veteran_name
+    veteranName: task.appeal.veteran_full_name
 }) %>

--- a/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
@@ -23,16 +23,11 @@ export default class EstablishClaimComplete extends React.Component {
     let availableTasksMessage, casesAssigned, employeeCountInt,
       hasQuotaReached, quotaReachedMessage, secondHeader, totalCases;
 
-    availableTasksMessage = () => {
-      if (availableTasks) {
-        return 'You can now establish the next claim or return to your Work History.';
-      }
-
-      return 'You can now close Caseflow or return to your Work History.';
-    };
+    availableTasksMessage = availableTasks ? 'You can now establish the next claim or return to your Work History.'
+    : 'You can now close Caseflow or return to your Work History.';
 
     secondHeader = <span>{veteranName}'s claim has been processed. <br />
-    {availableTasksMessage()}
+      {availableTasksMessage}
     </span>;
 
     quotaReachedMessage = () => {

--- a/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
@@ -14,14 +14,26 @@ export default class EstablishClaimComplete extends React.Component {
       buttonText,
       checklist,
       firstHeader,
-      secondHeader,
       totalCasesCompleted,
       totalCasesToComplete,
-      employeeCount
+      employeeCount,
+      veteranName
     } = this.props;
 
-    let casesAssigned, employeeCountInt,
-      hasQuotaReached, quotaReachedMessage, totalCases;
+    let availableTasksMessage, casesAssigned, employeeCountInt,
+      hasQuotaReached, quotaReachedMessage, secondHeader, totalCases;
+
+    availableTasksMessage = () => {
+      if (availableTasks) {
+        return 'You can now establish the next claim or return to your Work History.';
+      }
+
+      return 'You can now close Caseflow or return to your Work History.';
+    };
+
+    secondHeader = <span>{veteranName}'s claim has been processed. <br />
+    {availableTasksMessage()}
+    </span>;
 
     quotaReachedMessage = () => {
       if (hasQuotaReached) {
@@ -72,7 +84,7 @@ EstablishClaimComplete.propTypes = {
   checklist: PropTypes.array,
   employeeCount: PropTypes.string,
   firstHeader: PropTypes.string,
-  secondHeader: PropTypes.string,
   totalCasesAssigned: PropTypes.number,
-  totalCasesCompleted: PropTypes.number
+  totalCasesCompleted: PropTypes.number,
+  veteranName: PropTypes.string
 };

--- a/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimComplete.jsx
@@ -23,8 +23,8 @@ export default class EstablishClaimComplete extends React.Component {
     let availableTasksMessage, casesAssigned, employeeCountInt,
       hasQuotaReached, quotaReachedMessage, secondHeader, totalCases;
 
-    availableTasksMessage = availableTasks ? 'You can now establish the next claim or return to your Work History.'
-    : 'You can now close Caseflow or return to your Work History.';
+    availableTasksMessage = availableTasks ? 'You can now establish the next claim or return to your Work History.' :
+                            'You can now close Caseflow or return to your Work History.';
 
     secondHeader = <span>{veteranName}'s claim has been processed. <br />
       {availableTasksMessage}

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -441,7 +441,7 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
 
           page.find("#button-Assign-to-Claim1").click
 
-          expect(page).to have_content("Congratulations!")
+          expect(page).to have_content("Success!")
 
           task.reload
           expect(task.outgoing_reference_id).to eq("1")


### PR DESCRIPTION
This adds 30px spacing between the text on the right/"Establish Claim Button" and changes the copy in the Success Page:
_when the caseworker has available cases to work on in the queue:_
<img width="1006" alt="screen shot 2017-05-08 at 4 55 30 pm" src="https://cloud.githubusercontent.com/assets/4773320/25824977/2f964e92-340f-11e7-93d9-5b1072dc067a.png">

_when there are no more claims available in the queue:_
<img width="1014" alt="screen shot 2017-05-08 at 4 56 57 pm" src="https://cloud.githubusercontent.com/assets/4773320/25825049/6ba14b26-340f-11e7-8466-43b5e06d1863.png">

Connects #1523 #1524