### PR TITLE
State only required for domestic veterans

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -25,7 +25,7 @@ class Veteran
   end
 
   def country_requires_state?
-    country === 'USA'
+    country == "USA"
   end
 
   # Convert to hash used in AppealRepository.establish_claim!

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -16,11 +16,16 @@ class Veteran
 
   COUNTRIES_REQUIRING_ZIP = %w(USA CANADA).freeze
 
-  validates :ssn, :first_name, :last_name, :city, :state, :address_line1, :country, presence: true
+  validates :ssn, :first_name, :last_name, :city, :address_line1, :country, presence: true
   validates :zip_code, presence: true, if: "country_requires_zip?"
+  validates :state, presence: true, if: "country_requires_state?"
 
   def country_requires_zip?
     COUNTRIES_REQUIRING_ZIP.include?(country)
+  end
+
+  def country_requires_state?
+    country === 'USA'
   end
 
   # Convert to hash used in AppealRepository.establish_claim!


### PR DESCRIPTION
Only domestic veterans are required to have a state listed. This PR updates the validation to match. 

Connects #2246 