### PR TITLE
Document list | Document description

### DIFF
--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -47,6 +47,10 @@ $tag-backgrond-color: #d6d7d9;
   .documents-table {
     min-width: 810px;
     margin-top: 0;
+
+    tbody > tr > td {
+      vertical-align: top;
+    }
   }
 
   $last-read-column-width: 41px;

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -131,6 +131,11 @@ $tag-backgrond-color: #d6d7d9;
     color: $gray-font-color;
   }
 
+  .document-list-doc-description {
+    color: $color-gray;
+    font-size: 1.5rem;
+  }
+
   .document-list-comments-indicator-icon {
     font-weight: bold;
     margin: 3px;

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -134,6 +134,7 @@ $tag-backgrond-color: #d6d7d9;
   .document-list-doc-description {
     color: $color-gray;
     font-size: 1.5rem;
+    margin: 0;
   }
 
   .document-list-comments-indicator-icon {

--- a/client/app/reader/DocTypeColumn.jsx
+++ b/client/app/reader/DocTypeColumn.jsx
@@ -17,17 +17,23 @@ class DocTypeColumn extends React.PureComponent {
     // This will get fired in the current tab, as the link is followed in a new tab. We
     // also need to add a mouseUp event since middle clicking doesn't trigger an onClick.
     // This will not work if someone right clicks and opens in a new tab.
-    return <ViewableItemLink
-      boldCondition={!doc.opened_by_current_user}
-      onOpen={this.onClick}
-      linkProps={{
-        to: `${this.props.documentPathBase}/${doc.id}`,
-        'aria-label': doc.type + (doc.opened_by_current_user ? ' opened' : ' unopened')
-      }}>
-      <Highlight>
-        {doc.type}
-      </Highlight>
-    </ViewableItemLink>;
+    return <div>
+      <ViewableItemLink
+        boldCondition={!doc.opened_by_current_user}
+        onOpen={this.onClick}
+        linkProps={{
+          to: `${this.props.documentPathBase}/${doc.id}`,
+          'aria-label': doc.type + (doc.opened_by_current_user ? ' opened' : ' unopened')
+        }}>
+        <Highlight>
+          {doc.type}
+        </Highlight>
+      </ViewableItemLink>
+      <br />
+      {doc.description && <span className="document-list-doc-description">
+        {doc.description}
+      </span>}
+    </div>;
   }
 }
 

--- a/client/app/reader/DocTypeColumn.jsx
+++ b/client/app/reader/DocTypeColumn.jsx
@@ -29,10 +29,9 @@ class DocTypeColumn extends React.PureComponent {
           {doc.type}
         </Highlight>
       </ViewableItemLink>
-      <br />
-      {doc.description && <span className="document-list-doc-description">
+      {doc.description && <p className="document-list-doc-description">
         {doc.description}
-      </span>}
+      </p>}
     </div>;
   }
 }


### PR DESCRIPTION
Connects #3686, dependent on #3687 

## AC
- [ ] Validate that the document description that gets saved from [document viewer side menu](https://github.com/department-of-veterans-affairs/caseflow/issues/3687) gets saved in document list page, under the appropriate document type link. 
- [ ] Validate that the text is 1.5 rem and in $color-gray