### PR TITLE
Queue Spec | Fix date format check

### DIFF
--- a/spec/feature/queue_spec.rb
+++ b/spec/feature/queue_spec.rb
@@ -159,7 +159,7 @@ RSpec.feature "Queue" do
         safe_click("a[href='/queue/tasks/#{appeal.vacols_id}']")
 
         expect(page).to have_content("Hearing Preference: #{hearing.type.capitalize}")
-        expect(page).to have_content("Hearing held: #{hearing.date.strftime('%-m/%e/%y')}")
+        expect(page).to have_content("Hearing held: #{hearing.date.strftime('%-m/%-e/%y')}")
         expect(page).to have_content("Judge at hearing: #{hearing.user.full_name}")
 
         worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet']")


### PR DESCRIPTION
Earlier today, [Chris experienced](https://dsva.slack.com/archives/C54QCEHAL/p1518727344000096) repeated failures from `queue_spec`:

```
1) Queue loads task detail views loads appeal summary view appeal has hearing
     Failure/Error: expect(page).to have_content("Hearing held: #{hearing.date.
strftime('%-m/%e/%y')}")
       expected to find text "Hearing held: 3/ 1/18" in "...Hearing held: 3/1/18...
```

This fix removes padding from the day field in this test.