### PR TITLE
Update BGS dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "wannabe_bool"
 gem "uswds-rails", git: "https://github.com/18F/uswds-rails-gem.git"
 
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "e30db7fdf6f5c28c09d6081d062cad80820240a0"
 
 # PDF Tools
 gem "pdf-forms"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a
-  ref: 416f7a4ee49c7c80160e97416e7c7b0a7bd20a4a
+  revision: e30db7fdf6f5c28c09d6081d062cad80820240a0
+  ref: e30db7fdf6f5c28c09d6081d062cad80820240a0
   specs:
     bgs (0.1)
       nokogiri (~> 1.8.2)
@@ -206,7 +206,7 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     httpclient (2.8.3)
-    httpi (2.4.2)
+    httpi (2.4.3)
       rack
       socksify
     i18n (0.9.1)
@@ -386,12 +386,12 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    savon (2.11.2)
+    savon (2.12.0)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
       httpi (~> 2.3)
-      nokogiri (>= 1.4.0)
+      nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
     sawyer (0.8.1)


### PR DESCRIPTION
A [recent change](https://github.com/department-of-veterans-affairs/ruby-bgs/pull/50) to the ruby-bgs gem resolves an issue that was resulting in an uncaught NoMethodError. This change incorporates those changes from the latest version of the ruby-bgs gem.