### PR TITLE
Reader | Align all case information on landing page

### DIFF
--- a/app/assets/stylesheets/reader/_assignment_list.scss
+++ b/app/assets/stylesheets/reader/_assignment_list.scss
@@ -10,6 +10,6 @@
 
   td {
     vertical-align: top;
-    padding-top: 20px;
+    padding-top: 15px;
   }
 }

--- a/app/assets/stylesheets/reader/_assignment_list.scss
+++ b/app/assets/stylesheets/reader/_assignment_list.scss
@@ -1,9 +1,15 @@
 .assignment-list {
   .issue-list {
     padding-left: 0;
+    margin-top: 0;
   }
 
   .issue-level {
     margin: 0;
+  }
+
+  td {
+    vertical-align: top;
+    padding-top: 20px;
   }
 }


### PR DESCRIPTION
This aligns all the information in each assignment to the top of the row.
Connects #2820 
<img width="1029" alt="screen shot 2017-08-09 at 2 21 46 pm" src="https://user-images.githubusercontent.com/4773320/29137604-e5e737fe-7d0e-11e7-84b0-9f6ec91773d1.png">
