### PR TITLE
Include date_completed as attr accessor for the appeal

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -44,7 +44,7 @@ class Appeal < ActiveRecord::Base
   vacols_attr_accessor :prior_decision_date
 
   # These are only set when you pull in a case from the Case Assignment Repository
-  attr_accessor :date_assigned, :date_received, :signed_date, :docket_date, :date_due
+  attr_accessor :date_assigned, :date_received, :date_completed, :signed_date, :docket_date, :date_due
 
   cache_attribute :aod do
     self.class.repository.aod(vacols_id)

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -17,7 +17,7 @@ class Fakes::Initializer
         User.authentication_service = Fakes::AuthenticationService
         # This sets up the Fake::VBMSService with documents for the VBMS ID DEMO123. We normally
         # set this up in Fakes::AppealRepository.seed! which we don't call for this environment.
-        Fakes::VBMSService.document_records = { "DEMO123" => Fakes::AppealRepository.static_reader_documents }
+        Fakes::VBMSService.document_records = { "DEMO123" => Fakes::Data::AppealData.static_reader_documents }
       end
 
       if rails_env.development? || rails_env.demo?


### PR DESCRIPTION
I encountered this bug when I ran: `AppealRepository.load_user_case_assignments_from_vacols("CF_MCCOY_317")`

After adding date_completed to the appeal.rb, it worked fine