### PR TITLE
Don't delete ApiKeys when seeding.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -100,7 +100,7 @@ class SeedDB
   end
 
   def clean_db
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:truncation, {:except => %w[api_keys]})
   end
 
   def seed


### PR DESCRIPTION
This is so we can give a long lasting ApiKey to the demo environment