### PR TITLE
Set hearing IDs in Fakes

### DIFF
--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -27,8 +27,10 @@ class Generators::Hearing
     end
 
     def create(attrs = {})
-      hearing = build(attrs)
-      hearing.tap(&:save!) unless ::Hearing.exists?(vacols_id: attrs[:vacols_id])
+      hearing = Hearing.find_or_create_by(vacols_id: default_attrs.merge(attrs)[:vacols_id])
+      build(attrs.merge(id: hearing.id))
+      hearing.update_attributes(default_attrs.merge(attrs))
+
       hearing
     end
 

--- a/spec/models/judge_spec.rb
+++ b/spec/models/judge_spec.rb
@@ -36,6 +36,11 @@ describe Judge do
       expect(last_dates).to all(eq(keys.last.to_date))
     end
 
+    it "returns hearings with IDs" do
+      hearing_ids = subject.map { |key, _v| subject[key].hearings.map(&:id) }.flatten
+      expect(hearing_ids.compact.size).to eq 3
+    end
+
     it "excludes hearings for another judge" do
       hearing_ids = subject.map { |key, _v| subject[key].hearings.map(&:id) }.flatten
       expect(hearing_ids).to_not include(hearing_another_judge.id)


### PR DESCRIPTION
`Fakes::HearingRepository.hearing_records` contained hearing records without IDs. This fixes the issue. 

Example response:
![image](https://user-images.githubusercontent.com/3811786/28728165-9ccf4084-7395-11e7-9c44-293204297617.png)
