### PR TITLE
Give fake user access to efolder express

### DIFF
--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -43,7 +43,9 @@ class Fakes::Initializer
 
       User.authentication_service.user_session = {
         "id" => "Fake User",
-        "roles" => ["Certify Appeal", "Establish Claim", "Manage Claim Establishment", "Global Admin"],
+        "css_id" => "FAKEUSER",
+        "roles" =>
+          ["Certify Appeal", "Establish Claim", "Download eFolder", "Manage Claim Establishment", "Global Admin"],
         "station_id" => "283",
         "email" => "america@example.com",
         "name" => "Cave Johnson"


### PR DESCRIPTION
One cause of [this related efolder ticket](https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/717) is that the default caseflow fake user does not have a CSS ID or the efolder express role. This change adds a CSS ID and the efolder role.