### PR TITLE
Makes button more enticing

### DIFF
--- a/client/app/reader/CaseSelectSearch.jsx
+++ b/client/app/reader/CaseSelectSearch.jsx
@@ -107,7 +107,7 @@ class CaseSelectSearch extends React.PureComponent {
             onClick: this.handleModalClose
           },
           { classNames: ['usa-button', 'usa-button-primary'],
-            name: 'Okay',
+            name: 'Open Claims Folder',
             onClick: this.handleSelectAppeal,
             disabled: _.isEmpty(caseSelect.selectedAppealVacolsId)
           }

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature "Queue" do
       expect(appeal_options[0].find_all("li").count).to eq(appeal.issues.size)
 
       appeal_options[0].click
-      click_on "Okay"
+      click_on "Open Claims Folder"
 
       expect(page).to have_content("#{appeal.veteran_full_name}'s Claims Folder")
       expect(page).to have_link("Back to Your Queue", href: "/queue")

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -385,10 +385,10 @@ RSpec.feature "Reader" do
         expect(appeal_options[1]).to have_content("Veteran ID " + appeal4.vbms_id)
         expect(appeal_options[1]).to have_content("Issues")
         expect(appeal_options[1].find_all("li").count).to eq(appeal4.issues.count)
-        expect(find("button", text: "Okay")).to be_disabled
+        expect(find("button", text: "Open Claims Folder")).to be_disabled
 
         appeal_options[0].click
-        click_on "Okay"
+        click_on "Open Claims Folder"
         expect(page).to have_content(appeal3.veteran_full_name + "\'s Claims Folder")
       end
 
@@ -415,7 +415,7 @@ RSpec.feature "Reader" do
 
           click_button("Select-claims-folder-button-id-close")
           fill_in "searchBar", with: (appeal4.vbms_id + "\n")
-          expect(find("button", text: "Okay")).to be_disabled
+          expect(find("button", text: "Open Claims Folder")).to be_disabled
         end
       end
 


### PR DESCRIPTION
### Description
"Okay" isn't very meaningful. We should make the button's purpose clear.

### Acceptance Criteria
- [x] Button has a better name.

### Testing Plan
- [x] Log in as BVAAABSHIRE at 283.
- [x] On /queue, search for 686623298.
- [x] In the dialog box, check that the button's name is now "Open Claims Folder".