### PR TITLE
Move the localstack web ui to 8082 (from 8080)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     image: localstack/localstack
     ports:
       - "4567-4583:4567-4583"
-      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+      - "8082:${PORT_WEB_UI-8080}"
     environment:
       - SERVICES=sqs
     volumes:


### PR DESCRIPTION
The web ui for localstack is by default on 8080.  This conflicts with our `ssh uat` socks proxy forwarding port.  Move this to 8082.  

I'm not entirely sure if the localstack webui is useful.  It might be if we start to use more services like the s3 bucket.  For now, lets keep this on and open to perhaps 8082. 