### PR TITLE
changed text from 40px to 30px

### DIFF
--- a/client/app/containers/StyleGuide/StyleGuideHorizontalLine.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideHorizontalLine.jsx
@@ -13,7 +13,7 @@ export default class StyleGuideHorizontalLine extends React.Component {
 
   <p>The horizontal line helps provide clarity and improve legibility
   for users by separating different sections or UI components on a page.
-  Caseflow horizontal lines should always be light grey and have 40 px
+  Caseflow horizontal lines should always be light grey and have 30 px
   of space between the bottom of the section or component and the top of the horizontal line.</p>
 
   <div className="cf-help-divider"></div>


### PR DESCRIPTION
Connects #1091 
Fixed typo in the context text from 40px to 30px.
<img width="691" alt="screen shot 2017-06-08 at 1 19 38 pm" src="https://user-images.githubusercontent.com/23080951/26941641-2f92cd52-4c4d-11e7-800d-d5d343846561.png">
