### PR TITLE
Remove dispatch jobs from using sidekiq cron

### DIFF
--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -6,27 +6,11 @@
 # | | | | +- Day Of Week (0-6) (Sunday = 0)
 # | | | | |
 
-# Create establish claim task runs every day at 4:30pm
-# TODO (sunil) officially remove this from the config
-#create_establish_claim_tasks_job:
-#  cron: "30 16 * * * America/New_York"
-#  class: "CreateEstablishClaimTasksJob"
-#  queue: default
-#  active_job: true
-
 reassign_old_tasks:
   cron: "1 0 * * * America/New_York"
   class: "ReassignOldTasksJob"
   queue: default
   active_job: true
-
-# This runs 30 min after the create_establish_claim_tasks_job
-# TODO (sunil) officially remove this from the config
-#prepare_establish_claim_tasks_job:
-#  cron: "0 17 * * * America/New_York"
-#  class: "PrepareEstablishClaimTasksJob"
-#  queue: default
-#  active_job: true
 
 # This job is used to debug https://github.com/department-of-veterans-affairs/caseflow/issues/1814
 # It is scheduled to run every 5 minute to make sure Sidekiq and Sidekiq Cron

--- a/config/sidekiq_cron.yml
+++ b/config/sidekiq_cron.yml
@@ -7,11 +7,12 @@
 # | | | | |
 
 # Create establish claim task runs every day at 4:30pm
-create_establish_claim_tasks_job:
-  cron: "30 16 * * * America/New_York"
-  class: "CreateEstablishClaimTasksJob"
-  queue: default
-  active_job: true
+# TODO (sunil) officially remove this from the config
+#create_establish_claim_tasks_job:
+#  cron: "30 16 * * * America/New_York"
+#  class: "CreateEstablishClaimTasksJob"
+#  queue: default
+#  active_job: true
 
 reassign_old_tasks:
   cron: "1 0 * * * America/New_York"
@@ -20,11 +21,12 @@ reassign_old_tasks:
   active_job: true
 
 # This runs 30 min after the create_establish_claim_tasks_job
-prepare_establish_claim_tasks_job:
-  cron: "0 17 * * * America/New_York"
-  class: "PrepareEstablishClaimTasksJob"
-  queue: default
-  active_job: true
+# TODO (sunil) officially remove this from the config
+#prepare_establish_claim_tasks_job:
+#  cron: "0 17 * * * America/New_York"
+#  class: "PrepareEstablishClaimTasksJob"
+#  queue: default
+#  active_job: true
 
 # This job is used to debug https://github.com/department-of-veterans-affairs/caseflow/issues/1814
 # It is scheduled to run every 5 minute to make sure Sidekiq and Sidekiq Cron


### PR DESCRIPTION
Officially remove dispatch jobs.  

**Important:** This needs to be replaced with CW+lambda when deployed to production.  