### PR TITLE
Modifying reader search code to include and search for comments and highlight categories

### DIFF
--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -421,7 +421,7 @@ svg[aria-hidden=true],
   }
 
   .highlighted {
-    filter: drop-shadow( 0px 0px 5px $color-primary-alt);
+    filter: drop-shadow(0 0 5px $color-primary-alt);
   }
 
   li:not(:first-child) {

--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -420,6 +420,10 @@ svg[aria-hidden=true],
     float: left;
   }
 
+  .highlighted {
+    filter: drop-shadow( 0px 0px 5px $color-primary-alt);
+  }
+
   li:not(:first-child) {
     padding-left: 10px;
   }

--- a/app/assets/stylesheets/react/_comment.scss
+++ b/app/assets/stylesheets/react/_comment.scss
@@ -29,6 +29,7 @@
 
 .comment-container {
   word-wrap: break-word;
+  word-break: break-word;
   background-color: $color-white;
   border-radius: 3px;
   padding: 15px;

--- a/app/assets/stylesheets/react/_comment.scss
+++ b/app/assets/stylesheets/react/_comment.scss
@@ -28,6 +28,7 @@
 }
 
 .comment-container {
+  word-wrap: break-word;
   background-color: $color-white;
   border-radius: 3px;
   padding: 15px;

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -146,6 +146,7 @@ $tag-backgrond-color: #d6d7d9;
   }
 
   .cf-dropdown-filter {
+    z-index: 15;
     position: absolute;
     border: 1px solid $color-gray-lighter;
     background: $color-white;

--- a/client/app/components/DocumentCategoryIcons.jsx
+++ b/client/app/components/DocumentCategoryIcons.jsx
@@ -40,7 +40,8 @@ class DocumentCategoryIcons extends React.Component {
       {
         _.map(categories, (category) =>
           <li
-            className={docHighlights[getCategoryName(category.humanName)] ? `${listClassName} highlighted` : listClassName}
+            className={docHighlights[getCategoryName(category.humanName)] ?
+             `${listClassName} highlighted` : listClassName}
             key={category.renderOrder}
             aria-label={category.humanName}>
             {category.svg}

--- a/client/app/components/DocumentCategoryIcons.jsx
+++ b/client/app/components/DocumentCategoryIcons.jsx
@@ -26,7 +26,7 @@ class DocumentCategoryIcons extends React.Component {
   render() {
     const { searchCategoryHighlights, doc } = this.props;
     const categories = categoriesOfDocument(doc);
-    const docHighlights = searchCategoryHighlights[doc.id] || {};
+    const docHighlights = searchCategoryHighlights ? searchCategoryHighlights[doc.id] : {};
 
     if (!_.size(categories)) {
       return null;
@@ -60,6 +60,8 @@ DocumentCategoryIcons.propTypes = {
 const mapStateToProps = (state) => ({
   searchCategoryHighlights: state.ui.searchCategoryHighlights
 });
+
+export { DocumentCategoryIcons };
 
 export default connect(
   mapStateToProps, null

--- a/client/app/components/DocumentCategoryIcons.jsx
+++ b/client/app/components/DocumentCategoryIcons.jsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import _ from 'lodash';
 import { categoryFieldNameOfCategoryName } from '../reader/utils';
 import * as Constants from '../reader/constants';
+
+const SPACE_DELIMITER = ' ';
 
 const categoriesOfDocument = (document) => _(Constants.documentCategories).
     filter(
@@ -11,24 +14,33 @@ const categoriesOfDocument = (document) => _(Constants.documentCategories).
     sortBy('renderOrder').
     value();
 
-export default class DocumentCategoryIcons extends React.Component {
+class DocumentCategoryIcons extends React.Component {
   shouldComponentUpdate = (nextProps) => !_.isEqual(
     categoriesOfDocument(this.props.doc),
     categoriesOfDocument(nextProps.doc)
+  ) || !_.isEqual(
+    this.props.searchCategoryHighlights,
+    nextProps.searchCategoryHighlights
   )
 
   render() {
-    const categories = categoriesOfDocument(this.props.doc);
+    const { searchCategoryHighlights, doc } = this.props;
+    const categories = categoriesOfDocument(doc);
+    const docHighlights = searchCategoryHighlights[doc.id] || {};
 
     if (!_.size(categories)) {
       return null;
     }
+    const listClassName = 'cf-no-styling-list';
+
+    // helper function to get the name of the category
+    const getCategoryName = (humanName) => humanName.split(SPACE_DELIMITER)[0].toLowerCase();
 
     return <ul className="cf-document-category-icons" aria-label="document categories">
       {
         _.map(categories, (category) =>
           <li
-            className="cf-no-styling-list"
+            className={docHighlights[getCategoryName(category.humanName)] ? `${listClassName} highlighted` : listClassName}
             key={category.renderOrder}
             aria-label={category.humanName}>
             {category.svg}
@@ -40,5 +52,14 @@ export default class DocumentCategoryIcons extends React.Component {
 }
 
 DocumentCategoryIcons.propTypes = {
-  doc: PropTypes.object.isRequired
+  doc: PropTypes.object.isRequired,
+  searchCategoryHighlights: PropTypes.object
 };
+
+const mapStateToProps = (state) => ({
+  searchCategoryHighlights: state.ui.searchCategoryHighlights
+});
+
+export default connect(
+  mapStateToProps, null
+)(DocumentCategoryIcons);

--- a/client/app/components/Highlight.jsx
+++ b/client/app/components/Highlight.jsx
@@ -8,12 +8,12 @@ class Highlight extends PureComponent {
   render() {
     const { searchQuery } = this.props;
 
-    return <div aria-label="search result">
+    return <span>
       <Highlighter
         searchWords={_.union([searchQuery], searchQuery.split(' '))}
         textToHighlight={this.props.children}
       />
-    </div>;
+    </span>;
   }
 }
 

--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -8,7 +8,7 @@ import PdfSidebar from '../components/PdfSidebar';
 import { documentPath } from './DecisionReviewer';
 import Modal from '../components/Modal';
 import { closeAnnotationDeleteModal, deleteAnnotation, showPlaceAnnotationIcon,
-  handleSelectCommentIcon, selectCurrentPdf } from '../reader/actions';
+  selectCurrentPdf } from '../reader/actions';
 import { isUserEditingText, update } from '../reader/utils';
 import { bindActionCreators } from 'redux';
 import { getFilteredDocuments } from './selectors';
@@ -218,7 +218,6 @@ const mapDispatchToProps = (dispatch) => ({
     deleteAnnotation
   }, dispatch),
 
-  handleSelectCommentIcon: (comment) => dispatch(handleSelectCommentIcon(comment)),
   handleSelectCurrentPdf: (docId) => dispatch(selectCurrentPdf(docId))
 });
 
@@ -234,7 +233,6 @@ PdfViewer.propTypes = {
   }),
   deleteAnnotationModalIsOpenFor: PropTypes.number,
   onScrollToComment: PropTypes.func,
-  handleSelectCommentIcon: PropTypes.func,
   documents: PropTypes.array.isRequired,
   allDocuments: PropTypes.array.isRequired,
   selectCurrentPdf: PropTypes.func,

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -98,7 +98,7 @@ const updateFilteredDocIds = (nextState) => {
     }
 
     // updating the state of all annotations for expanded comments
-    if (commentContainsWords !== doc.listComments) {
+    if (containsWords !== doc.listComments) {
       updatedNextState = updateListComments(updatedNextState, doc.id, containsWords);
     }
   });

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -6,7 +6,6 @@ import { searchString, commentContainsWords, categoryContainsWords } from './sea
 import { timeFunction } from '../util/PerfDebug';
 
 const SHOW_EXPAND_ALL = false;
-const SEARCH_CATEGORY_HIGHLIGHTS_FIELD = 'searchCategoryHighlights';
 
 /**
  * This function takes all the documents and check the status of the
@@ -91,11 +90,11 @@ const updateFilteredDocIds = (nextState) => {
 
     // update the state for all the search category highlights
     if (matchesCategories !== updatedNextState.ui.searchCategoryHighlights[doc.id]) {
-      updatedNextState = updateState(updatedNextState, doc.id, SEARCH_CATEGORY_HIGHLIGHTS_FIELD, matchesCategories);
+      updatedNextState = updateState(updatedNextState, doc.id, 'searchCategoryHighlights', matchesCategories);
     }
 
     // updating the state of all annotations for expanded comments
-    if (doc.listComments !== commentContainsWords) {
+    if (commentContainsWords !== doc.listComments) {
       updatedNextState = updateListComments(updatedNextState, doc.id, containsWords);
     }
   });

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -86,6 +86,9 @@ const updateFilteredDocIds = (nextState) => {
   // looping through all the documents to update category highlights and expanding comments
   _.forEach(updatedNextState.documents, (doc) => {
     const containsWords = commentContainsWords(searchQuery, updatedNextState, doc);
+
+    // getting all the truthy values from the object
+    // {'medical': true, 'procedural': false } turns into {'medical': true}
     const matchesCategories = _.pickBy(categoryContainsWords(searchQuery, doc));
 
     // update the state for all the search category highlights

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -93,7 +93,8 @@ const updateFilteredDocIds = (nextState) => {
 
     // update the state for all the search category highlights
     if (matchesCategories !== updatedNextState.ui.searchCategoryHighlights[doc.id]) {
-      updatedNextState = updateStateWithIdAndValue(updatedNextState, doc.id, 'searchCategoryHighlights', matchesCategories);
+      updatedNextState = updateStateWithIdAndValue(updatedNextState,
+        doc.id, 'searchCategoryHighlights', matchesCategories);
     }
 
     // updating the state of all annotations for expanded comments

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -50,13 +50,13 @@ const updateFilteredDocIds = (nextState) => {
     });
   };
 
-  const updateStateWithIdAndValue = (state, id, key, value) => {
+  const updateSearchCategoryHighlights = (state, docId, categoryMatches) => {
     return update(state, {
       ui: {
-        [key]: {
+        searchCategoryHighlights: {
           $merge: {
-            [id]: {
-              ...value
+            [docId]: {
+              ...categoryMatches
             }
           }
         }
@@ -93,8 +93,8 @@ const updateFilteredDocIds = (nextState) => {
 
     // update the state for all the search category highlights
     if (matchesCategories !== updatedNextState.ui.searchCategoryHighlights[doc.id]) {
-      updatedNextState = updateStateWithIdAndValue(updatedNextState,
-        doc.id, 'searchCategoryHighlights', matchesCategories);
+      updatedNextState = updateSearchCategoryHighlights(updatedNextState,
+        doc.id, matchesCategories);
     }
 
     // updating the state of all annotations for expanded comments

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -50,7 +50,7 @@ const updateFilteredDocIds = (nextState) => {
     });
   };
 
-  const updateState = (state, id, key, value) => {
+  const updateStateWithIdAndValue = (state, id, key, value) => {
     return update(state, {
       ui: {
         [key]: {
@@ -93,7 +93,7 @@ const updateFilteredDocIds = (nextState) => {
 
     // update the state for all the search category highlights
     if (matchesCategories !== updatedNextState.ui.searchCategoryHighlights[doc.id]) {
-      updatedNextState = updateState(updatedNextState, doc.id, 'searchCategoryHighlights', matchesCategories);
+      updatedNextState = updateStateWithIdAndValue(updatedNextState, doc.id, 'searchCategoryHighlights', matchesCategories);
     }
 
     // updating the state of all annotations for expanded comments

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -64,17 +64,17 @@ const updateFilteredDocIds = (nextState) => {
     ).
     filter(
       (doc) => {
-        // doing a search through comments first
-        let queryTokens = _.compact(searchQuery.split(' '));
-        const commentFound = queryTokens.some((word) => {
-          return commentContainsString(word, nextState, doc);
-        });
-
         // update state with if comments should be shown
-        updatedNextState = updateListComments(doc.id, updatedNextState, commentFound);
+        // searchString returns an object that contains wordFound and commentFound
+        // This is done to re-use the comment found result to update the state to expand the
+        // comment section and to actually search the comment.
+        const searchResult = searchString(searchQuery, nextState)(doc);
 
-        // comment found or string found in other parts of annotation of the document
-        return commentFound || searchString(searchQuery)(doc);
+        // commentFound is used to update the state of expand comment
+        updatedNextState = updateListComments(doc.id, updatedNextState, searchResult.commentFound);
+
+        // if the search term is found in the document's annotations
+        return searchResult.wordFound;
       }
     ).
     sortBy(docFilterCriteria.sort.sortBy).

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -65,7 +65,7 @@ const updateFilteredDocIds = (nextState) => {
     filter(
       (doc) => {
         // update state with if comments should be shown
-        // searchString returns an object that contains wordFound and commentFound
+        // searchString returns an object that contains wordFound and commentFound.
         // This is done to re-use the comment found result to update the state to expand the
         // comment section and to actually search the comment.
         const searchResult = searchString(searchQuery, nextState)(doc);

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -70,10 +70,10 @@ const updateFilteredDocIds = (nextState) => {
     value();
 
     // updating the state of all annotations for expanded comments
-    _.forEach(updatedNextState.documents, (doc) => {
-      updatedNextState = updateListComments(doc.id, updatedNextState, 
+  _.forEach(updatedNextState.documents, (doc) => {
+    updatedNextState = updateListComments(doc.id, updatedNextState,
         commentContainsWords(searchQuery, updatedNextState, doc));
-    });
+  });
 
   if (docFilterCriteria.sort.sortAscending) {
     filteredIds.reverse();

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -2,7 +2,7 @@
 import * as Constants from './constants';
 import _ from 'lodash';
 import { categoryFieldNameOfCategoryName, update, moveModel } from './utils';
-import { searchString, commentContainsString } from './search';
+import { searchString } from './search';
 import { timeFunction } from '../util/PerfDebug';
 
 const SHOW_EXPAND_ALL = false;

--- a/client/app/reader/reducer.js
+++ b/client/app/reader/reducer.js
@@ -52,6 +52,7 @@ const updateFilteredDocIds = (nextState) => {
 
   const searchQuery = _.get(docFilterCriteria, 'searchQuery', '').toLowerCase();
   let updatedNextState = nextState;
+  let docFoundComments = [];
 
   const filteredIds = _(nextState.documents).
     filter(
@@ -64,14 +65,15 @@ const updateFilteredDocIds = (nextState) => {
     ).
     filter(
       (doc) => {
-        // update state with if comments should be shown
         // searchString returns an object that contains wordFound and commentFound.
         // This is done to re-use the comment found result to update the state to expand the
         // comment section and to actually search the comment.
         const searchResult = searchString(searchQuery, nextState)(doc);
 
-        // commentFound is used to update the state of expand comment
-        updatedNextState = updateListComments(doc.id, updatedNextState, searchResult.commentFound);
+        docFoundComments.push({
+          docId: doc.id,
+          commentFound: searchResult.commentFound
+        });
 
         // if the search term is found in the document's annotations
         return searchResult.wordFound;
@@ -80,6 +82,11 @@ const updateFilteredDocIds = (nextState) => {
     sortBy(docFilterCriteria.sort.sortBy).
     map('id').
     value();
+
+    // updating the state of all annotations for expand comments
+    _.forEach(docFoundComments, (docFoundComment) => {
+      updatedNextState = updateListComments(docFoundComment.docId, updatedNextState, docFoundComment.commentFound);
+    });
 
   if (docFilterCriteria.sort.sortAscending) {
     filteredIds.reverse();

--- a/client/app/reader/search.js
+++ b/client/app/reader/search.js
@@ -27,11 +27,22 @@ const categoryContainsString = (searchQuery, doc) =>
       doc[categoryFieldNameOfCategoryName(category)])
   , false);
 
+export const categoryContainsWords = (searchQuery, doc) => {
+  let queryTokens = _.compact(searchQuery.split(' '));
+
+  return _(_.keys(Constants.documentCategories)).
+        reduce((result, category) => {
+          return _.assign({
+            [`${category}`]: queryTokens.some((word) =>
+              category.includes(word) && doc[categoryFieldNameOfCategoryName(category)])
+          }, result);
+        }, {});
+};
+
 const tagContainsString = (searchQuery, doc) =>
   Object.keys(doc.tags || {}).reduce((acc, tag) => {
     return acc || (doc.tags[tag].text.toLowerCase().includes(searchQuery));
-  }
-  , false);
+  }, false);
 
 export const searchString = (searchQuery, state) => (doc) => {
   let queryTokens = _.compact(searchQuery.split(' '));

--- a/client/app/reader/search.js
+++ b/client/app/reader/search.js
@@ -37,7 +37,7 @@ export const searchString = (searchQuery, state) => (doc) => {
     // aggregating commentFound with all the words being searched
     // if a word is found in any of the comments, this will be true
     commentFoundAggregate = commentFoundAggregate || commentFound;
-    
+
     return searchWord.length > 0 && (
       doDatesMatch(doc.receivedAt, searchWord) ||
       commentFound ||

--- a/client/app/reader/search.js
+++ b/client/app/reader/search.js
@@ -33,6 +33,7 @@ export const searchString = (searchQuery, state) => (doc) => {
   wordFound = queryTokens.every((word) => {
     const searchWord = word.trim();
     const commentFound = commentContainsString(word, state, doc);
+
     // aggregating commentFound with all the words being searched
     // if a word is found in any of the comments, this will be true
     commentFoundAggregate = commentFoundAggregate || commentFound;

--- a/client/app/reader/search.js
+++ b/client/app/reader/search.js
@@ -25,16 +25,26 @@ const tagContainsString = (searchQuery, doc) =>
   }
   , false);
 
-export const searchString = (searchQuery) => (doc) => {
+export const searchString = (searchQuery, state) => (doc) => {
   let queryTokens = _.compact(searchQuery.split(' '));
+  let wordFound = false;
+  let commentFoundAggregate = false;
 
-  return queryTokens.every((word) => {
+  wordFound = queryTokens.every((word) => {
     const searchWord = word.trim();
-
+    const commentFound = commentContainsString(word, state, doc);
+    commentFoundAggregate = commentFoundAggregate || commentFound;
+    
     return searchWord.length > 0 && (
       doDatesMatch(doc.receivedAt, searchWord) ||
+      commentFound ||
       typeContainsString(searchWord, doc) ||
       categoryContainsString(searchWord, doc) ||
       tagContainsString(searchWord, doc));
   });
+
+  return {
+    wordFound,
+    commentFound: commentFoundAggregate
+  };
 };

--- a/client/app/reader/search.js
+++ b/client/app/reader/search.js
@@ -33,6 +33,8 @@ export const searchString = (searchQuery, state) => (doc) => {
   wordFound = queryTokens.every((word) => {
     const searchWord = word.trim();
     const commentFound = commentContainsString(word, state, doc);
+    // aggregating commentFound with all the words being searched
+    // if a word is found in any of the comments, this will be true
     commentFoundAggregate = commentFoundAggregate || commentFound;
     
     return searchWord.length > 0 && (

--- a/client/test/karma/components/DocumentCategoryIcons-test.js
+++ b/client/test/karma/components/DocumentCategoryIcons-test.js
@@ -6,7 +6,7 @@ import { DocumentCategoryIcons } from '../../../app/components/DocumentCategoryI
 describe('DocumentCategoryIcons', () => {
   it('renders no icons when the doc is not in any categories', () => {
     const wrapper = mount(<DocumentCategoryIcons doc={{}} />);
-    console.log(wrapper.html());
+
     expect(wrapper.find('.cf-document-category-icons li')).to.have.length(0);
   });
 

--- a/client/test/karma/components/DocumentCategoryIcons-test.js
+++ b/client/test/karma/components/DocumentCategoryIcons-test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import DocumentCategoryIcons from '../../../app/components/DocumentCategoryIcons';
+import { DocumentCategoryIcons } from '../../../app/components/DocumentCategoryIcons';
 
 describe('DocumentCategoryIcons', () => {
   it('renders no icons when the doc is not in any categories', () => {
     const wrapper = mount(<DocumentCategoryIcons doc={{}} />);
-
+    console.log(wrapper.html());
     expect(wrapper.find('.cf-document-category-icons li')).to.have.length(0);
   });
 

--- a/client/test/node/reader/DecisionReviewer-test.js
+++ b/client/test/node/reader/DecisionReviewer-test.js
@@ -406,6 +406,20 @@ describe('DecisionReviewer', () => {
         expect(wrapper.html()).to.include('<mark class=" ">Comment</mark>');
       });
 
+      it('does search highlighting for categories', () => {
+        wrapper.find('input').simulate('change',
+          { target: { value: 'medical' } });
+
+        // get the first category icon
+        let textArray = wrapper.find('tbody').find('tr').
+          find('.cf-document-category-icons').
+          find('li').
+          first();
+
+        expect(textArray.prop('aria-label')).to.equal('Medical');
+        expect(textArray.hasClass('highlighted')).to.be.true;
+      });
+
       it('date displays properly', () => {
         const receivedAt = formatDateStr(documents[1].received_at);
 


### PR DESCRIPTION
* This is a PR to fix a bug that's currently doing OR search for comments rather than a AND search. It was introduced in the Search Highlights PR.

connects #1507 