### PR TITLE
Styleguide Max-width For Help Pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "0051063bf7c7cb4980e3aee3397fb14844e11e8a"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "689f4f0483730d90608d84d240361c156d2a6e60"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 0051063bf7c7cb4980e3aee3397fb14844e11e8a
-  ref: 0051063bf7c7cb4980e3aee3397fb14844e11e8a
+  revision: 689f4f0483730d90608d84d240361c156d2a6e60
+  ref: 689f4f0483730d90608d84d240361c156d2a6e60
   specs:
     caseflow (0.1.6)
       aws-sdk (~> 2)


### PR DESCRIPTION
Connects #2116 
The max-width is set for the headings and body-texts of the help pages and styleguide.

Fixes this error
<img width="1000" alt="screen shot 2017-07-21 at 8 05 12 pm" src="https://user-images.githubusercontent.com/23080951/28486463-fcd7246a-6e4f-11e7-8c05-72b67eec9556.png">
