### PR TITLE
Fix rake commands that touch the DB

### DIFF
--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -53,7 +53,7 @@ class Fakes::Initializer
     end
 
     def running_rake_command?
-      File.basename($0) == "rake"
+      File.basename($PROGRAM_NAME) == "rake"
     end
   end
 end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -15,7 +15,7 @@ class Fakes::Initializer
         # If we are running a rake command like `rake db:seed` or
         # `rake db:schema:load`, we do not want to try and seed the fakes
         # because our schema may not be loaded yet and it will fail!
-        if File.basename($0) == "rake"
+        if running_rake_command?
           load!
         else
           load_fakes_and_seed!
@@ -50,6 +50,10 @@ class Fakes::Initializer
 
       Fakes::AppealRepository.seed!(app_name: app_name)
       Fakes::HearingRepository.seed! if app_name.nil? || app_name == "hearings"
+    end
+
+    def running_rake_command?
+      File.basename($0) == "rake"
     end
   end
 end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -11,7 +11,16 @@ class Fakes::Initializer
 
     # This method is called only 1 time during application bootup
     def app_init!(rails_env)
-      load_fakes_and_seed! if rails_env.development? || rails_env.demo?
+      if rails_env.development? || rails_env.demo?
+        # If we are running a rake command like `rake db:seed` or
+        # `rake db:schema:load`, we do not want to try and seed the fakes
+        # because our schema may not be loaded yet and it will fail!
+        if File.basename($0) == "rake"
+          load!
+        else
+          load_fakes_and_seed!
+        end
+      end
     end
 
     # This setup method is called on every request during development


### PR DESCRIPTION
Running `rake db:schema:load` was failing because we are trying to load fakes (saving to the DB) before the tables existed.

#### Test Plan
- [x] Verify running rake commands works again (in this order):
```
$ rake db:drop
$ rake db:create
$ rake db:schema:load
$ rake db:seed
```

#### TODO
This is a bandaid, and there are 2 key steps we should take to fix this setup longterm (will make tickets):
- Move storing fakes from a class that is auto-reloaded by Rails to one that is explicitly outside the autoreload path. We could create a `VACOLS::DB` class in a different directory and push the current `records` and `document_records` etc there. That way it can survive between file saves and rails class reload
- Remove any `Generator::Model.create()` calls from being used where possible. For example, right now `Generator::Hearing.build` internally creates (saves to the db) a new appeal & user. We should avoid this if possible and use existing users instead