### PR TITLE
Queue | Display VBMS ID in page

### DIFF
--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -39,7 +39,7 @@ class QueueDetailView extends React.PureComponent {
 
     return <AppSegment filledBackground>
       <h1 className="cf-push-left" {...css(headerStyling, fullWidth)}>
-        Draft Decision - {appeal.veteran_full_name} ({appeal.vacols_id})
+        Draft Decision - {appeal.veteran_full_name} ({appeal.vbms_id})
       </h1>
       <p className="cf-lead-paragraph" {...subHeadStyling}>
         Assigned to you {task.added_by_name ? `by ${task.added_by_name}` : ''} on&nbsp;

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -38,7 +38,7 @@ class QueueTable extends React.PureComponent {
       header: 'Decision Task Details',
       valueFunction: (task) => <span>
         <Link to={`/tasks/${task.vacolsId}`}>
-          {this.getAppealForTask(task, 'veteran_full_name')} ({task.vacolsId})
+          {this.getAppealForTask(task, 'veteran_full_name')} ({this.getAppealForTask(task, 'vbms_id')})
         </Link>
         {!this.veteranIsAppellant(task) && <React.Fragment>
           <br />

--- a/spec/feature/queue_spec.rb
+++ b/spec/feature/queue_spec.rb
@@ -115,7 +115,7 @@ RSpec.feature "Queue" do
       appeal_row = find("tbody").find("#table-row-#{appeal.vacols_id}")
       first_cell = appeal_row.find_all("td").first
 
-      expect(first_cell).to have_content("#{appeal.veteran_full_name} (#{appeal.vacols_id})")
+      expect(first_cell).to have_content("#{appeal.veteran_full_name} (#{appeal.vbms_id})")
       expect(first_cell).to have_content("Veteran is not the appellant")
     end
   end


### PR DESCRIPTION
Connects #4620 

## AC
- [ ] Navigate to `/queue`
- [ ] Observe that VBMS IDs are displayed in parentheses next to Appellant name
- [ ] Navigate to a decision page (`/queue/tasks/###`)
- [ ] Observe VACOLS ID used in URL, VBMS ID displayed in page