### PR TITLE
Intake | Add columns required for single table inheritance on intakes

### DIFF
--- a/db/migrate/20171206003916_add_type_to_intakes.rb
+++ b/db/migrate/20171206003916_add_type_to_intakes.rb
@@ -1,0 +1,5 @@
+class AddTypeToIntakes < ActiveRecord::Migration
+  def change
+    add_column :intakes, :type, :string
+  end
+end

--- a/db/migrate/20171206004956_fill_in_intake_types.rb
+++ b/db/migrate/20171206004956_fill_in_intake_types.rb
@@ -1,6 +1,6 @@
 class FillInIntakeTypes < ActiveRecord::Migration
   def up
-    # all intakes are Ramp Election Intakes right now. Set type accordingly
+    # all intakes are Ramp Election Intakes right now. Set type accordingly.
     Intake.update_all(type: "RampElectionIntake")
   end
 end

--- a/db/migrate/20171206004956_fill_in_intake_types.rb
+++ b/db/migrate/20171206004956_fill_in_intake_types.rb
@@ -1,0 +1,6 @@
+class FillInIntakeTypes < ActiveRecord::Migration
+  def up
+    # all intakes are Ramp Election Intakes right now. Set type accordingly
+    Intake.update_all(type: "RampElectionIntake")
+  end
+end

--- a/db/migrate/20171206005110_add_type_index_on_intakes.rb
+++ b/db/migrate/20171206005110_add_type_index_on_intakes.rb
@@ -1,0 +1,7 @@
+class AddTypeIndexOnIntakes < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :intakes, :type, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171106153924) do
+ActiveRecord::Schema.define(version: 20171206005110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -285,8 +285,10 @@ ActiveRecord::Schema.define(version: 20171106153924) do
     t.datetime "completed_at"
     t.string   "completion_status"
     t.string   "error_code"
+    t.string   "type"
   end
 
+  add_index "intakes", ["type"], name: "index_intakes_on_type", using: :btree
   add_index "intakes", ["user_id"], name: "index_intakes_on_user_id", using: :btree
   add_index "intakes", ["veteran_file_number"], name: "index_intakes_on_veteran_file_number", using: :btree
 


### PR DESCRIPTION
Add `type` column to intakes so that we can use Single Table Inheritance features in rails (see: http://edgeguides.rubyonrails.org/association_basics.html#single-table-inheritance) 

Once the type column is there, rails will begin filling it in automatically.

connects #3956