### PR TITLE
Order daily docket by id

### DIFF
--- a/client/app/hearings/reducers/index.js
+++ b/client/app/hearings/reducers/index.js
@@ -63,7 +63,7 @@ export const hearingsReducers = function(state = mapDataToInitialState(), action
   case Constants.POPULATE_DAILY_DOCKET:
     return update(state, {
       dailyDocket: {
-        [action.payload.date]: { $set: action.payload.dailyDocket }
+        [action.payload.date]: { $set: _.sortBy(action.payload.dailyDocket, hearing => hearing.id)}
       }
     });
 

--- a/client/app/hearings/reducers/index.js
+++ b/client/app/hearings/reducers/index.js
@@ -63,7 +63,7 @@ export const hearingsReducers = function(state = mapDataToInitialState(), action
   case Constants.POPULATE_DAILY_DOCKET:
     return update(state, {
       dailyDocket: {
-        [action.payload.date]: { $set: _.sortBy(action.payload.dailyDocket, hearing => hearing.id)}
+        [action.payload.date]: { $set: _.sortBy(action.payload.dailyDocket, (hearing) => hearing.id) }
       }
     });
 


### PR DESCRIPTION
Connects #4094 

We're ordering by the hearing id so that the hearings added last are displayed at the bottom of the page.

To test:
- Load daily docket page
- Confirm hearings are ordered by id