### PR TITLE
Intake | Fill in search page and more refactoring to support multiple forms

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -23,12 +23,12 @@ class IntakesController < ApplicationController
   end
 
   def create
-    if intake.start!
-      render json: intake_data(intake)
+    if new_intake.start!
+      render json: new_intake.ui_hash
     else
       render json: {
-        error_code: intake.error_code,
-        error_data: intake.error_data
+        error_code: new_intake.error_code,
+        error_data: new_intake.error_data
       }, status: 422
     end
   end
@@ -41,16 +41,19 @@ class IntakesController < ApplicationController
     response.headers["Expires"] = "Fri, 01 Jan 1990 00:00:00 GMT"
   end
 
-  def intake_data(intake)
-    intake ? intake.ui_hash : {}
-  end
-  helper_method :intake_data
-
   def fetch_current_intake
-    @current_intake = RampElectionIntake.in_progress.find_by(user: current_user)
+    @current_intake = Intake.in_progress.find_by(user: current_user)
   end
 
-  def intake
-    @intake ||= RampElectionIntake.new(user: current_user, veteran_file_number: params[:file_number])
+  def new_intake
+    @new_intake ||= Intake.build(
+      user: current_user,
+      veteran_file_number: params[:file_number],
+      form_type: form_type
+    )
+  end
+
+  def form_type
+    FeatureToggle.enabled?(:intake_reentry_form) ? params[:form_type] : "ramp_election"
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -1,4 +1,6 @@
 class Intake < ActiveRecord::Base
+  class FormTypeNotSupported < StandardError; end
+
   belongs_to :user
   belongs_to :detail, polymorphic: true
 
@@ -14,10 +16,23 @@ class Intake < ActiveRecord::Base
     veteran_not_accessible: "veteran_not_accessible"
   }.freeze
 
+  FORM_TYPES = {
+    ramp_election: "RampElectionIntake",
+    ramp_refiling: "RampRefilingIntake"
+  }.freeze
+
   attr_reader :error_data
 
   def self.in_progress
     where(completed_at: nil).where.not(started_at: nil)
+  end
+
+  def self.build(form_type:, veteran_file_number:, user:)
+    intake_classname = FORM_TYPES[form_type.to_sym]
+
+    fail FormTypeNotSupported unless intake_classname
+
+    intake_classname.constantize.new(veteran_file_number: veteran_file_number, user: user)
   end
 
   def start!
@@ -64,6 +79,21 @@ class Intake < ActiveRecord::Base
 
   def veteran
     @veteran ||= Veteran.new(file_number: veteran_file_number).load_bgs_record!
+  end
+
+  def ui_hash
+    {
+      id: id,
+      form_type: form_type,
+      veteran_file_number: veteran_file_number,
+      veteran_name: veteran.name.formatted(:readable_short),
+      veteran_form_name: veteran.name.formatted(:form),
+      completed_at: completed_at
+    }
+  end
+
+  def form_type
+    FORM_TYPES.key(self.class.name)
   end
 
   private

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -56,18 +56,11 @@ class RampElectionIntake < Intake
   end
 
   def ui_hash
-    {
-      id: id,
-      veteran_file_number: veteran_file_number,
-      veteran_name: veteran.name.formatted(:readable_short),
-      veteran_form_name: veteran.name.formatted(:form),
-      notice_date: ramp_election.notice_date,
-      option_selected: ramp_election.option_selected,
-      receipt_date: ramp_election.receipt_date,
-      completed_at: completed_at,
-      end_product_description: ramp_election.end_product_description,
-      appeals: serialized_appeal_issues
-    }
+    super.merge(notice_date: ramp_election.notice_date,
+                option_selected: ramp_election.option_selected,
+                receipt_date: ramp_election.receipt_date,
+                end_product_description: ramp_election.end_product_description,
+                appeals: serialized_appeal_issues)
   end
 
   private

--- a/app/models/ramp_refiling_intake.rb
+++ b/app/models/ramp_refiling_intake.rb
@@ -1,0 +1,8 @@
+class RampRefilingIntake < Intake
+  private
+
+  def find_or_create_initial_detail
+    # Placeholder
+    true
+  end
+end

--- a/app/views/intakes/index.html.erb
+++ b/app/views/intakes/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :full_page_content do %>
   <%= react_component("BaseContainer", props: {
     userDisplayName: current_user.display_name,
-    currentIntake: intake_data(@current_intake),
+    currentIntake: @current_intake ? @current_intake.ui_hash : {},
     dropdownUrls: dropdown_urls,
     page: "Intake",
     feedbackUrl: ENV["CASEFLOW_FEEDBACK_URL"],

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -7,7 +7,7 @@ export const PAGE_PATHS = {
 };
 
 export const ACTIONS = {
-  SET_FORM_SELECTION: 'SET_FORM_SELECTION',
+  SET_FORM_TYPE: 'SET_FORM_TYPE',
   START_NEW_INTAKE: 'START_NEW_INTAKE',
   SET_FILE_NUMBER_SEARCH: 'SET_FILE_NUMBER_SEARCH',
   FILE_NUMBER_SEARCH_START: 'FILE_NUMBER_SEARCH_START',
@@ -45,5 +45,5 @@ export const RAMP_INTAKE_STATES = {
 
 export const FORMS = {
   ramp_election: 'RAMP Opt-In Election Form',
-  ramp_reentry: '21-4138 RAMP Selection Form'
+  ramp_refiling: '21-4138 RAMP Selection Form'
 };

--- a/client/app/intake/pages/begin.jsx
+++ b/client/app/intake/pages/begin.jsx
@@ -29,7 +29,9 @@ const rampIneligibleInstructions = <div>
 </div>;
 
 class Begin extends React.PureComponent {
-  handleSearchSubmit = () => this.props.doFileNumberSearch(this.props.fileNumberSearchInput)
+  handleSearchSubmit = () => (
+    this.props.doFileNumberSearch('ramp_election', this.props.fileNumberSearchInput)
+  )
 
   clearSearch = () => this.props.setFileNumberSearch('')
 

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -1,9 +1,142 @@
 import React from 'react';
+import SearchBar from '../../components/SearchBar';
+import Alert from '../../components/Alert';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import { doFileNumberSearch, setFileNumberSearch } from '../redux/actions';
+import { REQUEST_STATE, PAGE_PATHS, RAMP_INTAKE_STATES } from '../constants';
+import { getRampElectionStatus } from '../redux/selectors';
 
-// Placeholder
-export default class Search extends React.PureComponent {
+const rampIneligibleInstructions = <div>
+  <p>
+    Please check the Veteran ID entered, and if the Veteran ID
+    is correct, take the following actions outside Caseflow:
+  </p>
+  <ul>
+    <li>
+      Upload the RAMP Election to the VBMS eFolder with
+      Document Type <b>Correspondence</b> and Subject Line "RAMP Election".
+    </li>
+    <li>
+      Notify the Veteran by mail of his/her ineligibility to participate
+      in RAMP using the <b>RAMP Ineligible Letter</b> in <em>Letter Creator</em>.
+    </li>
+    <li>
+      Document your actions as a permanent note in VBMS.
+    </li>
+  </ul>
+</div>;
+
+class Search extends React.PureComponent {
+  handleSearchSubmit = () => (
+    this.props.doFileNumberSearch(this.props.formType, this.props.fileNumberSearchInput)
+  )
+
+  clearSearch = () => this.props.setFileNumberSearch('')
+
+  getSearchErrorAlert = (searchErrorCode, searchErrorData) => {
+    // The values in this switch statement need to be snake_case
+    // because they're being matched to server response values.
+    const searchErrors = {
+      invalid_file_number: {
+        title: 'Veteran ID not found',
+        body: 'Please enter a valid Veteran ID and try again.'
+      },
+      veteran_not_found: {
+        title: 'Veteran ID not found',
+        body: 'Please enter a valid Veteran ID and try again.'
+      },
+      veteran_not_accessible: {
+        title: 'You don\'t have permission to view this veteran\'s information​',
+        body: 'Please enter a valid Veteran ID and try again.'
+      },
+      did_not_receive_ramp_election: {
+        title: 'A RAMP Opt-in Notice Letter was not sent to this Veteran.',
+        body: rampIneligibleInstructions
+      },
+      ramp_election_already_complete: {
+        title: 'Opt-in already processed in Caseflow',
+        body: `A RAMP opt-in with the notice date ${searchErrorData.duplicateNoticeDate}` +
+          ' was already processed in Caseflow. Please ensure this' +
+          ' is a duplicate election form, and proceed to the next intake.'
+      },
+      no_active_appeals: {
+        title: 'Ineligible to participate in RAMP: no active appeals',
+        body: rampIneligibleInstructions
+      },
+      no_eligible_appeals: {
+        title: 'Ineligible to participate in RAMP: appeal is at the Board',
+        body: rampIneligibleInstructions
+      },
+      default: {
+        title: 'Something went wrong',
+        body: 'Please try again. If the problem persists, please contact Caseflow support.'
+      }
+    };
+
+    const error = searchErrors[searchErrorCode] || searchErrors.default;
+
+    return <Alert title={error.title} type="error" lowerMargin>
+      { error.body }
+    </Alert>;
+  }
+
   render() {
+    const {
+      searchErrorCode,
+      searchErrorData,
+      rampElectionStatus,
+      formType
+    } = this.props;
+
+    if (!formType) {
+      return <Redirect to={PAGE_PATHS.BEGIN} />;
+    }
+
+    switch (rampElectionStatus) {
+    case RAMP_INTAKE_STATES.STARTED:
+      return <Redirect to={PAGE_PATHS.REVIEW} />;
+    case RAMP_INTAKE_STATES.REVIEWED:
+      return <Redirect to={PAGE_PATHS.FINISH} />;
+    case RAMP_INTAKE_STATES.COMPLETED:
+      return <Redirect to={PAGE_PATHS.COMPLETED} />;
+    default:
+    }
+
     return <div>
+      { searchErrorCode && this.getSearchErrorAlert(searchErrorCode, searchErrorData) }
+
+      <h1>Search for Veteran by ID</h1>
+      <p>
+        To continue processing this form,
+        enter the Veteran’s 8 or 9 digit ID number into the search bar below.
+      </p>
+
+      <SearchBar
+        size="small"
+        onSubmit={this.handleSearchSubmit}
+        onChange={this.props.setFileNumberSearch}
+        onClearSearch={this.clearSearch}
+        value={this.props.fileNumberSearchInput}
+        loading={this.props.fileNumberSearchRequestStatus === REQUEST_STATE.IN_PROGRESS}
+        submitUsingEnterKey
+      />
     </div>;
   }
 }
+
+export default connect(
+  (state) => ({
+    fileNumberSearchInput: state.inputs.fileNumberSearch,
+    fileNumberSearchRequestStatus: state.requestStatus.fileNumberSearch,
+    rampElectionStatus: getRampElectionStatus(state),
+    searchErrorCode: state.searchErrorCode,
+    searchErrorData: state.searchErrorData,
+    formType: state.formType
+  }),
+  (dispatch) => bindActionCreators({
+    doFileNumberSearch,
+    setFileNumberSearch
+  }, dispatch)
+)(Search);

--- a/client/app/intake/pages/selectForm.jsx
+++ b/client/app/intake/pages/selectForm.jsx
@@ -3,7 +3,7 @@ import RadioField from '../../components/RadioField';
 import Button from '../../components/Button';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { setFormSelection } from '../redux/actions';
+import { setFormType } from '../redux/actions';
 import { FORMS } from '../constants';
 import _ from 'lodash';
 
@@ -22,8 +22,8 @@ class SelectForm extends React.PureComponent {
         vertical
         strongLabel
         options={radioOptions}
-        onChange={this.props.setFormSelection}
-        value={this.props.formSelection}
+        onChange={this.props.setFormType}
+        value={this.props.formType}
       />
     </div>;
   }
@@ -31,10 +31,10 @@ class SelectForm extends React.PureComponent {
 
 export default connect(
   (state) => ({
-    formSelection: state.formSelection
+    formType: state.formType
   }),
   (dispatch) => bindActionCreators({
-    setFormSelection
+    setFormType
   }, dispatch)
 )(SelectForm);
 
@@ -48,12 +48,12 @@ class SelectFormButtonUnconnected extends React.PureComponent {
       name="continue-to-search"
       onClick={this.handleClick}
       legacyStyling={false}
-      disabled={!this.props.formSelection}
+      disabled={!this.props.formType}
     >
       Continue to search
     </Button>;
 }
 
 export const SelectFormButton = connect(
-  ({ formSelection }) => ({ formSelection }),
+  ({ formType }) => ({ formType }),
 )(SelectFormButtonUnconnected);

--- a/client/app/intake/redux/actions.js
+++ b/client/app/intake/redux/actions.js
@@ -23,13 +23,16 @@ export const setFileNumberSearch = (fileNumber) => ({
   }
 });
 
-export const doFileNumberSearch = (fileNumberSearch) => (dispatch) => {
+export const doFileNumberSearch = (formType, fileNumberSearch) => (dispatch) => {
   dispatch({
     type: ACTIONS.FILE_NUMBER_SEARCH_START,
     meta: { analytics }
   });
 
-  return ApiUtil.post('/intake', { data: { file_number: fileNumberSearch } }, ENDPOINT_NAMES.INTAKE).
+  const data = { file_number: fileNumberSearch,
+    form_type: formType };
+
+  return ApiUtil.post('/intake', { data }, ENDPOINT_NAMES.INTAKE).
     then(
       (response) => {
         const responseObject = JSON.parse(response.text);
@@ -76,14 +79,14 @@ export const setOptionSelected = (optionSelected) => ({
   }
 });
 
-export const setFormSelection = (formSelection) => ({
-  type: ACTIONS.SET_FORM_SELECTION,
+export const setFormType = (formType) => ({
+  type: ACTIONS.SET_FORM_TYPE,
   payload: {
-    formSelection
+    formType
   },
   meta: {
     analytics: {
-      label: formSelection
+      label: formType
     }
   }
 });

--- a/client/app/intake/redux/reducer.js
+++ b/client/app/intake/redux/reducer.js
@@ -61,7 +61,7 @@ const updateStateWithSavedIntake = (state, intake) => {
 
 export const mapDataToInitialState = (data = { currentIntake: {} }) => (
   updateStateWithSavedIntake({
-    formSelection: null,
+    formType: null,
     veteran: {
       name: '',
       formName: '',
@@ -125,10 +125,10 @@ export const reducer = (state = mapDataToInitialState(), action) => {
         }
       }
     });
-  case ACTIONS.SET_FORM_SELECTION:
+  case ACTIONS.SET_FORM_TYPE:
     return update(state, {
-      formSelection: {
-        $set: action.payload.formSelection
+      formType: {
+        $set: action.payload.formType
       }
     });
   case ACTIONS.SET_OPTION_SELECTED:

--- a/spec/feature/intake_spec.rb
+++ b/spec/feature/intake_spec.rb
@@ -316,7 +316,8 @@ RSpec.feature "RAMP Intake" do
       after { FeatureToggle.disable!(:intake_reentry_form) }
 
       scenario "flow starts with form selection" do
-        visit "/intake"
+        # Validate that you can't go directly to search
+        visit "/intake/search"
 
         # Validate that you cant move forward without selecting a form
         scroll_element_in_to_view(".cf-submit.usa-button")

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -17,6 +17,25 @@ describe Intake do
 
   let!(:veteran) { Generators::Veteran.build(file_number: "64205050") }
 
+  context ".build" do
+    subject { Intake.build(form_type: form_type, veteran_file_number: veteran_file_number, user: user) }
+
+    context "when form_type is supported" do
+      let(:form_type) { "ramp_election" }
+
+      it { is_expected.to be_a(RampElectionIntake) }
+      it { is_expected.to have_attributes(veteran_file_number: veteran_file_number, user: user) }
+    end
+
+    context "when form_type is not supported" do
+      let(:form_type) { "not_a_real_form" }
+
+      it "raises error" do
+        expect { subject }.to raise_error(Intake::FormTypeNotSupported)
+      end
+    end
+  end
+
   context ".in_progress" do
     subject { Intake.in_progress }
 


### PR DESCRIPTION
Dependent on https://github.com/department-of-veterans-affairs/caseflow/pull/4077. It must have been deployed before this can be deployed.

Allows the creation of multiple different types of intakes.

Add the search page for the new flow. It is mostly the same as the old except:
- It boots you back to the form selection page if you haven't selected a form type
- some copy changes per the AC
- it is uses the selected form to create the right type of intake

## Test Instructions
- You should be able to create a `RampElectionIntake` with the new flow. `RampRefilingIntake` still needs some more logic to be able to be created. The API will throw a 500 if you try and create one.

connects #3965