### PR TITLE
Temporary demo data fix

### DIFF
--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -90,8 +90,8 @@ class Fakes::AppealRepository
     return_records = MetricsService.record "load appeals ready for hearing for vbms_id #{vbms_id}" do
       records.select do |_, r|
         (r[:vbms_id] == vbms_id &&
-        (r[:decision_date].nil? || r[:disposition] == "Remanded") &&
-        r[:form9_date])
+        (r[:decision_date].nil? || r[:disposition] == "Remanded")) # &&
+        # r[:form9_date])
       end
     end
 

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -77,7 +77,7 @@ describe Hearing do
     let(:hearing) { Generators::Hearing.create(appeal_id: appeal1.id) }
 
     it "returns active appeals with no decision date and with form9 date" do
-      expect(subject.size).to eq 2
+      expect(subject.size).to eq 3
     end
   end
 


### PR DESCRIPTION
This PR is a super super temporary fix for the hearings demo this morning. Our active appeals streams aren't showing up for some hearings because the vacols attribute form9_date is returning null. Something is broken with how we're generating those appeals. To make sure that appeals show up for the demo, I'm taking out the form9_date check. I'll continue to look into a real fix this afternoon. 