### PR TITLE
No border top css change for hearing days table

### DIFF
--- a/client/app/hearings/Dockets.jsx
+++ b/client/app/hearings/Dockets.jsx
@@ -24,7 +24,8 @@ export const DOCKETS_TAB_INDEX_MAPPING = {
 
 const tableBorder = css({
   border: '1px solid #dadbdc',
-  marginTop: '0px'
+  marginTop: '0px',
+  borderTop: '0px'
 });
 
 const tableBodyStyling = css({
@@ -149,7 +150,7 @@ export class Dockets extends React.Component {
           className="hearings"
           columns={columns}
           rowObjects={upcomingRowObjects}
-          summary="Your Upcoming Hearing Days?"
+          summary="Your Upcoming Hearing Days"
           getKeyForRow={this.getKeyForRow}
           styling={tableBorder}
           bodyStyling={tableBodyStyling}
@@ -161,7 +162,7 @@ export class Dockets extends React.Component {
           className="hearings"
           columns={columns}
           rowObjects={pastRowObjects}
-          summary="Your Past Hearing Days?"
+          summary="Your Past Hearing Days"
           getKeyForRow={this.getKeyForRow}
           styling={tableBorder}
           bodyStyling={tableBodyStyling}


### PR DESCRIPTION
Resolves #4212 

### Description
removing border top of the table on Your Hearing days page

### Acceptance Criteria 
- [ ] notice no border at the top and tab looks clean

