### PR TITLE
Patched up the URL grouper to handle rare case IDs

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -32,7 +32,9 @@ label_builder = lambda do |env, code|
     # '/users/1234/comments' -> '/users/:id/comments'
     # '/hearings/dockets/2017-10-15' -> '/hearings/dockets/:id'
     # '/certifications/new/123C' -> '/certifications/new/:id'
-    path: env["PATH_INFO"].to_s.gsub(%r{\/\d+-?\d*-?\d*C?S?(\/|$)}, '/:id\\1')
+    # '/certifications/new/2562815LL' -> '/certifications/new/:id'
+    # '/certifications/new/2562815D2' -> '/certifications/new/:id'
+    path: env["PATH_INFO"].to_s.gsub(%r{\/\d+-?\d*-?\d*[A-Z]?[A-Z]?\d?(\/|$)}, '/:id\\1')
   }
 end
 


### PR DESCRIPTION
While the previous PR (https://github.com/department-of-veterans-affairs/caseflow/pull/3726) consolidated most of the IDs in the path, there are several odd case IDs that leaks through. These outliers case ID usually ends in "L", "LL", "W", "X" or "D2".

![image](https://user-images.githubusercontent.com/3258724/33107727-8caae448-cf06-11e7-864a-a5108e6dddcc.png)

This patch resolves this by checking for these types of case IDs. 

## Test Plan

I verified the regex using sample queries in production today. The test data is put in a test file and I verified the grouped results to match the expected outcome.
```ruby
require "set"
require "pp"

fileObj = File.new("test.txt", "r")
group = []
while (line = fileObj.gets)
  line = line.to_s.gsub(%r{\/\d+-?\d*-?\d*[A-Z]?[A-Z]?\d?(\/|$)}, '/:id\\1')
  puts line
  group.push(line)
end
fileObj.close

pp group.to_set
```

## Test Data
```
%2Fpdfjs%2Fweb%2Fimages%2FfindbarButton-next.png
%2Fpdfjs%2Fweb%2Fimages%2FfindbarButton-previous.png
%2Fpdfjs%2Fweb%2Fimages%2Floading-icon.gif
%2Fpdfjs%2Fweb%2Fimages%2Floading-small.png
%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-documentProperties.png
%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-firstPage.png
%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-handTool.png
%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-lastPage.png
%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-rotateCcw.png
%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-rotateCw.png
%2Fpdfjs%2Fweb%2Fimages%2Fshadow.png
%2Fpdfjs%2Fweb%2Fimages%2Ftexture.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-bookmark.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-download.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-menuArrows.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-openFile.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-pageDown.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-pageUp.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-presentationMode.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-print.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-search.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-secondaryToolbarToggle.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-sidebarToggle.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-viewAttachments.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-viewOutline.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-viewThumbnail.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-zoomIn.png
%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-zoomOut.png
%2Fpdfjs%2Fweb%2Flocale%2Fen-US%2Fviewer.properties
%2Fpdfjs%2Fweb%2Flocale%2Flocale.properties
/
/404.html
/api/v1/appeals
/api/v1/jobs
/certification/help
/certification/stats
/certification/stats/monthly
/certification/stats/weekly
/certification_cancellations
/certification_cancellations/show
/certifications/123c
/certifications/1930997L
/certifications/1930997L/certify_v2
/certifications/1930997L/form9_pdf
/certifications/1930997L/update_v2
/certifications/1953291L
/certifications/1953291L/certify_v2
/certifications/1953291L/form9_pdf
/certifications/1953291L/update_v2
/certifications/2021006L
/certifications/2021006L/certify_v2
/certifications/2021006L/form9_pdf
/certifications/2021006L/update_v2
/certifications/2029090L
/certifications/2029090L/certify_v2
/certifications/2029090L/form9_pdf
/certifications/2029090L/update_v2
/certifications/2091468L
/certifications/2091468L/certify_v2
/certifications/2091468L/form9_pdf
/certifications/2091468L/update_v2
/certifications/2246457L
/certifications/2246457L/certify_v2
/certifications/2246457L/form9_pdf
/certifications/2246457L/update_v2
/certifications/2294398L
/certifications/2294398L/certify_v2
/certifications/2294398L/form9_pdf
/certifications/2294398L/update_v2
/certifications/2317470L
/certifications/2317470L/certify_v2
/certifications/2317470L/check_documents
/certifications/2317470L/form9_pdf
/certifications/2317470L/update_v2
/certifications/2425967L
/certifications/2425967L/certify_v2
/certifications/2425967L/form9_pdf
/certifications/2425967L/update_v2
/certifications/2496855L
/certifications/2496855L/certify_v2
/certifications/2496855L/check_documents
/certifications/2496855L/form9_pdf
/certifications/2496855L/update_v2
/certifications/2519217L
/certifications/2519217L/certify_v2
/certifications/2519217L/form9_pdf
/certifications/2519217L/update_v2
/certifications/2562815LL
/certifications/2562815LL/certify_v2
/certifications/2562815LL/form9_pdf
/certifications/2562815LL/update_v2
/certifications/2571390L
/certifications/2571390L/certify_v2
/certifications/2571390L/form9_pdf
/certifications/2571390L/update_v2
/certifications/2584472L
/certifications/2584472L/certify_v2
/certifications/2584472L/form9_pdf
/certifications/2584472L/update_v2
/certifications/2841572L
/certifications/2841572L/certify_v2
/certifications/2841572L/update_v2
/certifications/2926168L
/certifications/2926168L/certify_v2
/certifications/2926168L/check_documents
/certifications/2926168L/form9_pdf
/certifications/2926168L/update_v2
/certifications/2997768L
/certifications/2997768L/certify_v2
/certifications/2997768L/check_documents
/certifications/2997768L/form9_pdf
/certifications/2997768L/update_v2
/certifications/3114937L
/certifications/3114937L/certify_v2
/certifications/3114937L/check_documents
/certifications/3114937L/form9_pdf
/certifications/3114937L/update_v2
/certifications/3122360L
/certifications/3122360L/certify_v2
/certifications/3122360L/form9_pdf
/certifications/3122360L/update_v2
/certifications/3133104L
/certifications/3133104L/certify_v2
/certifications/3133104L/form9_pdf
/certifications/3133104L/update_v2
/certifications/3170322L
/certifications/3170322L/certify_v2
/certifications/3170322L/check_documents
/certifications/3170322L/form9_pdf
/certifications/3170322L/update_v2
/certifications/3172933L
/certifications/3172933L/certify_v2
/certifications/3172933L/form9_pdf
/certifications/3172933L/update_v2
/certifications/3206328L
/certifications/3206328L/certify_v2
/certifications/3206328L/form9_pdf
/certifications/3206328L/update_v2
/certifications/3248459L
/certifications/3248459L/certify_v2
/certifications/3248459L/check_documents
/certifications/3248459L/form9_pdf
/certifications/3248459L/update_v2
/certifications/3283255L
/certifications/3283255L/certify_v2
/certifications/3283255L/form9_pdf
/certifications/3283255L/update_v2
/certifications/3307251L
/certifications/3307251L/certify_v2
/certifications/3307251L/check_documents
/certifications/3307251L/form9_pdf
/certifications/3307251L/update_v2
/certifications/3314900L
/certifications/3314900L/certify_v2
/certifications/3314900L/form9_pdf
/certifications/3314900L/update_v2
/certifications/3332203L
/certifications/3332203L/certify_v2
/certifications/3332203L/form9_pdf
/certifications/3332203L/update_v2
/certifications/3437468L
/certifications/3437468L/certify_v2
/certifications/3437468L/update_v2
/certifications/3450003L
/certifications/3450003L/certify_v2
/certifications/3450003L/form9_pdf
/certifications/3450003L/update_v2
/certifications/3468045L
/certifications/3468045L/certify_v2
/certifications/3468045L/form9_pdf
/certifications/3468045L/update_v2
/certifications/3558927L
/certifications/3558927L/certify_v2
/certifications/3558927L/form9_pdf
/certifications/3558927L/update_v2
/certifications/error
/certifications/new/123c
/certifications/new/1930997L
/certifications/new/1953291L
/certifications/new/2021006L
/certifications/new/2029090L
/certifications/new/2091468L
/certifications/new/2246457L
/certifications/new/2294398L
/certifications/new/2317470L
/certifications/new/2425967L
/certifications/new/2496855L
/certifications/new/2519217L
/certifications/new/2562815LL
/certifications/new/2571390L
/certifications/new/2584472L
/certifications/new/2841572L
/certifications/new/2926168L
/certifications/new/2997768L
/certifications/new/3051597LL
/certifications/new/3114937L
/certifications/new/3122360L
/certifications/new/3133104L
/certifications/new/3170322L
/certifications/new/3172933L
/certifications/new/3206328L
/certifications/new/3248459L
/certifications/new/3283255L
/certifications/new/3307251L
/certifications/new/3314900L
/certifications/new/3332203L
/certifications/new/3437468L
/certifications/new/3450003L
/certifications/new/3468045L
/certifications/new/3558927L
/dependencies-check
/dispatch
/dispatch/admin
/dispatch/establish-claim
/dispatch/establish-claim/assign
/dispatch/help
/dispatch/missing-decision
/dispatch/work-assignments
/full
/health-check
/hearings/dockets
/hearings/dockets.json
/hearings/help
/help
/intake
/login
/logout
/metrics
/reader/appeal
/reader/appeal.%20Please
/reader/appeal/1936557W/documents
/reader/appeal/1966818L
/reader/appeal/1966818L/claims_folder_searches
/reader/appeal/1966818L/documents
/reader/appeal/2062133L
/reader/appeal/2062133L/claims_folder_searches
/reader/appeal/2062133L/documents
/reader/appeal/2137771L
/reader/appeal/2137771L/claims_folder_searches
/reader/appeal/2137771L/documents
/reader/appeal/2568258L/documents
/reader/appeal/2650006L
/reader/appeal/2650006L/claims_folder_searches
/reader/appeal/2650006L/documents
/reader/appeal/2689741L
/reader/appeal/2689741L/claims_folder_searches
/reader/appeal/2689741L/documents
/reader/appeal/3304013L/documents
/reader/appeal/3306558L/documents
/reader/appeal/3497512L
/reader/appeal/3497512L/documents
/reader/appeal/3529933D2
/reader/appeal/3529933D2/documents
/reader/appeal/veteran-id
/reader/help
/sessions/update
/tasks
/unauthorized
```

## Output
```
#<Set: {"%2Fpdfjs%2Fweb%2Fimages%2FfindbarButton-next.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FfindbarButton-previous.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2Floading-icon.gif\n",
 "%2Fpdfjs%2Fweb%2Fimages%2Floading-small.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-documentProperties.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-firstPage.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-handTool.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-lastPage.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-rotateCcw.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FsecondaryToolbarButton-rotateCw.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2Fshadow.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2Ftexture.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-bookmark.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-download.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-menuArrows.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-openFile.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-pageDown.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-pageUp.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-presentationMode.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-print.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-search.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-secondaryToolbarToggle.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-sidebarToggle.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-viewAttachments.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-viewOutline.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-viewThumbnail.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-zoomIn.png\n",
 "%2Fpdfjs%2Fweb%2Fimages%2FtoolbarButton-zoomOut.png\n",
 "%2Fpdfjs%2Fweb%2Flocale%2Fen-US%2Fviewer.properties\n",
 "%2Fpdfjs%2Fweb%2Flocale%2Flocale.properties\n",
 "/\n",
 "/404.html\n",
 "/api/v1/appeals\n",
 "/api/v1/jobs\n",
 "/certification/help\n",
 "/certification/stats\n",
 "/certification/stats/monthly\n",
 "/certification/stats/weekly\n",
 "/certification_cancellations\n",
 "/certification_cancellations/show\n",
 "/certifications/123c\n",
 "/certifications/:id\n",
 "/certifications/:id/certify_v2\n",
 "/certifications/:id/form9_pdf\n",
 "/certifications/:id/update_v2\n",
 "/certifications/:id/check_documents\n",
 "/certifications/error\n",
 "/certifications/new/123c\n",
 "/certifications/new/:id\n",
 "/dependencies-check\n",
 "/dispatch\n",
 "/dispatch/admin\n",
 "/dispatch/establish-claim\n",
 "/dispatch/establish-claim/assign\n",
 "/dispatch/help\n",
 "/dispatch/missing-decision\n",
 "/dispatch/work-assignments\n",
 "/full\n",
 "/health-check\n",
 "/hearings/dockets\n",
 "/hearings/dockets.json\n",
 "/hearings/help\n",
 "/help\n",
 "/intake\n",
 "/login\n",
 "/logout\n",
 "/metrics\n",
 "/reader/appeal\n",
 "/reader/appeal.%20Please\n",
 "/reader/appeal/:id/documents\n",
 "/reader/appeal/:id\n",
 "/reader/appeal/:id/claims_folder_searches\n",
 "/reader/appeal/veteran-id\n",
 "/reader/help\n",
 "/sessions/update\n",
 "/tasks\n",
 "/unauthorized\n"}>

```