### PR TITLE
Move text into the comment layer

### DIFF
--- a/client/app/reader/CommentLayer.jsx
+++ b/client/app/reader/CommentLayer.jsx
@@ -20,7 +20,9 @@ const DIV_STYLING = {
 
 // The comment layer is a div on top of a page that draws the comment
 // icons on the page. It is also the div that receives the onClick
-// events when placing new comments.
+// events when placing new comments. It is also the div that displays
+// the text elements. We need text elements in this div since they
+// need to be click-able so you can highlight/copy/paste them.
 class CommentLayer extends PureComponent {
   constructor(props) {
     super(props);
@@ -143,6 +145,9 @@ class CommentLayer extends PureComponent {
       onMouseMove={this.mouseListener}
       ref={this.getCommentLayerDivRef}>
       {this.getCommentIcons()}
+      <div
+        ref={this.getTextLayerRef}
+        className="textLayer"/>
     </div>;
   }
 }
@@ -160,6 +165,7 @@ CommentLayer.propTypes = {
   isPlacingAnnotation: PropTypes.bool,
   scale: PropTypes.number,
   pageIndex: PropTypes.number,
+  isVisible: PropTypes.bool,
   documentId: PropTypes.number
 };
 

--- a/client/app/reader/CommentLayer.jsx
+++ b/client/app/reader/CommentLayer.jsx
@@ -19,10 +19,11 @@ const DIV_STYLING = {
 };
 
 // The comment layer is a div on top of a page that draws the comment
-// icons on the page. It is also the div that receives the onClick
+// icons on the page. It is the div that receives the onClick
 // events when placing new comments. It is also the div that displays
-// the text elements. We need text elements in this div since they
-// need to be click-able so you can highlight/copy/paste them.
+// the PDF text elements. We need text elements in this div since it
+// is the largest zIndex div, and blocks lower divs from receiving click events.
+// The text layer needs to be click-able so users can highlight/copy/paste them.
 class CommentLayer extends PureComponent {
   constructor(props) {
     super(props);
@@ -146,7 +147,7 @@ class CommentLayer extends PureComponent {
       ref={this.getCommentLayerDivRef}>
       {this.getCommentIcons()}
       <div
-        ref={this.getTextLayerRef}
+        ref={this.props.getTextLayerRef}
         className="textLayer"/>
     </div>;
   }
@@ -160,12 +161,12 @@ CommentLayer.propTypes = {
     x: PropTypes.number,
     y: PropTypes.number
   })),
+  getTextLayerRef: PropTypes.func,
   handleSelectCommentIcon: PropTypes.func,
   placingAnnotationIconPageCoords: PropTypes.object,
   isPlacingAnnotation: PropTypes.bool,
   scale: PropTypes.number,
   pageIndex: PropTypes.number,
-  isVisible: PropTypes.bool,
   documentId: PropTypes.number
 };
 

--- a/client/app/reader/CommentLayer.jsx
+++ b/client/app/reader/CommentLayer.jsx
@@ -138,7 +138,7 @@ class CommentLayer extends PureComponent {
 
   render() {
     return <div
-      id={`comment-layer-${this.props.pageIndex}`}
+      id={`comment-layer-${this.props.pageIndex}-${this.props.file}`}
       style={DIV_STYLING}
       onDragOver={this.onPageDragOver}
       onDrop={this.onCommentDrop}
@@ -167,6 +167,7 @@ CommentLayer.propTypes = {
   isPlacingAnnotation: PropTypes.bool,
   scale: PropTypes.number,
   pageIndex: PropTypes.number,
+  file: PropTypes.string,
   documentId: PropTypes.number
 };
 

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -93,6 +93,7 @@ export class PdfPage extends React.Component {
               pageIndex={this.props.pageIndex}
               scale={this.props.scale}
               getTextLayerRef={this.getTextLayerRef}
+              file={this.props.file}
             />
           </div>
         </div>

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -92,6 +92,7 @@ export class PdfPage extends React.Component {
               documentId={this.props.documentId}
               pageIndex={this.props.pageIndex}
               scale={this.props.scale}
+              getTextLayerRef={this.getTextLayerRef}
             />
           </div>
         </div>

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -88,15 +88,12 @@ export class PdfPage extends React.Component {
             ref={this.getCanvasRef}
             className="canvasWrapper" />
           <div className="cf-pdf-annotationLayer">
-            {this.props.isVisible && <CommentLayer
+            <CommentLayer
               documentId={this.props.documentId}
               pageIndex={this.props.pageIndex}
               scale={this.props.scale}
-            />}
+            />
           </div>
-          <div
-            ref={this.getTextLayerRef}
-            className="textLayer"/>
         </div>
       </div>;
   }

--- a/client/test/node/reader/DecisionReviewer-test.js
+++ b/client/test/node/reader/DecisionReviewer-test.js
@@ -159,7 +159,7 @@ describe('DecisionReviewer', () => {
         wrapper.find('#button-AddComment').simulate('click');
 
         // Click on the pdf at the location specified by event
-        wrapper.find('#comment-layer-0').simulate('click', event);
+        wrapper.find('#comment-layer-0-/document/1/pdf').simulate('click', event);
 
         // Add text to the comment text box.
         wrapper.find('#addComment').simulate('change',


### PR DESCRIPTION
Connects: #3183 

With the creation of the comment layer we created a new div that is above the text layer div in the DOM, and is preventing click events from making it down to the text layer. While I'd prefer to keep them separate, it seems like the simplest solution is to make the CommentLayer component contain the text layer div. Then it can receive all the clicks.

**Test Plan**
- [ ] Make sure we can now highlight.
- [ ] Make sure we did not break comment adding/moving..