### PR TITLE
Found some extra styles that were affected by refactoring

### DIFF
--- a/app/assets/stylesheets/_reviewer.scss
+++ b/app/assets/stylesheets/_reviewer.scss
@@ -41,24 +41,6 @@ $caseflow-text-select: transparentize($caseflow-text-select-without-transparency
   }
 }
 
-.cf-claims-folder-details {
-  p {
-    margin-top: 15px;
-  }
-
-  .claims-folder-issues {
-    margin-top: 20px;
-
-    ol {
-      padding-top: 3px;
-      padding-left: 1em;
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-  }
-}
-
-
 .rc-collapse > .rc-collapse-item-disabled > .rc-collapse-header {
   color: $color-base;
 }

--- a/app/assets/stylesheets/reader/_document_list.scss
+++ b/app/assets/stylesheets/reader/_document_list.scss
@@ -9,14 +9,6 @@ $tag-backgrond-color: #d6d7d9;
     font-style: italic;
   }
 
-  mark {
-    background: $color-gold-lightest;
-
-    &.highlighted {
-      background: $color-gold-light;
-    }
-  }
-
   .section--no-search-results {
     .cf-msg-screen-text {
       display: none;

--- a/client/app/constants/AppConstants.js
+++ b/client/app/constants/AppConstants.js
@@ -1,10 +1,16 @@
-import { COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
+import { COLORS as COMMON_COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
 
 // poll dependency outage every 2 minutes
 export const DEPENDENCY_OUTAGE_POLLING_INTERVAL = 120000;
 export const LONGER_THAN_USUAL_TIMEOUT = 10000;
 export const CERTIFICATION_DATA_POLLING_INTERVAL = 5000;
 export const CERTIFICATION_DATA_OVERALL_TIMEOUT = 180000;
+
+export const COLORS = {
+  ...COMMON_COLORS,
+  GOLD_LIGHTEST: '#FFF1D2',
+  GOLD_LIGHT: '#F9C642'
+};
 
 export const LOGO_COLORS = {
   READER: {
@@ -21,11 +27,11 @@ export const LOGO_COLORS = {
   },
   HEARINGS: {
     ACCENT: '#56b605',
-    OVERLAP: COLORS.GREY_LIGHT
+    OVERLAP: COMMON_COLORS.GREY_LIGHT
   },
   CERTIFICATION: {
     ACCENT: '#459FD7',
-    OVERLAP: COLORS.GREY_LIGHT
+    OVERLAP: COMMON_COLORS.GREY_LIGHT
   },
   QUEUE: {
     ACCENT: '#11598D',

--- a/client/app/reader/ClaimsFolderDetails.jsx
+++ b/client/app/reader/ClaimsFolderDetails.jsx
@@ -12,6 +12,18 @@ const rowDisplay = css({
   display: 'flex',
   justifyContent: 'space-between'
 });
+const viewedParagraphStyling = css({
+  marginTop: '15px'
+});
+const issueStyling = css({
+  marginTop: '20px',
+  '& ol': {
+    paddingTop: '3px',
+    paddingLeft: '1em',
+    marginTop: 0,
+    marginBottom: 0
+  }
+});
 
 class ClaimsFolderDetails extends React.PureComponent {
 
@@ -20,10 +32,10 @@ class ClaimsFolderDetails extends React.PureComponent {
     const appealDoesntExist = _.isEmpty(appeal);
     const docsViewedCount = _.filter(documents, 'opened_by_current_user').length;
 
-    return <div className="cf-claims-folder-details">
+    return <div>
       <div>
         { !appealDoesntExist && <h1 className="cf-push-left">{appeal.veteran_full_name}'s Claims Folder</h1> }
-        <p className="cf-push-right">
+        <p className="cf-push-right" {...viewedParagraphStyling}>
           You've viewed { docsViewedCount } out of { documents.length } documents
         </p>
       </div>
@@ -49,11 +61,9 @@ class ClaimsFolderDetails extends React.PureComponent {
                 <span>{`${appeal.regional_office.key} - ${appeal.regional_office.city}`}</span>
               </div>
             </div>
-            <div>
-              <div>
-                <b>Issues</b><br />
-                <IssueList appeal={appeal} />
-              </div>
+            <div {...issueStyling}>
+              <b>Issues</b><br />
+              <IssueList appeal={appeal} />
             </div>
           </div>}
         </AccordionSection>

--- a/client/app/reader/ClaimsFolderDetails.jsx
+++ b/client/app/reader/ClaimsFolderDetails.jsx
@@ -6,6 +6,12 @@ import AccordionSection from '../components/AccordionSection';
 import IssueList from './IssueList';
 
 import { getClaimTypeDetailInfo } from '../reader/utils';
+import { css } from 'glamor';
+
+const rowDisplay = css({
+  display: 'flex',
+  justifyContent: 'space-between'
+});
 
 class ClaimsFolderDetails extends React.PureComponent {
 
@@ -24,27 +30,30 @@ class ClaimsFolderDetails extends React.PureComponent {
       <Accordion style="bordered" accordion={false} defaultActiveKey={['Claims Folder details']}>
         <AccordionSection id="claim-folder-details-accordion" className="usa-grid"
           disabled={appealDoesntExist} title={appealDoesntExist ? 'Loading...' : 'Claims folder details'}>
-          {!appealDoesntExist &&
-          <div>
-            <div className="usa-width-one-fourth">
-              <b>Veteran ID</b><br />
-              <span>{appeal.vbms_id}</span>
+          {!appealDoesntExist && <div>
+            <div {...rowDisplay}>
+              <div>
+                <b>Veteran ID</b><br />
+                <span>{appeal.vbms_id}</span>
+              </div>
+              <div>
+                <b>Type</b><br />
+                <span>{appeal.type}</span> {getClaimTypeDetailInfo(appeal)}
+              </div>
+              <div>
+                <b>Docket Number</b><br />
+                <span>{appeal.docket_number}</span>
+              </div>
+              <div>
+                <b>Regional Office</b><br />
+                <span>{`${appeal.regional_office.key} - ${appeal.regional_office.city}`}</span>
+              </div>
             </div>
-            <div className="usa-width-one-fourth">
-              <b>Type</b><br />
-              <span>{appeal.type}</span> {getClaimTypeDetailInfo(appeal)}
-            </div>
-            <div className="usa-width-one-fourth">
-              <b>Docket Number</b><br />
-              <span>{appeal.docket_number}</span>
-            </div>
-            <div className="usa-width-one-fourth">
-              <b>Regional Office</b><br />
-              <span>{`${appeal.regional_office.key} - ${appeal.regional_office.city}`}</span>
-            </div>
-            <div className="usa-width-one-whole claims-folder-issues">
-              <b>Issues</b><br />
-              <IssueList appeal={appeal} />
+            <div {...rowDisplay}>
+              <div>
+                <b>Issues</b><br />
+                <IssueList appeal={appeal} />
+              </div>
             </div>
           </div>}
         </AccordionSection>

--- a/client/app/reader/ClaimsFolderDetails.jsx
+++ b/client/app/reader/ClaimsFolderDetails.jsx
@@ -61,7 +61,7 @@ class ClaimsFolderDetails extends React.PureComponent {
                 <span>{`${appeal.regional_office.key} - ${appeal.regional_office.city}`}</span>
               </div>
             </div>
-            <div {...issueStyling}>
+            <div id="claims-folder-issues" {...issueStyling}>
               <b>Issues</b><br />
               <IssueList appeal={appeal} />
             </div>

--- a/client/app/reader/ClaimsFolderDetails.jsx
+++ b/client/app/reader/ClaimsFolderDetails.jsx
@@ -49,7 +49,7 @@ class ClaimsFolderDetails extends React.PureComponent {
                 <span>{`${appeal.regional_office.key} - ${appeal.regional_office.city}`}</span>
               </div>
             </div>
-            <div {...rowDisplay}>
+            <div>
               <div>
                 <b>Issues</b><br />
                 <IssueList appeal={appeal} />

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -17,6 +17,7 @@ import { collectHistogram } from '../util/Metrics';
 
 import { css } from 'glamor';
 import classNames from 'classnames';
+import { COLORS } from '../constants/AppConstants';
 
 // This comes from the class .pdfViewer.singlePageView .page in _reviewer.scss.
 // We need it defined here to be able to expand/contract margin between pages
@@ -28,9 +29,9 @@ const PAGE_DIMENSION_SCALE = 1;
 
 const markStyle = css({
   '& mark': {
-    background: '#fff1d2',
+    background: COLORS.GOLD_LIGHTEST,
     '.highlighted': {
-      background: '#f9c642'
+      background: COLORS.GOLD_LIGHT
     }
   }
 });

--- a/client/app/reader/PdfPage.jsx
+++ b/client/app/reader/PdfPage.jsx
@@ -15,6 +15,7 @@ import { pageNumberOfPageIndex } from './utils';
 import { PDFJS } from 'pdfjs-dist/web/pdf_viewer';
 import { collectHistogram } from '../util/Metrics';
 
+import { css } from 'glamor';
 import classNames from 'classnames';
 
 // This comes from the class .pdfViewer.singlePageView .page in _reviewer.scss.
@@ -24,6 +25,15 @@ const PAGE_MARGIN_BOTTOM = 25;
 
 // Base scale used to calculate dimensions and draw text.
 const PAGE_DIMENSION_SCALE = 1;
+
+const markStyle = css({
+  '& mark': {
+    background: '#fff1d2',
+    '.highlighted': {
+      background: '#f9c642'
+    }
+  }
+});
 
 export class PdfPage extends React.PureComponent {
   constructor(props) {
@@ -289,7 +299,8 @@ export class PdfPage extends React.PureComponent {
       className={pageClassNames}
       style={divPageStyle}
       onClick={this.onClick}
-      ref={this.getPageContainerRef}>
+      ref={this.getPageContainerRef}
+      {...markStyle}>
       <div
         id={this.props.isFileVisible ? `rotationDiv${pageNumberOfPageIndex(this.props.pageIndex)}` : null}
         className={pageContentsVisibleClass}

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -243,7 +243,7 @@ RSpec.feature "Reader" do
       scenario "Claims folder details issues show no issues message" do
         visit "/reader/appeal/#{appeal.vacols_id}/documents"
         find(".rc-collapse-header", text: "Claims folder details").click
-        expect(find(".claims-folder-issues").text).to have_content("No issues on appeal")
+        expect(find("#claims-folder-issues").text).to have_content("No issues on appeal")
       end
 
       context "When both document source manifest retrieval times are set" do
@@ -1177,7 +1177,7 @@ RSpec.feature "Reader" do
       expect(page).to have_content(regional_office)
 
       # all the current issues listed in the UI
-      issue_list = all(".claims-folder-issues li")
+      issue_list = all("#claims-folder-issues li")
       expect(issue_list.count).to eq(appeal_info["issues"].length)
       issue_list.each_with_index do |issue, index|
         expect(issue.text.include?(appeal_info["issues"][index][:type])).to be true


### PR DESCRIPTION
Recent refactors have messed up the search styling and the claims folder issues styling. I'm moving these into glamor.

**Test Plan**
- [ ] Verify the claims folder detail dropdown displays data in two rows instead of each item on a new line.
- [ ] Verify document search properly highlights results as you search through them.