### PR TITLE
uses correct rep type/rep name

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -49,8 +49,8 @@ class CertificationsController < ApplicationController
     update_certification_from_v2_form
     validate_data_presence_v2
     form8.update_from_string_params(
-      representative_type: certification.representative_type,
-      representative_name: certification.representative_name,
+      representative_type: certification.rep_type,
+      representative_name: certification.rep_name,
       hearing_preference: certification.hearing_preference,
       # This field is necessary when on v2 certification but v1 form8
       hearing_requested: certification.hearing_preference == "NO_HEARING_DESIRED" ? "No" : "Yes",

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -81,10 +81,27 @@ class Certification < ActiveRecord::Base
     )
   end
 
-  def update_vacols_poa!
-    rep_type = poa_correct_in_bgs ? bgs_representative_type : representative_type
-    rep_name = poa_correct_in_bgs ? bgs_representative_name : representative_name
+  def rep_name
+    if poa_correct_in_vacols
+      vacols_representative_name
+    elsif poa_correct_in_bgs
+      bgs_representative_name
+    else
+      representative_name
+    end
+  end
 
+  def rep_type
+    if poa_correct_in_vacols
+      vacols_representative_type
+    elsif poa_correct_in_bgs
+      bgs_representative_type
+    else
+      representative_type
+    end
+  end
+
+  def update_vacols_poa!
     appeal.power_of_attorney.update_vacols_rep_info!(
       appeal: appeal,
       representative_type: rep_type,


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/2287

![image](https://user-images.githubusercontent.com/3781835/27005286-9f184100-4de9-11e7-8b3b-0f5c047d9206.png)

Testing:

- if VACOLS is selected as having the correct POA information, after certification, the Form 8 pdf at `/certifications/id/pdf` contains the VACOLS POA info
- if VBMS is selected as having the correct POA information, after certification, the Form 8 pdf at `/certifications/id/pdf` contains the VBMS/BGS POA info
- if None of the Above is selected as having the correct POA information, after certification, the Form 8 pdf at `/certifications/id/pdf` contains the info that the user entered