### PR TITLE
Nemo/Out of service mode toggled per individual application

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Clerical errors have the potential to delay the resolution of a veteran's appeal
 
 ![Screenshot of Caseflow Certification (Fake data, No PII here)](certification-screenshot.png "Caseflow Certification")
 
-## Setup 
+## Setup
 ### Docker container
 All dependencies for the application and external services are contained with the [Dockerfile](Dockerfile) and the [docker-compose.yml](docker-compose.yml) files.
 
@@ -45,12 +45,12 @@ First time user will need to run `create` before `setup`:
 
 ```
 docker-compose run rake db:create
-``` 
+```
 Followed by:
 
 ```
 docker-compose run rake db:setup
-``` 
+```
 
 
 
@@ -272,6 +272,28 @@ FeatureToggle.disable!(:apple, regional_offices: ["RO03", "RO09"])
 FeatureToggle.details_for(:apple)
 => { :regional_offices =>["RO08"] }
 ```
+
+## Out of Service
+
+To enable and disable 'Out of Service' feature using `rails c`. Example usage:
+
+# enable globally
+Rails.cache.write("out_of_service", true)
+
+# enable for certification only
+Rails.cache.write("certification_out_of_service", true)
+
+# enable for dispatch only
+Rails.cache.write("dispatch_out_of_service", true)
+
+# enable for hearings only
+Rails.cache.write("hearings_prep_out_of_service", true)
+
+# enable for reader only
+Rails.cache.write("reader_out_of_service", true)
+
+# to disable, i.e.
+Rails.cache.write("certification_out_of_service", false)
 
 # Support
 ![BrowserStack logo](./browserstack-logo.png)

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ Rails.cache.write("hearings_prep_out_of_service", true)
 # enable for reader only
 Rails.cache.write("reader_out_of_service", true)
 
-# to disable, i.e.
+# to disable, e.g.
 Rails.cache.write("certification_out_of_service", false)
 
 # Support

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -1,6 +1,5 @@
 class CertificationsController < ApplicationController
-  before_action :verify_access
-  before_action :check_certification_out_of_service
+  before_action :verify_access, :check_certification_out_of_service
 
   def new
     if feature_enabled?(:certification_v2)

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -1,5 +1,6 @@
 class CertificationsController < ApplicationController
   before_action :verify_access
+  before_action :check_certification_out_of_service
 
   def new
     if feature_enabled?(:certification_v2)
@@ -107,6 +108,10 @@ class CertificationsController < ApplicationController
   end
 
   private
+
+  def check_certification_out_of_service
+    render "out_of_service", layout: "application" if Rails.cache.read("certification_out_of_service")
+  end
 
   # Make sure all data is there in case user skips steps and goes straight to sign_and_certify
   def validate_data_presence_v2

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -1,7 +1,6 @@
 class HearingsController < ApplicationController
   # :nocov:
-  before_action :verify_access
-  before_action :check_hearings_prep_out_of_service
+  before_action :verify_access, :check_hearings_prep_out_of_service
 
   def update
     hearing.update(update_params)

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -1,6 +1,7 @@
 class HearingsController < ApplicationController
   # :nocov:
   before_action :verify_access
+  before_action :check_hearings_prep_out_of_service
 
   def update
     hearing.update(update_params)
@@ -16,6 +17,10 @@ class HearingsController < ApplicationController
   end
 
   private
+
+  def check_hearings_prep_out_of_service
+    render "out_of_service", layout: "application" if Rails.cache.read("hearings_prep_out_of_service")
+  end
 
   def hearing
     @hearing ||= Hearing.find(hearing_id)

--- a/app/controllers/reader/application_controller.rb
+++ b/app/controllers/reader/application_controller.rb
@@ -1,5 +1,5 @@
 class Reader::ApplicationController < ApplicationController
-  before_action :verify_access, :verify_reader_feature_enabled, :react_routed
+  before_action :verify_access, :verify_reader_feature_enabled, :react_routed, :check_reader_out_of_service
 
   def logo_name
     "Reader"
@@ -19,5 +19,11 @@ class Reader::ApplicationController < ApplicationController
 
   def verify_access
     verify_authorized_roles("Reader")
+  end
+
+  private
+
+  def check_reader_out_of_service
+    render "out_of_service", layout: "application" if Rails.cache.read("reader_out_of_service")
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,8 +3,13 @@
 #       from EstablishClaimsController can be abstracted out
 class TasksController < ApplicationController
   class TaskTypeMissingError < StandardError; end
+  before_action :check_dispatch_out_of_service
 
   private
+
+  def check_dispatch_out_of_service
+    render "out_of_service", layout: "application" if Rails.cache.read("dispatch_out_of_service")
+  end
 
   # Future safeguard for when we give managers a show view for a given task
   def start_task!

--- a/spec/feature/out_of_service_spec.rb
+++ b/spec/feature/out_of_service_spec.rb
@@ -145,7 +145,7 @@ RSpec.feature "Out of Service" do
     end
 
     let!(:current_user) do
-      User.authenticate!(roles: ["Hearings"])
+      User.authenticate!(roles: ["Hearing Prep"])
     end
 
     scenario "When out of service is disabled, it shows Hearings page" do

--- a/spec/feature/out_of_service_spec.rb
+++ b/spec/feature/out_of_service_spec.rb
@@ -1,20 +1,91 @@
 require "rails_helper"
 
 RSpec.feature "Out of Service" do
-  context "Out of service is disabled" do
-    scenario "Visit certify appeal page" do
-      visit "certifications/new/5555C"
+  context "Across all apps" do
+    after do
+      Rails.cache.write("out_of_service", false)
+    end
+
+    scenario "Out of service is disabled" do
+      visit "/"
       expect(page).not_to have_content("Technical Difficulties")
+    end
+
+    scenario "Out of service is enabled" do
+      Rails.cache.write("out_of_service", true)
+      visit "/"
+      expect(page).to have_content("Technical Difficulties")
     end
   end
 
-  context "Out of service is enabled" do
-    before do
-      Rails.cache.write("out_of_service", true)
+  context "Certification" do
+    let!(:current_user) { User.authenticate!(roles: ["Certify Appeal", "CertificationV2"]) }
+
+    after do
+      Rails.cache.write("certification_out_of_service", false)
     end
 
-    scenario "Visit root page" do
-      visit "/"
+    scenario "Out of service is disabled" do
+      visit "certifications/new/5555C"
+      expect(page).to_not have_content("Technical Difficulties")
+    end
+
+    scenario "Out of service is enabled" do
+      Rails.cache.write("certification_out_of_service", true)
+      visit "certifications/new/5555C"
+      expect(page).to have_content("Technical Difficulties")
+    end
+  end
+
+  context "Reader" do
+    after do
+      Rails.cache.write("reader_out_of_service", false)
+    end
+
+    scenario "Out of service is disabled" do
+      visit "reader/appeal/"
+      expect(page).to_not have_content("Technical Difficulties")
+    end
+
+    scenario "Out of service is enabled" do
+      Rails.cache.write("reader_out_of_service", true)
+      visit "reader/appeal/"
+      expect(page).to have_content("Technical Difficulties")
+    end
+  end
+
+  context "Hearings Prep" do
+    after do
+      Rails.cache.write("hearings_prep_out_of_service", false)
+    end
+
+    scenario "Out of service is disabled" do
+      visit "certifications/new/5555C"
+      expect(page).to_not have_content("Technical Difficulties")
+    end
+
+    scenario "Out of service is enabled" do
+      Rails.cache.write("hearings_prep_out_of_service", true)
+      visit "certifications/new/5555C"
+      expect(page).to have_content("Technical Difficulties")
+    end
+  end
+
+  context "Dispatch" do
+    let!(:current_user) { User.authenticate!(roles: ["Establish Claim", "Manage Claim Establishment"]) }
+
+    after do
+      Rails.cache.write("dispatch_out_of_service", false)
+    end
+
+    scenario "Out of service is disabled" do
+      visit "dispatch/establish-claim"
+      expect(page).to_not have_content("Technical Difficulties")
+    end
+
+    scenario "Out of service is enabled" do
+      Rails.cache.write("dispatch_out_of_service", true)
+      visit "dispatch/establish-claim"
       expect(page).to have_content("Technical Difficulties")
     end
   end

--- a/spec/feature/out_of_service_spec.rb
+++ b/spec/feature/out_of_service_spec.rb
@@ -6,12 +6,13 @@ RSpec.feature "Out of Service" do
       Rails.cache.write("out_of_service", false)
     end
 
-    scenario "Out of service is disabled" do
+    scenario "When out of service is disabled, it shows Caseflow Home page" do
       visit "/"
+      expect(page).to have_content("Caseflow Help")
       expect(page).not_to have_content("Technical Difficulties")
     end
 
-    scenario "Out of service is enabled" do
+    scenario "When out of service is enabled, it shows Out of service page" do
       Rails.cache.write("out_of_service", true)
       visit "/"
       expect(page).to have_content("Technical Difficulties")
@@ -19,71 +20,167 @@ RSpec.feature "Out of Service" do
   end
 
   context "Certification" do
-    let!(:current_user) { User.authenticate!(roles: ["Certify Appeal", "CertificationV2"]) }
+    before do
+      FeatureToggle.enable!(:certification_v2)
+    end
 
     after do
       Rails.cache.write("certification_out_of_service", false)
+      FeatureToggle.disable!(:certification_v2)
     end
 
-    scenario "Out of service is disabled" do
-      visit "certifications/new/5555C"
+    let!(:current_user) { User.authenticate!(roles: ["Certify Appeal", "CertificationV2"]) }
+    let(:nod) { Generators::Document.build(type: "NOD") }
+    let(:soc) { Generators::Document.build(type: "SOC", received_at: Date.new(1987, 9, 6)) }
+    let(:form9) { Generators::Document.build(type: "Form 9") }
+
+    let(:documents) { [nod, soc, form9] }
+    let(:appeal_ready) do
+      Generators::Appeal.build(vacols_record: vacols_record, documents: documents)
+    end
+    let(:vacols_record) do
+      {
+        template: :ready_to_certify,
+        type: "Original",
+        file_type: "VVA",
+        representative: "The American Legion",
+        veteran_first_name: "Davy",
+        veteran_last_name: "Crockett",
+        veteran_middle_initial: "X",
+        appellant_first_name: "Susie",
+        appellant_middle_initial: nil,
+        appellant_last_name: "Crockett",
+        appellant_relationship: "Daughter",
+        nod_date: nod.received_at,
+        soc_date: soc.received_at + 4.days,
+        form9_date: form9.received_at
+      }
+    end
+
+    scenario "When out of service is disabled, it shows Check Documents page" do
+      visit "certifications/new/#{appeal_ready.vacols_id}"
+      expect(page).to have_content("Check Documents")
       expect(page).to_not have_content("Technical Difficulties")
     end
 
-    scenario "Out of service is enabled" do
+    scenario "When out of service is enabled, it shows Out of service page" do
       Rails.cache.write("certification_out_of_service", true)
-      visit "certifications/new/5555C"
+      visit "certifications/new/#{appeal_ready.vacols_id}"
       expect(page).to have_content("Technical Difficulties")
     end
   end
 
   context "Reader" do
+    before do
+      FeatureToggle.enable!(:reader)
+
+      Fakes::Initializer.load!
+    end
+
     after do
+      FeatureToggle.disable!(:reader)
       Rails.cache.write("reader_out_of_service", false)
     end
 
-    scenario "Out of service is disabled" do
-      visit "reader/appeal/"
+    let(:vacols_record) { :remand_decided }
+
+    let(:documents) { [] }
+
+    let!(:issue_levels) do
+      ["Other", "Left knee", "Right knee"]
+    end
+
+    let!(:issues) do
+      [Generators::Issue.build(disposition: :allowed,
+                               program: :compensation,
+                               type: { name: :elbow, label: "Elbow" },
+                               category: :service_connection,
+                               levels: issue_levels
+                              )
+      ]
+    end
+
+    let(:appeal) do
+      Generators::Appeal.create(vacols_record: vacols_record, documents: documents, issues: issues)
+    end
+
+    let!(:current_user) do
+      User.authenticate!(roles: ["Reader"])
+    end
+
+    scenario "When out of service is disabled, it shows document page" do
+      visit "/reader/appeal/#{appeal.vacols_id}/documents"
+      expect(page).to have_content("Claims folder details")
       expect(page).to_not have_content("Technical Difficulties")
     end
 
-    scenario "Out of service is enabled" do
+    scenario "When out of service is enabled, it shows Out of service page" do
       Rails.cache.write("reader_out_of_service", true)
-      visit "reader/appeal/"
+      visit "/reader/appeal/#{appeal.vacols_id}/documents"
       expect(page).to have_content("Technical Difficulties")
     end
   end
 
   context "Hearings Prep" do
+    before do
+      current_user.update!(full_name: "Lauren Roth", vacols_id: "LROTH")
+
+      2.times do
+        Generators::Hearing.build(
+          user: current_user,
+          date: 5.days.from_now,
+          type: "video"
+        )
+      end
+
+      Generators::Hearing.build(
+        user: current_user,
+        type: "central_office",
+        date: Time.zone.now
+      )
+    end
+
     after do
       Rails.cache.write("hearings_prep_out_of_service", false)
     end
 
-    scenario "Out of service is disabled" do
-      visit "certifications/new/5555C"
+    let!(:current_user) do
+      User.authenticate!(roles: ["Hearings"])
+    end
+
+    scenario "When out of service is disabled, it shows Hearings page" do
+      visit "/hearings/dockets"
+      expect(page).to have_content("Upcoming Hearing Days")
       expect(page).to_not have_content("Technical Difficulties")
     end
 
-    scenario "Out of service is enabled" do
+    scenario "When out of service is enabled, it shows Out of service page" do
       Rails.cache.write("hearings_prep_out_of_service", true)
-      visit "certifications/new/5555C"
+      visit "/hearings/dockets"
       expect(page).to have_content("Technical Difficulties")
     end
   end
 
   context "Dispatch" do
-    let!(:current_user) { User.authenticate!(roles: ["Establish Claim", "Manage Claim Establishment"]) }
-
     after do
       Rails.cache.write("dispatch_out_of_service", false)
     end
 
-    scenario "Out of service is disabled" do
+    let!(:current_user) { User.authenticate!(roles: ["Establish Claim", "Manage Claim Establishment"]) }
+
+    let(:appeal) do
+      Generators::Appeal.create(vacols_record: vacols_record, documents: documents)
+    end
+
+    let(:vacols_record) { :remand_decided }
+
+    scenario "When out of service is disabled, it shows Work Assignments page" do
       visit "dispatch/establish-claim"
+      expect(page).to have_content("Your Work Assignments")
       expect(page).to_not have_content("Technical Difficulties")
     end
 
-    scenario "Out of service is enabled" do
+    scenario "When out of service is enabled, it shows Out of service page" do
       Rails.cache.write("dispatch_out_of_service", true)
       visit "dispatch/establish-claim"
       expect(page).to have_content("Technical Difficulties")


### PR DESCRIPTION
Connected to #2702 

Controllers responsible for application requests are:

- Certification:

 certifications_controller.rb, 

- Reader:

 reader/application_controller.rb, 

- Hearings prep:

 hearings_controller.rb, 

- Dispatch:

 tasks_controller.rb

![out](https://user-images.githubusercontent.com/4960030/28996325-4e730f82-79cc-11e7-9e35-431b2affffaa.gif)
