### PR TITLE
Fix failing queue test

### DIFF
--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -1,7 +1,5 @@
 require "rails_helper"
 
-include ActionView::Helpers::NumberHelper
-
 RSpec.feature "Queue" do
   before do
     Fakes::Initializer.load!

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
+include ActionView::Helpers::NumberHelper
+
 RSpec.feature "Queue" do
   before do
     Fakes::Initializer.load!
@@ -237,7 +239,7 @@ RSpec.feature "Queue" do
 
         expect(page).to have_content("Your Queue > #{appeal.veteran_full_name}")
 
-        click_on "Open #{appeal.documents.length} documents in Caseflow Reader"
+        click_on "Open #{number_with_delimiter(appeal.documents.length)} documents in Caseflow Reader"
 
         expect(page).to have_content("Back to #{appeal.veteran_full_name} (#{appeal.vbms_id})")
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -313,3 +313,7 @@ RSpec::Matchers.define :excluding do |expected|
     !actual.include?(expected)
   end
 end
+
+RSpec.configure do |config|
+  config.include ActionView::Helpers::NumberHelper
+end


### PR DESCRIPTION
One of the specs in feature/queue/queue_spec.rb attempts to click on a link with a number in the link.
The number in that link is rendered in the frontend with .toLocaleString, which means the number is formatted with commas in most locals (e.g., 1234 -> 1,234).
The spec selector does not account for this, and so when there is a link that says "Open 1,000 documents", the spec attempts to find and click a link that says "Open 1000 documents" (notice the missing comma), and fails.

This makes the spec a little more robust, asking it to look for a delimited string.