### PR TITLE
Hearing Prep - use venue location for timezone if is available

### DIFF
--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -81,9 +81,11 @@ class HearingRepository
 
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def vacols_attributes(vacols_record)
+      # use venue location on the hearing if it exists
+      ro = vacols_record.hearing_venue || vacols_record.bfregoff
       type = VACOLS::CaseHearing::HEARING_TYPES[vacols_record.hearing_type.to_sym]
       date = HearingMapper.datetime_based_on_type(datetime: vacols_record.hearing_date,
-                                                  regional_office_key: vacols_record.bfregoff,
+                                                  regional_office_key: ro,
                                                   type: type)
       {
         vacols_record: vacols_record,
@@ -102,7 +104,7 @@ class HearingRepository
         appellant_first_name: vacols_record.sspare1,
         appellant_middle_initial: vacols_record.sspare2,
         appellant_last_name: vacols_record.sspare3,
-        regional_office_key: vacols_record.bfregoff,
+        regional_office_key: ro,
         type: type,
         date: date,
         master_record: false

--- a/spec/repositories/hearing_repository_spec.rb
+++ b/spec/repositories/hearing_repository_spec.rb
@@ -38,6 +38,7 @@ describe HearingRepository do
       expect(subject.notes).to eq "test notes"
       expect(subject.representative_name).to eq "test rep name"
       expect(subject.representative).to eq "Jewish War Veterans"
+      expect(subject.regional_office_key).to eq "SO62"
     end
   end
 


### PR DESCRIPTION
connects #3796 

Steps to Validate:
1. When a hearing has a venue 
a) Find a hearing that is venue is different from the associated appeal location (`brieff.bfregoff`)
b) Ensure the date and start time are calculated based on the venue location 

1. When a hearing doesn't have a venue 
a) Ensure the date and start time are calculated based on the appeal location 