### PR TITLE
Case details | Remove 'Draft Decision' from title of appeal details page

### DIFF
--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -73,7 +73,7 @@ class QueueDetailView extends React.PureComponent {
 
     return <AppSegment filledBackground>
       <h1 className="cf-push-left" {...css(headerStyling, fullWidth)}>
-        Draft Decision - {appeal.veteran_full_name} ({appeal.vbms_id})
+        {appeal.veteran_full_name} ({appeal.vbms_id})
       </h1>
       <p className="cf-lead-paragraph" {...subHeadStyling}>
         Assigned to you {task.added_by_name ? `by ${task.added_by_name}` : ''} on&nbsp;

--- a/client/app/reader/BackToQueueLink.jsx
+++ b/client/app/reader/BackToQueueLink.jsx
@@ -19,7 +19,7 @@ class BackToQueueLink extends React.PureComponent {
       return queueTaskType;
     }
 
-    return `${queueTaskType} - ${veteranFullName} (${vbmsId})`;
+    return `${veteranFullName} (${vbmsId})`;
   }
 
   render = () => {

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -238,7 +238,7 @@ RSpec.feature "Queue" do
 
         click_on "Open #{appeal.documents.length} documents in Caseflow Reader"
 
-        expect(page).to have_content("Back to Draft Decision - #{appeal.veteran_full_name} (#{appeal.vbms_id})")
+        expect(page).to have_content("Back to #{appeal.veteran_full_name} (#{appeal.vbms_id})")
       end
     end
   end


### PR DESCRIPTION
Closes #4822 

## Acceptance Criteria
- [ ] Verify that the title of the case details page is just the Veteran's name and ID
- [ ] Verify that when the user navigates to Reader from the case details page, the breadcrumbs in Reader just say the Veteran's name
