### PR TITLE
Add access check to all Dispatch routes

### DIFF
--- a/app/controllers/establish_claims_controller.rb
+++ b/app/controllers/establish_claims_controller.rb
@@ -1,4 +1,5 @@
 class EstablishClaimsController < TasksController
+  before_action :verify_access
   before_action :verify_assigned_to_current_user, only: [:show, :pdf, :cancel, :perform]
   before_action :verify_not_complete, only: [:perform, :update_appeal]
   before_action :verify_bgs_info_valid, only: [:perform]

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -820,4 +820,15 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       end
     end
   end
+
+  context "As another employee" do
+    let!(:current_user) do
+      User.authenticate!(roles: ["Some non-Dispatch role"])
+    end
+
+    scenario "Attempts to view establish claim pages" do
+      visit "/dispatch/establish-claim"
+      expect(page).to have_content("You aren't authorized")
+    end
+  end
 end


### PR DESCRIPTION
Looks like we weren't properly checking for the employee permission for Dispatch routes. This re-introduces the before action, and adds a test to ensure this doesn't happen again

Connects #3236 


Test Plan
- Existing tests pass (with the proper roles)
- New test ensures other roles can't access dispatch