### PR TITLE
Styleguide | add efolder and certification logos

### DIFF
--- a/client/app/constants/AppConstants.js
+++ b/client/app/constants/AppConstants.js
@@ -36,5 +36,9 @@ export const LOGO_COLORS = {
   QUEUE: {
     ACCENT: '#11598D',
     OVERLAP: '#0E456C'
+  },
+  EFOLDER: {
+    ACCENT: '#F0835e',
+    OVERLAP: COMMON_COLORS.GREY_LIGHT
   }
 };

--- a/client/app/containers/StyleGuide/StyleGuideLogos.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideLogos.jsx
@@ -28,6 +28,16 @@ export default class StyleLogos extends React.PureComponent {
         accentColor: LOGO_COLORS.READER.ACCENT,
         overlapColor: LOGO_COLORS.READER.OVERLAP,
         appName: 'Reader'
+      },
+      {
+        accentColor: LOGO_COLORS.CERTIFICATION.ACCENT,
+        overlapColor: LOGO_COLORS.CERTIFICATION.OVERLAP,
+        appName: 'Certification'
+      },
+      {
+        accentColor: LOGO_COLORS.EFOLDER.ACCENT,
+        overlapColor: LOGO_COLORS.EFOLDER.OVERLAP,
+        appName: 'eFolder Express'
       }
     ];
 


### PR DESCRIPTION
Connects #4415 
<img width="689" alt="screen shot 2018-02-02 at 2 47 37 pm" src="https://user-images.githubusercontent.com/4773320/35751900-0f4b0842-0828-11e8-9903-17cc14394274.png">
