### PR TITLE
[Queue] Display appeal doc count in reader link from detail view

### DIFF
--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -32,6 +32,10 @@ class QueueDetailView extends React.PureComponent {
       page: 'TODO: Appellant detail page'
     }];
 
+    const readerLinkMsg = appeal.docCount ?
+      `Open ${appeal.docCount.toLocaleString()} documents in Caseflow Reader` :
+      'Open documents in Caseflow Reader';
+
     return <AppSegment filledBackground>
       <h1 className="cf-push-left" {...headerStyling}>
         Draft Decision - {appeal.veteran_full_name} ({appeal.vacols_id})
@@ -40,7 +44,7 @@ class QueueDetailView extends React.PureComponent {
         Assigned to you by <span {...redText}>Judge</span> on {moment(task.assigned_on).format('MM/DD/YY')}.
         Due {moment(task.due_on).format('MM/DD/YY')}
       </p>
-      <ReaderLink vacolsId={this.props.vacolsId} message="Open documents in Caseflow Reader" />
+      <ReaderLink vacolsId={this.props.vacolsId} message={readerLinkMsg} />
 
       <TabWindow
         name="queue-tabwindow"


### PR DESCRIPTION
Connects #4353

## Acceptance Criteria
- [ ] A link to 'Open documents in Caseflow Reader' exists in the task details view
- [ ] Verify that Reader opens to the correct Veteran's claims folder
- [ ] If error with call to eFolder to show the number of documents was unsuccessful, show error states