### PR TITLE
Disabling Reader cron job

### DIFF
--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -35,15 +35,6 @@ heartbeat_tasks_job:
   queue: default
   active_job: true
 
-# Retrieve all documents for active Reader users every night at midnight
-retrieve_documents_for_reader_job:
-  cron: "0 21 * * * America/New_York"
-  class: "RetrieveDocumentsForReaderJob"
-  args:
-    limit: 1500
-  queue: default
-  active_job: true
-
 # Checks dependecies every 30 seconds(BGS, VACOLS, VBMS, VBMS.FindDocumentSeriesReference)
 dependencies_check_job:
   cron: "*/30 * * * * * America/New_York"

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -43,7 +43,8 @@ retrieve_documents_for_reader_job:
   args:
     limit: 1500
   queue: default
-  active_job: false
+  active_job: true
+  disabled: true
 
 # Checks dependecies every 30 seconds(BGS, VACOLS, VBMS, VBMS.FindDocumentSeriesReference)
 dependencies_check_job:

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -35,6 +35,16 @@ heartbeat_tasks_job:
   queue: default
   active_job: true
 
+# Disabled until we have a conversation about how to handle VBMS load
+# Retrieve all documents for active Reader users every night at midnight
+retrieve_documents_for_reader_job:
+  cron: "0 21 * * * America/New_York"
+  class: "RetrieveDocumentsForReaderJob"
+  args:
+    limit: 1500
+  queue: default
+  active_job: false
+
 # Checks dependecies every 30 seconds(BGS, VACOLS, VBMS, VBMS.FindDocumentSeriesReference)
 dependencies_check_job:
   cron: "*/30 * * * * * America/New_York"


### PR DESCRIPTION
- Connects #3016 

Removing Reader cron job until we can have further discussion with the VBMS team about how we can handle load

I tested this by placing a `byebug` breakpoint on [the sidekiq initializer](https://github.com/department-of-veterans-affairs/caseflow/blob/master/config/initializers/sidekiq.rb#L11), executing `bundle exec sidekiq`, checking the values of `jobs["retrieve_documents_for_reader_job"]` and `active_jobs["retrieve_documents_for_reader_job"]` in the byebug console to verify that `active_jobs` does not contain the Reader job, and checking the log output of sidekiq startup to and saw the line `Cron Jobs - deleted job with name: retrieve_documents_for_reader_job` was logged.