### PR TITLE
Handle No POA gracefully

### DIFF
--- a/app/mappers/power_of_attorney_mapper.rb
+++ b/app/mappers/power_of_attorney_mapper.rb
@@ -9,7 +9,9 @@ module PowerOfAttorneyMapper
 
   def get_poa_from_bgs_poa(bgs_rep = {})
     # TODO: what do we do if we encounter a rep type we don't know?
-    return {} if bgs_rep[:message] =~ /No POA found/
+
+    return {} unless bgs_rep[:power_of_attorney]
+
     bgs_type = bgs_rep[:power_of_attorney][:org_type_nm]
     {
       representative_type: BGS_REP_TYPE_TO_REP_TYPE[bgs_type] || "Other",

--- a/app/mappers/power_of_attorney_mapper.rb
+++ b/app/mappers/power_of_attorney_mapper.rb
@@ -102,4 +102,14 @@ module PowerOfAttorneyMapper
     "NATIONAL VETERANS ORGANIZATION OF AMERICA, INC." => "1",
     "WOUNDED WARRIOR PROJECT" => "2"
   }.freeze
+
+  def get_poa_from_bgs_poa(bgs_poa)
+    # TODO: what do we do if we encounter a rep type we don't know?
+    return {} if bgs_poa[:message] =~ /No POA found/
+    bgs_type = bgs_poa[:power_of_attorney][:org_type_nm]
+    {
+      representative_type: BGS_REP_TYPE_TO_REP_TYPE[bgs_type] || "Other",
+      representative_name: bgs_poa[:power_of_attorney][:nm]
+    }
+  end
 end

--- a/app/mappers/power_of_attorney_mapper.rb
+++ b/app/mappers/power_of_attorney_mapper.rb
@@ -9,7 +9,7 @@ module PowerOfAttorneyMapper
 
   def get_poa_from_bgs_poa(bgs_rep = {})
     # TODO: what do we do if we encounter a rep type we don't know?
-    # TODO: gracefully handle possible cases where bgs poa is nil or unexpected
+    return {} if bgs_rep[:message] =~ /No POA found/
     bgs_type = bgs_rep[:power_of_attorney][:org_type_nm]
     {
       representative_type: BGS_REP_TYPE_TO_REP_TYPE[bgs_type] || "Other",
@@ -102,14 +102,4 @@ module PowerOfAttorneyMapper
     "NATIONAL VETERANS ORGANIZATION OF AMERICA, INC." => "1",
     "WOUNDED WARRIOR PROJECT" => "2"
   }.freeze
-
-  def get_poa_from_bgs_poa(bgs_poa)
-    # TODO: what do we do if we encounter a rep type we don't know?
-    return {} if bgs_poa[:message] =~ /No POA found/
-    bgs_type = bgs_poa[:power_of_attorney][:org_type_nm]
-    {
-      representative_type: BGS_REP_TYPE_TO_REP_TYPE[bgs_type] || "Other",
-      representative_name: bgs_poa[:power_of_attorney][:nm]
-    }
-  end
 end

--- a/spec/mappers/power_of_attorney_mapper_spec.rb
+++ b/spec/mappers/power_of_attorney_mapper_spec.rb
@@ -38,6 +38,7 @@ describe PowerOfAttorneyMapper do
     context "#get_poa_from_bgs_poa" do
       let(:attorney_poa) { { power_of_attorney: { nm: "Steve Holtz", org_type_nm: "POA Attorney" } } }
       let(:unknown_type_poa) { { power_of_attorney: { nm: "Mrs. Featherbottom", org_type_nm: "unfamiliar_type" } } }
+      let(:no_poa) { { message: "No POA found for 1234567" } }
 
       it "maps BGS rep type to our rep type" do
         poa = poa_mapper.new.get_poa_from_bgs_poa(attorney_poa)
@@ -49,6 +50,11 @@ describe PowerOfAttorneyMapper do
         poa = poa_mapper.new.get_poa_from_bgs_poa(unknown_type_poa)
         expect(poa[:representative_name]).to eq("Mrs. Featherbottom")
         expect(poa[:representative_type]).to eq("Other")
+      end
+
+      it "when no poa is found" do
+        poa = poa_mapper.new.get_poa_from_bgs_poa(no_poa)
+        expect(poa).to be {}
       end
     end
   end


### PR DESCRIPTION
When no POA is found, BGS returns this message and does not throw an exception: 
```{:file_number=>"516517680", :message=>"No POA found for 600161054", :ptcpnt_id=>"600161054"}```

fixes https://github.com/department-of-veterans-affairs/caseflow/issues/2090#issuecomment-304931688