### PR TITLE
Sending analytics only when bluring

### DIFF
--- a/client/app/components/DropdownMenu.jsx
+++ b/client/app/components/DropdownMenu.jsx
@@ -22,7 +22,7 @@ export default class DropdownMenu extends React.Component {
   setWrapperRef = (node) => this.wrapperRef = node
 
   onClickOutside = (event) => {
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && this.state.menu) {
       window.analyticsEvent(this.props.analyticsTitle, 'menu', 'blur');
 
       this.setState({


### PR DESCRIPTION
Connects: #3595

**Test Plan**
- [ ] Check the network tab to ensure we only fire blur events when the menu is open, not when it's closed. 