### PR TITLE
Changing how prefs are passed for chrome driver through capybara

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,16 +53,14 @@ end
 FeatureToggle.cache_namespace = "test_#{ENV['TEST_SUBCATEGORY'] || 'all'}"
 
 Capybara.register_driver(:parallel_sniffybara) do |app|
-  chrome_options = ::Selenium::WebDriver::Chrome::Options.new()
-  
-  chrome_options.add_preference(:download, { 
-    prompt_for_download: false,
-    default_directory: download_directory
-  })
+  chrome_options = ::Selenium::WebDriver::Chrome::Options.new
 
-  chrome_options.add_preference(:browser, { 
-    disk_cache_dir: cache_directory
-  })
+  chrome_options.add_preference(:download,
+                                prompt_for_download: false,
+                                default_directory: download_directory)
+
+  chrome_options.add_preference(:browser,
+                                disk_cache_dir: cache_directory)
 
   options = {
     port: 51_674,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -53,20 +53,23 @@ end
 FeatureToggle.cache_namespace = "test_#{ENV['TEST_SUBCATEGORY'] || 'all'}"
 
 Capybara.register_driver(:parallel_sniffybara) do |app|
+  chrome_options = ::Selenium::WebDriver::Chrome::Options.new()
+  
+  chrome_options.add_preference(:download, { 
+    prompt_for_download: false,
+    default_directory: download_directory
+  })
+
+  chrome_options.add_preference(:browser, { 
+    disk_cache_dir: cache_directory
+  })
+
   options = {
     port: 51_674,
     browser: :chrome,
-    prefs: {
-      download: {
-        prompt_for_download: false,
-        default_directory: download_directory
-      },
-      browser: {
-        disk_cache_dir: cache_directory
-      }
-    }
+    options: chrome_options
   }
-
+  
   Sniffybara::Driver.current_driver = Sniffybara::Driver.new(app, options)
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,7 +69,7 @@ Capybara.register_driver(:parallel_sniffybara) do |app|
     browser: :chrome,
     options: chrome_options
   }
-  
+
   Sniffybara::Driver.current_driver = Sniffybara::Driver.new(app, options)
 end
 


### PR DESCRIPTION
Removes this warning when running feature tests:
```
2018-02-05 14:09:26 WARN Selenium [DEPRECATION] :prefs is deprecated. Use Selenium::WebDriver::Chrome::Options#add_preference instead.
```

## Criteria
- [ ] Notice that the DEPRECATION warning doesn't show up when feature tests are run
- [ ] Tests pass on travis