### PR TITLE
Queue task details | Link to Hearing Worksheet

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -22,7 +22,8 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
       {
         held_by: hearing.user.present? ? hearing.user.full_name : "",
         held_on: hearing.date,
-        type: hearing.type
+        type: hearing.type,
+        id: hearing.id
       }
     end
   end

--- a/client/app/queue/AppealDetail.jsx
+++ b/client/app/queue/AppealDetail.jsx
@@ -59,7 +59,7 @@ export default class AppealDetail extends React.PureComponent {
         label: 'Hearing held',
         value: <React.Fragment>
           <DateString date={lastHearing.held_on} dateFormat="M/D/YY" style={marginRight} />
-          <Link target="_blank" href={`/hearings/${lastHearing.id}/worksheet/print`}>View Hearing Worksheet</Link>
+          <Link target="_blank" href={`/hearings/${lastHearing.id}/worksheet`}>View Hearing Worksheet</Link>
         </React.Fragment>
       }, {
         label: 'Judge at hearing',

--- a/client/app/queue/AppealDetail.jsx
+++ b/client/app/queue/AppealDetail.jsx
@@ -5,6 +5,8 @@ import _ from 'lodash';
 
 import IssueList from '../reader/IssueList';
 import BareList from '../components/BareList';
+import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
+
 import { boldText } from './constants';
 import StringUtil from '../util/StringUtil';
 import { DateString } from '../util/DateUtil';
@@ -13,6 +15,7 @@ const appealSummaryUlStyling = css({
   paddingLeft: 0,
   listStyle: 'none'
 });
+const marginRight = css({ marginRight: '1rem' });
 
 export default class AppealDetail extends React.PureComponent {
   getAppealAttr = (attr) => _.get(this.props.appeal.attributes, attr);
@@ -54,7 +57,10 @@ export default class AppealDetail extends React.PureComponent {
         value: StringUtil.snakeCaseToCapitalized(lastHearing.type)
       }, {
         label: 'Hearing held',
-        value: <DateString date={lastHearing.held_on} dateFormat="M/D/YY" />
+        value: <React.Fragment>
+          <DateString date={lastHearing.held_on} dateFormat="M/D/YY" style={marginRight} />
+          <Link target="_blank" href={`/hearings/${lastHearing.id}/worksheet/print`}>View Hearing Worksheet</Link>
+        </React.Fragment>
       }, {
         label: 'Judge at hearing',
         value: lastHearing.held_by

--- a/client/app/util/DateUtil.js
+++ b/client/app/util/DateUtil.js
@@ -34,7 +34,7 @@ export const formatDateStr = (dateString, dateFormat = 'YYYY-MM-DD', expectedFor
   return moment(dateString, dateFormat).format(expectedFormat);
 };
 
-export const DateString = ({ date, dateFormat = 'MM/DD/YY' }) => <span>
+export const DateString = ({ date, dateFormat = 'MM/DD/YY', style }) => <span {...style}>
   {formatDateStr(date, 'YYYY-MM-DD', dateFormat)}
 </span>;
 

--- a/spec/feature/queue_spec.rb
+++ b/spec/feature/queue_spec.rb
@@ -140,6 +140,8 @@ RSpec.feature "Queue" do
         expect(page).to have_content("Hearing Preference: #{hearing.type.capitalize}")
         expect(page).to have_content("Hearing held: #{hearing.date.strftime('%-m/%e/%y')}")
         expect(page).to have_content("Judge at hearing: #{hearing.user.full_name}")
+
+        expect(page).to have_content("View Hearing Worksheet")
       end
 
       scenario "appeal has no hearing" do

--- a/spec/feature/queue_spec.rb
+++ b/spec/feature/queue_spec.rb
@@ -162,7 +162,8 @@ RSpec.feature "Queue" do
         expect(page).to have_content("Hearing held: #{hearing.date.strftime('%-m/%e/%y')}")
         expect(page).to have_content("Judge at hearing: #{hearing.user.full_name}")
 
-        expect(page).to have_content("View Hearing Worksheet")
+        worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet/print']")
+        expect(worksheet_link.text).to eq("View Hearing Worksheet")
       end
 
       scenario "appeal has no hearing" do

--- a/spec/feature/queue_spec.rb
+++ b/spec/feature/queue_spec.rb
@@ -162,7 +162,7 @@ RSpec.feature "Queue" do
         expect(page).to have_content("Hearing held: #{hearing.date.strftime('%-m/%e/%y')}")
         expect(page).to have_content("Judge at hearing: #{hearing.user.full_name}")
 
-        worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet/print']")
+        worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet']")
         expect(worksheet_link.text).to eq("View Hearing Worksheet")
       end
 


### PR DESCRIPTION
Connects #4363 

## Acceptance Criteria
- [ ] If the appeal's hearing was held and it has a Hearing Worksheet established by Hearing Prep, a link to Hearing Worksheet exists in the Appeal Summary section (see mocks below for placement)
- [ ] Hearing Worksheet opens in a new tab (this is the same convention for Reader Welcome Gate and Claims folder details today)