### PR TITLE
Updating efolder_service to deserialize correct fields from eFolder 

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -397,7 +397,7 @@ class Appeal < ActiveRecord::Base
 
   def fetched_documents
     @fetched_documents ||= if RequestStore.store[:application] == "reader" && FeatureToggle.enabled?(:efolder_docs_api)
-                             EFolderService.fetch_documents_for(RequestStore.store[:current_user], self)
+                             EFolderService.fetch_documents_for(self, RequestStore.store[:current_user])
                            else
                              self.class.vbms.fetch_documents_for(self)
                            end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -63,7 +63,7 @@ class Document < ActiveRecord::Base
     new(efolder_id: hash["id"],
         type: type_from_vbms_type(hash["type_id"]),
         received_at: hash["received_at"],
-        vbms_document_id: hash["vbms_document_id"])
+        vbms_document_id: hash["external_document_id"])
   end
 
   def self.from_vbms_document(vbms_document)

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -1,7 +1,7 @@
 require "json"
 
 class ExternalApi::EfolderService
-  def self.fetch_documents_for(user, appeal)
+  def self.fetch_documents_for(appeal, user)
     # Makes a GET request to https://<efolder_url>/files/<file_number>
     # to return the list of documents associated with the appeal
     headers = { "FILE-NUMBER" => appeal.sanitized_vbms_id.to_s }

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -314,7 +314,7 @@ class Fakes::AppealRepository
   end
 
   def self.static_reader_documents
-    super_long_title = if FeatureToggle.enabled?(:efolder_enabled)
+    super_long_title = if FeatureToggle.enabled?(:efolder_docs_api)
                          "This is a very long document type that's loaded from eFOLDER!"
                        else
                          "This is a very long document type let's see what it does to the UI!"

--- a/spec/services/external_api/efolder_service_spec.rb
+++ b/spec/services/external_api/efolder_service_spec.rb
@@ -40,7 +40,7 @@ describe ExternalApi::EfolderService do
       it "are recorded using MetricsService" do
         expect(ExternalApi::EfolderService).to receive(:efolder_base_url).and_return(base_url).once
         expect(MetricsService).to receive(:record).and_return(expected_response).once
-        ExternalApi::EfolderService.fetch_documents_for(user, appeal)
+        ExternalApi::EfolderService.fetch_documents_for(appeal, user)
       end
     end
 
@@ -48,7 +48,7 @@ describe ExternalApi::EfolderService do
       it "throws ArgumentError" do
         expect(ExternalApi::EfolderService).to receive(:efolder_base_url).and_return(Faker::ChuckNorris.fact).once
         expect(HTTPI).not_to receive(:get)
-        expect { ExternalApi::EfolderService.fetch_documents_for(user, appeal) }.to raise_error(ArgumentError)
+        expect { ExternalApi::EfolderService.fetch_documents_for(appeal, user) }.to raise_error(ArgumentError)
       end
     end
 
@@ -63,7 +63,7 @@ describe ExternalApi::EfolderService do
         let(:expected_response_map) { { data: { attributes: { documents: nil } } } }
 
         it "returns empty array" do
-          expect(ExternalApi::EfolderService.fetch_documents_for(user, appeal)).to be_empty
+          expect(ExternalApi::EfolderService.fetch_documents_for(appeal, user)).to be_empty
         end
       end
 
@@ -71,7 +71,7 @@ describe ExternalApi::EfolderService do
         let(:expected_response_map) { { data: { attributes: { documents: [] } } } }
 
         it "returns empty array" do
-          expect(ExternalApi::EfolderService.fetch_documents_for(user, appeal)).to be_empty
+          expect(ExternalApi::EfolderService.fetch_documents_for(appeal, user)).to be_empty
         end
       end
 
@@ -96,7 +96,7 @@ describe ExternalApi::EfolderService do
           expected_document1.received_at = expected_received_at1.to_s
 
           # Use to_hash to do a deep comparison and ensure all properties were deserialized correctly
-          result = ExternalApi::EfolderService.fetch_documents_for(user, appeal).map(&:to_hash)
+          result = ExternalApi::EfolderService.fetch_documents_for(appeal, user).map(&:to_hash)
           expect(result).to contain_exactly(expected_document1.to_hash)
         end
       end
@@ -132,7 +132,7 @@ describe ExternalApi::EfolderService do
           expected_document2.received_at = expected_received_at2.to_s
 
           # Use to_hash to do a deep comparison and ensure all properties were deserialized correctly
-          result = ExternalApi::EfolderService.fetch_documents_for(user, appeal).map(&:to_hash)
+          result = ExternalApi::EfolderService.fetch_documents_for(appeal, user).map(&:to_hash)
           expect(result).to contain_exactly(expected_document1.to_hash, expected_document2.to_hash)
         end
       end
@@ -141,7 +141,7 @@ describe ExternalApi::EfolderService do
         let(:expected_response) { HTTPI::Response.new(404, [], {}) }
 
         it "throws Caseflow::Error::DocumentRetrievalError" do
-          expect { ExternalApi::EfolderService.fetch_documents_for(user, appeal) }
+          expect { ExternalApi::EfolderService.fetch_documents_for(appeal, user) }
             .to raise_error(Caseflow::Error::DocumentRetrievalError)
         end
       end

--- a/spec/services/external_api/efolder_service_spec.rb
+++ b/spec/services/external_api/efolder_service_spec.rb
@@ -85,7 +85,7 @@ describe ExternalApi::EfolderService do
                 {
                   id: "1",
                   type_id: "97",
-                  vbms_document_id: expected_document1.vbms_document_id,
+                  external_document_id: expected_document1.vbms_document_id,
                   received_at: expected_received_at1
                 }]
             } } }
@@ -109,13 +109,13 @@ describe ExternalApi::EfolderService do
                 {
                   id: "1",
                   type_id: "97",
-                  vbms_document_id: expected_document1.vbms_document_id,
+                  external_document_id: expected_document1.vbms_document_id,
                   received_at: expected_received_at1
                 },
                 {
                   id: "2",
                   type_id: "73",
-                  vbms_document_id: expected_document2.vbms_document_id,
+                  external_document_id: expected_document2.vbms_document_id,
                   received_at: expected_received_at2
                 }]
             } } }


### PR DESCRIPTION
- Connects #2334 
- Connects #2669 

- The response for the `files` endpoint of the eFolder API was updated to change `vbms_document_id` to `external_document_api`.
- Updating call to Fakes::VBMSService to reflect latest changes in efolder_service
- Updating appeals generator to use `FeatureToggle.enabled?(:efolder_docs_api)`
