### PR TITLE
Document viewer | Update keyboard shortcuts modal

### DIFF
--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -713,8 +713,8 @@ input[type="search"].cf-search-input-with-close {
   }
 }
 
-.cf-table-borderless + .cf-keyboard-modal-table thead th {
-  width: 23%;
+.cf-table-borderless.cf-keyboard-modal-table > thead > tr > th {
+  width: 200px;
 }
 
 .section--case-select {

--- a/client/app/reader/PdfKeyboardInfo.jsx
+++ b/client/app/reader/PdfKeyboardInfo.jsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { ArrowUp, ArrowDown, ArrowLeft, ArrowRight } from '../components/RenderFunctions';
 
-export const scrollInstructions = [
-  { scrollInstruction: 'Page up',
-    shortcut: <span><code>shift</code> + <code>space</code></span> },
-  { scrollInstruction: 'Page down',
-    shortcut: <span><code>space</code></span> }
-];
-
 export const scrollColumns = [{ header: 'Scroll',
   valueName: 'scrollInstruction',
   align: 'left' },
@@ -39,7 +32,27 @@ export const commentColumns = [{ header: 'Add/ edit comment',
   valueName: 'shortcut',
   align: 'left' }];
 
+export const searchColumns = [{ header: 'Search within document',
+  valueName: 'searchInstruction',
+  align: 'left'
+}, { header: 'Shortcut',
+  valueName: 'shortcut',
+  align: 'left' }];
+
+const metaKey = navigator.appVersion.includes('Win') ? 'ctrl' : 'cmd';
+
+export const searchInstructions = [
+  { searchInstruction: 'Open search box',
+    shortcut: <span><code>{metaKey}</code> + <code>f</code></span> },
+  { searchInstruction: 'Navigate search results',
+    shortcut: <span><code>{metaKey}</code> + <code>g</code></span> }
+];
+
 export const documentsInstructions = [
+  { documentsInstruction: 'Scroll page up',
+    shortcut: <span><code>shift</code> + <code>space</code></span> },
+  { documentsInstruction: 'Scroll page down',
+    shortcut: <span><code>space</code></span> },
   { documentsInstruction: 'View next document',
     shortcut: <span><ArrowRight /></span> },
   { documentsInstruction: 'View previous document',

--- a/client/app/reader/PdfKeyboardInfo.jsx
+++ b/client/app/reader/PdfKeyboardInfo.jsx
@@ -39,7 +39,11 @@ export const searchColumns = [{ header: 'Search within document',
   valueName: 'shortcut',
   align: 'left' }];
 
-const metaKey = navigator.appVersion.includes('Win') ? 'ctrl' : 'cmd';
+let metaKey = 'ctrl';
+
+if (navigator.appVersion && navigator.appVersion.includes('Mac')) {
+  metaKey = 'cmd';
+}
 
 export const searchInstructions = [
   { searchInstruction: 'Open search box',

--- a/client/app/reader/PdfSidebar.jsx
+++ b/client/app/reader/PdfSidebar.jsx
@@ -24,8 +24,8 @@ import {
 } from '../reader/PdfViewer/AnnotationActions';
 import { keyOfAnnotation, sortAnnotations }
   from './utils';
-import { scrollColumns, scrollInstructions, commentColumns, commentInstructions, documentsColumns,
-  documentsInstructions } from './PdfKeyboardInfo';
+import { commentColumns, commentInstructions, documentsColumns,
+  documentsInstructions, searchColumns, searchInstructions } from './PdfKeyboardInfo';
 import classNames from 'classnames';
 import { makeGetAnnotationsByDocumentId } from './selectors';
 import { CATEGORIES } from './analytics';
@@ -200,18 +200,18 @@ export class PdfSidebar extends React.Component {
             id="cf-keyboard-modal">
             <div className="cf-keyboard-modal-scroll">
               <Table
-                columns={scrollColumns}
-                rowObjects={scrollInstructions}
+                columns={documentsColumns}
+                rowObjects={documentsInstructions}
+                slowReRendersAreOk
+                className="cf-keyboard-modal-table" />
+              <Table
+                columns={searchColumns}
+                rowObjects={searchInstructions}
                 slowReRendersAreOk
                 className="cf-keyboard-modal-table" />
               <Table
                 columns={commentColumns}
                 rowObjects={commentInstructions}
-                slowReRendersAreOk
-                className="cf-keyboard-modal-table" />
-              <Table
-                columns={documentsColumns}
-                rowObjects={documentsInstructions}
                 slowReRendersAreOk
                 className="cf-keyboard-modal-table" />
             </div>


### PR DESCRIPTION
Connects #3774 

Add search result navigation keyboard shortcuts; reorganize keyboard shortcuts; make widths consistent.

Displays `ctrl` + `f` for Windows, `cmd` + `f` for Mac

## AC
- [x] Change the ordering of keyboard shortcut subsections so that it is in this order:
  - Navigate Reader
  - Search within document
  - Add/edit comment 
- [x] Add Scroll page up and Scroll page down as first two items under Navigate Reader
- [x] Add the following under new section Search within documents
  - Open search box `ctrl` + `f`
  - Navigate search results `ctrl` + `g`