### PR TITLE
Reader | update clearSearch, clearAllFilters import

### DIFF
--- a/client/app/reader/CaseSelect.jsx
+++ b/client/app/reader/CaseSelect.jsx
@@ -6,7 +6,7 @@ import Link from '../components/Link';
 import _ from 'lodash';
 
 import { getClaimTypeDetailInfo } from '../reader/utils';
-import { clearSearch, clearAllFilters } from './actions';
+import { clearSearch, clearAllFilters } from './DocumentList/DocumentListActions';
 
 import CaseSelectSearch from './CaseSelectSearch';
 import IssueList from './IssueList';


### PR DESCRIPTION
Fixes [#3451](https://github.com/department-of-veterans-affairs/caseflow/issues/3451).

After [#3763](https://github.com/department-of-veterans-affairs/caseflow/pull/3763) was merged, `clearSearch` and `clearAllFilters` actions were [relocated](https://github.com/department-of-veterans-affairs/caseflow/commit/5fc9177679c05c4cf81336784ee790edc71b8a5f), affecting their use in `CaseSelect.jsx`