### PR TITLE
Use default number of slots if Vacols does not contain the info

### DIFF
--- a/app/models/hearing_docket.rb
+++ b/app/models/hearing_docket.rb
@@ -5,6 +5,20 @@ class HearingDocket
 
   attr_accessor :date, :type, :regional_office_name, :hearings, :user, :regional_office_key
 
+  SLOTS_BY_TIMEZONE = {
+    "America/New_York" => 11,
+    "America/Chicago" => 9,
+    "America/Indiana/Indianapolis" => 11,
+    "America/Kentucky/Louisville" => 11,
+    "America/Denver" => 9,
+    "America/Los_Angeles" => 7,
+    "America/Boise" => 9,
+    "America/Puerto_Rico" => 11,
+    "Asia/Manila" => 7,
+    "Pacific/Honolulu" => 7,
+    "America/Anchorage" => 7
+  }.freeze
+
   def to_hash
     serializable_hash(
       methods: [:regional_office_name, :hearings_array, :slots]
@@ -27,7 +41,13 @@ class HearingDocket
       regional_office_key: regional_office_key,
       type: type,
       date: date
-    )
+    ) || SLOTS_BY_TIMEZONE[timezone]
+  end
+
+  private
+
+  def timezone
+    VACOLS::RegionalOffice::CITIES[regional_office_key][:timezone] if regional_office_key
   end
 
   class << self

--- a/lib/fakes/hearing_repository.rb
+++ b/lib/fakes/hearing_repository.rb
@@ -37,7 +37,6 @@ class Fakes::HearingRepository
   end
 
   def self.number_of_slots(*)
-    [8, 9, 10, 11, 12].sample
   end
 
   def self.appeals_ready_for_hearing(vbms_id)

--- a/spec/models/hearing_docket_spec.rb
+++ b/spec/models/hearing_docket_spec.rb
@@ -17,6 +17,7 @@ describe HearingDocket do
       date: 7.days.from_now,
       type: :video,
       regional_office_name: hearing.regional_office_name,
+      regional_office_key: "RO31",
       hearings: [
         hearing
       ]
@@ -35,6 +36,14 @@ describe HearingDocket do
     end
   end
 
+  context "#slots" do
+    subject { docket.slots }
+
+    context "should use the default number of slots for the regional office" do
+      it { is_expected.to eq 9 }
+    end
+  end
+
   context "#to_hash" do
     subject { docket.to_hash.symbolize_keys }
 
@@ -44,7 +53,7 @@ describe HearingDocket do
       expect(subject[:hearings_array].length).to eq(1)
       expect(subject[:type]).to eq(:video)
       expect(subject[:regional_office_name]).to eq(hearing.regional_office_name)
-      expect(subject[:slots].class).to eq(Fixnum)
+      expect(subject[:slots]).to eq 9
     end
   end
 


### PR DESCRIPTION
connects #3530 