### PR TITLE
Make 'refresh' action work on IE11

### DIFF
--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -62,7 +62,7 @@ class UnconnectedDocumentsCheck extends React.Component {
         SOC and SSOC dates are considered matching if the VBMS date is the same as the VACOLS date,
         or if the VBMS date is 4 days or fewer before the VACOLS date.
         <a href="/certification/help#cannot-find-documents"> Learn more about document dates.</a> </ul>
-        <p>Once you've made corrections, <a href="">refresh this page.</a></p>
+        <p>Once you've made corrections, <a href={`/certifications/${match.params.vacols_id}/check_documents`}>refresh this page.</a></p>
         <p>If you can't find the document, <a href="#"
           onClick={toggleCancellationModal}>cancel this certification.</a></p>
       </div>;

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -62,7 +62,8 @@ class UnconnectedDocumentsCheck extends React.Component {
         SOC and SSOC dates are considered matching if the VBMS date is the same as the VACOLS date,
         or if the VBMS date is 4 days or fewer before the VACOLS date.
         <a href="/certification/help#cannot-find-documents"> Learn more about document dates.</a> </ul>
-        <p>Once you've made corrections, <a href={`/certifications/${match.params.vacols_id}/check_documents`}>refresh this page.</a></p>
+        <p>Once you've made corrections,
+        <a href={`/certifications/${match.params.vacols_id}/check_documents`}>refresh this page.</a></p>
         <p>If you can't find the document, <a href="#"
           onClick={toggleCancellationModal}>cancel this certification.</a></p>
       </div>;


### PR DESCRIPTION
Specify the exact URL when refreshing `check_documents` page as IE11 doesn't know how to handle the `href=""` correctly. 

connects #2466 

Tested on IE11 and Chrome.
Automated tests are already present for the `refresh`