### PR TITLE
Adding contested claim status to hearing worksheet

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -23,7 +23,7 @@ class Appeal < ApplicationRecord
   vacols_attr_accessor :appellant_relationship, :appellant_ssn
   vacols_attr_accessor :appellant_address_line_1, :appellant_address_line_2
   vacols_attr_accessor :appellant_city, :appellant_state, :appellant_country, :appellant_zip
-  vacols_attr_accessor :representative
+  vacols_attr_accessor :representative, :rep_type
   vacols_attr_accessor :hearing_request_type, :video_hearing_requested
   vacols_attr_accessor :hearing_requested, :hearing_held
   vacols_attr_accessor :regional_office_key
@@ -183,6 +183,10 @@ class Appeal < ApplicationRecord
     @veteran ||= Veteran.new(file_number: sanitized_vbms_id).load_bgs_record!
   end
 
+  def contested_claim
+    rep_type == "C"
+  end
+
   delegate :age, to: :veteran, prefix: true
   delegate :sex, to: :veteran, prefix: true
 
@@ -302,6 +306,7 @@ class Appeal < ApplicationRecord
       "form9_date" => form9_date,
       "ssoc_dates" => ssoc_dates,
       "docket_number" => docket_number,
+      "contested_claim" => contested_claim,
       "cached_number_of_documents_after_certification" => cached_number_of_documents_after_certification,
       "worksheet_issues" => worksheet_issues
     }

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -14,7 +14,7 @@ class AppealRepository
     case_record = MetricsService.record("VACOLS: load_vacols_data #{appeal.vacols_id}",
                                         service: :vacols,
                                         name: "load_vacols_data") do
-      VACOLS::Case.includes(:folder, :correspondent).find(appeal.vacols_id)
+      VACOLS::Case.includes(:folder, :correspondent, :representative).find(appeal.vacols_id)
     end
 
     set_vacols_values(appeal: appeal, case_record: case_record)
@@ -124,6 +124,7 @@ class AppealRepository
       type: VACOLS::Case::TYPES[case_record.bfac],
       file_type: folder_type_from(folder_record),
       representative: VACOLS::Case::REPRESENTATIVES[case_record.bfso][:full_name],
+      rep_type: case_record.representative.try(:reptype),
       veteran_first_name: correspondent_record.snamef,
       veteran_middle_initial: correspondent_record.snamemi,
       veteran_last_name: correspondent_record.snamel,

--- a/client/app/hearings/components/HearingWorksheetDocs.jsx
+++ b/client/app/hearings/components/HearingWorksheetDocs.jsx
@@ -30,7 +30,10 @@ class HearingWorksheetDocs extends Component {
 
         return <div key={appeal.id} id={appeal.id}><div>
           {!this.props.print &&
-            <p className="cf-appeal-stream-label">APPEAL STREAM <span>{key + 1}</span></p>
+            <p className="cf-appeal-stream-label">
+              APPEAL STREAM <span>{key + 1}</span>
+              {appeal.contested_claim && <span className="cf-red-text"> CC</span>}
+            </p>
           }
           {this.props.print &&
             <p className="cf-hearings-print-appeal-stream">APPEAL STREAM <span>{key + 1}</span></p>

--- a/lib/generators/appeal.rb
+++ b/lib/generators/appeal.rb
@@ -35,7 +35,8 @@ class Generators::Appeal
         form9_date: 11.days.ago,
         appellant_city: "Huntingdon",
         appellant_state: "TN",
-        docket_number: 4198
+        docket_number: 4198,
+        rep_type: "C"
       }
     end
     # rubocop:enable Metrics/MethodLength

--- a/spec/feature/hearings_spec.rb
+++ b/spec/feature/hearings_spec.rb
@@ -192,6 +192,7 @@ RSpec.feature "Hearings" do
       expect(page).to have_content("Docket Number: 4198")
       expect(page).to have_content("Form 9: 12/21/2016")
       expect(page).to have_content("Army 02/13/2002 - 12/21/2003")
+      expect(page).to have_content("CC")
       expect(page.title).to eq "V. Veteran Last Name1's Hearing Worksheet"
     end
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -22,7 +22,8 @@ describe Appeal do
       manifest_vva_fetched_at: appeal_manifest_vva_fetched_at,
       location_code: location_code,
       status: status,
-      disposition: disposition
+      disposition: disposition,
+      rep_type: "C"
     )
   end
 
@@ -101,6 +102,11 @@ describe Appeal do
         expect(subject.last.type).to eq(type.last)
       end
     end
+  end
+
+  context "#contested_claim" do
+    subject { appeal.contested_claim }
+    it { is_expected.to eq(true) }
   end
 
   context "#nod" do


### PR DESCRIPTION
Connects #4337

### Description
This PR pulls contested claim status from VACOLS (reptype from rep table = "C") and displays it on the hearing worksheet.

<img width="796" alt="screen shot 2018-04-12 at 5 04 07 pm" src="https://user-images.githubusercontent.com/4306128/38704200-8cf0ecf4-3e73-11e8-9deb-8f507fec1b4d.png">

### Testing Plan
1. Find an appeal in UAT with a contested claim status
1. Create a hearing for that appeal
1. Go to the hearing worksheet for that hearing
1. Confirm that you see 'CC' as displayed in the above screenshot

