### PR TITLE
[wip] Nemo/Removed representativeName null check.

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -106,7 +106,7 @@ class CertificationsController < ApplicationController
   end
 
   def check_confirm_case_data
-    certification.representative_type && certification.representative_name
+    certification.representative_type
   end
 
   def check_confirm_hearing_data


### PR DESCRIPTION
Connects to #1894 

Since requirements on representativeName changed since original issue was created, we allow now to have representativeName equal to NULL. 
