### PR TITLE
update hearing schedule/prep title

### DIFF
--- a/app/views/hearings/dockets/index.html.erb
+++ b/app/views/hearings/dockets/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title do page_title('Schedule') end %>
+<% content_for :page_title do page_title('Upcoming Hearing Days') end %>
 
 <%= react_component("Hearings", props: {
   hearings: {

--- a/client/app/hearings/Dockets.jsx
+++ b/client/app/hearings/Dockets.jsx
@@ -74,14 +74,14 @@ export class Dockets extends React.Component {
     return <div>
       <div className="content cf-hearings-schedule">
         <div className="cf-hearings-title-and-judge">
-          <h1>Hearing Schedule</h1>
+          <h1>Upcoming Hearing Days</h1>
           <span>VLJ: {this.props.veteran_law_judge.full_name}</span>
         </div>
         <Table
           className="dockets"
           columns={columns}
           rowObjects={rowObjects}
-          summary={'Hearing Schedule?'}
+          summary={'Upcoming Hearing Days?'}
           getKeyForRow={this.getKeyForRow}
         />
       </div>

--- a/client/test/karma/hearings/DocketsContainer-test.js
+++ b/client/test/karma/hearings/DocketsContainer-test.js
@@ -61,6 +61,6 @@ describe('DocketsContainer', () => {
         }
       }
     }));
-    expect(wrapper.text()).to.include('Hearing Schedule');
+    expect(wrapper.text()).to.include('Upcoming Hearing Days');
   });
 });

--- a/spec/feature/hearings_spec.rb
+++ b/spec/feature/hearings_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Hearings" do
     Timecop.freeze(Time.utc(2017, 1, 1))
   end
 
-  context "Schedule" do
+  context "Upcoming Hearing Days" do
     let!(:current_user) do
       User.authenticate!(roles: ["Hearings"])
     end
@@ -33,7 +33,7 @@ RSpec.feature "Hearings" do
     scenario "Shows dockets for each day" do
       visit "/hearings/dockets"
 
-      expect(page).to have_content("Hearing Schedule")
+      expect(page).to have_content("Upcoming Hearing Days")
 
       # Verify user
       expect(page).to have_content("VLJ: Lauren Roth")


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/2553

Basically renaming the Schedule page to Upcoming Hearing Days.

New Look:
<img width="1015" alt="screen shot 2017-07-06 at 8 38 48 pm" src="https://user-images.githubusercontent.com/18075411/27938313-2d6c059e-628b-11e7-876b-81a193a95f8b.png">
