### PR TITLE
Lowers capybara default_max_wait_time to 5 seconds

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -102,7 +102,7 @@ end
 
 Capybara.default_driver = ENV["SAUCE_SPECS"] ? :sauce_driver : :parallel_sniffybara
 # the default default_max_wait_time is 2 seconds
-Capybara.default_max_wait_time = 20
+Capybara.default_max_wait_time = 5
 
 ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
Lowering from 20 to 5 seconds. The 20 second timer does not appear
to be necessary in any environments.