### PR TITLE
[Reader] Keep last read indicator in view

### DIFF
--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -82,11 +82,28 @@ export class PdfListView extends React.Component {
     window.removeEventListener('resize', this.setFilterIconPositions);
   }
 
-  getTbodyRef = (elem) => this.tbodyElem = elem;
+  getLastReadIndicatorRef = (elem) => this.lastReadIndicatorElem = elem
+  getTbodyRef = (elem) => this.tbodyElem = elem
 
   componentDidUpdate() {
     if (!this.hasSetScrollPosition) {
       this.tbodyElem.scrollTop = this.props.pdfList.scrollTop;
+
+      if (this.lastReadIndicatorElem) {
+        const lastReadBoundingRect = this.lastReadIndicatorElem.getBoundingClientRect();
+        const tbodyBoundingRect = this.tbodyElem.getBoundingClientRect();
+        const lastReadIndicatorIsInView = tbodyBoundingRect.top <= lastReadBoundingRect.top &&
+          lastReadBoundingRect.bottom >= tbodyBoundingRect.bottom;
+
+        if (lastReadIndicatorIsInView) {
+          const heightOfRowsBeforeLastRead = _(this.tbodyElem.children).
+          takeWhile((childElem) => !childElem.querySelector('#read-indicator')).
+          sumBy((childElem) => childElem.getBoundingClientRect().height);
+  
+          this.tbodyElem.scrollTop = heightOfRowsBeforeLastRead;
+        }
+      }
+
       this.hasSetScrollPosition = true;
     }
     this.setFilterIconPositions();
@@ -206,6 +223,7 @@ export class PdfListView extends React.Component {
             if (doc.id === this.props.pdfList.lastReadDocId) {
               return <span
                 id="read-indicator"
+                ref={this.getLastReadIndicatorRef}
                 aria-label="Most recently read document indicator">
                   {rightTriangle()}
                 </span>;

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -93,13 +93,13 @@ export class PdfListView extends React.Component {
         const lastReadBoundingRect = this.lastReadIndicatorElem.getBoundingClientRect();
         const tbodyBoundingRect = this.tbodyElem.getBoundingClientRect();
         const lastReadIndicatorIsInView = tbodyBoundingRect.top <= lastReadBoundingRect.top &&
-          lastReadBoundingRect.bottom >= tbodyBoundingRect.bottom;
+          lastReadBoundingRect.bottom <= tbodyBoundingRect.bottom;
 
-        if (lastReadIndicatorIsInView) {
+        if (!lastReadIndicatorIsInView) {
           const heightOfRowsBeforeLastRead = _(this.tbodyElem.children).
-          takeWhile((childElem) => !childElem.querySelector('#read-indicator')).
-          sumBy((childElem) => childElem.getBoundingClientRect().height);
-  
+            takeWhile((childElem) => !childElem.querySelector(`#${this.lastReadIndicatorElem.id}`)).
+            sumBy((childElem) => childElem.getBoundingClientRect().height);
+
           this.tbodyElem.scrollTop = heightOfRowsBeforeLastRead;
         }
       }

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -12,7 +12,7 @@ import TagTableColumn from '../components/reader/TagTableColumn';
 import * as Constants from './constants';
 import DropdownFilter from './DropdownFilter';
 import _ from 'lodash';
-import { setDocListScrollPosition, changeSortState, setTagFilter } from './actions';
+import { setDocListScrollPosition, changeSortState, setTagFilter, setCategoryFilter } from './actions';
 import DocCategoryPicker from './DocCategoryPicker';
 import DocTagPicker from './DocTagPicker';
 import { getAnnotationByDocumentId } from './utils';
@@ -96,11 +96,12 @@ export class PdfListView extends React.Component {
           lastReadBoundingRect.bottom <= tbodyBoundingRect.bottom;
 
         if (!lastReadIndicatorIsInView) {
-          const heightOfRowsBeforeLastRead = _(this.tbodyElem.children).
-            takeWhile((childElem) => !childElem.querySelector(`#${this.lastReadIndicatorElem.id}`)).
-            sumBy((childElem) => childElem.getBoundingClientRect().height);
+          const rowWithLastRead = _.find(
+            this.tbodyElem.children,
+            (tr) => tr.querySelector(`#${this.lastReadIndicatorElem.id}`)
+          );
 
-          this.tbodyElem.scrollTop = heightOfRowsBeforeLastRead;
+          this.tbodyElem.scrollTop += rowWithLastRead.getBoundingClientRect().top - tbodyBoundingRect.top;
         }
       }
 
@@ -409,23 +410,14 @@ const mapDispatchToProps = (dispatch) => ({
   ...bindActionCreators({
     setDocListScrollPosition,
     setTagFilter,
+    setCategoryFilter,
     changeSortState
   }, dispatch),
-
   toggleDropdownFilterVisiblity(filterName) {
     dispatch({
       type: Constants.TOGGLE_FILTER_DROPDOWN,
       payload: {
         filterName
-      }
-    });
-  },
-  setCategoryFilter(categoryName, checked) {
-    dispatch({
-      type: Constants.SET_CATEGORY_FILTER,
-      payload: {
-        categoryName,
-        checked
       }
     });
   },

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -12,7 +12,7 @@ import TagTableColumn from '../components/reader/TagTableColumn';
 import * as Constants from './constants';
 import DropdownFilter from './DropdownFilter';
 import _ from 'lodash';
-import { setDocListScrollPosition, changeSortState } from './actions';
+import { setDocListScrollPosition, changeSortState, setTagFilter } from './actions';
 import DocCategoryPicker from './DocCategoryPicker';
 import DocTagPicker from './DocTagPicker';
 import { getAnnotationByDocumentId } from './utils';
@@ -408,6 +408,7 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = (dispatch) => ({
   ...bindActionCreators({
     setDocListScrollPosition,
+    setTagFilter,
     changeSortState
   }, dispatch),
 
@@ -424,15 +425,6 @@ const mapDispatchToProps = (dispatch) => ({
       type: Constants.SET_CATEGORY_FILTER,
       payload: {
         categoryName,
-        checked
-      }
-    });
-  },
-  setTagFilter(text, checked) {
-    dispatch({
-      type: Constants.SET_TAG_FILTER,
-      payload: {
-        text,
         checked
       }
     });

--- a/client/app/reader/actions.js
+++ b/client/app/reader/actions.js
@@ -342,6 +342,14 @@ export const setTagFilter = (text, checked) => ({
   }
 });
 
+export const setCategoryFilter = (categoryName, checked) => ({
+  type: Constants.SET_CATEGORY_FILTER,
+  payload: {
+    categoryName,
+    checked
+  }
+});
+
 export const clearAllFilters = () => ({
   type: Constants.CLEAR_ALL_FILTERS
 });

--- a/client/app/reader/actions.js
+++ b/client/app/reader/actions.js
@@ -334,6 +334,14 @@ export const setPdfReadyToShow = (docId) => ({
   }
 });
 
+export const setTagFilter = (text, checked) => ({
+  type: Constants.SET_TAG_FILTER,
+  payload: {
+    text,
+    checked
+  }
+});
+
 export const clearAllFilters = () => ({
   type: Constants.CLEAR_ALL_FILTERS
 });

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -578,6 +578,22 @@ RSpec.feature "Reader" do
       expect(in_viewport("read-indicator")).to be true
       expect(scroll_position("documents-table-body")).to eq(original_scroll_position)
     end
+
+    scenario "Open a document and return to list", :focus => true do
+      visit "/reader/appeal/#{appeal.vacols_id}/documents"
+
+      scroll_to_bottom("documents-table-body")
+      original_scroll_position = scroll_position("documents-table-body")
+      click_on documents.last.type
+
+      10.times { find("#button-next").click }
+
+      click_on "Back to all documents"
+
+      expect(page).to have_content("#{num_documents} Documents")
+
+      expect(in_viewport("read-indicator")).to be true
+    end
   end
 
   context "When user is not whitelisted" do

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -580,7 +580,7 @@ RSpec.feature "Reader" do
       expect(scroll_position("documents-table-body")).to eq(original_scroll_position)
     end
 
-    scenario "Open a document and return to list" do
+    scenario "Open a document, navigate using buttons to see a new doc, and return to list" do
       visit "/reader/appeal/#{appeal.vacols_id}/documents"
 
       scroll_to_bottom("documents-table-body")

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -584,7 +584,6 @@ RSpec.feature "Reader" do
       visit "/reader/appeal/#{appeal.vacols_id}/documents"
 
       scroll_to_bottom("documents-table-body")
-      original_scroll_position = scroll_position("documents-table-body")
       click_on documents.last.type
 
       (num_documents - 1).times { find("#button-next").click }

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -551,6 +551,7 @@ RSpec.feature "Reader" do
   end
 
   context "Large number of documents" do
+    # This assumes that num_documents is enough to force the viewport to scroll.
     let(:num_documents) { 20 }
     let(:documents) do
       (1..num_documents).to_a.reduce([]) do |acc, number|
@@ -586,7 +587,7 @@ RSpec.feature "Reader" do
       original_scroll_position = scroll_position("documents-table-body")
       click_on documents.last.type
 
-      10.times { find("#button-next").click }
+      (num_documents - 1).times { find("#button-next").click }
 
       click_on "Back to all documents"
 

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -580,7 +580,7 @@ RSpec.feature "Reader" do
       expect(scroll_position("documents-table-body")).to eq(original_scroll_position)
     end
 
-    scenario "Open a document and return to list", :focus => true do
+    scenario "Open a document and return to list" do
       visit "/reader/appeal/#{appeal.vacols_id}/documents"
 
       scroll_to_bottom("documents-table-body")


### PR DESCRIPTION
Connect #1899.

## Test Plan
Verify:
1. Scroll the doc list
1. Click on a doc
1. Click "Back to all documents"
1. Observe that the doc list scroll position is retained

Verify:
1. Scroll on the doc list
1. Click on a doc
1. Use the "next" or "previous" arrows to navigate to a new doc that's far enough away from the original that if the scroll position were retained, the last read indicator would not be visible
1. Click "Back to all documents"
1. Observe that the last read indicator is visible