### PR TITLE
Reader | Receipt Date and Document Type become buttons

### DIFF
--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -83,18 +83,18 @@ $tag-backgrond-color: #d6d7d9;
   .cf-document-list-header-row tr {
     display: block;
 
-    th > span > button {
-      display: flex;
-      background-color: $color-white;
-      color: $color-gray-dark;
-      padding: 0;
-      margin: 0;
-      line-height: normal;
-    }
-
     th > div {
       display: flex;
     }
+  }
+
+  .cf-document-list-button-header {
+    display: flex;
+    background-color: $color-white;
+    color: $color-gray-dark;
+    padding: 0;
+    margin: 0;
+    line-height: normal;
   }
 
   .cf-document-list-body {

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -83,7 +83,7 @@ $tag-backgrond-color: #d6d7d9;
   .cf-document-list-header-row tr {
     display: block;
 
-    th > button {
+    th > span > button {
       display: flex;
       background-color: $color-white;
       color: $color-gray-dark;

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -83,6 +83,13 @@ $tag-backgrond-color: #d6d7d9;
   .cf-document-list-header-row tr {
     display: block;
 
+    th > button {
+      display: flex;
+      background-color: $color-white;
+      color: $color-gray-dark;
+      padding: 0;
+    }
+
     th > div {
       display: flex;
     }

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -88,6 +88,8 @@ $tag-backgrond-color: #d6d7d9;
       background-color: $color-white;
       color: $color-gray-dark;
       padding: 0;
+      margin: 0;
+      line-height: normal;
     }
 
     th > div {

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -279,6 +279,7 @@ class DocumentsTable extends React.Component {
         cellClass: 'receipt-date-column',
         header: <Button
           id="receipt-date-header"
+          classNames={['cf-document-list-button-header']}
           onClick={() => this.props.changeSortState('receivedAt')}>
           Receipt Date {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ? sortIcon : notsortedIcon}
         </Button>,
@@ -289,7 +290,9 @@ class DocumentsTable extends React.Component {
       },
       {
         cellClass: 'doc-type-column',
-        header: <Button id="type-header" onClick={() => this.props.changeSortState('type')}>
+        header: <Button id="type-header"
+        classNames={['cf-document-list-button-header']}
+        onClick={() => this.props.changeSortState('type')}>
           Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortIcon : notsortedIcon}
         </Button>,
         valueFunction: (doc) => boldUnreadContent(

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -8,6 +8,7 @@ import { openDocumentInNewTab } from '../reader/utils';
 import DocumentCategoryIcons from '../components/DocumentCategoryIcons';
 import TagTableColumn from '../components/reader/TagTableColumn';
 import Table from '../components/Table';
+import Button from '../components/Button';
 import * as Constants from './constants';
 import CommentIndicator from './CommentIndicator';
 import DropdownFilter from './DropdownFilter';
@@ -276,11 +277,11 @@ class DocumentsTable extends React.Component {
       },
       {
         cellClass: 'receipt-date-column',
-        header: <button
+        header: <Button
           id="receipt-date-header"
           onClick={() => this.props.changeSortState('receivedAt')}>
           Receipt Date {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ? sortIcon : notsortedIcon}
-        </button>,
+        </Button>,
         valueFunction: (doc) =>
           <span className="document-list-receipt-date">
             {formatDateStr(doc.receivedAt)}
@@ -288,9 +289,9 @@ class DocumentsTable extends React.Component {
       },
       {
         cellClass: 'doc-type-column',
-        header: <button id="type-header" onClick={() => this.props.changeSortState('type')}>
+        header: <Button id="type-header" onClick={() => this.props.changeSortState('type')}>
           Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortIcon : notsortedIcon}
-        </button>,
+        </Button>,
         valueFunction: (doc) => boldUnreadContent(
           <a
             href={this.singleDocumentView}

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -276,11 +276,11 @@ class DocumentsTable extends React.Component {
       },
       {
         cellClass: 'receipt-date-column',
-        header: <div
+        header: <button
           id="receipt-date-header"
           onClick={() => this.props.changeSortState('receivedAt')}>
           Receipt Date {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ? sortIcon : notsortedIcon}
-        </div>,
+        </button>,
         valueFunction: (doc) =>
           <span className="document-list-receipt-date">
             {formatDateStr(doc.receivedAt)}
@@ -288,9 +288,9 @@ class DocumentsTable extends React.Component {
       },
       {
         cellClass: 'doc-type-column',
-        header: <div id="type-header" onClick={() => this.props.changeSortState('type')}>
+        header: <button id="type-header" onClick={() => this.props.changeSortState('type')}>
           Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortIcon : notsortedIcon}
-        </div>,
+        </button>,
         valueFunction: (doc) => boldUnreadContent(
           <a
             href={this.singleDocumentView}

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -251,8 +251,7 @@ class DocumentsTable extends React.Component {
       {
         cellClass: 'categories-column',
         header: <div
-          id="categories-header"
-          className="document-list-header-categories">
+          id="categories-header">
           Categories <FilterIcon
             label="Filter by category"
             idPrefix="category"
@@ -279,7 +278,6 @@ class DocumentsTable extends React.Component {
         cellClass: 'receipt-date-column',
         header: <div
           id="receipt-date-header"
-          className="document-list-header-recepit-date"
           onClick={() => this.props.changeSortState('receivedAt')}>
           Receipt Date {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ? sortIcon : notsortedIcon}
         </div>,

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -223,13 +223,13 @@ RSpec.feature "Reader" do
       expect(find("#procedural", visible: false).checked?).to be false
 
       find("#receipt-date-header").send_keys :enter
-      expect(find :xpath, "//*[@id='table-row-1']/td[3]/span").to have_text((7.days.ago).strftime("%m/%d/%Y"))
+      expect((find :xpath, "//*[@id='table-row-1']/td[3]/span")).to have_text(7.days.ago.strftime("%m/%d/%Y"))
 
       # This resets the date header to original setup for next test
       find("#receipt-date-header").send_keys :enter
 
       find("#type-header").send_keys :enter
-      expect(find :xpath, "//*[@id='table-row-1']/td[4]/b/a").to have_text("BVA Decision")
+      expect((find :xpath, "//*[@id='table-row-1']/td[4]/b/a")).to have_text("BVA Decision")
     end
 
     scenario "Add comment" do

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -221,15 +221,6 @@ RSpec.feature "Reader" do
       expect_dropdown_filter_to_be_visible
 
       expect(find("#procedural", visible: false).checked?).to be false
-
-      find("#receipt-date-header").send_keys :enter
-      expect((find :xpath, "//*[@id='table-row-1']/td[3]/span")).to have_text(7.days.ago.strftime("%m/%d/%Y"))
-
-      # This resets the date header to original setup for next test
-      find("#receipt-date-header").send_keys :enter
-
-      find("#type-header").send_keys :enter
-      expect((find :xpath, "//*[@id='table-row-1']/td[4]/b/a")).to have_text("BVA Decision")
     end
 
     scenario "Add comment" do

--- a/spec/feature/reader_spec.rb
+++ b/spec/feature/reader_spec.rb
@@ -221,6 +221,15 @@ RSpec.feature "Reader" do
       expect_dropdown_filter_to_be_visible
 
       expect(find("#procedural", visible: false).checked?).to be false
+
+      find("#receipt-date-header").send_keys :enter
+      expect(find :xpath, "//*[@id='table-row-1']/td[3]/span").to have_text((7.days.ago).strftime("%m/%d/%Y"))
+
+      # This resets the date header to original setup for next test
+      find("#receipt-date-header").send_keys :enter
+
+      find("#type-header").send_keys :enter
+      expect(find :xpath, "//*[@id='table-row-1']/td[4]/b/a").to have_text("BVA Decision")
     end
 
     scenario "Add comment" do


### PR DESCRIPTION
Converts the fields "Receipt Date" and "Document Type" to buttons so they're accessible to keyboards.
Connects #1847 
![document-list-buttons](https://user-images.githubusercontent.com/4773320/27197917-2dd26554-51de-11e7-9c9f-ef6c42d6df2a.gif)
