### PR TITLE
Include issues' note when pulled from Vacols

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -3,7 +3,7 @@
 # VACOLS' equivalent
 class Issue < ActiveRecord::Base
   attr_accessor :program, :type, :category, :description, :disposition, :levels,
-                :program_description
+                :program_description, :note
 
   belongs_to :appeal
   belongs_to :hearing, foreign_key: :appeal_id, primary_key: :appeal_id
@@ -92,6 +92,7 @@ class Issue < ActiveRecord::Base
         vacols_sequence_id: hash["issseq"],
         program: PROGRAMS[hash["issprog"]],
         type: { name: TYPES[hash["isscode"]], label: hash["isscode_label"] },
+        note: hash["issdesc"],
         category: CATEGORIES[category_code],
         program_description: "#{hash['issprog']} - #{hash['issprog_label']}",
         description: description(hash),

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -19,7 +19,7 @@ describe Issue do
       { "isskey" => "12345678",
         "issseq" => 1,
         "issdc" => "3",
-        "issdesc" => nil,
+        "issdesc" => "CERVICAL CONDITION AS CLAIMED",
         "issprog" => "02",
         "isscode" => "15",
         "isslev1" => "02",
@@ -40,6 +40,7 @@ describe Issue do
         name: :service_connection,
         label: "1151 Eligibility"
       )
+      expect(subject.note).to eq("CERVICAL CONDITION AS CLAIMED")
       expect(subject.description).to eq(["15 - 1151 Eligibility", "02 - Other", "03 - Left knee", "04 - Right knee"])
       expect(subject.disposition).to eq(:remanded)
     end


### PR DESCRIPTION
connects #2472 

Steps to validate:
1. Start rails c and ensure you are connected to Vacols dev env
2. Check one of the issues' note
`Apeal.find(id).issues.first.note`
3. Should return `note`. 