### PR TITLE
Update docket range

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -468,7 +468,7 @@ class AppealRepository
     result = MetricsService.record("VACOLS: latest_docket_month",
                                    name: "latest_docket_month",
                                    service: :vacols) do
-      VACOLS::CaseDocket.docket_date_of_nth_appeal_in_case_storage(3500)
+      VACOLS::CaseDocket.docket_date_of_nth_appeal_in_case_storage(7000)
     end
 
     result.beginning_of_month


### PR DESCRIPTION
Per Nicholas, the Board changed its docket range logic to use the oldest 7,000 cases, instead of the oldest 3,500 cases, effective 2/5/19.