### PR TITLE
VBMS version bump

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,7 @@ gem 'therubyracer', platforms: :ruby
 
 gem 'pg', platforms: :ruby
 
-gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "2e401bf7749f0780280951cbde777b7d67765554"
+gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "5dda05573d424d557be7a09052ab24b0dc6a5c5f"
 
 gem 'redis-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 2e401bf7749f0780280951cbde777b7d67765554
-  ref: 2e401bf7749f0780280951cbde777b7d67765554
+  revision: 5dda05573d424d557be7a09052ab24b0dc6a5c5f
+  ref: 5dda05573d424d557be7a09052ab24b0dc6a5c5f
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
must be coordinated with: https://github.com/department-of-veterans-affairs/appeals-deployment/pull/1087

this will start using path matching for proxied routes