### PR TITLE
Anya/bgs rep name not being mapped to vacols code

### DIFF
--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -62,8 +62,10 @@ class PowerOfAttorney
     repo = PowerOfAttorney.repository
     vacols_rep_type = if representative_type == "Service Organization" ||
                          representative_type == "ORGANIZATION"
-                        # We set the rep type to the service organization name
-                        repo.get_vacols_rep_code(representative_name)
+                        # We set the rep type to the service organization name, unless we don't have a record
+                        # of it. Then we set it to 'other'.
+                        repo.get_vacols_rep_code(representative_name) ||
+                          repo.get_vacols_rep_code("Other")
                       else
                         repo.get_vacols_rep_code(representative_type)
                       end

--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -62,10 +62,8 @@ class PowerOfAttorney
     repo = PowerOfAttorney.repository
     vacols_rep_type = if representative_type == "Service Organization" ||
                          representative_type == "ORGANIZATION"
-                        # We set the rep type to the service organization name, unless we don't have a record
-                        # of it. Then we set it to 'other'.
-                        repo.get_vacols_rep_code(representative_name) ||
-                          repo.get_vacols_rep_code("Other")
+                        # We set the rep type to the service organization name
+                        repo.get_vacols_rep_code(representative_name)
                       else
                         repo.get_vacols_rep_code(representative_type)
                       end

--- a/app/services/power_of_attorney_repository.rb
+++ b/app/services/power_of_attorney_repository.rb
@@ -35,8 +35,10 @@ class PowerOfAttorneyRepository
   end
 
   def self.get_vacols_rep_code(name)
-    # If we don't have a record, we set it to 'O' (Other).
-    BGS_REP_NAMES_TO_VACOLS_REP_CODES[name] || "O"
+    VACOLS::Case::REPRESENTATIVES.each do |representative|
+      return representative[0] if representative[1][:short] == name
+    end
+    return BGS_REP_NAMES_TO_VACOLS_REP_CODES[name]
   end
 
   # :nocov:

--- a/app/services/power_of_attorney_repository.rb
+++ b/app/services/power_of_attorney_repository.rb
@@ -38,7 +38,7 @@ class PowerOfAttorneyRepository
     VACOLS::Case::REPRESENTATIVES.each do |representative|
       return representative[0] if representative[1][:short] == name
     end
-    return BGS_REP_NAMES_TO_VACOLS_REP_CODES[name]
+    BGS_REP_NAMES_TO_VACOLS_REP_CODES[name]
   end
 
   # :nocov:

--- a/app/services/power_of_attorney_repository.rb
+++ b/app/services/power_of_attorney_repository.rb
@@ -34,11 +34,9 @@ class PowerOfAttorneyRepository
     )
   end
 
-  def self.get_vacols_rep_code(short_name)
-    VACOLS::Case::REPRESENTATIVES.each do |representative|
-      return representative[0] if representative[1][:short] == short_name
-    end
-    nil
+  def self.get_vacols_rep_code(name)
+    # If we don't have a record, we set it to 'O' (Other).
+    BGS_REP_NAMES_TO_VACOLS_REP_CODES[name] || "O"
   end
 
   # :nocov:

--- a/spec/services/power_of_attorney_repository_spec.rb
+++ b/spec/services/power_of_attorney_repository_spec.rb
@@ -1,10 +1,15 @@
 describe PowerOfAttorneyRepository do
   context ".get_vacols_rep_code" do
-    subject { PowerOfAttorney.repository.get_vacols_rep_code(short_name) }
+    subject { PowerOfAttorney.repository.get_vacols_rep_code(name) }
 
-    context "returns the VACOLS code when it exists" do
+    context "returns the VACOLS code when rep type is passed" do
       let(:name) { "American Legion" }
       it { is_expected.to eq("A") }
+    end
+
+    context "returns the VACOLS code when rep name is passed" do
+      let(:name) { "AMERICAN RED CROSS" }
+      it { is_expected.to eq("C") }
     end
 
     context "returns nil when it does not exist" do

--- a/spec/services/power_of_attorney_repository_spec.rb
+++ b/spec/services/power_of_attorney_repository_spec.rb
@@ -1,9 +1,9 @@
 describe PowerOfAttorneyRepository do
   context ".get_vacols_rep_code" do
-    subject { PowerOfAttorney.repository.get_vacols_rep_code(name) }
+    subject { PowerOfAttorney.repository.get_vacols_rep_code(short_name) }
 
     context "returns the VACOLS code when it exists" do
-      let(:name) { "AMERICAN LEGION" }
+      let(:name) { "American Legion" }
       it { is_expected.to eq("A") }
     end
 

--- a/spec/services/power_of_attorney_repository_spec.rb
+++ b/spec/services/power_of_attorney_repository_spec.rb
@@ -1,14 +1,14 @@
 describe PowerOfAttorneyRepository do
   context ".get_vacols_rep_code" do
-    subject { PowerOfAttorney.repository.get_vacols_rep_code(short_name) }
+    subject { PowerOfAttorney.repository.get_vacols_rep_code(name) }
 
     context "returns the VACOLS code when it exists" do
-      let(:short_name) { "American Legion" }
+      let(:name) { "AMERICAN LEGION" }
       it { is_expected.to eq("A") }
     end
 
     context "returns nil when it does not exist" do
-      let(:short_name) { "Not an entry in the array" }
+      let(:name) { "Not an entry in the array" }
       it { is_expected.to eq(nil) }
     end
   end


### PR DESCRIPTION
If the user indicates that VBMS representative is correct, we use rep info from BGS. When BGS representative type is "Service Organization" or "Organization" , we set the representative type to rep name. In order to find the Vacols code using BGS rep name, we need to use `BGS_REP_NAMES_TO_VACOLS_REP_CODES` map. 