### PR TITLE
Stopping JSON from caching when hitting back button

### DIFF
--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -15,7 +15,7 @@ export class ReaderLoadingScreen extends React.Component {
       return Promise.resolve();
     }
 
-    return ApiUtil.get(`/reader/appeal/${this.props.vacolsId}/documents`, {}, ENDPOINT_NAMES.DOCUMENTS).
+    return ApiUtil.get(`/reader/appeal/${this.props.vacolsId}/documents?json`, {}, ENDPOINT_NAMES.DOCUMENTS).
       then((response) => {
         const returnedObject = JSON.parse(response.text);
         const documents = returnedObject.appealDocuments;


### PR DESCRIPTION
See validation-failed in: https://github.com/department-of-veterans-affairs/caseflow/issues/2940

Since we use the same endpoints to get JSON data and for our HTML request, we erroneously cache the JSON responses when users hit the back button from an external site. This change adds a query param to avoid caching.

**Test Plan**
- [ ] Go to list documents page. Navigate to external page. Hit back button. Should work properly and not display JSON.