### PR TITLE
Endpoint to delete issues from VACOLS

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -10,34 +10,34 @@ class IssuesController < ApplicationController
   def create
     return record_not_found unless appeal
 
-    record = Issue.create_in_vacols!(
+    Issue.create_in_vacols!(
       css_id: current_user.css_id,
       issue_attrs: create_params
     )
-    render json: { issue: record }, status: :created
+    render json: { issues: appeal.issues }, status: :created
   end
 
   def update
     return record_not_found unless appeal
 
-    record = Issue.update_in_vacols!(
+    Issue.update_in_vacols!(
       css_id: current_user.css_id,
       vacols_id: appeal.vacols_id,
       vacols_sequence_id: params[:vacols_sequence_id],
       issue_attrs: issue_params
     )
-    render json: { issue: record }, status: :ok
+    render json: { issues: appeal.issues }, status: :ok
   end
 
   def destroy
     return record_not_found unless appeal
 
-    record = Issue.delete_in_vacols!(
+    Issue.delete_in_vacols!(
       css_id: current_user.css_id,
       vacols_id: appeal.vacols_id,
       vacols_sequence_id: params[:vacols_sequence_id]
     )
-    render json: {}, status: :ok
+    render json: { issues: appeal.issues }, status: :ok
   end
 
   private

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -29,6 +29,17 @@ class IssuesController < ApplicationController
     render json: { issue: record }, status: :ok
   end
 
+  def destroy
+    return record_not_found unless appeal
+
+    record = Issue.delete_in_vacols!(
+      css_id: current_user.css_id,
+      vacols_id: appeal.vacols_id,
+      vacols_sequence_id: params[:vacols_sequence_id]
+    )
+    render json: {}, status: :ok
+  end
+
   private
 
   def appeal

--- a/app/mappers/issue_mapper.rb
+++ b/app/mappers/issue_mapper.rb
@@ -9,24 +9,43 @@ module IssueMapper
     vacols_id: :isskey
   }.freeze
 
-  def self.rename_and_validate_vacols_attrs(issue_attrs)
-    issue_attrs = slice_attributes(issue_attrs.symbolize_keys)
-    if IssueRepository.find_issue_reference(program: issue_attrs[:issprog],
-                                            issue: issue_attrs[:isscode],
-                                            level_1: issue_attrs[:isslev1],
-                                            level_2: issue_attrs[:isslev2],
-                                            level_3: issue_attrs[:isslev3]).size != 1
-      fail IssueRepository::IssueError, "Combination of VACOLS Issue codes is invalid: #{issue_attrs}"
-    end
-    issue_attrs
-  end
+  class << self
+    def rename_and_validate_vacols_attrs(slogid:, action:, issue_attrs:)
+      issue_attrs = rename(issue_attrs.symbolize_keys)
 
-  def self.slice_attributes(issue_attrs)
-    [:program, :issue, :level_1, :level_2, :level_3, :note, :vacols_id].each_with_object({}) do |k, result|
-      # skip only if the key is not passed, if the key is passed and the value is nil - include that
-      next unless issue_attrs.keys.include? k
-      result[COLUMN_NAMES[k]] = issue_attrs[k]
-      result
+      validate!(issue_attrs)
+
+      case action
+      when :create
+        issue_attrs[:issaduser] = slogid
+        issue_attrs[:issadtime] = VacolsHelper.local_time_with_utc_timezone
+      when :update
+        issue_attrs[:issmduser] = slogid
+        issue_attrs[:issmdtime] = VacolsHelper.local_time_with_utc_timezone
+      end
+      issue_attrs
+    end
+
+    private
+
+    def validate!(issue_attrs)
+      return if (issue_attrs.keys & [:issprog, :isscode, :isslev1, :isslev2, :isslev3]).empty?
+      if IssueRepository.find_issue_reference(program: issue_attrs[:issprog],
+                                              issue: issue_attrs[:isscode],
+                                              level_1: issue_attrs[:isslev1],
+                                              level_2: issue_attrs[:isslev2],
+                                              level_3: issue_attrs[:isslev3]).size != 1
+        fail IssueRepository::IssueError, "Combination of VACOLS Issue codes is invalid: #{issue_attrs}"
+      end
+    end
+
+    def rename(issue_attrs)
+      [:program, :issue, :level_1, :level_2, :level_3, :note, :vacols_id].each_with_object({}) do |k, result|
+        # skip only if the key is not passed, if the key is passed and the value is nil - include that
+        next unless issue_attrs.keys.include? k
+        result[COLUMN_NAMES[k]] = issue_attrs[k]
+        result
+      end
     end
   end
 end

--- a/app/mappers/issue_mapper.rb
+++ b/app/mappers/issue_mapper.rb
@@ -40,7 +40,7 @@ module IssueMapper
     end
 
     def rename(issue_attrs)
-      [:program, :issue, :level_1, :level_2, :level_3, :note, :vacols_id].each_with_object({}) do |k, result|
+      COLUMN_NAMES.keys.each_with_object({}) do |k, result|
         # skip only if the key is not passed, if the key is passed and the value is nil - include that
         next unless issue_attrs.keys.include? k
         result[COLUMN_NAMES[k]] = issue_attrs[k]

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -235,6 +235,14 @@ class Issue
       )
     end
 
+    def delete_in_vacols!(css_id:, vacols_id:, vacols_sequence_id:)
+      repository.delete_vacols_issue!(
+        css_id: css_id,
+        vacols_id: vacols_id,
+        vacols_sequence_id: vacols_sequence_id
+      )
+    end
+
     private
 
     def parse_codes_from_vacols(hash)

--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -111,5 +111,13 @@ class VACOLS::CaseIssue < VACOLS::Record
       update!(issue_attrs.merge(issmdtime: VacolsHelper.local_time_with_utc_timezone))
     end
   end
+
+  def delete_issue!
+    MetricsService.record("VACOLS: CaseIssue.delete_issue! for vacols ID #{isskey} and sequence ID: #{issseq}",
+                          service: :vacols,
+                          name: "CaseIssue.delete_issue") do
+      delete!
+    end
+  end
   # :nocov:
 end

--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -91,11 +91,7 @@ class VACOLS::CaseIssue < VACOLS::Record
   # rubocop:enable MethodLength
 
   def self.create_issue!(issue_attrs)
-    MetricsService.record("VACOLS: CaseIssue.create_issue! for #{issue_attrs[:isskey]}",
-                          service: :vacols,
-                          name: "CaseIssue.create_issue") do
-      create!(issue_attrs.merge(issseq: generate_sequence_id(issue_attrs[:isskey])))
-    end
+    create!(issue_attrs.merge(issseq: generate_sequence_id(issue_attrs[:isskey])))
   end
 
   def self.generate_sequence_id(vacols_id)
@@ -105,19 +101,11 @@ class VACOLS::CaseIssue < VACOLS::Record
   end
 
   def self.update_issue!(isskey, issseq, issue_attrs)
-    MetricsService.record("VACOLS: CaseIssue.update_issue! for vacols ID #{isskey} and sequence ID: #{issseq}",
-                          service: :vacols,
-                          name: "CaseIssue.update_issue") do
-      where(isskey: isskey, issseq: issseq).update_all(issue_attrs)
-    end
+    where(isskey: isskey, issseq: issseq).update_all(issue_attrs)
   end
 
   def self.delete_issue!(isskey, issseq)
-    MetricsService.record("VACOLS: CaseIssue.delete_issue! for vacols ID #{isskey} and sequence ID: #{issseq}",
-                          service: :vacols,
-                          name: "CaseIssue.delete_issue") do
-      where(isskey: isskey, issseq: issseq).delete_all
-    end
+    where(isskey: isskey, issseq: issseq).delete_all
   end
   # :nocov:
 end

--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -94,29 +94,29 @@ class VACOLS::CaseIssue < VACOLS::Record
     MetricsService.record("VACOLS: CaseIssue.create_issue! for #{issue_attrs[:isskey]}",
                           service: :vacols,
                           name: "CaseIssue.create_issue") do
-      create!(issue_attrs.merge(issadtime: VacolsHelper.local_time_with_utc_timezone,
-                                issseq: generate_sequence_id(issue_attrs[:isskey])))
+      create!(issue_attrs.merge(issseq: generate_sequence_id(issue_attrs[:isskey])))
     end
   end
 
   def self.generate_sequence_id(vacols_id)
     return unless vacols_id
-    descriptions(vacols_id)[vacols_id].count + 1
+    last_issue = (descriptions(vacols_id)[vacols_id] || []).sort_by { |k| k["issseq"] }.last
+    last_issue.present? ? last_issue["issseq"] + 1 : 1
   end
 
-  def update_issue!(issue_attrs)
+  def self.update_issue!(isskey, issseq, issue_attrs)
     MetricsService.record("VACOLS: CaseIssue.update_issue! for vacols ID #{isskey} and sequence ID: #{issseq}",
                           service: :vacols,
                           name: "CaseIssue.update_issue") do
-      update!(issue_attrs.merge(issmdtime: VacolsHelper.local_time_with_utc_timezone))
+      where(isskey: isskey, issseq: issseq).update_all(issue_attrs)
     end
   end
 
-  def delete_issue!
+  def self.delete_issue!(isskey, issseq)
     MetricsService.record("VACOLS: CaseIssue.delete_issue! for vacols ID #{isskey} and sequence ID: #{issseq}",
                           service: :vacols,
                           name: "CaseIssue.delete_issue") do
-      delete!
+      where(isskey: isskey, issseq: issseq).delete_all
     end
   end
   # :nocov:

--- a/app/repositories/issue_repository.rb
+++ b/app/repositories/issue_repository.rb
@@ -3,57 +3,56 @@ class IssueRepository
 
   # :nocov:
   def self.create_vacols_issue!(css_id:, issue_attrs:)
-    validate_access(css_id, issue_attrs[:vacols_id])
+    validate_access!(css_id, issue_attrs[:vacols_id])
 
-    issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(issue_attrs)
-    staff = find_staff_record(css_id)
+    issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(
+      slogid: slogid_based_on_css_id(css_id),
+      action: :create,
+      issue_attrs: issue_attrs
+    )
 
-    record = VACOLS::CaseIssue.create_issue!(issue_attrs.merge(issaduser: staff.slogid))
-
-    Issue.load_from_vacols(record.attributes)
+    VACOLS::CaseIssue.create_issue!(issue_attrs)
   end
 
   def self.update_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:, issue_attrs:)
-    validate_access(css_id, vacols_id)
+    validate_access!(css_id, vacols_id)
+    validate_issue_presence!(vacols_id, vacols_sequence_id)
 
-    record = VACOLS::CaseIssue.find_by(isskey: vacols_id, issseq: vacols_sequence_id)
+    issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(
+      slogid: slogid_based_on_css_id(css_id),
+      action: :update,
+      issue_attrs: issue_attrs
+    )
 
-     unless record
-      msg = "Cannot find issue with vacols ID: #{vacols_id} and sequence ID: #{vacols_sequence_id} in VACOLS"
-      fail IssueError, msg
-    end
-
-    issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(issue_attrs)
-    staff = find_staff_record(css_id)
-
-    record.update_issue!(issue_attrs.merge(issmduser: staff.slogid))
-
-    Issue.load_from_vacols(record.attributes)
+    VACOLS::CaseIssue.update_issue!(vacols_id, vacols_sequence_id, issue_attrs)
   end
 
   def self.delete_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:)
-    validate_access(css_id, vacols_id)
+    validate_access!(css_id, vacols_id)
+    validate_issue_presence!(vacols_id, vacols_sequence_id)
 
+    VACOLS::CaseIssue.delete_issue!(vacols_id, vacols_sequence_id)
+  end
+
+  def self.validate_issue_presence!(vacols_id, vacols_sequence_id)
     record = VACOLS::CaseIssue.find_by(isskey: vacols_id, issseq: vacols_sequence_id)
 
     unless record
       msg = "Cannot find issue with vacols ID: #{vacols_id} and sequence ID: #{vacols_sequence_id} in VACOLS"
       fail IssueError, msg
     end
-
-    record.delete_issue!
   end
 
-  def self.validate_access(css_id, vacols_id)
+  def self.validate_access!(css_id, vacols_id)
     unless QueueRepository.can_access_task?(css_id, vacols_id)
-      fail IssueError, "Current user cannot access task with vacols ID: #{vacols_id}"
+      fail IssueError, "Current user #{css_id} cannot access task with vacols ID: #{vacols_id}"
     end
   end
 
-  def self.find_staff_record(css_id)
+  def self.slogid_based_on_css_id(css_id)
     staff = VACOLS::Staff.find_by(sdomainid: css_id)
     fail IssueError, "Cannot find user with #{css_id} in VACOLS" unless staff
-    staff
+    staff.slogid
   end
 
   def self.find_issue_reference(program:, issue:, level_1:, level_2:, level_3:)

--- a/app/repositories/issue_repository.rb
+++ b/app/repositories/issue_repository.rb
@@ -3,6 +3,8 @@ class IssueRepository
 
   # :nocov:
   def self.create_vacols_issue!(css_id:, issue_attrs:)
+    validate_access(css_id, issue_attrs[:vacols_id])
+
     issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(issue_attrs)
     staff = find_staff_record(css_id)
 
@@ -12,10 +14,13 @@ class IssueRepository
   end
 
   def self.update_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:, issue_attrs:)
+    validate_access(css_id, vacols_id)
+
     record = VACOLS::CaseIssue.find_by(isskey: vacols_id, issseq: vacols_sequence_id)
 
-    unless record
-      fail IssueError, "Cannot find issue with vacols ID: #{vacols_id} and sequence ID: #{vacols_sequence_id} in VACOLS"
+     unless record
+      msg = "Cannot find issue with vacols ID: #{vacols_id} and sequence ID: #{vacols_sequence_id} in VACOLS"
+      fail IssueError, msg
     end
 
     issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(issue_attrs)
@@ -24,6 +29,25 @@ class IssueRepository
     record.update_issue!(issue_attrs.merge(issmduser: staff.slogid))
 
     Issue.load_from_vacols(record.attributes)
+  end
+
+  def self.delete_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:)
+    validate_access(css_id, vacols_id)
+
+    record = VACOLS::CaseIssue.find_by(isskey: vacols_id, issseq: vacols_sequence_id)
+
+    unless record
+      msg = "Cannot find issue with vacols ID: #{vacols_id} and sequence ID: #{vacols_sequence_id} in VACOLS"
+      fail IssueError, msg
+    end
+
+    record.delete_issue!
+  end
+
+  def self.validate_access(css_id, vacols_id)
+    unless QueueRepository.can_access_task?(css_id, vacols_id)
+      fail IssueError, "Current user cannot access task with vacols ID: #{vacols_id}"
+    end
   end
 
   def self.find_staff_record(css_id)

--- a/app/repositories/issue_repository.rb
+++ b/app/repositories/issue_repository.rb
@@ -3,35 +3,47 @@ class IssueRepository
 
   # :nocov:
   def self.create_vacols_issue!(css_id:, issue_attrs:)
-    validate_access!(css_id, issue_attrs[:vacols_id])
+    MetricsService.record("VACOLS: IssueRepository.create_vacols_issue! for #{issue_attrs[:vacols_id]}",
+                          service: :vacols,
+                          name: "IssueRepository.create_vacols_issue!") do
+      validate_access!(css_id, issue_attrs[:vacols_id])
 
-    issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(
-      slogid: slogid_based_on_css_id(css_id),
-      action: :create,
-      issue_attrs: issue_attrs
-    )
+      issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(
+        slogid: slogid_based_on_css_id(css_id),
+        action: :create,
+        issue_attrs: issue_attrs
+      )
 
-    VACOLS::CaseIssue.create_issue!(issue_attrs)
+      VACOLS::CaseIssue.create_issue!(issue_attrs)
+    end
   end
 
   def self.update_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:, issue_attrs:)
-    validate_access!(css_id, vacols_id)
-    validate_issue_presence!(vacols_id, vacols_sequence_id)
+    MetricsService.record("VACOLS: IssueRepository.update_vacols_issue! for vacols ID #{vacols_id} and sequence ID: #{vacols_sequence_id}",
+                          service: :vacols,
+                          name: "IssueRepository.update_vacols_issue!") do
+      validate_access!(css_id, vacols_id)
+      validate_issue_presence!(vacols_id, vacols_sequence_id)
 
-    issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(
-      slogid: slogid_based_on_css_id(css_id),
-      action: :update,
-      issue_attrs: issue_attrs
-    )
+      issue_attrs = IssueMapper.rename_and_validate_vacols_attrs(
+        slogid: slogid_based_on_css_id(css_id),
+        action: :update,
+        issue_attrs: issue_attrs
+      )
 
-    VACOLS::CaseIssue.update_issue!(vacols_id, vacols_sequence_id, issue_attrs)
+      VACOLS::CaseIssue.update_issue!(vacols_id, vacols_sequence_id, issue_attrs)
+    end
   end
 
   def self.delete_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:)
-    validate_access!(css_id, vacols_id)
-    validate_issue_presence!(vacols_id, vacols_sequence_id)
+    MetricsService.record("VACOLS: IssueRepository.delete_vacols_issue! for vacols ID #{vacols_id} and sequence ID: #{vacols_sequence_id}",
+                          service: :vacols,
+                          name: "IssueRepository.delete_vacols_issue!") do
+      validate_access!(css_id, vacols_id)
+      validate_issue_presence!(vacols_id, vacols_sequence_id)
 
-    VACOLS::CaseIssue.delete_issue!(vacols_id, vacols_sequence_id)
+      VACOLS::CaseIssue.delete_issue!(vacols_id, vacols_sequence_id)
+    end
   end
 
   def self.validate_issue_presence!(vacols_id, vacols_sequence_id)

--- a/app/repositories/issue_repository.rb
+++ b/app/repositories/issue_repository.rb
@@ -3,7 +3,7 @@ class IssueRepository
 
   # :nocov:
   def self.create_vacols_issue!(css_id:, issue_attrs:)
-    MetricsService.record("VACOLS: IssueRepository.create_vacols_issue! for #{issue_attrs[:vacols_id]}",
+    MetricsService.record("VACOLS: create_vacols_issue! for #{issue_attrs[:vacols_id]}",
                           service: :vacols,
                           name: "IssueRepository.create_vacols_issue!") do
       validate_access!(css_id, issue_attrs[:vacols_id])
@@ -19,7 +19,7 @@ class IssueRepository
   end
 
   def self.update_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:, issue_attrs:)
-    MetricsService.record("VACOLS: IssueRepository.update_vacols_issue! for vacols ID #{vacols_id} and sequence ID: #{vacols_sequence_id}",
+    MetricsService.record("VACOLS: update_vacols_issue! for vacols ID #{vacols_id} and sequence: #{vacols_sequence_id}",
                           service: :vacols,
                           name: "IssueRepository.update_vacols_issue!") do
       validate_access!(css_id, vacols_id)
@@ -36,7 +36,7 @@ class IssueRepository
   end
 
   def self.delete_vacols_issue!(css_id:, vacols_id:, vacols_sequence_id:)
-    MetricsService.record("VACOLS: IssueRepository.delete_vacols_issue! for vacols ID #{vacols_id} and sequence ID: #{vacols_sequence_id}",
+    MetricsService.record("VACOLS: delete_vacols_issue! for vacols ID #{vacols_id} and sequence: #{vacols_sequence_id}",
                           service: :vacols,
                           name: "IssueRepository.delete_vacols_issue!") do
       validate_access!(css_id, vacols_id)

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -9,6 +9,10 @@ class QueueRepository
     end
   end
 
+  def self.can_access_task?(css_id, vacols_id)
+    tasks_for_user(css_id).map(&:vacols_id).include?(vacols_id)
+  end
+
   def self.appeals_from_tasks(tasks)
     vacols_ids = tasks.map(&:vacols_id)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,7 +84,7 @@ Rails.application.routes.draw do
   end
 
   resources :appeals, only: [] do
-    resources :issues, only: [:create, :update, :delete], param: :vacols_sequence_id
+    resources :issues, only: [:create, :update, :destroy], param: :vacols_sequence_id
   end
 
   namespace :hearings do

--- a/lib/fakes/issue_repository.rb
+++ b/lib/fakes/issue_repository.rb
@@ -21,8 +21,6 @@ class Fakes::IssueRepository
       )
 
       Fakes::AppealRepository.issue_records[issue_attrs[:vacols_id]] << issue
-
-      issue
     end
 
     def update_vacols_issue!(args)
@@ -30,7 +28,6 @@ class Fakes::IssueRepository
       record = find_issue(args[:vacols_id], args[:vacols_sequence_id])
       record.codes = CODE_KEYS.collect { |k| issue_attrs[k] }.compact
       record.note = issue_attrs[:note]
-      record
     end
 
     def delete_vacols_issue!(args)

--- a/lib/fakes/issue_repository.rb
+++ b/lib/fakes/issue_repository.rb
@@ -31,7 +31,6 @@ class Fakes::IssueRepository
     end
 
     def delete_vacols_issue!(args)
-      issue_attrs = args[:issue_attrs]
       record = find_issue(args[:vacols_id], args[:vacols_sequence_id])
       Fakes::AppealRepository.issue_records[args[:vacols_id]].delete(record)
     end

--- a/lib/fakes/issue_repository.rb
+++ b/lib/fakes/issue_repository.rb
@@ -33,6 +33,12 @@ class Fakes::IssueRepository
       record
     end
 
+    def delete_vacols_issue!(args)
+      issue_attrs = args[:issue_attrs]
+      record = find_issue(args[:vacols_id], args[:vacols_sequence_id])
+      Fakes::AppealRepository.issue_records[args[:vacols_id]].delete(record)
+    end
+
     def find_issue(vacols_id, vacols_sequence_id)
       init_issue_records(vacols_id)
 

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -141,4 +141,48 @@ RSpec.describe IssuesController, type: :controller do
       end
     end
   end
+
+  describe "DELETE appeals/:appeal_id/issues/:vacols_sequence_id" do
+    context "when deleted successfully" do
+      let(:result_params) do
+        {
+          css_id: "DSUSER",
+          vacols_id: appeal.vacols_id,
+          vacols_sequence_id: "1",
+        }
+      end
+      it "should be successful" do
+        allow(Fakes::IssueRepository).to receive(:delete_vacols_issue!)
+          .with(result_params).and_return({})
+        post :destroy, appeal_id: appeal.id, vacols_sequence_id: 1
+        expect(response.status).to eq 200
+      end
+    end
+
+    context "when appeal is not found" do
+      it "should return not found" do
+        post :destroy, appeal_id: 45_545_454, vacols_sequence_id: 1, issues: {}
+        expect(response.status).to eq 404
+      end
+    end
+
+    context "when there is an error" do
+      let(:result_params) do
+        {
+          css_id: "DSUSER",
+          vacols_id: appeal.vacols_id,
+          vacols_sequence_id: "1",
+        }
+      end
+      it "should not be successful" do
+        allow(Fakes::IssueRepository).to receive(:delete_vacols_issue!)
+          .with(result_params).and_raise(IssueRepository::IssueError.new("Cannot find issue"))
+        post :destroy, appeal_id: appeal.id, vacols_sequence_id: 1
+        expect(response.status).to eq 400
+        error = JSON.parse(response.body)["errors"].first
+        expect(error["title"]).to eq "IssueRepository::IssueError"
+        expect(error["detail"]).to eq "Cannot find issue"
+      end
+    end
+  end
 end

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe IssuesController, type: :controller do
       it "should be successful" do
         post :create, appeal_id: appeal.id, issues: params
         expect(response.status).to eq 201
-        response_body = JSON.parse(response.body)["issue"]
+        response_body = JSON.parse(response.body)["issues"].first
         expect(response_body["codes"]).to eq %w[01 02 03 04 05]
         expect(response_body["labels"]).to eq "not_loaded"
         expect(response_body["vacols_sequence_id"]).to eq 1

--- a/spec/controllers/issues_controller_spec.rb
+++ b/spec/controllers/issues_controller_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe IssuesController, type: :controller do
         {
           css_id: "DSUSER",
           vacols_id: appeal.vacols_id,
-          vacols_sequence_id: "1",
+          vacols_sequence_id: "1"
         }
       end
       it "should be successful" do
@@ -171,7 +171,7 @@ RSpec.describe IssuesController, type: :controller do
         {
           css_id: "DSUSER",
           vacols_id: appeal.vacols_id,
-          vacols_sequence_id: "1",
+          vacols_sequence_id: "1"
         }
       end
       it "should not be successful" do

--- a/spec/mappers/issue_mapper_spec.rb
+++ b/spec/mappers/issue_mapper_spec.rb
@@ -1,5 +1,9 @@
 describe IssueMapper do
-  context ".transform_issue_attrs" do
+  before do
+    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+  end
+
+  context ".rename_and_validate_vacols_attrs" do
     let(:issue_attrs) do
       {
         program: "02",
@@ -10,30 +14,81 @@ describe IssueMapper do
       }
     end
 
-    let(:expected_result) do
-      # level_1 is not passed, level_3 is passed with nil value
-      {
-        issprog: "02",
-        isscode: "18",
-        isslev2: "03",
-        isslev3: nil,
-        issdesc: "another one"
-      }
-    end
+    subject { IssueMapper.rename_and_validate_vacols_attrs(slogid: "TEST1", action: action, issue_attrs: issue_attrs) }
 
-    subject { IssueMapper.rename_and_validate_vacols_attrs(issue_attrs) }
+    context "when action is create" do
+      let(:action) { :create }
+      let(:expected_result) do
+        # level_1 is not passed, level_3 is passed with nil value
+        {
+          issprog: "02",
+          isscode: "18",
+          isslev2: "03",
+          isslev3: nil,
+          issdesc: "another one",
+          issaduser: "TEST1",
+          issadtime: VacolsHelper.local_time_with_utc_timezone
+        }
+      end
 
-    context "when codes are valid" do
-      it "transforms the hash" do
-        allow(IssueRepository).to receive(:find_issue_reference).and_return([OpenStruct.new])
-        expect(subject).to eq expected_result
+      context "when codes are valid" do
+        it "transforms the hash" do
+          allow(IssueRepository).to receive(:find_issue_reference).and_return([OpenStruct.new])
+          expect(subject).to eq expected_result
+        end
+      end
+
+      context "when codes are not valid" do
+        it "raises IssueRepository::IssueError" do
+          allow(IssueRepository).to receive(:find_issue_reference).and_return([])
+          expect { subject }.to raise_error(IssueRepository::IssueError)
+        end
       end
     end
 
-    context "when codes are not valid" do
-      it "raises IssueRepository::IssueError" do
-        allow(IssueRepository).to receive(:find_issue_reference).and_return([])
-        expect { subject }.to raise_error(IssueRepository::IssueError)
+    context "when action is update" do
+      let(:action) { :update }
+      let(:expected_result) do
+        # level_1 is not passed, level_3 is passed with nil value
+        {
+          issprog: "02",
+          isscode: "18",
+          isslev2: "03",
+          isslev3: nil,
+          issdesc: "another one",
+          issmduser: "TEST1",
+          issmdtime: VacolsHelper.local_time_with_utc_timezone
+        }
+      end
+
+      context "when codes are valid" do
+        it "transforms the hash" do
+          allow(IssueRepository).to receive(:find_issue_reference).and_return([OpenStruct.new])
+          expect(subject).to eq expected_result
+        end
+      end
+
+      context "when codes are not passed" do
+        let(:issue_attrs) { { note: "another one" } }
+
+        let(:expected_result) do
+          {
+            issdesc: "another one",
+            issmduser: "TEST1",
+            issmdtime: VacolsHelper.local_time_with_utc_timezone
+          }
+        end
+        it "does not validate code combination" do
+          expect(IssueRepository).to_not receive(:find_issue_reference)
+          expect(subject).to eq expected_result
+        end
+      end
+
+      context "when codes are not valid" do
+        it "raises IssueRepository::IssueError" do
+          allow(IssueRepository).to receive(:find_issue_reference).and_return([])
+          expect { subject }.to raise_error(IssueRepository::IssueError)
+        end
       end
     end
   end


### PR DESCRIPTION
connects #4645 
1. Endpoint to delete issues in VACOLS
2. Add permission checking to make sure user can add/edit/delete issues on the appeal
3. Fix how we update and delete issues to ensure to match on isskey and issseq.