### PR TITLE
Update DECASS records if defolder and date_assigned match task_id

### DIFF
--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -1,4 +1,10 @@
 module QueueMapper
+  COLUMN_NAMES = {
+    work_product: :deprod,
+    note: :deatcom,
+    document_id: :dedocid
+  }.freeze
+
   WORK_PRODUCTS = {
     DEC: "Decision",
     IME: "OMO - IME",
@@ -11,16 +17,23 @@ module QueueMapper
     OTV: "OMO - VHA"
   }.freeze
 
-  def self.case_decision_fields_to_vacols_codes(info)
-    {
-      note: info[:note],
-      document_id: info[:document_id],
-      reassigned_at: info[:reassigned_at],
-      work_product: work_product_to_vacols_format(info[:work_product], info[:overtime])
-    }.select { |k, _v| info.keys.map(&:to_sym).include? k } # only send updates to key/values that are passed
+  def self.rename_and_validate_decass_attrs(decass_attrs)
+    response = COLUMN_NAMES.keys.each_with_object({}) do |k, result|
+      # skip only if the key is not passed, if the key is passed and the value is nil - include that
+      next unless decass_attrs.keys.include? k
+
+      if k == :work_product
+        decass_attrs[k] = work_product_to_vacols_code(decass_attrs[:work_product], decass_attrs[:overtime])
+      end
+
+      result[COLUMN_NAMES[k]] = decass_attrs[k]
+      result
+    end
+    VacolsHelper.validate_presence(response, [:deprod, :dedocid])
+    response.merge(dereceive: VacolsHelper.local_date_with_utc_timezone)
   end
 
-  def self.work_product_to_vacols_format(work_product, overtime)
+  def self.work_product_to_vacols_code(work_product, overtime)
     overtime ? OVERTIME_WORK_PRODUCTS.key(work_product) : WORK_PRODUCTS.key(work_product)
   end
 end

--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -18,7 +18,7 @@ module QueueMapper
   }.freeze
 
   def self.rename_and_validate_decass_attrs(decass_attrs)
-    response = COLUMN_NAMES.keys.each_with_object({}) do |k, result|
+    update_attrs = COLUMN_NAMES.keys.each_with_object({}) do |k, result|
       # skip only if the key is not passed, if the key is passed and the value is nil - include that
       next unless decass_attrs.keys.include? k
 
@@ -29,8 +29,8 @@ module QueueMapper
       result[COLUMN_NAMES[k]] = decass_attrs[k]
       result
     end
-    VacolsHelper.validate_presence(response, [:deprod, :dedocid])
-    response.merge(dereceive: VacolsHelper.local_date_with_utc_timezone)
+    VacolsHelper.validate_presence(update_attrs, [:deprod, :dedocid])
+    update_attrs.merge(dereceive: VacolsHelper.local_date_with_utc_timezone)
   end
 
   def self.work_product_to_vacols_code(work_product, overtime)

--- a/app/models/attorney_case_reviews/attorney_case_review.rb
+++ b/app/models/attorney_case_reviews/attorney_case_review.rb
@@ -20,6 +20,20 @@ class AttorneyCaseReview < ActiveRecord::Base
     task_id.split("-", 2).second.to_date
   end
 
+  def reassign_case_to_judge_in_vacols!
+    self.class.repository.reassign_case_to_judge(
+      vacols_id: vacols_id,
+      date_assigned: date_assigned,
+      judge_css_id: reviewing_judge.css_id,
+      decass_attrs: {
+        work_product: work_product,
+        document_id: document_id,
+        overtime: overtime,
+        note: note
+      }
+    )
+  end
+
   class << self
     attr_writer :repository
 
@@ -28,18 +42,7 @@ class AttorneyCaseReview < ActiveRecord::Base
         begin
           # Save to the Caseflow DB first to ensure required fields are present
           record = create!(params)
-
-          repository.reassign_case_to_judge(
-            vacols_id: record.vacols_id,
-            date_assigned: record.date_assigned,
-            judge_css_id: record.reviewing_judge.css_id,
-            decass_attrs: {
-              work_product: record.work_product,
-              document_id: record.document_id,
-              overtime: record.overtime,
-              note: record.note
-            }
-          )
+          record.reassign_case_to_judge_in_vacols!
         # :nocov:
         rescue *EXCEPTIONS => e
           Raven.capture_exception(e)

--- a/app/models/attorney_case_reviews/attorney_case_review.rb
+++ b/app/models/attorney_case_reviews/attorney_case_review.rb
@@ -21,7 +21,7 @@ class AttorneyCaseReview < ActiveRecord::Base
   end
 
   def reassign_case_to_judge_in_vacols!
-    self.class.repository.reassign_case_to_judge(
+    AttorneyCaseReview.repository.reassign_case_to_judge(
       vacols_id: vacols_id,
       date_assigned: date_assigned,
       judge_css_id: reviewing_judge.css_id,

--- a/app/models/vacols/decass.rb
+++ b/app/models/vacols/decass.rb
@@ -3,22 +3,4 @@ class VACOLS::Decass < VACOLS::Record
   self.primary_key = "defolder"
 
   has_one :case, foreign_key: :bfkey
-
-  COLUMN_NAMES = {
-    work_product: :deprod,
-    note: :deatcom,
-    document_id: :dedocid,
-    reassigned_at: :dereceive
-  }.freeze
-
-  # :nocov:
-  def update_decass_record!(decision_info)
-    attrs = decision_info.each_with_object({}) { |(k, v), result| result[COLUMN_NAMES[k]] = v }
-    MetricsService.record("VACOLS: update_decass_record! #{defolder}",
-                          service: :vacols,
-                          name: "update_decass_record") do
-      update(attrs)
-    end
-  end
-  # :nocov:
 end

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -1,5 +1,5 @@
 class QueueRepository
-  class ReassignCaseToJudgeError < StandardError; end
+  class QueueError < StandardError; end
   # :nocov:
   def self.tasks_for_user(css_id)
     MetricsService.record("VACOLS: fetch user tasks",
@@ -35,43 +35,34 @@ class QueueRepository
     appeals
   end
 
-  # decass_hash = {
-  #  task_id: "123456-2016-10-19",
-  #  judge_css_id: "GRATR_316"
-  #  work_product: "OMO - IME",
-  #  overtime: true,
-  #  document_id: "123456789.1234",
-  #  note: "Require action"
-  # }
-  def self.reassign_case_to_judge(decass_hash)
-    decass_record = find_decass_record(decass_hash[:task_id])
-    ActiveRecord::Base.transaction do
-      # update DECASS table
-      update_decass_record(decass_record,
-                           decass_hash.merge(reassigned_at: VacolsHelper.local_date_with_utc_timezone))
+  def self.reassign_case_to_judge(vacols_id:, date_assigned:, judge_css_id:, decass_attrs:)
+    # update DECASS table
+    update_decass_record(vacols_id, date_assigned, decass_attrs)
 
-      # update location with the judge's stafkey
-      update_location(decass_record.case, decass_hash[:judge_css_id])
-      true
-    end
+    # update location with the judge's slogid
+    update_location(vacols_id, judge_css_id)
+    true
   end
 
-  def self.decass_by_vacols_id_and_date_assigned(vacols_id, date_assigned)
-    VACOLS::Decass.find_by(defolder: vacols_id, deassign: date_assigned)
-  end
-
-  def self.update_location(case_record, css_id)
-    fail ReassignCaseToJudgeError unless css_id
+  def self.update_location(vacols_id, css_id)
     staff = VACOLS::Staff.find_by(sdomainid: css_id)
-    fail ReassignCaseToJudgeError unless staff
-    case_record.update_vacols_location!(staff.slogid)
+    fail QueueError, "Cannot find user with #{css_id} in VACOLS" unless staff
+    VACOLS::Case.find(vacols_id).update_vacols_location!(staff.slogid)
   end
 
-  def self.update_decass_record(decass_record, decass_hash)
-    info = QueueMapper.case_decision_fields_to_vacols_codes(decass_hash)
-    # Validate presence of the required fields after the mapper to ensure correctness
-    VacolsHelper.validate_presence(info, [:work_product, :document_id, :reassigned_at])
-    decass_record.update_decass_record!(info)
+  def self.update_decass_record(vacols_id, date_assigned, decass_attrs)
+    unless VACOLS::Decass.find_by(defolder: vacols_id, deassign: date_assigned)
+      msg = "Decass record does not exist for vacols_id: #{vacols_id} and date assigned: #{date_assigned}"
+      fail QueueError, msg
+    end
+
+    decass_attrs = QueueMapper.rename_and_validate_decass_attrs(decass_attrs)
+
+    MetricsService.record("VACOLS: update_decass_record! #{vacols_id}",
+                          service: :vacols,
+                          name: "update_decass_record") do
+      VACOLS::Decass.where(defolder: vacols_id, deassign: date_assigned).update_all(decass_attrs)
+    end
   end
 
   def self.tasks_query(css_id)
@@ -88,19 +79,6 @@ class QueueRepository
     VACOLS::Case.aod(vacols_ids)
   end
   # :nocov:
-
-  def self.find_decass_record(task_id)
-    # Task ID is a concatantion of the vacols ID and the date assigned
-    result = task_id.split("-", 2)
-    fail ReassignCaseToJudgeError, "Task ID is invalid format: #{task_id}" if result.size != 2
-    record = decass_by_vacols_id_and_date_assigned(result.first, result.second.to_date)
-    # TODO: check permission that the user can update the record
-    unless record
-      fail ReassignCaseToJudgeError,
-           "Decass record does not exist for vacols_id: #{result.first} and date assigned: #{result.second}"
-    end
-    record
-  end
 
   def self.filter_duplicate_tasks(records)
     # Keep the latest assignment if there are duplicate records

--- a/spec/mappers/queue_mapper_spec.rb
+++ b/spec/mappers/queue_mapper_spec.rb
@@ -1,6 +1,10 @@
 describe QueueMapper do
-  context ".case_decision_fields_to_vacols_codes" do
-    subject { QueueMapper.case_decision_fields_to_vacols_codes(info) }
+  before do
+    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+  end
+
+  context ".rename_and_validate_decass_attrs" do
+    subject { QueueMapper.rename_and_validate_decass_attrs(info) }
 
     context "when all fields are present" do
       let(:info) do
@@ -10,29 +14,70 @@ describe QueueMapper do
           note: "Require action4" }
       end
       let(:expected_result) do
-        { work_product: :IME,
-          document_id: "123456789.1234",
-          note: "Require action4" }
+        { deprod: :IME,
+          dedocid: "123456789.1234",
+          deatcom: "Require action4",
+          dereceive: VacolsHelper.local_date_with_utc_timezone }
       end
       it { is_expected.to eq expected_result }
     end
 
-    context "when not all fields are present" do
+    context "when optional note is nil" do
+      let(:info) do
+        { work_product: "OMO - IME",
+          overtime: true,
+          note: nil,
+          document_id: "123456789.1234" }
+      end
+      let(:expected_result) do
+        { deprod: :OTI,
+          deatcom: nil,
+          dedocid: "123456789.1234",
+          dereceive: VacolsHelper.local_date_with_utc_timezone }
+      end
+      it { is_expected.to eq expected_result }
+    end
+
+    context "when optional note is missing" do
+      let(:info) do
+        { work_product: "OMO - IME",
+          overtime: false,
+          document_id: "123456789.1234" }
+      end
+      let(:expected_result) do
+        { deprod: :IME,
+          dedocid: "123456789.1234",
+          dereceive: VacolsHelper.local_date_with_utc_timezone }
+      end
+      it { is_expected.to eq expected_result }
+    end
+
+    context "when required document ID is missing" do
       let(:info) do
         { work_product: "OMO - IME",
           overtime: true,
           note: "Require action4" }
       end
-      let(:expected_result) do
-        { work_product: :OTI,
+      it "raises an error" do
+        expect { subject }.to raise_error(VacolsHelper::MissingRequiredFieldError)
+      end
+    end
+
+    context "when required work product is missing" do
+      let(:info) do
+        { work_product: "Invalid",
+          overtime: true,
+          document_id: "1234",
           note: "Require action4" }
       end
-      it { is_expected.to eq expected_result }
+      it "raises an error" do
+        expect { subject }.to raise_error(VacolsHelper::MissingRequiredFieldError)
+      end
     end
   end
 
-  context ".work_product_to_vacols_format" do
-    subject { QueueMapper.work_product_to_vacols_format(work_product, overtime) }
+  context ".work_product_to_vacols_code" do
+    subject { QueueMapper.work_product_to_vacols_code(work_product, overtime) }
     context "when overtime" do
       let(:work_product) { "OMO - VHA" }
       let(:overtime) { true }

--- a/spec/models/attorney_case_reviews/attorney_case_review_spec.rb
+++ b/spec/models/attorney_case_reviews/attorney_case_review_spec.rb
@@ -35,12 +35,15 @@ describe AttorneyCaseReview do
     context "when all parameters are present and Vacols update is successful" do
       before do
         allow(QueueRepository).to receive(:reassign_case_to_judge).with(
-          task_id: "123456-2013-12-06",
+          vacols_id: "123456",
+          date_assigned: "2013-12-06".to_date,
           judge_css_id: judge.css_id,
-          work_product: "OMO - IME",
-          document_id: "123456789.1234",
-          overtime: true,
-          note: "something"
+          decass_attrs: {
+            work_product: "OMO - IME",
+            document_id: "123456789.1234",
+            overtime: true,
+            note: "something"
+          }
         ).and_return(true)
       end
 

--- a/spec/repositories/queue_repository_spec.rb
+++ b/spec/repositories/queue_repository_spec.rb
@@ -1,38 +1,4 @@
 describe QueueRepository do
-  before do
-    Timecop.freeze(Time.utc(2017, 10, 4))
-    Time.zone = "America/Chicago"
-  end
-
-  context ".find_decass_record" do
-    subject { QueueRepository.find_decass_record(task_id) }
-
-    context "when task id is valid and decass record is found" do
-      before do
-        allow(QueueRepository).to receive(:decass_by_vacols_id_and_date_assigned).and_return(OpenStruct.new)
-      end
-      let(:task_id) { "123456-2014-02-03" }
-      it { is_expected.to_not be nil }
-    end
-
-    context "when task id is valid and decass record is not found" do
-      before do
-        allow(QueueRepository).to receive(:decass_by_vacols_id_and_date_assigned).and_return(nil)
-      end
-      let(:task_id) { "123456-2014-02-03" }
-      it "raises QueueRepository::ReassignCaseToJudgeError" do
-        expect { subject }.to raise_error(QueueRepository::ReassignCaseToJudgeError)
-      end
-    end
-
-    context "when task id is not valid" do
-      let(:task_id) { "123456" }
-      it "raises QueueRepository::ReassignCaseToJudgeError" do
-        expect { subject }.to raise_error(QueueRepository::ReassignCaseToJudgeError)
-      end
-    end
-  end
-
   context ".filter_duplicate_tasks" do
     subject { QueueRepository.filter_duplicate_tasks(tasks) }
 


### PR DESCRIPTION
I noticed that when we do something like that:

```
record = VACOLS::Decass.find_by(defolder: "123456", deassign: <date>)
record.update(attrs)
```

It will update ALL decass records with defolder: "123456" and won’t take deassign in consideration because the primary key is defolder (WITHOUT deassign)

We need to change it to:

```
VACOLS::Decass.where(defolder: vacols_id, deassign: date_assigned).update_all(decass_attrs)
```

To Validate (check SQL output):
```
AttorneyCaseReview.complete!(
"type"=>"OMORequest",
 "reviewing_judge"=>User.first,
 "document_id"=>"123456789.9087",
 "work_product"=>"OMO - IME",
 "overtime"=>true,
 "note"=>"something",
 "attorney"=> User.last,
 "task_id"=>"3161788-2016-10-19"
)
```


How it looks now:
```
UPDATE "VACOLS"."DECASS" SET "VACOLS"."DECASS"."DEPROD" = 'OTI', "VACOLS"."DECASS"."DEATCOM" = 'something', "VACOLS"."DECASS"."DEDOCID" = '123456789.9087', "VACOLS"."DECASS"."DERECEIVE" = TO_DATE('2018-03-13 00:00:00','YYYY-MM-DD HH24:MI:SS') WHERE "VACOLS"."DECASS"."DEFOLDER" = :a1 AND "VACOLS"."DECASS"."DEASSIGN" = :a2  [["defolder", "3161788"], ["deassign", Wed, 19 Oct 2016]]
```
