### PR TITLE
Intake Stats | Add "By Fiscal Year"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/LineLength
 source ENV["GEM_SERVER_URL"] || "https://rubygems.org"
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "8f335782beabdf246ea63437762ea32fb8eb4c26"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "44dbb79"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/LineLength
 source ENV["GEM_SERVER_URL"] || "https://rubygems.org"
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "44dbb79"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "2970f415ba80ccf338e1b4ecb4386c98be29f8b9"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 8f335782beabdf246ea63437762ea32fb8eb4c26
-  ref: 8f335782beabdf246ea63437762ea32fb8eb4c26
+  revision: 44dbb7967fc689e01cd006bc13507eb1a41efdb5
+  ref: 44dbb79
   specs:
-    caseflow (0.2.12)
+    caseflow (0.3.0)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 44dbb7967fc689e01cd006bc13507eb1a41efdb5
-  ref: 44dbb79
+  revision: 2970f415ba80ccf338e1b4ecb4386c98be29f8b9
+  ref: 2970f415ba80ccf338e1b4ecb4386c98be29f8b9
   specs:
-    caseflow (0.3.0)
+    caseflow (0.3.1)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails

--- a/app/controllers/intake_stats_controller.rb
+++ b/app/controllers/intake_stats_controller.rb
@@ -10,7 +10,8 @@ class IntakeStatsController < ApplicationController
     @stats = {
       daily: 0...30,
       weekly: 0...26,
-      monthly: 0...24
+      monthly: 0...24,
+      fiscal_yearly: 0...3
     }[interval].map { |i| IntakeStats.offset(time: IntakeStats.now, interval: interval, offset: i) }
   end
 
@@ -24,6 +25,16 @@ class IntakeStatsController < ApplicationController
   helper_method :interval
 
   private
+
+  def interval_names
+    {
+      daily: "Daily",
+      weekly: "Weekly",
+      monthly: "Monthly",
+      fiscal_yearly: "By Fiscal Year"
+    }
+  end
+  helper_method(:interval_names)
 
   def verify_access
     verify_authorized_roles("Admin Intake")

--- a/app/models/intake_stats.rb
+++ b/app/models/intake_stats.rb
@@ -1,5 +1,5 @@
 class IntakeStats < Caseflow::Stats
-  INTERVALS = [:daily, :weekly, :monthly].freeze
+  INTERVALS = [:daily, :weekly, :monthly, :fiscal_yearly].freeze
 
   # Time to wait before recalculating stats
   THROTTLE_RECALCULATION_PERIOD = 20.minutes

--- a/app/views/intake_stats/show.html.erb
+++ b/app/views/intake_stats/show.html.erb
@@ -20,7 +20,7 @@
           <li class="cf-tab <%= (@stats[0].interval == interval) && "cf-active" %>">
           <span>
             <span>
-              <%= link_to interval.to_s.capitalize, intake_stats_path(interval) %>
+              <%= link_to interval_names[interval], intake_stats_path(interval) %>
             </span>
           </span>
           </li>


### PR DESCRIPTION
To test, visit intake stats, and see the fiscal year tab. Click
on it to see the stats.

![screen shot 2018-01-30 at 4 35 25 pm](https://user-images.githubusercontent.com/1596259/35595778-dac12f8c-05e5-11e8-8fc4-6a3232a252db.png)

This completes the AC for the issue.

connects #4460