### PR TITLE
Update Commons for cleaner Rails.cache.logger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "0414595a1856a10c57487b12732293342e7d4206"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "63418204dd50dbc5a4d88d55691829dbca85b5e1"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 0414595a1856a10c57487b12732293342e7d4206
-  ref: 0414595a1856a10c57487b12732293342e7d4206
+  revision: 63418204dd50dbc5a4d88d55691829dbca85b5e1
+  ref: 63418204dd50dbc5a4d88d55691829dbca85b5e1
   specs:
     caseflow (0.1.6)
       aws-sdk (~> 2)


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/caseflow/issues/2407

- Stops the prometheus spam of all the `Cache read` messages
- Instead redirects the log to `log/cache.log` like this:
```
[dsva@ip-172-30-70-145 ~]$ head /opt/caseflow-certification/src/log/cache.log
[2017-07-11 08:21:57 -0400] Cache read: prometheus_last_summary_observation_vacols_request_latency_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:57 -0400] Cache write: prometheus_last_summary_observation_vacols_request_latency_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_postgres_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_postgres_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_postgres_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_vacols_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_vacols_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_vacols_db_connections_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_background_jobs_summary ({:expires_in=>86400 seconds})
[2017-07-11 08:21:58 -0400] Cache read: prometheus_last_summary_observation_background_jobs_summary ({:expires_in=>86400 seconds})
```

This is from a custom setup in `UAT`