### PR TITLE
Add client/yarn-error.log to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.bundle
 
 client/.eslintcache
+client/yarn-error.log
 
 # Ignore the default SQLite database.
 /db/*.sqlite3


### PR DESCRIPTION
Not related to an issue, but would be nice for me and seems appropriate for .gitignore

