### PR TITLE
Add object-curly-newline: consistent javascript linting rule

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -215,6 +215,7 @@ module.exports = {
     'no-void': 'warn',
     'no-whitespace-before-property': 'warn',
     'no-with': 'error',
+    'object-curly-newline': ['error', { consistent: true }],
     'object-curly-spacing': [
       'warn',
       'always'

--- a/client/app/certification/CancelCertificationModal.jsx
+++ b/client/app/certification/CancelCertificationModal.jsx
@@ -144,12 +144,10 @@ export default class CancelCertificationModal extends BaseForm {
         buttons={[
           { classNames: ['cf-modal-link', 'cf-btn-link'],
             name: '\u226A Go back',
-            onClick: closeHandler
-          },
+            onClick: closeHandler },
           { classNames: ['usa-button', 'usa-button-secondary'],
             name: 'Cancel certification',
-            onClick: this.submitForm
-          }
+            onClick: this.submitForm }
         ]}
         visible
         closeHandler={closeHandler}

--- a/client/app/certification/ConfirmHearing.jsx
+++ b/client/app/certification/ConfirmHearing.jsx
@@ -213,8 +213,7 @@ export class ConfirmHearing extends React.Component {
       serverError,
       updateSucceeded,
       match,
-      certificationStatus
-    } = this.props;
+      certificationStatus } = this.props;
 
     if (!certificationStatus.includes('started')) {
       return <Redirect

--- a/client/app/containers/StyleGuide/StyleGuideModal.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideModal.jsx
@@ -48,12 +48,10 @@ export default class StyleGuideModal extends React.Component {
         buttons = {[
           { classNames: ['cf-modal-link', 'cf-btn-link'],
             name: 'Close',
-            onClick: this.handleModalClose
-          },
+            onClick: this.handleModalClose },
           { classNames: ['usa-button', 'usa-button-secondary'],
             name: 'Proceed with action',
-            onClick: this.handleModalClose
-          }
+            onClick: this.handleModalClose }
         ]}
         closeHandler={this.handleModalClose}
         title = "This is a Modal">

--- a/client/app/containers/StyleGuide/Typography/TextStyles.jsx
+++ b/client/app/containers/StyleGuide/Typography/TextStyles.jsx
@@ -26,64 +26,56 @@ export default class TextStyles extends React.Component {
           <span>font-weight: 700</span>
           <span>font-size: 52px</span>
           <span>line-height: 1.3em/68px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <div className="cf-display-2">Display 2</div>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 300</span>
           <span>font-size: 44px</span>
           <span>line-height: 1.3em/57px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <h1>Heading 1</h1>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 700</span>
           <span>font-size: 34px</span>
           <span>line-height: 1.3em/44px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <h2>Heading 2</h2>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 700</span>
           <span>font-size: 24px</span>
           <span>line-height: 1.3em/31px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <h3>Heading 3</h3>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 700</span>
           <span>font-size: 19px</span>
           <span>line-height: 1.3em/25px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <h4>Heading 4</h4>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 700</span>
           <span>font-size: 15px</span>
           <span>line-height: 1.3em/20px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <h5>Heading 5</h5>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 400</span>
           <span>font-size: 13px</span>
           <span>line-height: 1.3em/17px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <p className="cf-lead-paragraph">Lead paragraph</p>,
         rules: <span>
           <span>font-family: ‘Source Sans Pro’</span>
           <span>font-weight: 300</span>
           <span>font-size: 19px</span>
           <span>line-height: 1.5em/33px</span>
-        </span>
-      },
+        </span> },
       { textStyle: <p>
             Body copy. A series of
             sentences together which
@@ -94,8 +86,7 @@ export default class TextStyles extends React.Component {
         <span>font-weight: 400</span>
         <span>font-size: 17px</span>
         <span>line-height: 1.5em/26px</span>
-      </span>
-      },
+      </span> },
       { textStyle: <p><i>
             Italic body copy. A series of
             sentences together which
@@ -107,8 +98,7 @@ export default class TextStyles extends React.Component {
         <span>font-weight: 400</span>
         <span>font-size: 17px</span>
         <span>line-height: 1.5em/26px</span>
-      </span>
-      }
+      </span> }
     ];
 
     return <div>

--- a/client/app/establishClaim/components/CancelModal.jsx
+++ b/client/app/establishClaim/components/CancelModal.jsx
@@ -39,13 +39,11 @@ export const CancelModal = ({
       buttons={[
         { classNames: ['cf-modal-link', 'cf-btn-link'],
           name: 'Close',
-          onClick: handleCloseCancelModal
-        },
+          onClick: handleCloseCancelModal },
         { classNames: ['usa-button', 'usa-button-secondary'],
           loading: isCancelModalSubmitting,
           name: 'Stop processing claim',
-          onClick: handleCancelSubmit
-        }
+          onClick: handleCancelSubmit }
       ]}
       visible
       closeHandler={handleCloseCancelModal}

--- a/client/app/hearings/actions/Issue.js
+++ b/client/app/hearings/actions/Issue.js
@@ -132,8 +132,8 @@ export const onAddIssue = (appealId, vacolsSequenceId) => (dispatch) => {
     vacols_sequence_id: vacolsSequenceId
   };
 
-  ApiUtil.patch(`/hearings/appeals/${outgoingIssue.appeal_id}`, { data: { appeal: {
-    worksheet_issues_attributes: [outgoingIssue] } } }).
+  ApiUtil.patch(`/hearings/appeals/${outgoingIssue.appeal_id}`,
+    { data: { appeal: { worksheet_issues_attributes: [outgoingIssue] } } }).
     then((data) => {
       const issue = JSON.parse(data.text).appeal.worksheet_issues.filter((dbIssue) => {
         return outgoingIssue.vacols_sequence_id === dbIssue.vacols_sequence_id;
@@ -145,8 +145,7 @@ export const onAddIssue = (appealId, vacolsSequenceId) => (dispatch) => {
           analytics: {
             category: CATEGORIES.HEARING_WORKSHEET_PAGE
           }
-        }
-      });
+        } });
     });
 };
 
@@ -173,8 +172,8 @@ export const toggleIssueDeleteModal = (issueId, isShowingModal) => ({
 export const saveIssues = (worksheetIssues) => (dispatch) => {
   _.forEach(worksheetIssues, (issue) => {
     if (issue.edited) {
-      ApiUtil.patch(`/hearings/appeals/${issue.appeal_id}`, { data: { appeal: {
-        worksheet_issues_attributes: [issue] } } }).
+      ApiUtil.patch(`/hearings/appeals/${issue.appeal_id}`,
+        { data: { appeal: { worksheet_issues_attributes: [issue] } } }).
         then(() => {
           dispatch({ type: Constants.SET_ISSUE_EDITED_FLAG_TO_FALSE,
             payload: { issueId: issue.id },
@@ -183,8 +182,7 @@ export const saveIssues = (worksheetIssues) => (dispatch) => {
                 category: CATEGORIES.HEARING_WORKSHEET_PAGE,
                 action: ACTIONS.EDIT_ISSUE
               }
-            }
-          });
+            } });
         },
         () => {
           dispatch({ type: Constants.SET_WORKSHEET_SAVE_FAILED_STATUS,

--- a/client/app/hearings/components/HearingWorksheetIssueDelete.jsx
+++ b/client/app/hearings/components/HearingWorksheetIssueDelete.jsx
@@ -39,12 +39,10 @@ class HearingWorksheetIssueDelete extends PureComponent {
         buttons = {[
           { classNames: ['cf-modal-link', 'cf-btn-link'],
             name: 'Cancel',
-            onClick: this.handleModalClose(issue.id)
-          },
+            onClick: this.handleModalClose(issue.id) },
           { classNames: ['usa-button', 'usa-button-secondary'],
             name: 'Confirm delete',
-            onClick: this.onDeleteIssue(issue.id)
-          }]}
+            onClick: this.onDeleteIssue(issue.id) }]}
         closeHandler={this.handleModalClose(issue.id)}
         title = "Delete Issue Row">
         <p>Are you sure you want to remove this issue from Appeal Stream {appealKey + 1} on the worksheet? </p>

--- a/client/app/hearings/reducers/index.js
+++ b/client/app/hearings/reducers/index.js
@@ -161,12 +161,10 @@ export const hearingsReducers = function(state = mapDataToInitialState(), action
     return newHearingIssueState(state, action, { _destroy: { $set: true } });
 
   case Constants.TOGGLE_DOCKET_SAVING:
-    return update(state, { docketIsSaving: { $set: !state.isSaving }
-    });
+    return update(state, { docketIsSaving: { $set: !state.isSaving } });
 
   case Constants.TOGGLE_WORKSHEET_SAVING:
-    return update(state, { worksheetIsSaving: { $set: !state.isSaving }
-    });
+    return update(state, { worksheetIsSaving: { $set: !state.isSaving } });
 
   case Constants.SET_DOCKET_SAVE_FAILED:
     return update(state, {

--- a/client/app/manageEstablishClaim/selectors/index.js
+++ b/client/app/manageEstablishClaim/selectors/index.js
@@ -21,6 +21,5 @@ export const getQuotaTotals = createSelector([getUserQuotas], (userQuotas) => {
     tasksLeftCount: 0,
     fullGrantCount: 0,
     partialGrantCount: 0,
-    remandCount: 0
-  });
+    remandCount: 0 });
 });

--- a/client/app/reader/CaseSelectSearch.jsx
+++ b/client/app/reader/CaseSelectSearch.jsx
@@ -98,13 +98,11 @@ class CaseSelectSearch extends React.PureComponent {
         buttons = {[
           { classNames: ['cf-modal-link', 'cf-btn-link'],
             name: 'Cancel',
-            onClick: this.handleModalClose
-          },
+            onClick: this.handleModalClose },
           { classNames: ['usa-button', 'usa-button-primary'],
             name: 'Okay',
             onClick: this.handleSelectAppeal,
-            disabled: _.isEmpty(caseSelect.selectedAppealVacolsId)
-          }
+            disabled: _.isEmpty(caseSelect.selectedAppealVacolsId) }
         ]}
         closeHandler={this.handleModalClose}
         title = "Select claims folder">

--- a/client/app/reader/PdfKeyboardInfo.jsx
+++ b/client/app/reader/PdfKeyboardInfo.jsx
@@ -34,8 +34,7 @@ export const commentColumns = [{ header: 'Add/ edit comment',
 
 export const searchColumns = [{ header: 'Search within document',
   valueName: 'searchInstruction',
-  align: 'left'
-}, { header: 'Shortcut',
+  align: 'left' }, { header: 'Shortcut',
   valueName: 'shortcut',
   align: 'left' }];
 

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -64,8 +64,7 @@ const mapStateToProps = (state, props) => {
       state.readerReducer.loadedAppeal,
     caseSelectedAppeal: state.caseSelect.selectedAppeal,
     manifestVbmsFetchedAt: state.readerReducer.ui.manifestVbmsFetchedAt,
-    manifestVvaFetchedAt: state.readerReducer.ui.manifestVvaFetchedAt
-  };
+    manifestVvaFetchedAt: state.readerReducer.ui.manifestVvaFetchedAt };
 };
 
 const mapDispatchToProps = (dispatch) => (

--- a/client/app/reader/PdfSidebar.jsx
+++ b/client/app/reader/PdfSidebar.jsx
@@ -191,8 +191,7 @@ export class PdfSidebar extends React.Component {
             buttons = {[
               { classNames: ['usa-button', 'usa-button-secondary'],
                 name: 'Thanks, got it!',
-                onClick: this.closeKeyboardModalFromButton
-              }
+                onClick: this.closeKeyboardModalFromButton }
             ]}
             closeHandler={this.handleKeyboardModalClose}
             title="Keyboard shortcuts"

--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -220,15 +220,13 @@ export class PdfViewer extends React.Component {
           buttons={[
             { classNames: ['cf-modal-link', 'cf-btn-link'],
               name: 'Cancel',
-              onClick: this.props.closeAnnotationDeleteModal
-            },
+              onClick: this.props.closeAnnotationDeleteModal },
             { classNames: ['usa-button', 'usa-button-secondary'],
               name: 'Confirm delete',
               onClick: () => this.props.deleteAnnotation(
                 this.props.match.params.docId,
                 this.props.deleteAnnotationModalIsOpenFor
-              )
-            }
+              ) }
           ]}
           closeHandler={this.props.closeAnnotationDeleteModal}
           title="Delete Comment">

--- a/client/app/reader/SideBarIssueTags.jsx
+++ b/client/app/reader/SideBarIssueTags.jsx
@@ -16,8 +16,7 @@ class SideBarIssueTags extends PureComponent {
     let generateOptionsFromTags = (tags) =>
       _(tags).
         reject('pendingRemoval').
-        map((tag) => ({
-          value: tag.text,
+        map((tag) => ({ value: tag.text,
           label: tag.text,
           tagId: tag.id })
         ).

--- a/client/test/karma/components/Modal-test.js
+++ b/client/test/karma/components/Modal-test.js
@@ -11,8 +11,7 @@ describe('Modal', () => {
         <Modal
           buttons={[
             { classNames: ['test-class'],
-              name: 'first'
-            }
+              name: 'first' }
           ]}
           visible
           title="Test Title">
@@ -32,14 +31,11 @@ describe('Modal', () => {
         <Modal
           buttons={[
             { classNames: ['test-class'],
-              name: 'first'
-            },
+              name: 'first' },
             { classNames: ['test-class'],
-              name: 'second'
-            },
+              name: 'second' },
             { classNames: ['test-class'],
-              name: 'third'
-            }
+              name: 'third' }
           ]}
           visible
           title="Test Title">

--- a/client/test/karma/hearings/reducers/index-test.js
+++ b/client/test/karma/hearings/reducers/index-test.js
@@ -280,8 +280,7 @@ describe('hearingsReducer', () => {
       state = Hearings.hearingsReducers(initialState, {
         type: Constants.SET_REOPEN,
         payload: { reopen: true,
-          issueId: 6
-        }
+          issueId: 6 }
       });
     });
 
@@ -301,8 +300,7 @@ describe('hearingsReducer', () => {
       state = Hearings.hearingsReducers(initialState, {
         type: Constants.SET_ALLOW,
         payload: { allow: true,
-          issueId: 6
-        }
+          issueId: 6 }
       });
     });
 
@@ -322,8 +320,7 @@ describe('hearingsReducer', () => {
       state = Hearings.hearingsReducers(initialState, {
         type: Constants.SET_DENY,
         payload: { deny: true,
-          issueId: 6
-        }
+          issueId: 6 }
       });
     });
 
@@ -343,8 +340,7 @@ describe('hearingsReducer', () => {
       state = Hearings.hearingsReducers(initialState, {
         type: Constants.SET_REMAND,
         payload: { remand: true,
-          issueId: 6
-        }
+          issueId: 6 }
       });
     });
 
@@ -364,8 +360,7 @@ describe('hearingsReducer', () => {
       state = Hearings.hearingsReducers(initialState, {
         type: Constants.SET_DISMISS,
         payload: { dismiss: true,
-          issueId: 6
-        }
+          issueId: 6 }
       });
     });
 
@@ -385,8 +380,7 @@ describe('hearingsReducer', () => {
       state = Hearings.hearingsReducers(initialState, {
         type: Constants.SET_VHA,
         payload: { vha: true,
-          issueId: 6
-        }
+          issueId: 6 }
       });
     });
 


### PR DESCRIPTION
Adds the [object-curly-newline: consistent](https://eslint.org/docs/rules/object-curly-newline#consistent) javascript linting rule for consistency in how we wrap object constructors in curly braces across our codebase. [Other options](https://eslint.org/docs/rules/object-curly-newline) for how we achieve consistency in this regard are available (["multiline"](https://eslint.org/docs/rules/object-curly-newline#multiline) is particularly enticing to me), but the "consistent" rule causes the fewest changes, gives us more flexibility (though this could be a knock against), and generally jibes with how we are already using curly braces.

Thoughts? 👍? 👎?