### PR TITLE
Nemo/Included omitted options for no hearing as hearing preference.

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -44,12 +44,19 @@ class CertificationsController < ApplicationController
   def certify_v2
     update_certification_from_v2_form
     validate_data_presence_v2
+
+    if certification.hearing_preference == "NO_HEARING_DESIRED" || "NO_BOX_SELECTED" || "HEARING_CANCELLED"
+      hearing_requested = "No"
+    else
+      hearing_requested = "Yes"
+    end
+
     form8.update_from_string_params(
       representative_type: certification.rep_type,
       representative_name: certification.rep_name,
       hearing_preference: certification.hearing_preference,
       # This field is necessary when on v2 certification but v1 form8
-      hearing_requested: certification.hearing_preference == "NO_HEARING_DESIRED" || "NO_BOX_SELECTED" || "HEARING_CANCELLED" ? "No" : "Yes",
+      hearing_requested: hearing_requested,
       certifying_official_name: certification.certifying_official_name,
       certifying_official_title: certification.certifying_official_title
     )

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -49,7 +49,7 @@ class CertificationsController < ApplicationController
       representative_name: certification.rep_name,
       hearing_preference: certification.hearing_preference,
       # This field is necessary when on v2 certification but v1 form8
-      hearing_requested: certification.hearing_preference == "NO_HEARING_DESIRED" ? "No" : "Yes",
+      hearing_requested: certification.hearing_preference == "NO_HEARING_DESIRED" || "NO_BOX_SELECTED" || "HEARING_CANCELLED" ? "No" : "Yes",
       certifying_official_name: certification.certifying_official_name,
       certifying_official_title: certification.certifying_official_title
     )

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -45,7 +45,7 @@ class CertificationsController < ApplicationController
     update_certification_from_v2_form
     validate_data_presence_v2
 
-    if certification.hearing_preference == "NO_HEARING_DESIRED" || "NO_BOX_SELECTED" || "HEARING_CANCELLED"
+    if %w(NO_HEARING_DESIRED NO_BOX_SELECTED HEARING_CANCELLED).include?(certification.hearing_preference)
       hearing_requested = "No"
     else
       hearing_requested = "Yes"


### PR DESCRIPTION
To test, on ConfirmHearing page try following 3 scenarios:

1. Has the appellant requested a change to their hearing preference since submitting the Form 9?
 Yes
What did the appellant request in the document you found?
They cancelled their hearing request.

Result in DB:
Form8s: Hearing_requested: No
Certifications: Hearing_preference: HEARING_CANCELLED

2. Has the appellant requested a change to their hearing preference since submitting the Form 9?
No
Caseflow found the document below, labeled as a Form 9, from the appellant's eFolder. What type of substantive appeal is it?
Form 9
A. I do not want an optional board hearing

Result in DB:
Form8s: Hearing_requested: No
Certifications: Hearing_preference: NO_HEARING_DESIRED

3. Has the appellant requested a change to their hearing preference since submitting the Form 9?
No
Caseflow found the document below, labeled as a Form 9, from the appellant's eFolder. What type of substantive appeal is it?
Form 9
No box selected.

Result in DB:
Form8s: Hearing_requested: No
Certifications: Hearing_preference: NO_BOX_SELECTED

![hearing](https://user-images.githubusercontent.com/4960030/29073453-ace12a1e-7c19-11e7-8870-9e7bf532c08b.gif)

