### PR TITLE
Ensure comments listed in document table is listed by page order

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -264,7 +264,7 @@ class DocumentsTable extends React.Component {
 
       return [{
         valueFunction: (doc) => {
-          const comments = _.sortBy(this.props.annotationsPerDocument[doc.id], 'page');
+          const comments = _.sortBy(this.props.annotationsPerDocument[doc.id], ['page', 'y']);
           const commentNodes = comments.map((comment, commentIndex) => {
             return <Comment
               key={comment.uuid}

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -264,7 +264,7 @@ class DocumentsTable extends React.Component {
 
       return [{
         valueFunction: (doc) => {
-          const comments = this.props.annotationsPerDocument[doc.id];
+          const comments = _.sortBy(this.props.annotationsPerDocument[doc.id], 'page');
           const commentNodes = comments.map((comment, commentIndex) => {
             return <Comment
               key={comment.uuid}


### PR DESCRIPTION
Connects #2817.

Still need to add testing. 

- [ ]  Verify that the pages in jump to section are all in numerical order.
- [ ]  Verify that the comments on the same page are in order based on their location on the page. (i.e. comments with a smaller y value should come first).