### PR TITLE
Managers can't assign too few tasks

### DIFF
--- a/app/models/team_quota.rb
+++ b/app/models/team_quota.rb
@@ -26,6 +26,10 @@ class TeamQuota < ActiveRecord::Base
     task_type.is_a?(String) ? task_type.constantize : task_type
   end
 
+  def unlocked_user_count
+    user_count - assigned_quotas.locked.count
+  end
+
   private
 
   def calculate_task_count_for(quota_index)
@@ -52,10 +56,6 @@ class TeamQuota < ActiveRecord::Base
 
   def remainder_task_count
     tasks_to_assign % unlocked_user_count
-  end
-
-  def unlocked_user_count
-    user_count - assigned_quotas.locked.count
   end
 
   # Sum up the total of manually assigned tasks, or "locked" tasks. These will be taken

--- a/app/models/user_quota.rb
+++ b/app/models/user_quota.rb
@@ -69,11 +69,18 @@ class UserQuota < ActiveRecord::Base
     # Guard from going above the maximum assignable tasks
     result = [max_locked_task_count, new_locked_task_count.to_i].min
 
+    result = [min_locked_task_count, result].max if min_locked_task_count
+
     [0, result].max
   end
 
   def max_locked_task_count
     team_quota.tasks_to_assign + (locked_task_count || 0)
+  end
+
+  def min_locked_task_count
+    # If there's only one or fewer users left to be calculated, the min is the same as the max
+    team_quota.unlocked_user_count <= 1 ? max_locked_task_count : nil
   end
 
   # Allow team quota to adjust values based on the new user quota

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -136,6 +136,47 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       expect(page).to have_content("3. Jeffers Smith 0 1 0 1 2")
     end
 
+    scenario "Editing won't work if there's only one user" do
+      4.times { Generators::EstablishClaim.create(aasm_state: :unassigned) }
+
+      appeal_id = {
+        "Janet" => appeal.id
+      }
+
+      %w(Janet).each do |name|
+        Generators::EstablishClaim.create(
+            user: Generators::User.create(full_name: "#{name} Smith"),
+            aasm_state: :assigned,
+            appeal_id: appeal_id[name]
+        ).tap do |task|
+          task.start!
+          task.complete!(status: :routed_to_arc)
+        end
+      end
+
+      visit "/dispatch/establish-claim"
+      expect(page).to have_content("1. Janet Smith 0 0 1 1 5")
+
+      # Begin editing Janet's quota
+      janet_quota = UserQuota.where(user: User.where(full_name: "Janet Smith").first).first
+
+      within("#table-row-0") do
+        click_on "Edit"
+        fill_in "quota-#{janet_quota.id}", with: "7"
+        click_on "Save"
+      end
+
+      expect(page).to have_content("1. Janet Smith 0 0 1 1 5")
+
+      within("#table-row-0") do
+        click_on "Edit"
+        fill_in "quota-#{janet_quota.id}", with: "3"
+        click_on "Save"
+      end
+
+      expect(page).to have_content("1. Janet Smith 0 0 1 1 5")
+    end
+
     scenario "View unprepared tasks page" do
       unprepared_task = Generators::EstablishClaim.create(aasm_state: :unprepared)
 

--- a/spec/feature/establish_claim_spec.rb
+++ b/spec/feature/establish_claim_spec.rb
@@ -145,9 +145,9 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
 
       %w(Janet).each do |name|
         Generators::EstablishClaim.create(
-            user: Generators::User.create(full_name: "#{name} Smith"),
-            aasm_state: :assigned,
-            appeal_id: appeal_id[name]
+          user: Generators::User.create(full_name: "#{name} Smith"),
+          aasm_state: :assigned,
+          appeal_id: appeal_id[name]
         ).tap do |task|
           task.start!
           task.complete!(status: :routed_to_arc)

--- a/spec/models/user_quota_spec.rb
+++ b/spec/models/user_quota_spec.rb
@@ -87,7 +87,7 @@ describe UserQuota do
 
     context "when setting a negative number" do
       let(:new_locked_task_count) { -1 }
-      it { is_expected.to eq(0) }
+      it { is_expected.to eq(4) }
     end
 
     context "when setting to a number higher than the teams assignable tasks" do


### PR DESCRIPTION
This PR no longer allows managers to assign fewer than the number of tasks available. 

- [ ] Go to manager's page
- [ ] Put 1 for number of people working
- [ ] Confirm you can't increase or decrease that worker's assigned number of tasks

Connects #1693 