### PR TITLE
Fix local env without aws creds

### DIFF
--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -48,8 +48,8 @@ Rails.application.configure do
   config.sqs_endpoint = "http://localhost:4576"
 
   # since we mock aws using localstack, provide dummy creds to the aws gem
-  ENV["AWS_ACCESS_KEY_ID"] ||= "key"
-  ENV["AWS_SECRET_ACCESS_KEY"] ||= "secretkey"
+  ENV["AWS_ACCESS_KEY_ID"] ||= "dummykeyid"
+  ENV["AWS_SECRET_ACCESS_KEY"] ||= "dummysecretkey"
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/config/environments/local.rb
+++ b/config/environments/local.rb
@@ -47,6 +47,9 @@ Rails.application.configure do
   config.sqs_create_queues = true
   config.sqs_endpoint = "http://localhost:4576"
 
+  # since we mock aws using localstack, provide dummy creds to the aws gem
+  ENV["AWS_ACCESS_KEY_ID"] ||= "key"
+  ENV["AWS_SECRET_ACCESS_KEY"] ||= "secretkey"
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
The rake commands were erroring with 

```
Aws::Errors::MissingCredentialsError: unable to sign request without credentials set
```

for the `local` RAILS_ENV when no AWS credentials were picked up.  This sets dummy credentials if there are no prior AWS creds set.  Because the `local` RAILS_ENV uses localstack to mock AWS services, this works well. 

## To Test
1. unset all AWS_ environment variables
2. `mv ~/.aws ~/.aws.bak`
3. Run the rake db:setup command
```
RAILS_ENV=local rake db:setup
```
