### PR TITLE
Improvements to the load time for the upcoming docket page

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -5,7 +5,8 @@ class Hearing < ActiveRecord::Base
 
   vacols_attr_accessor :date, :type, :venue_key, :vacols_record, :disposition,
                        :aod, :hold_open, :transcript_requested, :notes, :add_on,
-                       :representative_name, :regional_office_key, :master_record
+                       :representative_name, :regional_office_key, :master_record,
+                       :representative
 
   belongs_to :appeal
   belongs_to :user # the judge
@@ -45,6 +46,7 @@ class Hearing < ActiveRecord::Base
       transcript_requested: transcript_requested,
       notes: notes,
       add_on: add_on,
+      representative: representative,
       representative_name: representative_name,
       regional_office_key: regional_office_key,
       master_record: master_record
@@ -68,11 +70,9 @@ class Hearing < ActiveRecord::Base
     :vbms_id, \
     :number_of_documents, \
     :number_of_documents_after_certification, \
-    :representative, \
     :veteran,  \
     to: :appeal, allow_nil: true
 
-  # rubocop:disable Metrics/MethodLength
   def to_hash
     serializable_hash(
       methods: [
@@ -85,13 +85,8 @@ class Hearing < ActiveRecord::Base
         :notes,
         :add_on,
         :master_record,
-        :appellant_last_first_mi,
-        :appellant_city,
-        :appellant_state,
         :representative,
         :representative_name,
-        :veteran_age,
-        :veteran_name,
         :regional_office_name,
         :venue,
         :vbms_id
@@ -99,15 +94,18 @@ class Hearing < ActiveRecord::Base
       except: :military_service
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
   def to_hash_for_worksheet
     serializable_hash(
       methods: [:appeal_id,
                 :appeal_vacols_id,
-                :representative,
                 :appeals_ready_for_hearing,
                 :cached_number_of_documents,
+                :veteran_age,
+                :veteran_name,
+                :appellant_last_first_mi,
+                :appellant_city,
+                :appellant_state,
                 :military_service]
     ).merge(to_hash)
   end

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -79,9 +79,10 @@ class VACOLS::CaseHearing < VACOLS::Record
              :holddays, :tranreq,
              :repname, :addon,
              :board_member, :mduser,
-             :mdtime, :sattyid)
+             :mdtime, :sattyid,
+             :bfregoff, :bfso)
         .joins("left outer join vacols.staff on staff.sattyid = board_member")
-        .includes(:brieff)
+        .joins("left outer join vacols.brieff on brieff.bfkey = folder_nr")
         .where(hearing_type: HEARING_TYPES.keys)
     end
   end

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -61,7 +61,7 @@ class HearingRepository
         }
       else
         { type: VACOLS::CaseHearing::HEARING_TYPES[vacols_record.hearing_type.to_sym],
-          regional_office_key: vacols_record.brieff.try(:bfregoff)
+          regional_office_key: vacols_record.bfregoff
         }
       end
     end
@@ -84,6 +84,7 @@ class HearingRepository
         disposition: VACOLS::CaseHearing::HEARING_DISPOSITIONS[vacols_record.hearing_disp.try(:to_sym)],
         date: vacols_record.hearing_date,
         representative_name: vacols_record.repname,
+        representative: VACOLS::Case::REPRESENTATIVES[vacols_record.bfso][:full_name],
         aod: VACOLS::CaseHearing::HEARING_AODS[vacols_record.aod.try(:to_sym)],
         hold_open: vacols_record.holddays,
         transcript_requested: VACOLS::CaseHearing::BOOLEAN_MAP[vacols_record.tranreq.try(:to_sym)],

--- a/lib/generators/hearing.rb
+++ b/lib/generators/hearing.rb
@@ -14,6 +14,7 @@ class Generators::Hearing
         contentions: "",
         evidence: "",
         comments_for_attorney: "",
+        representative: "Military Order of the Purple Heart",
         regional_office_key: VACOLS::RegionalOffice::CITIES.keys.sample,
         master_record: false
       }

--- a/spec/repositories/hearing_repository_spec.rb
+++ b/spec/repositories/hearing_repository_spec.rb
@@ -20,7 +20,8 @@ describe HearingRepository do
         tranreq: nil,
         holddays: 90,
         notes1: "test notes",
-        repname: "test rep name"
+        repname: "test rep name",
+        bfso: "E"
       )
     end
 
@@ -35,6 +36,7 @@ describe HearingRepository do
       expect(subject.hold_open).to eq 90
       expect(subject.notes).to eq "test notes"
       expect(subject.representative_name).to eq "test rep name"
+      expect(subject.representative).to eq "Jewish War Veterans"
     end
   end
 
@@ -90,7 +92,7 @@ describe HearingRepository do
         OpenStruct.new(
           hearing_type: "T",
           master_record_type: nil,
-          brieff: OpenStruct.new(bfregoff: "RO36")
+          bfregoff: "RO36"
         )
       end
       it { is_expected.to eq(type: :travel, regional_office_key: "RO36") }


### PR DESCRIPTION
connects #3514
Huge improvements to the upcoming dockets page:
1. Load `representative` when loading a hearing record instead of delegating this to the appeal later
2. Move appeal's :veteran_age, :veteran_name,  :appellant_last_first_mi, :appellant_city, :appellant_state to the worksheet hash. 