### PR TITLE
Hearing Prep | Time zone update

### DIFF
--- a/client/app/hearings/components/DocketHearingRow.jsx
+++ b/client/app/hearings/components/DocketHearingRow.jsx
@@ -86,7 +86,7 @@ export class DocketHearingRow extends React.PureComponent {
 
     let getRoTime = (date) => {
       return moment(date).tz(roTimeZone).
-        format('h:mm a z');
+        format('h:mm a z').replace(/(\w)(DT|ST)/g, "$1T");
     };
 
     // Appellant differs Veteran

--- a/client/app/hearings/components/DocketHearingRow.jsx
+++ b/client/app/hearings/components/DocketHearingRow.jsx
@@ -86,7 +86,8 @@ export class DocketHearingRow extends React.PureComponent {
 
     let getRoTime = (date) => {
       return moment(date).tz(roTimeZone).
-        format('h:mm a z').replace(/(\w)(DT|ST)/g, "$1T");
+        format('h:mm a z').
+        replace(/(\w)(DT|ST)/g, '$1T');
     };
 
     // Appellant differs Veteran

--- a/client/app/hearings/util/DateUtil.js
+++ b/client/app/hearings/util/DateUtil.js
@@ -3,7 +3,8 @@ import 'moment-timezone';
 
 export const getDateTime = (date) => {
   return moment(date).tz('America/New_York').
-    format('h:mm a z').replace(/(\w)(DT|ST)/g, "$1T");
+    format('h:mm a z').
+    replace(/(\w)(DT|ST)/g, '$1T');
 };
 
 export const getDate = (date) => {

--- a/client/app/hearings/util/DateUtil.js
+++ b/client/app/hearings/util/DateUtil.js
@@ -3,7 +3,7 @@ import 'moment-timezone';
 
 export const getDateTime = (date) => {
   return moment(date).tz('America/New_York').
-    format('h:mm a z');
+    format('h:mm a z').replace(/(\w)(DT|ST)/g, "$1T");
 };
 
 export const getDate = (date) => {


### PR DESCRIPTION
Connects #4494
AC:
Update time zones across the app to be ET/CT/MT/PT on Your Hearing Day, and Daily Docket.

<img width="1086" alt="screen shot 2018-02-22 at 2 26 06 pm" src="https://user-images.githubusercontent.com/23080951/36559577-684d7bfa-17dc-11e8-8bbb-26c7d9d37d41.png">

**Screenshot2**
<img width="1092" alt="screen shot 2018-02-22 at 2 25 47 pm" src="https://user-images.githubusercontent.com/23080951/36559582-6f8e2964-17dc-11e8-90fa-cbd93fdf0902.png">