### PR TITLE
Fixed a bug in the Jenkinsfile checkout stage

### DIFF
--- a/Jenkinsfile.pr
+++ b/Jenkinsfile.pr
@@ -95,7 +95,7 @@ podTemplate(cloud:'minikube', label:'caseflow', containers: [
             container('caseflow-test-runner') {
               sh """
               cd ${CASEFLOW_DIR}
-              Xvfb +extension RANDR :99 -screen 0 1024x768x16 &
+              Xvfb +extension RANDR :99 -screen 0 1600x900x16 &
               """
             }
           }

--- a/Jenkinsfile.pr
+++ b/Jenkinsfile.pr
@@ -34,7 +34,7 @@ podTemplate(cloud:'minikube', label:'caseflow', containers: [
     
     stage('git clone') {
       container('caseflow-test-runner') {
-        dir(WORKSPACE_DIR) {
+        dir(CASEFLOW_DIR) {
           checkout scm
         }
         sh """

--- a/Jenkinsfile.pr
+++ b/Jenkinsfile.pr
@@ -29,19 +29,17 @@ podTemplate(cloud:'minikube', label:'caseflow', containers: [
   )]) {
   node('caseflow') {
 
-    def WORKSPACE_DIR = '/home/jenkins/workspace'
-    def CASEFLOW_DIR = WORKSPACE_DIR + '/caseflow'
+    // /home/jenkins is a shared volume called workspace-volume for this k8s Pod.
+    // To keep the path short and avoid the "Chrome socket path too long" issue, we
+    // can force Jenkins to checkout code to this directory.
+    // See also: https://bugs.chromium.org/p/chromium/issues/detail?id=469065
+    def CASEFLOW_DIR = '/home/jenkins/workspace/caseflow'
     
     stage('git clone') {
       container('caseflow-test-runner') {
         dir(CASEFLOW_DIR) {
           checkout scm
         }
-        sh """
-        cd ${WORKSPACE_DIR}
-        pwd
-        ls -hal
-        """
       }
     }
 

--- a/Jenkinsfile.pr
+++ b/Jenkinsfile.pr
@@ -34,10 +34,13 @@ podTemplate(cloud:'minikube', label:'caseflow', containers: [
     
     stage('git clone') {
       container('caseflow-test-runner') {
+        dir(WORKSPACE_DIR) {
+          checkout scm
+        }
         sh """
         cd ${WORKSPACE_DIR}
-        git clone https://github.com/department-of-veterans-affairs/caseflow.git
-        cd caseflow && git checkout ${env.BRANCH_NAME}
+        pwd
+        ls -hal
         """
       }
     }


### PR DESCRIPTION
This PR fixes a bug where our Jenkinsfile does not checkout the correct branch in a Jenkins PR Build. By using `checkout scm`, the problem is corrected.

Once this is fixed, we can point the Jenkins builder job back to building opened PR.
![image](https://user-images.githubusercontent.com/3258724/28287700-a617ce88-6b0a-11e7-880d-8b070c148dd0.png)

