### PR TITLE
Style guide | Change button description

### DIFF
--- a/client/app/containers/StyleGuide/StyleGuideButton.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideButton.jsx
@@ -16,22 +16,22 @@ export default class StyleGuideButton extends React.Component {
     </p>
 
     <p>
-     Finally, there are actions that we generally want to discourage but should remain visible 
+     Finally, there are actions that we generally want to discourage but should remain visible
      to users as an escape hatch.
     </p>
 
     <p>
-     These actions can be <code> button-link </code> styles or use the <code> usa-button-secondary style</code>. 
-     For example, the “Cancel” button frequently found at the bottom of Caseflow workflow layouts 
-     is usually a button link because it launches a modal. 
+     These actions can be <code>button-link</code> styles or use the <code>usa-button-secondary style</code>.
+     For example, the “Cancel” button frequently found at the bottom of Caseflow workflow layouts
+     is usually a button link because it launches a modal.
      The button to confirm that a user wants to cancel is red and serves as a warning to the user
      that the action is destructive. These styles should be used sparingly.</p>
 
     <p>
-      The width of the button will vary depending on the length of the content. 
-      In the source code, the buttons are set so that there is always 20px padding on the left 
+      The width of the button will vary depending on the length of the content.
+      In the source code, the buttons are set so that there is always 20px padding on the left
       and right of the text. While it is ideal not to change the default setting, in a case where
-      buttons of various widths are stacked, we highly recommend adjusting the padding of the buttons 
+      buttons of various widths are stacked, we highly recommend adjusting the padding of the buttons
       so that they all match in width.</p>
 
     <h3>Primary buttons</h3>

--- a/client/app/containers/StyleGuide/StyleGuideButton.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideButton.jsx
@@ -11,6 +11,28 @@ export default class StyleGuideButton extends React.Component {
       id="buttons"
       link="StyleGuideButton.jsx"
     />
+    <p>
+     Primary actions are visually prioritized by being solid blue <code>usa-button</code> style.
+    </p>
+
+    <p>
+     Finally, there are actions that we generally want to discourage but should remain visible 
+     to users as an escape hatch.
+    </p>
+
+    <p>
+     These actions can be <code> button-link </code> styles or use the <code> usa-button-secondary style</code>. 
+     For example, the “Cancel” button frequently found at the bottom of Caseflow workflow layouts 
+     is usually a button link because it launches a modal. 
+     The button to confirm that a user wants to cancel is red and serves as a warning to the user
+     that the action is destructive. These styles should be used sparingly.</p>
+
+    <p>
+      The width of the button will vary depending on the length of the content. 
+      In the source code, the buttons are set so that there is always 20px padding on the left 
+      and right of the text. While it is ideal not to change the default setting, in a case where
+      buttons of various widths are stacked, we highly recommend adjusting the padding of the buttons 
+      so that they all match in width.</p>
 
     <h3>Primary buttons</h3>
     <div className="usa-grid">


### PR DESCRIPTION
Connects #2362
###  AC
- [x] Verify that the description for buttons (see copy below) is added to the Buttons section above the UI components
### Testing
I verified the change in UI.
![screen shot 2017-06-28 at 1 40 25 pm](https://user-images.githubusercontent.com/23080951/27652574-4a2ca738-5c0a-11e7-91be-36d16d7a2c06.png)
