### PR TITLE
Report Sidekiq errors to Raven/Sentry

### DIFF
--- a/app/jobs/middleware/job_raven_reporter_middleware.rb
+++ b/app/jobs/middleware/job_raven_reporter_middleware.rb
@@ -1,0 +1,9 @@
+class JobRavenReporterMiddleware
+  def call(worker, job, queue)
+    begin
+      yield
+    rescue => ex
+      Raven.capture_exception(ex)
+    end
+  end
+end

--- a/app/jobs/middleware/job_raven_reporter_middleware.rb
+++ b/app/jobs/middleware/job_raven_reporter_middleware.rb
@@ -1,14 +1,12 @@
-# This job captures all sidekiq job exceptions, forward them to Raven and and 
+# This job captures all sidekiq job exceptions, forward them to Raven and and
 # re-raise the exception to Sidekiq job runner.
 #
 # See https://github.com/mperham/sidekiq/wiki/Middleware#server-side-middleware
 class JobRavenReporterMiddleware
   def call(_worker, _job, _queue)
-    begin
-      yield
-    rescue => ex
-      Raven.capture_exception(ex)
-      raise
-    end
+    yield
+  rescue => ex
+    Raven.capture_exception(ex)
+    raise
   end
 end

--- a/app/jobs/middleware/job_raven_reporter_middleware.rb
+++ b/app/jobs/middleware/job_raven_reporter_middleware.rb
@@ -1,3 +1,7 @@
+# This job captures all sidekiq job exceptions, forward them to Raven and and 
+# re-raise the exception to Sidekiq job runner.
+#
+# See https://github.com/mperham/sidekiq/wiki/Middleware#server-side-middleware
 class JobRavenReporterMiddleware
   def call(_worker, _job, _queue)
     begin

--- a/app/jobs/middleware/job_raven_reporter_middleware.rb
+++ b/app/jobs/middleware/job_raven_reporter_middleware.rb
@@ -4,6 +4,7 @@ class JobRavenReporterMiddleware
       yield
     rescue => ex
       Raven.capture_exception(ex)
+      raise
     end
   end
 end

--- a/app/jobs/middleware/job_raven_reporter_middleware.rb
+++ b/app/jobs/middleware/job_raven_reporter_middleware.rb
@@ -1,5 +1,5 @@
 class JobRavenReporterMiddleware
-  def call(worker, job, queue)
+  def call(_worker, _job, _queue)
     begin
       yield
     rescue => ex

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,5 @@
 require "#{Rails.root}/app/jobs/middleware/job_prometheus_metric_middleware"
+require "#{Rails.root}/app/jobs/middleware/job_raven_reporter_middleware"
 
 Sidekiq.configure_server do |config|
   config.redis = { url: Rails.application.secrets.redis_url_sidekiq }
@@ -13,6 +14,7 @@ Sidekiq.configure_server do |config|
 
   config.server_middleware do |chain|
     chain.add JobPrometheusMetricMiddleware
+    chain.add JobRavenReporterMiddleware
   end
 end
 

--- a/spec/jobs/job_raven_reporter_middleware_spec.rb
+++ b/spec/jobs/job_raven_reporter_middleware_spec.rb
@@ -1,0 +1,25 @@
+describe JobRavenReporterMiddleware do
+  before do
+    @middleware = JobRavenReporterMiddleware.new
+    @yield_called = false
+    @raven_called = false
+    allow(Raven).to receive(:capture_exception) { @raven_called = true }
+  end
+
+  context ".call" do
+    let(:call) { 
+      @middleware.call(nil, @msg, :default) { 
+        @yield_called = true 
+        raise RuntimeError.new("tsk tsk tsk, you messed up!")
+      } 
+    }
+
+    it "yields properly, forwards errors to Raven and re-raises the exception" do
+      expect(@yield_called).to be_falsey
+      expect(@raven_called).to be_falsey
+      expect { call }.to raise_error(RuntimeError)
+      expect(@yield_called).to be_truthy
+      expect(@raven_called).to be_truthy
+    end
+  end
+end

--- a/spec/jobs/job_raven_reporter_middleware_spec.rb
+++ b/spec/jobs/job_raven_reporter_middleware_spec.rb
@@ -7,12 +7,12 @@ describe JobRavenReporterMiddleware do
   end
 
   context ".call" do
-    let(:call) { 
-      @middleware.call(nil, @msg, :default) { 
-        @yield_called = true 
-        raise RuntimeError.new("tsk tsk tsk, you messed up!")
-      } 
-    }
+    let(:call) do
+      @middleware.call(nil, @msg, :default) do
+        @yield_called = true
+        fail "tsk tsk tsk, you messed up!"
+      end
+    end
 
     it "yields properly, forwards errors to Raven and re-raises the exception" do
       expect(@yield_called).to be_falsey

--- a/spec/jobs/job_raven_reporter_middleware_spec.rb
+++ b/spec/jobs/job_raven_reporter_middleware_spec.rb
@@ -8,7 +8,7 @@ describe JobRavenReporterMiddleware do
 
   context ".call" do
     let(:call) do
-      @middleware.call(nil, @msg, :default) do
+      @middleware.call(nil, nil, :default) do
         @yield_called = true
         fail "tsk tsk tsk, you messed up!"
       end


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/2625

This PR adds a small sidekiq middleware to capture all exceptions, forward them to Raven, and re-raise them to sidekiq job runner for tracking purposes. This way, all sidekiq cronjob failure will show up in Sentry, and therefore in Slack for alert.