### PR TITLE
Pass ip address into the job

### DIFF
--- a/app/jobs/start_certification_job.rb
+++ b/app/jobs/start_certification_job.rb
@@ -1,8 +1,11 @@
 class StartCertificationJob < ActiveJob::Base
   queue_as :default
 
-  def perform(certification, user = nil)
+  def perform(certification, user = nil, ip_address = nil)
     RequestStore.store[:current_user] = user if user
+    # Passing in ip address since it's only available when
+    # the session is.
+    RequestStore.store[:ip_address] = ip_address if ip_address
     # Results in calls to VBMS and VACOLS
     status = certification.start!
     certification.fetch_power_of_attorney! if status == :started

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -18,7 +18,7 @@ class Certification < ActiveRecord::Base
 
     # We don't run sidekiq in development mode.
     if Rails.env.development? || Rails.env.test?
-      StartCertificationJob.perform_now(self, RequestStore[:current_user], RequestStore[:current_user].ip_address)
+      StartCertificationJob.perform_now(self)
     else
       StartCertificationJob.perform_later(self, RequestStore[:current_user], RequestStore[:current_user].ip_address)
     end

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -18,7 +18,6 @@ class Certification < ActiveRecord::Base
 
     # We don't run sidekiq in development mode.
     if Rails.env.development? || Rails.env.test?
-      binding.pry
       StartCertificationJob.perform_now(self, RequestStore[:current_user], RequestStore[:current_user].ip_address)
     else
       StartCertificationJob.perform_later(self, RequestStore[:current_user], RequestStore[:current_user].ip_address)

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -20,7 +20,7 @@ class Certification < ActiveRecord::Base
     if Rails.env.development? || Rails.env.test?
       StartCertificationJob.perform_now(self)
     else
-      StartCertificationJob.perform_later(self, current_user, current_user.ip_address)
+      StartCertificationJob.perform_later(self, RequestStore[:current_user], RequestStore[:current_user].ip_address)
     end
   end
 

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -20,7 +20,7 @@ class Certification < ActiveRecord::Base
     if Rails.env.development? || Rails.env.test?
       StartCertificationJob.perform_now(self)
     else
-      StartCertificationJob.perform_later(self, current_user)
+      StartCertificationJob.perform_later(self, RequestStore[:current_user])
     end
   end
 

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -20,7 +20,7 @@ class Certification < ActiveRecord::Base
     if Rails.env.development? || Rails.env.test?
       StartCertificationJob.perform_now(self)
     else
-      StartCertificationJob.perform_later(self, RequestStore[:current_user])
+      StartCertificationJob.perform_later(self, current_user, current_user.ip_address)
     end
   end
 

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -95,10 +95,15 @@ class ExternalApi::BGSService
     # Fetch current_user from global thread
     current_user = RequestStore[:current_user]
 
+    # This is here to make sure StartCertificationJob
+    # can pass the ip address to the BGS client.
+    # We should find a better way to do this.
+    ip_address = current_user.ip_address || RequestStore[:ip_address]
+
     BGS::Services.new(
       env: Rails.application.config.bgs_environment,
       application: "CASEFLOW",
-      client_ip: current_user.ip_address,
+      client_ip: ip_address,
       client_station_id: current_user.station_id,
       client_username: current_user.css_id,
       ssl_cert_key_file: ENV["BGS_KEY_LOCATION"],


### PR DESCRIPTION
Fix for an issue involving `current_user`'s non-persistent properties not getting passed to the job.
```
DEBUG -- : <?xml version=
'1.0' encoding='UTF-8'?><S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/"><S:Header><work:WorkContext xmlns:work="http://oracle.com/weblogic/soap/workarea/">rO0ABXdUAB13ZWJsb2dpYy5hcHAuQ29yc
G9yYXRlRGF0YUVBUgAAANYAAAAjd2VibG9naWMud29ya2FyZWEuU3RyaW5nV29ya0NvbnRleHQABjEwLjIuMAAA</work:WorkContext></S:Header><S:Body><S:Fault xmlns:ns4="http://www.w3.org/2003/05/soap-envelope"><faultcode>S:Client</faultcode><faultstring>ID: 7FF88841-E3E5-4D69-A8C3-0AB8C3FAD86A: Header element CLIENT_MACHINE is missing.</faultstring></S:Fault></S:Body></S:Envelope>
```