### PR TITLE
Not having a BIRLS record should register as not found

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -76,7 +76,7 @@ class Veteran
   end
 
   def found?
-    bgs_record != :not_found
+    bgs_record != :not_found && bgs_record[:file_number]
   end
 
   def accessible?

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1058,7 +1058,7 @@ describe Appeal do
   context "#veteran" do
     subject { appeal.veteran }
 
-    let(:veteran_record) { { first_name: "Ed", last_name: "Merica" } }
+    let(:veteran_record) { { file_number: "123", first_name: "Ed", last_name: "Merica" } }
 
     before do
       Fakes::BGSService.veteran_records = { appeal.sanitized_vbms_id => veteran_record }

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -41,6 +41,14 @@ describe Veteran do
       it { is_expected.to_not be_found }
     end
 
+    context "when veteran has no BIRLS record" do
+      let(:veteran_record) do
+        { file_number: nil }
+      end
+
+      it { is_expected.to_not be_found }
+    end
+
     it "returns the veteran with data loaded from BGS" do
       is_expected.to have_attributes(
         file_number: "445566",


### PR DESCRIPTION
Shows a not found error message instead of a permission denied message if there is no BIRLS record for a veteran

connects #3431