### PR TITLE
Hearing Prep | UI Fixes on Daily Docket and Hearing Worksheet

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -388,6 +388,12 @@ $color-hearings-saving: #777;
   }
 }
 
+.cf-hearings-worksheet-form {
+  label {
+    font-weight: bold;
+  }
+}
+
 .hearings-add-issue {
   margin-bottom: 20px;
 }

--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -131,6 +131,10 @@ $color-hearings-saving: #777;
           margin-right: .5em;
           width: 1.5em;
         }
+
+        &:last-child {
+          padding-left: 2em;
+        }
       }
     }
 

--- a/client/app/hearings/DocketHearingRow.jsx
+++ b/client/app/hearings/DocketHearingRow.jsx
@@ -66,7 +66,8 @@ export class DocketHearingRow extends React.PureComponent {
           <span>{index + 1}.</span>
           <span>
             {getDate(hearing.date, 'EST')}
-            <br/>
+          </span>
+          <span>
             {hearing.regional_office_name}
           </span>
         </td>


### PR DESCRIPTION
This bolds the longer text fields on the Hearing Worksheet and aligns the values in Time/Regional Office column in Daily Docket.

Connects #3369
<img width="573" alt="screen shot 2017-09-25 at 3 35 10 pm" src="https://user-images.githubusercontent.com/4773320/30827283-a6076168-a207-11e7-9a15-f45460cac788.png">

Connects #3371 
<img width="414" alt="screen shot 2017-09-25 at 3 35 29 pm" src="https://user-images.githubusercontent.com/4773320/30827289-ada0a6dc-a207-11e7-83c0-17cc19df6e60.png">
