### PR TITLE
Update user reference in HearingRepository to use css_id

### DIFF
--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -74,7 +74,7 @@ class VACOLS::CaseHearing < VACOLS::Record
       # VACOLS overloads the HEARSCHED table with other types of hearings
       # that work differently. Filter those out.
       select("VACOLS.HEARING_VENUE(vdkey) as hearing_venue",
-             "staff.stafkey as user_id",
+             "staff.sdomainid as css_id",
              :hearing_disp,
              :hearing_pkseq,
              :hearing_date,

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -46,7 +46,7 @@ class HearingRepository
         Hearing.find_or_create_by(vacols_id: vacols_record.hearing_pkseq).tap do |hearing|
           hearing.attributes = {
             appeal: Appeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
-            user: User.find_by(vacols_id: vacols_record.user_id)
+            user: User.find_by(css_id: vacols_record.css_id)
           }
           set_vacols_values(hearing, vacols_record)
         end


### PR DESCRIPTION
- Previously query was referencing now-removed User vacols_id column.
  Instead we want to reference the css_id column. We will probably want
  to make further adjustments to optimize this part of the code, but this
  is sufficient for now to get hearing prep working again

connects #3001

#### Test Plan:
- Ran the full controller query on UAT: `Judge.new(current_user).upcoming_dockets`
<img width="831" alt="screen shot 2017-08-16 at 2 46 32 pm" src="https://user-images.githubusercontent.com/2256237/29380388-938808c8-8293-11e7-845c-52676693238e.png">
- Verified the hearing record object returns a `css_id` attribute 
<img width="468" alt="screen shot 2017-08-16 at 2 41 13 pm" src="https://user-images.githubusercontent.com/2256237/29380408-a35dd7d2-8293-11e7-8794-7e8e2cd197cb.png">
- Verified Appeals status API still works (touches the same code), running ` Appeal.for_api(appellant_ssn: "091788897")`
<img width="575" alt="screen shot 2017-08-16 at 3 01 58 pm" src="https://user-images.githubusercontent.com/2256237/29380488-de4bb882-8293-11e7-83d7-5a61038b6a69.png">

