### PR TITLE
Updating react-input-autosize

### DIFF
--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -4,12 +4,12 @@
   "dependencies": {
     "acorn": {
       "version": "4.0.11",
-      "from": "acorn@>=4.0.4 <5.0.0",
+      "from": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
     },
     "acorn-dynamic-import": {
       "version": "2.0.2",
-      "from": "acorn-dynamic-import@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz"
     },
     "ajv": {
@@ -24,7 +24,7 @@
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
     },
     "amdefine": {
@@ -44,22 +44,22 @@
     },
     "anymatch": {
       "version": "1.3.0",
-      "from": "anymatch@>=1.3.0 <2.0.0",
+      "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
     },
     "arr-diff": {
       "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
     },
     "arr-flatten": {
       "version": "1.0.1",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
     },
     "arrify": {
@@ -74,22 +74,22 @@
     },
     "asn1.js": {
       "version": "4.9.1",
-      "from": "asn1.js@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz"
     },
     "assert": {
       "version": "1.4.1",
-      "from": "assert@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
     },
     "async": {
       "version": "2.3.0",
-      "from": "async@>=2.1.2 <3.0.0",
+      "from": "https://registry.npmjs.org/async/-/async-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-2.3.0.tgz"
     },
     "async-each": {
       "version": "1.0.1",
-      "from": "async-each@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
     },
     "babel-code-frame": {
@@ -106,19 +106,19 @@
     },
     "babel-core": {
       "version": "6.24.1",
-      "from": "babel-core@>=6.18.2 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
     },
     "babel-generator": {
       "version": "6.24.1",
-      "from": "babel-generator@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -130,7 +130,7 @@
     },
     "babel-helper-bindify-decorators": {
       "version": "6.24.1",
-      "from": "babel-helper-bindify-decorators@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -142,7 +142,7 @@
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
-      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -154,19 +154,19 @@
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
-      "from": "babel-helper-builder-react-jsx@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@^6.22.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
-      "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -178,7 +178,7 @@
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
-      "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -190,7 +190,7 @@
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
-      "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -202,7 +202,7 @@
     },
     "babel-helper-explode-class": {
       "version": "6.24.1",
-      "from": "babel-helper-explode-class@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -214,7 +214,7 @@
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -226,7 +226,7 @@
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -238,7 +238,7 @@
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -250,7 +250,7 @@
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -262,7 +262,7 @@
     },
     "babel-helper-regex": {
       "version": "6.24.1",
-      "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -274,7 +274,7 @@
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
-      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -286,7 +286,7 @@
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
-      "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -298,7 +298,7 @@
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "from": "babel-helpers@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -384,7 +384,7 @@
     },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
-      "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz"
     },
     "babel-plugin-syntax-function-bind": {
@@ -394,7 +394,7 @@
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz"
     },
     "babel-plugin-syntax-object-rest-spread": {
@@ -409,7 +409,7 @@
     },
     "babel-plugin-transform-async-generator-functions": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-async-generator-functions@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -421,7 +421,7 @@
     },
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-async-to-generator@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -433,7 +433,7 @@
     },
     "babel-plugin-transform-class-constructor-call": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-class-constructor-call@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -445,7 +445,7 @@
     },
     "babel-plugin-transform-class-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -457,7 +457,7 @@
     },
     "babel-plugin-transform-decorators": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-decorators@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -505,7 +505,7 @@
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -517,7 +517,7 @@
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -529,7 +529,7 @@
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -553,7 +553,7 @@
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -577,7 +577,7 @@
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -601,7 +601,7 @@
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -613,7 +613,7 @@
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -625,7 +625,7 @@
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -637,7 +637,7 @@
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -649,7 +649,7 @@
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -661,7 +661,7 @@
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -673,7 +673,7 @@
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -697,7 +697,7 @@
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -733,7 +733,7 @@
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -745,7 +745,7 @@
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-exponentiation-operator@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -769,12 +769,12 @@
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@^6.22.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
@@ -805,60 +805,60 @@
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.23.0.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-react-jsx@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@^6.22.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
     },
     "babel-plugin-transform-react-jsx-self": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@^6.22.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "dependencies": {
         "babel-runtime": {
           "version": "6.23.0",
-          "from": "babel-runtime@^6.22.0",
+          "from": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
         }
       }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -882,12 +882,12 @@
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
-      "from": "babel-preset-es2015@>=6.18.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz"
     },
     "babel-preset-flow": {
       "version": "6.23.0",
-      "from": "babel-preset-flow@>=6.23.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz"
     },
     "babel-preset-react": {
@@ -897,27 +897,27 @@
     },
     "babel-preset-stage-0": {
       "version": "6.24.1",
-      "from": "babel-preset-stage-0@>=6.16.0 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-0/-/babel-preset-stage-0-6.24.1.tgz"
     },
     "babel-preset-stage-1": {
       "version": "6.24.1",
-      "from": "babel-preset-stage-1@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz"
     },
     "babel-preset-stage-2": {
       "version": "6.24.1",
-      "from": "babel-preset-stage-2@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz"
     },
     "babel-preset-stage-3": {
       "version": "6.24.1",
-      "from": "babel-preset-stage-3@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
     },
     "babel-register": {
       "version": "6.24.1",
-      "from": "babel-register@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -941,7 +941,7 @@
     },
     "babel-template": {
       "version": "6.24.1",
-      "from": "babel-template@>=6.24.1 <7.0.0",
+      "from": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.24.1.tgz",
       "dependencies": {
         "babel-runtime": {
@@ -987,22 +987,22 @@
     },
     "base64-js": {
       "version": "1.2.0",
-      "from": "base64-js@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz"
     },
     "big.js": {
       "version": "3.1.3",
-      "from": "big.js@>=3.1.3 <4.0.0",
+      "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
     },
     "binary-extensions": {
       "version": "1.8.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
     },
     "bn.js": {
       "version": "4.11.6",
-      "from": "bn.js@>=4.1.1 <5.0.0",
+      "from": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz"
     },
     "brace-expansion": {
@@ -1012,47 +1012,47 @@
     },
     "braces": {
       "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
+      "from": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
     "brorand": {
       "version": "1.1.0",
-      "from": "brorand@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
     },
     "browserify-aes": {
       "version": "1.0.6",
-      "from": "browserify-aes@>=1.0.4 <2.0.0",
+      "from": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz"
     },
     "browserify-cipher": {
       "version": "1.0.0",
-      "from": "browserify-cipher@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz"
     },
     "browserify-des": {
       "version": "1.0.0",
-      "from": "browserify-des@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz"
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "from": "browserify-rsa@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz"
     },
     "browserify-sign": {
       "version": "4.0.4",
-      "from": "browserify-sign@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz"
     },
     "browserify-zlib": {
       "version": "0.1.4",
-      "from": "browserify-zlib@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
     },
     "buffer": {
       "version": "4.9.1",
-      "from": "buffer@>=4.9.0 <5.0.0",
+      "from": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
     },
     "buffer-shims": {
@@ -1062,27 +1062,27 @@
     },
     "buffer-xor": {
       "version": "1.0.3",
-      "from": "buffer-xor@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
     },
     "builtin-status-codes": {
       "version": "3.0.0",
-      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
     },
     "camelcase": {
       "version": "1.2.1",
-      "from": "camelcase@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
     "chalk": {
@@ -1092,27 +1092,27 @@
     },
     "chokidar": {
       "version": "1.6.1",
-      "from": "chokidar@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz"
     },
     "cipher-base": {
       "version": "1.0.3",
-      "from": "cipher-base@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz"
     },
     "classnames": {
       "version": "2.2.5",
-      "from": "classnames@>=2.2.4 <3.0.0",
+      "from": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
         }
       }
@@ -1134,7 +1134,7 @@
     },
     "commondir": {
       "version": "1.0.1",
-      "from": "commondir@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
     },
     "concat-map": {
@@ -1144,12 +1144,12 @@
     },
     "console-browserify": {
       "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
     },
     "constants-browserify": {
       "version": "1.0.0",
-      "from": "constants-browserify@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
     },
     "convert-source-map": {
@@ -1174,17 +1174,17 @@
     },
     "create-ecdh": {
       "version": "4.0.0",
-      "from": "create-ecdh@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz"
     },
     "create-hash": {
       "version": "1.1.2",
-      "from": "create-hash@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
     },
     "create-hmac": {
       "version": "1.1.4",
-      "from": "create-hmac@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
     },
     "create-react-class": {
@@ -1206,12 +1206,12 @@
     },
     "crypto-browserify": {
       "version": "3.11.0",
-      "from": "crypto-browserify@>=3.11.0 <4.0.0",
+      "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz"
     },
     "date-now": {
       "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
     },
     "debug": {
@@ -1221,12 +1221,12 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-diff": {
       "version": "0.3.4",
-      "from": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz",
+      "from": "deep-diff@0.3.4",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz"
     },
     "deep-is": {
@@ -1236,7 +1236,7 @@
     },
     "des.js": {
       "version": "1.0.0",
-      "from": "des.js@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz"
     },
     "detect-indent": {
@@ -1246,7 +1246,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.2",
-      "from": "diffie-hellman@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz"
     },
     "dom-walk": {
@@ -1256,17 +1256,17 @@
     },
     "domain-browser": {
       "version": "1.1.7",
-      "from": "domain-browser@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
     },
     "elliptic": {
       "version": "6.4.0",
-      "from": "elliptic@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
     },
     "emojis-list": {
       "version": "2.1.0",
-      "from": "emojis-list@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
     },
     "encoding": {
@@ -1276,17 +1276,17 @@
     },
     "enhanced-resolve": {
       "version": "3.1.0",
-      "from": "enhanced-resolve@>=3.0.0 <4.0.0",
+      "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz"
     },
     "errno": {
       "version": "0.1.4",
-      "from": "errno@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
     },
     "error-ex": {
       "version": "1.3.1",
-      "from": "error-ex@>=1.2.0 <2.0.0",
+      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
     },
     "error-stack-parser": {
@@ -1316,22 +1316,22 @@
     },
     "events": {
       "version": "1.1.1",
-      "from": "events@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz"
     },
     "evp_bytestokey": {
       "version": "1.0.0",
-      "from": "evp_bytestokey@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
     },
     "expand-range": {
       "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
+      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
     },
     "expose-loader": {
@@ -1341,7 +1341,7 @@
     },
     "extglob": {
       "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
+      "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "fast-levenshtein": {
@@ -1363,32 +1363,32 @@
     },
     "filename-regex": {
       "version": "2.0.0",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
     },
     "fill-range": {
       "version": "2.2.3",
-      "from": "fill-range@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "find-cache-dir": {
       "version": "0.1.1",
-      "from": "find-cache-dir@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz"
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
     },
     "for-in": {
       "version": "1.0.2",
-      "from": "for-in@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
     },
     "for-own": {
       "version": "0.1.5",
-      "from": "for-own@>=0.1.4 <0.2.0",
+      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
     },
     "fsevents": {
@@ -1815,7 +1815,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
         },
         "ms": {
@@ -1832,7 +1832,7 @@
         },
         "nopt": {
           "version": "3.0.6",
-          "from": "nopt@>=3.0.6 <3.1.0",
+          "from": "nopt@>=3.0.1 <3.1.0",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
           "optional": true
         },
@@ -2002,7 +2002,7 @@
         },
         "tar": {
           "version": "2.2.1",
-          "from": "tar@>=2.2.1 <2.3.0",
+          "from": "tar@>=2.2.0 <2.3.0",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
         },
         "tar-pack": {
@@ -2097,17 +2097,17 @@
     },
     "get-caller-file": {
       "version": "1.0.2",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
+      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
     },
     "glob-parent": {
       "version": "2.0.0",
-      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
     },
     "global": {
@@ -2149,7 +2149,7 @@
     },
     "hash.js": {
       "version": "1.0.3",
-      "from": "hash.js@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz"
     },
     "history": {
@@ -2176,7 +2176,7 @@
     },
     "hmac-drbg": {
       "version": "1.0.1",
-      "from": "hmac-drbg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
     },
     "home-or-tmp": {
@@ -2186,12 +2186,12 @@
     },
     "hosted-git-info": {
       "version": "2.4.1",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.1.tgz"
     },
     "https-browserify": {
       "version": "0.0.1",
-      "from": "https-browserify@0.0.1",
+      "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
     },
     "iconv-lite": {
@@ -2201,7 +2201,7 @@
     },
     "ieee754": {
       "version": "1.1.8",
-      "from": "ieee754@>=1.1.4 <2.0.0",
+      "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
     },
     "immutability-helper": {
@@ -2223,7 +2223,7 @@
     },
     "indexof": {
       "version": "0.0.1",
-      "from": "indexof@0.0.1",
+      "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
     },
     "inherits": {
@@ -2243,47 +2243,47 @@
     },
     "invert-kv": {
       "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "from": "is-binary-path@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
     },
     "is-buffer": {
       "version": "1.1.5",
-      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "is-dotfile": {
       "version": "1.0.2",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
     },
     "is-finite": {
@@ -2298,7 +2298,7 @@
     },
     "is-glob": {
       "version": "2.0.1",
-      "from": "is-glob@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
     },
     "is-my-json-valid": {
@@ -2308,17 +2308,17 @@
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "from": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
     },
     "is-property": {
@@ -2333,7 +2333,7 @@
     },
     "is-utf8": {
       "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
     },
     "isarray": {
@@ -2343,7 +2343,7 @@
     },
     "isobject": {
       "version": "2.1.0",
-      "from": "isobject@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
     },
     "isomorphic-fetch": {
@@ -2731,7 +2731,7 @@
     },
     "json-loader": {
       "version": "0.5.4",
-      "from": "json-loader@>=0.5.4 <0.6.0",
+      "from": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz"
     },
     "json-stable-stringify": {
@@ -2741,7 +2741,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "from": "json5@>=0.5.0 <0.6.0",
+      "from": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
     },
     "jsonify": {
@@ -2756,17 +2756,17 @@
     },
     "kind-of": {
       "version": "3.1.0",
-      "from": "kind-of@>=3.0.2 <4.0.0",
+      "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
     },
     "lcid": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
     },
     "levn": {
@@ -2776,24 +2776,24 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
         }
       }
     },
     "loader-runner": {
       "version": "2.3.0",
-      "from": "loader-runner@>=2.3.0 <3.0.0",
+      "from": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz"
     },
     "loader-utils": {
       "version": "0.2.17",
-      "from": "loader-utils@>=0.2.16 <0.3.0",
+      "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
     },
     "lodash": {
@@ -2803,7 +2803,7 @@
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "loose-envify": {
@@ -2813,17 +2813,17 @@
     },
     "memory-fs": {
       "version": "0.4.1",
-      "from": "memory-fs@>=0.4.1 <0.5.0",
+      "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz"
     },
     "micromatch": {
       "version": "2.3.11",
-      "from": "micromatch@>=2.1.5 <3.0.0",
+      "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
     },
     "miller-rabin": {
       "version": "4.0.0",
-      "from": "miller-rabin@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz"
     },
     "min-document": {
@@ -2833,12 +2833,12 @@
     },
     "minimalistic-assert": {
       "version": "1.0.0",
-      "from": "minimalistic-assert@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "from": "minimalistic-crypto-utils@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
     },
     "minimatch": {
@@ -2858,7 +2858,7 @@
     },
     "moment": {
       "version": "2.18.1",
-      "from": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "from": "moment@latest",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz"
     },
     "ms": {
@@ -2868,7 +2868,7 @@
     },
     "nan": {
       "version": "2.6.1",
-      "from": "nan@>=2.3.0 <3.0.0",
+      "from": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.1.tgz",
       "optional": true
     },
@@ -2884,17 +2884,17 @@
     },
     "node-libs-browser": {
       "version": "2.0.0",
-      "from": "node-libs-browser@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz"
     },
     "normalize-package-data": {
       "version": "2.3.6",
-      "from": "normalize-package-data@>=2.3.2 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz"
     },
     "normalize-path": {
       "version": "2.1.1",
-      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
     },
     "number-is-nan": {
@@ -2909,7 +2909,7 @@
     },
     "object.omit": {
       "version": "2.0.1",
-      "from": "object.omit@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
     },
     "optionator": {
@@ -2919,7 +2919,7 @@
     },
     "os-browserify": {
       "version": "0.2.1",
-      "from": "os-browserify@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
     },
     "os-homedir": {
@@ -2929,7 +2929,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
+      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
     },
     "os-tmpdir": {
@@ -2939,32 +2939,32 @@
     },
     "pako": {
       "version": "0.2.9",
-      "from": "pako@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
     },
     "parse-asn1": {
       "version": "5.1.0",
-      "from": "parse-asn1@>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
     },
     "path-browserify": {
       "version": "0.0.0",
-      "from": "path-browserify@0.0.0",
+      "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
     },
     "path-exists": {
       "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
     },
     "path-is-absolute": {
@@ -2986,12 +2986,12 @@
     },
     "path-type": {
       "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
     },
     "pbkdf2": {
       "version": "3.0.9",
-      "from": "pbkdf2@>=3.0.3 <4.0.0",
+      "from": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
     },
     "pdf-annotate.js": {
@@ -3021,7 +3021,7 @@
     },
     "pkg-dir": {
       "version": "1.0.0",
-      "from": "pkg-dir@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
     },
     "prelude-ls": {
@@ -3036,7 +3036,7 @@
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
     },
     "private": {
@@ -3046,7 +3046,7 @@
     },
     "process": {
       "version": "0.11.9",
-      "from": "process@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.9.tgz"
     },
     "process-nextick-args": {
@@ -3066,37 +3066,37 @@
     },
     "prr": {
       "version": "0.0.0",
-      "from": "prr@>=0.0.0 <0.1.0",
+      "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
     },
     "public-encrypt": {
       "version": "4.0.0",
-      "from": "public-encrypt@>=4.0.0 <5.0.0",
+      "from": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz"
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.2.4 <2.0.0",
+      "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
     },
     "querystring": {
       "version": "0.2.0",
-      "from": "querystring@0.2.0",
+      "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
     },
     "querystring-es3": {
       "version": "0.2.1",
-      "from": "querystring-es3@>=0.2.0 <0.3.0",
+      "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
     },
     "randomatic": {
       "version": "1.1.6",
-      "from": "randomatic@>=1.1.3 <2.0.0",
+      "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz"
     },
     "randombytes": {
       "version": "2.0.3",
-      "from": "randombytes@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
     },
     "react": {
@@ -3137,9 +3137,9 @@
       }
     },
     "react-input-autosize": {
-      "version": "1.1.0",
-      "from": "react-input-autosize@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.1.0.tgz"
+      "version": "1.1.4",
+      "from": "react-input-autosize@>=1.1.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.1.4.tgz"
     },
     "react-on-rails": {
       "version": "6.8.0",
@@ -3215,9 +3215,9 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.0.0.tgz"
     },
     "react-select": {
-      "version": "1.0.0-rc.3",
+      "version": "1.0.0-rc.4",
       "from": "react-select@latest",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.3.tgz"
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.4.tgz"
     },
     "react-test-renderer": {
       "version": "15.5.4",
@@ -3226,12 +3226,12 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
     },
     "readable-stream": {
@@ -3241,7 +3241,7 @@
     },
     "readdirp": {
       "version": "2.1.0",
-      "from": "readdirp@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
     },
     "redbox-react": {
@@ -3293,12 +3293,12 @@
     },
     "regenerator-transform": {
       "version": "0.9.11",
-      "from": "regenerator-transform@0.9.11",
+      "from": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz"
     },
     "regex-cache": {
       "version": "0.4.3",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
     },
     "regexpu-core": {
@@ -3325,17 +3325,17 @@
     },
     "remove-trailing-separator": {
       "version": "1.0.1",
-      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz"
     },
     "repeat-element": {
       "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
     },
     "repeating": {
@@ -3345,12 +3345,12 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
+      "from": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
     },
     "reselect": {
@@ -3360,27 +3360,27 @@
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
+      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
     },
     "ripemd160": {
       "version": "1.0.1",
-      "from": "ripemd160@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz"
     },
     "semver": {
       "version": "5.3.0",
-      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "from": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
     },
     "set-blocking": {
       "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
     },
     "set-immediate-shim": {
       "version": "1.0.1",
-      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
     },
     "setimmediate": {
@@ -3390,7 +3390,7 @@
     },
     "sha.js": {
       "version": "2.4.8",
-      "from": "sha.js@>=2.3.6 <3.0.0",
+      "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
     },
     "slash": {
@@ -3400,12 +3400,12 @@
     },
     "source-list-map": {
       "version": "1.1.1",
-      "from": "source-list-map@>=1.1.1 <2.0.0",
+      "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.1.tgz"
     },
     "source-map": {
       "version": "0.5.6",
-      "from": "source-map@>=0.5.6 <0.6.0",
+      "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
     },
     "source-map-support": {
@@ -3415,17 +3415,17 @@
     },
     "spdx-correct": {
       "version": "1.0.2",
-      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
-      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
     },
     "spdx-license-ids": {
       "version": "1.2.2",
-      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
     },
     "stackframe": {
@@ -3435,22 +3435,22 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "from": "stream-browserify@>=2.0.1 <3.0.0",
+      "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
     },
     "stream-http": {
       "version": "2.7.0",
-      "from": "stream-http@>=2.3.1 <3.0.0",
+      "from": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.0.tgz",
       "dependencies": {
         "readable-stream": {
           "version": "2.2.9",
-          "from": "readable-stream@>=2.2.6 <3.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
         },
         "string_decoder": {
           "version": "1.0.0",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz"
         }
       }
@@ -3572,17 +3572,17 @@
     },
     "tapable": {
       "version": "0.2.6",
-      "from": "tapable@>=0.2.5 <0.3.0",
+      "from": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz"
     },
     "timers-browserify": {
       "version": "2.0.2",
-      "from": "timers-browserify@>=2.0.2 <3.0.0",
+      "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz"
     },
     "to-arraybuffer": {
       "version": "1.0.1",
-      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
     },
     "to-fast-properties": {
@@ -3602,7 +3602,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "from": "tty-browserify@0.0.0",
+      "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
     },
     "type-check": {
@@ -3617,42 +3617,42 @@
     },
     "uglify-js": {
       "version": "2.8.22",
-      "from": "uglify-js@>=2.8.5 <3.0.0",
+      "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.22.tgz",
       "dependencies": {
         "yargs": {
           "version": "3.10.0",
-          "from": "yargs@>=3.10.0 <3.11.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "optional": true
     },
     "url": {
       "version": "0.11.0",
-      "from": "url@>=0.11.0 <0.12.0",
+      "from": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
-          "from": "punycode@1.3.2",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.3 <0.11.0",
+      "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@2.0.1",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         }
       }
@@ -3669,17 +3669,17 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "from": "vm-browserify@0.0.4",
+      "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
     },
     "watchpack": {
       "version": "1.3.1",
-      "from": "watchpack@>=1.3.1 <2.0.0",
+      "from": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz"
     },
     "webpack": {
@@ -3696,7 +3696,7 @@
     },
     "webpack-sources": {
       "version": "0.2.3",
-      "from": "webpack-sources@>=0.2.3 <0.3.0",
+      "from": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz"
     },
     "whatwg-fetch": {
@@ -3706,12 +3706,12 @@
     },
     "which-module": {
       "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
+      "from": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@0.1.0",
+      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
     },
     "wordwrap": {
@@ -3721,7 +3721,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
     },
     "xtend": {
@@ -3731,34 +3731,34 @@
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
+      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
     },
     "yargs": {
       "version": "6.6.0",
-      "from": "yargs@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         },
         "cliui": {
           "version": "3.2.0",
-          "from": "cliui@>=3.2.0 <4.0.0",
+          "from": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
         }
       }
     },
     "yargs-parser": {
       "version": "4.2.1",
-      "from": "yargs-parser@>=4.2.0 <5.0.0",
+      "from": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
-          "from": "camelcase@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
         }
       }

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -3216,7 +3216,7 @@
     },
     "react-select": {
       "version": "1.0.0-rc.4",
-      "from": "react-select@latest",
+      "from": "react-select@1.0.0-rc.4",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.4.tgz"
     },
     "react-test-renderer": {

--- a/client/package.json
+++ b/client/package.json
@@ -55,7 +55,7 @@
     "react-redux": "^5.0.3",
     "react-router": "^4.0.0",
     "react-router-dom": "^4.0.0",
-    "react-select": "^1.0.0-rc.3",
+    "react-select": "^1.0.0-rc.4",
     "react-test-renderer": "^15.5.4",
     "redux": "^3.6.0",
     "redux-logger": "^3.0.0",


### PR DESCRIPTION
This PR updates the react-input-autosize library to get rid of a console warning: 

<img width="504" alt="screen shot 2017-05-16 at 2 06 00 pm" src="https://cloud.githubusercontent.com/assets/4306128/26121025/d6ba9296-3a40-11e7-9505-48deb38db492.png">

Connects #1731 