### PR TITLE
Anya/2691 aod diary entry

### DIFF
--- a/app/helpers/vacols_helper.rb
+++ b/app/helpers/vacols_helper.rb
@@ -9,7 +9,7 @@ module VacolsHelper
     Time.utc(value.year, value.month, value.day, value.hour, value.min, value.sec)
   end
 
-  def self.validate_presence!(note, required_fields)
+  def self.validate_presence(note, required_fields)
     missing_keys = []
     required_fields.each { |k| missing_keys << k unless note[k] }
     fail(MissingRequiredFieldError, "Required fields: #{missing_keys.join(', ')}") unless missing_keys.empty?

--- a/app/helpers/vacols_helper.rb
+++ b/app/helpers/vacols_helper.rb
@@ -1,5 +1,4 @@
 module VacolsHelper
-
   class MissingRequiredFieldError < StandardError; end
 
   # There is a bug in Vacols where timestamps are saved in local time with UTC timezone

--- a/app/helpers/vacols_helper.rb
+++ b/app/helpers/vacols_helper.rb
@@ -1,8 +1,17 @@
 module VacolsHelper
+
+  class MissingRequiredFieldError < StandardError; end
+
   # There is a bug in Vacols where timestamps are saved in local time with UTC timezone
   # for example, Fri, 28 Jul 2017 14:28:01 UTC +00:00 is actually an EST time with UTC timezone
   def self.local_time_with_utc_timezone
     value = Time.zone.now.in_time_zone("Eastern Time (US & Canada)")
     Time.utc(value.year, value.month, value.day, value.hour, value.min, value.sec)
+  end
+
+  def self.validate_presence!(note, required_fields)
+    missing_keys = []
+    required_fields.each { |k| missing_keys << k unless note[k] }
+    fail(MissingRequiredFieldError, "Required fields: #{missing_keys.join(', ')}") unless missing_keys.empty?
   end
 end

--- a/app/models/vacols/actcode.rb
+++ b/app/models/vacols/actcode.rb
@@ -1,0 +1,4 @@
+class VACOLS::Actcode < VACOLS::Record
+  self.table_name = "vacols.actcode"
+  self.primary_key = "actckey"
+end

--- a/app/models/vacols/note.rb
+++ b/app/models/vacols/note.rb
@@ -96,7 +96,7 @@ class VACOLS::Note < VACOLS::Record
       record = find_active_by_user_and_type(note)
       return create!(note) unless record
 
-      VacolsHelper.validate_presence!(note, [:days_to_complete, :days_til_due])
+      VacolsHelper.validate_presence(note, [:days_to_complete, :days_til_due])
 
       record.update!(tskmdtm: VacolsHelper.local_time_with_utc_timezone,
                      tskdtc: note[:days_to_complete],
@@ -113,7 +113,7 @@ class VACOLS::Note < VACOLS::Record
     end
 
     def validate!(note)
-      VacolsHelper.validate_presence!(note, [:days_to_complete, :days_til_due, :code, :user_id, :assigned_to, :case_id, :text])
+      VacolsHelper.validate_presence(note, [:days_to_complete, :days_til_due, :code, :user_id, :assigned_to, :case_id, :text])
       fail(InvalidNotelengthError) if note[:text].length > 280
       fail(InvalidNoteCodeError) unless CODE_ACTKEY_MAPPING[note[:code]]
     end

--- a/app/models/vacols/note.rb
+++ b/app/models/vacols/note.rb
@@ -113,7 +113,8 @@ class VACOLS::Note < VACOLS::Record
     end
 
     def validate!(note)
-      VacolsHelper.validate_presence(note, [:days_to_complete, :days_til_due, :code, :user_id, :assigned_to, :case_id, :text])
+      required_fields = [:days_to_complete, :days_til_due, :code, :user_id, :assigned_to, :case_id, :text]
+      VacolsHelper.validate_presence(note, required_fields)
       fail(InvalidNotelengthError) if note[:text].length > 280
       fail(InvalidNoteCodeError) unless CODE_ACTKEY_MAPPING[note[:code]]
     end

--- a/spec/helpers/vacols_helper_spec.rb
+++ b/spec/helpers/vacols_helper_spec.rb
@@ -12,4 +12,30 @@ describe VacolsHelper do
       expect(subject.zone).to eq "UTC"
     end
   end
+
+  context ".validate_presence" do
+    subject { VacolsHelper.validate_presence(hash, required_keys) }
+
+    context "when there is a missing field" do
+      let(:hash) do
+        { foo: "bar", grip: "foo" }
+      end
+      let(:required_keys) { [:foo, :grip, :dre] }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(VacolsHelper::MissingRequiredFieldError)
+      end
+    end
+
+    context "when there is no missing field" do
+      let(:hash) do
+        { foo: "bar", grip: "foo" }
+      end
+      let(:required_keys) { [:foo, :grip] }
+
+      it "raises an error" do
+        expect { subject }.to_not raise_error(VacolsHelper::MissingRequiredFieldError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
connects #2691 

Steps to validate:
1. Start `rails c` and ensure you are connected to Vacols dev env
2. Set the user in the RequestStore:
```RequestStore.store[:current_user] = User.new(css_id: CSFLOW1")```
3. Find a hearing in the hearings table (make sure it exists in Vacols)
```h = Hearing.find(id)```
4. Update aod to granted or filed on the hearing object which should in turn trigger a create for an B diary (and B1 diary if brieff.bfso == "G"). For example,
```
h.update(aod: :granted)
```
5. The same diary should be created only once for the same user. Subsequent updates to aod, should update the existing diary (fields to be updated: `tskmdtm`, `tskdtc`, `tskddue`.
6. How do you determine if the query is the same? Based on these fields:
```
VACOLS::Note.find_by(
        tsktknm: note[:case_id],
        tskstown: note[:user_id],
        tskadusr: note[:user_id],
        tskactcd: CODE_ACTKEY_MAPPING[note[:code]],
        tskstat: "P"
      )
```
7. If we set aod to nil or none, the diaries should be deleted
8. Follow AC in the ticket to find out which fields should be updated.
