### PR TITLE
Rename securitylolz rake task to security_caseflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ jobs:
       env: TEST_CATEGORY=linters_and_security
       script:
         - bundle exec rake lint
-        - bundle exec rake securitylolz
+        - bundle exec rake security_caseflow
         - cd ./client
         - mv node_modules node_modules_bak && $YARN --frozen-lockfile --production && $YARN run build:production
         # Move the non-production node_modules back so that it's cached for next travis test run

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -2,7 +2,7 @@ require "open3"
 require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
-task :securitylolz do
+task :security_caseflow do
   puts "running Brakeman security scan..."
   brakeman_result = ShellCommand.run(
     "brakeman --exit-on-warn --run-all-checks --confidence-level=2"


### PR DESCRIPTION
Renamed the "security" task to "securitylolz" in #4318 to test a theory that there was a take task naming collision (there was). The name "securitylolz" is not a great name, so this PR changes the name of that task to "security_caseflow" to be more descriptive and mature.