### PR TITLE
Eager load directories in production env

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module CaseflowCertification
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     # config.load_defaults 5.1
-    
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
@@ -29,9 +29,9 @@ module CaseflowCertification
     # setup the deploy env environment variable
     ENV['DEPLOY_ENV'] ||= Rails.env
 
-    config.autoload_paths << Rails.root.join('lib')
-    config.autoload_paths << Rails.root.join('services')
-    config.autoload_paths += Dir[Rails.root.join('app', 'models', '{**}')]
+    config.eager_load_paths << Rails.root.join('lib')
+    config.eager_load_paths += Dir[Rails.root.join('app', 'models', '{**}')]
+
     config.exceptions_app = self.routes
 
     config.cache_store = :redis_store, Rails.application.secrets.redis_url_cache, { expires_in: 24.hours }


### PR DESCRIPTION
Resolves #5089 

### Description
In Production, Rails 5 will load all the constants from eager_load_paths but if a constant is missing then it will NOT look in autoload_paths and will NOT attempt to load the missing constant. So we need to change autoload_paths to be eager_load_paths. We can remove autoload_paths all together because in development autoloading is configured to check for eager loaded paths.

Resources: 
https://blog.arkency.com/2014/11/dont-forget-about-eager-load-when-extending-autoload/
https://blog.bigbinary.com/2016/08/29/rails-5-disables-autoloading-after-booting-the-app-in-production.html


