### PR TITLE
Remove references to date_diff

### DIFF
--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -41,10 +41,10 @@ class VACOLS::CaseHearing < VACOLS::Record
     vdkey is NOT NULL
   ).freeze
 
-  WITHOUT_DISPOSITION = %{
+  WITHOUT_DISPOSITION = %(
     hearing_disp IS NULL
     -- an older hearing still awaiting a disposition
-  }.freeze
+  ).freeze
 
   after_update :update_hearing_action, if: :hearing_disp_changed?
   after_update :create_or_update_diaries

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -41,11 +41,8 @@ class VACOLS::CaseHearing < VACOLS::Record
     vdkey is NOT NULL
   ).freeze
 
-  WITHOUT_DISPOSITION_OR_AFTER_DATE = %{
-    hearing_date >= to_date(?, 'YYYY-MM-DD HH24:MI')
-    -- Hearing is after a provided date (a recent hearing)
-
-    OR hearing_disp IS NULL
+  WITHOUT_DISPOSITION = %{
+    hearing_disp IS NULL
     -- an older hearing still awaiting a disposition
   }.freeze
 
@@ -59,8 +56,7 @@ class VACOLS::CaseHearing < VACOLS::Record
 
       select_hearings
         .where("staff.sdomainid = #{id}")
-        .where(WITHOUT_DISPOSITION_OR_AFTER_DATE,
-               relative_vacols_date(date_diff).to_formatted_s(:oracle_date))
+        .where(WITHOUT_DISPOSITION)
         .where(NOT_MASTER_RECORD)
     end
 


### PR DESCRIPTION
- Previous PR removed the date_diff parameter but failed to remove all
  references

#### Test Plan
- Copied the code to UAT and ran `VACOLS::CaseHearing.upcoming_for_judge(User.first.css_id)`. Verified the query comes back successfully