### PR TITLE
Upgrade to newer BUG FREE! commons version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "c03e122b4f0edfb7e26262289d480669d21df68e"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fcd32d536c46d827f21dbbb0e85c3376a20b1d83"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: c03e122b4f0edfb7e26262289d480669d21df68e
-  ref: c03e122b4f0edfb7e26262289d480669d21df68e
+  revision: fcd32d536c46d827f21dbbb0e85c3376a20b1d83
+  ref: fcd32d536c46d827f21dbbb0e85c3376a20b1d83
   specs:
-    caseflow (0.2.5)
+    caseflow (0.2.6)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails


### PR DESCRIPTION
The [most recent caseflow-commons update](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/129) fixed a bug where attempting to download a non-existent object from an S3 bucket (via `S3Service.fetch_content()`) threw an error. That scenario now results in the error being caught and nil being returned to `fetch_content` (the previous behaviour).