### PR TITLE
[Reader] Remove wasted renders

### DIFF
--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -109,7 +109,7 @@ const FooterRow = (props) => {
   </tfoot>;
 };
 
-export default class Table extends React.Component {
+export default class Table extends React.PureComponent {
   defaultRowClassNames = _.constant('')
 
   render() {

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -112,7 +112,7 @@ class FooterRow extends React.PureComponent {
 }
 
 export default class Table extends React.PureComponent {
-  defaultRowClassNames = _.constant('')
+  defaultRowClassNames = () => ''
 
   render() {
     let {

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -63,35 +63,42 @@ const getCellSpan = (rowObject, column) => {
   return 1;
 };
 
-const Row = (props) => {
-  let rowId = props.footer ? 'footer' : props.rowNumber;
+class Row extends React.PureComponent {
+  render() {
+    const props = this.props;
+    const rowId = props.footer ? 'footer' : props.rowNumber;
 
-  return <tr id={`table-row-${rowId}`} className={!props.footer && props.rowClassNames(props.rowObject)}>
-    {getColumns(props).map((column, columnNumber) =>
-      <td
-        key={columnNumber}
-        className={cellClasses(column)}
-        colSpan={getCellSpan(props.rowObject, column)}>
-        {props.footer ?
-          column.footer :
-          getCellValue(props.rowObject, props.rowNumber, column)}
-      </td>
-    )}
-  </tr>;
-};
+    return <tr id={`table-row-${rowId}`} className={!props.footer && props.rowClassNames(props.rowObject)}>
+      {getColumns(props).map((column, columnNumber) =>
+        <td
+          key={columnNumber}
+          className={cellClasses(column)}
+          colSpan={getCellSpan(props.rowObject, column)}>
+          {props.footer ?
+            column.footer :
+            getCellValue(props.rowObject, props.rowNumber, column)}
+        </td>
+      )}
+    </tr>;
+  }
+}
 
-const BodyRows = ({ rowObjects, bodyClassName, columns, rowClassNames, tbodyRef, id }) => {
-  return <tbody className={bodyClassName} ref={tbodyRef} id={id}>
-    {rowObjects.map((object, rowNumber) =>
-      <Row
-        rowObject={object}
-        columns={columns}
-        rowNumber={rowNumber}
-        rowClassNames={rowClassNames}
-        key={rowNumber} />
-    )}
-  </tbody>;
-};
+class BodyRows extends React.PureComponent {
+  render() {
+    const { rowObjects, bodyClassName, columns, rowClassNames, tbodyRef, id } = this.props;
+
+    return <tbody className={bodyClassName} ref={tbodyRef} id={id}>
+      {rowObjects.map((object, rowNumber) =>
+        <Row
+          rowObject={object}
+          columns={columns}
+          rowNumber={rowNumber}
+          rowClassNames={rowClassNames}
+          key={rowNumber} />
+      )}
+    </tbody>;
+  }
+}
 
 const FooterRow = (props) => {
   let hasFooters = _.some(props.columns, (column) => column.footer);

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import _ from 'lodash';
-import { PerfDebugPureComponent } from '../util/PerfDebug';
 
 /**
  * This component can be used to easily build tables.

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -84,7 +84,7 @@ class Row extends React.PureComponent {
   }
 }
 
-class BodyRows extends PerfDebugPureComponent {
+class BodyRows extends React.PureComponent {
   render() {
     const { rowObjects, bodyClassName, columns, rowClassNames, tbodyRef, id } = this.props;
 
@@ -101,13 +101,16 @@ class BodyRows extends PerfDebugPureComponent {
   }
 }
 
-const FooterRow = (props) => {
-  let hasFooters = _.some(props.columns, (column) => column.footer);
+class FooterRow extends React.PureComponent {
+  render() {
+    const props = this.props;
+    const hasFooters = _.some(props.columns, 'footer');
 
-  return <tfoot>
-    {hasFooters && <Row columns={props.columns} footer={true}/>}
-  </tfoot>;
-};
+    return <tfoot>
+      {hasFooters && <Row columns={props.columns} footer={true}/>}
+    </tfoot>;
+  }
+}
 
 export default class Table extends React.PureComponent {
   defaultRowClassNames = _.constant('')

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import _ from 'lodash';
+import { PerfDebugPureComponent } from '../util/PerfDebug';
 
 /**
  * This component can be used to easily build tables.
@@ -83,7 +84,7 @@ class Row extends React.PureComponent {
   }
 }
 
-class BodyRows extends React.PureComponent {
+class BodyRows extends PerfDebugPureComponent {
   render() {
     const { rowObjects, bodyClassName, columns, rowClassNames, tbodyRef, id } = this.props;
 
@@ -109,6 +110,8 @@ const FooterRow = (props) => {
 };
 
 export default class Table extends React.Component {
+  defaultRowClassNames = _.constant('')
+
   render() {
     let {
       columns,
@@ -116,7 +119,7 @@ export default class Table extends React.Component {
       summary,
       headerClassName = '',
       bodyClassName = '',
-      rowClassNames = () => '',
+      rowClassNames = this.defaultRowClassNames,
       tbodyId,
       tbodyRef,
       id

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -225,7 +225,7 @@ export class PdfListView extends React.Component {
       {
         cellClass: 'last-read-column',
         valueFunction: (doc) => {
-          if (doc.id === this.props.pdfList.lastReadDocId) {
+          if (doc.isLastRead) {
             return <span
               id="read-indicator"
               ref={this.getLastReadIndicatorRef}
@@ -360,7 +360,12 @@ export class PdfListView extends React.Component {
     }
 
     let rowObjects = this.props.documents.reduce((acc, row) => {
-      acc.push(row);
+      const docIsLastRead = row.id === this.props.pdfList.lastReadDocId;
+
+      acc.push({
+        ...row,
+        isLastRead: docIsLastRead
+      });
       const doc = _.find(this.props.documents, _.pick(row, 'id'));
 
       if (_.size(this.props.annotationsPerDocument[doc.id]) && doc.listComments) {

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -64,6 +64,26 @@ FilterIcon.propTypes = {
   className: PropTypes.string
 };
 
+class LastReadIndicator extends React.PureComponent {
+  render() {
+    if (!this.props.shouldShow) {
+      return null;
+    }
+
+    return <span
+      id="read-indicator"
+      ref={this.props.getRef}
+      aria-label="Most recently read document indicator">
+        {rightTriangle()}
+      </span>;
+  }
+}
+
+const lastReadIndicatorMapStateToProps = (state, ownProps) => ({
+  shouldShow: state.ui.pdfList.lastReadDocId === ownProps.docId
+});
+const ConnectedLastReadIndicator = connect(lastReadIndicatorMapStateToProps)(LastReadIndicator);
+
 export class PdfListView extends React.Component {
   constructor() {
     super();
@@ -224,16 +244,7 @@ export class PdfListView extends React.Component {
     return [
       {
         cellClass: 'last-read-column',
-        valueFunction: (doc) => {
-          if (doc.id === this.props.pdfList.lastReadDocId) {
-            return <span
-              id="read-indicator"
-              ref={this.getLastReadIndicatorRef}
-              aria-label="Most recently read document indicator">
-                {rightTriangle()}
-              </span>;
-          }
-        }
+        valueFunction: (doc) => <ConnectedLastReadIndicator docId={doc.id} getRef={this.getLastReadIndicatorRef} />
       },
       {
         cellClass: 'categories-column',

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -22,34 +22,38 @@ import {
 
 const NUMBER_OF_COLUMNS = 6;
 
-const FilterIcon = ({
-  handleActivate, label, getRef, selected, idPrefix
-}) => {
-  const handleKeyDown = (event) => {
-    if (event.key === ' ' || event.key === 'Enter') {
-      handleActivate(event);
-      event.preventDefault();
+class FilterIcon extends React.PureComponent {
+  render() {
+    const {
+      handleActivate, label, getRef, selected, idPrefix
+    } = this.props;
+
+    const handleKeyDown = (event) => {
+      if (event.key === ' ' || event.key === 'Enter') {
+        handleActivate(event);
+        event.preventDefault();
+      }
+    };
+
+    const className = 'table-icon';
+
+    const props = {
+      role: 'button',
+      getRef,
+      'aria-label': label,
+      className,
+      tabIndex: '0',
+      onKeyDown: handleKeyDown,
+      onClick: handleActivate
+    };
+
+    if (selected) {
+      return <SelectedFilterIcon {...props} idPrefix={idPrefix} />;
     }
-  };
 
-  const className = 'table-icon';
-
-  const props = {
-    role: 'button',
-    getRef,
-    'aria-label': label,
-    className,
-    tabIndex: '0',
-    onKeyDown: handleKeyDown,
-    onClick: handleActivate
-  };
-
-  if (selected) {
-    return <SelectedFilterIcon {...props} idPrefix={idPrefix} />;
+    return <UnselectedFilterIcon {...props} />;
   }
-
-  return <UnselectedFilterIcon {...props} />;
-};
+}
 
 FilterIcon.propTypes = {
   label: PropTypes.string.isRequired,
@@ -144,6 +148,10 @@ export class PdfListView extends React.Component {
   }
 
   getCategoryFilterIconRef = (categoryFilterIcon) => this.categoryFilterIcon = categoryFilterIcon
+  getTagFilterIconRef = (tagFilterIcon) => this.tagFilterIcon = tagFilterIcon
+
+  toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('category')
+  toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('tag')
 
   // eslint-disable-next-line max-statements
   getDocumentColumns = (row) => {
@@ -161,12 +169,6 @@ export class PdfListView extends React.Component {
 
       return content;
     };
-
-    const toggleCategoryDropdownFilterVisiblity = () =>
-      this.props.toggleDropdownFilterVisiblity('category');
-
-    const toggleTagDropdownFilterVisiblity = () =>
-      this.props.toggleDropdownFilterVisiblity('tag');
 
     const clearFilters = () => {
       _(Constants.documentCategories).keys().
@@ -243,14 +245,14 @@ export class PdfListView extends React.Component {
             idPrefix="category"
             getRef={this.getCategoryFilterIconRef}
             selected={isCategoryDropdownFilterOpen || anyCategoryFiltersAreSet}
-            handleActivate={toggleCategoryDropdownFilterVisiblity} />
+            handleActivate={this.toggleCategoryDropdownFilterVisiblity} />
 
           {isCategoryDropdownFilterOpen &&
             <DropdownFilter baseCoordinates={this.state.filterPositions.category}
               clearFilters={clearFilters}
               name="category"
               isClearEnabled={anyCategoryFiltersAreSet}
-              handleClose={toggleCategoryDropdownFilterVisiblity}>
+              handleClose={this.toggleCategoryDropdownFilterVisiblity}>
               <DocCategoryPicker
                 categoryToggleStates={this.props.docFilterCriteria.category}
                 handleCategoryToggle={this.props.setCategoryFilter} />
@@ -292,18 +294,16 @@ export class PdfListView extends React.Component {
           Issue Tags <FilterIcon
             label="Filter by tag"
             idPrefix="tag"
-            getRef={(tagFilterIcon) => {
-              this.tagFilterIcon = tagFilterIcon;
-            }}
+            getRef={this.getTagFilterIconRef}
             selected={isTagDropdownFilterOpen || anyTagFiltersAreSet}
-            handleActivate={toggleTagDropdownFilterVisiblity}
+            handleActivate={this.toggleTagDropdownFilterVisiblity}
           />
           {isTagDropdownFilterOpen &&
             <DropdownFilter baseCoordinates={this.state.filterPositions.tag}
               clearFilters={clearTagFilters}
               name="tag"
               isClearEnabled={anyTagFiltersAreSet}
-              handleClose={toggleTagDropdownFilterVisiblity}>
+              handleClose={this.toggleTagDropdownFilterVisiblity}>
               <DocTagPicker
                 tags={this.props.tagOptions}
                 tagToggleStates={this.props.docFilterCriteria.tag}

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -225,7 +225,7 @@ export class PdfListView extends React.Component {
       {
         cellClass: 'last-read-column',
         valueFunction: (doc) => {
-          if (doc.isLastRead) {
+          if (doc.id === this.props.pdfList.lastReadDocId) {
             return <span
               id="read-indicator"
               ref={this.getLastReadIndicatorRef}
@@ -360,12 +360,7 @@ export class PdfListView extends React.Component {
     }
 
     let rowObjects = this.props.documents.reduce((acc, row) => {
-      const docIsLastRead = row.id === this.props.pdfList.lastReadDocId;
-
-      acc.push({
-        ...row,
-        isLastRead: docIsLastRead
-      });
+      acc.push(row);
       const doc = _.find(this.props.documents, _.pick(row, 'id'));
 
       if (_.size(this.props.annotationsPerDocument[doc.id]) && doc.listComments) {

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -143,6 +143,8 @@ export class PdfListView extends React.Component {
     this.props.handleToggleCommentOpened(id);
   }
 
+  getCategoryFilterIconRef = (categoryFilterIcon) => this.categoryFilterIcon = categoryFilterIcon
+
   // eslint-disable-next-line max-statements
   getDocumentColumns = (row) => {
     const className = this.props.docFilterCriteria.sort.sortAscending ? 'fa-caret-up' : 'fa-caret-down';
@@ -239,9 +241,7 @@ export class PdfListView extends React.Component {
           Categories <FilterIcon
             label="Filter by category"
             idPrefix="category"
-            getRef={(categoryFilterIcon) => {
-              this.categoryFilterIcon = categoryFilterIcon;
-            }}
+            getRef={this.getCategoryFilterIconRef}
             selected={isCategoryDropdownFilterOpen || anyCategoryFiltersAreSet}
             handleActivate={toggleCategoryDropdownFilterVisiblity} />
 


### PR DESCRIPTION
Connect #1983.

## Before
Using the dropdown felt super sluggish:
![perf before](https://cloud.githubusercontent.com/assets/829827/26081034/08f183c8-3997-11e7-9423-ff5404b2fc94.gif)

Logging showed that closing the dropdown took almost half a second (!)
![image](https://cloud.githubusercontent.com/assets/829827/26081073/309ff120-3997-11e7-8550-9cc09d9fa575.png)

React perf tools show us that we had many wasted renders, the biggest offender being `BodyRows`.
![image](https://cloud.githubusercontent.com/assets/829827/26081097/54e356e4-3997-11e7-84ba-fced7f710606.png)

## After
The dropdown is performant again:
![perf after](https://cloud.githubusercontent.com/assets/829827/26081041/0b60a77e-3997-11e7-9e11-8c626cedb303.gif)

Closing the dropdown now takes `~10x` faster.
![image](https://cloud.githubusercontent.com/assets/829827/26081119/69285352-3997-11e7-9a27-de982459824f.png)

There is only one wasted render. We can fix it by implementing `shouldComponentUpdate()` and doing a deep equality check on the props, but I think the better thing would be to understand why the props are not deeply equal. In any event, it's such a small amount of time that I don't think it's worth optimizing at this point.
![image](https://cloud.githubusercontent.com/assets/829827/26081126/717a0172-3997-11e7-838d-246cf9db8393.png)

## General Notes
Some of this diff is just wrapping/unwrapping everything in a function. View this diff with `?w=1` on the GitHub URL querystring to see it with whitespace ignored, and you'll get a smaller diff.