### PR TITLE
Reverting Changing Hearings to WorksheetIssues

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -132,9 +132,9 @@ class User < ActiveRecord::Base
   end
 
   def appeal_hearings(appeal_ids)
-    WorksheetIssue.where(appeal_id: appeal_ids).each_with_object({}) do |issue, object|
-      hearings_array = object[issue.appeal_id] || []
-      object[issue.appeal_id] = hearings_array.push(issue.hearing) unless hearings_array.include?(issue.hearing)
+    Hearing.where(appeal_id: appeal_ids).each_with_object({}) do |hearing, object|
+      hearings_array = object[hearing.appeal_id] || []
+      object[hearing.appeal_id] = hearings_array.push(hearing)
     end
   end
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -21,13 +21,10 @@ class Fakes::AppealRepository
     def load_user_case_assignments_from_vacols(_css_id)
       user_case_assignments = appeal_records || Fakes::Data::AppealData.default_records
       appeal = user_case_assignments.first
-      # Create fake hearings and worksheet issues for the first appeal if one doesn't already exist
-      if Hearing.where(appeal: appeal).empty?
-        2.times do |i|
-          hearing = Fakes::HearingRepository.create_hearing_for_appeal(i, appeal)
-          Generators::WorksheetIssue.create(appeal: appeal, hearing: hearing)
-        end
-      end
+      # Create fake hearings for the first appeal if one doesn't already exist
+      2.times { |i| Fakes::HearingRepository.create_hearing_for_appeal(i, appeal) } if Hearing
+          .where(appeal: appeal).empty?
+
       user_case_assignments
     end
   end

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -295,11 +295,6 @@ RSpec.feature "Reader" do
         Generators::Hearing.create(appeal: appeal)
       end
 
-      let!(:worksheet_issue) do
-        Generators::Hearing.create(appeal: appeal)
-        Generators::WorksheetIssue.create(appeal: appeal)
-      end
-
       before do
         Fakes::AppealRepository.appeal_records = [appeal, appeal2, appeal3, appeal4, appeal5]
       end


### PR DESCRIPTION
This reverts commit 9de54832eac1b552386b71657c3849a9c815c15d.

The commit seems to break the Reader Welcome Gate for users who have hearings assigned to them.

The theory is that this works in the fakes, but not real code paths. In the real code path, I don't see anything that sets up the relationship between Hearings and Worksheet Issues, so it seems like it always returns nil.