### PR TITLE
Fix time_to_complete so that we do not go to vacols for this info

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::JobsController < Api::ApplicationController
   # available jobs supported by this endpoint
   SUPPORTED_JOBS = {
-    "calculate_dispatch_stats_job" => CalculateDispatchStatsJob,
+    "calculate_dispatch_stats" => CalculateDispatchStatsJob,
     "create_establish_claim" => CreateEstablishClaimTasksJob,
     "dependencies_check" => DependenciesCheckJob,
     "dependencies_report_service_log" => DependenciesReportServiceLogJob,

--- a/app/models/tasks/establish_claim.rb
+++ b/app/models/tasks/establish_claim.rb
@@ -126,8 +126,8 @@ class EstablishClaim < Task
   end
 
   def time_to_complete
-    return nil if !appeal.outcoding_date || !created_at
-    completed_at - appeal.outcoding_date
+    return nil if !created_at
+    completed_at - created_at
   end
 
   def completion_status_text


### PR DESCRIPTION
This fixes an issue where dispatch stats job and page takes way too long.  We were going to VACOLS to receive data.  This adjusts the logic so that fetching from VACOLS is no longer needed.  

Addresses: https://github.com/department-of-veterans-affairs/caseflow/issues/3304