### PR TITLE
Capybara: Increases matcher timeout

### DIFF
--- a/config/initializers/konacha.rb
+++ b/config/initializers/konacha.rb
@@ -1,4 +1,0 @@
-Konacha.configure do |config|
-  require 'capybara/poltergeist'
-  config.driver = :poltergeist
-end if defined?(Konacha)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,8 @@ Capybara.register_driver(:parallel_sniffybara) do |app|
 end
 
 Capybara.default_driver = ENV["SAUCE_SPECS"] ? :sauce_driver : :parallel_sniffybara
+# the default default_max_wait_time is 2 seconds
+Capybara.default_max_wait_time = 20
 
 ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
## Summary
With this change, [Capybara will wait longer to fail a matcher](https://github.com/teamcapybara/capybara/blob/master/README.md#asynchronous-javascript-ajax-and-friends). Also deletes some confusing dead code.

## Test Plan
- [x] Build succeeded
- [x] Build succeeded
- [x] Build succeeded
- [x] Build succeeded
- [x] Build succeeded