### PR TITLE
Add better logging for failed Dispatch prepare job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -134,6 +134,7 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0', platforms: :ruby
   gem 'foreman'
+  gem 'dotenv-rails'
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem 'spring', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -455,8 +455,8 @@ DEPENDENCIES
   caseflow!
   connect_vbms!
   database_cleaner
-  faker
   dotenv-rails
+  faker
   font-awesome-sass
   foreman
   jbuilder (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,12 +147,16 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
-    d3-rails (4.10.0)
+    d3-rails (4.9.1)
       railties (>= 3.1)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     diff-lcs (1.3)
     docile (1.1.5)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubis (2.7.0)
     et-orbi (1.0.5)
       tzinfo
@@ -452,6 +456,7 @@ DEPENDENCIES
   connect_vbms!
   database_cleaner
   faker
+  dotenv-rails
   font-awesome-sass
   foreman
   jbuilder (~> 2.0)

--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -2,10 +2,24 @@ class PrepareEstablishClaimTasksJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    @prepared_count = EstablishClaim.unprepared.inject(0) do |count, task|
-      count + (task.prepare_with_decision! == :success ? 1 : 0)
-    end
+    count = { success: 0, fail: 0 }
 
-    Rails.logger.info "Successfully prepared #{@prepared_count} tasks"
+    EstablishClaim.unprepared.each do |task|
+      status = task.prepare_with_decision!
+      count[:success] += (status == :success ? 1 : 0)
+      count[:fail] += (status == :failed ? 1 : 0)
+    end
+    log_info(count)
+  end
+
+  def log_info(count)
+    msg = "PrepareEstablishClaimTasksJob successfully ran: #{count[:success]} tasks prepared and #{count[:fail]} tasks failed"
+    Rails.logger.info msg
+    msg += "\n<!here>" if count[:fail] > 0
+    SlackService.new(url: url).send_notification(msg)
+  end
+
+  def url
+    ENV["SLACK_DISPATCH_ALERT_URL"]
   end
 end

--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -13,7 +13,8 @@ class PrepareEstablishClaimTasksJob < ActiveJob::Base
   end
 
   def log_info(count)
-    msg = "PrepareEstablishClaimTasksJob successfully ran: #{count[:success]} tasks prepared and #{count[:fail]} tasks failed"
+    msg = "PrepareEstablishClaimTasksJob successfully ran: #{count[:success]} tasks " \
+          "prepared and #{count[:fail]} tasks failed"
     Rails.logger.info msg
     msg += "\n<!here>" if count[:fail] > 0
     SlackService.new(url: url).send_notification(msg)

--- a/app/models/tasks/establish_claim.rb
+++ b/app/models/tasks/establish_claim.rb
@@ -160,7 +160,12 @@ class EstablishClaim < Task
     return :already_prepared unless may_prepare?
     return :missing_decision if appeal.decisions.empty?
 
-    appeal.decisions.each(&:fetch_and_cache_document_from_vbms)
+    begin
+      appeal.decisions.each(&:fetch_and_cache_document_from_vbms)
+    rescue VBMS::ClientError => e
+      Rails.logger.info "Failed EstablishClaim (id = #{id}), Error: #{e}"
+      return :failed
+    end
 
     prepare! && :success
   end

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -1,0 +1,16 @@
+class SlackService
+  include ActiveModel::Model
+
+  attr_accessor :url
+
+  def http_service
+    HTTPClient.new
+  end
+
+  def send_notification(msg)
+    return unless url
+    body = { "text": msg }.to_json
+    params = { body: body, headers: { "Content-Type" => "application/json" } }
+    http_service.post(url, params)
+  end
+end

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -1,6 +1,14 @@
-# Create establish claim tasks every night at midnight
+# For reference:
+# +--------- Minute (0-59)
+# | +------- Hour (0-23)
+# | | +----- Day Of Month (1-31)
+# | | | +--- Month (1 -12)
+# | | | | +- Day Of Week (0-6) (Sunday = 0)
+# | | | | |
+
+# Create establish claim task runs every day at 4:30pm
 create_establish_claim_tasks_job:
-  cron: "1 0 * * * America/New_York"
+  cron: "30 16 * * * America/New_York"
   class: "CreateEstablishClaimTasksJob"
   queue: default
   active_job: true
@@ -11,10 +19,9 @@ reassign_old_tasks:
   queue: default
   active_job: true
 
-# This runs an hour after the other tasks because it
-# has to run on all the tasks that the other jobs created.
+# This runs 30 min after the create_establish_claim_tasks_job
 prepare_establish_claim_tasks_job:
-  cron: "2 0 * * * America/New_York"
+  cron: "0 17 * * * America/New_York"
   class: "PrepareEstablishClaimTasksJob"
   queue: default
   active_job: true

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -1,0 +1,8 @@
+describe SlackService do
+  it "posts to http" do
+    slack_service = SlackService.new(url: "http://www.example.com")
+    allow_any_instance_of(HTTPClient).to receive(:post).and_return('response')
+    response = slack_service.send_notification("hello")
+    expect(response).to eq("response")
+  end
+end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -1,7 +1,7 @@
 describe SlackService do
   it "posts to http" do
     slack_service = SlackService.new(url: "http://www.example.com")
-    allow_any_instance_of(HTTPClient).to receive(:post).and_return('response')
+    allow_any_instance_of(HTTPClient).to receive(:post).and_return("response")
     response = slack_service.send_notification("hello")
     expect(response).to eq("response")
   end


### PR DESCRIPTION
1. Run Dispatch jobs at 4:30pm and 4:45pm
2. Send notifications to Slasc devops-alerts channel
3. prepare_establish_claim_tasks_job - if a task fails, catch the exception and continue with the job.

Notification to Slack when at least one task fails:
![image](https://user-images.githubusercontent.com/3811786/28373260-e838faf6-6c6f-11e7-8f49-5707b1a4d5f7.png)

Notification to Slack when no tasks fail:
![image](https://user-images.githubusercontent.com/3811786/28373298-017cbb9c-6c70-11e7-8a8f-78215f62f230.png)

I will add SLACK_WEBHOOK_URL to Caseflow 
connects #1814 