### PR TITLE
Update dispatch stats job timing to fetch only once every 23 hours

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::JobsController < Api::ApplicationController
   # available jobs supported by this endpoint
   SUPPORTED_JOBS = {
-    "calculate_dispatch_stats_job" => CalculateDispatchStatsJob,
+    "calculate_dispatch_stats" => CalculateDispatchStatsJob,
     "create_establish_claim" => CreateEstablishClaimTasksJob,
     "dependencies_check" => DependenciesCheckJob,
     "dependencies_report_service_log" => DependenciesReportServiceLogJob,

--- a/app/models/dispatch_stats.rb
+++ b/app/models/dispatch_stats.rb
@@ -1,6 +1,6 @@
 class DispatchStats < Caseflow::Stats
-  # since this is a heavy calculation, only run this at most once an hour
-  THROTTLE_RECALCULATION_PERIOD = 1.hour
+  # since this is a heavy calculation, only run this at most once every 23 hours
+  THROTTLE_RECALCULATION_PERIOD = 23.hours
 
   class << self
     def throttled_calculate_all!

--- a/spec/models/dispatch_stats_spec.rb
+++ b/spec/models/dispatch_stats_spec.rb
@@ -22,8 +22,8 @@ describe DispatchStats do
       end
     end
 
-    context "when last calculated more than 61 minutes ago" do
-      before { Rails.cache.write("DispatchStats-last-calculated-timestamp", 61.minutes.ago.to_i) }
+    context "when last calculated more than 23 hours ago" do
+      before { Rails.cache.write("DispatchStats-last-calculated-timestamp", 24.hours.ago.to_i) }
 
       it "calculates stats" do
         expect(DispatchStats).to receive(:calculate_all!)
@@ -32,8 +32,8 @@ describe DispatchStats do
       end
     end
 
-    context "when last calculated less than 60 minutes ago" do
-      before { Rails.cache.write("DispatchStats-last-calculated-timestamp", 59.minutes.ago.to_i) }
+    context "when last calculated less than 23 hours ago" do
+      before { Rails.cache.write("DispatchStats-last-calculated-timestamp", 22.hours.ago.to_i) }
 
       it "doesn't recalculate stats" do
         expect(DispatchStats).to_not receive(:calculate_all!)


### PR DESCRIPTION
I've noticed in production the dispatch stats job takes over an hour to run.  This now limits this calculation to happen at most once every 23 hours. 



