### PR TITLE
removing the logic to download all documents for a case on the loadin…

### DIFF
--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -10,8 +10,6 @@ import LoadingScreen from '../components/LoadingScreen';
 import * as Constants from './constants';
 import _ from 'lodash';
 
-const PARALLEL_DOCUMENT_REQUESTS = 3;
-
 export class ReaderLoadingScreen extends React.Component {
 
   componentDidMount = () => {
@@ -26,23 +24,6 @@ export class ReaderLoadingScreen extends React.Component {
       this.props.onReceiveDocs(documents, this.props.vacolsId);
       this.props.onReceiveManifests(manifestVbmsFetchedAt, manifestVvaFetchedAt);
       this.props.onReceiveAnnotations(annotations);
-
-      const downloadDocuments = (documentUrls, index) => {
-        if (index >= documentUrls.length) {
-          return;
-        }
-
-        ApiUtil.get(documentUrls[index], {
-          cache: true,
-          withCredentials: true
-        }, ENDPOINT_NAMES.DOCUMENT_CONTENT).then(
-          () => downloadDocuments(documentUrls, index + PARALLEL_DOCUMENT_REQUESTS)
-        );
-      };
-
-      for (let i = 0; i < PARALLEL_DOCUMENT_REQUESTS; i++) {
-        downloadDocuments(_.map(documents, 'content_url'), i);
-      }
     }, this.props.onInitialDataLoadingFail);
   }
 

--- a/client/app/reader/analytics.js
+++ b/client/app/reader/analytics.js
@@ -22,6 +22,5 @@ export const ENDPOINT_NAMES = {
   APPEAL_DETAILS: 'appeal-details',
   APPEAL_DETAILS_BY_VET_ID: 'appeal-details-by-vet-id',
   CLAIMS_FOLDER_SEARCHES: 'claims-folder-searches',
-  DOCUMENTS: 'documents',
-  DOCUMENT_CONTENT: 'document-content'
+  DOCUMENTS: 'documents'
 };


### PR DESCRIPTION
…g screen

connects #3948 

* This PR is removing the code to download all the pdfs associated to the case initially when loading
* The remaining logic downloads the current viewing document, previous document, the next document if they exist.

**Goal**
To reduce the amount of load put on the efolder when a case initially loads to reduce the spikes seen in efolder.

**What needs to be done**
After merging this PR, this needs to be tested in the UAT to make sure the user experience is not majorly affected by this change.

**PR AC**
* Open a Case Folder
* Open the PdfView of the documents
* Navigate through the documents to make sure things are working as expected.

**Notes**
We might see some minor delay in loading of documents when navigating through the documents quickly. As it's the case that the documents are not being cached in the browser after the initial load.