### PR TITLE
Wrap multiple VACOLS closures in a transaction

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -532,13 +532,14 @@ class Appeal < ActiveRecord::Base
 
     # Wraps the closure of appeals in a transaction
     # add additional code inside the transaction by passing a block
+    # rubocop:disable Metrics/ParameterLists
     def close(appeal:nil, appeals:nil, user:, closed_on:, disposition:, &inside_transaction)
       fail "Only pass either appeal or appeals" if appeal && appeals
 
       repository.transaction do
-        (appeals || [appeal]).each do |appeal|
+        (appeals || [appeal]).each do |close_appeal|
           close_single(
-            appeal: appeal,
+            appeal: close_appeal,
             user: user,
             closed_on: closed_on,
             disposition: disposition
@@ -548,6 +549,7 @@ class Appeal < ActiveRecord::Base
         inside_transaction.call if block_given?
       end
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def certify(appeal)
       form8 = Form8.find_by(vacols_id: appeal.vacols_id)

--- a/app/models/ramp_intake.rb
+++ b/app/models/ramp_intake.rb
@@ -16,9 +16,12 @@ class RampIntake < Intake
     transaction do
       complete_with_status!(:success)
 
-      eligible_appeals.each do |appeal|
-        appeal.close!(user: user, closed_on: Time.zone.today, disposition: "RAMP Opt-in")
-      end
+      Appeal.close(
+        appeals: eligible_appeals,
+        user: user,
+        closed_on: Time.zone.today,
+        disposition: "RAMP Opt-in"
+      )
     end
   end
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -9,6 +9,12 @@ class AppealRepository
     VACOLS::Record.connection.active?
   end
 
+  def self.transaction
+    VACOLS::Case.transaction do
+      yield
+    end
+  end
+
   # Returns a boolean saying whether the load succeeded
   def self.load_vacols_data(appeal)
     case_record = MetricsService.record("VACOLS: load_vacols_data #{appeal.vacols_id}",

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -62,6 +62,10 @@ class Fakes::AppealRepository
     true
   end
 
+  def self.transaction
+    yield
+  end
+
   def self.certify(appeal:, certification:)
     @certification = certification
     @certified_appeal = appeal

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -1,6 +1,7 @@
 require "ostruct"
 
 # frozen_string_literal: true
+# rubocop:disable Metrics/ClassLength
 class Fakes::AppealRepository
   class << self
     attr_accessor :issue_records
@@ -492,3 +493,4 @@ class Fakes::AppealRepository
     true
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -506,44 +506,88 @@ describe Appeal do
     end
   end
 
-  context "#close!" do
+  context ".close" do
     let(:vacols_record) { :ready_to_certify }
     let(:appeal) { Generators::Appeal.build(vacols_record: vacols_record) }
+    let(:another_appeal) { Generators::Appeal.build(vacols_record: vacols_record) }
     let(:user) { Generators::User.build }
+    let(:disposition) { "RAMP Opt-in" }
 
-    subject { appeal.close!(user: user, closed_on: 4.days.ago, disposition: disposition) }
-
-    context "when disposition is not valid" do
-      let(:disposition) { "I'm not a disposition" }
+    context "when called with both appeal and appeals" do
+      let(:vacols_record) { :ready_to_certify }
 
       it "should raise error" do
-        expect { subject }.to raise_error(/Disposition/)
+        expect do
+          Appeal.close(
+            appeal: appeal,
+            appeals: [appeal, another_appeal],
+            user: user,
+            closed_on: 4.days.ago,
+            disposition: disposition
+          )
+        end.to raise_error("Only pass either appeal or appeals")
       end
     end
 
-    context "when disposition is valid" do
-      let(:disposition) { "RAMP Opt-in" }
+    context "when multiple appeals" do
+      it "closes each appeal" do
+        expect(Fakes::AppealRepository).to receive(:close!).with(
+          appeal: appeal,
+          user: user,
+          closed_on: 4.days.ago,
+          disposition_code: "P"
+        )
+        expect(Fakes::AppealRepository).to receive(:close!).with(
+          appeal: another_appeal,
+          user: user,
+          closed_on: 4.days.ago,
+          disposition_code: "P"
+        )
 
-      context "when appeal is not active" do
-        let(:vacols_record) { :full_grant_decided }
+        Appeal.close(
+          appeals: [appeal, another_appeal],
+          user: user,
+          closed_on: 4.days.ago,
+          disposition: disposition
+        )
+      end
+    end
+
+    context "when just one appeal" do
+      subject do
+        Appeal.close(appeal: appeal, user: user, closed_on: 4.days.ago, disposition: disposition)
+      end
+
+      context "when disposition is not valid" do
+        let(:disposition) { "I'm not a disposition" }
 
         it "should raise error" do
-          expect { subject }.to raise_error(/active/)
+          expect { subject }.to raise_error(/Disposition/)
         end
       end
 
-      context "when appeal is active" do
-        let(:vacols_record) { :ready_to_certify }
+      context "when disposition is valid" do
+        context "when appeal is not active" do
+          let(:vacols_record) { :full_grant_decided }
 
-        it "closes the appeal in VACOLS" do
-          expect(Fakes::AppealRepository).to receive(:close!).with(
-            appeal: appeal,
-            user: user,
-            closed_on: 4.days.ago,
-            disposition_code: "P"
-          )
+          it "should raise error" do
+            expect { subject }.to raise_error(/active/)
+          end
+        end
 
-          subject
+        context "when appeal is active" do
+          let(:vacols_record) { :ready_to_certify }
+
+          it "closes the appeal in VACOLS" do
+            expect(Fakes::AppealRepository).to receive(:close!).with(
+              appeal: appeal,
+              user: user,
+              closed_on: 4.days.ago,
+              disposition_code: "P"
+            )
+
+            subject
+          end
         end
       end
     end


### PR DESCRIPTION
Currently, if there are multiple appeals being closed in VACOLS, and one of them fails, it will not rollback the others. This is obviously a problem.

This PR creates `Appeal.close` which takes an an array of appeals and closes them all within a transaction, solving the issue.

It also allows a block to be provided which also will be run inside the VACOLS transaction. This will allow us to safely transactionalize the creation of the end product with the VACOLS appeal closings.

Wasn't sure a good way to do an automated test on the VACOLS rollback. I think it's going to be either very difficult or very janky and not worth doing. Went ahead and pushed it without it.

The happy path still works, but there isn't a great way to test the sad path, because you need a situation where one Appeal fails and the other succeeds. There will be a better way to test when we create the end product, since we can test that an end product creation failure rolls back the VACOLS closures.

connects #3749 


