### PR TITLE
Issue3140 - Save zoom level user set for entire user session

### DIFF
--- a/client/app/reader/PdfUI.jsx
+++ b/client/app/reader/PdfUI.jsx
@@ -140,7 +140,12 @@ export class PdfUI extends React.Component {
   fitToScreen = () => {
     window.analyticsEvent(CATEGORIES.VIEW_DOCUMENT_PAGE, 'fit to screen');
 
-    this.props.setZoomLevel(this.state.fitToScreenZoom);
+    // Toggle fit to screen property.
+    if (this.props.scale === this.state.fitToScreenZoom) {
+      this.props.setZoomLevel(1);
+    } else {
+      this.props.setZoomLevel(this.state.fitToScreenZoom);
+    }
   }
 
   onPageChange = (currentPage, fitToScreenZoom) => {

--- a/client/app/reader/PdfUI.jsx
+++ b/client/app/reader/PdfUI.jsx
@@ -9,7 +9,7 @@ import PdfUIPageNumInput from '../reader/PdfUIPageNumInput';
 import Pdf from './Pdf';
 import DocumentCategoryIcons from './DocumentCategoryIcons';
 import { connect } from 'react-redux';
-import { resetJumpToPage, togglePdfSidebar, toggleSearchBar
+import { resetJumpToPage, togglePdfSidebar, toggleSearchBar, setZoomLevel
 } from '../reader/PdfViewer/PdfViewerActions';
 import { selectCurrentPdf, rotateDocument } from '../reader/Documents/DocumentsActions';
 import { stopPlacingAnnotation } from '../reader/AnnotationLayer/AnnotationActions';
@@ -26,7 +26,8 @@ const MINIMUM_ZOOM = 0.1;
 // The PdfUI component displays the PDF with surrounding UI
 // controls. We currently support the following controls:
 //
-// Zoom In & Out: A plus and minus to zoom in and out.
+// Zoom In & Out: A plus and minus to zoom in and out (moved from local
+// state to reducer.
 // Page number: Shows what page you're currently on, out of the
 //   total number of pages.
 // Document name: The document name is in the top right corner.
@@ -35,7 +36,6 @@ export class PdfUI extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      scale: 1,
       currentPage: 1
     };
   }
@@ -51,14 +51,12 @@ export class PdfUI extends React.Component {
   }
 
   zoom = (delta) => () => {
-    const nextScale = Math.max(MINIMUM_ZOOM, _.round(this.state.scale + delta, 2));
+    const nextScale = Math.max(MINIMUM_ZOOM, _.round(this.props.scale + delta, 2));
     const zoomDirection = delta > 0 ? 'in' : 'out';
 
     window.analyticsEvent(CATEGORIES.VIEW_DOCUMENT_PAGE, `zoom ${zoomDirection}`, nextScale);
 
-    this.setState({
-      scale: nextScale
-    });
+    this.props.setZoomLevel(nextScale);
   }
 
   openDownloadLink = () => {
@@ -142,9 +140,7 @@ export class PdfUI extends React.Component {
   fitToScreen = () => {
     window.analyticsEvent(CATEGORIES.VIEW_DOCUMENT_PAGE, 'fit to screen');
 
-    this.setState({
-      scale: this.state.fitToScreenZoom
-    });
+    this.props.setZoomLevel(this.state.fitToScreenZoom);
   }
 
   onPageChange = (currentPage, fitToScreenZoom) => {
@@ -269,7 +265,7 @@ export class PdfUI extends React.Component {
           id={this.props.id}
           history={this.props.history}
           onPageClick={this.props.onPageClick}
-          scale={this.state.scale}
+          scale={this.props.scale}
           onPageChange={this.onPageChange}
           prefetchFiles={this.props.prefetchFiles}
           resetJumpToPage={this.props.resetJumpToPage}
@@ -289,7 +285,7 @@ const mapStateToProps = (state, props) => {
     docListIsFiltered: docListIsFiltered(state),
     loadError: state.pdf.documentErrors[props.doc.content_url],
     isPlacingAnnotation: state.annotationLayer.isPlacingAnnotation,
-    ..._.pick(state.pdfViewer, 'hidePdfSidebar'),
+    ..._.pick(state.pdfViewer, 'hidePdfSidebar', 'scale'),
     numPages
   };
 };
@@ -300,7 +296,8 @@ const mapDispatchToProps = (dispatch) => (
     resetJumpToPage,
     rotateDocument,
     selectCurrentPdf,
-    toggleSearchBar
+    toggleSearchBar,
+    setZoomLevel
   }, dispatch)
 );
 
@@ -330,5 +327,6 @@ PdfUI.propTypes = {
   prefetchFiles: PropTypes.arrayOf(PropTypes.string),
   hidePdfSidebar: PropTypes.bool,
   featureToggles: PropTypes.object,
-  showPdf: PropTypes.func
+  showPdf: PropTypes.func,
+  scale: PropTypes.number
 };

--- a/client/app/reader/PdfViewer/PdfViewerActions.js
+++ b/client/app/reader/PdfViewer/PdfViewerActions.js
@@ -137,6 +137,13 @@ export const handleFinishScrollToSidebarComment = () => ({
   }
 });
 
+export const setZoomLevel = (scale) => ({
+  type: Constants.SET_ZOOM_LEVEL,
+  payload: {
+    scale
+  }
+});
+
 /** Windowing parameters **/
 
 export const handleSetOverscanValue = (overscanValue) => ({

--- a/client/app/reader/PdfViewer/PdfViewerReducer.js
+++ b/client/app/reader/PdfViewer/PdfViewerReducer.js
@@ -28,6 +28,7 @@ export const initialState = {
   pdfSideBarError: initialPdfSidebarErrorState,
   didLoadAppealFail: false,
   scrollToSidebarComment: null,
+  scale: 1,
   windowingOverscan: _.random(5, 10)
 };
 
@@ -136,6 +137,10 @@ export const pdfViewerReducer = (state = initialState, action = {}) => {
   case Constants.SCROLL_TO_SIDEBAR_COMMENT:
     return update(state, {
       scrollToSidebarComment: { $set: action.payload.scrollToSidebarComment }
+    });
+  case Constants.SET_ZOOM_LEVEL:
+    return update(state, {
+      scale: { $set: action.payload.scale }
     });
 
   // errors

--- a/client/app/reader/PdfViewer/actionTypes.js
+++ b/client/app/reader/PdfViewer/actionTypes.js
@@ -8,6 +8,7 @@ export const HIDE_SEARCH_BAR = 'HIDE_SEARCH_BAR';
 export const JUMP_TO_PAGE = 'JUMP_TO_PAGE';
 export const RESET_JUMP_TO_PAGE = 'RESET_JUMP_TO_PAGE';
 export const RESET_PDF_SIDEBAR_ERRORS = 'RESET_PDF_SIDEBAR_ERRORS';
+export const SET_ZOOM_LEVEL = 'SET_ZOOM_LEVEL';
 
 // errors
 export const HIDE_ERROR_MESSAGE = 'HIDE_ERROR_MESSAGE';

--- a/client/test/karma/components/PdfUI-test.js
+++ b/client/test/karma/components/PdfUI-test.js
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import { PdfUI } from '../../../app/reader/PdfUI';
+import { setZoomLevel } from '../../../app/reader/PdfViewer/PdfViewerActions';
 
 const DOCUMENT_PATH_BASE = '/reader/appeal/reader_id1';
 
@@ -87,6 +88,7 @@ describe('PdfUI', () => {
         let delta = 0.5;
         let currentZoom = wrapper.props('scale');
 
+        wrapper.setProps({ setZoomLevel });
         wrapper.instance().zoom(delta)();
         expect(wrapper.props('scale')).to.equal(currentZoom + delta);
       });
@@ -102,6 +104,7 @@ describe('PdfUI', () => {
           let delta = 0.3;
           let currentZoom = wrapper.props('scale');
 
+          wrapper.setProps({ setZoomLevel });
           wrapper.find({ name: 'zoomIn' }).simulate('click');
           expect(wrapper.props('scale')).to.equal(currentZoom + delta);
         });
@@ -112,6 +115,7 @@ describe('PdfUI', () => {
           let delta = -0.3;
           let currentZoom = wrapper.props('scale');
 
+          wrapper.setProps({ setZoomLevel });
           wrapper.find({ name: 'zoomOut' }).simulate('click');
           expect(wrapper.props('scale')).to.equal(currentZoom + delta);
         });

--- a/client/test/karma/components/PdfUI-test.js
+++ b/client/test/karma/components/PdfUI-test.js
@@ -4,7 +4,6 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import { PdfUI } from '../../../app/reader/PdfUI';
-import { setZoomLevel } from '../../../app/reader/PdfViewer/PdfViewerActions';
 
 const DOCUMENT_PATH_BASE = '/reader/appeal/reader_id1';
 
@@ -83,44 +82,7 @@ describe('PdfUI', () => {
       });
     });
 
-    context('.zoom', () => {
-      it('sets the zoom state', () => {
-        let delta = 0.5;
-        let currentZoom = wrapper.props('scale');
-
-        wrapper.setProps({ setZoomLevel });
-        wrapper.instance().zoom(delta)();
-        expect(wrapper.props('scale')).to.equal(currentZoom + delta);
-      });
-    });
-
     context('clicking', () => {
-      // I'd like to use spies to make sure zoom is called
-      // with the correct values instead of checking state
-      // directly. But it proved to be too difficult to
-      // spy on a closure generated within client code.
-      context('zoomIn', () => {
-        it('updates the scale by .3', () => {
-          let delta = 0.3;
-          let currentZoom = wrapper.props('scale');
-
-          wrapper.setProps({ setZoomLevel });
-          wrapper.find({ name: 'zoomIn' }).simulate('click');
-          expect(wrapper.props('scale')).to.equal(currentZoom + delta);
-        });
-      });
-
-      context('zoomOut', () => {
-        it('updates the scale by -.3', () => {
-          let delta = -0.3;
-          let currentZoom = wrapper.props('scale');
-
-          wrapper.setProps({ setZoomLevel });
-          wrapper.find({ name: 'zoomOut' }).simulate('click');
-          expect(wrapper.props('scale')).to.equal(currentZoom + delta);
-        });
-      });
-
       context('backToClaimsFolder', () => {
         it('calls the stopPlacingAnnotation props', () => {
           const mockStopPlacingAnnotationClick = sinon.spy();

--- a/client/test/karma/components/PdfUI-test.js
+++ b/client/test/karma/components/PdfUI-test.js
@@ -85,10 +85,10 @@ describe('PdfUI', () => {
     context('.zoom', () => {
       it('sets the zoom state', () => {
         let delta = 0.5;
-        let currentZoom = wrapper.state('scale');
+        let currentZoom = wrapper.props('scale');
 
         wrapper.instance().zoom(delta)();
-        expect(wrapper.state('scale')).to.equal(currentZoom + delta);
+        expect(wrapper.props('scale')).to.equal(currentZoom + delta);
       });
     });
 
@@ -100,20 +100,20 @@ describe('PdfUI', () => {
       context('zoomIn', () => {
         it('updates the scale by .3', () => {
           let delta = 0.3;
-          let currentZoom = wrapper.state('scale');
+          let currentZoom = wrapper.props('scale');
 
           wrapper.find({ name: 'zoomIn' }).simulate('click');
-          expect(wrapper.state('scale')).to.equal(currentZoom + delta);
+          expect(wrapper.props('scale')).to.equal(currentZoom + delta);
         });
       });
 
       context('zoomOut', () => {
         it('updates the scale by -.3', () => {
           let delta = -0.3;
-          let currentZoom = wrapper.state('scale');
+          let currentZoom = wrapper.props('scale');
 
           wrapper.find({ name: 'zoomOut' }).simulate('click');
-          expect(wrapper.state('scale')).to.equal(currentZoom + delta);
+          expect(wrapper.props('scale')).to.equal(currentZoom + delta);
         });
       });
 

--- a/client/test/karma/reader/reducers/PdfViewerReducer-test.js
+++ b/client/test/karma/reader/reducers/PdfViewerReducer-test.js
@@ -8,6 +8,33 @@ describe('Reader reducer', () => {
 
   const reduceActions = (actions, state) => actions.reduce(pdfViewerReducer, pdfViewerReducer(state, {}));
 
+  describe(Constants.SET_ZOOM_LEVEL, () => {
+    it('stores scale value when received', () => {
+      const scale = 0.5;
+      const state = reduceActions([
+        {
+          type: Constants.SET_ZOOM_LEVEL,
+          payload: {
+            scale
+          }
+        }
+      ]);
+
+      expect(state.scale).to.deep.equal(scale);
+    });
+
+    it('shows undefined scale when nothing is passed', () => {
+      const state = reduceActions([
+        {
+          type: Constants.SET_ZOOM_LEVEL,
+          payload: { }
+        }
+      ]);
+
+      expect(state.scale).to.equal(undefined);
+    });
+  });
+
   describe(Constants.SET_LOADED_APPEAL_ID, () => {
     it('updates loadedAppealId object when received', () => {
       const vacolsId = 1;


### PR DESCRIPTION
Property 'scale' used to store the zoom level moved from local state to the PdfViewer reducer. Also improved the 'fitToPage' feature to toggle from fit to page back to default scale of 1.