### PR TITLE
Queue | Use EFolderService

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -592,8 +592,7 @@ class Appeal < ActiveRecord::Base
 
   def document_service
     @document_service ||=
-      if %w[reader queue hearings].include?(RequestStore.store[:application]) &&
-         FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
+      if %w[reader queue hearings].include?(RequestStore.store[:application])
         EFolderService
       else
         VBMSService

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -592,7 +592,7 @@ class Appeal < ActiveRecord::Base
 
   def document_service
     @document_service ||=
-      if (RequestStore.store[:application] == "reader" || RequestStore.store[:application] == "hearings") &&
+      if %w[reader queue hearings].include?(RequestStore.store[:application]) &&
          FeatureToggle.enabled?(:efolder_docs_api, user: RequestStore.store[:current_user])
         EFolderService
       else


### PR DESCRIPTION
Following [user feedback](https://dsva.slack.com/archives/C2ZBKPMND/p1518722771000350) mentioning incorrect / inconsistent document counts in Queue and Reader in production, Mark discovered that Queue was fetching the document count from Reader: [`Appeal.number_of_documents_url`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/appeal.rb#L129) was returning the incorrect URL. After a change to [`RequestStore.store[:application]`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/controllers/queue_controller.rb#L5) in Queue, [`Appeal.document_service`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/appeal.rb#L593) no longer returned the correct service (`ExternalApi::EfolderService`) when using Queue.

Previously, we enabled `EFolderService` for all applications (#4657), but this broke part of dispatch, and was reverted in #4689. This enables the service only for Queue.