### PR TITLE
Load appeals ready for hearing by vbms ID for the hearing prep

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -23,6 +23,10 @@ class Hearing < ActiveRecord::Base
     date && !closed?
   end
 
+  def active_appeal_streams
+    self.class.repository.appeals_ready_for_hearing(appeal.vbms_id)
+  end
+
   def update(hearing_hash)
     transaction do
       self.class.repository.update_vacols_hearing!(vacols_record, hearing_hash)

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -21,6 +21,10 @@ class HearingRepository
     rescue ActiveRecord::RecordNotFound
       false
     end
+
+    def appeals_ready_for_hearing(vbms_id)
+      AppealRepository.appeals_ready_for_hearing(vbms_id)
+    end
     # :nocov:
 
     def set_vacols_values(hearing, vacols_record)

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -37,6 +37,20 @@ class AppealRepository
     cases.map { |case_record| build_appeal(case_record) }
   end
 
+  def self.appeals_ready_for_hearing(vbms_id)
+    cases = MetricsService.record("VACOLS: appeals_ready_for_hearing",
+                                  service: :vacols,
+                                  name: "appeals_ready_for_hearing") do
+      # An appeal is ready for hearing if form 9 has been submitted, but no decision
+      # has yet been made
+      VACOLS::Case.where(bfcorlid: vbms_id, bfddec: nil)
+                  .where.not(bfd19: nil)
+                  .includes(:folder, :correspondent)
+    end
+
+    cases.map { |case_record| build_appeal(case_record) }
+  end
+
   def self.load_vacols_data_by_vbms_id(appeal:, decision_type:)
     case_scope = case decision_type
                  when "Full Grant"

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -93,6 +93,12 @@ class Fakes::AppealRepository
     true
   end
 
+  def self.appeals_ready_for_hearing(vbms_id)
+    (records || []).select do |_, a|
+      a[:vbms_id] == vbms_id && a[:decision_date].nil? && !a[:form9_date].nil?
+    end
+  end
+
   def self.load_vacols_data_by_vbms_id(appeal:, decision_type:)
     Rails.logger.info("Load faked VACOLS data for appeal VBMS ID: #{appeal.vbms_id}")
     Rails.logger.info("Decision Type:\n#{decision_type}")

--- a/lib/fakes/hearing_repository.rb
+++ b/lib/fakes/hearing_repository.rb
@@ -30,6 +30,10 @@ class Fakes::HearingRepository
     true
   end
 
+  def self.appeals_ready_for_hearing(vbms_id)
+    Fakes::AppealRepository.appeals_ready_for_hearing(vbms_id)
+  end
+
   def self.find_by_vacols_id(vacols_id)
     hearing_records.find { |h| h.vacols_id == vacols_id }
   end

--- a/lib/generators/appeal.rb
+++ b/lib/generators/appeal.rb
@@ -28,7 +28,8 @@ class Generators::Appeal
         appellant_last_name: last_name,
         appellant_relationship: "Child",
         regional_office_key: "RO13",
-        decision_date: 7.days.ago
+        decision_date: 7.days.ago,
+        form9_date: 11.days.ago
       }
     end
 
@@ -48,6 +49,10 @@ class Generators::Appeal
         },
         certified: {
           certification_date: 1.day.ago
+        },
+        form9_not_submitted: {
+          decision_date: nil,
+          form9_date: nil
         },
         pending_hearing: {
           status: "Active",
@@ -207,7 +212,6 @@ class Generators::Appeal
                                     end
 
       template = vacols_record_templates[template_key] || {}
-
       vacols_record_default_attrs.merge(template).merge(vacols_record)
     end
   end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -1,5 +1,27 @@
 describe Hearing do
-  context ".update" do
+  context "#active_appeal_streams" do
+    subject { hearing.active_appeal_streams }
+
+    let(:appeal1) do
+      Generators::Appeal.create(vacols_record: { template: :pending_hearing }, vbms_id: "123C")
+    end
+    let!(:appeal2) do
+      Generators::Appeal.create(vacols_record: { template: :remand_decided }, vbms_id: "123C")
+    end
+    let!(:appeal3) do
+      Generators::Appeal.create(vacols_record: { template: :pending_hearing }, vbms_id: "123C")
+    end
+    let!(:appeal4) do
+      Generators::Appeal.create(vacols_record: { template: :form9_not_submitted }, vbms_id: "123C")
+    end
+    let(:hearing) { Generators::Hearing.create(appeal_id: appeal1.id) }
+
+    it "returns active appeals with no decision date and with form9 date" do
+      expect(subject.size).to eq 2
+    end
+  end
+
+  context "#update" do
     subject { hearing.update(hearing_hash) }
     let(:hearing) { Generators::Hearing.build }
 


### PR DESCRIPTION
connects #2245 

Steps to validate:
1. Start `rails c` in UAT Caseflow server and ensure you are connected to the Vacols dev env
3. Find a hearing in the hearings table (make sure it exists in Vacols)
```h = Hearing.find(id)```
4. Run `h.active_appeal_streams` and ensure it returns all active appeals associated with the hearing appeal's vbms id
Note:  Active appeal is an appeal where bfrieff.bfddec is nil and brieff.bfd19 is NOT nil
5. Find more hearings that have more than one appeal; ensure all ACTIVE appeals are being returned for that hearing

