### PR TITLE
Deleting test pdf created during confirm_certification test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /db/*.sqlite3-journal
 
 # Ignore all logfiles and tempfiles.
+.byebug_history
 /log/*
 !/log/.keep
 /tmp

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -15,6 +15,13 @@ RSpec.feature "Confirm Certification" do
     certification.form8.save_pdf!
   end
 
+  after do
+    # Clean up generated PDF
+    expected_form8 = Form8.new(vacols_id: appeal.vacols_id)
+    form8_location = Form8.pdf_service.output_location_for(expected_form8)
+    File.delete(form8_location) if File.exist?(form8_location)
+  end
+
   let(:nod) { Generators::Document.build(type: "NOD") }
   let(:soc) { Generators::Document.build(type: "SOC", received_at: Date.new(1987, 9, 6)) }
   let(:form9) { Generators::Document.build(type: "Form 9") }

--- a/spec/support/fake_pdf_service.rb
+++ b/spec/support/fake_pdf_service.rb
@@ -4,7 +4,7 @@ class FakePdfService
   end
 
   def self.output_location_for(_form8)
-    File.join(Rails.root, "spec", "support", "form8-TEST.pdf")
+    File.join(Rails.root, "tmp", "pdfs", "form8-TEST.pdf")
   end
 
   class << self


### PR DESCRIPTION
#2397 

Fixes:
- Deleted form8-TEST.pdf created during confirm_certification.spec
- Adds .bybug_history file to .gitignore
- Changes the location of the FakePdfService to a tmp directory