### PR TITLE
Hearing Worksheet move autosave above canvas

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -16,19 +16,8 @@ $color-hearings-saving: #777;
 .cf-hearings-daily-docket-container {
   position: relative;
 
-  > .saving {
-    width: 12em;
-    text-align: right;
-    position: absolute;
-    top: 8.9em;
-    right: 1.8em;
-
-    .loadingSymbol {
-      height: 1em;
-      width: 1em;
-      display: inline-block;
-      vertical-align: middle;
-    }
+  .cf-hearings {
+    margin-top: 0;
   }
 }
 

--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -9,13 +9,14 @@ $color-hearings-saving: #777;
 .saving {
   font-style: italic;
   color: $color-hearings-saving;
+  text-align: right;
+  display: block;
 }
 
 .cf-hearings-daily-docket-container {
   position: relative;
 
   > .saving {
-    display: inline-block;
     width: 12em;
     text-align: right;
     position: absolute;
@@ -264,11 +265,6 @@ $color-hearings-saving: #777;
     resize: vertical;
   }
 
-  .saving {
-    position: absolute;
-    top: 0;
-    right: 0;
-  }
 
   .cf-hearings-worksheet-header {
     margin-bottom: 1em;
@@ -447,6 +443,12 @@ $color-hearings-saving: #777;
 }
 
 @media print {
+  h1,
+  h2,
+  h3 {
+    font-family: sans-serif;
+  }
+
   h1 {
     font-size: 25px;
   }

--- a/client/app/hearings/HearingWorksheet.jsx
+++ b/client/app/hearings/HearingWorksheet.jsx
@@ -7,6 +7,8 @@ import HearingWorksheetStream from './components/HearingWorksheetStream';
 import PrintPageBreak from '../components/PrintPageBreak';
 import WorksheetHeader from './components/WorksheetHeader';
 import classNames from 'classnames';
+import AutoSave from '../components/AutoSave';
+import * as AppConstants from '../constants/AppConstants';
 import _ from 'lodash';
 
 // TODO Move all stream related to streams container
@@ -16,8 +18,13 @@ import {
   onContentionsChange,
   onMilitaryServiceChange,
   onEvidenceChange,
-  onCommentsForAttorneyChange
+  onCommentsForAttorneyChange,
+  toggleWorksheetSaving,
+  setWorksheetSaveFailedStatus,
+  saveWorksheet
 } from './actions/Dockets';
+
+import { saveIssues } from './actions/Issue';
 
 class WorksheetFormEntry extends React.PureComponent {
   render() {
@@ -47,9 +54,16 @@ class WorksheetFormEntry extends React.PureComponent {
 export class HearingWorksheet extends React.PureComponent {
 
   componentDidMount() {
-
     document.title = `${this.props.worksheet.appellant_mi_formatted}'s ${document.title}`;
   }
+
+  save = (worksheet, worksheetIssues) => () => {
+    this.props.toggleWorksheetSaving();
+    this.props.setWorksheetSaveFailedStatus(false);
+    this.props.saveWorksheet(worksheet);
+    this.props.saveIssues(worksheetIssues);
+    this.props.toggleWorksheetSaving();
+  };
 
   onContentionsChange = (event) => this.props.onContentionsChange(event.target.value);
   onMilitaryServiceChange = (event) => this.props.onMilitaryServiceChange(event.target.value);
@@ -57,7 +71,7 @@ export class HearingWorksheet extends React.PureComponent {
   onCommentsForAttorneyChange = (event) => this.props.onCommentsForAttorneyChange(event.target.value);
 
   render() {
-    let { worksheet } = this.props;
+    let { worksheet, worksheetIssues } = this.props;
     let readerLink = `/reader/appeal/${worksheet.appeal_vacols_id}/documents`;
 
     const appellant = worksheet.appellant_mi_formatted ?
@@ -116,6 +130,14 @@ export class HearingWorksheet extends React.PureComponent {
     });
 
     return <div>
+      {!this.props.print &&
+            <AutoSave
+              save={this.save(worksheet, worksheetIssues)}
+              spinnerColor={AppConstants.LOADING_INDICATOR_COLOR_HEARINGS}
+              isSaving={this.props.worksheetIsSaving}
+              saveFailed={this.props.saveWorksheetFailed}
+            />
+      }
       <div className={wrapperClassNames}>
         {firstWorksheetPage}
         <PrintPageBreak />
@@ -140,14 +162,19 @@ export class HearingWorksheet extends React.PureComponent {
 
 const mapStateToProps = (state) => ({
   worksheet: state.worksheet,
-  worksheetAppeals: state.worksheetAppeals
+  worksheetAppeals: state.worksheetAppeals,
+  worksheetIssues: state.worksheetIssues
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   onContentionsChange,
   onMilitaryServiceChange,
   onEvidenceChange,
-  onCommentsForAttorneyChange
+  onCommentsForAttorneyChange,
+  toggleWorksheetSaving,
+  saveWorksheet,
+  setWorksheetSaveFailedStatus,
+  saveIssues
 }, dispatch);
 
 export default connect(

--- a/client/app/hearings/components/WorksheetHeader.jsx
+++ b/client/app/hearings/components/WorksheetHeader.jsx
@@ -1,38 +1,18 @@
 import React from 'react';
-import AutoSave from '../../components/AutoSave';
 import moment from 'moment';
 import TextField from '../../components/TextField';
-import * as AppConstants from '../../constants/AppConstants';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import Textarea from 'react-textarea-autosize';
-
-import { saveIssues } from '../actions/Issue';
-
-import {
-  toggleWorksheetSaving,
-  setWorksheetSaveFailedStatus,
-  onRepNameChange,
-  onWitnessChange,
-  saveWorksheet
-} from '../actions/Dockets';
+import { onRepNameChange, onWitnessChange } from '../actions/Dockets';
 
 class WorksheetHeader extends React.PureComponent {
   onWitnessChange = (event) => this.props.onWitnessChange(event.target.value);
-
-  save = (worksheet, worksheetIssues) => () => {
-    this.props.toggleWorksheetSaving();
-    this.props.setWorksheetSaveFailedStatus(false);
-    this.props.saveWorksheet(worksheet);
-    this.props.saveIssues(worksheetIssues);
-    this.props.toggleWorksheetSaving();
-  };
 
   render() {
     const {
       appellant,
       worksheet,
-      worksheetIssues,
       veteranLawJudge
     } = this.props;
 
@@ -64,14 +44,6 @@ class WorksheetHeader extends React.PureComponent {
 
       <div className="cf-hearings-worksheet-data">
         <h2 className="cf-hearings-worksheet-header">Appellant/Veteran Information</h2>
-        {!this.props.print &&
-            <AutoSave
-              save={this.save(worksheet, worksheetIssues)}
-              spinnerColor={AppConstants.LOADING_INDICATOR_COLOR_HEARINGS}
-              isSaving={this.props.worksheetIsSaving}
-              saveFailed={this.props.saveWorksheetFailed}
-            />
-        }
         <div className="cf-hearings-worksheet-data-cell column-1">
           <div>Appellant Name:</div>
           <div><b>{appellant}</b></div>
@@ -135,17 +107,12 @@ class WorksheetHeader extends React.PureComponent {
   }
 }
 const mapStateToProps = (state) => ({
-  worksheet: state.worksheet,
-  worksheetIssues: state.worksheetIssues
+  worksheet: state.worksheet
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
-  toggleWorksheetSaving,
   onRepNameChange,
-  onWitnessChange,
-  saveWorksheet,
-  setWorksheetSaveFailedStatus,
-  saveIssues
+  onWitnessChange
 }, dispatch);
 
 export default connect(

--- a/client/app/hearings/containers/DailyDocketContainer.jsx
+++ b/client/app/hearings/containers/DailyDocketContainer.jsx
@@ -46,18 +46,21 @@ export class DailyDocketContainer extends React.Component {
       return <div>You have no hearings on this date.</div>;
     }
 
-    return <div className="cf-hearings-daily-docket-container">
+    return <div>
+
       <AutoSave
         save={this.props.save(dailyDocket, this.props.date)}
         spinnerColor={AppConstants.LOADING_INDICATOR_COLOR_HEARINGS}
         isSaving={this.props.docketIsSaving}
         saveFailed={this.props.saveDocketFailed}
       />
-      <DailyDocket
-        veteran_law_judge={this.props.veteran_law_judge}
-        date={this.props.date}
-        docket={dailyDocket}
-      />
+      <div className="cf-hearings-daily-docket-container">
+        <DailyDocket
+          veteran_law_judge={this.props.veteran_law_judge}
+          date={this.props.date}
+          docket={dailyDocket}
+        />
+      </div>
     </div>;
   }
 }


### PR DESCRIPTION
#4230 
This PR doesn't change any functionality, Just moves the location of the Autosave component. 
Most of the changes are moving the redux stuff from `WorksheetHeader` to `HearingWorksheet`

<img width="1450" alt="screen shot 2018-01-04 at 4 37 53 pm" src="https://user-images.githubusercontent.com/1745984/34586471-17d7f1a4-f172-11e7-9ae0-1b527f2abc53.png">
<img width="1439" alt="screen shot 2018-01-04 at 5 06 03 pm" src="https://user-images.githubusercontent.com/1745984/34586472-17e40052-f172-11e7-9ddd-549a0f13868f.png">
