### PR TITLE
Fix DocketContainer Test

### DIFF
--- a/client/test/karma/hearings/DocketsContainer-test.js
+++ b/client/test/karma/hearings/DocketsContainer-test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
-import DocketsContainer from '../../../app/hearings/DocketsContainer';
+import { shallow } from 'enzyme';
+import { DocketsContainer } from '../../../app/hearings/DocketsContainer';
+import Dockets from '../../../app/hearings/Dockets';
 
 /* eslint-disable camelcase */
 describe('DocketsContainer', () => {
   it('notifies user when no dockets are returned', () => {
-    const wrapper = mount(<DocketsContainer veteran_law_judge={{ name: 'me' }} dockets={{}} />);
+    const wrapper = shallow(<DocketsContainer veteran_law_judge={{ name: 'me' }} dockets={{}} />);
 
     expect(wrapper.text()).to.include('You have no upcoming hearings.');
   });
@@ -44,8 +45,8 @@ describe('DocketsContainer', () => {
         }
       }
     };
-    const wrapper = mount(<DocketsContainer veteran_law_judge={{ name: 'me' }} dockets={dockets} />);
+    const wrapper = shallow(<DocketsContainer veteran_law_judge={{ name: 'me' }} dockets={dockets} />);
 
-    expect(wrapper.text()).to.include('Upcoming Hearing Days');
+    expect(wrapper.find(Dockets)).to.have.length(1);
   });
 });

--- a/client/test/karma/hearings/DocketsContainer-test.js
+++ b/client/test/karma/hearings/DocketsContainer-test.js
@@ -1,53 +1,18 @@
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import { createStore, applyMiddleware } from 'redux';
-import thunk from 'redux-thunk';
-import { Provider } from 'react-redux';
-import ApiUtilStub from '../../helpers/ApiUtilStub';
-import hearingsReducers from '../../../app/hearings/reducers/index';
-import { populateDockets } from '../../../app/hearings/actions/Dockets';
 import DocketsContainer from '../../../app/hearings/DocketsContainer';
 
-const store = createStore(hearingsReducers, { dockets: {} }, applyMiddleware(thunk));
-
 /* eslint-disable camelcase */
-/* eslint-disable no-unused-expressions */
-/* eslint-disable max-statements */
 describe('DocketsContainer', () => {
-  let wrapper;
-
-  beforeEach(() => {
-    ApiUtilStub.beforeEach();
-
-    wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={['/']}>
-          <div>
-            <DocketsContainer veteran_law_judge={{ name: 'me' }} />
-          </div>
-        </MemoryRouter>
-      </Provider>);
-  });
-
-  afterEach(() => {
-    ApiUtilStub.afterEach();
-  });
-
-  it('retrieves dockets', () => {
-    setTimeout(() => {
-      expect(ApiUtilStub.apiGet.calledOnce).to.be.true;
-    });
-  });
-
   it('notifies user when no dockets are returned', () => {
-    store.dispatch(populateDockets({}));
+    const wrapper = mount(<DocketsContainer veteran_law_judge={{ name: 'me' }} dockets={{}} />);
+
     expect(wrapper.text()).to.include('You have no upcoming hearings.');
   });
 
   it('renders loaded dockets', () => {
-    store.dispatch(populateDockets({
+    const dockets = {
       '2017-06-17': {
         date: '2017-06-17T17:52:09.742-04:00',
         hearings_array: [{
@@ -78,7 +43,9 @@ describe('DocketsContainer', () => {
           timezone: 'America/New_York'
         }
       }
-    }));
+    };
+    const wrapper = mount(<DocketsContainer veteran_law_judge={{ name: 'me' }} dockets={dockets} />);
+
     expect(wrapper.text()).to.include('Upcoming Hearing Days');
   });
 });


### PR DESCRIPTION
I ran these tests `1000` times locally, and they passed.

I've simplified the tests here, since I believe the complexity with `ApiUtil` was causing the crash, and that test was redundant with what we already have in spec tests.

I also removed the Redux testing, and instead made the unit test purely focusing on whether `DocketsContainer` returns the right values for the right props. This more focused test is much easier to reason about and make correct.