### PR TITLE
Treat master records differently

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -1,6 +1,8 @@
 # rubocop:disable Metrics/ClassLength
 class Appeal < ActiveRecord::Base
   include AssociatedVacolsModel
+  include RegionalOffice
+
   has_many :tasks
   has_many :appeal_views
 
@@ -217,14 +219,6 @@ class Appeal < ActiveRecord::Base
 
   def hearing_pending?
     hearing_requested && !hearing_held
-  end
-
-  def regional_office
-    { key: regional_office_key }.merge(VACOLS::RegionalOffice::CITIES[regional_office_key] || {})
-  end
-
-  def regional_office_name
-    "#{regional_office[:city]}, #{regional_office[:state]}"
   end
 
   def attributes_for_hearing

--- a/app/models/concerns/regional_office.rb
+++ b/app/models/concerns/regional_office.rb
@@ -1,0 +1,11 @@
+module RegionalOffice
+  extend ActiveSupport::Concern
+
+  def regional_office
+    { key: regional_office_key }.merge(VACOLS::RegionalOffice::CITIES[regional_office_key] || {})
+  end
+
+  def regional_office_name
+    "#{regional_office[:city]}, #{regional_office[:state]}"
+  end
+end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -126,6 +126,7 @@ class Hearing < ActiveRecord::Base
         find_or_initialize_by(vacols_id: vacols_record.hearing_pkseq).tap do |hearing|
           # If it is a master record, do not create a record in the hearings table
           return hearing if vacols_record.master_record?
+
           hearing.update(appeal: Appeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
                          user: User.find_by(css_id: vacols_record.css_id))
           hearing.set_issues_from_appeal

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,13 +1,14 @@
 class Hearing < ActiveRecord::Base
   include CachedAttributes
   include AssociatedVacolsModel
+  include RegionalOffice
 
   belongs_to :appeal
   belongs_to :user
 
   vacols_attr_accessor :date, :type, :venue_key, :vacols_record, :disposition,
                        :aod, :hold_open, :transcript_requested, :notes, :add_on,
-                       :representative_name
+                       :representative_name, :regional_office_key, :master_record
 
   belongs_to :appeal
   belongs_to :user # the judge
@@ -55,12 +56,11 @@ class Hearing < ActiveRecord::Base
     :appellant_last_first_mi, \
     :appellant_city, \
     :appellant_state, \
-    :regional_office_name, \
     :vbms_id, \
     :number_of_documents, \
     :number_of_documents_after_certification, \
     :representative, \
-    to: :appeal
+    to: :appeal, allow_nil: true
 
   # rubocop:disable Metrics/MethodLength
   def to_hash
@@ -74,6 +74,7 @@ class Hearing < ActiveRecord::Base
         :hold_open,
         :notes,
         :add_on,
+        :master_record,
         :appellant_last_first_mi,
         :appellant_city,
         :appellant_state,
@@ -122,7 +123,9 @@ class Hearing < ActiveRecord::Base
 
     def create_from_vacols_record(vacols_record)
       transaction do
-        find_or_create_by(vacols_id: vacols_record.hearing_pkseq).tap do |hearing|
+        find_or_initialize_by(vacols_id: vacols_record.hearing_pkseq).tap do |hearing|
+          # If it is a master record, do not create a record in the hearings table
+          return hearing if vacols_record.master_record?
           hearing.update(appeal: Appeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
                          user: User.find_by(css_id: vacols_record.css_id))
           hearing.set_issues_from_appeal

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -63,7 +63,7 @@ class VACOLS::CaseHearing < VACOLS::Record
       # the child records (veterans scheduled for that video) to the parent record
       children_ids = hearings.map(&:vdkey).compact.map(&:to_i)
       # Filter out video master records with children
-      hearings.reject { |hearing| hearing.folder_nr =~ /VIDEO/ && children_ids.include?(hearing.hearing_pkseq) }
+      hearings.reject { |hearing| hearing.master_record? && children_ids.include?(hearing.hearing_pkseq) }
     end
 
     def for_appeal(appeal_vacols_id)
@@ -100,6 +100,15 @@ class VACOLS::CaseHearing < VACOLS::Record
         .joins("left outer join vacols.staff on staff.sattyid = board_member")
         .where(hearing_type: HEARING_TYPES.keys)
     end
+  end
+
+  def master_record_type
+    return :video if folder_nr =~ /VIDEO/
+    # TODO: return :travel_board if a record is from tb_sched
+  end
+
+  def master_record?
+    master_record_type.present?
   end
 
   def update_hearing!(hearing_info)

--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -14,7 +14,9 @@ class Generators::Hearing
         contentions: "The veteran believes their knee is hurt",
         evidence: "Medical exam occurred on 10/10/2008",
         military_service: "Veteran was in the Vietnam War",
-        comments_for_attorney: "Look for knee-related medical records"
+        comments_for_attorney: "Look for knee-related medical records",
+        regional_office_key: VACOLS::RegionalOffice::CITIES.keys.sample,
+        master_record: [true, false].sample
       }
     end
 

--- a/spec/models/concerns/regional_office_spec.rb
+++ b/spec/models/concerns/regional_office_spec.rb
@@ -1,0 +1,15 @@
+describe RegionalOffice do
+  class TestThing
+    include ActiveModel::Model
+    include RegionalOffice
+    attr_accessor :regional_office_key
+  end
+
+  let(:model) { TestThing.new(regional_office_key: "RO22") }
+
+  context "#regional_office_name" do
+    subject { model.regional_office_name }
+
+    it { is_expected.to eq "Montgomery, AL" }
+  end
+end

--- a/spec/repositories/hearing_repository_spec.rb
+++ b/spec/repositories/hearing_repository_spec.rb
@@ -32,4 +32,30 @@ describe HearingRepository do
       expect(subject.representative_name).to eq "test rep name"
     end
   end
+
+  context ".values_based_on_type" do
+    subject { HearingRepository.values_based_on_type(vacols_record) }
+
+    context "when a hearing is a video master record" do
+      let(:vacols_record) do
+        OpenStruct.new(
+          hearing_type: "V",
+          folder_nr: "VIDEO RO15",
+          master_record_type: :video
+        )
+      end
+      it { is_expected.to eq(type: :video, regional_office_key: "RO15") }
+    end
+
+    context "when a hearing is not a master record" do
+      let(:vacols_record) do
+        OpenStruct.new(
+          hearing_type: "T",
+          master_record_type: nil,
+          brieff: OpenStruct.new(bfregoff: "RO36")
+        )
+      end
+      it { is_expected.to eq(type: :travel, regional_office_key: "RO36") }
+    end
+  end
 end


### PR DESCRIPTION
Master records for video are stored in the `hearshed` table, however, the column values differ from the regular hearing record. We need to handle master records differently. 
1. If it is a master record, don’t create a hearing in the DB, only in memory
2. If it is a master record (either video or travel_board), set hearing_type and regional_office_key based on certain conditions
3. return `master_record` boolean value as part of the hearing object to the FE