### PR TITLE
Ignoring some endpoints

### DIFF
--- a/app/controllers/dependencies_checks_controller.rb
+++ b/app/controllers/dependencies_checks_controller.rb
@@ -1,4 +1,6 @@
 class DependenciesChecksController < ApplicationBaseController
+  newrelic_ignore
+  
   def show
     render json: { dependencies_outage: DependenciesReportService.outage_present? }
   end

--- a/app/controllers/dependencies_checks_controller.rb
+++ b/app/controllers/dependencies_checks_controller.rb
@@ -1,5 +1,5 @@
 class DependenciesChecksController < ApplicationBaseController
-  newrelic_ignore
+  newrelic_ignore_apdex
   
   def show
     render json: { dependencies_outage: DependenciesReportService.outage_present? }

--- a/app/controllers/dependencies_checks_controller.rb
+++ b/app/controllers/dependencies_checks_controller.rb
@@ -1,6 +1,6 @@
 class DependenciesChecksController < ApplicationBaseController
   newrelic_ignore_apdex
-  
+
   def show
     render json: { dependencies_outage: DependenciesReportService.outage_present? }
   end

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,6 +1,6 @@
 class HealthChecksController < ActionController::Base
   protect_from_forgery with: :exception
-  newrelic_ignore
+  newrelic_ignore_apdex
 
   def show
     healthcheck = HealthCheck.new

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,5 +1,6 @@
 class HealthChecksController < ActionController::Base
   protect_from_forgery with: :exception
+  newrelic_ignore
 
   def show
     healthcheck = HealthCheck.new


### PR DESCRIPTION
These endpoint are not user-facing, so we don't want them to be represented in our apdex score.

To verify that this works, check the output in `logs/newrelic_audit.log`.