### PR TITLE
Allow fake user to access hearing prep for the demo

### DIFF
--- a/lib/fakes/hearing_repository.rb
+++ b/lib/fakes/hearing_repository.rb
@@ -5,8 +5,8 @@ class Fakes::HearingRepository
     attr_accessor :master_records
   end
 
-  def self.upcoming_hearings_for_judge(css_id)
-    user = User.find_by_css_id(css_id)
+  def self.upcoming_hearings_for_judge(_css_id)
+    user = User.find_by_css_id("Hearing Prep")
     records.select { |h| h.user_id == user.id }
   end
 

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -42,7 +42,7 @@ class Fakes::Initializer
 
       User.authentication_service.user_session = {
         "id" => "Fake User",
-        "roles" => ["Certify Appeal", "Establish Claim", "Manage Claim Establishment"],
+        "roles" => ["Certify Appeal", "Establish Claim", "Manage Claim Establishment", "Hearing Prep"],
         "station_id" => "283",
         "email" => "america@example.com",
         "name" => "Cave Johnson"

--- a/spec/feature/hearings_spec.rb
+++ b/spec/feature/hearings_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Hearings" do
 
   context "Hearings Prep" do
     let!(:current_user) do
-      User.authenticate!(roles: ["Hearing Prep"])
+      User.authenticate!(roles: ["Hearing Prep"], id: "Hearing Prep")
     end
 
     before do

--- a/spec/feature/out_of_service_spec.rb
+++ b/spec/feature/out_of_service_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature "Out of Service" do
     end
 
     let!(:current_user) do
-      User.authenticate!(roles: ["Hearing Prep"])
+      User.authenticate!(roles: ["Hearing Prep"], id: "Hearing Prep")
     end
 
     scenario "When out of service is disabled, it shows Hearings page" do

--- a/spec/models/judge_spec.rb
+++ b/spec/models/judge_spec.rb
@@ -7,7 +7,7 @@ describe Judge do
   context ".upcoming_dockets" do
     subject { Judge.new(user).upcoming_dockets }
 
-    let(:user) { Generators::User.create }
+    let(:user) { Generators::User.create(css_id: "Hearing Prep") }
     let!(:hearing)            { Generators::Hearing.create(user: user, date: 1.day.from_now) }
     let!(:hearing_same_date)  { Generators::Hearing.create(user: user, date: 1.day.from_now + 2.hours) }
     let!(:hearing_later_date) { Generators::Hearing.create(user: user, date: 3.days.from_now) }
@@ -48,7 +48,7 @@ describe Judge do
   end
 
   context "#docket?" do
-    let(:user) { Generators::User.create }
+    let(:user) { Generators::User.create(css_id: "Hearing Prep") }
     let(:judge) { Judge.new(user) }
     let(:date) { Time.zone.now }
     let(:out_of_range_date) { date - 300.years }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,14 +86,14 @@ module StubbableUser
       @stub = user
     end
 
-    def authenticate!(roles: nil)
+    def authenticate!(roles: nil, id: nil)
       if roles && roles.include?("System Admin")
         Functions.grant!("System Admin", users: ["DSUSER"])
       end
 
       self.stub = User.from_session(
         { "user" =>
-          { "id" => "DSUSER",
+          { "id" => id || "DSUSER",
             "name" => "Lauren Roth",
             "station_id" => "283",
             "email" => "test@example.com",


### PR DESCRIPTION
We will let judges access demo so default to a Fake user having a hearing prep role.

This PR will be reverted once the demo testing is done.