### PR TITLE
Updates caseflow-commons to fix fiscal year label

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/LineLength
 source ENV["GEM_SERVER_URL"] || "https://rubygems.org"
 
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "5e6830534124f578f43c619c8620c0560365aa55"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "aedd9ddfee4018a26b8b9ad77b519eb61ad03382"
 
 gem "moment_timezone-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 5e6830534124f578f43c619c8620c0560365aa55
-  ref: 5e6830534124f578f43c619c8620c0560365aa55
+  revision: aedd9ddfee4018a26b8b9ad77b519eb61ad03382
+  ref: aedd9ddfee4018a26b8b9ad77b519eb61ad03382
   specs:
-    caseflow (0.3.4)
+    caseflow (0.3.5)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails
@@ -247,7 +247,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     moment_timezone-rails (0.5.0)
-    momentjs-rails (2.17.1)
+    momentjs-rails (2.20.1)
       railties (>= 3.1)
     multi_json (1.12.2)
     multipart-post (2.0.0)

--- a/spec/feature/intake_stats_spec.rb
+++ b/spec/feature/intake_stats_spec.rb
@@ -185,8 +185,8 @@ RSpec.feature "Intake Stats Dashboard" do
     Timecop.freeze(Time.utc(2020, 11, 7, 17, 55, 0, rand(1000)))
     User.authenticate!(roles: ["Admin Intake"])
     expect(CalculateIntakeStatsJob).to receive(:perform_later)
-    visit "/intake/stats/fiscal_yearly" 
-    expect(find("#ramp-elections-sent")).to have_content("RAMP Elections Sent for FY 2021 (so far)")   
+    visit "/intake/stats/fiscal_yearly"
+    expect(find("#ramp-elections-sent")).to have_content("RAMP Elections Sent for FY 2021 (so far)")
   end
 
   scenario "Unauthorized user access" do

--- a/spec/feature/intake_stats_spec.rb
+++ b/spec/feature/intake_stats_spec.rb
@@ -5,6 +5,10 @@ RSpec.feature "Intake Stats Dashboard" do
     Timecop.freeze(Time.utc(2020, 1, 7, 17, 55, 0, rand(1000)))
   end
 
+  after do
+    Timecop.return
+  end
+
   scenario "Switching tab intervals" do
     User.authenticate!(roles: ["Admin Intake"])
 
@@ -117,7 +121,7 @@ RSpec.feature "Intake Stats Dashboard" do
       established_at: nil
     )
 
-    expect(CalculateIntakeStatsJob).to receive(:perform_later)
+    expect(CalculateIntakeStatsJob).to receive(:perform_later).twice
     visit "/intake/stats"
     expect(find("#ramp-elections-sent")).to have_content("RAMP Elections Sent for January (so far)")
     expect(find("#ramp-elections-sent")).to have_content("Total 4")
@@ -172,6 +176,17 @@ RSpec.feature "Intake Stats Dashboard" do
     expect(find("#ramp-elections-received")).to have_content("Higher Level Reviews with Hearing 0")
     expect(find("#ramp-elections-received")).to have_content("Supplemental Claims 1")
     expect(find("#ramp-elections-received")).to have_content("Average Response Time 6.00 days")
+
+    click_on "By Fiscal Year"
+    expect(find("#ramp-elections-sent")).to have_content("RAMP Elections Sent for FY 2020 (so far)")
+  end
+
+  scenario "Fiscal Year tab shows correct year after October 1" do
+    Timecop.freeze(Time.utc(2020, 11, 7, 17, 55, 0, rand(1000)))
+    User.authenticate!(roles: ["Admin Intake"])
+    expect(CalculateIntakeStatsJob).to receive(:perform_later)
+    visit "/intake/stats/fiscal_yearly" 
+    expect(find("#ramp-elections-sent")).to have_content("RAMP Elections Sent for FY 2021 (so far)")   
   end
 
   scenario "Unauthorized user access" do


### PR DESCRIPTION
Resolves #5113 

### Description
- Made changes to caseflow-commons to fix fiscal year label for stats page
- Updates Gemfile to include new caseflow-commons
- Adds tests to verify new behavior

### Acceptance Criteria 
- [ ] Fiscal year labels are correct both before and after October 1 for a given year

### Testing Plan
1. Go to /intake/stats and look at fiscal year label

