### PR TITLE
Fix for premature v2 certification issue

### DIFF
--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -82,12 +82,14 @@ class Certification < ActiveRecord::Base
   end
 
   def complete!(user_id)
-    unless poa_correct_in_vacols
-      appeal.power_of_attorney.update_vacols_rep_info!(
-        appeal: appeal,
-        representative_type: representative_type,
-        representative_name: representative_name
-      )
+    if FeatureToggle.enabled?(:certification_v2, user: RequestStore[:current_user])
+      unless poa_correct_in_vacols
+        appeal.power_of_attorney.update_vacols_rep_info!(
+          appeal: appeal,
+          representative_type: representative_type,
+          representative_name: representative_name
+        )
+      end
     end
     appeal.certify!
     update_attributes!(completed_at: Time.zone.now, user_id: user_id)


### PR DESCRIPTION
Smoke test:

Ran through a certification on dev and it still works/doesn't crash:
![image](https://user-images.githubusercontent.com/3781835/26885092-9834b462-4b6f-11e7-87e0-ef3ccec044e7.png)
