### PR TITLE
Your Queue | Rename "Decision task details" to "Case details"

### DIFF
--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -35,7 +35,7 @@ class QueueTable extends React.PureComponent {
 
   getQueueColumns = () => [
     {
-      header: 'Decision Task Details',
+      header: 'Case Details',
       valueFunction: (task) => <span>
         <Link to={`/tasks/${task.vacolsId}`}>
           {this.getAppealForTask(task, 'veteran_full_name')} ({this.getAppealForTask(task, 'vbms_id')})

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -161,7 +161,7 @@ RSpec.feature "Queue" do
 
         safe_click("a[href='/queue/tasks/#{appeal.vacols_id}']")
 
-        expect(page).to have_content("Hearing preference: #{hearing.type.capitalize}")
+        expect(page).to have_content("Hearing preference: #{hearing.type.to_s.split('_').map(&:capitalize).join(' ')}")
 
         if hearing.disposition.eql? :cancelled
           expect(page).not_to have_content("Hearing held")


### PR DESCRIPTION
Closes #4840 

## Acceptance Criteria
- [ ] Verify that the first column in attorneys' queues is titled "Case details"