### PR TITLE
Mock response in test suite rather than going to sqs

### DIFF
--- a/spec/controllers/api/v1/jobs_controller_spec.rb
+++ b/spec/controllers/api/v1/jobs_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe Api::V1::JobsController, type: :controller do
     end
 
     it "should successfully start HeartbeatTasksJob asynchronously" do
+      allow(HeartbeatTasksJob).to receive(:perform_later).and_return(HeartbeatTasksJob.new)
       post :create, "job_type": "heartbeat"
       expect(response.status).to eq 200
       expect(response_body["job_id"]).not_to be_empty


### PR DESCRIPTION
This should allow for test cases to pass even if invalid AWS credentials exist.  While I'm not sure why this was failing for @ferlatte, it's still better practice not to have our test suite hit the SQS dependency. 