### PR TITLE
EP creation required fields

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -16,7 +16,7 @@ class Veteran
 
   COUNTRIES_REQUIRING_ZIP = %w(USA CANADA).freeze
 
-  validates :ssn, presence: true
+  validates :ssn, :first_name, :last_name, :city, :state, :address_line1, :country, presence: true
   validates :zip_code, presence: true, if: "country_requires_zip?"
 
   def country_requires_zip?


### PR DESCRIPTION
EP creation was failing because we were missing city, state, and address_line_1. @kierachell looked through VBMS to figure out what fields were required, and hopefully, we now catch them all in the validation step.

Connects #2246 