### PR TITLE
Removing margins from daily docket table

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -77,10 +77,7 @@ $color-hearings-saving: $color-gray;
 .cf-hearings,
 .cf-hearings-schedule,
 .cf-hearings-worksheet {
-  padding-bottom: $cf-30px;
-  padding-top: 50px;
-  padding-left: 40px;
-  padding-right: 40px;
+  padding: 40px;
 
   .cf-hearings-title-and-judge {
     h1 {
@@ -113,6 +110,9 @@ $color-hearings-saving: $color-gray;
 
   .cf-hearings-docket {
     margin-top: 0;
+    margin-bottom: -40px;
+    margin-right: -40px;
+    margin-left: -40px;
 
     // TODO: see if this can become a part of the general style
     .Select-arrow-zone {
@@ -146,7 +146,7 @@ $color-hearings-saving: $color-gray;
       &:first-child {
         font-weight: bold;
         padding-right: 0;
-        padding-left: 0;
+        padding-left: 20px;
         float: right;
       }
     }
@@ -233,7 +233,7 @@ $color-hearings-saving: $color-gray;
       background-color: $color-gray-lightest;
 
       .cf-form-dropdown {
-        min-width: 170px;
+        min-width: 150px;
         text-align: left;
         display: inline-block;
         width: 33%;


### PR DESCRIPTION
Resolves #4332 

### Description
This PR updates the margins on the daily docket table so we can see all the dropdowns in one row. 


<img width="1106" alt="screen shot 2018-04-04 at 3 21 41 pm" src="https://user-images.githubusercontent.com/4306128/38329477-ee867a50-381b-11e8-84aa-25905b545144.png">

### Testing Plan
1. Confirm the upcoming hearings and the hearing worksheet pages of hearing prep display as usual
2. Confirm the daily docket dropdowns display in one row

