### PR TITLE
Allow Google analytics info from both Caseflow domains

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,6 +134,12 @@ module ApplicationHelper
     ["", route[:controller], route[:action]].join("/")
   end
 
+  # Get the alternate domain name associated with the application
+  # i.e. If request is from certification.cf.ds.va.gov, it should return appeals.cf.ds.va.gov
+  def ga_alternate_domain
+    (Rails.configuration.google_analytics_domains - [request.host]).first
+  end
+
   def print_link
     link_to "Print", "#", onclick: "window.print()"
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,16 +67,22 @@
 
 -->
 
-  <!-- Script for GA. Currently setup for production only. To add more environements, set google_analytics_account variable for that environment -->
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script', '<%= Rails.configuration.google_analytics_host %>','ga');
+  <!-- Script for Google Analytics (GA). Currently setup for production only. -->
+  <% if Rails.deploy_env?(:prod) %>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script', '<%= Rails.configuration.google_analytics_host %>','ga');
 
-        ga('create', '<%= Rails.configuration.google_analytics_account %>', 'auto');
-        ga('send', 'pageview', '<%= current_ga_path %>');
-      </script>
+      // Allow both caseflow domains to send analytics data
+      ga('create', '<%= Rails.configuration.google_analytics_account %>', 'auto', {'allowLinker': true});
+      ga('require', 'linker');
+      ga('linker:autoLink', ['<%= ga_alternate_domain %>'] );
+
+      ga('send', 'pageview', '<%= current_ga_path %>');
+    </script>
+  <% end %>
 
   <%= favicon_link_tag %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -68,7 +68,7 @@
 -->
 
   <!-- Script for Google Analytics (GA). Currently setup for production only. -->
-  <% if Rails.deploy_env?(:prod) %>
+  <% if Rails.env.production? && Rails.deploy_env?(:prod) %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/app/views/layouts/application_alt.html.erb
+++ b/app/views/layouts/application_alt.html.erb
@@ -67,16 +67,22 @@
 
 -->
 
-  <!-- Script for GA. Currently setup for production only. To add more environements, set google_analytics_account variable for that environment -->
-      <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script', '<%= Rails.configuration.google_analytics_host %>','ga');
+  <!-- Script for Google Analytics (GA). Currently setup for production only. -->
+  <% if Rails.deploy_env?(:prod) %>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script', '<%= Rails.configuration.google_analytics_host %>','ga');
 
-        ga('create', '<%= Rails.configuration.google_analytics_account %>', 'auto');
-        ga('send', 'pageview', '<%= current_ga_path %>');
-      </script>
+      // Allow both caseflow domains to send analytics data
+      ga('create', '<%= Rails.configuration.google_analytics_account %>', 'auto', {'allowLinker': true});
+      ga('require', 'linker');
+      ga('linker:autoLink', ['<%= ga_alternate_domain %>'] );
+
+      ga('send', 'pageview', '<%= current_ga_path %>');
+    </script>
+  <% end %>
 
   <%= favicon_link_tag %>
 

--- a/app/views/layouts/application_alt.html.erb
+++ b/app/views/layouts/application_alt.html.erb
@@ -68,7 +68,7 @@
 -->
 
   <!-- Script for Google Analytics (GA). Currently setup for production only. -->
-  <% if Rails.deploy_env?(:prod) %>
+  <% if Rails.env.production? && Rails.deploy_env?(:prod) %>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,4 +81,8 @@ Rails.application.configure do
 
   config.google_analytics_account = "UA-74789258-1"
   config.google_analytics_host = "//www.google-analytics.com/analytics.js"
+  config.google_analytics_domains = [
+    "appeals#{ENV["COOKIE_DOMAIN"]}",
+    "certification#{ENV["COOKIE_DOMAIN"]}"
+  ]
 end


### PR DESCRIPTION
Followed the guide here:
https://support.google.com/analytics/answer/1034342?hl=en

- Tested both domains locally connected to prod GA by overriding `/etc/hosts`

connects #2430