### PR TITLE
Remove unused pdf document objects

### DIFF
--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -600,6 +600,15 @@ export class Pdf extends React.PureComponent {
 
     if (nextProps.prefetchFiles !== this.props.prefetchFiles) {
       this.setUpFakeCanvasRefFunctions();
+
+      const newPrerenderedPdfs = _.pick(this.prerenderedPdfs, [...nextProps.prefetchFiles, nextProps.file]);
+      const pdfsToCleanup = _.omit(this.prerenderedPdfs, [...nextProps.prefetchFiles, nextProps.file]);
+
+      _.forEach(pdfsToCleanup, (pdf) => {
+        pdf.pdfDocument.destroy();
+      });
+
+      this.prerenderedPdfs = newPrerenderedPdfs;
     }
     /* eslint-enable no-negated-condition */
   }

--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -599,16 +599,15 @@ export class Pdf extends React.PureComponent {
     }
 
     if (nextProps.prefetchFiles !== this.props.prefetchFiles) {
-      this.setUpFakeCanvasRefFunctions();
+      const pdfsToKeep = [...nextProps.prefetchFiles, nextProps.file];
 
-      const newPrerenderedPdfs = _.pick(this.prerenderedPdfs, [...nextProps.prefetchFiles, nextProps.file]);
-      const pdfsToCleanup = _.omit(this.prerenderedPdfs, [...nextProps.prefetchFiles, nextProps.file]);
-
-      _.forEach(pdfsToCleanup, (pdf) => {
+      _.forEach(_.omit(this.prerenderedPdfs, pdfsToKeep), (pdf) => {
         pdf.pdfDocument.destroy();
       });
 
-      this.prerenderedPdfs = newPrerenderedPdfs;
+      this.prerenderedPdfs = _.pick(this.prerenderedPdfs, pdfsToKeep);
+
+      this.setUpFakeCanvasRefFunctions();
     }
     /* eslint-enable no-negated-condition */
   }


### PR DESCRIPTION
Connects #1960 

We were storing all the documents in memory at once. And we did not know how to properly cleaning up our documents. We were merely dropping our references to them. However, you're supposed to actually call PDFJS to destroy the worker thread and associated objects. https://mozilla.github.io/pdf.js/api/draft/PDFDocumentProxy.html

**Test Plan**
- [x] Use the chrome dev tools to take heap snapshots after going to one document, then three, then 10, etc and see if the memory usage increases.
![screen shot 2017-06-22 at 2 32 23 pm](https://user-images.githubusercontent.com/3885236/27449822-ac8a2dfe-5757-11e7-8cdb-cc2e3818673d.png)
