### PR TITLE
If postgres env vars are set, use that for the test environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -76,8 +76,6 @@ test:
   <% if ENV['POSTGRES_HOST'] %>
   host: <%= ENV['POSTGRES_HOST'] %>
   <% end %>
-  # If we set the value to nil when the variable isn't present,
-  # the k8s Jenkins environment won't connect
   <% if ENV['POSTGRES_PASSWORD'] %>
   password: <%= ENV['POSTGRES_PASSWORD'] %>
   <% end %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -71,8 +71,16 @@ production_vacols:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  username: <%= `whoami` %>
+  username: <%= ENV['POSTGRES_USER'] || `whoami` %>
   database: caseflow_certification_test<%= ENV['TEST_SUBCATEGORY'] %>
+  <% if ENV['POSTGRES_HOST'] %>
+  host: <%= ENV['POSTGRES_HOST'] %>
+  <% end %>
+  # If we set the value to nil when the variable isn't present,
+  # the k8s Jenkins environment won't connect
+  <% if ENV['POSTGRES_PASSWORD'] %>
+  password: <%= ENV['POSTGRES_PASSWORD'] %>
+  <% end %>
 
 test_vacols:
   adapter: sqlite3


### PR DESCRIPTION
I've started to use docker for my redis and postgres dependencies for my local setup.  

We currently allow for postgres env vars to be set for the development environment, however not for the test environment.  This sets up the same config environment variable overrides for the `test` environment.  