### PR TITLE
add fixed column widths for hearings worksheet

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -361,6 +361,22 @@ $color-hearings-saving: #777;
     vertical-align: top;
     padding: .5em;
 
+    &:nth-of-type(1) {
+      width: 45px;
+    }
+
+    &:nth-of-type(2) {
+      width: 180px;
+    }
+
+    &:nth-of-type(3) {
+      width: 140px;
+    }
+
+    &:nth-of-type(4) {
+      width: 190px;
+    }
+
     &:nth-of-type(5) {
       width: 20%;
     }

--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -362,19 +362,19 @@ $color-hearings-saving: #777;
     padding: .5em;
 
     &:nth-of-type(1) {
-      width: 45px;
+      width: 4.5em;
     }
 
     &:nth-of-type(2) {
-      width: 180px;
+      width: 18em;
     }
 
     &:nth-of-type(3) {
-      width: 140px;
+      width: 14em;
     }
 
     &:nth-of-type(4) {
-      width: 190px;
+      width: 19em;
     }
 
     &:nth-of-type(5) {


### PR DESCRIPTION
This fix provides fixed column widths for fields on the Hearings worksheet.
Connects #3478 
![issue-table-fix](https://user-images.githubusercontent.com/4773320/31954411-80cf6a68-b8b3-11e7-8be9-72892fd238e1.gif)
