### PR TITLE
Intake | Add validations to RAMP refiling review page

### DIFF
--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -88,8 +88,8 @@ class RampElection < RampReview
 
     if notice_date > receipt_date
       errors.add(:receipt_date, "before_notice_date")
-    elsif Time.zone.today < receipt_date
-      errors.add(:receipt_date, "in_future")
+    else
+      validate_receipt_date_not_in_future
     end
   end
 end

--- a/app/models/ramp_refiling.rb
+++ b/app/models/ramp_refiling.rb
@@ -1,3 +1,27 @@
 class RampRefiling < RampReview
   belongs_to :ramp_election
+
+  validate :validate_receipt_date, :validate_option_selected
+
+  def election_receipt_date
+    ramp_election && ramp_election.receipt_date
+  end
+
+  def validate_receipt_date
+    return unless receipt_date && ramp_election
+
+    if election_receipt_date > receipt_date
+      errors.add(:receipt_date, "before_ramp_receipt_date")
+    else
+      validate_receipt_date_not_in_future
+    end
+  end
+
+  def validate_option_selected
+    return unless option_selected && ramp_election
+
+    if ramp_election.higher_level_review? && higher_level_review?
+      errors.add(:option_selected, "higher_level_review_invalid")
+    end
+  end
 end

--- a/app/models/ramp_refiling_intake.rb
+++ b/app/models/ramp_refiling_intake.rb
@@ -24,7 +24,8 @@ class RampRefilingIntake < Intake
   def ui_hash
     super.merge(
       option_selected: detail.option_selected,
-      receipt_date: detail.receipt_date
+      receipt_date: detail.receipt_date,
+      election_receipt_date: detail.election_receipt_date
     )
   end
 

--- a/app/models/ramp_review.rb
+++ b/app/models/ramp_review.rb
@@ -10,6 +10,8 @@ class RampReview < ActiveRecord::Base
     appeal: "appeal"
   }
 
+  HIGHER_LEVEL_REVIEW_OPTIONS = %w(higher_level_review higher_level_review_with_hearing).freeze
+
   END_PRODUCT_DATA_BY_OPTION = {
     "supplemental_claim" => { code: "683SCRRRAMP", modifier: "683" },
     "higher_level_review" => { code: "682HLRRRAMP", modifier: "682" },
@@ -23,5 +25,15 @@ class RampReview < ActiveRecord::Base
   # Allows us to enable certain validations only when saving the review
   def start_review!
     @saving_review = true
+  end
+
+  def higher_level_review?
+    HIGHER_LEVEL_REVIEW_OPTIONS.include?(option_selected)
+  end
+
+  private
+
+  def validate_receipt_date_not_in_future
+    errors.add(:receipt_date, "in_future") if Time.zone.today < receipt_date
   end
 end

--- a/client/app/intake/index.js
+++ b/client/app/intake/index.js
@@ -31,9 +31,13 @@ const Intake = (props) => {
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
-    module.hot.accept('./redux/reducer', () => {
-      store.replaceReducer(reducer);
-    });
+    module.hot.accept([
+      './reducers/intake',
+      './reducers/rampElection',
+      './reducers/rampRefiling'
+    ],
+    () => store.replaceReducer(reducer)
+    );
   }
 
   return <Provider store={store}>

--- a/client/app/intake/pages/rampRefiling/review.jsx
+++ b/client/app/intake/pages/rampRefiling/review.jsx
@@ -5,6 +5,7 @@ import CancelButton from '../../components/CancelButton';
 import RadioField from '../../../components/RadioField';
 import DateSelector from '../../../components/DateSelector';
 import Button from '../../../components/Button';
+import Alert from '../../../components/Alert';
 import { Redirect } from 'react-router-dom';
 import _ from 'lodash';
 import { REQUEST_STATE, PAGE_PATHS, RAMP_INTAKE_STATES, REVIEW_OPTIONS } from '../../constants';
@@ -18,6 +19,7 @@ class Review extends React.PureComponent {
       veteranName,
       optionSelected,
       optionSelectedError,
+      hasInvalidOption,
       receiptDate,
       receiptDateError
     } = this.props;
@@ -36,6 +38,12 @@ class Review extends React.PureComponent {
     }));
 
     return <div>
+      { hasInvalidOption && <Alert title="Ineligible for Higher-Level Review" type="error" lowerMargin>
+          Contact the Veteran to verify their lane selection. If you are unable to reach
+          the Veteran, send a letter indicating that their selected lane is not available,
+          and that they may clarify their lane selection within 30 days.
+      </Alert>
+      }
       <h1>Review { veteranName }'s 21-4138 RAMP Selection Form</h1>
 
       <DateSelector
@@ -66,6 +74,7 @@ export default connect(
     rampRefilingStatus: getRampElectionStatus(state),
     optionSelected: state.rampRefiling.optionSelected,
     optionSelectedError: state.rampRefiling.optionSelectedError,
+    hasInvalidOption: state.rampRefiling.hasInvalidOption,
     receiptDate: state.rampRefiling.receiptDate,
     receiptDateError: state.rampRefiling.receiptDateError
   }),

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 export const getOptionSelectedError = (responseErrorCodes) => (
-  _.get(responseErrorCodes.option_selected, 0) && 'Please select an option.'
+  (_.get(responseErrorCodes.option_selected, 0) === 'blank') && 'Please select an option.'
 );
 
 export const getReceiptDateError = (responseErrorCodes, state) => (
@@ -11,7 +11,9 @@ export const getReceiptDateError = (responseErrorCodes, state) => (
     in_future:
       'Receipt date cannot be in the future.',
     before_notice_date: 'Receipt date cannot be earlier than the election notice ' +
-      `date of ${state.noticeDate}`
+      `date of ${state.noticeDate}`,
+    before_ramp_receipt_date: 'Receipt date cannot be earlier than the original ' +
+      `RAMP election receipt date of ${state.electionReceiptDate}`
   }[_.get(responseErrorCodes.receipt_date, 0)]
 );
 

--- a/spec/models/ramp_refiling_spec.rb
+++ b/spec/models/ramp_refiling_spec.rb
@@ -1,0 +1,135 @@
+describe RampRefilingIntake do
+  before do
+    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+  end
+
+  let(:user) { Generators::User.build }
+  let!(:veteran) { Generators::Veteran.build(file_number: "64205555") }
+  let(:veteran_file_number) { "64205555" }
+  let(:detail) { nil }
+  let(:original_election_option) { "higher_level_review" }
+  let(:option_selected) { nil }
+  let(:receipt_date) { nil }
+
+  let(:completed_ramp_election) do
+    RampElection.create!(
+      veteran_file_number: "64205555",
+      notice_date: 3.days.ago,
+      receipt_date: 2.days.ago,
+      option_selected: original_election_option,
+      end_product_reference_id: "123"
+    )
+  end
+
+  let(:ramp_refiling) do
+    RampRefiling.new(
+      ramp_election: completed_ramp_election,
+      veteran_file_number: veteran_file_number,
+      receipt_date: receipt_date,
+      option_selected: option_selected
+    )
+  end
+
+  context "#valid?" do
+    subject { ramp_refiling.valid? }
+
+    context "receipt_date" do
+      context "when it is nil" do
+        it { is_expected.to be true }
+      end
+
+      context "when it is after today" do
+        let(:receipt_date) { 1.day.from_now }
+
+        it "adds an error to receipt_date" do
+          is_expected.to be false
+          expect(ramp_refiling.errors[:receipt_date]).to include("in_future")
+        end
+      end
+
+      context "when it is before ramp election receipt date" do
+        let(:receipt_date) { 3.days.ago }
+
+        it "adds an error to receipt_date" do
+          is_expected.to be false
+          expect(ramp_refiling.errors[:receipt_date]).to include("before_ramp_receipt_date")
+        end
+      end
+
+      context "when it is on or after ramp election receipt date and on or before today" do
+        let(:receipt_date) { 1.day.ago }
+        it { is_expected.to be true }
+      end
+    end
+
+    context "option_selected" do
+      context "when orginal election was higher level review" do
+        let(:original_election_option) { "higher_level_review" }
+
+        context "when higher level review" do
+          let(:option_selected) { "higher_level_review" }
+
+          it "adds an error to option_selected" do
+            is_expected.to be false
+            expect(ramp_refiling.errors[:option_selected]).to include("higher_level_review_invalid")
+          end
+        end
+
+        context "when higher level review with hearing" do
+          let(:option_selected) { "higher_level_review_with_hearing" }
+
+          it "adds an error to option_selected" do
+            is_expected.to be false
+            expect(ramp_refiling.errors[:option_selected]).to include("higher_level_review_invalid")
+          end
+        end
+
+        context "when another option" do
+          let(:option_selected) { "supplemental_claim" }
+          it { is_expected.to be true }
+        end
+
+        context "when nil" do
+          let(:option_selected) { nil }
+          it { is_expected.to be true }
+        end
+      end
+
+      context "when orginal election was higher level review with hearing" do
+        let(:original_election_option) { "higher_level_review_with_hearing" }
+
+        context "when higher level review" do
+          let(:option_selected) { "higher_level_review" }
+
+          it "adds an error to option_selected" do
+            is_expected.to be false
+            expect(ramp_refiling.errors[:option_selected]).to include("higher_level_review_invalid")
+          end
+        end
+
+        context "when higher level review with hearing" do
+          let(:option_selected) { "higher_level_review_with_hearing" }
+
+          it "adds an error to option_selected" do
+            is_expected.to be false
+            expect(ramp_refiling.errors[:option_selected]).to include("higher_level_review_invalid")
+          end
+        end
+
+        context "when another option" do
+          let(:option_selected) { "appeal" }
+          it { is_expected.to be true }
+        end
+      end
+
+      context "when orginal election was supplemental claim" do
+        let(:original_election_option) { "supplemental_claim" }
+
+        context "when higher level review" do
+          let(:option_selected) { "higher_level_review" }
+          it { is_expected.to be true }
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -231,17 +231,21 @@ end
 
 def scroll_element_in_to_view(selector)
   expect do
-    page.evaluate_script <<-EOS
-      function() {
-        var elem = document.querySelector('#{selector.gsub("'", "\\\\'")}');
-        if (!elem) {
-          return false;
-        }
-        elem.scrollIntoView();
-        return true;
-      }();
-    EOS
-  end.to become_truthy
+    scroll_to_element_in_view_with_script(selector)
+  end.to become_truthy, "Could not find element #{selector}"
+end
+
+def scroll_to_element_in_view_with_script(selector)
+  page.evaluate_script <<-EOS
+    function() {
+      var elem = document.querySelector('#{selector.gsub("'", "\\\\'")}');
+      if (!elem) {
+        return false;
+      }
+      elem.scrollIntoView();
+      return true;
+    }();
+  EOS
 end
 
 # We generally avoid writing our own polling code, since proper Cappybara use generally


### PR DESCRIPTION
Follow on from #4204 to complete all AC for the issue.

## To test
- Start a RAMP refiling and enter a date far in the past and click continue.
  You should see an error
- Start a RAMP refiling and enter a date in the future and click continue,
  You should see an error
- Start a RAMP refiling of a HLR and select HLR and click continue,
  You should see an alert.

Note: We will be following up on more functionality to support the HLR invalid case #4216

connects #3958