### PR TITLE
Queue | Rename issue readjudication field

### DIFF
--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -113,7 +113,7 @@ class SubmitDecisionView extends React.PureComponent {
       data: {
         queue: {
           type: decision.type,
-          issues: _.map(issues, (issue) =>_.pick(issue,
+          issues: _.map(issues, (issue) => _.pick(issue,
             ['disposition', 'vacols_sequence_id', 'remand_reasons', 'type', 'readjudication']
           )),
           ...decision.opts

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -113,8 +113,9 @@ class SubmitDecisionView extends React.PureComponent {
       data: {
         queue: {
           type: decision.type,
-          issues: _.map(issues, (issue) =>
-            _.pick(issue, 'disposition', 'vacols_sequence_id', 'remand_reasons', 'type')),
+          issues: _.map(issues, (issue) =>_.pick(issue,
+            ['disposition', 'vacols_sequence_id', 'remand_reasons', 'type', 'readjudication']
+          )),
           ...decision.opts
         }
       }

--- a/client/app/queue/components/SelectIssueDispositionDropdown.jsx
+++ b/client/app/queue/components/SelectIssueDispositionDropdown.jsx
@@ -55,7 +55,7 @@ class SelectIssueDispositionDropdown extends React.PureComponent {
         }))}
         onChange={({ value }) => this.props.updateIssue({
           disposition: value,
-          duplicate: false
+          readjudication: false
         })}
         name={`dispositions_dropdown_${issue.vacols_sequence_id}`} />
       {issue.disposition === 'Vacated' && <Checkbox
@@ -64,8 +64,8 @@ class SelectIssueDispositionDropdown extends React.PureComponent {
           marginBottom: 0,
           marginTop: '1rem'
         })}
-        onChange={(duplicate) => this.props.updateIssue({ duplicate })}
-        value={issue.duplicate}
+        onChange={(readjudication) => this.props.updateIssue({ readjudication })}
+        value={issue.readjudication}
         label="Automatically create vacated issue for readjudication." />}
     </div>;
   };


### PR DESCRIPTION
### Description
Renames the "Automatically create vacated issue for readjudication" field to `readjudication`, as per [AttorneyCaseReview::update_issue_dispositions!](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/attorney_case_reviews/attorney_case_review.rb#L35)

### Acceptance Criteria 
- [ ] Submit Draft Decision checkout flow, setting some issues to Vacated and choosing to create new vacated issue
- [ ] Verify duplicate issues are created in the backend

