### PR TITLE
Update fetch_documents_for() to return same structure for all services

### DIFF
--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -44,9 +44,11 @@ class ExternalApi::VBMSService
 
     Rails.logger.info("Document list length: #{documents.length}")
 
-    documents.map do |vbms_document|
-      Document.from_vbms_document(vbms_document)
-    end
+    {
+      manifest_vbms_fetched_at: nil,
+      manifest_vva_fetched_at: nil,
+      documents: documents.map { |vbms_document| Document.from_vbms_document(vbms_document) }
+    }
   end
 
   def self.upload_document_to_vbms(appeal, form8)


### PR DESCRIPTION
Connects #3488.

Update VBMSService.fetch_documents_for() to return same data structure as EfolderService so we can pass validation (all reader uses of Appeal will use EfolderService so the ...fetched_at times being null is fine).