### PR TITLE
Direct AppealController#show to documents page

### DIFF
--- a/app/controllers/reader/appeal_controller.rb
+++ b/app/controllers/reader/appeal_controller.rb
@@ -29,6 +29,7 @@ class Reader::AppealController < Reader::ApplicationController
     vacols_id = params[:id]
 
     respond_to do |format|
+      format.html { redirect_to reader_appeal_documents_path(appeal_id: vacols_id) }
       format.json do
         MetricsService.record("VACOLS: Get appeal information for #{vacols_id}",
                               name: "AppealController.show") do

--- a/spec/requests/appeal_controller_spec.rb
+++ b/spec/requests/appeal_controller_spec.rb
@@ -31,15 +31,12 @@ RSpec.describe "Reader Appeal Requests", type: :request do
       get "/reader/appeal/veteran-id", nil, headers
       expect(JSON.parse(response.body)["appeals"].size).to be(0)
     end
+  end
 
-    it "fails routing validation" do
-      headers["HTTP_VETERAN_ID"] = "2"
-      get "/reader/appeal/veteran-id", nil, headers
-      expect(response).to have_http_status(:not_acceptable)
-
-      headers["HTTP_VETERAN_ID"] = nil
-      get "/reader/appeal/veteran-id", nil, headers
-      expect(response).to have_http_status(:not_acceptable)
+  describe "Appeals controller #show in html" do
+    it "redirects the page to Case page" do
+      get "/reader/appeal/#{appeal.vacols_id}"      
+      expect(response).to have_http_status(:redirect)
     end
   end
 end

--- a/spec/requests/appeal_controller_spec.rb
+++ b/spec/requests/appeal_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Reader Appeal Requests", type: :request do
 
   describe "Appeals controller #show in html" do
     it "redirects the page to Case page" do
-      get "/reader/appeal/#{appeal.vacols_id}"      
+      get "/reader/appeal/#{appeal.vacols_id}"
       expect(response).to have_http_status(:redirect)
     end
   end


### PR DESCRIPTION
connects #2940 

Note: This fixes one of the Reader sentry errors.

AC:
* Browse to any case folder 
* Remove documents path from the url
* It should redirect back to the documents page of Case folder rather than showing json or an error message.

