### PR TITLE
Check VACOLS DB connection health in healthcheck

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -10,5 +10,4 @@ class HealthChecksController < ApplicationController
 
     render json: body, status: status
   end
-
 end

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -2,6 +2,13 @@ class HealthChecksController < ApplicationController
   skip_before_action :verify_authentication
 
   def show
-    render json: { healthy: true }.merge(Rails.application.config.build_version || {})
+    healthcheck = HealthCheck.new
+    status = healthcheck.healthy? ? :ok : :bad_request
+    body = {
+      healthy: healthcheck.healthy?
+    }.merge(Rails.application.config.build_version || {})
+
+    render json: body, status: status
   end
+
 end

--- a/app/models/health_check.rb
+++ b/app/models/health_check.rb
@@ -1,0 +1,9 @@
+class HealthCheck
+  def healthy?
+    vacols_db_connection_active?
+  end
+
+  def vacols_db_connection_active?
+    Appeal.repository.vacols_db_connection_active?
+  end
+end

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -2,6 +2,13 @@
 
 class AppealRepository
   # :nocov:
+  # Used by healthcheck endpoint
+  # Calling .active? triggers a query to VACOLS
+  # `select 1 from dual`
+  def self.vacols_db_connection_active?
+    VACOLS::Record.connection.active?
+  end
+
   # Returns a boolean saying whether the load succeeded
   def self.load_vacols_data(appeal)
     case_record = MetricsService.record("VACOLS: load_vacols_data #{appeal.vacols_id}",

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -53,6 +53,10 @@ class Fakes::AppealRepository
     appeal
   end
 
+  def self.vacols_db_connection_active?
+    true
+  end
+
   def self.certify(appeal:, certification:)
     @certification = certification
     @certified_appeal = appeal


### PR DESCRIPTION
- On healthcheck requests, query VACOLS and verify that the connection
  is active

Connects #727 

Testing:
- Locally, manually set the db connection to false in the Fakes::AppealRepository
<img width="693" alt="screen shot 2017-07-13 at 4 48 56 pm" src="https://user-images.githubusercontent.com/2256237/28187149-a7a1bdbc-67eb-11e7-9501-0fbc2769f7bf.png">

- Manually ran the `VACOLS::Record.connection.active?` on UAT