### PR TITLE
Remove sleep from sync_all

### DIFF
--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -24,9 +24,6 @@ class RampElection < RampReview
         Rails.logger.error "RampElection.sync_all! failed: #{e.message}"
         Raven.capture_exception(e)
       end
-
-      # Sleep for 1 second to avoid tripping BGS alerts
-      sleep 1
     end
   end
 

--- a/spec/models/ramp_election_spec.rb
+++ b/spec/models/ramp_election_spec.rb
@@ -68,7 +68,6 @@ describe RampElection do
       expect(ramp_election2).to receive(:recreate_issues_from_contentions!).and_raise(ActiveRecord::RecordInvalid)
       expect(Rails.logger).to receive(:error)
       expect(Raven).to receive(:capture_exception)
-      expect(RampElection).to receive(:sleep).with(1).twice
       allow(RampElection).to receive(:active).and_return([ramp_election1, ramp_election2])
 
       RampElection.sync_all!


### PR DESCRIPTION
connects #4658 

We've learned that this sleep is probably not necessary because other folks have successfully run jobs with higher rate and volume of requests against BGS with no issue.