### PR TITLE
white-space fix for non pdf print view

### DIFF
--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -4,7 +4,6 @@
 // variables here should eventually find their way into commons
 @import 'variables';
 
-
 .worksheet-header {
   .question-label {
     margin-bottom: 4px;
@@ -406,7 +405,6 @@
 
 .cf-hearings-worksheet-issues {
   margin: 0;
-  white-space: pre-line;
 
   .cf-form-textarea {
     min-height: 48px;
@@ -636,7 +634,6 @@
  }
 
   .cf-hearings-worksheet-data {
-    white-space: pre-line;
     margin-bottom: 0;
 
     p {

--- a/app/assets/stylesheets/_hearings.scss
+++ b/app/assets/stylesheets/_hearings.scss
@@ -327,6 +327,7 @@
 }
 
 .cf-hearings-worksheet-data {
+  white-space: pre-line;
   position: relative;
   margin-bottom: 1.765em;
 
@@ -405,6 +406,7 @@
 
 .cf-hearings-worksheet-issues {
   margin: 0;
+  white-space: pre-line;
 
   .cf-form-textarea {
     min-height: 48px;
@@ -634,6 +636,7 @@
  }
 
   .cf-hearings-worksheet-data {
+    white-space: pre-line;
     margin-bottom: 0;
 
     p {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -9,6 +9,7 @@ body {
   margin: 0;
   height: 100%;
   color: $color-gray-dark;
+  white-space: pre-line;
 }
 
 .cf-content {

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -9,7 +9,6 @@ body {
   margin: 0;
   height: 100%;
   color: $color-gray-dark;
-  white-space: pre-line;
 }
 
 .cf-content {


### PR DESCRIPTION
Resolves #4800 

### Description
White space is maintained on the PDF view, and on the print view

<img width="490" alt="screen shot 2018-04-05 at 4 06 50 pm" src="https://user-images.githubusercontent.com/4306128/38389112-64d8008c-38eb-11e8-85eb-be6cc78010ad.png">


<img width="605" alt="screen shot 2018-04-05 at 4 13 01 pm" src="https://user-images.githubusercontent.com/4306128/38389374-419b2378-38ec-11e8-8bd7-66929e5f39c8.png">
