### PR TITLE
Fix flakey Reader tests

### DIFF
--- a/client/test/karma/hearings/reducers/index-test.js
+++ b/client/test/karma/hearings/reducers/index-test.js
@@ -3,7 +3,7 @@ import * as Hearings from '../../../../app/hearings/reducers/index';
 import * as Constants from '../../../../app/hearings/constants/constants';
 
 /* eslint max-statements: ["error", 10, { "ignoreTopLevelFunctions": true }]*/
-describe.only('hearingsReducer', () => {
+describe.skip('hearingsReducer', () => {
   let initialState;
 
   beforeEach(() => {
@@ -410,9 +410,8 @@ describe.only('hearingsReducer', () => {
       });
     });
 
-    it.only('sets worksheet comments for attorney', () => { 
-      console.log('state', state);
-      // expect(state.worksheet.comments_for_attorney).to.deep.equal('filled');
+    it('sets worksheet comments for attorney', () => {
+      expect(state.worksheet.comments_for_attorney).to.deep.equal('filled');
     });
   });
 });

--- a/client/test/karma/hearings/reducers/index-test.js
+++ b/client/test/karma/hearings/reducers/index-test.js
@@ -3,7 +3,7 @@ import * as Hearings from '../../../../app/hearings/reducers/index';
 import * as Constants from '../../../../app/hearings/constants/constants';
 
 /* eslint max-statements: ["error", 10, { "ignoreTopLevelFunctions": true }]*/
-describe.skip('hearingsReducer', () => {
+describe.only('hearingsReducer', () => {
   let initialState;
 
   beforeEach(() => {
@@ -410,8 +410,9 @@ describe.skip('hearingsReducer', () => {
       });
     });
 
-    it('sets worksheet comments for attorney', () => {
-      expect(state.worksheet.comments_for_attorney).to.deep.equal('filled');
+    it.only('sets worksheet comments for attorney', () => { 
+      console.log('state', state);
+      // expect(state.worksheet.comments_for_attorney).to.deep.equal('filled');
     });
   });
 });

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -760,28 +760,21 @@ RSpec.feature "Reader" do
 
         ensure_stable do
           scenario "Switch between pages to ensure rendering", :focus => true do
-            begin
-              visit "/reader/appeal/#{appeal.vacols_id}/documents"
+            visit "/reader/appeal/#{appeal.vacols_id}/documents"
 
-              click_on documents[3].type
+            click_on documents[3].type
 
-              fill_in "page-progress-indicator-input", with: "23\n"
+            fill_in "page-progress-indicator-input", with: "23\n"
 
-              expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
+            expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
 
-              expect(in_viewport("pageContainer23")).to be true
-              expect(find_field("page-progress-indicator-input").value).to eq "23"
+            expect(in_viewport("pageContainer23")).to be true
+            expect(find_field("page-progress-indicator-input").value).to eq "23"
 
-              # Entering invalid values leaves the viewer on the same page.
-              fill_in "page-progress-indicator-input", with: "abcd\n"
-              expect(in_viewport("pageContainer23")).to be true
-              expect(find_field("page-progress-indicator-input").value).to eq "23"
-            rescue Exception => e
-              puts 'Got exception'
-              puts e.message
-              puts e.backtrace.inspect
-              sleep(inspection_timeout=10000)
-            end
+            # Entering invalid values leaves the viewer on the same page.
+            fill_in "page-progress-indicator-input", with: "abcd\n"
+            expect(in_viewport("pageContainer23")).to be true
+            expect(find_field("page-progress-indicator-input").value).to eq "23"
           end
         end
       end

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -31,10 +31,10 @@ end
 
 # Returns true if an element is currently visible on the page.
 def expect_in_viewport(element)
-  expect {
+  expect do
     page.evaluate_script("document.getElementById('#{element}').getBoundingClientRect().top > 0" \
       " && document.getElementById('#{element}').getBoundingClientRect().top < window.innerHeight;")
-  }.to become_truthy(wait: 10)
+  end.to become_truthy(wait: 10)
 end
 
 def get_size(element)
@@ -771,7 +771,7 @@ RSpec.feature "Reader" do
 
           expect_in_viewport("pageContainer23")
           expect(find_field("page-progress-indicator-input").value).to eq "23"
-          
+
           # Entering invalid values leaves the viewer on the same page.
           fill_in "page-progress-indicator-input", with: "abcd\n"
           expect_in_viewport("pageContainer23")

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -758,22 +758,31 @@ RSpec.feature "Reader" do
           )
         end
 
-        scenario "Switch between pages to ensure rendering" do
-          visit "/reader/appeal/#{appeal.vacols_id}/documents"
+        ensure_stable do
+          scenario "Switch between pages to ensure rendering", :focus => true do
+            begin
+              visit "/reader/appeal/#{appeal.vacols_id}/documents"
 
-          click_on documents[3].type
+              click_on documents[3].type
 
-          fill_in "page-progress-indicator-input", with: "23\n"
+              fill_in "page-progress-indicator-input", with: "23\n"
 
-          expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
+              expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
 
-          expect(in_viewport("pageContainer23")).to be true
-          expect(find_field("page-progress-indicator-input").value).to eq "23"
+              expect(in_viewport("pageContainer23")).to be true
+              expect(find_field("page-progress-indicator-input").value).to eq "23"
 
-          # Entering invalid values leaves the viewer on the same page.
-          fill_in "page-progress-indicator-input", with: "abcd\n"
-          expect(in_viewport("pageContainer23")).to be true
-          expect(find_field("page-progress-indicator-input").value).to eq "23"
+              # Entering invalid values leaves the viewer on the same page.
+              fill_in "page-progress-indicator-input", with: "abcd\n"
+              expect(in_viewport("pageContainer23")).to be true
+              expect(find_field("page-progress-indicator-input").value).to eq "23"
+            rescue Exception => e
+              puts 'Got exception'
+              puts e.message
+              puts e.backtrace.inspect
+              sleep(inspection_timeout=10000)
+            end
+          end
         end
       end
     end

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -34,7 +34,7 @@ def expect_in_viewport(element)
   expect {
     page.evaluate_script("document.getElementById('#{element}').getBoundingClientRect().top > 0" \
       " && document.getElementById('#{element}').getBoundingClientRect().top < window.innerHeight;")
-  }.to become_truthy
+  }.to become_truthy(wait: 10)
 end
 
 def get_size(element)

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -768,7 +768,7 @@ RSpec.feature "Reader" do
 
             expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
 
-            expect(in_viewport("pageContainer23")).to be true
+            expect(in_viewport("pageContainer23"), wait: 10).to be true
             expect(find_field("page-progress-indicator-input").value).to eq "23"
 
             # Entering invalid values leaves the viewer on the same page.

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -760,24 +760,22 @@ RSpec.feature "Reader" do
           )
         end
 
-        ensure_stable do
-          scenario "Switch between pages to ensure rendering", :focus => true do
-            visit "/reader/appeal/#{appeal.vacols_id}/documents"
+        scenario "Switch between pages to ensure rendering" do
+          visit "/reader/appeal/#{appeal.vacols_id}/documents"
 
-            click_on documents[3].type
+          click_on documents[3].type
 
-            fill_in "page-progress-indicator-input", with: "23\n"
+          fill_in "page-progress-indicator-input", with: "23\n"
 
-            expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
+          expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
 
-            expect_in_viewport("pageContainer23")
-            expect(find_field("page-progress-indicator-input").value).to eq "23"
-            
-            # Entering invalid values leaves the viewer on the same page.
-            fill_in "page-progress-indicator-input", with: "abcd\n"
-            expect_in_viewport("pageContainer23")
-            expect(find_field("page-progress-indicator-input").value).to eq "23"
-          end
+          expect_in_viewport("pageContainer23")
+          expect(find_field("page-progress-indicator-input").value).to eq "23"
+          
+          # Entering invalid values leaves the viewer on the same page.
+          fill_in "page-progress-indicator-input", with: "abcd\n"
+          expect_in_viewport("pageContainer23")
+          expect(find_field("page-progress-indicator-input").value).to eq "23"
         end
       end
     end

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -29,10 +29,12 @@ def scroll_to_bottom(element)
   EOS
 end
 
-# This utility function returns true if an element is currently visible on the page
-def in_viewport(element)
-  page.evaluate_script("document.getElementById('#{element}').getBoundingClientRect().top > 0" \
-  " && document.getElementById('#{element}').getBoundingClientRect().top < window.innerHeight;")
+# Returns true if an element is currently visible on the page.
+def expect_in_viewport(element)
+  expect {
+    page.evaluate_script("document.getElementById('#{element}').getBoundingClientRect().top > 0" \
+      " && document.getElementById('#{element}').getBoundingClientRect().top < window.innerHeight;")
+  }.to become_truthy
 end
 
 def get_size(element)
@@ -671,7 +673,7 @@ RSpec.feature "Reader" do
         # wait for comment annotations to load
         all(".commentIcon-container", wait: 3, count: 1)
 
-        expect { in_viewport(comment_icon_id) }.to become_truthy
+        expect_in_viewport(comment_icon_id)
       end
 
       scenario "Scroll to comment" do
@@ -768,12 +770,12 @@ RSpec.feature "Reader" do
 
             expect(find("#pageContainer23")).to have_content("Rating Decision", wait: 10)
 
-            expect(in_viewport("pageContainer23"), wait: 10).to be true
+            expect_in_viewport("pageContainer23")
             expect(find_field("page-progress-indicator-input").value).to eq "23"
-
+            
             # Entering invalid values leaves the viewer on the same page.
             fill_in "page-progress-indicator-input", with: "abcd\n"
-            expect(in_viewport("pageContainer23")).to be true
+            expect_in_viewport("pageContainer23")
             expect(find_field("page-progress-indicator-input").value).to eq "23"
           end
         end
@@ -1178,7 +1180,7 @@ RSpec.feature "Reader" do
       click_on "Back to claims folder"
 
       expect(page).to have_content("#{num_documents} Documents")
-      expect(in_viewport("read-indicator")).to be true
+      expect_in_viewport("read-indicator")
       expect(scroll_position("documents-table-body")).to eq(original_scroll_position)
     end
 
@@ -1189,7 +1191,7 @@ RSpec.feature "Reader" do
 
       expect(page).to have_content("#{num_documents} Documents")
 
-      expect(in_viewport("read-indicator")).to be true
+      expect_in_viewport("read-indicator")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -158,6 +158,8 @@ User.authentication_service = Fakes::AuthenticationService
 CAVCDecision.repository = Fakes::CAVCDecisionRepository
 
 RSpec.configure do |config|
+  config.fail_fast = true
+
   # This checks whether compiled webpack assets already exist
   # If it does, it will not execute ReactOnRails, since that slows down tests
   # Thus this will only run once (to initially compile assets) and not on

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -219,13 +219,14 @@ end
 
 # We generally avoid writing our own polling code, since proper Cappybara use generally
 # doesn't require it. That said, there may be some situations (such as evaluating javascript)
-# that require a spinning test. We got the following matcher from https://gist.github.com/jnicklas/4129937
-RSpec::Matchers.define :become_truthy do |_event_name|
+# that require a spinning test. We got the following matcher from
+# https://gist.github.com/showaltb/0456ce0002842c88c3fc06db43f3ee7b
+RSpec::Matchers.define :become_truthy do |wait: Capybara.default_max_wait_time|
   supports_block_expectations
 
   match do |block|
     begin
-      Timeout.timeout(10) do
+      Timeout.timeout(wait) do
         sleep(0.1) until value = block.call
         value
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -212,7 +212,7 @@ end
 # Wrap this around your test to run it many times and ensure that it passes consistently.
 # Note: do not merge to master like this, or the tests will be slow! Ha.
 def ensure_stable
-  100.times do
+  20.times do
     yield
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -210,7 +210,7 @@ end
 # Wrap this around your test to run it many times and ensure that it passes consistently.
 # Note: do not merge to master like this, or the tests will be slow! Ha.
 def ensure_stable
-  20.times do
+  100.times do
     yield
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -227,6 +227,7 @@ RSpec::Matchers.define :become_truthy do |wait: Capybara.default_max_wait_time|
   match do |block|
     begin
       Timeout.timeout(wait) do
+        # rubocop:disable AssignmentInCondition
         sleep(0.1) until value = block.call
         value
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -158,8 +158,6 @@ User.authentication_service = Fakes::AuthenticationService
 CAVCDecision.repository = Fakes::CAVCDecisionRepository
 
 RSpec.configure do |config|
-  config.fail_fast = true
-
   # This checks whether compiled webpack assets already exist
   # If it does, it will not execute ReactOnRails, since that slows down tests
   # Thus this will only run once (to initially compile assets) and not on

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -225,9 +225,9 @@ RSpec::Matchers.define :become_truthy do |_event_name|
 
   match do |block|
     begin
-      Timeout.timeout(Capybara.default_max_wait_time) do
-        sleep(0.1) until block.call
-        true
+      Timeout.timeout(10) do
+        sleep(0.1) until value = block.call
+        value
       end
     rescue TimeoutError
       false


### PR DESCRIPTION
An earlier commit in this branch saw 100 consecutive failures of a test that previously failed 11/100 times: https://travis-ci.org/department-of-veterans-affairs/caseflow/jobs/281492669.

We need to wait longer for `in_viewport`. And we should always be using `become_truthy`. I've refactored our tests to do both those things.