### PR TITLE
Fixing two bugs in our calling of the eX service

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -36,8 +36,6 @@ class ExternalApi::EfolderService
   def self.efolder_v2_api(vbms_id, user)
     headers = { "FILE-NUMBER" => vbms_id }
 
-    response_attrs = {}
-
     response = send_efolder_request("/api/v2/manifests", user, headers, method: :post)
 
     TRIES.times do

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -47,15 +47,18 @@ class ExternalApi::EfolderService
 
       fail Caseflow::Error::DocumentRetrievalError if response_attrs["sources"].blank?
 
-      break if response_attrs["sources"].select { |s| s["status"] == "pending" }.blank?
+      if response_attrs["sources"].select { |s| s["status"] == "pending" }.blank?
+        return generate_response(response_attrs, vbms_id)
+      end
+
       sleep 1
 
-      manifest_id = response_attrs["id"]
+      manifest_id = JSON.parse(response.body)["data"]["id"]
 
       response = send_efolder_request("/api/v2/manifests/#{manifest_id}", user, headers)
     end
 
-    generate_response(response_attrs, vbms_id)
+    fail Caseflow::Error::DocumentRetrievalError
   end
 
   def self.generate_response(response_attrs, vbms_id)


### PR DESCRIPTION
Whoopsies, made a mistake in the last PR. I need to get the id from `JSON.parse(response.body)["data"]["id"]` not `response_attrs["id"]` I think last time I tested the results were already calculated so the first post responded with the correct output. I also noticed that if we never got a valid response, we didn't throw an error. I reworked the loop to fail at the end and return directly from the loop.