### PR TITLE
Certification V2 Veteran name and id styling 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "1e7925e18a9a0dfd0ac1e3fca19feb7cf6755b00"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "6e8bed78dcb4e6699f55257ad90d016b71639ec0"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 1e7925e18a9a0dfd0ac1e3fca19feb7cf6755b00
-  ref: 1e7925e18a9a0dfd0ac1e3fca19feb7cf6755b00
+  revision: 6e8bed78dcb4e6699f55257ad90d016b71639ec0
+  ref: 6e8bed78dcb4e6699f55257ad90d016b71639ec0
   specs:
     caseflow (0.1.6)
       aws-sdk (~> 2)
@@ -121,13 +121,13 @@ GEM
       nokogiri
     arel (6.0.4)
     ast (2.3.0)
-    aws-sdk (2.10.19)
-      aws-sdk-resources (= 2.10.19)
-    aws-sdk-core (2.10.19)
+    aws-sdk (2.10.20)
+      aws-sdk-resources (= 2.10.20)
+    aws-sdk-core (2.10.20)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.19)
-      aws-sdk-core (= 2.10.19)
+    aws-sdk-resources (2.10.20)
+      aws-sdk-core (= 2.10.20)
     aws-sigv4 (1.0.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -716,7 +716,7 @@ select {
 }
 
 .cf-veteran-name-control{
-  line-height: 2.3;
+  line-height: 2.2;
   font-size: 22px;
   color: $color-gray-dark;
 }

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -714,3 +714,9 @@ select {
     margin-bottom: 8px;
   }
 }
+
+.cf-veteran-name-control{
+  line-height: 2.3;
+  font-size: 22px;
+  color: $color-gray-dark;
+}

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -715,8 +715,9 @@ select {
   }
 }
 
-.cf-veteran-name-control{
+.cf-veteran-name-control {
   line-height: 2.2;
   font-size: 22px;
   color: $color-gray-dark;
 }
+

--- a/client/app/certification/Header.jsx
+++ b/client/app/certification/Header.jsx
@@ -35,6 +35,7 @@ const UnconnectedHeader = ({
         </button>
       </div>
     </div>}
+   <div className="cf-help-divider"></div>
   </div>;
 };
 

--- a/client/app/certification/Header.jsx
+++ b/client/app/certification/Header.jsx
@@ -8,8 +8,12 @@ const UnconnectedHeader = ({
 }) => {
   return <div>
     { !serverError && <div id="certifications-header" className="cf-app-segment">
+    <div className="cf-txt-uc cf-veteran-name-control cf-push-left">
+       {veteranName} &nbsp;
+      </div>
+
       <div className="cf-txt-uc cf-apppeal-id-control cf-push-right">
-        {veteranName} &nbsp;
+        Veteran ID &nbsp;
 
         <button type="submit"
           title="Copy to clipboard"


### PR DESCRIPTION
Connects #2216 

## AC
1. Verify that the veteran name and ID number currently to the the right of the application name 'eFolder Express' are removed.
1. Verify that the user name displays in title case, 17px, color #5B616B
1. Verify that the Veteran Name is left aligned and displays in all caps, 22px, color #323A44
1. Verify that the label Appeal ID is changed to Veteran ID
1. Verify that the Veteran ID is displayed in color: #5B616A, style: bold, 17px, inside a button to the left of the 'copy' icon (also color: #5B616A). Button fill color: #FFFFFF, with a border: 2px, color: #5B616A.
1. Verify that there are 30px above the Vet ID button, and 30 px below the vet ID button
1. Verify that when there is not a box or border below the Vet Name and ID, a line is added between them and the progress bar:
<img width="1056" alt="screen shot 2017-08-01 at 2 21 51 pm" src="https://user-images.githubusercontent.com/23080951/28840395-d48b81b8-76c4-11e7-80c1-e4c4972764f2.png">
