### PR TITLE
Hearings Prep | Make recent documents show up in case summary

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,6 +46,8 @@ class Document < ActiveRecord::Base
     "VA 21-527EZ, Fully Developed Claim (Pension)"
   ].freeze
 
+  CASE_SUMMARY_RECENT_DOCUMENT_CUTOFF = 30.days.ago.freeze
+
   DECISION_TYPES = ["BVA Decision", "Remand BVA or CAVC"].freeze
   FUZZY_MATCH_DAYS = 4.days.freeze
 
@@ -173,7 +175,7 @@ class Document < ActiveRecord::Base
   end
 
   def category_case_summary
-    CASE_SUMMARY_TYPES.include?(type)
+    CASE_SUMMARY_TYPES.include?(type) || received_at >= CASE_SUMMARY_RECENT_DOCUMENT_CUTOFF
   end
 
   def serialized_vacols_date

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 require "faker"
 
 describe Document do
-  let(:document) { Document.new(type: "NOD", vbms_document_id: "123", received_at: received_at) }
+  let(:document_type) { "NOD" }
+  let(:document) { Document.new(type: document_type, vbms_document_id: "123", received_at: received_at) }
   let(:file) { document.default_path }
   let(:received_at) { nil }
   let(:case_file_number) { Random.rand(999_999_999).to_s }
@@ -59,9 +60,18 @@ describe Document do
       it { is_expected.to eq(true) }
     end
 
-    let(:old_document) { Generators::Document.build(type: "not normally in case summary", received_at: 31.days.ago) }
-    let(:new_document) { Generators::Document.build(type: "not normally in case summary", received_at: 1.days.ago) }
-    
+    context "by received_at" do
+      let(:document_type) { "not normally in case summary" }
+      context "when document is recently received" do
+        let(:received_at) { 1.day.ago }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when document is not recently received" do
+        let(:received_at) { 1.day.ago }
+        it { is_expected.to eq(false) }
+      end
+    end
   end
 
   context ".content_url" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -58,6 +58,10 @@ describe Document do
     context "when category is part of case summary" do
       it { is_expected.to eq(true) }
     end
+
+    let(:old_document) { Generators::Document.build(type: "not normally in case summary", received_at: 31.days.ago) }
+    let(:new_document) { Generators::Document.build(type: "not normally in case summary", received_at: 1.days.ago) }
+    
   end
 
   context ".content_url" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -68,7 +68,7 @@ describe Document do
       end
 
       context "when document is not recently received" do
-        let(:received_at) { 1.day.ago }
+        let(:received_at) { 31.days.ago }
         it { is_expected.to eq(false) }
       end
     end


### PR DESCRIPTION
Connects #3878

## Test
See that the "this is a very long document" doc only shows up with this change applied. That document was received within the last 30 days, but it doesn't have a document type is that is otherwise considered to be case summary.

### `master`
![image](https://user-images.githubusercontent.com/25331532/34171513-90a6741a-e4bc-11e7-9ccb-9d439b554ecc.png)

### With this change
![image](https://user-images.githubusercontent.com/25331532/34171568-c099f534-e4bc-11e7-83c0-55c7551f29c3.png)

