### PR TITLE
Anya/3266 travel board master records

### DIFF
--- a/app/helpers/master_record_helper.rb
+++ b/app/helpers/master_record_helper.rb
@@ -1,0 +1,53 @@
+module MasterRecordHelper
+  class << self
+    # This method filters master records that have children;
+    # we are only interested in master records with no children
+    # and children records
+    def remove_master_records_with_children(records)
+      children_vdkeys = records.map(&:vdkey).compact
+      records.reject { |record| children?(record, children_vdkeys) }
+    end
+
+    # Fields such as 'type', 'regional_office_key', 'date' are stored in different places
+    # depending whether it is a video or travel board master record
+    def values_based_on_type(vacols_record)
+      case vacols_record.master_record_type
+      when :video
+        # master record is from hearshed table
+        { ro: vacols_record.folder_nr.split(" ").second,
+          type: :video,
+          dates: [vacols_record.hearing_date] }
+      when :travel_board
+        # master record is from tbshed table
+        { ro: vacols_record.tbro,
+          type: :travel,
+          dates: days_within_range(vacols_record.tbstdate, vacols_record.tbenddate) }
+      end
+    end
+
+    private
+
+    def children?(record, children_vdkeys)
+      case record.master_record_type
+      when :video
+        # For a video master record, the hearshed.hearing_pkseq becomes the VDKEY that links all
+        # the child records (veterans scheduled for that video) to the parent record
+        return children_vdkeys.map(&:to_i).include?(record.hearing_pkseq)
+      when :travel_board
+        # For a travel board master record, the tbsched_vdkey becomes the VDKEY that links all
+        # the child records (veterans scheduled for that video) to the parent record
+        # tbsched_vdkey is composed of tbshed.tbyear, tbshed.tbleg, and tbshed.tbtrip
+        return children_vdkeys.include?(record.tbsched_vdkey)
+      end
+    end
+
+    def days_within_range(start_date, end_date)
+      dates = []
+      while start_date < (end_date + 1)
+        dates << start_date
+        start_date += 1.day
+      end
+      dates
+    end
+  end
+end

--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -33,6 +33,20 @@ module HearingMapper
       end
     end
 
+    # The hearing datetime reflect the timezone of the local RO,
+    # So we append the timezone based on the regional office location
+    # And then convert the date to Eastern Time
+    def normalize_datetime(datetime, regional_office_key)
+      # asctime - returns a canonical string representation of time
+      datetime.asctime.in_time_zone(timezone(regional_office_key)).in_time_zone("Eastern Time (US & Canada)")
+    end
+
+    def timezone(regional_office_key)
+      regional_office = VACOLS::RegionalOffice::CITIES[regional_office_key] ||
+                        VACOLS::RegionalOffice::SATELLITE_OFFICES[regional_office_key]
+      regional_office[:timezone]
+    end
+
     private
 
     def code_based_on_hearing_type(type)

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -135,9 +135,6 @@ class Hearing < ActiveRecord::Base
     def create_from_vacols_record(vacols_record)
       transaction do
         find_or_initialize_by(vacols_id: vacols_record.hearing_pkseq).tap do |hearing|
-          # If it is a master record, do not create a record in the hearings table
-          return hearing if vacols_record.master_record?
-
           hearing.update(
             appeal: Appeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
             user: User.find_by(css_id: vacols_record.css_id)

--- a/app/models/hearing_docket.rb
+++ b/app/models/hearing_docket.rb
@@ -41,13 +41,7 @@ class HearingDocket
       regional_office_key: regional_office_key,
       type: type,
       date: date
-    ) || SLOTS_BY_TIMEZONE[timezone]
-  end
-
-  private
-
-  def timezone
-    VACOLS::RegionalOffice::CITIES[regional_office_key][:timezone] if regional_office_key
+    ) || SLOTS_BY_TIMEZONE[HearingMapper.timezone(regional_office_key)]
   end
 
   class << self

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -47,14 +47,8 @@ class VACOLS::CaseHearing < VACOLS::Record
     def upcoming_for_judge(css_id)
       id = connection.quote(css_id)
 
-      hearings = select_hearings.where("staff.sdomainid = #{id}")
-                                .where("hearing_date > ?", 1.week.ago)
-
-      # For a video master record, the hearing_pkseq number becomes the VDKEY that links all
-      # the child records (veterans scheduled for that video) to the parent record
-      children_ids = hearings.map(&:vdkey).compact.map(&:to_i)
-      # Filter out video master records with children
-      hearings.reject { |hearing| hearing.master_record? && children_ids.include?(hearing.hearing_pkseq) }
+      select_hearings.where("staff.sdomainid = #{id}")
+                     .where("hearing_date > ?", 1.week.ago)
     end
 
     def for_appeal(appeal_vacols_id)
@@ -89,11 +83,6 @@ class VACOLS::CaseHearing < VACOLS::Record
 
   def master_record_type
     return :video if folder_nr =~ /VIDEO/
-    # TODO: return :travel_board if a record is from tb_sched
-  end
-
-  def master_record?
-    master_record_type.present?
   end
 
   def update_hearing!(hearing_info)

--- a/app/models/vacols/travel_board_schedule.rb
+++ b/app/models/vacols/travel_board_schedule.rb
@@ -1,0 +1,35 @@
+# Travel Board master schedule is in a table called TBSCHED
+class VACOLS::TravelBoardSchedule < VACOLS::Record
+  self.table_name = "vacols.tbsched"
+
+  class << self
+    def upcoming_for_judge(css_id)
+      id = connection.quote(css_id)
+
+      # css_id is stored in the STAFF.SDOMAINID column and corresponds to TBSCHED.tbmem1, tbmem2, tbmem3, tbmem4
+      select("(TBSCHED.TBYEAR||'-'||TBSCHED.TBTRIP||'-'||TBSCHED.TBLEG) as tbsched_vdkey",
+             :tbmem1,
+             :tbmem2,
+             :tbmem3,
+             :tbmem4,
+             :tbro,
+             :tbstdate,
+             :tbenddate)
+        .joins("join vacols.staff on
+                staff.sattyid = tbmem1 OR
+                staff.sattyid = tbmem2 OR
+                staff.sattyid = tbmem3 OR
+                staff.sattyid = tbmem4")
+        .where("staff.sdomainid = #{id}")
+        .where("tbstdate > ?", 1.week.ago)
+    end
+  end
+
+  def master_record_type
+    :travel_board
+  end
+
+  def vdkey
+    nil
+  end
+end

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -2,7 +2,9 @@ class HearingRepository
   class << self
     # :nocov:
     def upcoming_hearings_for_judge(css_id)
-      hearings_for(VACOLS::CaseHearing.upcoming_for_judge(css_id))
+      records = VACOLS::CaseHearing.upcoming_for_judge(css_id) +
+                VACOLS::TravelBoardSchedule.upcoming_for_judge(css_id)
+      hearings_for(MasterRecordHelper.remove_master_records_with_children(records))
     end
 
     def hearings_for_appeal(appeal_vacols_id)
@@ -15,6 +17,7 @@ class HearingRepository
     end
 
     def load_vacols_data(hearing)
+      return if hearing.master_record
       vacols_record = VACOLS::CaseHearing.load_hearing(hearing.vacols_id)
       set_vacols_values(hearing, vacols_record)
       true
@@ -51,48 +54,34 @@ class HearingRepository
       end
     end
 
-    # Fields such as 'type', 'regional_office_key' are stored in different places
-    # depending whether it is a child record or a master record (video or travel_board)
-    def values_based_on_type(vacols_record)
-      case vacols_record.master_record_type
-      when :video
-        ro = vacols_record.folder_nr.split(" ").second
-        type = :video
-      else
-        ro = vacols_record.bfregoff
-        type = VACOLS::CaseHearing::HEARING_TYPES[vacols_record.hearing_type.to_sym]
-      end
-      date = hearing_datetime(vacols_record.hearing_date, ro) if vacols_record.hearing_date && ro
-
-      { type: type,
-        regional_office_key: ro,
-        date: date
-      }
-    end
-
-    # The hearing datetime reflect the timezone of the local RO,
-    # So we append the timezone based on the regional office location
-    # And then convert the date to Eastern Time
-    def hearing_datetime(datetime, regional_office_key)
-      timezone = VACOLS::RegionalOffice::CITIES[regional_office_key][:timezone]
-      # asctime - returns a canonical string representation of time
-      datetime.asctime.in_time_zone(timezone).in_time_zone("Eastern Time (US & Canada)")
+    def hearings_for(case_hearings)
+      case_hearings.map do |vacols_record|
+        next empty_dockets(vacols_record) if master_record?(vacols_record)
+        hearing = Hearing.create_from_vacols_record(vacols_record)
+        set_vacols_values(hearing, vacols_record)
+      end.flatten
     end
 
     private
 
-    # :nocov:
-    def hearings_for(case_hearings)
-      case_hearings.map do |vacols_record|
-        hearing = Hearing.create_from_vacols_record(vacols_record)
-        set_vacols_values(hearing, vacols_record)
+    def master_record?(record)
+      record.master_record_type.present?
+    end
+
+    def empty_dockets(vacols_record)
+      values = MasterRecordHelper.values_based_on_type(vacols_record)
+      # Travel Board master records have a date range, so we create a master record for each day
+      values[:dates].inject([]) do |result, date|
+        result << Hearing.new(date: HearingMapper.normalize_datetime(date, values[:ro]),
+                              type: values[:type],
+                              master_record: true,
+                              regional_office_key: values[:ro])
+        result
       end
     end
-    # :nocov:
 
     def vacols_attributes(vacols_record)
-      attrs = values_based_on_type(vacols_record)
-      attrs.merge(
+      {
         vacols_record: vacols_record,
         venue_key: vacols_record.hearing_venue,
         disposition: VACOLS::CaseHearing::HEARING_DISPOSITIONS[vacols_record.hearing_disp.try(:to_sym)],
@@ -103,8 +92,11 @@ class HearingRepository
         transcript_requested: VACOLS::CaseHearing::BOOLEAN_MAP[vacols_record.tranreq.try(:to_sym)],
         add_on: VACOLS::CaseHearing::BOOLEAN_MAP[vacols_record.addon.try(:to_sym)],
         notes: vacols_record.notes1,
-        master_record: vacols_record.master_record?
-      )
+        regional_office_key: vacols_record.bfregoff,
+        type: VACOLS::CaseHearing::HEARING_TYPES[vacols_record.hearing_type.to_sym],
+        date: HearingMapper.normalize_datetime(vacols_record.hearing_date, vacols_record.bfregoff),
+        master_record: false
+      }
     end
   end
 end

--- a/spec/helpers/master_record_helper_spec.rb
+++ b/spec/helpers/master_record_helper_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe MasterRecordHelper, type: :helper do
+  before do
+    Timecop.freeze(Time.utc(2017, 2, 2))
+    Time.zone = "America/Chicago"
+  end
+
+  context ".remove_master_records_with_children" do
+    subject { MasterRecordHelper.remove_master_records_with_children(records) }
+
+    context "when master records have children" do
+      let(:video_parent1) { OpenStruct.new(master_record_type: :video, hearing_pkseq: 1234) }
+      let(:video_parent2) { OpenStruct.new(master_record_type: :video, hearing_pkseq: 5678) }
+      let(:video_child1) { OpenStruct.new(hearing_pkseq: 9999, vdkey: "1234") }
+      let(:video_child2) { OpenStruct.new(hearing_pkseq: 8888, vdkey: "1234") }
+      let(:co_child1) { OpenStruct.new(hearing_pkseq: 7777) }
+      let(:tb_parent1) { OpenStruct.new(master_record_type: :travel_board, tbsched_vdkey: "2012-26-1") }
+      let(:tb_parent2) { OpenStruct.new(master_record_type: :travel_board, tbsched_vdkey: "2013-12-1") }
+      let(:tb_child2) { OpenStruct.new(hearing_pkseq: 6666, vdkey: "2013-12-1") }
+
+      let(:records) do
+        [video_parent1, video_parent2, video_child1, video_child2, co_child1, tb_parent1, tb_parent2, tb_child2]
+      end
+
+      it "should remove master records with children" do
+        # 2 master records with children
+        expect(subject.size).to eq 6
+        # video_parent1 and tb_parent2 have children
+        expect(subject).to_not include video_parent1
+        expect(subject).to_not include tb_parent2
+      end
+    end
+  end
+
+  context ".values_based_on_type" do
+    subject { MasterRecordHelper.values_based_on_type(vacols_record) }
+
+    context "when a hearing is a video master record" do
+      let(:vacols_record) do
+        OpenStruct.new(
+          folder_nr: "VIDEO RO15",
+          hearing_date: Time.zone.now,
+          master_record_type: :video
+        )
+      end
+      it { is_expected.to eq(type: :video, ro: "RO15", dates: [Time.zone.now]) }
+    end
+
+    context "when a hearing is a travel board master record" do
+      let(:vacols_record) do
+        OpenStruct.new(
+          tbro: "RO19",
+          tbstdate: Time.zone.now,
+          tbenddate: Time.zone.now + 3.days,
+          master_record_type: :travel_board
+        )
+      end
+      it do
+        is_expected.to eq(type: :travel,
+                          ro: "RO19",
+                          dates: [Time.zone.now, Time.zone.now + 1.day,
+                                  Time.zone.now + 2.days, Time.zone.now + 3.days])
+      end
+    end
+
+    context "when a hearing is not a master record" do
+      let(:vacols_record) do
+        OpenStruct.new(
+          hearing_type: "T",
+          master_record_type: nil,
+          bfregoff: "RO36"
+        )
+      end
+      it { is_expected.to eq(nil) }
+    end
+  end
+end

--- a/spec/helpers/vacols_helper_spec.rb
+++ b/spec/helpers/vacols_helper_spec.rb
@@ -1,6 +1,7 @@
 describe VacolsHelper do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+    Time.zone = "Eastern Time (US & Canada)"
   end
 
   context ".local_time_with_utc_timezone" do

--- a/spec/mappers/hearing_mapper_spec.rb
+++ b/spec/mappers/hearing_mapper_spec.rb
@@ -1,6 +1,6 @@
 describe HearingMapper do
   before do
-    Timecop.freeze(Time.utc(2017, 2, 2))
+    Timecop.freeze(Time.utc(2017, 10, 4))
     Time.zone = "America/Chicago"
   end
 
@@ -55,6 +55,20 @@ describe HearingMapper do
       let(:hearing_type) { "C" }
 
       it { is_expected.to eq "5" }
+    end
+  end
+
+  context ".normalize_datetime" do
+    subject { HearingMapper.normalize_datetime(Time.zone.now, regional_office_key) }
+
+    context "uses regional office timezone to set the zone" do
+      let(:regional_office_key) { "RO58" }
+
+      it "calculates the date and hour correctly" do
+        expect(subject.day).to eq 3
+        expect(subject.hour).to eq 7
+        expect(subject.zone).to eq "EDT"
+      end
     end
   end
 

--- a/spec/repositories/hearing_repository_spec.rb
+++ b/spec/repositories/hearing_repository_spec.rb
@@ -41,6 +41,48 @@ describe HearingRepository do
     end
   end
 
+  context ".hearings_for" do
+    subject { HearingRepository.hearings_for(records) }
+
+    let(:record1) do
+      OpenStruct.new(
+        hearing_type: "T",
+        master_record_type: nil,
+        bfregoff: "RO36",
+        hearing_pkseq: "1234",
+        folder_nr: "5678",
+        hearing_date: Time.zone.now,
+      )
+    end
+
+    let(:record2) do
+      OpenStruct.new(
+        folder_nr: "VIDEO RO15",
+        hearing_date: Time.zone.now,
+        master_record_type: :video
+      )
+    end
+
+    let(:record3) do
+      OpenStruct.new(
+        tbro: "RO19",
+        tbstdate: Time.zone.now,
+        tbenddate: Time.zone.now,
+        master_record_type: :travel_board
+      )
+    end
+
+    let(:records) { [record1, record2, record3] }
+
+    it "should create hearing records" do
+      expect(subject.size).to eq 3
+      expect(subject.first.vacols_id).to eq "1234"
+      expect(subject.first.master_record).to eq false
+      expect(subject.second.master_record).to eq true
+      expect(subject.third.master_record).to eq true
+    end
+  end
+
   context ".slots_based_on_type" do
     subject { HearingRepository.slots_based_on_type(staff: staff, type: type, date: date) }
 
@@ -71,46 +113,6 @@ describe HearingRepository do
         let(:date) { Time.zone.now }
         it { is_expected.to eq 9 }
       end
-    end
-  end
-
-  context ".hearing_datetime" do
-    subject { HearingRepository.hearing_datetime(Time.zone.now, regional_office_key) }
-
-    context "uses regional office timezone to set the zone" do
-      let(:regional_office_key) { "RO58" }
-
-      it "calculates the date and hour correctly" do
-        expect(subject.day).to eq 3
-        expect(subject.hour).to eq 7
-        expect(subject.zone).to eq "EDT"
-      end
-    end
-  end
-
-  context ".values_based_on_type" do
-    subject { HearingRepository.values_based_on_type(vacols_record) }
-
-    context "when a hearing is a video master record" do
-      let(:vacols_record) do
-        OpenStruct.new(
-          hearing_type: "V",
-          folder_nr: "VIDEO RO15",
-          master_record_type: :video
-        )
-      end
-      it { is_expected.to eq(type: :video, regional_office_key: "RO15", date: nil) }
-    end
-
-    context "when a hearing is not a master record" do
-      let(:vacols_record) do
-        OpenStruct.new(
-          hearing_type: "T",
-          master_record_type: nil,
-          bfregoff: "RO36"
-        )
-      end
-      it { is_expected.to eq(type: :travel, regional_office_key: "RO36", date: nil) }
     end
   end
 end

--- a/spec/repositories/hearing_repository_spec.rb
+++ b/spec/repositories/hearing_repository_spec.rb
@@ -51,7 +51,7 @@ describe HearingRepository do
         bfregoff: "RO36",
         hearing_pkseq: "1234",
         folder_nr: "5678",
-        hearing_date: Time.zone.now,
+        hearing_date: Time.zone.now
       )
     end
 


### PR DESCRIPTION
connects #3266 

This is a PR to get travel board master records added to the upcoming dockets page. 
We can continue improving the implementation in the subsequent PRs.

Steps to Validate:
1. Populate `tbshed` table with travel board master records associated with the judge's CSS_ID
2. Associate children records in hearshed table with some travel board master records
3. Populate `hearshed` with video master records with children and without children
4. Populate `hearshed` with central office records 
5. Go to the judge's dockets page and ensure master records with no children and children records themselves show up. 
6.  Travel board master records have a date range so a master record is created for each day
