### PR TITLE
Adjust so that we fetch at most 3 users (by default)

### DIFF
--- a/app/jobs/retrieve_documents_for_reader_job.rb
+++ b/app/jobs/retrieve_documents_for_reader_job.rb
@@ -3,7 +3,7 @@
 class RetrieveDocumentsForReaderJob < ActiveJob::Base
   queue_as :low_priority
 
-  DEFAULT_USERS_LIMIT = 10
+  DEFAULT_USERS_LIMIT = 3
   def perform(args = {})
     RequestStore.store[:application] = "reader"
 


### PR DESCRIPTION
Assessing the load graphs, it appears that it'd ideal to do at most 3 users in parallel for fetching reader docs. 