### PR TITLE
Removing unused attribute from CaseAssignment VACOLS query

### DIFF
--- a/app/models/vacols/case_assignment.rb
+++ b/app/models/vacols/case_assignment.rb
@@ -16,7 +16,6 @@ class VACOLS::CaseAssignment < VACOLS::Record
       select("decass.defolder as vacols_id",
              "decass.deassign as date_assigned",
              "decass.dereceive as date_received",
-             "staff.slogid as vacols_user_id",
              "brieff.bfddec as signed_date",
              "brieff.bfcorlid as vbms_id",
              "corres.snamef as veteran_first_name",


### PR DESCRIPTION
Connects #2774 + #2804

- This broke because the Appeal model no longer has the `vacols_user_id` attribute
- I don't have a good way to set up unit tests for this. I tried to create doubles for the VACOLS::CaseAssignment class, but I couldn't get it to play nice since it acts as a model and a service.
    - This may be problematic in the future because we won't have any way of knowing if this is broken if any of the required attributes in the `Appeal` model are changed/removed.
    - Adding doubles also means we'll have to update the test whenever we change the `CaseAssignment` query. The test won't actually break if updates are made to the query, so it will have to be understood by people in the future making the change.
- I had Artem run the original query in UAT which returned:
```
{
"vacols_id"=>"SOME ##", 
"date_assigned"=>2000-12-11 00:00:00 UTC, 
"date_received"=>2000-12-27 00:00:00 UTC, 
"vacols_user_id"=>"SOMETHING", 
"signed_date"=>2001-01-02 00:00:00 UTC, 
"vbms_id"=>"60003775C", 
"veteran_first_name"=>"DJ", 
"veteran_middle_initial"=>nil, 
"veteran_last_name"=>"AWESOME"
}
```
- I tested this in the Rails console by removing `vacols_user_id` from the hash and ran:
```
a = Appeal.new
a.attributes = <test_hash>
```

This worked so all other columns returned by this query are fine.

