### PR TITLE
Return amount of documents information for a hearing

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -96,6 +96,15 @@ class Appeal < ActiveRecord::Base
     @saved_documents ||= fetch_documents!(save: true)
   end
 
+  def number_of_documents
+    documents.size
+  end
+
+  def number_of_documents_after_certification
+    return 0 unless certification_date
+    documents.count { |d| d.received_at > certification_date }
+  end
+
   # If we do not yet have the vbms_id saved in Caseflow's DB, then
   # we want to fetch it from VACOLS, save it to the DB, then return it
   def vbms_id

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,4 +1,5 @@
 class Hearing < ActiveRecord::Base
+  include CachedAttributes
   include AssociatedVacolsModel
   belongs_to :appeal
   belongs_to :user
@@ -38,6 +39,14 @@ class Hearing < ActiveRecord::Base
     type != :central_office ? type.to_s.capitalize : "CO"
   end
 
+  cache_attribute :cached_number_of_documents do
+    number_of_documents
+  end
+
+  cache_attribute :cached_number_of_documents_after_certification do
+    number_of_documents_after_certification
+  end
+
   delegate \
     :veteran_age, \
     :veteran_full_name, \
@@ -47,8 +56,11 @@ class Hearing < ActiveRecord::Base
     :appellant_state, \
     :regional_office_name, \
     :vbms_id, \
+    :number_of_documents, \
+    :number_of_documents_after_certification, \
     to: :appeal
 
+  # rubocop:disable Metrics/MethodLength
   def to_hash
     serializable_hash(
       methods: [
@@ -67,10 +79,13 @@ class Hearing < ActiveRecord::Base
         :veteran_age,
         :veteran_full_name,
         :venue,
+        :cached_number_of_documents,
+        :cached_number_of_documents_after_certification,
         :vbms_id
       ]
     )
   end
+  # rubocop:enable Metrics/MethodLength
 
   def to_hash_with_all_information
     serializable_hash(

--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -44,14 +44,21 @@ class Generators::Hearing
     private
 
     def default_appeal
-      Generators::Appeal.create(vacols_record: { template: :pending_hearing })
+      Generators::Appeal.create(vacols_record: { template: :pending_hearing }, documents: documents)
+    end
+
+    def documents
+      [Generators::Document.build(type: "NOD", received_at: 4.days.ago),
+       Generators::Document.build(type: "SOC", received_at: 1.day.ago),
+       Generators::Document.build(type: "SSOC", received_at: 5.days.ago)]
     end
 
     def default_appeal_id(hearing)
       if hearing.appeal_id
         Generators::Appeal.build(
           vacols_record: { template: :pending_hearing },
-          vacols_id: hearing.appeal.vacols_id
+          vacols_id: hearing.appeal.vacols_id,
+          documents: documents
         )
         return hearing.appeal_id
       end

--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -49,7 +49,7 @@ class Generators::Hearing
 
     def documents
       documents = []
-      types = ["NOD", "SOC", "SSOC"]
+      types = %w(NOD SOC SSOC)
       rand(5).times do
         documents << Generators::Document.build(type: types.sample, received_at: 4.days.ago)
       end

--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -48,9 +48,12 @@ class Generators::Hearing
     end
 
     def documents
-      [Generators::Document.build(type: "NOD", received_at: 4.days.ago),
-       Generators::Document.build(type: "SOC", received_at: 1.day.ago),
-       Generators::Document.build(type: "SSOC", received_at: 5.days.ago)]
+      documents = []
+      types = ["NOD", "SOC", "SSOC"]
+      rand(5).times do
+        documents << Generators::Document.build(type: types.sample, received_at: 4.days.ago)
+      end
+      documents
     end
 
     def default_appeal_id(hearing)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -245,6 +245,50 @@ describe Appeal do
     end
   end
 
+  context "#number_of_documents" do
+    let(:documents) do
+      [Generators::Document.build(type: "NOD"),
+       Generators::Document.build(type: "SOC"),
+       Generators::Document.build(type: "SSOC")]
+    end
+
+    let(:appeal) do
+      Generators::Appeal.build(documents: documents)
+    end
+
+    subject { appeal.number_of_documents }
+
+    it "should return number of documents" do
+      expect(subject).to eq 3
+    end
+  end
+
+  context "#number_of_documents_after_certification" do
+    let(:documents) do
+      [Generators::Document.build(type: "NOD", received_at: 4.days.ago),
+       Generators::Document.build(type: "SOC", received_at: 1.day.ago),
+       Generators::Document.build(type: "SSOC", received_at: 5.days.ago)]
+    end
+
+    let(:appeal) do
+      Generators::Appeal.build(documents: documents, certification_date: certification_date)
+    end
+
+    subject { appeal.number_of_documents_after_certification }
+
+    context "when certification_date is nil" do
+      let(:certification_date) { nil }
+
+      it { is_expected.to eq 0 }
+    end
+
+    context "when certification_date is set" do
+      let(:certification_date) { 2.days.ago }
+
+      it { is_expected.to eq 1 }
+    end
+  end
+
   context "#fetch_documents!" do
     let(:documents) do
       [Generators::Document.build(type: "NOD"), Generators::Document.build(type: "SOC")]

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -25,12 +25,18 @@ describe Hearing do
     subject { hearing.to_hash_with_all_information }
 
     let(:appeal) do
-      Generators::Appeal.create(vacols_record: { template: :pending_hearing }, vbms_id: "123C")
+      Generators::Appeal.create(vacols_record: { template: :pending_hearing },
+                                vbms_id: "123C",
+                                documents: documents)
     end
     let!(:additional_appeal) do
       Generators::Appeal.create(vacols_record: { template: :pending_hearing }, vbms_id: "123C")
     end
     let(:hearing) { Generators::Hearing.create(appeal: appeal) }
+    let(:documents) do
+      [Generators::Document.build(type: "NOD", received_at: 4.days.ago),
+       Generators::Document.build(type: "SOC", received_at: 1.day.ago)]
+    end
 
     context "when appeal has issues" do
       let!(:issue1) { Generators::Issue.create(appeal: appeal) }
@@ -56,6 +62,8 @@ describe Hearing do
         expect(subject["appellant_state"]).to eq(appeal.appellant_state)
         expect(subject["veteran_age"]).to eq(appeal.veteran_age)
         expect(subject["veteran_full_name"]).to eq(appeal.veteran_full_name)
+        expect(subject["cached_number_of_documents"]).to eq 2
+        expect(subject["cached_number_of_documents_after_certification"]).to eq 0
       end
     end
   end


### PR DESCRIPTION
connects #2955 

![image](https://user-images.githubusercontent.com/3811786/29941452-9dfa649e-8e60-11e7-8176-af3d56a2c6d4.png)

Steps to Validate:
1. Login as a judge
2. Get `/hearings/dockets.json` 
3. Compare VBMS/efolder amount of documents total and amount of documents since certification