### PR TITLE
Styleguide | Search ahead

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -594,52 +594,6 @@ select {
   }
 }
 
-.usa-search {
-  &.usa-search-big {
-    [type="submit"] {
-      background-image: none;
-
-      &[class*="cf-loading"] {
-        width: 14rem;
-      }
-    }
-
-    [type="button"].cf-search-close-icon {
-      margin-left: -20px;
-      margin-top: 6px;
-      position: absolute;
-    }
-  }
-
-  &.usa-search-small {
-    [type="submit"] {
-
-      &[class*="cf-loading"] {
-        width: 13rem;
-        background-image: none;
-      }
-    }
-  }
-
-  &.cf-search-ahead {
-    flex-grow: 1;
-
-    input {
-      &::placeholder {
-        font-style: italic;
-      }
-    }
-  }
-
-  [type="search"] {
-    border: 1px solid $color-gray-dark;
-  }
-}
-
-.cf-search-ahead-parent {
-  display: flex;
-}
-
 .cf-title-meta-right {
   line-height: 1em;
   margin-bottom: 1.76em;

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -603,6 +603,11 @@ select {
         width: 14rem;
       }
     }
+    [type="button"].cf-search-close-icon {
+      margin-left: -20px;
+      margin-top: 6px;
+      position: absolute;
+    }
   }
 
   &.usa-search-small {
@@ -615,9 +620,23 @@ select {
     }
   }
 
+  &.cf-search-ahead {
+    flex-grow: 1;
+
+    input {
+      &::placeholder {
+        font-style: italic;
+      }
+    }
+  }
+
   [type="search"]{
     border: 1px solid $color-gray-dark;
   }
+}
+
+.cf-search-ahead-parent {
+  display: flex;
 }
 
 .cf-title-meta-right {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -610,6 +610,10 @@ select {
       }
     }
   }
+
+  [type="search"]{
+    border: 1px solid $color-gray-dark;
+  }
 }
 
 .cf-title-meta-right {
@@ -720,4 +724,3 @@ select {
   font-size: 22px;
   color: $color-gray-dark;
 }
-

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -603,6 +603,7 @@ select {
         width: 14rem;
       }
     }
+
     [type="button"].cf-search-close-icon {
       margin-left: -20px;
       margin-top: 6px;
@@ -630,7 +631,7 @@ select {
     }
   }
 
-  [type="search"]{
+  [type="search"] {
     border: 1px solid $color-gray-dark;
   }
 }

--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -629,10 +629,12 @@ input[type="search"].cf-search-input-with-close {
 }
 // scss-lint:enable QualifyingElement
 
-[type="button"].cf-search-close-icon {
-  margin-left: -20px;
-  margin-top: 2px;
-  position: absolute;
+.usa-search-small {
+  [type="button"].cf-search-close-icon {
+    margin-left: -20px;
+    margin-top: 2px;
+    position: absolute;
+  }
 }
 
 .cf-pdf-page-hidden {

--- a/app/assets/stylesheets/_style_guide.scss
+++ b/app/assets/stylesheets/_style_guide.scss
@@ -236,6 +236,8 @@ pre {
     position: relative;
     left: auto;
   }
+
+  margin-bottom: 15px;
 }
 
 .cf-sg-loader {

--- a/app/assets/stylesheets/react/_react_styles_root.css
+++ b/app/assets/stylesheets/react/_react_styles_root.css
@@ -14,4 +14,5 @@
  *= require ./_toggle_button.scss
  *= require ./_performance_degradation_banner.scss
  *= require ./_loading-message.scss
+ *= require ./_search_bar.scss
  */

--- a/app/assets/stylesheets/react/_search_bar.scss
+++ b/app/assets/stylesheets/react/_search_bar.scss
@@ -1,4 +1,4 @@
-/* TODO(marian): add all styles in this file to commons */
+// TODO(marian): add all styles in this file to commons
 @import 'uswds/lib/addons/font-stacks';
 @import 'uswds/core/variables';
 

--- a/app/assets/stylesheets/react/_search_bar.scss
+++ b/app/assets/stylesheets/react/_search_bar.scss
@@ -1,0 +1,49 @@
+/* TODO(marian): add all styles in this file to commons */
+@import 'uswds/lib/addons/font-stacks';
+@import 'uswds/core/variables';
+
+.usa-search {
+  &.usa-search-big {
+    [type="submit"] {
+      background-image: none;
+
+      &[class*="cf-loading"] {
+        width: 14rem;
+      }
+    }
+
+    [type="button"].cf-search-close-icon {
+      margin-left: -20px;
+      margin-top: 6px;
+      position: absolute;
+    }
+  }
+
+  &.usa-search-small {
+    [type="submit"] {
+
+      &[class*="cf-loading"] {
+        width: 13rem;
+        background-image: none;
+      }
+    }
+  }
+
+  &.cf-search-ahead {
+    flex-grow: 1;
+
+    input {
+      &::placeholder {
+        font-style: italic;
+      }
+    }
+  }
+
+  [type="search"] {
+    border: 1px solid $color-gray-dark;
+  }
+}
+
+.cf-search-ahead-parent {
+  display: flex;
+}

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -297,11 +297,9 @@ $tag-backgrond-color: #d6d7d9;
   justify-content: space-between;
 
   .search-bar-and-doc-count {
-    display: flex;
     flex-grow: 2;
 
     .usa-search {
-      margin-right: 25px;
       flex-grow: 1;
     }
 

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -52,6 +52,7 @@ export default class SearchBar extends React.Component {
       loading,
       onClearSearch,
       size,
+      placeholder,
       title
     } = this.props;
 
@@ -80,6 +81,7 @@ export default class SearchBar extends React.Component {
         onBlur={this.onBlur}
         type="search"
         name="search"
+        placeholder={placeholder}
         value={value}/>
       {_.size(value) > 0 &&
         <Button
@@ -108,4 +110,3 @@ SearchBar.propTypes = {
   value: PropTypes.string,
   analyticsCategory: PropTypes.string
 };
-

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -72,8 +72,6 @@ export default class SearchBar extends React.Component {
       'usa-search-small': size === 'small'
     });
 
-    const removeSearchButton = isSearchAhead ? {float: 'none'} : null;
-
     return <span className={sizeClasses} role="search">
       <label className={title ? label : 'usa-sr-only'} htmlFor={id}>
         {title || 'Search small'}
@@ -87,7 +85,7 @@ export default class SearchBar extends React.Component {
         name="search"
         placeholder={placeholder}
         value={value}
-        style={removeSearchButton}/>
+        style={isSearchAhead ? {float: 'none'} : null}/>
       {_.size(value) > 0 &&
         <Button
           ariaLabel="clear search"

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -58,9 +58,10 @@ export default class SearchBar extends React.Component {
       title
     } = this.props;
 
-    const sizeClasses = classnames('usa-search', {
+    const searchTypeClasses = classnames('usa-search', {
       'usa-search-big': size === 'big',
-      'usa-search-small': size === 'small'
+      'usa-search-small': size === 'small',
+      'cf-search-ahead': isSearchAhead
     });
 
     const buttonClassNames = classnames({
@@ -72,7 +73,7 @@ export default class SearchBar extends React.Component {
       'usa-search-small': size === 'small'
     });
 
-    return <span className={sizeClasses} role="search">
+    return <span className={searchTypeClasses} role="search">
       <label className={title ? label : 'usa-sr-only'} htmlFor={id}>
         {title || 'Search small'}
       </label>
@@ -84,8 +85,7 @@ export default class SearchBar extends React.Component {
         type="search"
         name="search"
         placeholder={placeholder}
-        value={value}
-        style={isSearchAhead ? {float: 'none'} : null}/>
+        value={value}/>
       {_.size(value) > 0 &&
         <Button
           ariaLabel="clear search"

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -51,6 +51,7 @@ export default class SearchBar extends React.Component {
       value,
       loading,
       onClearSearch,
+      isSearchAhead,
       onClick,
       size,
       placeholder,
@@ -92,9 +93,9 @@ export default class SearchBar extends React.Component {
           onClick={onClearSearch}>
           {closeIcon()}
         </Button>}
-      <Button name={`search-${id}`} onClick={onClick} type="submit" loading={loading}>
+      { !isSearchAhead && <Button name={`search-${id}`} onClick={onClick} type="submit" loading={loading}>
         <span className={buttonClassNames}>Search</span>
-      </Button>
+      </Button> }
     </span>;
   }
 }

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -51,6 +51,7 @@ export default class SearchBar extends React.Component {
       value,
       loading,
       onClearSearch,
+      onClick,
       size,
       placeholder,
       title
@@ -91,7 +92,7 @@ export default class SearchBar extends React.Component {
           onClick={onClearSearch}>
           {closeIcon()}
         </Button>}
-      <Button name={`search-${id}`} type="submit" loading={loading}>
+      <Button name={`search-${id}`} onClick={onClick} type="submit" loading={loading}>
         <span className={buttonClassNames}>Search</span>
       </Button>
     </span>;

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -72,6 +72,8 @@ export default class SearchBar extends React.Component {
       'usa-search-small': size === 'small'
     });
 
+    const removeSearchButton = isSearchAhead ? {float: 'none'} : null;
+
     return <span className={sizeClasses} role="search">
       <label className={title ? label : 'usa-sr-only'} htmlFor={id}>
         {title || 'Search small'}
@@ -84,7 +86,8 @@ export default class SearchBar extends React.Component {
         type="search"
         name="search"
         placeholder={placeholder}
-        value={value}/>
+        value={value}
+        style={removeSearchButton}/>
       {_.size(value) > 0 &&
         <Button
           ariaLabel="clear search"

--- a/client/app/components/reader/DocumentListHeader.jsx
+++ b/client/app/components/reader/DocumentListHeader.jsx
@@ -30,6 +30,7 @@ class DocumentListHeader extends React.Component {
             onClearSearch={props.clearSearch}
             recordSearch={this.recordSearch}
             isSearchAhead={true}
+            placeholder="Type to search..."
             value={props.docFilterCriteria.searchQuery}
             size="small"
             analyticsCategory="Claims Folder"

--- a/client/app/components/reader/DocumentListHeader.jsx
+++ b/client/app/components/reader/DocumentListHeader.jsx
@@ -23,7 +23,7 @@ class DocumentListHeader extends React.Component {
 
     return <div>
       <div className="document-list-header">
-        <div className="search-bar-and-doc-count">
+        <div className="search-bar-and-doc-count cf-search-ahead-parent">
           <SearchBar
             id="searchBar"
             onChange={props.setSearch}

--- a/client/app/components/reader/DocumentListHeader.jsx
+++ b/client/app/components/reader/DocumentListHeader.jsx
@@ -29,6 +29,7 @@ class DocumentListHeader extends React.Component {
             onChange={props.setSearch}
             onClearSearch={props.clearSearch}
             recordSearch={this.recordSearch}
+            isSearchAhead={true}
             value={props.docFilterCriteria.searchQuery}
             size="small"
             analyticsCategory="Claims Folder"

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -9,9 +9,9 @@ class StyleGuideSearch extends Component {
     this.state = {
       loading: {
         small: false,
-        big: false,
-        searchAheadValue: ''
-      }
+        big: false
+      },
+      searchAheadValue: ''
     };
 
   }
@@ -32,9 +32,36 @@ class StyleGuideSearch extends Component {
 
   handleSmallClick = () => this.handleSearchClick('small')
 
-  onChange = (value) => this.setState({ value });
+  onChange = (searchBarName) => {
+    const changeState = () => {
+      this.setState({searchBarName: event.target.value});
+    }
+
+    changeState();
+  }
+
+  changeSmallValue = () => this.onChange('smallValue');
+
+  changeBigValue = () => this.onChange('bigValue');
+
+  changeSearchAheadValue = () => this.onChange('searchAheadValue');
+
+  onClearSearch = (searchBarName) => {
+    const clearSearch = () => {
+      this.setState({searchBarName: ''});
+    }
+
+    clearSearch();
+  }
+
+  clearSmallValue = () => this.onClearSearch('smallValue');
+
+  clearBigValue = () => this.onClearSearch('bigValue');
+
+  clearSearchAheadValue = () => this.onClearSearch('searchAheadValue');
 
   render() {
+    console.log("my value " , this.state.searchAheadValue);
 
     return (
       <div>
@@ -65,9 +92,11 @@ class StyleGuideSearch extends Component {
             id="search-big"
             title="Search Big"
             size="big"
+            onChange={this.changeBigValue}
             onClick={this.handleBigClick}
+            onClearSearch={this.clearSmallValue}
             loading={this.state.big}
-            onChange={this.onChange}
+            value={this.state.value}
           />
         </div>
         <div className="cf-sg-searchbar-example">
@@ -75,9 +104,11 @@ class StyleGuideSearch extends Component {
             id="search-small"
             title="Search Small"
             size="small"
+            onChange={this.changeSmallValue}
             onClick={this.handleSmallClick}
+            onClearSearch={this.clearBigValue}
             loading={this.state.small}
-            onChange={this.onChange}
+            value={this.state.value}
           />
        </div>
        <div className="cf-sg-searchbar-example">
@@ -85,9 +116,11 @@ class StyleGuideSearch extends Component {
            id="search-ahead"
            title="Search Ahead"
            size="small"
+           onChange={this.changeSearchAheadValue}
+           onClearSearch={this.clearSearchAheadValue}
            placeholder="Type to search..."
-           onChange={this.onChange}
            isSearchAhead={true}
+           value={this.state.searchAheadValue}
          />
       </div>
     </div>

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -9,7 +9,8 @@ class StyleGuideSearch extends Component {
     this.state = {
       loading: {
         small: false,
-        big: false
+        big: false,
+        searchAhead: false
       }
     };
 
@@ -30,6 +31,8 @@ class StyleGuideSearch extends Component {
   handleBigClick = () => this.handleSearchClick('big')
 
   handleSmallClick = () => this.handleSearchClick('small')
+
+  handleSearchAheadClick = () => this.handleSearchClick('searchAhead')
 
   render() {
 
@@ -70,6 +73,16 @@ class StyleGuideSearch extends Component {
             loading={this.state.small}
           />
        </div>
+       <div className="cf-sg-searchbar-example">
+         <SearchBar
+           id="search-ahead"
+           title="Search Ahead"
+           size="small"
+           placeholder="Type to search..."
+           onClick={this.handleSearchAheadClick}
+           loading={this.state.searchAhead}
+         />
+      </div>
     </div>
     );
   }

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -36,8 +36,8 @@ class StyleGuideSearch extends Component {
 
   onChange = (searchBarName, value) => {
     const changeState = () => {
-      this.setState({[searchBarName]: value});
-    }
+      this.setState({ [searchBarName]: value });
+    };
 
     changeState();
   }
@@ -50,8 +50,8 @@ class StyleGuideSearch extends Component {
 
   onClearSearch = (searchBarName) => {
     const clearSearch = () => {
-      this.setState({[searchBarName]: ''});
-    }
+      this.setState({ [searchBarName]: '' });
+    };
 
     clearSearch();
   }

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -10,8 +10,7 @@ class StyleGuideSearch extends Component {
       loading: {
         small: false,
         big: false
-      },
-      searchAheadValue: ''
+      }
     };
 
   }
@@ -32,37 +31,35 @@ class StyleGuideSearch extends Component {
 
   handleSmallClick = () => this.handleSearchClick('small')
 
-  onChange = (searchBarName) => {
+  onChange = (searchBarName, value) => {
     const changeState = () => {
-      this.setState({searchBarName: event.target.value});
+      this.setState({[searchBarName]: value});
     }
 
     changeState();
   }
 
-  changeSmallValue = () => this.onChange('smallValue');
+  changeSmallValue = (value) => this.onChange('smallValue', value);
 
-  changeBigValue = () => this.onChange('bigValue');
+  changeBigValue = (value) => this.onChange('bigValue', value);
 
-  changeSearchAheadValue = () => this.onChange('searchAheadValue');
+  changeSearchAheadValue = (value) => this.onChange('searchAheadValue', value);
 
   onClearSearch = (searchBarName) => {
     const clearSearch = () => {
-      this.setState({searchBarName: ''});
+      this.setState({[searchBarName]: ''});
     }
 
     clearSearch();
   }
 
-  clearSmallValue = () => this.onClearSearch('smallValue');
+  clearSmallValue = () => this.onClearSearch('smallValue', value);
 
-  clearBigValue = () => this.onClearSearch('bigValue');
+  clearBigValue = () => this.onClearSearch('bigValue', value);
 
-  clearSearchAheadValue = () => this.onClearSearch('searchAheadValue');
+  clearSearchAheadValue = () => this.onClearSearch('searchAheadValue', value);
 
   render() {
-    console.log("my value " , this.state.searchAheadValue);
-
     return (
       <div>
         <StyleGuideComponentTitle
@@ -96,7 +93,6 @@ class StyleGuideSearch extends Component {
             onClick={this.handleBigClick}
             onClearSearch={this.clearSmallValue}
             loading={this.state.big}
-            value={this.state.value}
           />
         </div>
         <div className="cf-sg-searchbar-example">
@@ -108,7 +104,6 @@ class StyleGuideSearch extends Component {
             onClick={this.handleSmallClick}
             onClearSearch={this.clearBigValue}
             loading={this.state.small}
-            value={this.state.value}
           />
        </div>
        <div className="cf-sg-searchbar-example">
@@ -120,7 +115,6 @@ class StyleGuideSearch extends Component {
            onClearSearch={this.clearSearchAheadValue}
            placeholder="Type to search..."
            isSearchAhead={true}
-           value={this.state.searchAheadValue}
          />
       </div>
     </div>

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -9,8 +9,7 @@ class StyleGuideSearch extends Component {
     this.state = {
       loading: {
         small: false,
-        big: false,
-        searchAhead: false
+        big: false
       }
     };
 
@@ -32,7 +31,7 @@ class StyleGuideSearch extends Component {
 
   handleSmallClick = () => this.handleSearchClick('small')
 
-  handleSearchAheadClick = () => this.handleSearchClick('searchAhead')
+  onChange = (value) => this.setState({ value });
 
   render() {
 
@@ -54,6 +53,12 @@ class StyleGuideSearch extends Component {
         There is also a unique Caseflow search behavior that displays a spinning logo to indicate load times.
         </p>
 
+        <p>
+        <b>Technical notes:</b> In the "Search Big" and the "Search Small" examples below,
+        click on the Search buttons to activate the loading spinner for a 2 second
+        period.
+        </p>
+
         <div className="cf-sg-searchbar-example">
           <SearchBar
             id="search-big"
@@ -61,9 +66,9 @@ class StyleGuideSearch extends Component {
             size="big"
             onClick={this.handleBigClick}
             loading={this.state.big}
+            onChange={this.onChange}
           />
         </div>
-        <br/>
         <div className="cf-sg-searchbar-example">
           <SearchBar
             id="search-small"
@@ -71,6 +76,7 @@ class StyleGuideSearch extends Component {
             size="small"
             onClick={this.handleSmallClick}
             loading={this.state.small}
+            onChange={this.onChange}
           />
        </div>
        <div className="cf-sg-searchbar-example">
@@ -79,8 +85,7 @@ class StyleGuideSearch extends Component {
            title="Search Ahead"
            size="small"
            placeholder="Type to search..."
-           onClick={this.handleSearchAheadClick}
-           loading={this.state.searchAhead}
+           onChange={this.onChange}
          />
       </div>
     </div>

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -9,7 +9,8 @@ class StyleGuideSearch extends Component {
     this.state = {
       loading: {
         small: false,
-        big: false
+        big: false,
+        searchAheadValue: ''
       }
     };
 
@@ -86,6 +87,7 @@ class StyleGuideSearch extends Component {
            size="small"
            placeholder="Type to search..."
            onChange={this.onChange}
+           isSearchAhead={true}
          />
       </div>
     </div>

--- a/client/app/containers/StyleGuide/StyleGuideSearch.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearch.jsx
@@ -10,7 +10,10 @@ class StyleGuideSearch extends Component {
       loading: {
         small: false,
         big: false
-      }
+      },
+      smallValue: '',
+      bigValue: '',
+      searchAheadValue: ''
     };
 
   }
@@ -53,11 +56,11 @@ class StyleGuideSearch extends Component {
     clearSearch();
   }
 
-  clearSmallValue = () => this.onClearSearch('smallValue', value);
+  clearSmallValue = () => this.onClearSearch('smallValue');
 
-  clearBigValue = () => this.onClearSearch('bigValue', value);
+  clearBigValue = () => this.onClearSearch('bigValue');
 
-  clearSearchAheadValue = () => this.onClearSearch('searchAheadValue', value);
+  clearSearchAheadValue = () => this.onClearSearch('searchAheadValue');
 
   render() {
     return (
@@ -81,7 +84,8 @@ class StyleGuideSearch extends Component {
         <p>
         <b>Technical notes:</b> In the "Search Big" and the "Search Small" examples below,
         click on the Search buttons to activate the loading spinner for a 2 second
-        period.
+        period. For any search ahead search bars, the class <code>cf-search-ahead-parent</code>
+        must be applied to the parent element.
         </p>
 
         <div className="cf-sg-searchbar-example">
@@ -91,8 +95,9 @@ class StyleGuideSearch extends Component {
             size="big"
             onChange={this.changeBigValue}
             onClick={this.handleBigClick}
-            onClearSearch={this.clearSmallValue}
+            onClearSearch={this.clearBigValue}
             loading={this.state.big}
+            value={this.state.bigValue}
           />
         </div>
         <div className="cf-sg-searchbar-example">
@@ -102,11 +107,12 @@ class StyleGuideSearch extends Component {
             size="small"
             onChange={this.changeSmallValue}
             onClick={this.handleSmallClick}
-            onClearSearch={this.clearBigValue}
+            onClearSearch={this.clearSmallValue}
             loading={this.state.small}
+            value={this.state.smallValue}
           />
        </div>
-       <div className="cf-sg-searchbar-example">
+       <div className="cf-sg-searchbar-example cf-search-ahead-parent">
          <SearchBar
            id="search-ahead"
            title="Search Ahead"
@@ -115,6 +121,7 @@ class StyleGuideSearch extends Component {
            onClearSearch={this.clearSearchAheadValue}
            placeholder="Type to search..."
            isSearchAhead={true}
+           value={this.state.searchAheadValue}
          />
       </div>
     </div>


### PR DESCRIPTION
This adds the "Search ahead" search bar to style guide and makes existing changes to the "Search ahead" bar in Reader.
![search-ahead](https://user-images.githubusercontent.com/4773320/29433995-54eea630-836f-11e7-814f-e8940587e97b.gif)

Connects #2952 