### PR TITLE
Intake | Validate that appeals are eligible for RAMP

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -229,6 +229,10 @@ class Appeal < ActiveRecord::Base
     hearing_requested && !hearing_held
   end
 
+  def eligible_for_ramp?
+    status == "Advance"
+  end
+
   def attributes_for_hearing
     {
       "id" => id,

--- a/app/models/ramp_intake.rb
+++ b/app/models/ramp_intake.rb
@@ -9,7 +9,7 @@ class RampIntake < Intake
     transaction do
       complete_with_status!(:success)
 
-      eligibile_appeals.each do |appeal|
+      eligible_appeals.each do |appeal|
         appeal.close!(user: user, closed_on: Time.zone.today, disposition: "RAMP Opt-in")
       end
     end
@@ -27,7 +27,7 @@ class RampIntake < Intake
   end
 
   def serialized_appeal_issues
-    eligibile_appeals.map do |appeal|
+    eligible_appeals.map do |appeal|
       {
         id: appeal.id,
         issues: appeal.issues.map(&:description_attributes)
@@ -39,7 +39,7 @@ class RampIntake < Intake
 
   # Appeals in VACOLS that will be closed out in favor
   # of a new format review
-  def eligibile_appeals
+  def eligible_appeals
     Appeal.fetch_appeals_by_file_number(veteran_file_number).select(&:eligible_for_ramp?)
   end
 
@@ -47,7 +47,7 @@ class RampIntake < Intake
     if !matching_ramp_election
       @error_code = :did_not_receive_ramp_election
 
-    elsif eligibile_appeals.empty?
+    elsif eligible_appeals.empty?
       @error_code = :no_eligible_appeals
     end
   end

--- a/client/app/intake/pages/begin.jsx
+++ b/client/app/intake/pages/begin.jsx
@@ -45,6 +45,28 @@ const searchErrors = {
       </ul>
     </div>
   },
+  no_eligible_appeals: {
+    title: 'This Veteran is not eligible to participate in RAMP.',
+    body: <div>
+      <p>
+        Please check the Veteran ID entered, and if the Veteran ID
+        is correct, take the following actions outside Caseflow:
+      </p>
+      <ul>
+        <li>
+          Upload the RAMP Election to the VBMS eFolder with
+          Document Type <b>Correspondence</b> and Subject Line "RAMP Election".
+        </li>
+        <li>
+          Notify the Veteran by mail of his/her ineligibility to participate
+          in RAMP using the <b>RAMP Ineligible Letter</b> in <em>Letter Creator</em>.
+        </li>
+        <li>
+          Document your actions as a permanent note in VBMS.
+        </li>
+      </ul>
+    </div>
+  },
   default: {
     title: 'Something went wrong',
     body: 'Please try again. If the problem persists, please contact Caseflow support.'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -96,6 +96,11 @@ class SeedDB
         notice_date: i.weeks.ago
       )
     end
+
+    RampElection.create!(
+      veteran_file_number: "11555555",
+      notice_date: 3.weeks.ago
+    )
   end
 
   def create_tags

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -460,14 +460,18 @@ class Fakes::AppealRepository
 
   def self.seed_intake_data!
     9.times do |i|
-      Generators::Veteran.build(file_number: "#{i}5555555")
-      Generators::Veteran.build(file_number: "#{i}0555555")
+      Generators::Veteran.build(file_number: "#{i + 1}0555555")
 
       Generators::Appeal.build(
         vbms_id: "#{i}5555555C",
         issues: (1..2).map { Generators::Issue.build }
       )
     end
+
+    Generators::Appeal.build(
+      vbms_id: "11555555C",
+      vacols_record: :remand_decided
+    )
 
     Generators::Appeal.build(
       vbms_id: "25555555C",

--- a/lib/generators/appeal.rb
+++ b/lib/generators/appeal.rb
@@ -54,9 +54,15 @@ class Generators::Appeal
           regional_office_key: "DSUSER"
         },
         certified: {
+          status: "Advance",
           certification_date: 1.day.ago
         },
+        activated: {
+          certification_date: 4.days.ago,
+          case_review_date: 1.day.ago
+        },
         form9_not_submitted: {
+          status: "Advance",
           decision_date: nil,
           form9_date: nil
         },

--- a/spec/feature/intake_spec.rb
+++ b/spec/feature/intake_spec.rb
@@ -34,6 +34,13 @@ RSpec.feature "RAMP Intake" do
     )
   end
 
+  let!(:ineligible_appeal) do
+    Generators::Appeal.build(
+      vbms_id: "77776666C",
+      vacols_record: :full_grant_decided
+    )
+  end
+
   context "As a user with Mail Intake role" do
     let!(:current_user) do
       User.authenticate!(roles: ["Mail Intake"])
@@ -55,6 +62,17 @@ RSpec.feature "RAMP Intake" do
 
       expect(page).to have_current_path("/intake")
       expect(page).to have_content("A RAMP Opt-in Notice Letter was not sent to this Veteran.")
+    end
+
+    scenario "Search for a veteran with an ineligible appeal" do
+      RampElection.create!(veteran_file_number: "77776666", notice_date: 5.days.ago)
+
+      visit "/intake"
+      fill_in "Search small", with: "77776666"
+      click_on "Search"
+
+      expect(page).to have_current_path("/intake")
+      expect(page).to have_content("This Veteran is not eligible to participate in RAMP.")
     end
 
     scenario "Search for a veteran that has received a RAMP election" do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -742,6 +742,20 @@ describe Appeal do
     end
   end
 
+  context "#eligible_for_ramp?" do
+    subject { appeal.eligible_for_ramp? }
+
+    context "is false if status is not advance" do
+      let(:appeal) { Generators::Appeal.build(vacols_id: "123", status: "Remand") }
+      it { is_expected.to be_falsey }
+    end
+
+    context "is true if status is advance" do
+      let(:appeal) { Generators::Appeal.build(vacols_id: "123", status: "Advance") }
+      it { is_expected.to be_truthy }
+    end
+  end
+
   context "#disposition_remand_priority" do
     subject { appeal.disposition_remand_priority }
     context "when disposition is allowed and one of the issues is remanded" do

--- a/spec/models/ramp_intake_spec.rb
+++ b/spec/models/ramp_intake_spec.rb
@@ -204,7 +204,7 @@ describe RampIntake do
       context "there are no eligible appeals" do
         let(:appeal_vacols_record) { :full_grant_decided }
 
-        it "adds did_not_receive_ramp_election and returns false" do
+        it "adds no_eligible_appeals and returns false" do
           expect(subject).to eq(false)
           expect(intake.error_code).to eq(:no_eligible_appeals)
         end

--- a/spec/models/ramp_intake_spec.rb
+++ b/spec/models/ramp_intake_spec.rb
@@ -7,6 +7,14 @@ describe RampIntake do
   let(:user) { Generators::User.build }
   let(:detail) { nil }
   let!(:veteran) { Generators::Veteran.build(file_number: "64205555") }
+  let(:appeal_vacols_record) { :ready_to_certify }
+  let!(:appeal) do
+    Generators::Appeal.build(
+      vbms_id: "64205555C",
+      vacols_record: appeal_vacols_record,
+      veteran: veteran
+    )
+  end
   let(:intake) do
     RampIntake.new(
       user: user,
@@ -189,7 +197,18 @@ describe RampIntake do
         RampElection.create!(veteran_file_number: "64205555", notice_date: 6.days.ago)
       end
 
-      it { is_expected.to eq(true) }
+      context "there are no eligible appeals" do
+        let(:appeal_vacols_record) { :full_grant_decided }
+
+        it "adds did_not_receive_ramp_election and returns false" do
+          expect(subject).to eq(false)
+          expect(intake.error_code).to eq(:no_eligible_appeals)
+        end
+      end
+
+      context "there are eligible appeals" do
+        it { is_expected.to eq(true) }
+      end
     end
   end
 end

--- a/spec/models/ramp_intake_spec.rb
+++ b/spec/models/ramp_intake_spec.rb
@@ -8,18 +8,20 @@ describe RampIntake do
   let(:detail) { nil }
   let!(:veteran) { Generators::Veteran.build(file_number: "64205555") }
   let(:appeal_vacols_record) { :ready_to_certify }
-  let!(:appeal) do
-    Generators::Appeal.build(
-      vbms_id: "64205555C",
-      vacols_record: appeal_vacols_record,
-      veteran: veteran
-    )
-  end
+
   let(:intake) do
     RampIntake.new(
       user: user,
       detail: detail,
       veteran_file_number: veteran_file_number
+    )
+  end
+
+  let(:appeal) do
+    Generators::Appeal.build(
+      vbms_id: "64205555C",
+      vacols_record: appeal_vacols_record,
+      veteran: veteran
     )
   end
 
@@ -157,6 +159,7 @@ describe RampIntake do
 
   context "#start!" do
     subject { intake.start! }
+    let!(:ramp_appeal) { appeal }
 
     let!(:ramp_election) do
       RampElection.create!(veteran_file_number: "64205555", notice_date: 5.days.ago)
@@ -184,6 +187,7 @@ describe RampIntake do
 
   context "#validate_start" do
     subject { intake.validate_start }
+    let!(:ramp_appeal) { appeal }
 
     context "there is not a ramp election for veteran" do
       it "adds did_not_receive_ramp_election and returns false" do


### PR DESCRIPTION
Checks that the vet still has appeals that are in the ADV status, according to #3433

connects #3433
connects #3442