### PR TITLE
Fixing parameter for retrieve_documents batch job

### DIFF
--- a/app/jobs/retrieve_documents_for_reader_job.rb
+++ b/app/jobs/retrieve_documents_for_reader_job.rb
@@ -1,9 +1,11 @@
 require "set"
 
-class RetrieveAppealsDocumentsForReaderJob < ActiveJob::Base
+class RetrieveDocumentsForReaderJob < ActiveJob::Base
   queue_as :default
 
-  def perform(limit = 1500)
+  def perform(args = {})
+    # Args should be set in sidekiq_cron.yml, but default the limit to 1500 if they aren't
+    limit = args[:limit] || 1500
     successful_count = 0
     failed_count = 0
     docs_attempted = 0

--- a/app/jobs/retrieve_documents_for_reader_job.rb
+++ b/app/jobs/retrieve_documents_for_reader_job.rb
@@ -5,7 +5,7 @@ class RetrieveDocumentsForReaderJob < ActiveJob::Base
 
   def perform(args = {})
     # Args should be set in sidekiq_cron.yml, but default the limit to 1500 if they aren't
-    limit = args[:limit] || 1500
+    limit = args["limit"] || 1500
     successful_count = 0
     failed_count = 0
     docs_attempted = 0

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -29,9 +29,9 @@ heartbeat_tasks_job:
   active_job: true
 
 # Retrieve all documents for active Reader users every night at midnight
-retrieve_appeals_documents_for_reader_job:
+retrieve_documents_for_reader_job:
   cron: "0 21 * * * America/New_York"
-  class: "RetrieveAppealsDocumentsForReaderJob"
+  class: "RetrieveDocumentsForReaderJob"
   args:
     limit: 1500
   queue: default

--- a/spec/jobs/retrieve_documents_for_reader_job_spec.rb
+++ b/spec/jobs/retrieve_documents_for_reader_job_spec.rb
@@ -112,7 +112,7 @@ describe RetrieveAppealsDocumentsForReaderJob do
       end
 
       it "stops if limit is reached after finishing current case" do
-        RetrieveAppealsDocumentsForReaderJob.perform_now(1)
+        RetrieveAppealsDocumentsForReaderJob.perform_now(limit: 1)
 
         expect(S3Service.files[expected_doc1.vbms_document_id]).to eq(doc1_expected_content)
         expect(S3Service.files[new_doc.vbms_document_id]).to eq(new_doc_expected_content)

--- a/spec/jobs/retrieve_documents_for_reader_job_spec.rb
+++ b/spec/jobs/retrieve_documents_for_reader_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 require "faker"
 
-describe RetrieveAppealsDocumentsForReaderJob do
+describe RetrieveDocumentsForReaderJob do
   before(:all) do
     S3Service = Caseflow::Fakes::S3Service
     User.case_assignment_repository = Fakes::CaseAssignmentRepository
@@ -77,7 +77,7 @@ describe RetrieveAppealsDocumentsForReaderJob do
       end
 
       it "retrieves the appeal documents for all reader users" do
-        RetrieveAppealsDocumentsForReaderJob.perform_now
+        RetrieveDocumentsForReaderJob.perform_now
 
         # Validate that the decision content is cached in S3 mock
         expect(S3Service.files[expected_doc1.vbms_document_id]).to eq(doc1_expected_content)
@@ -112,7 +112,7 @@ describe RetrieveAppealsDocumentsForReaderJob do
       end
 
       it "stops if limit is reached after finishing current case" do
-        RetrieveAppealsDocumentsForReaderJob.perform_now(limit: 1)
+        RetrieveDocumentsForReaderJob.perform_now("limit" => 1)
 
         expect(S3Service.files[expected_doc1.vbms_document_id]).to eq(doc1_expected_content)
         expect(S3Service.files[new_doc.vbms_document_id]).to eq(new_doc_expected_content)
@@ -136,7 +136,7 @@ describe RetrieveAppealsDocumentsForReaderJob do
       end
 
       it "catches the exception and continues to the next document" do
-        RetrieveAppealsDocumentsForReaderJob.perform_now
+        RetrieveDocumentsForReaderJob.perform_now
 
         expect(S3Service.files[expected_doc1.vbms_document_id]).to be_nil
         expect(S3Service.files[expected_doc2.vbms_document_id]).to eq(doc2_expected_content)


### PR DESCRIPTION
- Connects #2698 
- Connects #2338 

Changes:
- The parameters for the job are passed as a hash from sidekiq-cron. Fixing the job to retrieve the limit from a hash, rather than expecting it to be passed directly.
- Renaming the job to have a more concise name

I was able to successfully test this on my local machine running `bundle exec sidekiq`