### PR TITLE
Stops login_spec from breaking other specs

### DIFF
--- a/spec/feature/log_in_as_user_spec.rb
+++ b/spec/feature/log_in_as_user_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature "Log in as User" do
     safe_click("#button-Log-in-as-user")
     expect(page).to have_content("ANNE MERICA (DSUSER)")
     expect(page).not_to have_content("Log in as user")
-    click_on "ANNE MERICA"
+    click_on "ANNE MERICA (DSUSER)"
     click_on "Sign out"
     expect(page).not_to have_content("ANNE MERICA")
   end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -4,9 +4,14 @@ RSpec.feature "Login" do
   let(:appeal) { Generators::Appeal.build(vacols_record: :ready_to_certify) }
 
   before do
+    @old_session = Fakes::AuthenticationService.user_session
     Fakes::AuthenticationService.user_session = {
       "id" => "ANNE MERICA", "roles" => ["Certify Appeal"], "station_id" => "405", "email" => "test@example.com"
     }
+  end
+
+  after do
+    Fakes::AuthenticationService.user_session = @old_session
   end
 
   after(:all) do


### PR DESCRIPTION
With @shanear, we bisected a failing Circle build and found that login_spec was causing downstream test failures. From there, we figured out that if we properly "cleaned up" in an `after` block, we could resolve the downstream failures. We did not dive any more deeply into the exact nature of these failures.