### PR TITLE
Queue | Make checkbox IDs specific to issue

### DIFF
--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -89,15 +89,15 @@ class IssueRemandReasonsOptions extends React.PureComponent {
   }
 
   toggleRemandReason = (checked, event) => this.setState({
-    [event.target.id]: {
+    [event.target.id.split('-')[1]]: {
       checked,
       after_certification: 'false'
     }
   });
 
-  getCheckbox = (option, onChange, values) => <div className="checkbox" key={option.id}>
+  getCheckbox = (option, onChange, values) => <React.Fragment key={option.id}>
     <Checkbox
-      name={option.id}
+      name={`${this.props.issue.vacols_sequence_id}-${option.id}`}
       onChange={onChange}
       value={values[option.id].checked}
       label={option.label}
@@ -124,7 +124,7 @@ class IssueRemandReasonsOptions extends React.PureComponent {
         }
       })}
     />}
-  </div>;
+  </React.Fragment>;
 
   render = () => {
     const {

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -107,7 +107,7 @@ class IssueRemandReasonsOptions extends React.PureComponent {
       vertical
       key={`${option.id}-after-certification`}
       styling={css(smallLeftMargin, smallBottomMargin)}
-      name={`${option.id}-after-cert-radio-btns`}
+      name={`${this.props.issue.vacols_sequence_id}-${option.id}`}
       hideLabel
       options={[{
         displayText: 'Before certification',


### PR DESCRIPTION
Resolves an issue with #5074

### Description
After reviewing the Remand Reasons pr (#5074), Mark suggested we should use `<Checkbox>` rather than `<input type="checkbox"... />`. I made this change and confirmed it worked with one issue remand reason bank rendered, but failed to test with multiple option sets on screen.

### Acceptance Criteria 
- [ ] `IssueRemandReasonsOptions` checkboxes update state only within that component, no others

### Testing Plan
1. Go to Draft Decision checkout flow, set > 1 issue dispositions to Remanded
2. Make sure all remand reason blocks are rendered, check different options for different issues
3. Verify that changes made to an issue's remand reasons show up only in that block

Before:
![remand_reason_checkbox_error](https://user-images.githubusercontent.com/8533004/38749675-783aebfe-3f20-11e8-94e0-57397104116c.gif)

After:
![remand_reason_success](https://user-images.githubusercontent.com/8533004/38749786-e2a6dc8c-3f20-11e8-8553-902a818d7437.gif)
