### PR TITLE
Add API authentication

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -4,9 +4,24 @@ class Api::V1::ApplicationController < ActionController::Base
   force_ssl if: :ssl_enabled?
   before_action :strict_transport_security
 
-  before_action :setup_fakes
+  before_action :setup_fakes,
+                :verify_authentication_token
 
   private
+
+  def verify_authentication_token
+    return unauthorized unless api_key
+
+    Rails.logger.info("API authenticated by #{api_key.consumer_name}")
+  end
+
+  def api_key
+    @api_key ||= authenticate_with_http_token { |token, _options| ApiKey.authorize(token) }
+  end
+
+  def unauthorized
+    render json: { status: "unauthorized" }, status: 401
+  end
 
   def not_found
     render json: { status: "not found" }, status: 404

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,25 @@
+require "digest"
+require "securerandom"
+require "base64"
+
+class ApiKey < ActiveRecord::Base
+  before_create :generate_key_string
+
+  # Value of the key string, only available during creation
+  attr_accessor :key_string
+
+  def self.authorize(key_string)
+    find_by(key_digest: digest_key_string(key_string))
+  end
+
+  def self.digest_key_string(key_string)
+    Base64.encode64(Digest::SHA256.digest(key_string))
+  end
+
+  private
+
+  def generate_key_string
+    self.key_string = SecureRandom.uuid.delete("-")
+    self.key_digest = self.class.digest_key_string(key_string)
+  end
+end

--- a/app/models/appeal_events.rb
+++ b/app/models/appeal_events.rb
@@ -34,8 +34,6 @@ class AppealEvents
     appeal.ssoc_dates.map { |ssoc_date| AppealEvent.new(type: :ssoc, date: ssoc_date) }
   end
 
-  # TODO: Confirm with Chris
-  # if not decision_date, then disposition doesn't matter
   def decision_event
     AppealEvent.new(disposition: appeal.disposition, date: appeal.decision_date)
   end

--- a/db/migrate/20170522132232_create_api_keys.rb
+++ b/db/migrate/20170522132232_create_api_keys.rb
@@ -1,0 +1,14 @@
+class CreateApiKeys < ActiveRecord::Migration
+  # This is a new table, so the new indecies will be fine
+  safety_assured
+
+  def change
+    create_table :api_keys do |t|
+      t.string :consumer_name, null: false
+      t.string :key_digest, null: false
+    end
+
+    add_index(:api_keys, :key_digest, unique: true)
+    add_index(:api_keys, :consumer_name, unique: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517141505) do
+ActiveRecord::Schema.define(version: 20170522132232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,14 @@ ActiveRecord::Schema.define(version: 20170517141505) do
 
   add_index "annotations", ["document_id"], name: "index_annotations_on_document_id", using: :btree
   add_index "annotations", ["user_id"], name: "index_annotations_on_user_id", using: :btree
+
+  create_table "api_keys", force: :cascade do |t|
+    t.string "consumer_name", null: false
+    t.string "key_digest",    null: false
+  end
+
+  add_index "api_keys", ["consumer_name"], name: "index_api_keys_on_consumer_name", unique: true, using: :btree
+  add_index "api_keys", ["key_digest"], name: "index_api_keys_on_key_digest", unique: true, using: :btree
 
   create_table "appeals", force: :cascade do |t|
     t.string  "vacols_id",                                                                    null: false

--- a/spec/feature/api/v1/appeals_spec.rb
+++ b/spec/feature/api/v1/appeals_spec.rb
@@ -40,16 +40,30 @@ describe "Appeals API v1", type: :request do
       Generators::Appeal.create(
         vacols_record: {
           template: :remand_decided,
-          ssn: "3332223333"
+          appellant_ssn: "3332223333"
         }
       )
     end
 
-    let(:headers) do
-      { "ssn": "1112223333" }
+    let(:api_key) { ApiKey.create!(consumer_name: "Testington Roboterson") }
+
+    it "returns 401 if API key not authorized" do
+      headers = {
+        "ssn": "1112223333",
+        "Authorization": "Token token=12312kdasdaskd"
+      }
+
+      get "/api/v1/appeals", nil, headers
+
+      expect(response.code).to eq("401")
     end
 
     it "returns list of appeals for veteran with SSN" do
+      headers = {
+        "ssn": "1112223333",
+        "Authorization": "Token token=#{api_key.key_string}"
+      }
+
       get "/api/v1/appeals", nil, headers
 
       json = JSON.parse(response.body)

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,25 @@
+describe ApiKey do
+  context ".create!" do
+    subject { ApiKey.create!(consumer_name: "CaseSlow") }
+
+    it "creates a key and digest" do
+      expect(subject.key_string.length > 30).to be_truthy
+      expect(subject.reload.key_digest).to be_truthy
+    end
+  end
+
+  context ".authorize" do
+    subject { ApiKey.authorize(key_string) }
+    let(:api_key) { ApiKey.create!(consumer_name: "CaseSlow") }
+
+    context "when key is not authorized" do
+      let(:key_string) { api_key.key_string + "A" }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when key is authorized" do
+      let(:key_string) { api_key.key_string }
+      it { is_expected.to have_attributes(consumer_name: "CaseSlow") }
+    end
+  end
+end


### PR DESCRIPTION
New API keys will be created via the Rails shell.

```
> k = ApiKey.create!(consumer_name: "vets.gov")
> k.key_string # returns the key
```

connects #1915

## Test plan
- manual test
- automated feature and unit tests