### PR TITLE
Intake | refactor actions based on form

### DIFF
--- a/client/app/intake/IntakeFrame.jsx
+++ b/client/app/intake/IntakeFrame.jsx
@@ -19,11 +19,11 @@ import ReviewPage, { ReviewButtons } from './pages/review';
 import FinishPage, { FinishButtons } from './pages/finish';
 import CompletedPage, { CompletedNextButton } from './pages/completed';
 import { PAGE_PATHS, REQUEST_STATE } from './constants';
-import { toggleCancelModal, submitCancel } from './redux/actions';
+import { toggleCancelModal, submitCancel } from './actions/common';
 
 class IntakeFrame extends React.PureComponent {
   handleSubmitCancel = () => (
-    this.props.submitCancel(this.props.rampElection)
+    this.props.submitCancel(this.props.intakeId)
   )
 
   render() {
@@ -163,9 +163,9 @@ class IntakeFrame extends React.PureComponent {
 }
 
 export default connect(
-  ({ veteran, requestStatus, cancelModalVisible, rampElection }) => ({
+  ({ veteran, requestStatus, cancelModalVisible, intakeId }) => ({
     veteran,
-    rampElection,
+    intakeId,
     cancelModalVisible,
     requestStatus
   }),

--- a/client/app/intake/actions/common.js
+++ b/client/app/intake/actions/common.js
@@ -1,0 +1,105 @@
+import { ACTIONS, ENDPOINT_NAMES } from '../constants';
+import ApiUtil from '../../util/ApiUtil';
+import { formatDateStringForApi } from '../../util/DateUtil';
+import _ from 'lodash';
+
+const analytics = true;
+
+export const startNewIntake = () => ({
+  type: ACTIONS.START_NEW_INTAKE,
+  meta: { analytics }
+});
+
+export const setFileNumberSearch = (fileNumber) => ({
+  type: ACTIONS.SET_FILE_NUMBER_SEARCH,
+  payload: {
+    fileNumber
+  }
+});
+
+export const doFileNumberSearch = (formType, fileNumberSearch) => (dispatch) => {
+  dispatch({
+    type: ACTIONS.FILE_NUMBER_SEARCH_START,
+    meta: { analytics }
+  });
+
+  const data = { file_number: fileNumberSearch,
+    form_type: formType };
+
+  return ApiUtil.post('/intake', { data }, ENDPOINT_NAMES.INTAKE).
+    then(
+      (response) => {
+        const responseObject = JSON.parse(response.text);
+
+        dispatch({
+          type: ACTIONS.FILE_NUMBER_SEARCH_SUCCEED,
+          payload: {
+            intake: responseObject
+          },
+          meta: { analytics }
+        });
+      },
+      (error) => {
+        const responseObject = JSON.parse(error.response.text);
+        const errorCode = responseObject.error_code;
+
+        dispatch({
+          type: ACTIONS.FILE_NUMBER_SEARCH_FAIL,
+          payload: {
+            errorCode,
+            errorData: responseObject.error_data || {}
+          },
+          meta: {
+            analytics: {
+              label: errorCode
+            }
+          }
+        });
+
+        throw error;
+      }
+    );
+};
+
+export const setFormType = (formType) => ({
+  type: ACTIONS.SET_FORM_TYPE,
+  payload: {
+    formType
+  },
+  meta: {
+    analytics: {
+      label: formType
+    }
+  }
+});
+
+export const toggleCancelModal = () => ({
+  type: ACTIONS.TOGGLE_CANCEL_MODAL,
+  meta: {
+    analytics: {
+      label: (nextState) => nextState.cancelModalVisible ? 'show' : 'hide'
+    }
+  }
+});
+
+export const submitCancel = (intakeId) => (dispatch) => {
+  dispatch({
+    type: ACTIONS.CANCEL_INTAKE_START,
+    meta: { analytics }
+  });
+
+  return ApiUtil.delete(`/intake/${intakeId}`, {}, ENDPOINT_NAMES.INTAKE_RAMP).
+    then(
+      () => dispatch({
+        type: ACTIONS.CANCEL_INTAKE_SUCCEED,
+        meta: { analytics }
+      }),
+      (error) => {
+        dispatch({
+          type: ACTIONS.CANCEL_INTAKE_FAIL,
+          meta: { analytics }
+        });
+        throw error;
+      }
+    );
+};

--- a/client/app/intake/actions/common.js
+++ b/client/app/intake/actions/common.js
@@ -1,7 +1,5 @@
 import { ACTIONS, ENDPOINT_NAMES } from '../constants';
 import ApiUtil from '../../util/ApiUtil';
-import { formatDateStringForApi } from '../../util/DateUtil';
-import _ from 'lodash';
 
 const analytics = true;
 

--- a/client/app/intake/actions/rampElection.js
+++ b/client/app/intake/actions/rampElection.js
@@ -1,71 +1,9 @@
-import { ACTIONS } from '../constants';
+import { ACTIONS, ENDPOINT_NAMES } from '../constants';
 import ApiUtil from '../../util/ApiUtil';
 import { formatDateStringForApi } from '../../util/DateUtil';
 import _ from 'lodash';
 
 const analytics = true;
-
-const ENDPOINT_NAMES = {
-  INTAKE: 'intake',
-  INTAKE_RAMP: 'intake-ramp',
-  INTAKE_RAMP_COMPLETE: 'intake-ramp-complete'
-};
-
-export const startNewIntake = () => ({
-  type: ACTIONS.START_NEW_INTAKE,
-  meta: { analytics }
-});
-
-export const setFileNumberSearch = (fileNumber) => ({
-  type: ACTIONS.SET_FILE_NUMBER_SEARCH,
-  payload: {
-    fileNumber
-  }
-});
-
-export const doFileNumberSearch = (formType, fileNumberSearch) => (dispatch) => {
-  dispatch({
-    type: ACTIONS.FILE_NUMBER_SEARCH_START,
-    meta: { analytics }
-  });
-
-  const data = { file_number: fileNumberSearch,
-    form_type: formType };
-
-  return ApiUtil.post('/intake', { data }, ENDPOINT_NAMES.INTAKE).
-    then(
-      (response) => {
-        const responseObject = JSON.parse(response.text);
-
-        dispatch({
-          type: ACTIONS.FILE_NUMBER_SEARCH_SUCCEED,
-          payload: {
-            intake: responseObject
-          },
-          meta: { analytics }
-        });
-      },
-      (error) => {
-        const responseObject = JSON.parse(error.response.text);
-        const errorCode = responseObject.error_code;
-
-        dispatch({
-          type: ACTIONS.FILE_NUMBER_SEARCH_FAIL,
-          payload: {
-            errorCode,
-            errorData: responseObject.error_data || {}
-          },
-          meta: {
-            analytics: {
-              label: errorCode
-            }
-          }
-        });
-
-        throw error;
-      }
-    );
-};
 
 export const setOptionSelected = (optionSelected) => ({
   type: ACTIONS.SET_OPTION_SELECTED,
@@ -75,18 +13,6 @@ export const setOptionSelected = (optionSelected) => ({
   meta: {
     analytics: {
       label: optionSelected
-    }
-  }
-});
-
-export const setFormType = (formType) => ({
-  type: ACTIONS.SET_FORM_TYPE,
-  payload: {
-    formType
-  },
-  meta: {
-    analytics: {
-      label: formType
     }
   }
 });
@@ -174,37 +100,6 @@ export const completeIntake = (rampElection) => (dispatch) => {
       (error) => {
         dispatch({
           type: ACTIONS.COMPLETE_INTAKE_FAIL,
-          meta: { analytics }
-        });
-        throw error;
-      }
-    );
-};
-
-export const toggleCancelModal = () => ({
-  type: ACTIONS.TOGGLE_CANCEL_MODAL,
-  meta: {
-    analytics: {
-      label: (nextState) => nextState.cancelModalVisible ? 'show' : 'hide'
-    }
-  }
-});
-
-export const submitCancel = (rampElection) => (dispatch) => {
-  dispatch({
-    type: ACTIONS.CANCEL_INTAKE_START,
-    meta: { analytics }
-  });
-
-  return ApiUtil.delete(`/intake/${rampElection.intakeId}`, {}, ENDPOINT_NAMES.INTAKE_RAMP).
-    then(
-      () => dispatch({
-        type: ACTIONS.CANCEL_INTAKE_SUCCEED,
-        meta: { analytics }
-      }),
-      (error) => {
-        dispatch({
-          type: ACTIONS.CANCEL_INTAKE_FAIL,
           meta: { analytics }
         });
         throw error;

--- a/client/app/intake/components/CancelButton.jsx
+++ b/client/app/intake/components/CancelButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '../../components/Button';
-import { toggleCancelModal } from '../redux/actions';
+import { toggleCancelModal } from '../actions/common';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -43,6 +43,12 @@ export const RAMP_INTAKE_STATES = {
   COMPLETED: 'COMPLETED'
 };
 
+export const ENDPOINT_NAMES = {
+  INTAKE: 'intake',
+  INTAKE_RAMP: 'intake-ramp',
+  INTAKE_RAMP_COMPLETE: 'intake-ramp-complete'
+};
+
 export const FORM_TYPES = {
   RAMP_ELECTION: { key: 'ramp_election',
     name: 'RAMP Opt-In Election Form' },

--- a/client/app/intake/pages/begin.jsx
+++ b/client/app/intake/pages/begin.jsx
@@ -4,7 +4,7 @@ import Alert from '../../components/Alert';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import { doFileNumberSearch, setFileNumberSearch } from '../redux/actions';
+import { doFileNumberSearch, setFileNumberSearch } from '../actions/common';
 import { REQUEST_STATE, PAGE_PATHS, RAMP_INTAKE_STATES } from '../constants';
 import { getRampElectionStatus } from '../redux/selectors';
 

--- a/client/app/intake/pages/completed.jsx
+++ b/client/app/intake/pages/completed.jsx
@@ -3,7 +3,7 @@ import Button from '../../components/Button';
 import StatusMessage from '../../components/StatusMessage';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { startNewIntake } from '../redux/actions';
+import { startNewIntake } from '../actions/common';
 import { Redirect } from 'react-router-dom';
 import { PAGE_PATHS, RAMP_INTAKE_STATES } from '../constants';
 import { getRampElectionStatus } from '../redux/selectors';

--- a/client/app/intake/pages/finish.jsx
+++ b/client/app/intake/pages/finish.jsx
@@ -8,7 +8,7 @@ import Table from '../../components/Table';
 import { Redirect } from 'react-router-dom';
 import { REQUEST_STATE, PAGE_PATHS, RAMP_INTAKE_STATES } from '../constants';
 import { connect } from 'react-redux';
-import { completeIntake, confirmFinishIntake } from '../redux/actions';
+import { completeIntake, confirmFinishIntake } from '../actions/rampElection';
 import { bindActionCreators } from 'redux';
 import { getRampElectionStatus } from '../redux/selectors';
 import _ from 'lodash';

--- a/client/app/intake/pages/rampElection/review.jsx
+++ b/client/app/intake/pages/rampElection/review.jsx
@@ -6,7 +6,7 @@ import DateSelector from '../../../components/DateSelector';
 import CancelButton from '../../components/CancelButton';
 import { Redirect } from 'react-router-dom';
 import Button from '../../../components/Button';
-import { setOptionSelected, setReceiptDate, submitReview } from '../../redux/actions';
+import { setOptionSelected, setReceiptDate, submitReview } from '../../actions/rampElection';
 import { getRampElectionStatus } from '../../redux/selectors';
 import { REQUEST_STATE, PAGE_PATHS, RAMP_INTAKE_STATES } from '../../constants';
 

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -4,7 +4,7 @@ import Alert from '../../components/Alert';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import { doFileNumberSearch, setFileNumberSearch } from '../redux/actions';
+import { doFileNumberSearch, setFileNumberSearch } from '../actions/common';
 import { REQUEST_STATE, PAGE_PATHS, RAMP_INTAKE_STATES } from '../constants';
 import { getRampElectionStatus } from '../redux/selectors';
 

--- a/client/app/intake/pages/selectForm.jsx
+++ b/client/app/intake/pages/selectForm.jsx
@@ -4,7 +4,7 @@ import Button from '../../components/Button';
 import { Redirect } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { setFormType } from '../redux/actions';
+import { setFormType } from '../actions/common';
 import { FORM_TYPES, PAGE_PATHS } from '../constants';
 import _ from 'lodash';
 


### PR DESCRIPTION
A strict refactor. No change to functionality.

Makes way for actions to be separated based on form selection.

Moved `/redux/actions.js` to `/actions/common.js` and `actions/rampElection.js`