### PR TITLE
Filter out duplicate tasks for judges and attorneys

### DIFF
--- a/app/models/vacols/case_assignment.rb
+++ b/app/models/vacols/case_assignment.rb
@@ -10,7 +10,6 @@ class VACOLS::CaseAssignment < VACOLS::Record
       id = connection.quote(css_id.upcase)
 
       select_assignments.where("staff.sdomainid = #{id}")
-        .where("decass.decomp is null")
     end
 
     # Valid case assignments must have an associated staff table
@@ -50,7 +49,6 @@ class VACOLS::CaseAssignment < VACOLS::Record
       id = connection.quote(css_id.upcase)
 
       select_tasks.where("s2.sdomainid = #{id}")
-        .where("decass.decomp is null")
     end
 
     def select_tasks

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -79,9 +79,15 @@ class QueueRepository
 
   # :nocov:
   def self.tasks_query(css_id)
-    VACOLS::CaseAssignment.tasks_for_user(css_id)
+    records = VACOLS::CaseAssignment.tasks_for_user(css_id)
+    filter_duplicate_tasks(records)
   end
   # :nocov:
+
+  def self.filter_duplicate_tasks(records)
+    # Keep the latest assignment if there are duplicate records
+    records.group_by(&:vacols_id).each_with_object([]) { |(_k, v), result| result << v.sort_by(&:date_assigned).last }
+  end
 
   # :nocov:
   def self.appeal_info_query(vacols_ids)

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -1,4 +1,5 @@
 class QueueRepository
+  # :nocov:
   def self.tasks_for_user(css_id)
     MetricsService.record("VACOLS: fetch user tasks",
                           service: :vacols,
@@ -32,6 +33,7 @@ class QueueRepository
     appeals.map(&:save)
     appeals
   end
+  # :nocov:
 
   # :nocov:
   def self.find_case(vacols_id, css_id)

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -429,6 +429,7 @@ class AppealRepository
                           service: :vacols,
                           name: "active_cases_for_user") do
       active_cases_for_user = VACOLS::CaseAssignment.active_cases_for_user(css_id)
+      active_cases_for_user = QueueRepository.filter_duplicate_tasks(active_cases_for_user)
       active_cases_vacols_ids = active_cases_for_user.map(&:vacols_id)
       active_cases_aod_results = VACOLS::Case.aod(active_cases_vacols_ids)
       active_cases_issues = VACOLS::CaseIssue.descriptions(active_cases_vacols_ids)

--- a/spec/repositories/queue_repository_spec.rb
+++ b/spec/repositories/queue_repository_spec.rb
@@ -1,0 +1,28 @@
+describe QueueRepository do
+  before do
+    Timecop.freeze(Time.utc(2017, 10, 4))
+    Time.zone = "America/Chicago"
+  end
+
+  context ".filter_duplicate_tasks" do
+
+    subject { QueueRepository.filter_duplicate_tasks(tasks) }
+
+    let(:tasks) do
+      [
+        OpenStruct.new(vacols_id: "123C", date_assigned: 3.days.ago),
+        OpenStruct.new(vacols_id: "123B", date_assigned: 5.days.ago),
+        OpenStruct.new(vacols_id: "123C", date_assigned: 2.days.ago),
+        OpenStruct.new(vacols_id: "123C", date_assigned: 9.days.ago),
+        OpenStruct.new(vacols_id: "123A", date_assigned: 9.days.ago)
+        ]
+    end
+
+    it "should filter duplicate tasks and keep the latest" do
+      expect(subject.size).to eq 3
+      expect(subject).to include tasks.third
+      expect(subject).to include tasks.second
+      expect(subject).to include tasks.last
+    end
+  end
+end

--- a/spec/repositories/queue_repository_spec.rb
+++ b/spec/repositories/queue_repository_spec.rb
@@ -5,7 +5,6 @@ describe QueueRepository do
   end
 
   context ".filter_duplicate_tasks" do
-
     subject { QueueRepository.filter_duplicate_tasks(tasks) }
 
     let(:tasks) do
@@ -15,7 +14,7 @@ describe QueueRepository do
         OpenStruct.new(vacols_id: "123C", date_assigned: 2.days.ago),
         OpenStruct.new(vacols_id: "123C", date_assigned: 9.days.ago),
         OpenStruct.new(vacols_id: "123A", date_assigned: 9.days.ago)
-        ]
+      ]
     end
 
     it "should filter duplicate tasks and keep the latest" do


### PR DESCRIPTION
We received some reports that judges are not seeing cases in their welcome gate reader page. We added `.where("decass.decomp is null")` to filter out duplicates which was not 100% correct because judges might have two DECASS records (where one of them has decomp nil) and they can also have only one DECASS record (where it has decomp date). Solution is to always return only the latest assignment.  