### PR TITLE
[Reader] Fix flakey test

### DIFF
--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -763,9 +763,6 @@ RSpec.feature "Reader" do
 
           click_on documents[3].type
 
-          # Expect the 23 page to only be rendered once scrolled to.
-          expect(find("#pageContainer23")).to_not have_content("Rating Decision")
-
           fill_in "page-progress-indicator-input", with: "23\n"
 
           expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)


### PR DESCRIPTION
I wrapped a test in `ensure_stable` and found that it consistently failed within the `20` retries.

The line that failed expected part of the PDF text layer to not be rendered. However, looking in the code, I don't see why we have that expectation. It looks like we will render all PDF pages when the document is loaded. So I removed the assertion.

@mdbenjam let's chat if I am missing something.