### PR TITLE
Comment out docker vacols and use sqlite3 instead

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -42,12 +42,19 @@ production:
 
 # For connecting to the VACOLS Databases
 development_vacols:
-  adapter: oracle_enhanced
-  host: localhost
-  port: 1521
-  username: VACOLS
-  password: VACOLS
-  database: BVAP.localdomain
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+  database: db/development-vacols.sqlite3
+
+# Docker setup
+#development_vacols:
+#  adapter: oracle_enhanced
+#  host: localhost
+#  port: 1521
+#  username: VACOLS
+#  password: VACOLS
+#  database: BVAP.localdomain
 
 demo_vacols:
   adapter: sqlite3


### PR DESCRIPTION
This turns off trying to use the new docker based VACOLS in favor of the old method (for now). This will fix local dev setups again. 