### PR TITLE
Fix for different rep type mappings from VACOLS and our system

### DIFF
--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -62,7 +62,8 @@ class PowerOfAttorney
 
   def update_vacols_rep_info!(appeal:, representative_type:, representative_name:, address:)
     repo = PowerOfAttorney.repository
-    vacols_rep_type = if representative_type == "Service Organization"
+    vacols_rep_type = if representative_type == "Service Organization" ||
+                         representative_type == "ORGANIZATION"
                         # We set the rep type to the service organization name, unless we don't have a record
                         # of it. Then we set it to 'other'.
                         repo.get_vacols_rep_code(representative_name) ||

--- a/client/app/certification/constants/constants.js
+++ b/client/app/certification/constants/constants.js
@@ -48,6 +48,7 @@ export const form9Types = {
 };
 
 // representation for the appellant
+// TODO: We need to map these more closely with the rep types we pull in from BGS and VACOLS.
 export const representativeTypes = {
   ATTORNEY: 'ATTORNEY',
   AGENT: 'AGENT',


### PR DESCRIPTION
We have two different mappings for service organizations: "Service Organization" and "ORGANIZATION". This PR fixes the POA method to check for both mappings.

Connects #2098 

- [ ] Go to confirm case details.
- [ ] Select 'No'
- [ ] Select 'None of the above'
- [ ] Select 'Service Organization'
- [ ] Select 'Unlisted service organization'
- [ ] Confirm that in line 74 of power_of_attorney.rb, we send "O" for representative_type


