### PR TITLE
Anya/2684 hearing prep vacols hearing table

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -2,6 +2,11 @@ class HearingsController < ApplicationController
   # :nocov:
   before_action :verify_access
 
+  def update
+    hearing.update(update_params)
+    render json: {}
+  end
+
   def logo_name
     "Hearing Prep"
   end
@@ -26,6 +31,14 @@ class HearingsController < ApplicationController
 
   def set_application
     RequestStore.store[:application] = "hearings"
+  end
+
+  def update_params
+    params.require("hearing").permit(:notes,
+                                     :disposition,
+                                     :hold_open,
+                                     :aod,
+                                     :transcript_requested)
   end
 
   def date_from_string(date_string)

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -68,7 +68,7 @@ class VACOLS::CaseHearing < VACOLS::Record
     def update_hearing!(pkseq, hearing_info)
       record = VACOLS::CaseHearing.find_by(hearing_pkseq: pkseq)
 
-      attrs = hearing_info.each_with_object({}) { |(k, v), result| result[TABLE_NAMES[k]] = v; }
+      attrs = hearing_info.each_with_object({}) { |(k, v), result| result[TABLE_NAMES[k]] = v }
       MetricsService.record("VACOLS: update_hearing! #{pkseq}",
                             service: :vacols,
                             name: "update_hearing") do

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -68,7 +68,7 @@ class VACOLS::CaseHearing < VACOLS::Record
     def update_hearing!(pkseq, hearing_info)
       record = VACOLS::CaseHearing.find_by(hearing_pkseq: pkseq)
 
-      attrs = hearing_info.inject({}){ |result, (k,v)| result[TABLE_NAMES[k]] = v; result }
+      attrs = hearing_info.each_with_object({}) { |(k, v), result| result[TABLE_NAMES[k]] = v; }
       MetricsService.record("VACOLS: update_hearing! #{pkseq}",
                             service: :vacols,
                             name: "update_hearing") do

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -1,5 +1,6 @@
 class HearingRepository
   class << self
+    # :nocov:
     def upcoming_hearings_for_judge(vacols_user_id, date_diff: 7.days)
       hearings_for(VACOLS::CaseHearing.upcoming_for_judge(vacols_user_id, date_diff: date_diff))
     end
@@ -8,10 +9,28 @@ class HearingRepository
       hearings_for(VACOLS::CaseHearing.for_appeal(appeal_vacols_id))
     end
 
+    def update_vacols_hearing!(vacols_id, hearing_hash)
+      hearing_hash = transform_hearing_info(hearing_hash)
+      VACOLS::CaseHearing.update_hearing!(vacols_id, hearing_hash) unless hearing_hash.empty?
+    end
+    # :nocov:
+
+    def transform_hearing_info(hearing_hash)
+      {
+        notes: hearing_hash[:notes].present? ? hearing_hash[:notes][0, 100] : nil,
+        disposition: VACOLS::CaseHearing::HEARING_DISPOSITIONS.key(hearing_hash[:disposition]),
+        hold_open: hearing_hash[:hold_open],
+        aod: VACOLS::CaseHearing::HEARING_AODS.key(hearing_hash[:aod]),
+        transcript_requested: VACOLS::CaseHearing::BOOLEAN_MAP.key(hearing_hash[:transcript_requested])
+      }.select { |k, _v| hearing_hash.keys.include? k } # only send updates to key/values that are passed
+    end
+
     private
 
+    # :nocov:
     def hearings_for(case_hearings)
       case_hearings.map { |hearing| Hearing.load_from_vacols(hearing) }
     end
+    # :nocov:
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -72,6 +72,8 @@ Rails.application.routes.draw do
     resources :worksheets, only: [:update, :show]
   end
 
+  resources :hearings, only: [:update]
+
   patch "certifications" => "certifications#create"
 
   namespace :admin do

--- a/lib/fakes/hearing_repository.rb
+++ b/lib/fakes/hearing_repository.rb
@@ -1,3 +1,4 @@
+require "prime"
 class Fakes::HearingRepository
   class << self
     attr_accessor :hearing_records
@@ -11,8 +12,13 @@ class Fakes::HearingRepository
   def self.hearings_for_appeal(appeal_vacols_id)
     appeal = Appeal.find_by(vacols_id: appeal_vacols_id)
     return [] unless appeal
-
     (hearing_records || []).select { |h| h.appeal_id == appeal.id }
+  end
+
+  def self.update_vacols_hearing!(vacols_id, hearing_info)
+    return if (hearing_info.keys & [:notes, :aod, :disposition, :hold_open, :transcript_requested]).empty?
+    hearing = hearing_records.find { |h| h.vacols_id == vacols_id }
+    hearing.update_attributes(hearing_info)
   end
 
   def self.clean!
@@ -21,13 +27,19 @@ class Fakes::HearingRepository
 
   def self.seed!
     user = User.find_by_vacols_id("LROTH")
-    50.times.each do |i|
-      type = VACOLS::CaseHearing::HEARING_TYPES.values[i % 3]
-      Generators::Hearing.build(
-        type: type,
-        date: Time.zone.now - (i % 9).days - rand(3).days,
-        user: user
-      )
-    end
+    50.times.each { |i| Generators::Hearing.create(random_attrs(i).merge(user: user)) }
+  end
+
+  def self.random_attrs(i)
+    {
+      type: VACOLS::CaseHearing::HEARING_TYPES.values[i % 3],
+      date: Time.zone.now - (i % 9).days - rand(3).days,
+      vacols_id: 950_330_575 + (i * 1465),
+      disposition: VACOLS::CaseHearing::HEARING_DISPOSITIONS.values[i % 4],
+      aod: [VACOLS::CaseHearing::HEARING_AODS.values[i % 3], nil].sample,
+      hold_open: [30, 60, 90].sample,
+      notes: Prime.prime?(i) ? "The Veteran had active service from November 1989 to November 1990" : nil,
+      transcript_requested: [VACOLS::CaseHearing::BOOLEAN_MAP.values[i % 2], nil].sample
+    }
   end
 end

--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -26,6 +26,12 @@ class Generators::Hearing
       hearing
     end
 
+    def create(attrs = {})
+      hearing = build(attrs)
+      hearing.tap(&:save!) unless ::Hearing.exists?(vacols_id: attrs[:vacols_id])
+      hearing
+    end
+
     private
 
     def default_appeal

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -1,0 +1,16 @@
+RSpec.describe HearingsController, type: :controller do
+  let!(:user) { User.authenticate!(roles: ["Hearings"]) }
+  let(:hearing) { Generators::Hearing.create }
+
+  describe "PATCH update" do
+    it "should be succesful" do
+      patch :update, id: hearing.id, hearing: { notes: "Test", hold_open: 30, transcript_requested: false }
+      expect(response.status).to eq 200
+    end
+
+    it "should return not found" do
+      patch :update, id: "78484", hearing: { notes: "Test", hold_open: 30, transcript_requested: false }
+      expect(response.status).to eq 404
+    end
+  end
+end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -17,7 +17,11 @@ describe Hearing do
         folder_nr: appeal.vacols_id,
         hearing_type: "V",
         hearing_pkseq: "12345678",
-        hearing_disp: "N"
+        hearing_disp: "N",
+        aod: "Y",
+        tranreq: nil,
+        holddays: 90,
+        notes1: "test notes"
       )
     end
 
@@ -29,43 +33,75 @@ describe Hearing do
       expect(subject.appeal.id).to eq(appeal.id)
       expect(subject.user.id).to eq(user.id)
       expect(subject.disposition).to eq(:no_show)
+      expect(subject.aod).to eq :filed
+      expect(subject.transcript_requested).to eq nil
+      expect(subject.hold_open).to eq 90
+      expect(subject.notes).to eq "test notes"
     end
   end
 
   context ".update" do
     subject { hearing.update(hearing_hash) }
     let(:hearing) { Generators::Hearing.build }
-    let(:issue) { hearing.appeal.issues.first }
-    let(:hearing_hash) do
-      {
-        worksheet_military_service: "Vietnam 1968 - 1970",
-        issues_attributes: [
-          {
-            hearing_worksheet_status: :remand,
-            hearing_worksheet_vha: true
-          }
-        ]
-      }
+
+    context "when Vacols does not need an update" do
+      let(:issue) { hearing.appeal.issues.first }
+      let(:hearing_hash) do
+        {
+          worksheet_military_service: "Vietnam 1968 - 1970",
+          issues_attributes: [
+            {
+              hearing_worksheet_status: :remand,
+              hearing_worksheet_vha: true
+            }
+          ]
+        }
+      end
+
+      it "updates nested attributes (issues)" do
+        expect(hearing.issues.count).to eq(0)
+        subject # do update
+        expect(hearing.issues.count).to eq(1)
+
+        expect(hearing.issues.first.hearing_worksheet_status).to eq("remand")
+        expect(hearing.issues.first.hearing_worksheet_vha).to be_truthy
+
+        # test that a 2nd save updates the same record, rather than create new one
+        hearing_issue_id = hearing.issues.first.id
+        hearing_hash[:issues_attributes][0][:hearing_worksheet_status] = :deny
+        hearing_hash[:issues_attributes][0][:id] = hearing_issue_id
+
+        hearing.update(hearing_hash)
+
+        expect(hearing.issues.count).to eq(1)
+        expect(hearing.issues.first.id).to eq(hearing_issue_id)
+        expect(hearing.issues.first.hearing_worksheet_status).to eq("deny")
+      end
     end
 
-    it "updates nested attributes (issues)" do
-      expect(hearing.issues.count).to eq(0)
-      subject # do update
-      expect(hearing.issues.count).to eq(1)
+    context "when Vacols needs an update" do
+      let(:hearing_hash) do
+        { notes: "test notes",
+          aod: :granted,
+          transcript_requested: false,
+          disposition: :postponed,
+          hold_open: 60
+        }
+      end
 
-      expect(hearing.issues.first.hearing_worksheet_status).to eq("remand")
-      expect(hearing.issues.first.hearing_worksheet_vha).to be_truthy
-
-      # test that a 2nd save updates the same record, rather than create new one
-      hearing_issue_id = hearing.issues.first.id
-      hearing_hash[:issues_attributes][0][:hearing_worksheet_status] = :deny
-      hearing_hash[:issues_attributes][0][:id] = hearing_issue_id
-
-      hearing.update(hearing_hash)
-
-      expect(hearing.issues.count).to eq(1)
-      expect(hearing.issues.first.id).to eq(hearing_issue_id)
-      expect(hearing.issues.first.hearing_worksheet_status).to eq("deny")
+      it "updates vacols hearing" do
+        expect(hearing.notes).to eq nil
+        expect(hearing.aod).to eq nil
+        expect(hearing.transcript_requested).to eq nil
+        expect(hearing.disposition).to eq nil
+        expect(hearing.hold_open).to eq nil
+        subject
+        expect(hearing.notes).to eq "test notes"
+        expect(hearing.aod).to eq :granted
+        expect(hearing.transcript_requested).to eq false
+        expect(hearing.disposition).to eq :postponed
+        expect(hearing.hold_open).to eq 60
+      end
     end
   end
 end

--- a/spec/services/hearing_repository_spec.rb
+++ b/spec/services/hearing_repository_spec.rb
@@ -1,0 +1,63 @@
+describe HearingRepository do
+  context ".transform_hearing_info" do
+    subject { HearingRepository.transform_hearing_info(info) }
+
+    context "when all values are present" do
+      let(:info) do
+        { notes: "test notes",
+          aod: :none,
+          transcript_requested: false,
+          disposition: :postponed,
+          hold_open: 60 }
+      end
+
+      it "should convert to Vacols values" do
+        result = subject
+        expect(result[:notes]).to eq "test notes"
+        expect(result[:aod]).to eq :N
+        expect(result[:transcript_requested]).to eq :N
+        expect(result[:disposition]).to eq :P
+        expect(result[:hold_open]).to eq 60
+      end
+    end
+
+    context "when some values are missing" do
+      let(:info) do
+        { notes: "test notes",
+          aod: :granted }
+      end
+
+      it "should skip these values" do
+        result = subject
+        expect(result.values.size).to eq 2
+        expect(result[:notes]).to eq "test notes"
+        expect(result[:aod]).to eq :G
+      end
+    end
+
+    context "values with nil" do
+      let(:info) do
+        { notes: nil,
+          aod: :filed }
+      end
+
+      it "should clear these values" do
+        result = subject
+        expect(result.values.size).to eq 2
+        expect(result[:notes]).to eq nil
+        expect(result[:aod]).to eq :Y
+      end
+    end
+
+    context "when some values do not need Vacols update" do
+      let(:info) do
+        { worksheet_military_service: "Vietnam 1968 - 1970" }
+      end
+
+      it "should skip these values" do
+        result = subject
+        expect(result.values.size).to eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
connects #2684 
1. Update VACOLS hearing table:
```patch /hearings/:id, { "hearing": { "notes": "test", aod: "granted", "hold_open": 30, "disposition": "held", transcript_requested: false } } ```

2. #2725 is needed to load Vacols data in memory 
