### PR TITLE
Make enter open documents

### DIFF
--- a/client/app/components/Link.jsx
+++ b/client/app/components/Link.jsx
@@ -16,6 +16,7 @@ export default class Link extends React.Component {
       to,
       target,
       name,
+      onClick,
       href,
       button,
       children
@@ -37,7 +38,8 @@ export default class Link extends React.Component {
       target,
       type,
       id: name,
-      className: CLASS_NAME_MAPPING[button]
+      className: CLASS_NAME_MAPPING[button],
+      onClick
     };
 
     if (to) {
@@ -60,5 +62,6 @@ Link.propTypes = {
   ariaLabel: PropTypes.string,
   to: PropTypes.string,
   button: PropTypes.string,
+  onClick: PropTypes.func,
   children: PropTypes.node
 };

--- a/client/app/components/Link.jsx
+++ b/client/app/components/Link.jsx
@@ -17,6 +17,7 @@ export default class Link extends React.Component {
       target,
       name,
       onClick,
+      onMouseUp,
       href,
       button,
       children
@@ -39,7 +40,8 @@ export default class Link extends React.Component {
       type,
       id: name,
       className: CLASS_NAME_MAPPING[button],
-      onClick
+      onClick,
+      onMouseUp
     };
 
     if (to) {
@@ -62,6 +64,7 @@ Link.propTypes = {
   ariaLabel: PropTypes.string,
   to: PropTypes.string,
   button: PropTypes.string,
+  onMouseUp: PropTypes.func,
   onClick: PropTypes.func,
   children: PropTypes.node
 };

--- a/client/app/components/PdfUI.jsx
+++ b/client/app/components/PdfUI.jsx
@@ -149,7 +149,7 @@ export class PdfUI extends React.Component {
                 ariaLabel="open document in new tab"
                 target="_blank"
                 button="matte"
-                href={singleDocumentLink(this.props.documentPathBase, this.props.doc)}>
+                href={singleDocumentLink(`/reader/appeal${this.props.documentPathBase}`, this.props.doc)}>
                 <span title={this.props.doc.type}>{this.props.doc.type}</span>
               </Link>
             </span>

--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -29,35 +29,9 @@ export class DecisionReviewer extends React.PureComponent {
     this.documentsRoute.displayName = 'DocumentsRoute';
   }
 
-  showPdf = (history, vacolsId) => (docId) => (event) => {
+  showPdf = (history, vacolsId) => (docId) => () => {
     if (!this.props.storeDocuments[docId]) {
       return;
-    }
-
-    if (event) {
-      // If the user is trying to open the link in a new tab/window
-      // then follow the link. Otherwise if they just clicked the link
-      // keep them contained within the SPA.
-      // ctrlKey for windows
-      // shift key for opening in new window
-      // metaKey for Macs
-      // button for middle click
-      if (event.ctrlKey ||
-          event.shiftKey ||
-          event.metaKey ||
-          (event.button &&
-          event.button === 1)) {
-
-        // For some reason calling this synchronosly prevents the new
-        // tab from opening. Move it to an asynchronus call.
-        setTimeout(() =>
-          this.props.handleSelectCurrentPdf(docId)
-        );
-
-        return true;
-      }
-
-      event.preventDefault();
     }
 
     history.push(`/${vacolsId}/documents/${docId}`);

--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -122,7 +122,7 @@ export class DecisionReviewer extends React.PureComponent {
         sortBy={this.state.sortBy}
         selectedLabels={this.state.selectedLabels}
         isCommentLabelSelected={this.state.isCommentLabelSelected}
-        documentPathBase={`/reader/appeal/${vacolsId}/documents`}
+        documentPathBase={`/${vacolsId}/documents`}
         onJumpToComment={this.onJumpToComment(props.history, vacolsId)}
         {...props}
       />;
@@ -139,7 +139,7 @@ export class DecisionReviewer extends React.PureComponent {
         onShowList={this.onShowList(props.history, vacolsId)}
         showPdf={this.showPdf(props.history, vacolsId)}
         onJumpToComment={this.onJumpToComment(props.history, vacolsId)}
-        documentPathBase={`/reader/appeal/${vacolsId}/documents`}
+        documentPathBase={`/${vacolsId}/documents`}
         {...props}
       />
     ;

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -98,7 +98,12 @@ class DocTypeColumn extends React.PureComponent {
     return content;
   };
 
-  render() {
+  onClick = (id) => () => {
+    console.log('here');
+    setTimeout(() => this.props.selectCurrentPdf(id), 0);
+  }
+
+  render = () => {
     const { doc } = this.props;
 
     return this.boldUnreadContent(
@@ -113,10 +118,21 @@ class DocTypeColumn extends React.PureComponent {
   }
 }
 
+const mapDocTypeDispatchToProps = (dispatch) => ({
+  ...bindActionCreators({
+    selectCurrentPdf
+  }, dispatch)
+});
+
 DocTypeColumn.propTypes = {
   doc: PropTypes.object,
   documentPathBase: PropTypes.string
 };
+
+const ConnectedDocTypeColumn = connect(
+  null, mapDocTypeDispatchToProps
+)(DocTypeColumn);
+
 
 class DocumentsTable extends React.Component {
   constructor() {
@@ -159,10 +175,6 @@ class DocumentsTable extends React.Component {
   getTagFilterIconRef = (tagFilterIcon) => this.tagFilterIcon = tagFilterIcon
   toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('category')
   toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('tag')
-
-  onClick = (id) => () => {
-    this.props.selectCurrentPdf(id);
-  }
 
   getKeyForRow = (index, { isComment, id }) => {
     return isComment ? `${id}-comment` : id;
@@ -320,7 +332,7 @@ class DocumentsTable extends React.Component {
         onClick={() => this.props.changeSortState('type')}>
           Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortArrowIcon : notSortedIcon }
         </Button>,
-        valueFunction: (doc) => <DocTypeColumn doc={doc} showPdf={this.props.showPdf}
+        valueFunction: (doc) => <ConnectedDocTypeColumn doc={doc}
           documentPathBase={this.props.documentPathBase}/>
       },
       {
@@ -409,8 +421,7 @@ const mapDispatchToProps = (dispatch) => ({
     setDocListScrollPosition,
     setTagFilter,
     setCategoryFilter,
-    changeSortState,
-    selectCurrentPdf
+    changeSortState
   }, dispatch),
   toggleDropdownFilterVisiblity(filterName) {
     dispatch({

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -131,7 +131,6 @@ class DocumentsTable extends React.Component {
   toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('tag')
 
   onClick = (id) => (event) => {
-    debugger;
     setTimeout(() => this.props.selectCurrentPdf(id), 0);
   }
 

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -99,7 +99,9 @@ class DocTypeColumn extends React.PureComponent {
   };
 
   onClick = (id) => () => {
-    this.props.selectCurrentPdfLocally(id);
+    // Annoyingly if we make this call in the thread, it won't follow the link. Instead
+    // we use setTimeout to force it to run at a later point.
+    setTimeout(() => this.props.selectCurrentPdfLocally(id), 0);
   }
 
   render = () => {

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -99,12 +99,16 @@ class DocTypeColumn extends React.PureComponent {
   };
 
   onClick = (id) => () => {
-    setTimeout(() => this.props.selectCurrentPdfLocally(id), 0);
+    this.props.selectCurrentPdfLocally(id);
   }
 
   render = () => {
     const { doc } = this.props;
 
+    // We add a click handler to mark a document as read even if it's opened in a new tab.
+    // This will get fired in the current tab, as the link is followed in a new tab. We
+    // also need to add a mouseUp event since middle clicking doesn't trigger an onClick.
+    // This will not work if someone right clicks and opens in a new tab.
     return this.boldUnreadContent(
       <Link
         onMouseUp={this.onClick(doc.id)}

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -131,7 +131,7 @@ class DocumentsTable extends React.Component {
   toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('tag')
 
   onClick = (id) => (event) => {
-    setTimeout(() => this.props.selectCurrentPdf(id), 0);
+    this.props.selectCurrentPdf(id);
   }
 
   getKeyForRow = (index, { isComment, id }) => {

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -130,7 +130,7 @@ class DocumentsTable extends React.Component {
   toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('category')
   toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('tag')
 
-  onClick = (id) => (event) => {
+  onClick = (id) => () => {
     this.props.selectCurrentPdf(id);
   }
 

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -13,9 +13,10 @@ import * as Constants from './constants';
 import CommentIndicator from './CommentIndicator';
 import DropdownFilter from './DropdownFilter';
 import { bindActionCreators } from 'redux';
+import Link from '../components/Link';
 
 import { setDocListScrollPosition, changeSortState,
-  setTagFilter, setCategoryFilter } from './actions';
+  setTagFilter, setCategoryFilter, selectCurrentPdf } from './actions';
 import { getAnnotationsPerDocument } from './selectors';
 import {
   SelectedFilterIcon, UnselectedFilterIcon, rightTriangle,
@@ -128,6 +129,11 @@ class DocumentsTable extends React.Component {
   getTagFilterIconRef = (tagFilterIcon) => this.tagFilterIcon = tagFilterIcon
   toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('category')
   toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisiblity('tag')
+
+  onClick = (id) => (event) => {
+    debugger;
+    setTimeout(() => this.props.selectCurrentPdf(id), 0);
+  }
 
   getKeyForRow = (index, { isComment, id }) => {
     return isComment ? `${id}-comment` : id;
@@ -292,12 +298,12 @@ class DocumentsTable extends React.Component {
           Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortArrowIcon : notSortedIcon }
         </Button>,
         valueFunction: (doc) => boldUnreadContent(
-          <a
-            href={singleDocumentLink(this.props.documentPathBase, doc)}
-            aria-label={doc.type + (doc.opened_by_current_user ? ' opened' : ' unopened')}
-            onMouseUp={this.props.showPdf(doc.id)}>
+          <Link
+            onClick={this.onClick(doc.id)}
+            to={singleDocumentLink(this.props.documentPathBase, doc)}
+            aria-label={doc.type + (doc.opened_by_current_user ? ' opened' : ' unopened')}>
             {doc.type}
-          </a>, doc)
+          </Link>, doc)
       },
       {
         cellClass: 'tags-column',
@@ -387,7 +393,8 @@ const mapDispatchToProps = (dispatch) => ({
     setDocListScrollPosition,
     setTagFilter,
     setCategoryFilter,
-    changeSortState
+    changeSortState,
+    selectCurrentPdf
   }, dispatch),
   toggleDropdownFilterVisiblity(filterName) {
     dispatch({

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -99,7 +99,6 @@ class DocTypeColumn extends React.PureComponent {
   };
 
   onClick = (id) => () => {
-    console.log('here');
     setTimeout(() => this.props.selectCurrentPdf(id), 0);
   }
 

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -17,7 +17,7 @@ import Link from '../components/Link';
 import Highlight from '../components/Highlight';
 
 import { setDocListScrollPosition, changeSortState,
-  setTagFilter, setCategoryFilter, selectCurrentPdf } from './actions';
+  setTagFilter, setCategoryFilter, selectCurrentPdfLocally } from './actions';
 import { getAnnotationsPerDocument } from './selectors';
 import {
   SelectedFilterIcon, UnselectedFilterIcon, rightTriangle,
@@ -99,7 +99,7 @@ class DocTypeColumn extends React.PureComponent {
   };
 
   onClick = (id) => () => {
-    setTimeout(() => this.props.selectCurrentPdf(id), 0);
+    setTimeout(() => this.props.selectCurrentPdfLocally(id), 0);
   }
 
   render = () => {
@@ -107,6 +107,7 @@ class DocTypeColumn extends React.PureComponent {
 
     return this.boldUnreadContent(
       <Link
+        onMouseUp={this.onClick(doc.id)}
         onClick={this.onClick(doc.id)}
         to={singleDocumentLink(this.props.documentPathBase, doc)}
         aria-label={doc.type + (doc.opened_by_current_user ? ' opened' : ' unopened')}>
@@ -119,7 +120,7 @@ class DocTypeColumn extends React.PureComponent {
 
 const mapDocTypeDispatchToProps = (dispatch) => ({
   ...bindActionCreators({
-    selectCurrentPdf
+    selectCurrentPdfLocally
   }, dispatch)
 });
 

--- a/client/app/reader/actions.js
+++ b/client/app/reader/actions.js
@@ -331,6 +331,13 @@ export const newTagRequestFailed = (docId, tagsThatWereAttemptedToBeCreated) => 
   }
 });
 
+export const selectCurrentPdfLocally = (docId) => ({
+  type: Constants.SELECT_CURRENT_VIEWER_PDF,
+  payload: {
+    docId
+  }
+});
+
 export const selectCurrentPdf = (docId) => (dispatch) => {
   ApiUtil.patch(`/document/${docId}/mark-as-read`).
     catch((err) => {
@@ -338,12 +345,9 @@ export const selectCurrentPdf = (docId) => (dispatch) => {
       console.log('Error marking as read', docId, err);
     });
 
-  dispatch({
-    type: Constants.SELECT_CURRENT_VIEWER_PDF,
-    payload: {
-      docId
-    }
-  });
+  dispatch(
+    selectCurrentPdfLocally(docId)
+  );
 };
 
 export const removeTagRequestFailure = (docId, tagId) => ({

--- a/client/test/node/reader/DecisionReviewer-test.js
+++ b/client/test/node/reader/DecisionReviewer-test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import sinon from 'sinon';
 
 import { MemoryRouter } from 'react-router-dom';
 import DecisionReviewer from '../../../app/reader/DecisionReviewer';
@@ -86,7 +85,7 @@ describe('DecisionReviewer', () => {
         // Click on first document link
         wrapper.find('a').filterWhere(
           (link) => link.text() === documents[0].type).
-          simulate('mouseUp');
+          simulate('click', { button: 0 });
         await pause();
 
         expect(wrapper.find('PdfViewer')).to.have.length(1);
@@ -106,7 +105,7 @@ describe('DecisionReviewer', () => {
         // Enter the pdf view
         wrapper.find('a').filterWhere(
           (link) => link.text() === documents[1].type).
-          simulate('mouseUp');
+          simulate('click', { button: 0 });
 
         // Verify the arrow navigations keys are not present
         expect(wrapper.find('#button-next')).to.have.length(0);
@@ -150,7 +149,7 @@ describe('DecisionReviewer', () => {
 
         wrapper.find('a').filterWhere(
           (link) => link.text() === documents[0].type).
-          simulate('mouseUp');
+          simulate('click', { button: 0 });
 
         await pause();
 
@@ -205,7 +204,7 @@ describe('DecisionReviewer', () => {
       it('comment has page number', asyncTest(async() => {
         wrapper.find('a').filterWhere(
           (link) => link.text() === documents[1].type).
-          simulate('mouseUp');
+          simulate('click', { button: 0 });
 
         expect(wrapper.text()).to.include(`Page ${annotations[0].page}`);
       }));
@@ -215,80 +214,12 @@ describe('DecisionReviewer', () => {
   context('PDF list view', () => {
     beforeEach(() => setUpDocuments());
 
-    // In general, we shouldn't have to write tests to make sure that links work. However,
-    // with the document type links we are calling prevent default to override what they
-    // do when you click on them. They should still open up new tabs when you press the
-    // meta-key, control, or middle click. These tests make sure we don't prevent default
-    // in these cases.
-    context('follows the link when', () => {
-      it('document is ctrl + clicked', asyncTest(async() => {
-        const preventDefault = sinon.spy();
-        const event = {
-          ctrlKey: true,
-          preventDefault
-        };
-
-        wrapper.find('a').filterWhere(
-          (link) => link.text() === documents[0].type).
-          simulate('mouseUp', event);
-        await pause();
-
-        expect(preventDefault.notCalled).to.eq(true);
-      }));
-
-      it('document is meta + clicked', asyncTest(async() => {
-        const preventDefault = sinon.spy();
-        const event = {
-          metaKey: true,
-          preventDefault
-        };
-
-        wrapper.find('a').filterWhere(
-          (link) => link.text() === documents[0].type).
-          simulate('mouseUp', event);
-        await pause();
-
-        expect(preventDefault.notCalled).to.eq(true);
-      }));
-
-      it('document is middle clicked', asyncTest(async() => {
-        const preventDefault = sinon.spy();
-        const event = {
-          button: 1,
-          preventDefault
-        };
-
-        wrapper.find('a').filterWhere(
-          (link) => link.text() === documents[0].type).
-          simulate('mouseUp', event);
-        await pause();
-
-        expect(preventDefault.notCalled).to.eq(true);
-      }));
-    });
-
-    context('does not follow the link when', () => {
-      it('document is clicked normally', asyncTest(async() => {
-        const preventDefault = sinon.spy();
-        const event = {
-          preventDefault
-        };
-
-        wrapper.find('a').filterWhere(
-          (link) => link.text() === documents[0].type).
-          simulate('mouseUp', event);
-        await pause();
-
-        expect(preventDefault.calledOnce).to.eq(true);
-      }));
-    });
-
     context('last read indicator', () => {
       it('appears on latest read document', asyncTest(async() => {
         // Click on first document link
         wrapper.find('a').filterWhere(
           (link) => link.text() === documents[0].type).
-          simulate('mouseUp');
+          simulate('click', { button: 0 });
         await pause();
 
         // Previous button moves us to the previous page
@@ -304,12 +235,13 @@ describe('DecisionReviewer', () => {
 
       it('appears on document opened in new tab', asyncTest(async() => {
         const event = {
-          ctrlKey: true
+          ctrlKey: true,
+          button: 0
         };
 
         wrapper.find('a').filterWhere(
           (link) => link.text() === documents[0].type).
-          simulate('mouseUp', event);
+          simulate('click', event);
         await pause();
 
         // Make sure that the 0th row has the last


### PR DESCRIPTION
Currently when you tab to a document on the list view and hit enter it leaves the SPA and opens the document in the single document view.

Now using enter should work the same as clicking.

**Test Plan**
- [x] Verify you can use enter to open a document within the SPA.
- [x] Verify you can use enter + meta/ctrl/shift to open a document in a new tab/window.