### PR TITLE
Fix closing remand appeals with non new material issues

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -352,30 +352,36 @@ class Appeal < ActiveRecord::Base
     end
   end
 
-  def partial_grant?
+  # These three methods are used to decide whether the appeal is processed
+  # as a partial grant, remand, or full grant when dispatching it.
+  def partial_grant_on_dispatch?
     status == "Remand" && issues.any?(&:non_new_material_allowed?)
   end
 
-  def full_grant?
+  def full_grant_on_dispatch?
     status == "Complete" && issues.any?(&:non_new_material_allowed?)
   end
 
-  def remand?
-    status == "Remand" && issues.none?(&:non_new_material_allowed?)
+  def remand_on_dispatch?
+    remand? && issues.none?(&:non_new_material_allowed?)
+  end
+
+  def dispatch_decision_type
+    return "Full Grant" if full_grant_on_dispatch?
+    return "Partial Grant" if partial_grant_on_dispatch?
+    return "Remand" if remand_on_dispatch?
   end
 
   def active?
     status != "Complete"
   end
 
-  def merged?
-    disposition == "Merged Appeal"
+  def remand?
+    status == "Remand"
   end
 
-  def decision_type
-    return "Full Grant" if full_grant?
-    return "Partial Grant" if partial_grant?
-    return "Remand" if remand?
+  def merged?
+    disposition == "Merged Appeal"
   end
 
   def special_issues

--- a/app/models/claim_establishment.rb
+++ b/app/models/claim_establishment.rb
@@ -22,7 +22,7 @@ class ClaimEstablishment < ActiveRecord::Base
   # returns the type of a decision based on appeal data
   # If a type is not matched, it returns nil
   def self.get_decision_type(appeal)
-    DECSION_TYPES[appeal.decision_type]
+    DECSION_TYPES[appeal.dispatch_decision_type]
   end
 
   def sent_email

--- a/app/models/tasks/establish_claim.rb
+++ b/app/models/tasks/establish_claim.rb
@@ -9,7 +9,7 @@ class EstablishClaim < Task
   after_create :init_claim_establishment!
 
   cache_attribute :cached_decision_type do
-    appeal.decision_type
+    appeal.dispatch_decision_type
   end
 
   cache_attribute :cached_veteran_name do
@@ -54,7 +54,7 @@ class EstablishClaim < Task
           :serialized_decision_date,
           :disposition,
           :veteran_name,
-          :decision_type,
+          :dispatch_decision_type,
           :station_key,
           :regional_office_key,
           :issues,
@@ -148,7 +148,7 @@ class EstablishClaim < Task
   def should_invalidate?
     !appeal.vacols_record_exists? ||
       !appeal.decision_date ||
-      !appeal.decision_type ||
+      !appeal.dispatch_decision_type ||
       appeal.status == "Active"
   end
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -255,7 +255,7 @@ class AppealRepository
 
   # Determine VACOLS location desired after dispatching a decision
   def self.location_after_dispatch(appeal:)
-    return if appeal.full_grant?
+    return unless appeal.active?
 
     return "54" if appeal.vamc?
     return "53" if appeal.national_cemetery_administration?

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -242,7 +242,7 @@ export default class EstablishClaim extends React.Component {
   }
 
   getClaimTypeFromDecision = () => {
-    let decisionType = this.props.task.appeal.decision_type;
+    let decisionType = this.props.task.appeal.dispatch_decision_type;
     let values = END_PRODUCT_INFO[this.getRoutingType()][decisionType];
 
     if (!values) {
@@ -286,7 +286,7 @@ export default class EstablishClaim extends React.Component {
   validModifiers = () => {
     return validModifiers(
       this.props.task.appeal.pending_eps,
-      this.props.task.appeal.decision_type
+      this.props.task.appeal.dispatch_decision_type
     );
   }
 
@@ -311,7 +311,7 @@ export default class EstablishClaim extends React.Component {
       });
 
       if (!this.willCreateEndProduct()) {
-        if (this.props.task.appeal.decision_type === FULL_GRANT) {
+        if (this.props.task.appeal.dispatch_decision_type === FULL_GRANT) {
           this.setUnhandledSpecialIssuesEmailAndRegionalOffice();
           this.handlePageChange(EMAIL_PAGE);
         } else {
@@ -465,7 +465,7 @@ export default class EstablishClaim extends React.Component {
       pdfLink,
       pdfjsLink
     } = this.props;
-    let decisionType = this.props.task.appeal.decision_type;
+    let decisionType = this.props.task.appeal.dispatch_decision_type;
 
     const { initialState, reducer } = bootstrapRedux(this.props);
 

--- a/client/app/establishClaim/reducers/establishClaimForm.js
+++ b/client/app/establishClaim/reducers/establishClaimForm.js
@@ -9,7 +9,7 @@ export const getEstablishClaimFormInitialState = (props) => {
   if (props) {
     initialModifier = validModifiers(
       props.task.appeal.pending_eps,
-      props.task.appeal.decision_type
+      props.task.appeal.dispatch_decision_type
     )[0];
   }
 

--- a/client/test/karma/containers/EstablishClaim-test.js
+++ b/client/test/karma/containers/EstablishClaim-test.js
@@ -20,7 +20,7 @@ describe('EstablishClaim', () => {
       const task = {
         appeal: {
           vbms_id: '516517691',
-          decision_type: 'Remand',
+          dispatch_decision_type: 'Remand',
           decisions: [{
             label: null
           }],
@@ -127,7 +127,7 @@ describe('EstablishClaim', () => {
     let task, wrapper;
 
     const mountApp = (decisionType, stationOfJurisdiction = '397') => {
-      task.appeal.decision_type = decisionType;
+      task.appeal.dispatch_decision_type = decisionType;
 
       wrapper = mount(<EstablishClaim
         regionalOfficeCities={{}}
@@ -162,7 +162,7 @@ describe('EstablishClaim', () => {
       task = {
         appeal: {
           vbms_id: '516517691',
-          decision_type: 'Remand',
+          dispatch_decision_type: 'Remand',
           decisions: [{
             label: null
           }],

--- a/client/test/node/containers/EstablishClaim-test.js
+++ b/client/test/node/containers/EstablishClaim-test.js
@@ -19,7 +19,7 @@ describe('EstablishClaim', () => {
       const task = {
         appeal: {
           vbms_id: '516517691',
-          decision_type: 'Remand',
+          dispatch_decision_type: 'Remand',
           decisions: [{
             label: null
           }],

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -80,7 +80,7 @@ class Fakes::AppealRepository
   end
 
   def self.update_location_after_dispatch!(appeal:)
-    return if appeal.full_grant?
+    return unless appeal.active?
     self.location_updated_for = appeal
   end
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1031,8 +1031,8 @@ describe Appeal do
     end
   end
 
-  context "#decision_type" do
-    subject { appeal.decision_type }
+  context "#dispatch_decision_type" do
+    subject { appeal.dispatch_decision_type }
     context "when it has a mix of allowed and granted issues" do
       let(:issues) do
         [

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -932,7 +932,7 @@ describe Appeal do
     end
   end
 
-  context "#remand_on_dispatch?", focus: true do
+  context "#remand_on_dispatch?" do
     subject { appeal.remand_on_dispatch? }
 
     context "status is not remand" do

--- a/spec/services/appeals_repository_spec.rb
+++ b/spec/services/appeals_repository_spec.rb
@@ -199,8 +199,8 @@ describe AppealRepository do
 
     subject { AppealRepository.location_after_dispatch(appeal: appeal) }
 
-    context "when appeal is a full grant" do
-      let(:vacols_record) { :full_grant_decided }
+    context "when appeal is inactive (in 'history status')" do
+      let(:vacols_record) { { status: "Complete" } }
       it { is_expected.to be_nil }
     end
 


### PR DESCRIPTION
Also rename the decision_type methods used in dispatch to convey that
they are only relevant when the appeal is being dispatched.

To test, I ran all dispatch integration test methods locally (even the skipped ones)

@cmgiven any ideas on what the full testing strategy should be here?