### PR TITLE
Styleguide scroll

### DIFF
--- a/app/assets/stylesheets/_style_guide.scss
+++ b/app/assets/stylesheets/_style_guide.scss
@@ -13,6 +13,7 @@ $color-tab-text-hover: #1f5593;
     width: 10em;
     height: 100%;
     clip: rect(0, auto, auto, 0);
+    box-sizing: border-box;
 
     &.re-topped {
       top: -120px;

--- a/client/app/components/StickyNav.jsx
+++ b/client/app/components/StickyNav.jsx
@@ -48,16 +48,4 @@ export default class StickyNav extends React.Component {
       </div>
     );
   }
-
-  renderold() {
-    return (
-      <div className={this.state.className}>
-        <div className="cf-push-left cf-sg-nav">
-          <ul className="usa-sidenav-list">
-            { this.props.children }
-          </ul>
-        </div>
-      </div>
-    );
-  }
 }

--- a/client/app/components/StickyNav.jsx
+++ b/client/app/components/StickyNav.jsx
@@ -7,7 +7,6 @@ export default class StickyNav extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      className: 'cf-sg-nav-not-scrolling',
       reTopped: ''
     };
   }
@@ -21,15 +20,13 @@ export default class StickyNav extends React.Component {
   }
 
   handleScroll = () => {
-    // Nav bar will attach to top of page if the user scrolls down by 150px
-    if (window.scrollY > 150) {
+    // Nav bar will attach to top of page if the user scrolls down by 120px
+    if (window.scrollY > 120) {
       this.setState({
-        className: 'cf-sg-nav-scrolling',
         topClass: 're-topped'
       });
-    } else if (window.scrollY < 150) {
+    } else if (window.scrollY < 120) {
       this.setState({
-        className: 'cf-sg-nav-not-scrolling',
         topClass: ''
       });
     }
@@ -40,7 +37,7 @@ export default class StickyNav extends React.Component {
   render() {
     return (
       <div className={`cf-sg-nav ${this.state.topClass}`}>
-        <div className={this.state.className}>
+        <div className="cf-sg-nav-scrolling">
           <ul className="usa-sidenav-list">
             { this.props.children }
           </ul>

--- a/client/app/components/StickyNav.jsx
+++ b/client/app/components/StickyNav.jsx
@@ -21,11 +21,11 @@ export default class StickyNav extends React.Component {
 
   handleScroll = () => {
     // Nav bar will attach to top of page if the user scrolls down by 120px
-    if (window.scrollY > 120) {
+    if (window.scrollY >= 120) {
       this.setState({
         topClass: 're-topped'
       });
-    } else if (window.scrollY < 120) {
+    } else {
       this.setState({
         topClass: ''
       });


### PR DESCRIPTION
This allows a user to scroll through the menu on Style guide without needing to scroll the whole page.
![styleguide-scroll](https://user-images.githubusercontent.com/4773320/31627104-0a30a276-b27a-11e7-99ce-691e5dae463a.gif)

Connects #2285