### PR TITLE
Nemo/Fix for POA missing issue

### DIFF
--- a/app/jobs/start_certification_job.rb
+++ b/app/jobs/start_certification_job.rb
@@ -15,6 +15,7 @@ class StartCertificationJob < ActiveJob::Base
       update_certification_attributes
     end
     fetch_power_of_attorney! if @certification.certification_status == :started
+    update_data_complete
   rescue => e
     Rails.logger.info "StartCertificationJob failed: #{e.message}"
     Rails.logger.info e.backtrace.join("\n")
@@ -38,7 +39,12 @@ class StartCertificationJob < ActiveJob::Base
       certifying_office: @certification.appeal.regional_office_name,
       certifying_username: @certification.appeal.regional_office_key,
       certifying_official_name: user ? user.full_name : nil,
-      certification_date: Time.zone.now.to_date,
+      certification_date: Time.zone.now.to_date
+    )
+  end
+
+  def update_data_complete
+    @certification.update_attributes!(
       loading_data: false,
       loading_data_failed: false
     )

--- a/client/app/certification/Certification.jsx
+++ b/client/app/certification/Certification.jsx
@@ -166,7 +166,7 @@ export class Certification extends React.Component {
         (this.state.loadingDataFailed || this.state.overallTimeout) && !this.state.certification && failureMessage
       }
 
-      { this.state.certification &&
+      { this.state.certification && !this.state.loading_data &&
       <Provider store={configureStore(this.state.certification, this.state.form9PdfPath)}>
         <div>
           <BrowserRouter>


### PR DESCRIPTION
Fixes #3820 
There were 2 problems both of them were race condition.
The first problem was that front end was checking if there was a certification, but not if the update was finished. 
The second problem was that the job was marking update completed before the actual update, so it would create race condition. 