### PR TITLE
Reader | Fix flakey annotations_controller.rb coverage issue

### DIFF
--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -2,9 +2,12 @@ class AnnotationController < ApplicationController
   before_action :verify_access
 
   rescue_from ActiveRecord::RecordInvalid do |e|
+    # This is prevented in the UI and should never happen.
+    # :nocov:
     Rails.logger.error "AnnotationController failed validation: #{e.message}"
 
     render json: { "errors": ["title": e.class.to_s, "detail": e.message] }, status: 400
+    # :nocov:
   end
 
   ANNOTATION_AUTHORIZED_ROLES = ["Reader"].freeze

--- a/client/app/reader/EditComment.jsx
+++ b/client/app/reader/EditComment.jsx
@@ -14,9 +14,13 @@ export default class EditComment extends React.Component {
     this.shouldAutosave = true;
   }
 
+  isSaveDisabled = () => (
+    this.props.disableOnEmpty && this.isStringEmpty(this.props.comment.comment)
+  )
+
   handleAutoSave = () => {
     // only autosave when a comment exists
-    if (this.shouldAutosave && this.props.comment.comment) {
+    if (this.shouldAutosave && !this.isSaveDisabled()) {
       this.onSaveCommentEdit();
     }
   }
@@ -85,7 +89,7 @@ export default class EditComment extends React.Component {
               Cancel
           </Button>
           <Button
-            disabled={this.props.disableOnEmpty && this.isStringEmpty(this.props.comment.comment)}
+            disabled={this.isSaveDisabled()}
             name="save"
             onClick={this.onSaveCommentEdit}>
               Save


### PR DESCRIPTION
## The Problem
Most of the time `annotations_controller.rb` is 100% covered:
![screen shot 2018-01-26 at 6 12 21 pm](https://user-images.githubusercontent.com/1596259/35523588-30796c72-04ed-11e8-8913-3cf10229ceba.png)

But occasionally, tests will fail because it's only 89% covered:
![screen shot 2018-01-26 at 5 18 28 pm](https://user-images.githubusercontent.com/1596259/35523594-3239fe82-04ed-11e8-8cff-25d350814406.png)

The reason the two uncovered lines were being covered at all is because the tests inside `context "when comment box contains only whitespace characters" ` were sending an [autosave POST request](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/reader/EditComment.jsx#L20) with an invalid comment to annotations controller as part of the `'beforeunload'` listener. This triggered a validation error.

However, since the request is sent after the test ends, there is a race condition between the test closing and request (and thus the code coverage) being processed. This is what caused the coverage to sometimes not work.

## The Fix
1) Prevent autosaves for invalid annotations. This means the `rescue_from` block should never trigger.
2) Add `nocov` blocks to the `rescue_from` block, now that it should never happen.