### PR TITLE
Caseflow | Use EFolderService for all apps

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -127,7 +127,11 @@ class Appeal < ActiveRecord::Base
   end
 
   def number_of_documents_url
-    EFolderService.efolder_files_url
+    if Rails.env.production? || Rails.env.staging?
+      ExternalApi::EfolderService.efolder_files_url
+    else
+      "/queue/#{id}/docs"
+    end
   end
 
   def number_of_documents_after_certification

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -127,11 +127,7 @@ class Appeal < ActiveRecord::Base
   end
 
   def number_of_documents_url
-    if document_service == ExternalApi::EfolderService
-      ExternalApi::EfolderService.efolder_files_url
-    else
-      "/queue/#{id}/docs"
-    end
+    EFolderService.efolder_files_url
   end
 
   def number_of_documents_after_certification
@@ -578,7 +574,7 @@ class Appeal < ActiveRecord::Base
   def fetch_documents_from_service!
     return if @fetched_documents
 
-    doc_struct = document_service.fetch_documents_for(self, RequestStore.store[:current_user])
+    doc_struct = EFolderService.fetch_documents_for(self, RequestStore.store[:current_user])
 
     @fetched_documents = doc_struct[:documents]
     @manifest_vbms_fetched_at = doc_struct[:manifest_vbms_fetched_at].try(:in_time_zone)
@@ -591,12 +587,7 @@ class Appeal < ActiveRecord::Base
   end
 
   def document_service
-    @document_service ||=
-      if ["dispatch", :certification].include? RequestStore.store[:application]
-        VBMSService
-      else
-        EFolderService
-      end
+    @document_service ||= VBMSService
   end
 
   # Used for serialization

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -592,8 +592,7 @@ class Appeal < ActiveRecord::Base
 
   def document_service
     @document_service ||=
-      if (RequestStore.store[:application] == "reader" || RequestStore.store[:application] == "hearings") &&
-         FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
+      if FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
         EFolderService
       else
         VBMSService

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -590,10 +590,6 @@ class Appeal < ActiveRecord::Base
     @fetched_documents
   end
 
-  def document_service
-    @document_service ||= VBMSService
-  end
-
   # Used for serialization
   def regional_office_hash
     regional_office.to_h

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -591,12 +591,7 @@ class Appeal < ActiveRecord::Base
   end
 
   def document_service
-    @document_service ||=
-      if FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
-        EFolderService
-      else
-        VBMSService
-      end
+    @document_service ||= EFolderService
   end
 
   # Used for serialization

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -591,7 +591,12 @@ class Appeal < ActiveRecord::Base
   end
 
   def document_service
-    @document_service ||= EFolderService
+    @document_service ||=
+      if ["dispatch", :certification].include? RequestStore.store[:application]
+        VBMSService
+      else
+        EFolderService
+      end
   end
 
   # Used for serialization

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -202,7 +202,6 @@ class Document < ActiveRecord::Base
 
   def reader_with_efolder_api?
     EFolderService == ExternalApi::EfolderService &&
-      RequestStore.store[:application] == "reader" &&
       FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
   end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -202,6 +202,7 @@ class Document < ActiveRecord::Base
 
   def reader_with_efolder_api?
     EFolderService == ExternalApi::EfolderService &&
+      RequestStore.store[:application] == "reader" &&
       FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
   end
 


### PR DESCRIPTION
Following [user feedback](https://dsva.slack.com/archives/C2ZBKPMND/p1518722771000350) mentioning incorrect / inconsistent document counts in Queue and Reader in production, Mark discovered that Queue was fetching the document count from Reader: [`Appeal.number_of_documents_url`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/appeal.rb#L129) was returning the incorrect URL. After a change to [`RequestStore.store[:application]`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/controllers/queue_controller.rb#L5) in Queue, [`Appeal.document_service`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/appeal.rb#L593) no longer returned the correct service (`ExternalApi::EfolderService`) when using Queue.

At this point, there is [no reason](https://dsva.slack.com/archives/C2ZBKPMND/p1518724915000674?thread_ts=1518722771.000350&cid=C2ZBKPMND) for any app not to have access to `ExternalApi::EfolderService`. This removes the `RequestStore.store[:application]` restrictions.