### PR TITLE
Fix for when a Veteran has opted into RAMP without a letter

### DIFF
--- a/app/models/appeal_series_alerts.rb
+++ b/app/models/appeal_series_alerts.rb
@@ -119,7 +119,7 @@ class AppealSeriesAlerts
   end
 
   def ramp
-    if appeal_series.ramp_election && Time.zone.today <= appeal_series.ramp_election.due_date
+    if appeal_series.ramp_election.try(&:due_date) && Time.zone.today <= appeal_series.ramp_election.due_date
       {
         type: appeal_series.eligible_for_ramp? ? :ramp_eligible : :ramp_ineligible,
         details: {

--- a/spec/models/appeal_series_alerts_spec.rb
+++ b/spec/models/appeal_series_alerts_spec.rb
@@ -204,6 +204,15 @@ describe AppealSeriesAlerts do
           expect(alerts.find { |a| a[:type] == :ramp_ineligible }).to be_nil
         end
       end
+
+      context "when a Veteran has opted into RAMP without receiving a letter" do
+        let(:notice_date) { nil }
+
+        it "does not include an alert" do
+          expect(alerts.find { |a| a[:type] == :ramp_eligible }).to be_nil
+          expect(alerts.find { |a| a[:type] == :ramp_ineligible }).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
connects https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1062/