### PR TITLE
An issue without a disposition should be marked as nil, not :other

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -206,7 +206,7 @@ class Issue
         labels: hash.key?("issprog_label") ? parse_labels_from_vacols(hash) : :not_loaded,
         note: hash["issdesc"],
         # disposition is a snake_case symbol, i.e. :remanded
-        disposition: (VACOLS::Case::DISPOSITIONS[hash["issdc"]] || "other").parameterize.underscore.to_sym,
+        disposition: (VACOLS::Case::DISPOSITIONS[hash["issdc"]]).parameterize.underscore.to_sym,
         # readable disposition is a string, i.e. "Remanded"
         readable_disposition: (VACOLS::Case::DISPOSITIONS[hash["issdc"]]),
         close_date: AppealRepository.normalize_vacols_date(hash["issdcls"])


### PR DESCRIPTION
connects #4666 

Steps taken to ensure this does not cause a regression:

* Looked for any instance of checking an issue for the `:other` disposition.
* This code dates back to the [original commit](https://github.com/department-of-veterans-affairs/caseflow/commit/e0415c8afe8b2cab10a1ad791fa72f56f123a0e1#diff-b4d2426dbdcb62ca15098fd8b5be9f0dR53) on this file.