### PR TITLE
Anya/3291 fix hearing times

### DIFF
--- a/app/helpers/vacols_helper.rb
+++ b/app/helpers/vacols_helper.rb
@@ -8,6 +8,22 @@ module VacolsHelper
     Time.utc(value.year, value.month, value.day, value.hour, value.min, value.sec)
   end
 
+  # dates in VACOLS are incorrectly recorded as UTC.
+  def self.normalize_vacols_datetime(datetime)
+    return nil unless datetime
+
+    utc_datetime = datetime.in_time_zone("UTC")
+
+    Time.zone.local(
+      utc_datetime.year,
+      utc_datetime.month,
+      utc_datetime.day,
+      utc_datetime.hour,
+      utc_datetime.min,
+      utc_datetime.sec
+    )
+  end
+
   def self.validate_presence(note, required_fields)
     missing_keys = []
     required_fields.each { |k| missing_keys << k unless note[k] }

--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -33,13 +33,13 @@ module HearingMapper
       end
     end
 
-    # The TB hearing datetime reflect the timezone of the local RO,
+    # The TB abd Video hearing datetime reflect the timezone of the local RO,
     # So we append the timezone based on the regional office location
     # And then convert the date to Eastern Time
     # asctime - returns a canonical string representation of time
     def datetime_based_on_type(datetime:, regional_office_key:, type:)
       datetime = VacolsHelper.normalize_vacols_datetime(datetime)
-      return datetime unless type == :travel
+      return datetime if type == :central_office
 
       datetime.asctime.in_time_zone(timezone(regional_office_key)).in_time_zone("Eastern Time (US & Canada)")
     end

--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -33,11 +33,14 @@ module HearingMapper
       end
     end
 
-    # The hearing datetime reflect the timezone of the local RO,
+    # The TB hearing datetime reflect the timezone of the local RO,
     # So we append the timezone based on the regional office location
     # And then convert the date to Eastern Time
-    def normalize_datetime(datetime, regional_office_key)
-      # asctime - returns a canonical string representation of time
+    # asctime - returns a canonical string representation of time
+    def datetime_based_on_type(datetime:, regional_office_key:, type:)
+      datetime = VacolsHelper.normalize_vacols_datetime(datetime)
+      return datetime unless type == :travel
+
       datetime.asctime.in_time_zone(timezone(regional_office_key)).in_time_zone("Eastern Time (US & Canada)")
     end
 

--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -33,7 +33,7 @@ module HearingMapper
       end
     end
 
-    # The TB abd Video hearing datetime reflect the timezone of the local RO,
+    # The TB and Video hearing datetime reflect the timezone of the local RO,
     # So we append the timezone based on the regional office location
     # And then convert the date to Eastern Time
     # asctime - returns a canonical string representation of time

--- a/app/models/concerns/regional_office_concern.rb
+++ b/app/models/concerns/regional_office_concern.rb
@@ -2,7 +2,8 @@ module RegionalOfficeConcern
   extend ActiveSupport::Concern
 
   def regional_office
-    { key: regional_office_key }.merge(VACOLS::RegionalOffice::CITIES[regional_office_key] || {})
+    { key: regional_office_key }.merge(VACOLS::RegionalOffice::CITIES[regional_office_key] ||
+                                       VACOLS::RegionalOffice::SATELLITE_OFFICES[regional_office_key] || {})
   end
 
   def regional_office_name

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -2,7 +2,6 @@ class HearingRepository
   class << self
     # :nocov:
     def upcoming_hearings_for_judge(css_id)
-      css_id = "CASEFLOW_283"
       records = VACOLS::CaseHearing.upcoming_for_judge(css_id) +
                 VACOLS::TravelBoardSchedule.upcoming_for_judge(css_id)
       hearings_for(MasterRecordHelper.remove_master_records_with_children(records))

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -2,6 +2,7 @@ class HearingRepository
   class << self
     # :nocov:
     def upcoming_hearings_for_judge(css_id)
+      css_id = "CASEFLOW_283"
       records = VACOLS::CaseHearing.upcoming_for_judge(css_id) +
                 VACOLS::TravelBoardSchedule.upcoming_for_judge(css_id)
       hearings_for(MasterRecordHelper.remove_master_records_with_children(records))

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -72,7 +72,7 @@ class HearingRepository
       values = MasterRecordHelper.values_based_on_type(vacols_record)
       # Travel Board master records have a date range, so we create a master record for each day
       values[:dates].inject([]) do |result, date|
-        result << Hearing.new(date: HearingMapper.normalize_datetime(date, values[:ro]),
+        result << Hearing.new(date: VacolsHelper.normalize_vacols_datetime(date),
                               type: values[:type],
                               master_record: true,
                               regional_office_key: values[:ro])
@@ -81,6 +81,10 @@ class HearingRepository
     end
 
     def vacols_attributes(vacols_record)
+      type = VACOLS::CaseHearing::HEARING_TYPES[vacols_record.hearing_type.to_sym]
+      date = HearingMapper.datetime_based_on_type(datetime: vacols_record.hearing_date,
+                                                  regional_office_key: vacols_record.bfregoff,
+                                                  type: type)
       {
         vacols_record: vacols_record,
         venue_key: vacols_record.hearing_venue,
@@ -93,8 +97,8 @@ class HearingRepository
         add_on: VACOLS::CaseHearing::BOOLEAN_MAP[vacols_record.addon.try(:to_sym)],
         notes: vacols_record.notes1,
         regional_office_key: vacols_record.bfregoff,
-        type: VACOLS::CaseHearing::HEARING_TYPES[vacols_record.hearing_type.to_sym],
-        date: HearingMapper.normalize_datetime(vacols_record.hearing_date, vacols_record.bfregoff),
+        type: type,
+        date: date,
         master_record: false
       }
     end

--- a/spec/mappers/hearing_mapper_spec.rb
+++ b/spec/mappers/hearing_mapper_spec.rb
@@ -76,6 +76,16 @@ describe HearingMapper do
     context "when video" do
       let(:type) { :video }
 
+      it "uses a regional office timezone to set the zone" do
+        expect(subject.day).to eq 5
+        expect(subject.hour).to eq 16
+        expect(subject.zone).to eq "EDT"
+      end
+    end
+
+    context "when central_office" do
+      let(:type) { :central_office }
+
       it "does not use a regional office timezone" do
         expect(subject.day).to eq 6
         expect(subject.hour).to eq 4

--- a/spec/mappers/hearing_mapper_spec.rb
+++ b/spec/mappers/hearing_mapper_spec.rb
@@ -1,9 +1,4 @@
 describe HearingMapper do
-  before do
-    Timecop.freeze(Time.utc(2017, 10, 4))
-    Time.zone = "America/Chicago"
-  end
-
   context ".bfha_vacols_code" do
     let(:hearing) do
       OpenStruct.new(
@@ -58,16 +53,33 @@ describe HearingMapper do
     end
   end
 
-  context ".normalize_datetime" do
-    subject { HearingMapper.normalize_datetime(Time.zone.now, regional_office_key) }
+  context ".datetime_based_on_type" do
+    before { Time.zone = "America/Chicago" }
+    subject do
+      HearingMapper.datetime_based_on_type(datetime: datetime,
+                                           regional_office_key: regional_office_key,
+                                           type: type)
+    end
+    let(:regional_office_key) { "RO58" }
+    let(:datetime) { Time.new(2013, 9, 5, 20, 0, 0, "-08:00") }
 
-    context "uses regional office timezone to set the zone" do
-      let(:regional_office_key) { "RO58" }
+    context "when travel board" do
+      let(:type) { :travel }
 
-      it "calculates the date and hour correctly" do
-        expect(subject.day).to eq 3
-        expect(subject.hour).to eq 7
+      it "uses a regional office timezone to set the zone" do
+        expect(subject.day).to eq 5
+        expect(subject.hour).to eq 16
         expect(subject.zone).to eq "EDT"
+      end
+    end
+
+    context "when video" do
+      let(:type) { :video }
+
+      it "does not use a regional office timezone" do
+        expect(subject.day).to eq 6
+        expect(subject.hour).to eq 4
+        expect(subject.zone).to eq "CDT"
       end
     end
   end


### PR DESCRIPTION
1. Parse the hearing dates correctly
2. Travel board and video records are scheduled for that RO's timezone.
3. Travel Board master records all have start time of midnight 

Steps to Validate:
1. Navigate to the upcoming dockets page
2. Ensure that the start times are accurate.
* CO should always show in EST time
* Video should be in EST but reflect the accurate start time for that RO location
* Travel board should be in EST but reflect the accurate start time for that RO location
3. Travel board master records should always start at midnight.
4. If possible compare with Vacols UI results for the start times. 

Tested against prod copy records.

![image](https://user-images.githubusercontent.com/3811786/31733395-7fb65dd4-b409-11e7-8dde-44bda35dc990.png)


![image](https://user-images.githubusercontent.com/3811786/31733529-e8c7d9e2-b409-11e7-9f53-d37327709af8.png)


