### PR TITLE
Removes VACOLS check from health check

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -2,12 +2,10 @@ class HealthChecksController < ApplicationController
   skip_before_action :verify_authentication
 
   def show
-    healthcheck = HealthCheck.new
-    status = healthcheck.healthy? ? :ok : :bad_request
     body = {
-      healthy: healthcheck.healthy?
+      healthy: true
     }.merge(Rails.application.config.build_version || {})
 
-    render json: body, status: status
+    render json: body
   end
 end

--- a/app/models/health_check.rb
+++ b/app/models/health_check.rb
@@ -1,9 +1,0 @@
-class HealthCheck
-  def healthy?
-    vacols_db_connection_active?
-  end
-
-  def vacols_db_connection_active?
-    Appeal.repository.vacols_db_connection_active?
-  end
-end


### PR DESCRIPTION
## Summary
Stops health check from failing if the app server can't connect to VACOLS. Fixes https://github.com/department-of-veterans-affairs/caseflow/issues/3196.

## Test Plan
- [x] Health check passes locally.