### PR TITLE
Fix some hearings problems with Appeals status API

### DIFF
--- a/app/models/appeal_event.rb
+++ b/app/models/appeal_event.rb
@@ -54,7 +54,7 @@ class AppealEvent
 
   def hearing=(hearing)
     self.type = EVENT_TYPE_FOR_HEARING_DISPOSITIONS.key(hearing.disposition)
-    self.date = hearing.closed_at
+    self.date = hearing.date
   end
 
   def valid?

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -2,7 +2,7 @@ class Hearing < ActiveRecord::Base
   belongs_to :appeal
   belongs_to :user
 
-  attr_accessor :date, :type, :venue_key, :vacols_record, :closed_at, :disposition
+  attr_accessor :date, :type, :venue_key, :vacols_record, :disposition
 
   belongs_to :appeal
   belongs_to :user # the judge
@@ -14,7 +14,7 @@ class Hearing < ActiveRecord::Base
   end
 
   def closed?
-    !!closed_at
+    !!disposition
   end
 
   def scheduled_pending?
@@ -56,7 +56,6 @@ class Hearing < ActiveRecord::Base
           vacols_record: vacols_hearing,
           venue_key: vacols_hearing.hearing_venue,
           disposition: VACOLS::CaseHearing::HEARING_DISPOSITIONS[vacols_hearing.hearing_disp.try(:to_sym)],
-          closed_at: AppealRepository.normalize_vacols_date(vacols_hearing.clsdate),
           date: AppealRepository.normalize_vacols_date(vacols_hearing.hearing_date),
           appeal: Appeal.find_or_create_by(vacols_id: vacols_hearing.folder_nr),
           user: User.find_by_vacols_id(vacols_hearing.user_id),

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -49,6 +49,8 @@ class VACOLS::CaseHearing < VACOLS::Record
     private
 
     def select_hearings
+      # VACOLS overloads the HEARSCHED table with other types of hearings
+      # that work differently. Filter those out.
       select("VACOLS.HEARING_VENUE(vdkey) as hearing_venue",
              "staff.stafkey as user_id",
              :hearing_disp,
@@ -58,9 +60,9 @@ class VACOLS::CaseHearing < VACOLS::Record
              :notes1,
              :folder_nr,
              :vdkey,
-             :sattyid,
-             :clsdate)
+             :sattyid)
         .joins(:staff)
+        .where(hearing_type: HEARING_TYPES.keys)
     end
   end
 

--- a/spec/feature/api/v1/appeals_spec.rb
+++ b/spec/feature/api/v1/appeals_spec.rb
@@ -45,7 +45,7 @@ describe "Appeals API v1", type: :request do
     let!(:held_hearing) do
       Generators::Hearing.create(
         appeal: resolved_appeal,
-        closed_at: 6.months.ago,
+        date: 6.months.ago,
         disposition: :held
       )
     end

--- a/spec/models/appeal_event_spec.rb
+++ b/spec/models/appeal_event_spec.rb
@@ -33,7 +33,7 @@ describe AppealEvent do
     subject { appeal_event.hearing = hearing }
 
     context "when disposition is supported" do
-      let(:hearing) { Hearing.new(closed_at: 4.days.ago, disposition: :no_show) }
+      let(:hearing) { Hearing.new(date: 4.days.ago, disposition: :no_show) }
 
       it "sets type and date based off of hearing" do
         subject
@@ -44,7 +44,7 @@ describe AppealEvent do
     end
 
     context "when disposition is not supported" do
-      let(:hearing) { Hearing.new(closed_at: 4.days.ago, disposition: :postponed) }
+      let(:hearing) { Hearing.new(date: 4.days.ago, disposition: :postponed) }
 
       it "sets type to falsey" do
         subject

--- a/spec/models/appeal_events_spec.rb
+++ b/spec/models/appeal_events_spec.rb
@@ -148,23 +148,23 @@ describe AppealEvents do
       before { appeal.save! }
 
       let!(:held_hearing) do
-        Generators::Hearing.create(disposition: :held, closed_at: 4.days.ago, appeal: appeal)
+        Generators::Hearing.create(disposition: :held, date: 4.days.ago, appeal: appeal)
       end
 
       let!(:canceled_hearing) do
-        Generators::Hearing.build(disposition: :cancelled, closed_at: 3.days.ago, appeal: appeal)
+        Generators::Hearing.build(disposition: :cancelled, date: 3.days.ago, appeal: appeal)
       end
 
       let!(:hearing_not_closed) do
-        Generators::Hearing.create(disposition: :held, closed_at: nil, appeal: appeal)
+        Generators::Hearing.create(disposition: nil, appeal: appeal)
       end
 
       let!(:hearing_another_appeal) do
-        Generators::Hearing.build(disposition: :held, closed_at: 2.days.ago)
+        Generators::Hearing.build(disposition: :held, date: 2.days.ago)
       end
 
       let!(:postponed_hearing) do
-        Generators::Hearing.build(disposition: :postponed, closed_at: 2.days.ago, appeal: appeal)
+        Generators::Hearing.build(disposition: :postponed, date: 2.days.ago, appeal: appeal)
       end
 
       let(:hearing_held_events) do

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -17,7 +17,6 @@ describe Hearing do
         folder_nr: appeal.vacols_id,
         hearing_type: "V",
         hearing_pkseq: "12345678",
-        clsdate: Time.zone.now,
         hearing_disp: "N"
       )
     end
@@ -29,7 +28,6 @@ describe Hearing do
       expect(subject.date).to eq(date)
       expect(subject.appeal.id).to eq(appeal.id)
       expect(subject.user.id).to eq(user.id)
-      expect(subject.closed_at).to be_a(Time)
       expect(subject.disposition).to eq(:no_show)
     end
   end


### PR DESCRIPTION
- Filter out any hearings with a type we don't support
- Use date & disposition instead of clsdate to determine closed hearings
- clsdate is useless so remove it

## Tested locally connected to UAT
with the appeals in question
```
> a = Appeal.find_or_create_by_vacols_id(2520602).events
[#<AppealEvent:0x007f97ebb2fa40 @date=Fri, 21 Oct 2011 00:00:00 UTC +00:00, @type=:nod>,
 #<AppealEvent:0x007f97ebb2f888 @date=Thu, 05 Jul 2012 00:00:00 UTC +00:00, @type=:soc>,
 #<AppealEvent:0x007f97ebb2f720 @date=Fri, 27 Jul 2012 00:00:00 UTC +00:00, @type=:form9>,
 #<AppealEvent:0x007f97ebb2f5b8 @date=Mon, 06 Aug 2012 00:00:00 UTC +00:00, @type=:certified>,
 #<AppealEvent:0x007f97ebb2f478 @date=Thu, 06 Sep 2012 00:00:00 UTC +00:00, @type=:activated>,
 #<AppealEvent:0x007f97e3f20c38 @date=Wed, 12 Dec 2012 00:00:00 UTC +00:00, @type=:hearing_held>]

> a = Appeal.find_or_create_by_vacols_id(2520602).scheduled_hearings
[]
```

```
> a = Appeal.find_or_create_by_vacols_id(1844858).events
[#<AppealEvent:0x007f97e3403a08 @date=Mon, 10 Jul 2006 00:00:00 UTC +00:00, @type=:activated>,
 #<AppealEvent:0x007f97e3409de0 @date=Fri, 26 Oct 2007 00:00:00 UTC +00:00, @type=:soc>]

> a = Appeal.find_or_create_by_vacols_id(1844858).scheduled_hearings
[]
```
These were the expected return values according to @cmgiven 🎇 

connects #2537