### PR TITLE
[WIP] Queue Breadcrumbs Suggestion

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -4,6 +4,12 @@
     userId: current_user.id,
     dropdownUrls: dropdown_urls,
     feedbackUrl: feedback_url,
-    buildDate: build_date
+    buildDate: build_date,
+
+    # Passthrough for Reader. This needs to be kept in sync with the react_component() call for Reader.
+    featureToggles: {
+      windowSlider: FeatureToggle.enabled?(:window_slider, user: current_user)
+    },
+    pdfWorker: asset_path('pdf.worker.js'),
   }) %>
 <% end %>

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -76,11 +76,13 @@ class QueueApp extends React.PureComponent {
           <PageRoute
             exact
             path="/"
+            breadcrumb="Your Queue"
             title="Your Queue | Caseflow Queue"
             render={this.routedQueueList} />
           <PageRoute
             exact
             path="/tasks/:vacolsId"
+            breadcrumb="Draft Decision"
             title="Draft Decision | Caseflow Queue"
             render={this.routedQueueDetail} />
           <PageRoute

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -41,10 +41,10 @@ class QueueApp extends React.PureComponent {
   getEmbeddedReader = () => {
     const passthroughReaderProps = _.pick(
       this.props, 'userDisplayName', 'dropdownUrls', 'feedbackUrl', 'featureToggles', 'pdfWorker', 'buildDate'
-    )
+    );
 
-    return <Reader embedded {...passthroughReaderProps} basename={basename} />
-}
+    return <Reader embedded {...passthroughReaderProps} basename={basename} />;
+  }
 
   routedQueueList = () => <QueueLoadingScreen {...this.props}>
     <CaseSelectSearch

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -35,7 +35,17 @@ const searchStyling = (isRequestingAppealsUsingVeteranId) => css({
   }
 });
 
+const basename = '/queue';
+
 class QueueApp extends React.PureComponent {
+  getEmbeddedReader = () => {
+    const passthroughReaderProps = _.pick(
+      this.props, 'userDisplayName', 'dropdownUrls', 'feedbackUrl', 'featureToggles', 'pdfWorker', 'buildDate'
+    )
+
+    return <Reader embedded {...passthroughReaderProps} basename={basename} />
+}
+
   routedQueueList = () => <QueueLoadingScreen {...this.props}>
     <CaseSelectSearch
       navigateToPath={(path) => window.location.href = `/reader/appeal${path}`}
@@ -51,7 +61,7 @@ class QueueApp extends React.PureComponent {
     <QueueDetailView vacolsId={props.match.params.vacolsId} />
   </QueueLoadingScreen>;
 
-  render = () => <BrowserRouter basename="/queue">
+  render = () => <BrowserRouter basename={basename}>
     <NavigationBar
       defaultUrl="/"
       userDisplayName={this.props.userDisplayName}
@@ -73,6 +83,10 @@ class QueueApp extends React.PureComponent {
             path="/tasks/:vacolsId"
             title="Draft Decision | Caseflow Queue"
             render={this.routedQueueDetail} />
+          <PageRoute
+            path="/reader"
+            title="QueueReader"
+            render={this.getEmbeddedReader} />
         </div>
       </AppFrame>
       <Footer

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -15,6 +15,7 @@ import AppFrame from '../components/AppFrame';
 import QueueDetailView from './QueueDetailView';
 import { LOGO_COLORS } from '../constants/AppConstants';
 import { connect } from 'react-redux';
+import Reader from '../reader';
 
 const appStyling = css({
   paddingTop: '3rem'

--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -46,7 +46,8 @@ class QueueDetailView extends React.PureComponent {
         <DateString date={task.assigned_on} dateFormat="MM/DD/YY" />.
         Due <DateString date={task.due_on} dateFormat="MM/DD/YY" />.
       </p>
-      <ReaderLink vacolsId={this.props.vacolsId} message={readerLinkMsg} />
+      <ReaderLink vacolsId={this.props.vacolsId} message={readerLinkMsg}
+        backToPathname={this.props.location.pathname} />
 
       <TabWindow
         name="queue-tabwindow"

--- a/client/app/queue/QueueListView.jsx
+++ b/client/app/queue/QueueListView.jsx
@@ -22,7 +22,7 @@ class QueueListView extends React.PureComponent {
     } else {
       tableContent = <div>
         <h1 className="cf-push-left" {...fullWidth}>Your Queue</h1>
-        <QueueTable />
+        <QueueTable location={this.props.location} />
       </div>;
     }
 

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -64,7 +64,8 @@ class QueueTable extends React.PureComponent {
       valueFunction: (task) => <LoadingDataDisplay
         createLoadPromise={this.createLoadPromise(task)}
         errorComponent="span"
-        failStatusMessageChildren={<ReaderLink vacolsId={task.vacolsId} />}
+        failStatusMessageChildren={<ReaderLink vacolsId={task.vacolsId}
+          backToPathname={this.props.location.pathname} />}
         loadingComponent={SmallLoader}
         loadingComponentProps={{
           message: 'Loading...',
@@ -74,7 +75,7 @@ class QueueTable extends React.PureComponent {
             href: `/reader/appeal/${task.vacolsId}/documents`
           }
         }}>
-        <ReaderLink vacolsId={task.vacolsId} />
+        <ReaderLink vacolsId={task.vacolsId} backToPathname={this.props.location.pathname} />
       </LoadingDataDisplay>
     }
   ];

--- a/client/app/queue/ReaderLink.jsx
+++ b/client/app/queue/ReaderLink.jsx
@@ -21,7 +21,7 @@ class ReaderLink extends React.PureComponent {
       linkText = `View ${docCount.toLocaleString()} in Reader`;
     }
 
-    return <Link href={`/reader/appeal/${vacolsId}/documents`}>
+    return <Link href={`/queue/reader/appeal/${vacolsId}/documents`}>
       {linkText}
     </Link>;
   };

--- a/client/app/queue/ReaderLink.jsx
+++ b/client/app/queue/ReaderLink.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'lodash';
+import url from 'url';
+import querystring from 'querystring';
 
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 
 class ReaderLink extends React.PureComponent {
   render = () => {
     const {
+      backToPathname,
       docCount,
       message,
       vacols_id: vacolsId
@@ -21,7 +24,12 @@ class ReaderLink extends React.PureComponent {
       linkText = `View ${docCount.toLocaleString()} in Reader`;
     }
 
-    return <Link href={`/queue/reader/appeal/${vacolsId}/documents`}>
+    const href = url.format({
+      pathname: `/queue/reader/appeal/${vacolsId}/documents`,
+      search: querystring.stringify({ backToPathname })
+    });
+
+    return <Link href={href}>
       {linkText}
     </Link>;
   };

--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -93,6 +93,7 @@ export class DecisionReviewer extends React.PureComponent {
       annotations={this.props.annotations}
       vacolsId={vacolsId}>
       <PdfListView
+        backToLink={this.props.backToLink}
         showPdf={this.showPdf(props.history, vacolsId)}
         sortBy={this.state.sortBy}
         selectedLabels={this.state.selectedLabels}

--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -139,52 +139,51 @@ export class DecisionReviewer extends React.PureComponent {
 
     const core = <Router basename={`${this.props.basename}/reader/appeal`} {...this.props.routerTestProps}>
       <React.Fragment>
-      <PageRoute
+        <PageRoute
+          exact
+          title="Document Viewer | Caseflow Reader"
+          breadcrumb="Document Viewer"
+          path="/:vacolsId/documents/:docId"
+          render={this.routedPdfViewer} />
+        <AppFrame wideApp>
+          <PageRoute
             exact
-            title="Document Viewer | Caseflow Reader"
-            breadcrumb="Document Viewer"
-            path="/:vacolsId/documents/:docId"
-            render={this.routedPdfViewer} />
-          <AppFrame wideApp>
-            <PageRoute
-              exact
-              title={this.getClaimsFolderPageTitle(this.props.appeal)}
-              breadcrumb="Claims Folder"
-              path="/:vacolsId/documents"
-              render={this.routedPdfListView} />
-            <PageRoute
-              exact
-              path="/"
-              title="Assignments | Caseflow Reader"
-              render={this.routedCaseSelect} />
-          </AppFrame>
-          </React.Fragment>
-          </Router>
-    
+            title={this.getClaimsFolderPageTitle(this.props.appeal)}
+            breadcrumb="Claims Folder"
+            path="/:vacolsId/documents"
+            render={this.routedPdfListView} />
+          <PageRoute
+            exact
+            path="/"
+            title="Assignments | Caseflow Reader"
+            render={this.routedCaseSelect} />
+        </AppFrame>
+      </React.Fragment>
+    </Router>;
 
     if (this.props.embedded) {
       return core;
     }
 
     return <React.Fragment>
-        <NavigationBar
-          wideApp
-          appName="Reader"
-          logoProps={{
-            accentColor: LOGO_COLORS.READER.ACCENT,
-            overlapColor: LOGO_COLORS.READER.OVERLAP
-          }}
-          userDisplayName={this.props.userDisplayName}
-          dropdownUrls={this.props.dropdownUrls}
-          defaultUrl="/">
-          {core}
-        </NavigationBar>
-        <Footer
-          wideApp
-          appName="Reader"
-          feedbackUrl={this.props.feedbackUrl}
-          buildDate={this.props.buildDate} />
-      </React.Fragment>
+      <NavigationBar
+        wideApp
+        appName="Reader"
+        logoProps={{
+          accentColor: LOGO_COLORS.READER.ACCENT,
+          overlapColor: LOGO_COLORS.READER.OVERLAP
+        }}
+        userDisplayName={this.props.userDisplayName}
+        dropdownUrls={this.props.dropdownUrls}
+        defaultUrl="/">
+        {core}
+      </NavigationBar>
+      <Footer
+        wideApp
+        appName="Reader"
+        feedbackUrl={this.props.feedbackUrl}
+        buildDate={this.props.buildDate} />
+    </React.Fragment>
     ;
   }
 }

--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -137,19 +137,9 @@ export class DecisionReviewer extends React.PureComponent {
   render() {
     const Router = this.props.router || BrowserRouter;
 
-    return <Router basename="/reader/appeal" {...this.props.routerTestProps}>
-      <div>
-        <NavigationBar
-          wideApp
-          appName="Reader"
-          logoProps={{
-            accentColor: LOGO_COLORS.READER.ACCENT,
-            overlapColor: LOGO_COLORS.READER.OVERLAP
-          }}
-          userDisplayName={this.props.userDisplayName}
-          dropdownUrls={this.props.dropdownUrls}
-          defaultUrl="/">
-          <PageRoute
+    const core = <Router basename={`${this.props.basename}/reader/appeal`} {...this.props.routerTestProps}>
+      <React.Fragment>
+      <PageRoute
             exact
             title="Document Viewer | Caseflow Reader"
             breadcrumb="Document Viewer"
@@ -168,14 +158,34 @@ export class DecisionReviewer extends React.PureComponent {
               title="Assignments | Caseflow Reader"
               render={this.routedCaseSelect} />
           </AppFrame>
+          </React.Fragment>
+          </Router>
+    
+
+    if (this.props.embedded) {
+      return core;
+    }
+
+    return <React.Fragment>
+        <NavigationBar
+          wideApp
+          appName="Reader"
+          logoProps={{
+            accentColor: LOGO_COLORS.READER.ACCENT,
+            overlapColor: LOGO_COLORS.READER.OVERLAP
+          }}
+          userDisplayName={this.props.userDisplayName}
+          dropdownUrls={this.props.dropdownUrls}
+          defaultUrl="/">
+          {core}
         </NavigationBar>
         <Footer
           wideApp
           appName="Reader"
           feedbackUrl={this.props.feedbackUrl}
           buildDate={this.props.buildDate} />
-      </div>
-    </Router>;
+      </React.Fragment>
+    ;
   }
 }
 

--- a/client/app/reader/PdfListView.jsx
+++ b/client/app/reader/PdfListView.jsx
@@ -57,7 +57,10 @@ export class PdfListView extends React.Component {
       />;
     }
 
+    const BackToLink = this.props.backToLink;
+
     return <div>
+      {BackToLink && <BackToLink location={this.props.location} />}
       <AppSegment filledBackground>
         <div className="section--document-list">
           <ClaimsFolderDetails appeal={this.props.appeal} documents={this.props.documents} />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,7 @@ Rails.application.routes.draw do
     get '/tasks/:vacols_id', to: 'queue#index'
     get '/:user_id', to: 'queue#tasks'
     get '/:appeal_id/docs', to: 'queue#document_count'
+    get '/(*path)', to: 'queue#index'
   end
 
   get "health-check", to: "health_checks#show"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180205183203) do
 
+ActiveRecord::Schema.define(version: 20180205183203) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 20180205183203) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
In response to @amprokop asking for suggestions on #4565. I don't necessarily advocate merging this as-is.

With #4565's approach, we redirect the user to `/reader`, and then make Reader customizable to make it feel like it's still part of Queue. (This requirement adds considerable complexity. Hearings Prep doesn't do this. Do we really need it for Queue? Does it really provide value to end-users to think about different Caseflow apps the way we do? Should we just have one app name and logo color and just stop worrying about all this?)

The approach I explored here was embedding Reader within Queue. Passing props felt more natural than setting querystring params that Reader would have to know how to interpret, or adding one-off customizations to Reader to change things like the header app name.

This is not without downsides. We have to remember to pass `<Reader />` the same components it would get from `react_component`. And the "back to links" and breadcrumbs are not totally working and felt fairly complicated to set up. And I still am doing some querystring magic. (The need for this would be removed if react-router gave us access to every path we've visited in the SPA, but I don't think it does. We could look into adding something like this ourselves.)

