### PR TITLE
Handles null venue

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -81,6 +81,7 @@ class Hearing < ActiveRecord::Base
         :representative_name,
         :veteran_age,
         :veteran_name,
+        :regional_office_name,
         :venue,
         :cached_number_of_documents,
         :cached_number_of_documents_after_certification,
@@ -93,7 +94,6 @@ class Hearing < ActiveRecord::Base
   def to_hash_for_worksheet
     serializable_hash(
       methods: [:appeal_id,
-                :regional_office_name,
                 :representative,
                 :appeals_ready_for_hearing],
       include: :issues

--- a/client/app/hearings/DocketHearingRow.jsx
+++ b/client/app/hearings/DocketHearingRow.jsx
@@ -65,9 +65,9 @@ export class DocketHearingRow extends React.PureComponent {
         <td className="cf-hearings-docket-date">
           <span>{index + 1}.</span>
           <span>
-            {getDate(hearing.date, hearing.venue.timezone)}
+            {getDate(hearing.date, 'EST')}
             <br/>
-            {`${hearing.venue.city}, ${hearing.venue.state}`}
+            {hearing.regional_office_name}
           </span>
         </td>
         <td className="cf-hearings-docket-appellant">


### PR DESCRIPTION
Connects #3317 

This PR updates the daily docket page to use regional_office instead of hearing_venue. This is consistent with the other two pages. It also updates the start_times to always use 'EST'. Confirming with Jed that this is correct. For now, this update is needed to fix UAT.