### PR TITLE
Add shoryuken gem to environment [Replace Sidekiq with SQS pt 1]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,3 +142,5 @@ group :development do
   # POSIX systems should have this already, so we're not going to bring it in on other platforms
   gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 end
+
+gem 'shoryuken', '3.1.11'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -379,6 +379,10 @@ GEM
       websocket (~> 1.0)
     sentry-raven (2.4.0)
       faraday (>= 0.7.6, < 1.0)
+    shoryuken (3.1.11)
+      aws-sdk-core (>= 2)
+      concurrent-ruby
+      thor
     sidekiq (5.0.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -492,6 +496,7 @@ DEPENDENCIES
   scss_lint
   sdoc (~> 0.4.0)
   sentry-raven
+  shoryuken (= 3.1.11)
   sidekiq
   sidekiq-cron (~> 0.4.0)
   simplecov!
@@ -508,4 +513,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.15.3
+   1.15.4


### PR DESCRIPTION
Part 1 of 3 for: #3182 

Install shoryuken gem to environment.  This is the first in a 3 step process.   

Once this is deployed we'll want to install the worker on the environments: https://github.com/department-of-veterans-affairs/appeals-deployment/issues/869