### PR TITLE
Fix pageIndex search bug

### DIFF
--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -176,18 +176,17 @@ export class PdfFile extends React.PureComponent {
 
   getPageIndexofMatch = (matchIndex = this.props.currentMatchIndex) => {
     // get index in matchesPerPage of page containing match index
-    let pageIndex = 0;
-    let matchesProcessed = this.props.matchesPerPage[pageIndex].matches;
+    let cumulativeMatches = 0;
 
-    while (matchesProcessed < matchIndex + 1) {
-      pageIndex += 1;
-      matchesProcessed += this.props.matchesPerPage[pageIndex].matches;
+    for (let pageIndex = 0; pageIndex < this.props.matchesPerPage.length; pageIndex++) {
+      cumulativeMatches += this.props.matchesPerPage[pageIndex].matches;
+
+      if (matchIndex < cumulativeMatches) {
+        return pageIndex;
+      }
     }
 
-    const pageIdRE = /\/document\/\d+\/pdf-(\d+)/gi;
-    const pageIdMatch = pageIdRE.exec(this.props.matchesPerPage[pageIndex].id);
-
-    return parseInt(pageIdMatch[1], 10);
+    return -1;
   }
 
   componentDidUpdate = (prevProps) => {
@@ -200,15 +199,17 @@ export class PdfFile extends React.PureComponent {
       if (this.props.searchText && this.props.matchesPerPage.length) {
         const pageIndex = this.getPageIndexofMatch();
 
-        if (pageIndex === this.getPageIndexofMatch(prevProps.currentMatchIndex)) {
-          // todo: scroll to page if page is not rendered
-          if (!_.isNull(this.props.scrollTop)) {
-            this.scrollToPosition(pageIndex, this.props.scrollTop);
-            this.props.setDocScrollPosition(null);
+        if (pageIndex >= 0) {
+          if (pageIndex === this.getPageIndexofMatch(prevProps.currentMatchIndex)) {
+            // todo: scroll to page if page is not rendered
+            if (!_.isNull(this.props.scrollTop)) {
+              this.scrollToPosition(pageIndex, this.props.scrollTop);
+              this.props.setDocScrollPosition(null);
+            }
+          } else {
+            // scroll to mark page before highlighting--may not be in DOM
+            this.list.scrollToRow(pageIndex);
           }
-        } else {
-          // scroll to mark page before highlighting--may not be in DOM
-          this.list.scrollToRow(pageIndex);
         }
       }
     }

--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -189,6 +189,25 @@ export class PdfFile extends React.PureComponent {
     return -1;
   }
 
+  scrollToSearchTerm = (prevProps) => {
+    if (this.props.searchText && this.props.matchesPerPage.length) {
+      const pageIndex = this.getPageIndexofMatch();
+
+      if (pageIndex >= 0) {
+        if (pageIndex === this.getPageIndexofMatch(prevProps.currentMatchIndex)) {
+          // todo: scroll to page if page is not rendered
+          if (!_.isNull(this.props.scrollTop)) {
+            this.scrollToPosition(pageIndex, this.props.scrollTop);
+            this.props.setDocScrollPosition(null);
+          }
+        } else {
+          // scroll to mark page before highlighting--may not be in DOM
+          this.list.scrollToRow(pageIndex);
+        }
+      }
+    }
+  }
+
   componentDidUpdate = (prevProps) => {
     if (this.list && this.props.isVisible) {
       this.list.recomputeRowHeights();
@@ -196,22 +215,7 @@ export class PdfFile extends React.PureComponent {
       this.jumpToPage();
       this.jumpToComment();
 
-      if (this.props.searchText && this.props.matchesPerPage.length) {
-        const pageIndex = this.getPageIndexofMatch();
-
-        if (pageIndex >= 0) {
-          if (pageIndex === this.getPageIndexofMatch(prevProps.currentMatchIndex)) {
-            // todo: scroll to page if page is not rendered
-            if (!_.isNull(this.props.scrollTop)) {
-              this.scrollToPosition(pageIndex, this.props.scrollTop);
-              this.props.setDocScrollPosition(null);
-            }
-          } else {
-            // scroll to mark page before highlighting--may not be in DOM
-            this.list.scrollToRow(pageIndex);
-          }
-        }
-      }
+      this.scrollToSearchTerm(prevProps);
     }
   }
 

--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -178,11 +178,11 @@ export class PdfFile extends React.PureComponent {
     // get index in matchesPerPage of page containing match index
     let cumulativeMatches = 0;
 
-    for (let pageIndex = 0; pageIndex < this.props.matchesPerPage.length; pageIndex++) {
-      cumulativeMatches += this.props.matchesPerPage[pageIndex].matches;
+    for (let matchesPerPageIndex = 0; matchesPerPageIndex < this.props.matchesPerPage.length; matchesPerPageIndex++) {
+      cumulativeMatches += this.props.matchesPerPage[matchesPerPageIndex].matches;
 
       if (matchIndex < cumulativeMatches) {
-        return pageIndex;
+        return this.props.matchesPerPage[matchesPerPageIndex].pageIndex;
       }
     }
 

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -55,10 +55,10 @@ export class PdfPage extends React.PureComponent {
   highlightMarkAtIndex = (scrollToMark) => {
     _.each(this.marks, (mark) => mark.classList.remove('highlighted'));
 
-    const [pageWithMatch, indexInPage] = this.getIndexInPage();
+    const [pageIndexWithMatch, indexInPage] = this.getIndexInPage();
     const selectedMark = this.marks[indexInPage];
 
-    if (_.endsWith(pageWithMatch.id, `pdf-${this.props.pageIndex}`)) {
+    if (pageIndexWithMatch === this.props.pageIndex) {
       if (selectedMark) {
         selectedMark.classList.add('highlighted');
 
@@ -83,10 +83,9 @@ export class PdfPage extends React.PureComponent {
       pageIndex += 1;
       matchesProcessed += this.props.matchesPerPage[pageIndex].matches;
     }
-
     const pageWithMatch = this.props.matchesPerPage[pageIndex];
 
-    return [pageWithMatch, pageWithMatch.matches - (matchesProcessed - this.props.currentMatchIndex)];
+    return [pageIndex, this.props.currentMatchIndex + pageWithMatch.matches - matchesProcessed];
   }
 
   // This method is the interaction between our component and PDFJS.

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -76,16 +76,20 @@ export class PdfPage extends React.PureComponent {
 
   getIndexInPage = (matchIndex = this.props.currentMatchIndex) => {
     // get page, relative index of match at absolute index
-    let pageIndex = 0;
-    let matchesProcessed = this.props.matchesPerPage[pageIndex].matches;
+    let cumulativeMatches = 0;
 
-    while (matchesProcessed < matchIndex + 1) {
-      pageIndex += 1;
-      matchesProcessed += this.props.matchesPerPage[pageIndex].matches;
+    for (let matchesPerPageIndex = 0; matchesPerPageIndex < this.props.matchesPerPage.length; matchesPerPageIndex++) {
+      if (matchIndex < cumulativeMatches + this.props.matchesPerPage[matchesPerPageIndex].matches) {
+        return [
+          this.props.matchesPerPage[matchesPerPageIndex].pageIndex,
+          this.props.currentMatchIndex - cumulativeMatches
+        ];
+      }
+
+      cumulativeMatches += this.props.matchesPerPage[matchesPerPageIndex].matches;
     }
-    const pageWithMatch = this.props.matchesPerPage[pageIndex];
 
-    return [pageIndex, this.props.currentMatchIndex + pageWithMatch.matches - matchesProcessed];
+    return [-1, -1];
   }
 
   // This method is the interaction between our component and PDFJS.

--- a/client/app/reader/selectors.js
+++ b/client/app/reader/selectors.js
@@ -96,6 +96,7 @@ export const getMatchesPerPageInFile = createSelector(
   (matchedPages, txt) => matchedPages.
     map((page) => ({
       id: page.id,
+      pageIndex: page.pageIndex,
       matches: (page.text.match(new RegExp(txt, 'gi')) || []).length
     }))
 );


### PR DESCRIPTION
Connects: #3659

Our last attempted fix for the page index, introduced a new bug when there aren't search results on every page. The returned array with search results only contain results from pages that have at least one result. We need to know which page index each result is on. So we have added the page index to the array of returned search results.