### PR TITLE
Worksheet Pdf print title

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -543,6 +543,10 @@ $color-hearings-saving: $color-gray;
   }
 
   .cf-hearings-worksheet-issues {
+    thead {
+      display: table-row-group;
+    }
+
     td {
       padding: 0 .5em;
       padding-bottom: 0;
@@ -559,6 +563,7 @@ $color-hearings-saving: $color-gray;
 
     tr {
       border-bottom: 1px solid $color-gray-lighter;
+      page-break-inside: avoid;
    }
 
 }
@@ -695,13 +700,6 @@ $color-hearings-saving: $color-gray;
      }
   }
 
-
-  .cf-hearings-worksheet-issues {
-    thead > tr:nth-child(2) {
-      display: none;
-   }
- }
-
   .cf-hearings-worksheet {
     margin-bottom: 0;
     padding-bottom: 0;
@@ -716,6 +714,11 @@ $color-hearings-saving: $color-gray;
         flex-grow: 1;
         display: flex;
         flex-direction: column;
+
+        p {
+          margin-top: 0;
+          margin-bottom: 1.2rem;
+       }
 
         .cf-hearings-worksheet-data:last-child {
           margin-bottom: inherit;


### PR DESCRIPTION
Resolves #4769

### Description
When the appeal stream continues to the next page, the headers will not appear.
### Acceptance Criteria 
- [ ] When user is on a Hearing Worksheet, and clicks on "Save as PDF", the issue titles (issue, notes, disposition, preliminary impressions) repeat at the bottom of the page and the next page, which should not repeat and where the page breaks.

### Testing Plan
1. Go to the first Up coming hearings `Fri 03/30/2018`  and on Daily document click on the appeal that has 13 issues.
2. On Worksheet, click `Save as PDF button` and view the changes on print pdf.

<img width="1007" alt="screen shot 2018-03-30 at 9 59 55 am" src="https://user-images.githubusercontent.com/23080951/38147167-0c90bb74-341f-11e8-900f-cb9fd5f640ae.png">
