### PR TITLE
Anya/hold open diary

### DIFF
--- a/app/models/vacols/note.rb
+++ b/app/models/vacols/note.rb
@@ -7,67 +7,118 @@ class VACOLS::Note < VACOLS::Record
   class TextRequiredError < StandardError; end
 
   CODE_ACTKEY_MAPPING = {
-    other: "BVA30"
+    other: "BVA30",
+    A: "A",
+    B: "B",
+    B1: "B1"
   }.freeze
 
-  # simple alias for more concise code
-  def self.conn
-    connection
-  end
-
-  # VACOLS does not auto-generate primary keys. Instead we must manually create one.
-  # Below is the logic currently used by VACOLS apps to generate note IDs
-  # NOTE: For consistency, we should keep this logic in sync with the VACOLS applets
-  def self.generate_primary_key(bfkey)
-    case_id = conn.quote(bfkey)
-
-    query = <<-SQL
-      SELECT count(*) as count
-      FROM ASSIGN
-      WHERE TSKTKNM = #{case_id}
-    SQL
-
-    count_res = MetricsService.record "VACOLS: Note.generate_primary_key #{bfkey}" do
-      conn.exec_query(query)
-    end
-    count = count_res.to_a.first["count"]
-
-    "#{bfkey}D#{count + 1}"
-  end
-
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-  def self.create!(case_record:, text:, note_code: :other, days_to_complete: 30, days_til_due: 30)
-    validate!(text: text, note_code: note_code)
-
-    text = conn.quote(text)
-    case_id = conn.quote(case_record.bfkey)
-    regional_office_key = conn.quote(case_record.bfregoff)
-    days_to_complete = conn.quote(days_to_complete)
-    due_date = conn.quote(Time.zone.now + days_til_due.days)
-    note_code = conn.quote(CODE_ACTKEY_MAPPING[note_code])
-    user_id = conn.quote(RequestStore.store[:current_user].regional_office.upcase)
-    primary_key = generate_primary_key(case_record.bfkey)
-    quoted_primary_key = conn.quote(primary_key)
-
-    query = <<-SQL
-      INSERT into ASSIGN
-        (TASKNUM, TSKRQACT, TSKSTAT, TSKDTC, TSKCLASS, TSKACTCD, TSKDASSN,
-         TSKDDUE, TSKTKNM, TSKSTFAS, TSKSTOWN, TSKADUSR, TSKADTM)
-      VALUES
-        (#{quoted_primary_key}, #{text}, 'P', #{days_to_complete}, 'ACTIVE', #{note_code}, SYSDATE,
-         #{due_date}, #{case_id}, #{regional_office_key}, #{user_id}, #{user_id}, SYSDATE)
-    SQL
-
-    MetricsService.record "VACOLS: Note.create! #{case_id}" do
-      conn.execute(query)
+  class << self
+    # simple alias for more concise code
+    def conn
+      connection
     end
 
-    primary_key
-  end
+    # VACOLS does not auto-generate primary keys. Instead we must manually create one.
+    # Below is the logic currently used by VACOLS apps to generate note IDs
+    # NOTE: For consistency, we should keep this logic in sync with the VACOLS applets
+    def generate_primary_key(bfkey)
+      case_id = conn.quote(bfkey)
 
-  def self.validate!(text:, note_code:)
-    fail(TextRequiredError) unless text
-    fail(InvalidNotelengthError) if text.length > 280
-    fail InvalidNoteCodeError unless CODE_ACTKEY_MAPPING[note_code]
+      query = <<-SQL
+        SELECT count(*) as count
+        FROM ASSIGN
+        WHERE TSKTKNM = #{case_id}
+      SQL
+
+      count_res = MetricsService.record("VACOLS: Note.generate_primary_key #{bfkey}",
+                                        service: :vacols,
+                                        name: "generate_primary_key") do
+        conn.exec_query(query)
+      end
+      count = count_res.to_a.first["count"]
+
+      "#{bfkey}D#{count + 1}"
+    end
+
+    # rubocop:disable MethodLength
+    def create!(note)
+      validate!(text: note[:text], code: note[:code])
+
+      primary_key = generate_primary_key(note[:case_id])
+
+      MetricsService.record("VACOLS: Note.create! #{note[:case_id]}",
+                            service: :vacols,
+                            name: "create") do
+        VACOLS::Note.create(
+          tasknum: primary_key,
+          tskrqact: note[:text],
+          tskstat: "P",
+          tskdtc: note[:days_to_complete],
+          tskclass: "ACTIVE",
+          tskactcd: CODE_ACTKEY_MAPPING[note[:code]],
+          tskdassn: VacolsHelper.local_time_with_utc_timezone,
+          tskddue: Time.zone.now + note[:days_til_due].days,
+          tsktknm: note[:case_id],
+          tskstfas: note[:assigned_to],
+          tskstown: note[:user_id],
+          tskadusr: note[:user_id],
+          tskadtm: VacolsHelper.local_time_with_utc_timezone
+        )
+      end
+      primary_key
+    end
+    # rubocop:enable MethodLength
+
+    def find_active_by_user_and_type(note)
+      VACOLS::Note.find_by(
+        tsktknm: note[:case_id],
+        tskstown: note[:user_id],
+        tskadusr: note[:user_id],
+        tskactcd: CODE_ACTKEY_MAPPING[note[:code]],
+        tskstat: "P"
+      )
+    end
+
+    def delete!(note)
+      record = find_active_by_user_and_type(note)
+      return unless record
+      MetricsService.record("VACOLS: Note.delete! #{note[:case_id]}",
+                            service: :vacols,
+                            name: "delete") do
+        record.delete
+      end
+    end
+
+    def update_or_create!(note)
+      # First check if the query already exists. Search for:
+      # 1) active diary, 2) of the same type, 3) owned by the same person.
+      # If not found, create a new note
+      record = find_active_by_user_and_type(note)
+      return create!(note) unless record
+
+      attrs = {
+        tskmdtm: VacolsHelper.local_time_with_utc_timezone,
+        tskdtc: note[:days_to_complete]
+      }
+      # only send update to tskddue if days_til_due is passed, otherwise it will cause
+      # invalid updates to tskddue
+      attrs = attrs.merge(tskddue: Time.zone.now + note[:days_til_due].days) if note[:days_til_due]
+      record.update(attrs)
+    end
+
+    # ACTCODE keeps track who should be assigned diaries of a given type (based on the note_code)
+    def assignee(note_code)
+      note_code = conn.quote(CODE_ACTKEY_MAPPING[note_code])
+      conn.exec_query(<<-SQL).to_hash.first["acspare1"]
+        select ACSPARE1 from ACTCODE where ACTCKEY = #{note_code}
+      SQL
+    end
+
+    def validate!(text:, code:)
+      fail(TextRequiredError) unless text
+      fail(InvalidNotelengthError) if text.length > 280
+      fail(InvalidNoteCodeError) unless CODE_ACTKEY_MAPPING[code]
+    end
   end
 end

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -184,8 +184,14 @@ class AppealRepository
       update_location_after_dispatch!(appeal: appeal)
 
       if vacols_note
-        VACOLS::Note.create!(case_record: appeal.case_record,
-                             text: vacols_note)
+        VACOLS::Note.create!(case_id: appeal.case_record.bfkey,
+                             text: vacols_note,
+                             user_id: RequestStore.store[:current_user].regional_office.upcase,
+                             assigned_to: appeal.case_record.bfregoff,
+                             code: :other,
+                             days_to_complete: 30,
+                             days_til_due: 30
+                            )
       end
     end
   end


### PR DESCRIPTION
connects #2692 

Steps to validate:
1. Start `rails c` and ensure you are connected to Vacols dev env
2. Set the user in the RequestStore:
```RequestStore.store[:current_user] = User.new(css_id: CSFLOW1")```
3. Find a hearing in the hearings table (make sure it exists in Vacols)
```h = Hearing.find(id)```
4. Update hold_open on the hearing object which should in turn trigger a create for an A diary. For example,
```
h.update(hold_open: 30)
```
5. The same diary should be created only once for the same user. Subsequent updates to hold_open, should update the existing diary (fields to be updated: `tskmdtm`, `tskdtc`, `tskddue`.
6. How do you determine if the query is the same? Based on these fields:
```
VACOLS::Note.find_by(
        tsktknm: note[:case_id],
        tskstown: note[:user_id],
        tskadusr: note[:user_id],
        tskactcd: CODE_ACTKEY_MAPPING[note[:code]],
        tskstat: "P"
      )
```
7. If we set hold_open to nil, the diary should be deleted
8. Follow AC in the ticket to find out which fields should be updated.
9. Viola!