### PR TITLE
Queue/Reader breadcrumbs | Navigate back to Queue from any Reader claims folder

### DIFF
--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -40,6 +40,7 @@ class QueueApp extends React.PureComponent {
     <CaseSelectSearch
       navigateToPath={(path) => {
         const redirectUrl = encodeURIComponent(window.location.pathname);
+
         location.href = `/reader/appeal${path}?queue_redirect_url=${redirectUrl}`;
       }}
       alwaysShowCaseSelectionModal

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -38,7 +38,10 @@ const searchStyling = (isRequestingAppealsUsingVeteranId) => css({
 class QueueApp extends React.PureComponent {
   routedQueueList = () => <QueueLoadingScreen {...this.props}>
     <CaseSelectSearch
-      navigateToPath={(path) => window.location.href = `/reader/appeal${path}`}
+      navigateToPath={(path) => {
+        const redirectUrl = encodeURIComponent(window.location.pathname);
+        location.href = `/reader/appeal${path}?queue_redirect_url=${redirectUrl}`;
+      }}
       alwaysShowCaseSelectionModal
       feedbackUrl={this.props.feedbackUrl}
       searchSize="big"

--- a/spec/feature/queue_spec.rb
+++ b/spec/feature/queue_spec.rb
@@ -96,6 +96,7 @@ RSpec.feature "Queue" do
       click_on "Okay"
 
       expect(page).to have_content("#{appeal.veteran_full_name}'s Claims Folder")
+      expect(page).to have_link("Back to Your Queue", href: "/queue")
     end
   end
 


### PR DESCRIPTION
Connects #4701 

## AC
- [ ] Navigate to `/queue`, search for case, navigate to it
- [ ] Confirm `< Back to your queue` link displayed, links back to `/queue`.