### PR TITLE
Adding RO78 as unknown...

### DIFF
--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -380,7 +380,7 @@ class RegionalOffice
       timezone: "America/Los_Angeles"
     },
     "RO78" => {
-      label: "Unknown regional office",
+      label: "Unknown regional office (RO78)",
       city: "Unknown", state: "??",
       timezone: "America/New_York"
     },

--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -380,7 +380,7 @@ class RegionalOffice
       timezone: "America/Los_Angeles"
     },
     "RO78" => {
-      label: "Unknown regional office (RO78)",
+      label: "Legacy RO (RO78)",
       city: "Unknown", state: "??",
       timezone: "America/New_York"
     },

--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -379,6 +379,11 @@ class RegionalOffice
       city: "San Diego", state: "CA",
       timezone: "America/Los_Angeles"
     },
+    "RO78" => {
+      label: "Unknown regional office",
+      city: "Unknown", state: "??",
+      timezone: "America/New_York"
+    },
     "RO79" => { city: "St. Paul Regional Loan Center", state: "MN", timezone: "America/Chicago" },
     "RO80" => { city: "Philadelphia Insurance Center", state: "PA", timezone: "America/New_York" },
     "RO81" => { city: "Philadelphia Pension Center", state: "PA", timezone: "America/New_York" },


### PR DESCRIPTION
There are 5 cases in VACOLS with RO78. We do not know what this RO is, so we're adding it to our list as "unknown" so that users can load the Reader welcome gate even if they have a case with RO78. Currently it throws an error.

![screen shot 2018-03-02 at 3 59 00 pm](https://user-images.githubusercontent.com/3885236/36921544-b7a102ec-1e32-11e8-9f28-c065d720d7b1.png)
