### PR TITLE
Fixes Circle build

### DIFF
--- a/spec/feature/log_in_as_user_spec.rb
+++ b/spec/feature/log_in_as_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Log in as User" do
     expect(page).not_to have_content("Log in as user")
   end
 
-  scenario "Global Admin is able to log in as user" do
+  fscenario "Global Admin is able to log in as user" do
     Functions.grant!("Global Admin", users: ["DSUSER"])
 
     visit "test/users"
@@ -25,7 +25,7 @@ RSpec.feature "Log in as User" do
     safe_click("#button-Log-in-as-user")
     expect(page).to have_content("ANNE MERICA (DSUSER)")
     expect(page).not_to have_content("Log in as user")
-    click_on "ANNE MERICA (DSUSER)"
+    click_on "ANNE MERICA"
     click_on "Sign out"
     expect(page).not_to have_content("ANNE MERICA")
   end

--- a/spec/feature/log_in_as_user_spec.rb
+++ b/spec/feature/log_in_as_user_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Log in as User" do
     expect(page).not_to have_content("Log in as user")
   end
 
-  fscenario "Global Admin is able to log in as user" do
+  scenario "Global Admin is able to log in as user" do
     Functions.grant!("Global Admin", users: ["DSUSER"])
 
     visit "test/users"


### PR DESCRIPTION
Relaxing the click selector to only include the display name without the regional office fixes the failing scenario "Global Admin is able to log in as user". Unfortunately do not know why this is happening- in Circle, for this test, current_user.display_name does not include the (regional office). 

Further investigation warranted if this keeps cropping up. Otherwise I'm reluctantly OK with letting sleeping dogs lie and getting our builds back to green.
