### PR TITLE
Nemo/Set certification date before start_certification_job starts

### DIFF
--- a/app/jobs/start_certification_job.rb
+++ b/app/jobs/start_certification_job.rb
@@ -36,8 +36,7 @@ class StartCertificationJob < ActiveJob::Base
       vacols_hearing_preference: @certification.appeal.hearing_request_type,
       certifying_office: @certification.appeal.regional_office_name,
       certifying_username: @certification.appeal.regional_office_key,
-      certifying_official_name: user ? user.full_name : nil,
-      certification_date: Time.zone.now.to_date
+      certifying_official_name: user ? user.full_name : nil
     )
   end
 

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -13,7 +13,8 @@ class Certification < ActiveRecord::Base
     update_attributes!(
       v2: true,
       loading_data: true,
-      loading_data_failed: false
+      loading_data_failed: false,
+      certification_date: Time.zone.now.to_date
     )
 
     # Most developers don't run shoryuken in development mode.


### PR DESCRIPTION
Fix for https://github.com/department-of-veterans-affairs/appeals-support/issues/1088