### PR TITLE
Hearing worksheet header styles

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -712,7 +712,7 @@ $color-hearings-saving: $color-gray;
 
     .cf-form-textarea {
       textarea {
-        min-height: 28px;
+        height: 28px !important;
    }
  }
 

--- a/client/app/hearings/components/HearingWorksheetIssues.jsx
+++ b/client/app/hearings/components/HearingWorksheetIssues.jsx
@@ -25,7 +25,7 @@ class HearingWorksheetIssues extends PureComponent {
         valueName: 'counter'
       },
       {
-        header: `Appeal Stream ${appealKey + 1}`,
+        header: `Appeal Stream ${appealKey + 1} Issues`,
         align: 'left',
         valueName: 'description'
       },


### PR DESCRIPTION
Resolves #4597

### Description
This PR updates the headers for `Appeal Stream`. It also takes updates the height of the table rows and adds the !important rule. Because we are using Textarea that automatically resizes so it would probably be some internal behavior that sets it's own height to `66px`  in `import Texture from 'react-textarea-autosize';`. Originally I had set the !important rule the height and it worked pretty fine but because I removed it in previous PR `https://github.com/department-of-veterans-affairs/caseflow/pull/5027`. It automatically resized it once PR was merged. I have set it back to `height: 28px !important`

### Acceptance Criteria 
- [x]  1. Label each Appeal Stream under 'Issues on Appeal' as follows: 'Appeal Stream [#] Issues' using 17px, bold

### Testing Plan
1. Go to Worksheet, Check for `Appeal Stream 1 Issues` header to be updated.
2. Go to Worksheet Pdf and view changes

<img width="1008" alt="screen shot 2018-04-02 at 6 47 29 pm" src="https://user-images.githubusercontent.com/23080951/38220078-800489bc-36a6-11e8-8afe-757d0101599f.png">
