### PR TITLE
Tag filter needs to be longer

### DIFF
--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -184,7 +184,7 @@ $tag-backgrond-color: #d6d7d9;
     .cf-document-tag-picker {
       padding-bottom: 0;
       margin: 0;
-      max-height: 325px;
+      max-height: 345px;
       word-break: break-word;
       max-width: 218px;
       overflow-y: auto;


### PR DESCRIPTION
Connects:  #3084 

Currently you can't tell the tag filter can be scrolled. We're making it a little longer so you can see half of the next comment as a visual indicator that it is scrollable.