### PR TITLE
Making docs list use strong tag instead of bold

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -187,7 +187,7 @@ class DocumentsTable extends React.Component {
 
     let boldUnreadContent = (content, doc) => {
       if (!doc.opened_by_current_user) {
-        return <b>{content}</b>;
+        return <strong>{content}</strong>;
       }
 
       return content;


### PR DESCRIPTION
# Description
HTML element type changed from `<b>` to `<strong>` for #2233. No visual change, just HTML document change for accessibility

# Before
<img width="1508" alt="screen shot 2017-06-19 at 1 36 19 pm" src="https://user-images.githubusercontent.com/10132008/27297801-59d9cf48-54f4-11e7-9a7a-3e43230c95b7.png">

# After
<img width="1512" alt="screen shot 2017-06-19 at 1 35 49 pm" src="https://user-images.githubusercontent.com/10132008/27297803-5be8e648-54f4-11e7-8659-b073f4fb993e.png">