### PR TITLE
Improve MonitorBusinessCritical failure message

### DIFF
--- a/app/jobs/monitor_business_critical_jobs_job.rb
+++ b/app/jobs/monitor_business_critical_jobs_job.rb
@@ -11,7 +11,7 @@ class MonitorBusinessCriticalJobsJob < CaseflowJob
 
   ALERT_THRESHOLD_IN_HOURS = 5 # in hours
 
-  MESSAGE_BASE = "| Business critical job monitor results:\n".freeze
+  MESSAGE_BASE = "Business critical job monitor results:\n".freeze
 
   def perform
     # Log monitoring information to both logs & slack
@@ -36,7 +36,7 @@ class MonitorBusinessCriticalJobsJob < CaseflowJob
   # the last start and complete times
   def results_message
     @results_message ||= results.reduce("") do |message, (job_class, result)|
-      message += "| #{job_class}: Last started: #{result[:started]}. " \
+      message += "#{job_class}: Last started: #{result[:started]}. " \
              "Last completed: #{result[:completed]}\n"
       message
     end
@@ -48,11 +48,11 @@ class MonitorBusinessCriticalJobsJob < CaseflowJob
     @failure_message ||= begin
       message = results.reduce("") do |message, (job_class, result)|
         if !result[:started] || result[:started] < ALERT_THRESHOLD_IN_HOURS.hours.ago
-          message += "*#{job_class} failed to start in the last #{ALERT_THRESHOLD_IN_HOURS} hours.* "
+          message += "*#{job_class} failed to start in the last #{ALERT_THRESHOLD_IN_HOURS} hours.*\n"
         end
 
         if !result[:completed] || result[:completed] < ALERT_THRESHOLD_IN_HOURS.hours.ago
-          message += "*#{job_class} failed to complete in the last #{ALERT_THRESHOLD_IN_HOURS} hours.* "
+          message += "*#{job_class} failed to complete in the last #{ALERT_THRESHOLD_IN_HOURS} hours.*\n"
         end
 
         message

--- a/app/jobs/monitor_business_critical_jobs_job.rb
+++ b/app/jobs/monitor_business_critical_jobs_job.rb
@@ -46,7 +46,7 @@ class MonitorBusinessCriticalJobsJob < CaseflowJob
   # failed to start or complete and @here the slack channel
   def failure_message
     @failure_message ||= begin
-      message = results.reduce("") do |message, (job_class, result)|
+      failure_message = results.reduce("") do |message, (job_class, result)|
         if !result[:started] || result[:started] < ALERT_THRESHOLD_IN_HOURS.hours.ago
           message += "*#{job_class} failed to start in the last #{ALERT_THRESHOLD_IN_HOURS} hours.*\n"
         end
@@ -58,8 +58,8 @@ class MonitorBusinessCriticalJobsJob < CaseflowJob
         message
       end
 
-      message += "<!here>\n" if !message.length.zero?
-      message
+      failure_message += "<!here>\n" if !failure_message.length.zero?
+      failure_message
     end
   end
 

--- a/app/services/prometheus_service.rb
+++ b/app/services/prometheus_service.rb
@@ -127,6 +127,7 @@ class PrometheusService
       metrics = Prometheus::Client.registry
       url = Rails.application.secrets.prometheus_push_gateway_url
 
+      return unless url
       Prometheus::Client::Push.new("push-gateway", nil, url).add(metrics)
     end
 


### PR DESCRIPTION
Improve the text formatting of the failure message for the MonitorBusinessCriticalJobsJob

- Declutters the output, no longer repeating the "last started at" when failure has happened
- Remove double "@here". Now only one will happen

connects #3023 

![screen shot 2017-08-25 at 6 11 15 pm](https://user-images.githubusercontent.com/2256237/29734582-02667408-89c1-11e7-80c8-cd1e7b1a5fbd.png)
