### PR TITLE
Updating issues_pulled when issues are pulled

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -476,7 +476,12 @@ class Appeal < ActiveRecord::Base
   # If we do not yet have the worksheet issues saved in Caseflow's DB, then
   # we want to fetch it from VACOLS, save it to the DB, then return it
   def worksheet_issues
-    issues.each { |i| WorksheetIssue.create_from_issue(self, i) } if super.empty?
+    if super.empty?
+      transaction do
+        issues.each { |i| WorksheetIssue.create_from_issue(self, i) }
+        update!(issues_pulled: true)
+      end
+    end
     super
   end
 


### PR DESCRIPTION
Part 2/4

Connects #4673 

Part 3 will be running a job in production to update issues_pulled for appeals that already have worksheet_issues in the db
Part 4 will be updating the check on line 479 in worksheet_issues in appeal.rb to check issues_pulled instead of super.empty?

To test: 
Confirm issues_pulled is updated when running 'appeal.worksheet_issues' for an appeal with no worksheet_issues in the console