### PR TITLE
Increase Timeout

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -29,6 +29,7 @@ class ExternalApi::EfolderService
     request = HTTPI::Request.new(url)
     request.auth.ssl.ssl_version  = :TLSv1_2
     request.auth.ssl.ca_cert_file = ENV["SSL_CERT_FILE"]
+    request.read_timeout = 60
 
     headers["AUTHORIZATION"] = "Token token=#{efolder_key}"
     headers["CSS-ID"] = user.css_id.to_s


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/2808

Our calls to eFolder have been timing out. Not the ideal solution but until we can implement https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/562, we are just upping the timeout to match our NGINX timeout of 60 seconds.

**Test Plan**
- [ ] Run `ExternalApi::EfolderService.fetch_documents_for(Appeal.new(vbms_id: "22222222"), User.first)` from Caseflow UAT box, and make sure there is a response.