### PR TITLE
Fetch vbms_id from VACOLS if not cached

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -90,16 +90,13 @@ class Appeal < ActiveRecord::Base
     @saved_documents ||= fetch_documents!(save: true)
   end
 
+  # If we do not yet have the vbms_id saved in Caseflow's DB, then
+  # we want to fetch it from VACOLS, save it to the DB, then return it
   def vbms_id
     super || begin
-      # Despite already having an appeal object in memory, we want to
-      # call this class level method so that we "centralize" the logic
-      # for loading an appeal from VACOLS
-      appeal = self.class.find_or_create_by_vacols_id(vacols_id)
-
-      # In order to avoid an infinite loop (in the event VACOLS does not have a file number)
-      # We want to directly reference the attributes hash to retrieve the vbms_id
-      appeal.attributes["vbms_id"]
+      check_and_load_vacols_data!
+      save
+      super
     end
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -97,7 +97,8 @@ class Appeal < ActiveRecord::Base
       # for loading an appeal from VACOLS
       appeal = self.class.find_or_create_by_vacols_id(vacols_id)
 
-      # In order to avoid an infinite loop (in the event VACOLS does not have a file number)      # We want to directly reference the attributes hash to retrieve the vbms_id
+      # In order to avoid an infinite loop (in the event VACOLS does not have a file number)
+      # We want to directly reference the attributes hash to retrieve the vbms_id
       appeal.attributes["vbms_id"]
     end
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -90,6 +90,18 @@ class Appeal < ActiveRecord::Base
     @saved_documents ||= fetch_documents!(save: true)
   end
 
+  def vbms_id
+    super || begin
+      # Despite already having an appeal object in memory, we want to
+      # call this class level method so that we "centralize" the logic
+      # for loading an appeal from VACOLS
+      appeal = self.class.find_or_create_by_vacols_id(vacols_id)
+
+      # In order to avoid an infinite loop (in the event VACOLS does not have a file number)      # We want to directly reference the attributes hash to retrieve the vbms_id
+      appeal.attributes["vbms_id"]
+    end
+  end
+
   def events
     @events ||= AppealEvents.new(appeal: self).all.sort_by(&:date)
   end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1129,8 +1129,8 @@ describe Appeal do
   context "#vbms_id" do
     context "when vbms_id exists in the caseflow DB" do
       it "does not make a request to VACOLS" do
-        expect(Appeal).to receive(:find_or_create_by_vacols_id)
-          .with(appeal.vacols_id).exactly(0).times
+        expect(appeal).to receive(:perform_vacols_request)
+          .exactly(0).times
 
         expect(appeal.attributes["vbms_id"]).to_not be_nil
         expect(appeal.vbms_id).to_not be_nil
@@ -1141,8 +1141,8 @@ describe Appeal do
       let(:no_vbms_id_appeal) { Appeal.create(vacols_id: appeal.vacols_id) }
 
       it "looks up vbms_id in VACOLS" do
-        expect(Appeal).to receive(:find_or_create_by_vacols_id)
-          .with(appeal.vacols_id).exactly(1).times.and_return(appeal)
+        expect(no_vbms_id_appeal).to receive(:perform_vacols_request)
+          .exactly(1).times.and_call_original
 
         expect(no_vbms_id_appeal.attributes["vbms_id"]).to be_nil
         expect(no_vbms_id_appeal.vbms_id).to_not be_nil

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1124,4 +1124,28 @@ describe Appeal do
       expect { appeal.veteran_first_name }.to raise_error(AssociatedVacolsModel::LazyLoadingTurnedOffError)
     end
   end
+
+  context "#vbms_id" do
+    context "when vbms_id exists in the caseflow DB" do
+      it "does not make a request to VACOLS" do
+        expect(Appeal).to receive(:find_or_create_by_vacols_id)
+          .with(appeal.vacols_id).exactly(0).times
+
+        expect(appeal.attributes["vbms_id"]).to_not be_nil
+        expect(appeal.vbms_id).to_not be_nil
+      end
+    end
+
+    context "when vbms_id is nil" do
+      let (:no_vbms_id_appeal) { Appeal.create(vacols_id: appeal.vacols_id) }
+
+      it "looks up vbms_id in VACOLS" do
+        expect(Appeal).to receive(:find_or_create_by_vacols_id)
+          .with(appeal.vacols_id).exactly(1).times.and_return(appeal)
+
+        expect(no_vbms_id_appeal.attributes["vbms_id"]).to be_nil
+        expect(no_vbms_id_appeal.vbms_id).to_not be_nil
+      end
+    end
+  end
 end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1145,7 +1145,7 @@ describe Appeal do
           .exactly(1).times.and_call_original
 
         expect(no_vbms_id_appeal.attributes["vbms_id"]).to be_nil
-        expect(no_vbms_id_appeal.vbms_id).to_not be_nil
+        expect(no_vbms_id_appeal.reload.vbms_id).to_not be_nil
       end
     end
   end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1137,7 +1137,7 @@ describe Appeal do
     end
 
     context "when vbms_id is nil" do
-      let (:no_vbms_id_appeal) { Appeal.create(vacols_id: appeal.vacols_id) }
+      let(:no_vbms_id_appeal) { Appeal.create(vacols_id: appeal.vacols_id) }
 
       it "looks up vbms_id in VACOLS" do
         expect(Appeal).to receive(:find_or_create_by_vacols_id)


### PR DESCRIPTION
- For an appeal object that does not yet have a vbms_id, we want to try
  and fetch it from VACOLS. Once we have the vbms_id saved, we should
only reference it from the Caseflow DB