### PR TITLE
Don't send rails page view for react routed pages.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -175,6 +175,12 @@ class ApplicationController < ActionController::Base
     redirect_to "/unauthorized" unless current_user.admin?
   end
 
+  # Set a flag to say the page has routing managed by React
+  # This suppress rails Google Analytics page view events
+  def react_routed
+    @react_routed = true
+  end
+
   def on_vbms_error
     respond_to do |format|
       format.html do

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -11,6 +11,8 @@ class CertificationsController < ApplicationController
       # only make the bgs and vacols calls if we're actually
       # starting a certification
       certification.fetch_power_of_attorney! if status == :started
+
+      react_routed
       render "v2", layout: "application"
       return
     end

--- a/app/controllers/reader/application_controller.rb
+++ b/app/controllers/reader/application_controller.rb
@@ -1,5 +1,5 @@
 class Reader::ApplicationController < ApplicationController
-  before_action :verify_access, :verify_reader_feature_enabled
+  before_action :verify_access, :verify_reader_feature_enabled, :react_routed
 
   def logo_name
     "Reader"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -86,7 +86,9 @@
         ga('send', 'event', category, action, label)
       }
 
-      analyticsPageView('<%= current_ga_path %>');
+      <% unless @react_routed %>
+        analyticsPageView('<%= current_ga_path %>');
+      <% end %>
     </script>
   <% end %>
 

--- a/app/views/layouts/application_alt.html.erb
+++ b/app/views/layouts/application_alt.html.erb
@@ -91,7 +91,9 @@
         ga('send', 'event', category, action, label)
       }
 
-      analyticsPageView('<%= current_ga_path %>');
+      <% unless @react_routed %>
+        analyticsPageView('<%= current_ga_path %>');
+      <% end %>
     </script>
   <% end %>
 


### PR DESCRIPTION
I thought it would be fine, but it messes up what we want to
record as the landing page in the  "Behavior Flow" report.

<img width="1073" alt="screen shot 2017-07-18 at 1 31 07 pm" src="https://user-images.githubusercontent.com/1596259/28330937-63676a54-6bbd-11e7-928a-c93f21fdce36.png">

## Test Plan
tested locally

connects #2563