### PR TITLE
[WIP]Hearing Worksheet make pdf headline fonts default

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -447,6 +447,13 @@ $color-hearings-saving: #777;
 }
 
 @media print {
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: sans-serif;
+  }
+
   h1 {
     font-size: 25px;
   }


### PR DESCRIPTION
When the user clicks save to pdf, the head fonts do not render before the PDF dialog comes up because of a font postscript issue. This PR just changes the fonts to default sans

related #3067 

![screen shot 2017-12-13 at 9 46 25 am](https://user-images.githubusercontent.com/1745984/33944576-993f738c-dfea-11e7-8b04-cf711d3c0d97.png)
