### PR TITLE
Fix cancel race condition

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -37,6 +37,10 @@ class Intake < ActiveRecord::Base
     intake_classname.constantize.new(veteran_file_number: veteran_file_number, user: user)
   end
 
+  def complete?
+    !!completed_at
+  end
+
   def start!
     preload_intake_data!
 

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -43,6 +43,8 @@ class RampElectionIntake < Intake
   end
 
   def cancel!
+    return if complete?
+
     transaction do
       detail.update_attributes!(receipt_date: nil, option_selected: nil)
       complete_with_status!(:canceled)

--- a/db/migrate/20180321153005_add_established_at_to_ramp_refilings.rb
+++ b/db/migrate/20180321153005_add_established_at_to_ramp_refilings.rb
@@ -1,0 +1,5 @@
+class AddEstablishedAtToRampRefilings < ActiveRecord::Migration
+  def change
+    add_column :ramp_refilings, :established_at, :datetime
+  end
+end

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -10,12 +10,14 @@ describe RampElectionIntake do
   let(:appeal_vacols_record) { :ready_to_certify }
   let(:compensation_issue) { Generators::Issue.build(template: :compensation) }
   let(:issues) { [compensation_issue] }
+  let(:completed_at) { nil }
 
   let(:intake) do
     RampElectionIntake.new(
       user: user,
       detail: detail,
-      veteran_file_number: veteran_file_number
+      veteran_file_number: veteran_file_number,
+      completed_at: completed_at
     )
   end
 
@@ -48,6 +50,18 @@ describe RampElectionIntake do
         option_selected: nil,
         receipt_date: nil
       )
+    end
+
+    context "when already complete" do
+      let(:completed_at) { 2.seconds.ago }
+
+      it "returns and does nothing" do
+        expect(intake.reload).to_not be_canceled
+        expect(detail.reload).to have_attributes(
+          option_selected: "supplemental_claim",
+          notice_date: 5.days.ago
+        )
+      end
     end
   end
 

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -56,10 +56,11 @@ describe RampElectionIntake do
       let(:completed_at) { 2.seconds.ago }
 
       it "returns and does nothing" do
-        expect(intake.reload).to_not be_canceled
+        expect(intake).to_not be_persisted
+        expect(intake).to_not be_canceled
         expect(detail.reload).to have_attributes(
           option_selected: "supplemental_claim",
-          notice_date: 5.days.ago
+          receipt_date: 3.days.ago.to_date
         )
       end
     end


### PR DESCRIPTION
Just hiding the cancel button didn't get us there. We saw two examples
of intakes that we completed and then cancelled today.

Now preventing this on the back end. There is still small room for a race condition, but this should stop the bleeding

connects #4889