### PR TITLE
Cleanup Components

### DIFF
--- a/client/app/reader/Pdf.jsx
+++ b/client/app/reader/Pdf.jsx
@@ -617,8 +617,10 @@ export class Pdf extends React.PureComponent {
 
     this.props.prefetchFiles.forEach((file) => {
       this.getDocument(file).then((pdfDocument) => {
+        // If this document is not in the state yet, we need to add it
+        // since we use its presence in the state to determine if we should
+        // draw the PdfPage component.
         if (!this.state.pdfDocument[file]) {
-          console.log('adding pdfDocument')
           this.setState({
             pdfDocument: {
               ...this.state.pdfDocument,

--- a/client/app/reader/Pdf.jsx
+++ b/client/app/reader/Pdf.jsx
@@ -617,6 +617,16 @@ export class Pdf extends React.PureComponent {
 
     this.props.prefetchFiles.forEach((file) => {
       this.getDocument(file).then((pdfDocument) => {
+        if (!this.state.pdfDocument[file]) {
+          console.log('adding pdfDocument')
+          this.setState({
+            pdfDocument: {
+              ...this.state.pdfDocument,
+              [file]: pdfDocument
+            }
+          });
+        }
+
         if (pdfDocument) {
           _.range(NUM_PAGES_TO_PREDRAW).forEach((pageIndex) => {
             if (pageIndex < pdfDocument.pdfInfo.numPages &&

--- a/client/app/reader/Pdf.jsx
+++ b/client/app/reader/Pdf.jsx
@@ -548,6 +548,10 @@ export class Pdf extends React.PureComponent {
       isDrawn: {
         ...this.state.isDrawn,
         [file]: _.get(this.state.isDrawn, ['file'], []).map(() => null)
+      },
+      pdfDocument: {
+        ...this.state.pdfDocument,
+        [file]: null
       }
     });
   }
@@ -704,7 +708,7 @@ export class Pdf extends React.PureComponent {
           />;
       }
 
-      return <div />;
+      return null;
     }));
 
     return <div


### PR DESCRIPTION
Connects: #2826 #3203

We are currently leaving divs and components from pages we are no longer rendering. We were checking for the presence of the pdfDocument. But since we were not properly cleaning it up, we would draw the pages when we shouldn't be.

**Test Plan**
- [ ] Move between documents and verify that only the current, next and previous are visible in the DOM.