### PR TITLE
Intake | Add `established_end_product` method to RampElection

### DIFF
--- a/app/controllers/test/users_controller.rb
+++ b/app/controllers/test/users_controller.rb
@@ -66,22 +66,23 @@ class Test::UsersController < ApplicationController
 
   # Set end products in DEMO
   def set_end_products
-    case params[:type]
-    when "full"
-      BGSService.end_product_data = BGSService.existing_full_grants
-    when "partial"
-      BGSService.end_product_data = BGSService.existing_partial_grants
-    when "none"
-      BGSService.end_product_data = BGSService.no_grants
-    when "all"
-      BGSService.end_product_data = BGSService.all_grants
-    end
+    BGSService.end_product_records[:default] = new_default_end_products
 
     render nothing: true, status: 200
   end
 
   def require_demo
     redirect_to "/unauthorized" unless Rails.deploy_env?(:demo)
+  end
+
+  private
+
+  def new_default_end_products
+    {
+      "full" => BGSService.existing_full_grants,
+      "partial" => BGSService.existing_partial_grants,
+      "all" => BGSService.all_grants
+    }[params[:type]] || BGSService.no_grants
   end
   # :nocov:
 end

--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -2,6 +2,7 @@ class EndProduct
   include ActiveModel::Model
   include ActiveModel::Validations
 
+  # NOTE: This is not a comprehensive list of possible statuses
   STATUSES = {
     "PEND" => "Pending",
     "CLR" => "Cleared",

--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -67,13 +67,12 @@ class RampElection < ActiveRecord::Base
   def fetch_established_end_product
     return nil unless end_product_reference_id
 
-    Veteran.new(file_number: veteran_file_number).end_products.find do |end_product|
+    result = Veteran.new(file_number: veteran_file_number).end_products.find do |end_product|
       end_product.claim_id == end_product_reference_id
-    end.tap do |result|
-      # All end_product_reference_ids should have a cooresponding end product.
-      # if not, throw an error so we know about it.
-      fail EstablishedEndProductNotFound unless result
     end
+
+    fail EstablishedEndProductNotFound unless result
+    result
   end
 
   def end_product

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -54,6 +54,10 @@ class Veteran
     self
   end
 
+  def end_products
+    @end_products ||= fetch_end_products
+  end
+
   def periods_of_service
     return [] unless service
     service.inject([]) do |result, s|
@@ -97,6 +101,10 @@ class Veteran
         bgs_record[bgs_attribute]
       )
     end
+  end
+
+  def fetch_end_products
+    self.class.bgs.get_end_products(file_number).map { |ep_hash| EndProduct.from_bgs_hash(ep_hash) }
   end
 
   def period_of_service(s)

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -2,7 +2,7 @@ class Fakes::BGSService
   include PowerOfAttorneyMapper
   include AddressMapper
 
-  cattr_accessor :end_product_data
+  cattr_accessor :end_product_records
   cattr_accessor :inaccessible_appeal_vbms_ids
   cattr_accessor :veteran_records
   cattr_accessor :power_of_attorney_records
@@ -200,10 +200,13 @@ class Fakes::BGSService
   def self.clean!
     self.ssn_not_found = false
     self.inaccessible_appeal_vbms_ids = []
+    self.end_product_records = {}
   end
 
-  def get_end_products(_veteran_id)
-    end_product_data || self.class.no_grants
+  def get_end_products(veteran_id)
+    records = self.class.end_product_records || {}
+
+    records[veteran_id] || records[:default] || []
   end
 
   def fetch_veteran_info(vbms_id)
@@ -276,88 +279,6 @@ class Fakes::BGSService
       trsury_addrs_two_txt: "9999 MISSION ST",
       trsury_seq_nbr: "5",
       zip_prefix_nbr: "94103"
-    }
-  end
-
-  def default_veteran_record
-    {
-      address_line1: "1234 FAKE ST",
-      address_line2: nil,
-      address_line3: nil,
-      area_number_one: nil,
-      area_number_two: nil,
-      city: "BRISTOW",
-      competency_decision_type_code: nil,
-      country: "USA",
-      cp_payment_address_line1: "219 WASHINGTON ST",
-      cp_payment_address_line2: nil,
-      cp_payment_address_line3: nil,
-      cp_payment_city: "INDIANA",
-      cp_payment_country: "USA",
-      cp_payment_foreign_zip: nil,
-      cp_payment_post_office_type_code: nil,
-      cp_payment_postal_type_code: nil,
-      cp_payment_state: "PA",
-      cp_payment_zip_code: "15701",
-      date_of_birth: "05/04/1955",
-      debit_card_ind: "N",
-      eft_account_number: nil,
-      eft_account_type: nil,
-      eft_routing_number: nil,
-      email_address: nil,
-      fiduciary_decision_category_type_code: nil,
-      fiduciary_folder_location: nil,
-      file_number: "111223334",
-      first_name: "Kat",
-      foreign_code: nil,
-      last_name: "Stevens",
-      middle_name: nil,
-      military_post_office_type_code: nil,
-      military_postal_type_code: nil,
-      org_name: nil,
-      org_title: nil,
-      org_type: nil,
-      phone_number_one: nil,
-      phone_number_two: nil,
-      phone_type_name_one: nil,
-      phone_type_name_two: nil,
-      prep_phrase_type: nil,
-      province_name: nil,
-      ptcpnt_id: "124443",
-      ptcpnt_relationship: nil,
-      return_code: "SHAR 9999",
-      return_message: "Records found.",
-      salutation_name: nil,
-      sensitive_level_of_record: "0",
-      ssn: "111223334",
-      state: "VA",
-      suffix_name: nil,
-      temporary_custodian_indicator: nil,
-      territory_name: nil,
-      treasury_mailing_address_line1: "Kat Stevens",
-      treasury_mailing_address_line2: "1234 FAKE ST",
-      treasury_mailing_address_line3: "BRISTOW VA",
-      treasury_mailing_address_line4: nil,
-      treasury_mailing_address_line5: nil,
-      treasury_mailing_address_line6: nil,
-      treasury_payment_address_line1: nil,
-      treasury_payment_address_line2: nil,
-      treasury_payment_address_line3: nil,
-      treasury_payment_address_line4: nil,
-      treasury_payment_address_line5: nil,
-      treasury_payment_address_line6: nil,
-      zip_code: "20136",
-      power_of_atty_code1: "0",
-      power_of_atty_code2: "00",
-      sex: "F",
-      service: [{ branch_of_service: "Army",
-                  entered_on_duty_date: "02132002",
-                  released_active_duty_date: "12212003",
-                  char_of_svc_code: "HON" },
-                { branch_of_service: "Navy",
-                  entered_on_duty_date: "07022006",
-                  released_active_duty_date: "06282008",
-                  char_of_svc_code: "UHC" }]
     }
   end
 end

--- a/spec/feature/switch_user_spec.rb
+++ b/spec/feature/switch_user_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature "Test Users for Demo" do
   before do
     # Switch user only works in demo
     ENV["DEPLOY_ENV"] = "demo"
-    BGSService.end_product_data = BGSService.all_grants
+    BGSService.end_product_records = { default:  BGSService.all_grants }
 
     User.create(station_id: "283", css_id: User::FUNCTIONS.sample)
     User.create(station_id: "ABC", css_id: User::FUNCTIONS.sample)
@@ -27,8 +27,8 @@ RSpec.feature "Test Users for Demo" do
     visit "test/users"
     safe_click('#main-tab-1')
     safe_click('#button-Seed-all-grants')
-    expect(BGSService.end_product_data).to include(hash_including(end_product_type_code: "070"))
-    expect(BGSService.end_product_data).to include(hash_including(end_product_type_code: "071"))
-    expect(BGSService.end_product_data).to include(hash_including(end_product_type_code: "072"))
+    expect(BGSService.end_product_records[:default]).to include(hash_including(end_product_type_code: "070"))
+    expect(BGSService.end_product_records[:default]).to include(hash_including(end_product_type_code: "071"))
+    expect(BGSService.end_product_records[:default]).to include(hash_including(end_product_type_code: "072"))
   end
 end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1143,32 +1143,52 @@ describe Appeal do
     let(:appeal) { Generators::Appeal.build(decision_date: 1.day.ago) }
     let(:result) { appeal.non_canceled_end_products_within_30_days }
 
-    before do
-      BGSService.end_product_data = [
-        {
+    let!(:twenty_day_old_pending_ep) do
+      Generators::EndProduct.build(
+        veteran_file_number: appeal.sanitized_vbms_id,
+        bgs_attrs: {
           claim_receive_date: twenty_days_ago,
           claim_type_code: "172GRANT",
           status_type_code: "PEND"
-        },
-        {
+        }
+      )
+    end
+
+    let!(:recent_cleared_ep) do
+      Generators::EndProduct.build(
+        veteran_file_number: appeal.sanitized_vbms_id,
+        bgs_attrs: {
           claim_receive_date: yesterday,
           claim_type_code: "170RMD",
           status_type_code: "CLR"
-        },
-        {
+        }
+      )
+    end
+
+    let!(:recent_cancelled_ep) do
+      Generators::EndProduct.build(
+        veteran_file_number: appeal.sanitized_vbms_id,
+        bgs_attrs: {
           claim_receive_date: yesterday,
           claim_type_code: "172BVAG",
           status_type_code: "CAN"
-        },
-        {
+        }
+      )
+    end
+
+    let!(:year_old_ep) do
+      Generators::EndProduct.build(
+        veteran_file_number: appeal.sanitized_vbms_id,
+        bgs_attrs: {
           claim_receive_date: last_year,
           claim_type_code: "172BVAG",
           status_type_code: "CLR"
         }
-      ]
+      )
     end
 
     it "returns correct eps" do
+      puts BGSService.end_product_records
       expect(result.length).to eq(2)
 
       expect(result.first.claim_type_code).to eq("172GRANT")
@@ -1193,33 +1213,50 @@ describe Appeal do
   context "#pending_eps" do
     let(:appeal) { Generators::Appeal.build(decision_date: 1.day.ago) }
 
-    before do
-      BGSService.end_product_data = [
-        {
-          claim_receive_date: twenty_days_ago,
-          claim_type_code: "070BVAGR",
-          end_product_type_code: "071",
-          status_type_code: "PEND"
-        },
-        {
-          claim_receive_date: last_year,
-          claim_type_code: "070BVAGRARC",
-          end_product_type_code: "070",
-          status_type_code: "PEND"
-        },
-        {
+    let!(:pending_eps) do
+      [
+        Generators::EndProduct.build(
+          veteran_file_number: appeal.sanitized_vbms_id,
+          bgs_attrs: {
+            claim_receive_date: twenty_days_ago,
+            claim_type_code: "070BVAGR",
+            end_product_type_code: "071",
+            status_type_code: "PEND"
+          }
+        ),
+        Generators::EndProduct.build(
+          veteran_file_number: appeal.sanitized_vbms_id,
+          bgs_attrs: {
+            claim_receive_date: last_year,
+            claim_type_code: "070BVAGRARC",
+            end_product_type_code: "070",
+            status_type_code: "PEND"
+          }
+        )
+      ]
+    end
+
+    let!(:cancelled_ep) do
+      Generators::EndProduct.build(
+        veteran_file_number: appeal.sanitized_vbms_id,
+        bgs_attrs: {
           claim_receive_date: yesterday,
           claim_type_code: "070RMND",
           end_product_type_code: "072",
           status_type_code: "CAN"
-        },
-        {
+        }
+      )
+    end
+
+    let!(:cleared_ep) do
+      Generators::EndProduct.build(
+        veteran_file_number: appeal.sanitized_vbms_id,
+        bgs_attrs: {
           claim_receive_date: last_year,
-          claim_type_code: "070RMNDARC",
-          end_product_type_code: "072",
+          claim_type_code: "172BVAG",
           status_type_code: "CLR"
         }
-      ]
+      )
     end
 
     let(:result) { appeal.pending_eps }

--- a/spec/models/ramp_election_spec.rb
+++ b/spec/models/ramp_election_spec.rb
@@ -8,13 +8,15 @@ describe RampElection do
   let(:notice_date) { 1.day.ago }
   let(:receipt_date) { 1.day.ago }
   let(:option_selected) { nil }
+  let(:end_product_reference_id) { nil }
 
   let(:ramp_election) do
     RampElection.new(
       veteran_file_number: veteran_file_number,
       notice_date: notice_date,
       option_selected: option_selected,
-      receipt_date: receipt_date
+      receipt_date: receipt_date,
+      end_product_reference_id: end_product_reference_id
     )
   end
 
@@ -120,6 +122,33 @@ describe RampElection do
 
     context "when there is no intake referencing the election" do
       it { is_expected.to eq(false) }
+    end
+  end
+
+  context "#established_end_product" do
+    subject { ramp_election.established_end_product }
+
+    let!(:other_ep) { Generators::EndProduct.build(veteran_file_number: veteran_file_number) }
+    let!(:matching_ep) { Generators::EndProduct.build(veteran_file_number: veteran_file_number) }
+
+    context "when matching end product has not yet been established" do
+      context "when end_product_reference_id is nil" do
+        it { is_expected.to be_nil }
+      end
+
+      context "when end_product_reference_id is set" do
+        let(:end_product_reference_id) { "not matching" }
+
+        it "raises EstablishedEndProductNotFound error" do
+          expect { subject }.to raise_error(RampElection::EstablishedEndProductNotFound)
+        end
+      end
+    end
+
+    context "when a matching end product has been established" do
+      let(:end_product_reference_id) { matching_ep.claim_id }
+
+      it { is_expected.to have_attributes(claim_id: matching_ep.claim_id) }
     end
   end
 


### PR DESCRIPTION
This will allow us to see if the end product of a ramp election
is still active or not.

This is just a back end change for now.

Also create `Generators::EndProduct` to make it easier to mock
end products. This change includes scoping mocks to specific
veteran ids to improve test coverage.

connects #3957