### PR TITLE
Updates konacha dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,7 @@ gem "sidekiq-cron", "~> 0.4.0"
 # remove when upgrading to rails 5
 gem 'where-or'
 
-gem 'prometheus-client'
+gem 'prometheus-client', "~> 0.6"
 
 gem 'request_store'
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'wannabe_bool'
 gem "uswds-rails", git: "https://github.com/18F/uswds-rails-gem.git"
 
 # BGS
-gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: '0fd06422252e427f501cbaa42da80a1de55875a6'
+gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: 'a9041f859632ccd32cf8e3a22554505d6baa4276'
 
 # PDF Tools
 gem 'pdf-forms'
@@ -63,7 +63,7 @@ gem 'therubyracer', platforms: :ruby
 
 gem 'pg', platforms: :ruby
 
-gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f561599c8b68806ae838530b2fc02d481157b02a"
+gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "dd26fbff2179d400b4f19f91084835686276297f"
 
 gem 'redis-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,25 +30,25 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: f561599c8b68806ae838530b2fc02d481157b02a
-  ref: f561599c8b68806ae838530b2fc02d481157b02a
+  revision: dd26fbff2179d400b4f19f91084835686276297f
+  ref: dd26fbff2179d400b4f19f91084835686276297f
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail
-      nokogiri (>= 1.7.1)
+      nokogiri (>= 1.8.1)
       nori
       xmldsig (~> 0.3.1)
       xmlenc
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 0fd06422252e427f501cbaa42da80a1de55875a6
-  ref: 0fd06422252e427f501cbaa42da80a1de55875a6
+  revision: a9041f859632ccd32cf8e3a22554505d6baa4276
+  ref: a9041f859632ccd32cf8e3a22554505d6baa4276
   specs:
     bgs (0.1)
-      nokogiri (~> 1.7.1)
+      nokogiri (~> 1.8.1)
       savon (~> 2.11)
 
 GIT
@@ -114,8 +114,8 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.5.0)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
@@ -140,9 +140,9 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.0.6)
-    capybara (2.13.0)
+    capybara (2.15.1)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
@@ -156,6 +156,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    crass (1.0.2)
     d3-rails (4.10.2)
       railties (>= 3.1)
     database_cleaner (1.5.3)
@@ -188,7 +189,7 @@ GEM
     httpi (2.4.2)
       rack
       socksify
-    i18n (0.8.1)
+    i18n (0.8.6)
     jbuilder (2.6.3)
       activesupport (>= 3.0.0, < 5.2)
       multi_json (~> 1.2)
@@ -214,7 +215,8 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.19)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
@@ -222,8 +224,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
-    minitest (5.10.1)
+    mini_mime (0.1.4)
+    mini_portile2 (2.3.0)
+    minitest (5.10.3)
     moment_timezone-rails (0.5.0)
     momentjs-rails (2.17.1)
       railties (>= 3.1)
@@ -232,10 +235,10 @@ GEM
     neat (2.1.0)
       sass (~> 3.4)
       thor (~> 0.19)
-    nokogiri (1.7.2)
-      mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.2-x64-mingw32)
-      mini_portile2 (~> 2.1.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    nokogiri (1.8.1-x64-mingw32)
+      mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     parallel (1.11.1)
     parser (2.4.0.0)
@@ -255,7 +258,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (2.0.5)
+    public_suffix (3.0.0)
     puma (2.16.0)
     quantile (0.2.0)
     rack (1.6.8)
@@ -289,7 +292,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.1)
-    rake (12.0.0)
+    rake (12.1.0)
     rb-readline (0.5.4)
     rdoc (4.3.0)
     react_on_rails (6.8.1)
@@ -398,7 +401,7 @@ GEM
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -409,7 +412,7 @@ GEM
       ref
     thor (0.19.4)
     thread_safe (0.3.6)
-    tilt (2.0.7)
+    tilt (2.0.8)
     timecop (0.8.1)
     tzinfo (1.2.3)
       thread_safe (~> 0.1)
@@ -440,7 +443,7 @@ GEM
       xmlmapper (~> 0.6)
     xmlmapper (0.7.2)
       nokogiri (~> 1.5)
-    xpath (2.0.0)
+    xpath (2.1.0)
       nokogiri (~> 1.3)
     zero_downtime_migrations (0.0.7)
       activerecord

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -480,7 +480,7 @@ DEPENDENCIES
   pdfjs_viewer-rails!
   pg
   poltergeist
-  prometheus-client
+  prometheus-client (~> 0.6)
   pry
   puma (~> 2.16.0)
   rails (= 4.2.7.1)


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/caseflow/issues/3376

- Updates `connect-vbms` and `bgs` gems due to a nokogiri security issue that makes brakeman fail
- Runs `bundle update konacha` and checks in the resultant Gemfile.lock
- Pins prometheus-client to 0.6. We tested previously that 0.7 does not work, so we might as well pin it to a working version now. 

Testing:
security linter passes
foreman start succeeds
app loads and runs