### PR TITLE
Modifying CircleCI bundler cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,21 +34,21 @@ jobs:
           command: mkdir -p ~/project/tmp/testfiles
 
       - restore_cache:
-          name: Restore bundler cache
-          key: vendor-bundle-{{ checksum "Gemfile.lock" }}
+          keys:
+            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - gem-cache-{{ arch }}-{{ .Branch }}
+            - gem-cache
+            
+      - run: bundle install --path vendor/bundle
+      
+      - save_cache:
+          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
 
       - restore_cache:
           name: Restore yarn cache
           key: dot-cache-yarn-{{ checksum "client/yarn.lock" }}
-
-      - run:
-          name: bundle install
-          command: bundle check || bundle install
-
-      - save_cache:
-          key: vendor-bundle-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
 
       - run:
           name: yarn install


### PR DESCRIPTION
Using the exact caching strategy from the CircleCI doc here- https://circleci.com/docs/2.0/caching/

Doing this because recently our bundle cache stopped working and our Circle builds were 2-3 minutes slower due to bundle install. I believe this happened around the time we started using our own Docker image for our Circle builds, but because master was failing it's hard to say for sure. I am not sure why our bundler cache stopped working, but I've validated that this fixes it. Will investigate further if this happens again.