### PR TITLE
Fixing VBMS service

### DIFF
--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -31,7 +31,7 @@ class ExternalApi::VBMSService
     result && result.content
   end
 
-  def self.fetch_documents_for(appeal)
+  def self.fetch_documents_for(appeal, _user = nil)
     @vbms_client ||= init_vbms_client
 
     sanitized_id = appeal.sanitized_vbms_id


### PR DESCRIPTION
Connects: #2870 
We now pass an extra parameter to fetch_documents_for in our new eFolderService. We need to make the API the same for VBMSService so that the same call works.