### PR TITLE
Removing extra fakes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
   # - Ensure the fakes are loaded (reset in dev mode on file save & class reload)
   # - Setup the default authenticated user
   def setup_fakes
-    Fakes::Initializer.setup!(Rails.env)
+    Fakes::Initializer.setup!(Rails.env, app_name: logo_name)
   end
 
   def test_user?

--- a/config/initializers/fake_dependencies.rb
+++ b/config/initializers/fake_dependencies.rb
@@ -1,1 +1,1 @@
-Fakes::Initializer.load! if Rails.env.development? || Rails.env.demo?
+Fakes::Initializer.load! if Rails.env.development? || Rails.env.demo? || Rails.env.test?

--- a/config/initializers/fake_dependencies.rb
+++ b/config/initializers/fake_dependencies.rb
@@ -1,1 +1,1 @@
-Fakes::Initializer.load! if Rails.env.development? || Rails.env.demo? || Rails.env.test?
+Fakes::Initializer.load! if Rails.env.development? || Rails.env.demo?

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -206,12 +206,12 @@ class Fakes::AppealRepository
   ## ALL SEED SCRIPTS BELOW THIS LINE ------------------------------
   # TODO: pull seed scripts into seperate object/module?
 
-  def self.seed!
+  def self.seed!(app_name: nil)
     return if Rails.env.test?
 
-    seed_certification_data!
-    seed_establish_claim_data!
-    seed_reader_data!
+    seed_certification_data! if app_name == "Certification"
+    seed_establish_claim_data! if app_name == "Dispatch"
+    seed_reader_data! if app_name == "Reader"
   end
 
   def self.certification_documents

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -9,13 +9,13 @@ class Fakes::Initializer
       User.case_assignment_repository = Fakes::CaseAssignmentRepository
     end
 
-    def setup!(rails_env)
-      development! if rails_env.development? || rails_env.demo?
+    def setup!(rails_env, app_name: nil)
+      development!(app_name: app_name) if rails_env.development? || rails_env.demo?
     end
 
     private
 
-    def development!
+    def development!(app_name: nil)
       load!
 
       User.authentication_service.vacols_regional_offices = {
@@ -31,8 +31,8 @@ class Fakes::Initializer
         "name" => "Cave Johnson"
       }
 
-      Fakes::AppealRepository.seed!
-      Fakes::HearingRepository.seed!
+      Fakes::AppealRepository.seed!(app_name: app_name)
+      Fakes::HearingRepository.seed! if app_name == "Hearing Prep"
     end
   end
 end


### PR DESCRIPTION
We are currently seeding the DB on a before action: setup_fakes. This causes a lot of DB churn every time our app is hit.

This is a temporary fix to scope it by app.