### PR TITLE
When hearing type is not specified default to video conference

### DIFF
--- a/app/services/form8_pdf_service.rb
+++ b/app/services/form8_pdf_service.rb
@@ -97,6 +97,7 @@ class Form8PdfService
     hearing_preference: {
       "HEARING_CANCELLED" => "CheckBox21[0]",
       "NO_HEARING_DESIRED" => "CheckBox21[0]",
+      "HEARING_TYPE_NOT_SPECIFIED" => "CheckBox21[1]",
       "VIDEO" => "CheckBox21[1]",
       "WASHINGTON_DC" => "CheckBox21[2]",
       "TRAVEL_BOARD" => "CheckBox21[3]",


### PR DESCRIPTION
connects #2299 

Resulting PDF:
![image](https://user-images.githubusercontent.com/3811786/27197644-09e15372-51dd-11e7-8956-29361a195cd2.png)
