### PR TITLE
Artem/deploy message

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ node('deploy') {
                    | sort -t/ -nk4 \
                    | awk -F\"/\" '{print \$0}' \
                    | tail -n 1 \
-                   | awk '{print \$1}')..ff6729b4ee9247047257fa19d2d59d065af975d9 --pretty='format:%H     %<(25)%an     %s'",
+                   | awk '{print \$1}')..a127c3f146c2c315597136a42f43086d98d2b563 --pretty='format:%h %<(20)%an %s'",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ node('deploy') {
       if (env.APP_ENV == 'demo') {
         DEPLOY_MESSAGE = sh (
           // magical shell script that will find the latest tag for the repository
-          script: "git log \$(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print $1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
+          script: "git log $(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print $1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,8 @@ def APP_NAME = 'certification';
 // See http://docs.ansible.com/ansible/git_module.html version field
 def APP_VERSION = 'HEAD'
 
+def DEPLOY_MESSAGE = null
+
 // Allows appeals-deployment branch (defaults to master) to be overridden for
 // testing purposes
 def DEPLOY_BRANCH = (env.DEPLOY_BRANCH != null) ? env.DEPLOY_BRANCH : 'master'
@@ -43,10 +45,10 @@ node('deploy') {
       sh "git clone -b $DEPLOY_BRANCH https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
 
       // For prod deploys we want to pull the latest `stable` tag; the logic here will pass it to ansible git module as APP_VERSION
-      if (env.APP_ENV == 'prod') {
-        APP_VERSION = sh (
+      if (env.APP_ENV == 'demo') {
+        DEPLOY_MESSAGE = sh (
           // magical shell script that will find the latest tag for the repository
-          script: "git ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1",
+          script: "git log \$(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print $1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
           returnStdout: true
         ).trim()
       }
@@ -61,4 +63,4 @@ node('deploy') {
 // Execute the common pipeline.
 // Note that this must be outside of the node block since the common pipeline
 // runs another set of stages.
-commonPipeline.deploy(APP_NAME, APP_VERSION);
+commonPipeline.deploy(APP_NAME, APP_VERSION, DEPLOY_MESSAGE);

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ node('deploy') {
 
     // Checkout the deployment repo for the ansible script. This is needed
     // since the deployment scripts are separated from the source code.
-    stage ('checkout-deploy-repo') {
+    stage ('pull-deploy-repo') {
 
       sh "git clone -b $DEPLOY_BRANCH https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ node('deploy') {
     stage ('pull-deploy-repo') {
 
       sh "git clone -b $DEPLOY_BRANCH https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
-
+      checkout scm
       // For prod deploys we want to pull the latest `stable` tag; the logic here will pass it to ansible git module as APP_VERSION
       if (env.APP_ENV == 'demo') {
         DEPLOY_MESSAGE = sh (

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ node('deploy') {
                    | sort -t/ -nk4 \
                    | awk -F\"/\" '{print \$0}' \
                    | tail -n 1 \
-                   | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s'",
+                   | awk '{print \$1}')..ff6729b4ee9247047257fa19d2d59d065af975d9 --pretty='format:%H     %<(25)%an     %s'",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ node('deploy') {
       if (env.APP_ENV == 'demo') {
         DEPLOY_MESSAGE = sh (
           // magical shell script that will find the latest tag for the repository
-          script: "git log $(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
+          script: "git log \$(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ node('deploy') {
       if (env.APP_ENV == 'demo') {
         DEPLOY_MESSAGE = sh (
           // magical shell script that will find the latest tag for the repository
-          script: "git log $(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print $1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
+          script: "git log $(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ node('deploy') {
       if (env.APP_ENV == 'demo') {
         DEPLOY_MESSAGE = sh (
           // magical shell script that will find the latest tag for the repository
-          script: "git log \$(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s'",
+          script: "git log \$(git ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s'",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ node('deploy') {
           script: "git log \$(git ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s'",
           returnStdout: true
         ).trim()
+        sh "echo ${DEPLOY_MESSAGE}"
       }
       dir ('./appeals-deployment/ansible') {
         // The commmon pipeline script should kick off the deployment.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ node('deploy') {
                    | sort -t/ -nk4 \
                    | awk -F\"/\" '{print \$0}' \
                    | tail -n 1 \
-                   | awk '{print \$1}')..a127c3f146c2c315597136a42f43086d98d2b563 --pretty='format:%h %<(20)%an %s'",
+                   | awk '{print \$1}')..a127c3f146c2c315597136a42f43086d98d2b563 --pretty='format:%h %<(15)%an %s'",
           returnStdout: true
         ).trim()
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,7 +48,7 @@ node('deploy') {
       if (env.APP_ENV == 'demo') {
         DEPLOY_MESSAGE = sh (
           // magical shell script that will find the latest tag for the repository
-          script: "git log \$(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s",
+          script: "git log \$(ls-remote --tags https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/caseflow.git | awk '{print \$2}' | grep -E 'manual|stable' | sort -t/ -nk4 | awk -F\"/\" '{print \$0}' | tail -n 1 | awk '{print \$1}')..HEAD --pretty='format:%H     %<(25)%an     %s'",
           returnStdout: true
         ).trim()
       }


### PR DESCRIPTION
This adds deploy message script that is kind of a copy from:
https://github.com/department-of-veterans-affairs/appeals-pm/blob/master/caseflow/tech_specs/lean_deployments.md#appendix-a-bash-function

It will be used by https://github.com/department-of-veterans-affairs/appeals-deployment/pull/1075

to make an announcement in slack:

<img width="480" alt="screen shot 2017-12-02 at 9 55 09 am" src="https://user-images.githubusercontent.com/18075411/33516809-e85a7c48-d746-11e7-97ed-afa573cd5086.png">

- The developer who is deploying will have to check the box and click Proceed in Jenkins in order to allow for the deploy to happen
- Timeout is 15 minutes

**NB** The production deploys will parse `deployed` tags now instead of `manual/stable` because that is what's actually in production.
- this way the integration test gate is removed
- `stable` history is preserved but does not block `deployed` history