### PR TITLE
Checking flag instead of number of issues

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -476,7 +476,7 @@ class Appeal < ActiveRecord::Base
   # If we do not yet have the worksheet issues saved in Caseflow's DB, then
   # we want to fetch it from VACOLS, save it to the DB, then return it
   def worksheet_issues
-    if super.empty?
+    unless issues_pulled
       transaction do
         issues.each { |i| WorksheetIssue.create_from_issue(self, i) }
         update!(issues_pulled: true)


### PR DESCRIPTION
Connects #4673 

Part 3 will be to run this in production:

```
WorksheetIssue.find_each do |issue|
  issue.appeal.update!(issues_pulled: true)
end
```

This PR is part 4. 

To test: 
- Run the above command in your rails console
- Load the daily docket
- Confirm that we make a request to VACOLS to load issues and that the appeals' issues_pulled flag is set to true
- Refresh the page and confirm we don't make any requests to VACOLS