### PR TITLE
Skip fakes initializer setup in demo mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
   # - Ensure the fakes are loaded (reset in dev mode on file save & class reload)
   # - Setup the default authenticated user
   def setup_fakes
-    Fakes::Initializer.setup!(Rails.env, app_name: logo_name)
+    Fakes::Initializer.setup!(Rails.env, app_name: application)
   end
 
   def test_user?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
   # - Ensure the fakes are loaded (reset in dev mode on file save & class reload)
   # - Setup the default authenticated user
   def setup_fakes
-    Fakes::Initializer.setup!(Rails.env)
+    Fakes::Initializer.setup!(Rails.env, app_name: logo_name)
   end
 
   def test_user?

--- a/app/controllers/test/setup_controller.rb
+++ b/app/controllers/test/setup_controller.rb
@@ -1,5 +1,6 @@
 class Test::SetupController < ApplicationController
   before_action :require_non_prod, only: [:index, :uncertify_appeal, :appeal_location_date_reset, :delete_test_data]
+  before_action :set_application
 
   def index
     @certification_appeal = "UNCERTIFY_ME"
@@ -68,6 +69,10 @@ class Test::SetupController < ApplicationController
   end
 
   private
+
+  def set_application
+    RequestStore.store[:application] = "internal"
+  end
 
   def require_non_prod
     redirect_to "/unauthorized" unless test_user?

--- a/app/controllers/test/setup_controller.rb
+++ b/app/controllers/test/setup_controller.rb
@@ -1,5 +1,6 @@
 class Test::SetupController < ApplicationController
   before_action :require_non_prod, only: [:index, :uncertify_appeal, :appeal_location_date_reset, :delete_test_data]
+  before_action :set_application
 
   def index
     @certification_appeal = "UNCERTIFY_ME"
@@ -65,6 +66,10 @@ class Test::SetupController < ApplicationController
       flash[:error] = "Failed to toggle #{feature}!"
     end
     redirect_to action: "index"
+  end
+
+  def set_application
+    RequestStore.store[:application] = "internal"
   end
 
   private

--- a/config/initializers/fake_dependencies.rb
+++ b/config/initializers/fake_dependencies.rb
@@ -1,1 +1,1 @@
-Fakes::Initializer.load! if Rails.env.development? || Rails.env.demo?
+Fakes::Initializer.app_init!(Rails.env)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,6 +107,11 @@ class SeedDB
     ApiKey.new(consumer_name: "PUBLIC", key_string: "PUBLICDEMO123").save!
   end
 
+  def setup_feature_toggles
+    FeatureToggle.disable!(:reader)
+    FeatureToggle.enable!(:reader, users: ["Reader"])
+  end
+
   def clean_db
     DatabaseCleaner.clean_with(:truncation)
   end
@@ -121,6 +126,7 @@ class SeedDB
     create_tags
     create_hearings
     create_api_key
+    setup_feature_toggles
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -111,6 +111,11 @@ class SeedDB
     DatabaseCleaner.clean_with(:truncation)
   end
 
+   def set_up_feature_toggles
+     FeatureToggle.disable!(:reader)
+     FeatureToggle.enable!(:reader, users: ["Reader"])
+   end
+
   def seed
     clean_db
     create_default_users
@@ -121,6 +126,7 @@ class SeedDB
     create_tags
     create_hearings
     create_api_key
+    set_up_feature_toggles
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,7 +107,7 @@ class SeedDB
     ApiKey.new(consumer_name: "PUBLIC", key_string: "PUBLICDEMO123").save!
   end
 
-  def setup_feature_toggles
+  def set_up_feature_toggles
     FeatureToggle.disable!(:reader)
     FeatureToggle.enable!(:reader, users: ["Reader"])
   end
@@ -126,7 +126,7 @@ class SeedDB
     create_tags
     create_hearings
     create_api_key
-    setup_feature_toggles
+    set_up_feature_toggles
   end
 end
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -206,12 +206,12 @@ class Fakes::AppealRepository
   ## ALL SEED SCRIPTS BELOW THIS LINE ------------------------------
   # TODO: pull seed scripts into seperate object/module?
 
-  def self.seed!
+  def self.seed!(app_name: nil)
     return if Rails.env.test?
 
-    seed_certification_data!
-    seed_establish_claim_data!
-    seed_reader_data!
+    seed_certification_data! if app_name == "Certification"
+    seed_establish_claim_data! if app_name == "Dispatch"
+    seed_reader_data! if app_name == "Reader"
   end
 
   def self.certification_documents

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -206,12 +206,14 @@ class Fakes::AppealRepository
   ## ALL SEED SCRIPTS BELOW THIS LINE ------------------------------
   # TODO: pull seed scripts into seperate object/module?
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def self.seed!(app_name: nil)
     return if Rails.env.test?
 
-    seed_certification_data! if app_name == "Certification"
-    seed_establish_claim_data! if app_name == "Dispatch"
-    seed_reader_data! if app_name == "Reader"
+    seed_certification_data! if app_name.nil? || app_name == "certification"
+    seed_establish_claim_data! if app_name.nil? || app_name == "dispatch-arc"
+    seed_reader_data! if app_name.nil? || app_name == "reader"
   end
 
   def self.certification_documents
@@ -402,8 +404,6 @@ class Fakes::AppealRepository
 
   # rubocop:disable Metrics/MethodLength
   def self.seed_reader_data!
-    FeatureToggle.enable!(:reader)
-
     Generators::Appeal.build(
       vacols_id: "reader_id1",
       vbms_id: "reader_id1",

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -238,7 +238,7 @@ class Fakes::AppealRepository
 
   def self.seed_establish_claim_data!
     # Make every other case have two decision documents
-    50.times.each do |i|
+    10.times.each do |i|
       Generators::Appeal.build(
         vacols_id: "vacols_id#{i}",
         vbms_id: "vbms_id#{i}",

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -211,6 +211,10 @@ class Fakes::AppealRepository
   def self.seed!(app_name: nil)
     return if Rails.env.test?
 
+    # In demo mode, on app bootup (rails console or server) the app_name will be nil and we
+    # want to load *all* of the seeds
+    # In development mode, we call these on every request, so we only want to load the ones
+    # relevant to our current app
     seed_certification_data! if app_name.nil? || app_name == "certification"
     seed_establish_claim_data! if app_name.nil? || app_name == "dispatch-arc"
     seed_reader_data! if app_name.nil? || app_name == "reader"

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -209,9 +209,9 @@ class Fakes::AppealRepository
   def self.seed!(app_name: nil)
     return if Rails.env.test?
 
-    seed_certification_data! if app_name == "Certification"
-    seed_establish_claim_data! if app_name == "Dispatch"
-    seed_reader_data! if app_name == "Reader"
+    seed_certification_data! if app_name.nil? || app_name == "Certification"
+    seed_establish_claim_data! if app_name.nil? || app_name == "Dispatch"
+    seed_reader_data! if app_name.nil? || app_name == "Reader"
   end
 
   def self.certification_documents
@@ -402,8 +402,6 @@ class Fakes::AppealRepository
 
   # rubocop:disable Metrics/MethodLength
   def self.seed_reader_data!
-    FeatureToggle.enable!(:reader)
-
     Generators::Appeal.build(
       vacols_id: "reader_id1",
       vbms_id: "reader_id1",

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -206,6 +206,8 @@ class Fakes::AppealRepository
   ## ALL SEED SCRIPTS BELOW THIS LINE ------------------------------
   # TODO: pull seed scripts into seperate object/module?
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def self.seed!(app_name: nil)
     return if Rails.env.test?
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -209,9 +209,9 @@ class Fakes::AppealRepository
   def self.seed!(app_name: nil)
     return if Rails.env.test?
 
-    seed_certification_data! if app_name.nil? || app_name == "Certification"
-    seed_establish_claim_data! if app_name.nil? || app_name == "Dispatch"
-    seed_reader_data! if app_name.nil? || app_name == "Reader"
+    seed_certification_data! if app_name.nil? || app_name == "certification"
+    seed_establish_claim_data! if app_name.nil? || app_name == "dispatch-arc"
+    seed_reader_data! if app_name.nil? || app_name == "reader"
   end
 
   def self.certification_documents
@@ -238,7 +238,7 @@ class Fakes::AppealRepository
 
   def self.seed_establish_claim_data!
     # Make every other case have two decision documents
-    10.times.each do |i|
+    50.times.each do |i|
       Generators::Appeal.build(
         vacols_id: "vacols_id#{i}",
         vbms_id: "vbms_id#{i}",

--- a/lib/fakes/hearing_repository.rb
+++ b/lib/fakes/hearing_repository.rb
@@ -21,7 +21,7 @@ class Fakes::HearingRepository
 
   def self.seed!
     user = User.find_by_vacols_id("LROTH")
-    50.times.each do |i|
+    10.times.each do |i|
       type = VACOLS::CaseHearing::HEARING_TYPES.values[i % 3]
       Generators::Hearing.build(
         type: type,

--- a/lib/fakes/hearing_repository.rb
+++ b/lib/fakes/hearing_repository.rb
@@ -21,7 +21,7 @@ class Fakes::HearingRepository
 
   def self.seed!
     user = User.find_by_vacols_id("LROTH")
-    10.times.each do |i|
+    50.times.each do |i|
       type = VACOLS::CaseHearing::HEARING_TYPES.values[i % 3]
       Generators::Hearing.build(
         type: type,

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -13,11 +13,14 @@ class Fakes::Initializer
     def app_init!(rails_env)
       if rails_env.development? || rails_env.demo?
 
-        # If we are booting up the rails console or server,
-        # we also want to load the fakes. When running other rake commands
-        # like `rake db:seed`, we do **NOT** want to seed the fakes yet, as we
-        # must first seed the caseflow postgres DB for things to properly be
-        # aligned
+        # If we are booting up the rails console or server we want to load
+        # the fakes & seed our in-memory VACOLS "DB"
+        #
+        # When running other rake commands (e.g. `rake db:seed`), we do **NOT**
+        # want to seed the fakes because
+        #   1) it's unnecessary and slows down the command
+        #   2) it can cause the seed data we put into postres vacols_ids to become
+        #      unaligned with what we put into our in-memory VACOLS "DB"
         if Rails.const_defined?("Console") || Rails.const_defined?("Server")
           load_fakes_and_seed!
         else

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -9,13 +9,21 @@ class Fakes::Initializer
       User.case_assignment_repository = Fakes::CaseAssignmentRepository
     end
 
+    # This method is called only 1 time during application bootup
+    def app_init!(rails_env)
+      load_fakes_and_seed! if rails_env.development? || rails_env.demo?
+    end
+
+    # This setup method is called on every request during development
+    # to properly reload class attributes like the fake repositories and
+    # their seed data (which is currently cached as class attributes)
     def setup!(rails_env, app_name: nil)
-      development!(app_name: app_name) if rails_env.development? || rails_env.demo?
+      load_fakes_and_seed!(app_name: app_name) if rails_env.development? #|| rails_env.demo?
     end
 
     private
 
-    def development!(app_name: nil)
+    def load_fakes_and_seed!(app_name: nil)
       load!
 
       User.authentication_service.vacols_regional_offices = {
@@ -32,7 +40,7 @@ class Fakes::Initializer
       }
 
       Fakes::AppealRepository.seed!(app_name: app_name)
-      Fakes::HearingRepository.seed! if app_name == "Hearing Prep"
+      Fakes::HearingRepository.seed! if app_name.nil? || app_name == "Hearing Prep"
     end
   end
 end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -19,7 +19,7 @@ class Fakes::Initializer
         # When running other rake commands (e.g. `rake db:seed`), we do **NOT**
         # want to seed the fakes because
         #   1) it's unnecessary and slows down the command
-        #   2) it can cause the seed data we put into postres vacols_ids to become
+        #   2) it can cause the seed data we put into postgres vacols_ids to become
         #      unaligned with what we put into our in-memory VACOLS "DB"
         if Rails.const_defined?("Console") || Rails.const_defined?("Server")
           load_fakes_and_seed!

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -18,7 +18,7 @@ class Fakes::Initializer
     # to properly reload class attributes like the fake repositories and
     # their seed data (which is currently cached as class attributes)
     def setup!(rails_env, app_name: nil)
-      load_fakes_and_seed!(app_name: app_name) if rails_env.development? #|| rails_env.demo?
+      load_fakes_and_seed!(app_name: app_name) if rails_env.development?
     end
 
     private

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -18,7 +18,7 @@ class Fakes::Initializer
         # like `rake db:seed`, we do **NOT** want to seed the fakes yet, as we
         # must first seed the caseflow postgres DB for things to properly be
         # aligned
-        if Rails.const_defined?('Console') || Rails.const_defined?('Server')
+        if Rails.const_defined?("Console") || Rails.const_defined?("Server")
           load_fakes_and_seed!
         else
           load!

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -9,13 +9,13 @@ class Fakes::Initializer
       User.case_assignment_repository = Fakes::CaseAssignmentRepository
     end
 
-    def setup!(rails_env)
-      development! if rails_env.development? || rails_env.demo?
+    def setup!(rails_env, app_name: nil)
+      development!(app_name: app_name) if rails_env.development? || rails_env.demo?
     end
 
     private
 
-    def development!
+    def development!(app_name: nil)
       load!
 
       User.authentication_service.vacols_regional_offices = {
@@ -31,8 +31,8 @@ class Fakes::Initializer
         "name" => "Cave Johnson"
       }
 
-      Fakes::AppealRepository.seed!
-      Fakes::HearingRepository.seed!
+      Fakes::AppealRepository.seed!(app_name: app_name)
+      Fakes::HearingRepository.seed! if app_name == "Hearing Prep"
     end
   end
 end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -11,7 +11,19 @@ class Fakes::Initializer
 
     # This method is called only 1 time during application bootup
     def app_init!(rails_env)
-      load_fakes_and_seed! if rails_env.development? || rails_env.demo?
+      if rails_env.development? || rails_env.demo?
+
+        # If we are booting up the rails console or server,
+        # we also want to load the fakes. When running other rake commands
+        # like `rake db:seed`, we do **NOT** want to seed the fakes yet, as we
+        # must first seed the caseflow postgres DB for things to properly be
+        # aligned
+        if Rails.const_defined?('Console') || Rails.const_defined?('Server')
+          load_fakes_and_seed!
+        else
+          load!
+        end
+      end
     end
 
     # This setup method is called on every request during development

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -52,7 +52,7 @@ class Fakes::Initializer
       }
 
       Fakes::AppealRepository.seed!(app_name: app_name)
-      Fakes::HearingRepository.seed! if app_name.nil? || app_name == "Hearing Prep"
+      Fakes::HearingRepository.seed! if app_name.nil? || app_name == "hearings"
     end
   end
 end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -18,12 +18,12 @@ class Fakes::Initializer
     # to properly reload class attributes like the fake repositories and
     # their seed data (which is currently cached as class attributes)
     def setup!(rails_env, app_name: nil)
-      development!(app_name: app_name) if rails_env.development?
+      load_fakes_and_seed!(app_name: app_name) if rails_env.development?
     end
 
     private
 
-    def development!(app_name: nil)
+    def load_fakes_and_seed!(app_name: nil)
       load!
 
       User.authentication_service.vacols_regional_offices = {
@@ -40,7 +40,7 @@ class Fakes::Initializer
       }
 
       Fakes::AppealRepository.seed!(app_name: app_name)
-      Fakes::HearingRepository.seed! if app_name == "Hearing Prep"
+      Fakes::HearingRepository.seed! if app_name.nil? || app_name == "hearings"
     end
   end
 end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -11,22 +11,7 @@ class Fakes::Initializer
 
     # This method is called only 1 time during application bootup
     def app_init!(rails_env)
-      if rails_env.development? || rails_env.demo?
-
-        # If we are booting up the rails console or server we want to load
-        # the fakes & seed our in-memory VACOLS "DB"
-        #
-        # When running other rake commands (e.g. `rake db:seed`), we do **NOT**
-        # want to seed the fakes because
-        #   1) it's unnecessary and slows down the command
-        #   2) it can cause the seed data we put into postgres vacols_ids to become
-        #      unaligned with what we put into our in-memory VACOLS "DB"
-        if Rails.const_defined?("Console") || Rails.const_defined?("Server")
-          load_fakes_and_seed!
-        else
-          load!
-        end
-      end
+      load_fakes_and_seed! if rails_env.development? || rails_env.demo?
     end
 
     # This setup method is called on every request during development

--- a/lib/generators/user.rb
+++ b/lib/generators/user.rb
@@ -6,8 +6,7 @@ class Generators::User
       {
         station_id: "283",
         css_id: generate_external_id,
-        full_name: "#{generate_first_name} #{generate_last_name}",
-        vacols_id: "LROTH"
+        full_name: "#{generate_first_name} #{generate_last_name}"
       }
     end
 


### PR DESCRIPTION
This is round 2 on a previous PR here https://github.com/department-of-veterans-affairs/caseflow/pull/2379, which was already approved

It's identical, except for one key difference removing:
```
 if Rails.const_defined?("Console") || Rails.const_defined?("Server")
   load_fakes_and_seed!
  else
    load!
  end
```
Now instead we always calls `load_fakes_and_seed!`. It's slightly less efficient when calling `rake db:seed`, but works proper in all scenarios.

#### Problem with original PR
The reason the original version broke on demo environment is the way we run the rails server via puma, the `Server` variable was not defined (unexpectedly, and I'm not sure why)

On demo environment:
<img width="662" alt="screen shot 2017-06-20 at 8 02 09 pm" src="https://user-images.githubusercontent.com/2256237/27361510-d981502a-55f5-11e7-92db-5cd993584da7.png">
