### PR TITLE
turn on fetch all lazy loaded attributes for appeal to fix Welcome date

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -468,7 +468,6 @@ class Appeal < ActiveRecord::Base
 
     def initialize_appeal_without_lazy_load(hash)
       appeal = find_or_initialize_by(vacols_id: hash[:vacols_id])
-      appeal.turn_off_lazy_loading(initial_values: hash)
       appeal
     end
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -433,6 +433,6 @@ class Fakes::AppealRepository
   end
 
   def self.aod(_vacols_id)
-    1
+    true
   end
 end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1104,7 +1104,8 @@ describe Appeal do
     end
   end
 
-  context ".initialize_appeal_without_lazy_load" do
+  context ".initialize_appeal_without_lazy_load",
+          skip: "Disabled without_lazy_load for appeals for fixing Welcome Gate" do
     let(:date) { Time.zone.today }
     let(:saved_appeal) do
       Generators::Appeal.build(


### PR DESCRIPTION
connects #1998 

I crated an issue to fix to enable the flag and not fetch the attributes from Vacols that are not always needed.
https://github.com/department-of-veterans-affairs/caseflow/issues/2774