### PR TITLE
[Reader] #1675 Fix test

### DIFF
--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -105,7 +105,7 @@ RSpec.feature "Reader" do
       click_on documents[0].type
       expect(find(".doc-list-progress-indicator")).to have_text("Document 1 of 3")
       click_on "Back to all documents"
-      fill_in "searchBar", with: "9"
+      fill_in "searchBar", with: "Form"
       click_on documents[1].type
       expect(find(".doc-list-progress-indicator")).to have_text("Document 1 of 1")
       expect(page).to have_selector(".doc-list-progress-indicator .filter-icon")


### PR DESCRIPTION
Connect #1675.

In the test, we searched for something that would only return one document, and then looked to see that the doc progress indicator said that there was only one document. Our search query was `9`. Our test documents are defined with relative dates:

```rb
        Generators::Document.create(
          # ...
          received_at: 7.days.ago,
        ),
        Generators::Document.create(
          # ...
          received_at: 5.days.ago,
        ),
        Generators::Document.create(
          # ...
          received_at: 1.day.ago,
        )
```

On some days, the search query `9` matches more than one doc, because `9` shows up in one of the document types, and can also match a document's date. So, this test will pass on some days but not others.

![image](https://cloud.githubusercontent.com/assets/829827/26500852/8cba665e-4205-11e7-962c-19f4443983b6.png)
