### PR TITLE
Adding search for description and preventing unnecessary state changes

### DIFF
--- a/client/app/reader/DocTypeColumn.jsx
+++ b/client/app/reader/DocTypeColumn.jsx
@@ -30,7 +30,7 @@ class DocTypeColumn extends React.PureComponent {
         </Highlight>
       </ViewableItemLink>
       {doc.description && <p className="document-list-doc-description">
-        {doc.description}
+        <Highlight>{doc.description}</Highlight>
       </p>}
     </div>;
   }

--- a/client/app/reader/DocumentSearch.jsx
+++ b/client/app/reader/DocumentSearch.jsx
@@ -88,7 +88,11 @@ export class DocumentSearch extends React.PureComponent {
       this.clearSearch();
     }
 
-    this.props.setSearchIsLoading(!this.props.pdfText.length && this.searchTerm.length > 0);
+    const searchIsLoading = !this.props.pdfText.length && this.searchTerm.length > 0;
+
+    if (this.props.searchIsLoading !== searchIsLoading) {
+      this.props.setSearchIsLoading(searchIsLoading);
+    }
   }
 
   componentDidMount = () => window.addEventListener('keydown', this.shortcutHandler)

--- a/client/app/reader/search.js
+++ b/client/app/reader/search.js
@@ -44,6 +44,9 @@ const tagContainsString = (searchQuery, doc) =>
     return acc || (doc.tags[tag].text.toLowerCase().includes(searchQuery));
   }, false);
 
+const descriptionContainsString = (searchQuery, doc) =>
+  doc.description && doc.description.toLowerCase().includes(searchQuery);
+
 export const searchString = (searchQuery, state) => (doc) => {
   let queryTokens = _.compact(searchQuery.split(' '));
 
@@ -55,6 +58,7 @@ export const searchString = (searchQuery, state) => (doc) => {
       commentContainsString(word, state, doc) ||
       typeContainsString(searchWord, doc) ||
       categoryContainsString(searchWord, doc) ||
-      tagContainsString(searchWord, doc));
+      tagContainsString(searchWord, doc) ||
+      descriptionContainsString(searchWord, doc));
   });
 };


### PR DESCRIPTION
Resolves #5071

### Description
Two changes, removed an unnecessary update to state. Added ability to search for descriptions in documents.

## AC
1) Searching for text that is in a document description should filter that document into the search.
1) Searching for text that is in a document description, the text should be highlighted.

### Testing Plan
1. Go to document page, add a description in the document information sidebar
1. Go to the list page and make sure you can search for that document based on the description.

