### PR TITLE
Removing "new-jenkins" branch for deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,13 +13,7 @@ def APP_VERSION = 'HEAD'
 
 // Allows appeals-deployment branch (defaults to master) to be overridden for
 // testing purposes 
-def DEPLOY_BRANCH;
-if(env.DEPLOY_BRANCH) {
-  DEPLOY_BRANCH = env.DEPLOY_BRANCH
-} else {
-  DEPLOY_BRANCH = 'master'
-  print "DEPLOY_BRANCH is not defined. Defaulting to ${DEPLOY_BRANCH}."
-}
+def DEPLOY_BRANCH = (env.DEPLOY_BRANCH != null) ? env.DEPLOY_BRANCH : 'master'
 
 /************************ Common Pipeline boilerplate ************************/
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,15 @@ def APP_NAME = 'certification';
 // See http://docs.ansible.com/ansible/git_module.html version field
 def APP_VERSION = 'HEAD'
 
+// Allows appeals-deployment branch (defaults to master) to be overridden for
+// testing purposes 
+def DEPLOY_BRANCH;
+if(env.DEPLOY_BRANCH) {
+  DEPLOY_BRANCH = env.DEPLOY_BRANCH
+} else {
+  DEPLOY_BRANCH = 'master'
+  print "DEPLOY_BRANCH is not defined. Defaulting to ${DEPLOY_BRANCH}."
+}
 
 /************************ Common Pipeline boilerplate ************************/
 
@@ -36,8 +45,8 @@ node('deploy') {
     // Checkout the deployment repo for the ansible script. This is needed
     // since the deployment scripts are separated from the source code.
     stage ('checkout-deploy-repo') {
-      // Using "new-jenkins" is temporary until we fully migrate to the new Jenkins.
-      sh "git clone -b new-jenkins https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
+
+      sh "git clone -b $DEPLOY_BRANCH https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
       
       // For prod deploys we want to pull the latest `stable` tag; the logic here will pass it to ansible git module as APP_VERSION
       if (env.APP_ENV == 'prod') {


### PR DESCRIPTION
Also added the concept of `DEPLOY_BRANCH` env that allows you to override the target appeals-deployment branch. This will ease the pain of testing different appeals-deployment branch in Jenkins.