### PR TITLE
Allow more time for eX to fetch the manifest

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -1,7 +1,7 @@
 require "json"
 
 class ExternalApi::EfolderService
-  TRIES = 20
+  TRIES = 60
 
   def self.fetch_documents_for(appeal, user)
     # Makes a GET request to https://<efolder_url>/files/<file_number>


### PR DESCRIPTION
An attempt to fix https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/995/events/41741/