### PR TITLE
Intake | Generate Ramp Issues for prior election when starting refiling

### DIFF
--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -121,6 +121,10 @@ class EndProduct
     !INACTIVE_STATUSES.include?(status_type_code)
   end
 
+  def contentions
+    @contentions ||= claim_id ? VBMSService.fetch_contentions(claim_id: claim_id) : nil
+  end
+
   private
 
   def label

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -36,6 +36,8 @@ class Intake < ActiveRecord::Base
   end
 
   def start!
+    preload_intake_data!
+
     if validate_start
       update_attributes(
         started_at: Time.zone.now,
@@ -62,6 +64,11 @@ class Intake < ActiveRecord::Base
 
   def cancel!
     fail Caseflow::Error::MustImplementInSubclass
+  end
+
+  # Optional step to load and data into the Caseflow DB that will be used for the intake
+  def preload_intake_data!
+    nil
   end
 
   def complete_with_status!(status)

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -66,7 +66,7 @@ class Intake < ActiveRecord::Base
     fail Caseflow::Error::MustImplementInSubclass
   end
 
-  # Optional step to load and data into the Caseflow DB that will be used for the intake
+  # Optional step to load data into the Caseflow DB that will be used for the intake
   def preload_intake_data!
     nil
   end

--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -5,6 +5,7 @@ class RampElection < RampReview
   attr_reader :saving_receipt
 
   has_many :intakes, as: :detail, class_name: "RampElectionIntake"
+  has_many :ramp_refilings
 
   RESPOND_BY_TIME = 60.days.freeze
 
@@ -41,6 +42,23 @@ class RampElection < RampReview
 
   def established_end_product
     @established_end_product ||= fetch_established_end_product
+  end
+
+  def recreate_issues_from_contentions!
+    # If there is a saved refiling for this election, then the issues
+    # are locked and cannot be recreated
+    return false if ramp_refilings.count > 0
+
+    # Load contentions outside of the Postgres transaction
+    end_product.contentions
+
+    transaction do
+      issues.destroy_all
+
+      end_product.contentions.each do |contention|
+        issues.create!(contention: contention)
+      end
+    end
   end
 
   private

--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -49,7 +49,8 @@ class RampElection < RampReview
     # are locked and cannot be recreated
     return false if ramp_refilings.count > 0
 
-    # Load contentions outside of the Postgres transaction
+    # Load contentions outside of the Postgres transaction so we don't keep a connection
+    # open needlessly for the entirety of what could be a slow VBMS request.
     end_product.contentions
 
     transaction do

--- a/app/models/ramp_issue.rb
+++ b/app/models/ramp_issue.rb
@@ -1,0 +1,8 @@
+class RampIssue < ActiveRecord::Base
+  belongs_to :review, polymorphic: true
+
+  def contention=(contention)
+    self.contention_reference_id = contention.id
+    self.description = contention.text
+  end
+end

--- a/app/models/ramp_review.rb
+++ b/app/models/ramp_review.rb
@@ -10,6 +10,8 @@ class RampReview < ActiveRecord::Base
     appeal: "appeal"
   }
 
+  has_many :issues, as: :review, class_name: "RampIssue"
+
   HIGHER_LEVEL_REVIEW_OPTIONS = %w(higher_level_review higher_level_review_with_hearing).freeze
 
   END_PRODUCT_DATA_BY_OPTION = {

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -118,6 +118,14 @@ class ExternalApi::VBMSService
     send_and_log_request(veteran_hash[:file_number], request)
   end
 
+  def self.fetch_contentions(claim_id:)
+    @vbms_client ||= init_vbms_client
+
+    request = VBMS::Requests::ListContentions.new(claim_id)
+
+    send_and_log_request(claim_id, request)
+  end
+
   def self.init_vbms_client
     VBMS::Client.from_env_vars(
       logger: VBMSCaseflowLogger.new,

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -80,6 +80,10 @@ class Search extends React.PureComponent {
         body: 'If this Veteran has not yet received a RAMP decision on their RAMP Opt-In' +
           ' Election Form, notify them using the “RAMP Ineligible Letter” (premature election).'
       },
+      ramp_election_no_issues: {
+        title: 'This Veteran has a pending RAMP EP with no contentions',
+        body: 'Please ensure contentions were added to the original RAMP Election EP'
+      },
       default: {
         title: 'Something went wrong',
         body: 'Please try again. If the problem persists, please contact Caseflow support.'

--- a/db/migrate/20171230164910_create_ramp_issues.rb
+++ b/db/migrate/20171230164910_create_ramp_issues.rb
@@ -1,0 +1,13 @@
+class CreateRampIssues < ActiveRecord::Migration
+  safety_assured
+
+  def change
+    create_table :ramp_issues do |t|
+      t.belongs_to :review, polymorphic: true, null: false
+      t.string     :contention_reference_id, null: false
+      t.string     :description, null: false
+    end
+
+    add_index(:ramp_issues, [:review_type, :review_id])
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171219182526) do
+ActiveRecord::Schema.define(version: 20171230164910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -311,6 +311,15 @@ ActiveRecord::Schema.define(version: 20171219182526) do
   end
 
   add_index "ramp_elections", ["veteran_file_number"], name: "index_ramp_elections_on_veteran_file_number", using: :btree
+
+  create_table "ramp_issues", force: :cascade do |t|
+    t.integer "review_id",               null: false
+    t.string  "review_type",             null: false
+    t.string  "contention_reference_id", null: false
+    t.string  "description",             null: false
+  end
+
+  add_index "ramp_issues", ["review_type", "review_id"], name: "index_ramp_issues_on_review_type_and_review_id", using: :btree
 
   create_table "ramp_refilings", force: :cascade do |t|
     t.string  "veteran_file_number",      null: false

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -467,22 +467,53 @@ class Fakes::AppealRepository
     )
   end
 
+  # Intake demo file number guide:
+  #
+  # 05555555 - 95555555 are valid file numbers for RampElections
+  # 85555555 will not have contentions for ramp refiling
+  # 11555555 has an appeal ineligible for ramp
+  # 12555555 has no active appeals
+  # 13555555 has no ramp election
   def self.seed_intake_data!
+    Fakes::VBMSService.end_product_claim_ids_by_file_number ||= {}
+
     9.times do |i|
-      Generators::Veteran.build(file_number: "#{i + 1}0555555")
+      file_number = "#{i + 1}5555555"
+      claim_id = "FAKEEP123#{i}"
+
+      Generators::Veteran.build(file_number: file_number)
 
       Generators::Appeal.build(
-        vbms_id: "#{i + 1}5555555C",
+        vbms_id: "#{file_number}C",
         issues: (1..2).map { Generators::Issue.build }
       )
 
       Generators::EndProduct.build(
-        veteran_file_number: "#{i + 1}5555555",
+        veteran_file_number: file_number,
         bgs_attrs: {
-          benefit_claim_id: "FAKEEP123",
+          benefit_claim_id: claim_id,
           status_type_code: (i == 0 ? "PEND" : "CLR")
         }
       )
+
+      if i != 7
+        Generators::Contention.build(
+          claim_id: claim_id,
+          text: "Right knee service connection"
+        )
+
+        Generators::Contention.build(
+          claim_id: claim_id,
+          text: "Right hip service connection"
+        )
+
+        Generators::Contention.build(
+          claim_id: claim_id,
+          text: "PTSD rating increase"
+        )
+      end
+
+      Fakes::VBMSService.end_product_claim_ids_by_file_number[file_number] = claim_id
     end
 
     Generators::Appeal.build(
@@ -496,11 +527,14 @@ class Fakes::AppealRepository
     )
 
     Generators::Appeal.build(
+      vbms_id: "13555555C",
+      vacols_record: :activated
+    )
+
+    Generators::Appeal.build(
       vbms_id: "25555555C",
       issues: (1..3).map { Generators::Issue.build }
     )
-
-    Fakes::VBMSService.end_product_claim_id = "FAKEEP123"
   end
 
   def self.aod(_vacols_id)

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -23,6 +23,8 @@ class Fakes::VBMSService
     attr_accessor :end_product_claim_id
     attr_accessor :uploaded_form8, :uploaded_form8_appeal
     attr_accessor :manifest_vbms_fetched_at, :manifest_vva_fetched_at
+    attr_accessor :contention_records
+    attr_accessor :end_product_claim_ids_by_file_number
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
@@ -72,7 +74,21 @@ class Fakes::VBMSService
     Rails.logger.info("Veteran data:\n #{veteran_hash}")
     Rails.logger.info("Claim data:\n #{claim_hash}")
 
+    self.end_product_claim_ids_by_file_number ||= {}
+
+    # The id will either be:
+    # A claim id set specificly for claims created on a specific file_number
+    # A default claim id used for all created claims
+    # A randomly generated id
+    claim_id = end_product_claim_ids_by_file_number[veteran_hash[:file_number]] ||
+               @end_product_claim_id ||
+               Generators::Appeal.generate_external_id
+
     # return fake end product
-    OpenStruct.new(claim_id: @end_product_claim_id || Generators::Appeal.generate_external_id)
+    OpenStruct.new(claim_id: claim_id)
+  end
+
+  def self.fetch_contentions(claim_id:)
+    (contention_records || {})[claim_id] || []
   end
 end

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -77,7 +77,7 @@ class Fakes::VBMSService
     self.end_product_claim_ids_by_file_number ||= {}
 
     # The id will either be:
-    # A claim id set specificly for claims created on a specific file_number
+    # A claim id set specifically for claims created on a specific file_number
     # A default claim id used for all created claims
     # A randomly generated id
     claim_id = end_product_claim_ids_by_file_number[veteran_hash[:file_number]] ||

--- a/lib/generators/contention.rb
+++ b/lib/generators/contention.rb
@@ -1,0 +1,26 @@
+class Generators::Contention
+  extend Generators::Base
+
+  class << self
+    def default_attrs
+      {
+        id: generate_external_id,
+        claim_id: generate_external_id,
+        text: "Generic contention",
+        start_date: 5.days.ago,
+        submit_date: 5.days.ago
+      }
+    end
+
+    def build(attrs = {})
+      attrs = default_attrs.merge(attrs)
+      claim_id = attrs.delete(:claim_id)
+
+      OpenStruct.new(attrs).tap do |contention|
+        Fakes::VBMSService.contention_records ||= {}
+        Fakes::VBMSService.contention_records[claim_id] ||= []
+        Fakes::VBMSService.contention_records[claim_id] << contention
+      end
+    end
+  end
+end

--- a/spec/feature/intake_spec.rb
+++ b/spec/feature/intake_spec.rb
@@ -681,14 +681,20 @@ RSpec.feature "RAMP Intake" do
             ).claim_id
           )
 
-          intake = RampRefilingIntake.create!(
+          Generators::Contention.build(
+            claim_id: ramp_election.end_product_reference_id,
+            text: "Left knee"
+          )
+
+          intake = RampRefilingIntake.new(
             veteran_file_number: "12341234",
             user: current_user,
-            detail: RampRefiling.create!(
+            detail: RampRefiling.new(
               veteran_file_number: "12341234",
               ramp_election: ramp_election
             )
           )
+
           intake.start!
 
           visit "/intake"
@@ -714,6 +720,11 @@ RSpec.feature "RAMP Intake" do
             ).claim_id
           )
 
+          Generators::Contention.build(
+            claim_id: ramp_election.end_product_reference_id,
+            text: "Left knee"
+          )
+
           # Validate that you can't go directly to search
           visit "/intake/search"
 
@@ -730,6 +741,9 @@ RSpec.feature "RAMP Intake" do
           click_on "Search"
 
           expect(page).to have_current_path("/intake/review-request")
+
+          # Validate issues have been created based on contentions
+          expect(ramp_election.issues.count).to eq(1)
 
           # Validate validation
           fill_in "What is the Receipt Date of this form?", with: "08/02/2017"


### PR DESCRIPTION
In order to check whether the contentions had been created for the previous
RAMP election EP, we need to load them from VBMS on search.

Decided to go ahead and generate the RAMPIssues from those contentions on
the search step to save costly additonal calls to VBMS for the contentions.

## Testing Instructions
Start a refiling for any veteran between 05555555-75555555, go to the console and see that `RampIssues` have been created for the faked contentions.

85555555 has been configured in demo to not have contentions mapped to the
EP for the Ramp Election. First complete the RAMP Election intake for this
file number, then attempt to complete the RAMP Refiling intake for it. You
should see the no contentions error.

## Notes
The check for an EP having no contentions handles an edge case that
was not listed on the AC. The copy for the error is temporary and I'll check
in with Abby on what the final copy should be.

connects #3966