### PR TITLE
Rendering multiple issues for an Appeal on the Welcome Gate

### DIFF
--- a/client/app/reader/CaseSelect.jsx
+++ b/client/app/reader/CaseSelect.jsx
@@ -14,10 +14,10 @@ class CaseSelect extends React.PureComponent {
 
     return (
       <ol className="issue-list">
-        {issues.map((issue) => {
+        { issues.map((issue) => {
           const descriptionLabel = issue.levels ? `${issue.description_label}:` : issue.description_label;
 
-          return <li key={issue.toString()}>
+          return <li key={issue.vacols_sequence_id}>
               {descriptionLabel}
              {this.renderIssueLevels(issue)}
           </li>;

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -360,7 +360,15 @@ class Fakes::AppealRepository
         veteran_first_name: "Joe",
         veteran_last_name: "Smith"
       },
-      issues: [Generators::Issue.build(vacols_id: "reader_id1")],
+      issues: [Generators::Issue.build(vacols_id: "reader_id1"),
+               Generators::Issue.build(disposition: "Osteomyelitis",
+                                       levels: ["Osteomyelitis"],
+                                       description: [
+                                         "15 - Compensation",
+                                         "26 - Osteomyelitis"
+                                       ],
+                                       program_description: "06 - Medical",
+                                       vacols_id: "reader_id2")],
       documents: static_reader_documents
     )
     Generators::Appeal.build(

--- a/lib/generators/issue.rb
+++ b/lib/generators/issue.rb
@@ -29,6 +29,7 @@ class Generators::Issue
         Fakes::AppealRepository.issue_records ||= {}
         Fakes::AppealRepository.issue_records[vacols_id] ||= []
         Fakes::AppealRepository.issue_records[vacols_id].push(issue)
+        issue.vacols_sequence_id = Fakes::AppealRepository.issue_records[vacols_id].length
       end
 
       issue


### PR DESCRIPTION
- Connects #2511 

Fixed a bug where the `issue` key was not unique for the Issues column on CaseSelect.jsx, which prevented all of the issues associated for an appeal from rendering.