### PR TITLE
Adds established_by_user_id to RampElection and RampRefiling

### DIFF
--- a/app/jobs/sync_intake_job.rb
+++ b/app/jobs/sync_intake_job.rb
@@ -8,6 +8,6 @@ class SyncIntakeJob < ActiveJob::Base
     RampElection.active.map(&:recreate_issues_from_contentions!)
 
     # Then sync the EP statuses
-    RampElection.active.map(&:sync_ep_status!)
+    RampElection.established.map(&:sync_ep_status!)
   end
 end

--- a/app/jobs/sync_intake_job.rb
+++ b/app/jobs/sync_intake_job.rb
@@ -4,10 +4,14 @@ class SyncIntakeJob < ActiveJob::Base
   queue_as :low_priority
 
   def perform
-    # First sync the issues
+    # First sync the issues from all the known active RampElections
+    # This will not sync issues from known inactive RampElections
+    # nor from RampElections whose true status we dont know
+    # (RampElections with end_product_status: nil)
     RampElection.active.map(&:recreate_issues_from_contentions!)
 
-    # Then sync the EP statuses
+    # Now call sync_ep_status over all established claims
+    # #sync_ep_status bails early on explicitly inactive elections
     RampElection.established.map(&:sync_ep_status!)
   end
 end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -146,6 +146,15 @@ class Intake < ActiveRecord::Base
 
   private
 
+  def mark_detail_as_established
+    unless detail.established_at
+      detail.update!(
+        established_at: Time.zone.now,
+        established_by_user_id: user.id
+      )
+    end
+  end
+
   def file_number_valid?
     return false unless veteran_file_number
 

--- a/app/models/ramp_closed_appeal.rb
+++ b/app/models/ramp_closed_appeal.rb
@@ -1,5 +1,4 @@
 class RampClosedAppeal < ActiveRecord::Base
   belongs_to :ramp_election
-
   delegate :established_at, to: :ramp_election
 end

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -47,6 +47,11 @@ class RampElectionIntake < Intake
           nod_date: appeal.nod_date
         )
       end
+
+      detail.update!(
+        established_at: Time.zone.now,
+        established_by_user_id: user.id
+      ) unless detail.established_at
     end
   end
 

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -40,18 +40,8 @@ class RampElectionIntake < Intake
         ramp_election.create_end_product!
       end
 
-      eligible_appeals.each do |appeal|
-        RampClosedAppeal.create!(
-          vacols_id: appeal.vacols_id,
-          ramp_election_id: ramp_election.id,
-          nod_date: appeal.nod_date
-        )
-      end
-
-      detail.update!(
-        established_at: Time.zone.now,
-        established_by_user_id: user.id
-      ) unless detail.established_at
+      complete_eligible_appeals
+      mark_detail_as_established
     end
   end
 
@@ -88,6 +78,25 @@ class RampElectionIntake < Intake
   end
 
   private
+
+  def mark_detail_as_established
+    unless detail.established_at
+      detail.update!(
+        established_at: Time.zone.now,
+        established_by_user_id: user.id
+      )
+    end
+  end
+
+  def complete_eligible_appeals
+    eligible_appeals.each do |appeal|
+      RampClosedAppeal.create!(
+        vacols_id: appeal.vacols_id,
+        ramp_election_id: ramp_election.id,
+        nod_date: appeal.nod_date
+      )
+    end
+  end
 
   # Appeals in VACOLS that will be closed out in favor of a new format review
   def eligible_appeals

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -36,10 +36,9 @@ class RampElectionIntake < Intake
         user: user,
         closed_on: Time.zone.today,
         disposition: "RAMP Opt-in"
-      ) do
-        ramp_election.create_end_product!
-      end
+      )
 
+      ramp_election.create_end_product!
       complete_eligible_appeals
       mark_detail_as_established
     end

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -79,15 +79,6 @@ class RampElectionIntake < Intake
 
   private
 
-  def mark_detail_as_established
-    unless detail.established_at
-      detail.update!(
-        established_at: Time.zone.now,
-        established_by_user_id: user.id
-      )
-    end
-  end
-
   def complete_eligible_appeals
     eligible_appeals.each do |appeal|
       RampClosedAppeal.create!(

--- a/app/models/ramp_refiling_intake.rb
+++ b/app/models/ramp_refiling_intake.rb
@@ -40,12 +40,7 @@ class RampRefilingIntake < Intake
     detail.create_end_product_and_contentions! if detail.needs_end_product?
 
     complete_with_status!(:success)
-    unless detail.established_at
-      detail.update!(
-        established_at: Time.zone.now,
-        established_by_user_id: user.id
-      )
-    end
+    mark_detail_as_established
   end
 
   def review_errors

--- a/app/models/ramp_refiling_intake.rb
+++ b/app/models/ramp_refiling_intake.rb
@@ -40,10 +40,12 @@ class RampRefilingIntake < Intake
     detail.create_end_product_and_contentions! if detail.needs_end_product?
 
     complete_with_status!(:success)
-    detail.update!(
-      established_at: Time.zone.now,
-      established_by_user_id: user.id
-    ) unless detail.established_at
+    unless detail.established_at
+      detail.update!(
+        established_at: Time.zone.now,
+        established_by_user_id: user.id
+      )
+    end
   end
 
   def review_errors

--- a/app/models/ramp_refiling_intake.rb
+++ b/app/models/ramp_refiling_intake.rb
@@ -40,7 +40,10 @@ class RampRefilingIntake < Intake
     detail.create_end_product_and_contentions! if detail.needs_end_product?
 
     complete_with_status!(:success)
-    detail.update!(established_at: Time.zone.now) unless detail.established_at
+    detail.update!(
+      established_at: Time.zone.now,
+      established_by_user_id: user.id
+    ) unless detail.established_at
   end
 
   def review_errors

--- a/app/models/ramp_review.rb
+++ b/app/models/ramp_review.rb
@@ -50,7 +50,8 @@ class RampReview < ActiveRecord::Base
     establish_claim_in_vbms(end_product).tap do |result|
       update!(
         end_product_reference_id: result.claim_id,
-        established_at: Time.zone.now
+        established_at: Time.zone.now,
+        established_by_user_id: current_user.id
       )
     end
   rescue VBMS::HTTPError => error

--- a/db/migrate/20180330234328_add_established_by_user_id_to_ramp_election_and_refiling.rb
+++ b/db/migrate/20180330234328_add_established_by_user_id_to_ramp_election_and_refiling.rb
@@ -1,6 +1,6 @@
 class AddEstablishedByUserIdToRampElectionAndRefiling < ActiveRecord::Migration
   def change
-    add_column :ramp_elections, :established_by_user_id, :string
-    add_column :ramp_refilings, :established_by_user_id, :string
+    add_column :ramp_elections, :established_by_user_id, :integer
+    add_column :ramp_refilings, :established_by_user_id, :integer
   end
 end

--- a/db/migrate/20180330234328_add_established_by_user_id_to_ramp_election_and_refiling.rb
+++ b/db/migrate/20180330234328_add_established_by_user_id_to_ramp_election_and_refiling.rb
@@ -1,0 +1,6 @@
+class AddEstablishedByUserIdToRampElectionAndRefiling < ActiveRecord::Migration
+  def change
+    add_column :ramp_elections, :established_by_user_id, :string
+    add_column :ramp_refilings, :established_by_user_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180402231703) do
+ActiveRecord::Schema.define(version: 20180330234328) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -377,6 +377,7 @@ ActiveRecord::Schema.define(version: 20180402231703) do
     t.datetime "established_at"
     t.string   "end_product_status"
     t.datetime "end_product_status_last_synced_at"
+    t.string   "established_by_user_id"
   end
 
   add_index "ramp_elections", ["veteran_file_number"], name: "index_ramp_elections_on_veteran_file_number", using: :btree
@@ -400,6 +401,7 @@ ActiveRecord::Schema.define(version: 20180402231703) do
     t.boolean  "has_ineligible_issue"
     t.string   "appeal_docket"
     t.datetime "established_at"
+    t.string   "established_by_user_id"
   end
 
   add_index "ramp_refilings", ["veteran_file_number"], name: "index_ramp_refilings_on_veteran_file_number", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180330234328) do
+ActiveRecord::Schema.define(version: 20180402231703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 20180402231703) do
     t.datetime "established_at"
     t.string   "end_product_status"
     t.datetime "end_product_status_last_synced_at"
-    t.string   "established_by_user_id"
+    t.integer  "established_by_user_id"
   end
 
   add_index "ramp_elections", ["veteran_file_number"], name: "index_ramp_elections_on_veteran_file_number", using: :btree
@@ -401,7 +401,7 @@ ActiveRecord::Schema.define(version: 20180402231703) do
     t.boolean  "has_ineligible_issue"
     t.string   "appeal_docket"
     t.datetime "established_at"
-    t.string   "established_by_user_id"
+    t.integer  "established_by_user_id"
   end
 
   add_index "ramp_refilings", ["veteran_file_number"], name: "index_ramp_refilings_on_veteran_file_number", using: :btree

--- a/spec/jobs/sync_intake_job_spec.rb
+++ b/spec/jobs/sync_intake_job_spec.rb
@@ -2,7 +2,8 @@ describe SyncIntakeJob do
   context ".perform" do
     it "calls recreate_issues_from_contentions and sync_ep_status" do
       ramp_election = instance_double(RampElection)
-      expect(RampElection).to receive(:active).and_return([ramp_election]).twice
+      expect(RampElection).to receive(:active).and_return([ramp_election])
+      expect(RampElection).to receive(:established).and_return([ramp_election])
       allow(ramp_election).to receive(:recreate_issues_from_contentions!).and_return(true)
       allow(ramp_election).to receive(:sync_ep_status!).and_return(true)
 

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -69,6 +69,14 @@ describe RampElectionIntake do
   context "#complete!" do
     subject { intake.complete!({}) }
 
+    before do
+      User.authenticate!
+    end
+
+    after do
+      User.unauthenticate!
+    end
+    
     let(:detail) do
       RampElection.create!(
         veteran_file_number: "64205555",
@@ -114,10 +122,16 @@ describe RampElectionIntake do
         disposition_code: "P"
       )
 
+      puts("Hello")
+      puts(intake.detail.established_at)
+
       subject
 
+      puts("Hello")
+      puts(intake.detail.established_at)
       expect(intake.reload).to be_success
       expect(intake.detail.established_at).to_not be_nil
+      expect(intake.detail.established_by_user_id).to eq(current_user.id)
     end
 
     context "if VACOLS closure fails" do


### PR DESCRIPTION
connects #4658 

This will be used in a later commit for authenticating with BGS during the SyncIntakeJob so that we can use the correct user ID during authentication to avoid sensitivity errors.