### PR TITLE
Display formal form 9 on demo

### DIFF
--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -251,6 +251,8 @@ class Fakes::AppealRepository
   def self.seed_appeal_ready_to_certify!
     nod, soc, form9, ssoc1, ssoc2 = certification_documents
 
+    form9.vbms_document_id = "2"
+
     Generators::Appeal.build(
       vacols_id: "123C",
       vbms_id: "1111",


### PR DESCRIPTION
connects #2135 

In Fakes Appeal Repository, the file to be used is determined based on the `vbms_document_id`. See here: https://github.com/department-of-veterans-affairs/caseflow/blob/master/lib/fakes/appeal_repository.rb#L171

Testing:
1. certifications/124C/confirm_hearing (was already working)

![image](https://user-images.githubusercontent.com/3811786/26878239-c7cb8fda-4b5a-11e7-97dc-7e5caabb70f5.png)

2. certifications/123C/confirm_hearing

![image](https://user-images.githubusercontent.com/3811786/26878257-e0888154-4b5a-11e7-8b2d-92d11dbec658.png)




