### PR TITLE
adds current_user

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -456,7 +456,8 @@ class Appeal < ActiveRecord::Base
 
   def document_service
     @document_service ||=
-      if RequestStore.store[:application] == "reader" && FeatureToggle.enabled?(:efolder_docs_api)
+      if RequestStore.store[:application] == "reader" &&
+        FeatureToggle.enabled?(:efolder_docs_api, RequestStore.store[:current_user])
         EFolderService
       else
         VBMSService

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -457,7 +457,7 @@ class Appeal < ActiveRecord::Base
   def document_service
     @document_service ||=
       if RequestStore.store[:application] == "reader" &&
-        FeatureToggle.enabled?(:efolder_docs_api, RequestStore.store[:current_user])
+        FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
         EFolderService
       else
         VBMSService

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -457,7 +457,7 @@ class Appeal < ActiveRecord::Base
   def document_service
     @document_service ||=
       if RequestStore.store[:application] == "reader" &&
-        FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
+         FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
         EFolderService
       else
         VBMSService

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -152,6 +152,7 @@ class Document < ActiveRecord::Base
   end
 
   def to_hash
+    byebug
     serializable_hash
   end
 
@@ -183,7 +184,7 @@ class Document < ActiveRecord::Base
   def content_url
     if EFolderService == ExternalApi::EfolderService &&
        RequestStore.store[:application] == "reader" &&
-       FeatureToggle.enabled?(:efolder_docs_api, RequestStore.store[:current_user])
+       FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
       URI(ExternalApi::EfolderService.efolder_base_url + "/api/v1/documents/#{efolder_id}").to_s
     else
       "/document/#{id}/pdf"

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -183,7 +183,7 @@ class Document < ActiveRecord::Base
   def content_url
     if EFolderService == ExternalApi::EfolderService &&
        RequestStore.store[:application] == "reader" &&
-       FeatureToggle.enabled?(:efolder_docs_api)
+       FeatureToggle.enabled?(:efolder_docs_api, RequestStore.store[:current_user])
       URI(ExternalApi::EfolderService.efolder_base_url + "/api/v1/documents/#{efolder_id}").to_s
     else
       "/document/#{id}/pdf"

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -152,7 +152,6 @@ class Document < ActiveRecord::Base
   end
 
   def to_hash
-    byebug
     serializable_hash
   end
 


### PR DESCRIPTION
Testing:
- Placed byebug and ensured that `RequestStore[:current_user]` was set when the relevant lines were reached
- browsed around reader and saw that it didn't crash
- The only other place where `enabled?(:efolder_docs_api)` is used is in RetrieveDocumentsForReaderJob, which doesn't run