### PR TITLE
Flattening worksheet's redux structure

### DIFF
--- a/client/app/hearings/reducers/index.js
+++ b/client/app/hearings/reducers/index.js
@@ -57,10 +57,27 @@ export const hearingsReducers = function(state = mapDataToInitialState(), action
       dockets: { $set: action.payload.dockets }
     });
 
-  case Constants.POPULATE_WORKSHEET:
+  case Constants.POPULATE_WORKSHEET: {
+    const worksheetAppeals = _.keyBy(
+      action.payload.worksheet.appeals_ready_for_hearing,
+      (appeal) => appeal.id
+    );
+    let worksheetIssues = {};
+
+    Object.keys(worksheetAppeals).forEach((key) => {
+      worksheetIssues = Object.assign(
+        {},
+        worksheetIssues,
+        _.keyBy(worksheetAppeals[key].worksheet_issues, (issue) => issue.id));
+    });
+    // TODO: After updating the reducers, we need to remove appeals_ready_for_hearing from the worksheet object
+
     return update(state, {
+      worksheetIssues: { $set: worksheetIssues },
+      worksheetAppeals: { $set: worksheetAppeals },
       worksheet: { $set: action.payload.worksheet }
     });
+  }
 
   case Constants.HANDLE_WORKSHEET_SERVER_ERROR:
     return update(state, {

--- a/client/app/hearings/reducers/index.js
+++ b/client/app/hearings/reducers/index.js
@@ -58,18 +58,10 @@ export const hearingsReducers = function(state = mapDataToInitialState(), action
     });
 
   case Constants.POPULATE_WORKSHEET: {
-    const worksheetAppeals = _.keyBy(
-      action.payload.worksheet.appeals_ready_for_hearing,
-      (appeal) => appeal.id
-    );
-    let worksheetIssues = {};
-
-    Object.keys(worksheetAppeals).forEach((key) => {
-      worksheetIssues = Object.assign(
-        {},
-        worksheetIssues,
-        _.keyBy(worksheetAppeals[key].worksheet_issues, (issue) => issue.id));
-    });
+    const worksheetAppeals = _.keyBy(action.payload.worksheet.appeals_ready_for_hearing, 'id');
+    const worksheetIssues = _(worksheetAppeals).flatMap('worksheet_issues').
+      keyBy('id').
+      value();
     // TODO: After updating the reducers, we need to remove appeals_ready_for_hearing from the worksheet object
 
     return update(state, {


### PR DESCRIPTION
Connects #3728 

This is the first of three PRs for the ticket listed above. The reducers still use appeals_ready_for_hearing. 

- [x] Confirm worksheetIssues is populated with the page's issues
- [x] Confirm worksheetAppeals is populated with the page's appeals