### PR TITLE
Hearing-Prep update header Padding

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -716,7 +716,7 @@ $color-hearings-saving: $color-gray;
 
     .cf-form-textarea {
       textarea {
-        min-height: 28px;
+        height: 28px !important;
    }
  }
 

--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -77,7 +77,10 @@ $color-hearings-saving: $color-gray;
 .cf-hearings,
 .cf-hearings-schedule,
 .cf-hearings-worksheet {
-  padding: $cf-30px;
+  padding-bottom: $cf-30px;
+  padding-top: 50px;
+  padding-left: 40px;
+  padding-right: 40px;
 
   .cf-hearings-title-and-judge {
     h1 {
@@ -506,6 +509,7 @@ $color-hearings-saving: $color-gray;
 
 .cf_hearing_body {
   font-size: 11px;
+  padding: $cf-30px;
 }
 
 .hearings-add-issue {


### PR DESCRIPTION
Resolves #4607

### Description
This PR updates the h1 padding.

### Acceptance Criteria 
1. Ensure that all page headers start 50px from the top edge of the canvas.
1. Ensure that all page headers start 40px from the left edge of the canvas.
1. Ensure that all copy and text boxes, and tables start 40px in from the left edge of the canvas.
1. Ensure that all copy, text boxes, tables and dropdown boxes end 40px from the right edge of the canvas.

### Testing Plan
1. Go to Daily Docket, Check if padding has been adjusted.
2. Go to Hearing Worksheet and check if padding has been adjusted.

<img width="1147" alt="screen shot 2018-04-02 at 9 06 32 pm" src="https://user-images.githubusercontent.com/23080951/38254156-84280872-3726-11e8-925f-a64d4ba7b419.png">

