### PR TITLE
Fix PDF hang on eFolder integration 

### DIFF
--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -615,7 +615,7 @@ export class Pdf extends React.PureComponent {
     this.updatePageBounds();
   }
 
-  comopnentWillUnmount() {
+  componentWillUnmount() {
     window.removeEventListener('resize', this.drawInViewPages);
     window.removeEventListener('keydown', this.keyListener);
   }

--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -670,9 +670,9 @@ export class Pdf extends React.PureComponent {
     if (nextProps.prefetchFiles !== this.props.prefetchFiles) {
       const pdfsToKeep = [...nextProps.prefetchFiles, nextProps.file];
 
-      Object.keys(this.predrawnPdfs).forEach((pdf) => {
-        if (!pdfsToKeep.includes(pdf)) {
-          this.cleanUpPdf(this.predrawnPdfs[pdf], pdf);
+      Object.keys(this.predrawnPdfs).forEach((file) => {
+        if (!pdfsToKeep.includes(file)) {
+          this.cleanUpPdf(this.predrawnPdfs[file], file);
         }
       });
 

--- a/client/app/components/Pdf.jsx
+++ b/client/app/components/Pdf.jsx
@@ -670,7 +670,11 @@ export class Pdf extends React.PureComponent {
     if (nextProps.prefetchFiles !== this.props.prefetchFiles) {
       const pdfsToKeep = [...nextProps.prefetchFiles, nextProps.file];
 
-      _.forEach(_.omit(this.predrawnPdfs, pdfsToKeep), this.cleanUpPdf);
+      Object.keys(this.predrawnPdfs).forEach((pdf) => {
+        if (!pdfsToKeep.includes(pdf)) {
+          this.cleanUpPdf(this.predrawnPdfs[pdf], pdf);
+        }
+      });
 
       this.predrawnPdfs = _.pick(this.predrawnPdfs, pdfsToKeep);
     }


### PR DESCRIPTION
Connects: #2960 

Currently when we turn on the eFolder integration, EVERYTHING HANGS when switching PDFs. After some digging we found that lodash's omit function accepts keys to omit, or paths to omit (where a path is defined with `.`). The idea being that you can deep omit into a nested object.

This worked fine with our old pdf urls since they were local and didn't contain the part of the URL with `.`. But when we move to eFolder we needed an absolute url which started with `efolder.` This matched the regex they use to determine if we are specifying a path, which triggered a deep clone of the object. Deep cloning this particular object takes a long time since the PDF objects are really big!

This was a breaking change introduced last year: https://github.com/lodash/lodash/pull/2794

**Test Plan**
- [ ] Monkey patched in UAT, verified that switching PDFs was fast.
- [ ] Added a breakpoint in the cleanupPdf code locally to ensure it was still being called.