### PR TITLE
Anya/5053 judge assign to another attorney

### DIFF
--- a/app/controllers/queue_controller.rb
+++ b/app/controllers/queue_controller.rb
@@ -119,7 +119,7 @@ class QueueController < ApplicationController
 
   def task_params
     params.require("queue")
-      .permit(:appeal_id, :appeal_type)
+      .permit(:appeal_type, :appeal_id)
       .merge(assigned_to: User.find(params[:queue][:attorney_id]))
       .merge(assigned_by: current_user)
   end

--- a/app/controllers/queue_controller.rb
+++ b/app/controllers/queue_controller.rb
@@ -11,7 +11,6 @@ class QueueController < ApplicationController
   end
 
   ROLES = %w[Judge Attorney].freeze
-  APPEAL_TYPES = %w[Legacy Ama].freeze
 
   def set_application
     RequestStore.store[:application] = "queue"
@@ -31,21 +30,15 @@ class QueueController < ApplicationController
   end
 
   def create
-    return invalid_appeal_type unless APPEAL_TYPES.include?(create_params[:appeal_type])
-
     return invalid_role_error if current_user.vacols_role != "Judge"
-
     JudgeCaseAssignment.new(task_params).assign_to_attorney!
     render json: {}, status: :created
   end
 
   def update
-    return invalid_appeal_type unless APPEAL_TYPES.include?(create_params[:appeal_type])
-
     return invalid_role_error if current_user.vacols_role != "Judge"
-
-    JudgeCaseAssignment.new(tasks_params.merge(task_id: params[:task_id])).reassign_to_attorney!
-    render json: {}, status: :updated
+    JudgeCaseAssignment.new(task_params.merge(task_id: params[:task_id])).reassign_to_attorney!
+    render json: {}, status: 200
   end
 
   def tasks
@@ -104,15 +97,6 @@ class QueueController < ApplicationController
     }, status: 400
   end
 
-  def invalid_appeal_type
-    render json: {
-      "errors": [
-        "title": "Appeal Type is Invalid",
-        "detail": "Appeal type should be one of the following: #{APPEAL_TYPES.join(', ')}"
-      ]
-    }, status: 400
-  end
-
   def attorney_case_review_error
     render json: {
       "errors": [
@@ -133,12 +117,11 @@ class QueueController < ApplicationController
                                             remand_reasons: [:code, :after_certification]])
   end
 
-  def tasks_params
+  def task_params
     params.require("queue")
       .permit(:appeal_id, :appeal_type)
       .merge(assigned_to: User.find(params[:queue][:attorney_id]))
       .merge(assigned_by: current_user)
-      )
   end
 
   def json_appeals(appeals)

--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -3,7 +3,11 @@ module QueueMapper
     work_product: :deprod,
     note: :deatcom,
     document_id: :dedocid,
-    modifying_user: :demdusr
+    modifying_user: :demdusr,
+    reassigned_to_judge_date: :dereceive,
+    assigned_to_attorney_date: :deassign,
+    attorney_id: :deatty,
+    group_name: :deteam
   }.freeze
 
   WORK_PRODUCTS = {
@@ -30,11 +34,8 @@ module QueueMapper
       result[COLUMN_NAMES[k]] = decass_attrs[k]
       result
     end
-    VacolsHelper.validate_presence(update_attrs, [:deprod, :dedocid])
-    update_attrs.merge(
-      dereceive: VacolsHelper.local_date_with_utc_timezone,
-      demdtim: VacolsHelper.local_date_with_utc_timezone
-    )
+
+    update_attrs.merge(demdtim: VacolsHelper.local_date_with_utc_timezone)
   end
 
   def self.work_product_to_vacols_code(work_product, overtime)

--- a/app/models/attorney_case_reviews/attorney_case_review.rb
+++ b/app/models/attorney_case_reviews/attorney_case_review.rb
@@ -4,6 +4,7 @@ class AttorneyCaseReview < ApplicationRecord
 
   validates :attorney, :type, :task_id, :reviewing_judge, :document_id, :work_product, presence: true
   validates :overtime, inclusion: { in: [true, false] }
+  validates :work_product, inclusion: { in: QueueMapper::WORK_PRODUCTS.values }
 
   attr_accessor :issues
 
@@ -25,7 +26,8 @@ class AttorneyCaseReview < ApplicationRecord
         document_id: document_id,
         overtime: overtime,
         note: note,
-        modifying_user: attorney.vacols_uniq_id
+        modifying_user: attorney.vacols_uniq_id,
+        reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone
       }
     )
   end

--- a/app/models/judge_case_assignment.rb
+++ b/app/models/judge_case_assignment.rb
@@ -37,7 +37,7 @@ class JudgeCaseAssignment
           judge: assigned_by,
           attorney: assigned_to,
           vacols_id: vacols_id,
-          created_in_vacols_date: created_in_vacols_date
+          created_in_vacols_date: task_id.split("-", 2).second.to_date
         )
       end
     end
@@ -47,10 +47,6 @@ class JudgeCaseAssignment
 
   def validate!
     fail ActiveRecord::RecordInvalid unless valid?
-  end
-
-  def created_in_vacols_date
-    task_id.split("-", 2).second.to_date
   end
 
   class << self

--- a/app/models/judge_case_assignment.rb
+++ b/app/models/judge_case_assignment.rb
@@ -14,8 +14,8 @@ class JudgeCaseAssignment
     when "Legacy"
       vacols_id = Appeal.find(appeal_id).vacols_id
       MetricsService.record("VACOLS: assign_case_to_attorney #{vacols_id}",
-                              service: :vacols,
-                              name: "assign_case_to_attorney") do
+                            service: :vacols,
+                            name: "assign_case_to_attorney") do
         self.class.repository.assign_case_to_attorney!(
           judge: assigned_by,
           attorney: assigned_to,
@@ -32,8 +32,8 @@ class JudgeCaseAssignment
     when "Legacy"
       vacols_id = task_id.split("-", 2).first
       MetricsService.record("VACOLS: reassign_case_to_attorney #{vacols_id}",
-                              service: :vacols,
-                              name: "reassign_case_to_attorney") do
+                            service: :vacols,
+                            name: "reassign_case_to_attorney") do
         self.class.repository.reassign_case_to_attorney!(
           judge: assigned_by,
           attorney: assigned_to,

--- a/app/models/judge_case_assignment.rb
+++ b/app/models/judge_case_assignment.rb
@@ -1,22 +1,49 @@
 class JudgeCaseAssignment
-  class << self
-    attr_writer :repository
+  include ActiveModel::Model
 
-    def assign_to_attorney!(params)
-      case params[:appeal_type]
-      when "Legacy"
-        vacols_id = Appeal.find(params[:appeal_id]).vacols_id
-        MetricsService.record("VACOLS: assign_case_to_attorney #{vacols_id}",
+  attr_accessor :task_id, :assigned_by, :assigned_to, :appeal_id, :appeal_type
+
+  def assign_to_attorney!
+    case appeal_type
+    when "Legacy"
+      MetricsService.record("VACOLS: assign_case_to_attorney #{vacols_id}",
                               service: :vacols,
                               name: "assign_case_to_attorney") do
-          repository.assign_case_to_attorney!(
-            judge: params[:assigned_by],
-            attorney: params[:assigned_to],
-            vacols_id: vacols_id
-          )
-        end
+        self.class.repository.assign_case_to_attorney!(
+          judge: assigned_by,
+          attorney: assigned_to,
+          vacols_id: vacols_id
+        )
       end
     end
+  end
+
+  def reassign_to_attorney!
+    case appeal_type
+    when "Legacy"
+      self.class.repository.reassign_case_to_attorney!(
+        judge: assigned_by,
+        attorney: assigned_to,
+        vacols_id: vacols_id,
+        created_in_vacols_date: created_in_vacols_date
+      )
+      end
+    end
+  end
+
+  private
+
+  def vacols_id
+    return Appeal.find(:appeal_id).vacols_id if appeal_id
+    task_id.split("-", 2).first if task_id
+  end
+
+  def created_in_vacols_date
+    task_id.split("-", 2).second.to_date
+  end
+
+  class << self
+    attr_writer :repository
 
     def repository
       @repository ||= QueueRepository

--- a/app/models/judge_case_assignment.rb
+++ b/app/models/judge_case_assignment.rb
@@ -3,9 +3,16 @@ class JudgeCaseAssignment
 
   attr_accessor :task_id, :assigned_by, :assigned_to, :appeal_id, :appeal_type
 
+  # task ID is vacols_id concatenated with the date assigned
+  validates :task_id, format: { with: /\A[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}\Z/i }, allow_blank: true
+  validates :appeal_type, inclusion: { in: %w[Legacy Ama] }
+  validates :assigned_by, :assigned_to, presence: true
+
   def assign_to_attorney!
+    validate!
     case appeal_type
     when "Legacy"
+      vacols_id = Appeal.find(appeal_id).vacols_id
       MetricsService.record("VACOLS: assign_case_to_attorney #{vacols_id}",
                               service: :vacols,
                               name: "assign_case_to_attorney") do
@@ -19,23 +26,27 @@ class JudgeCaseAssignment
   end
 
   def reassign_to_attorney!
+    validate!
     case appeal_type
     when "Legacy"
-      self.class.repository.reassign_case_to_attorney!(
-        judge: assigned_by,
-        attorney: assigned_to,
-        vacols_id: vacols_id,
-        created_in_vacols_date: created_in_vacols_date
-      )
+      vacols_id = task_id.split("-", 2).first
+      MetricsService.record("VACOLS: reassign_case_to_attorney #{vacols_id}",
+                              service: :vacols,
+                              name: "reassign_case_to_attorney") do
+        self.class.repository.reassign_case_to_attorney!(
+          judge: assigned_by,
+          attorney: assigned_to,
+          vacols_id: vacols_id,
+          created_in_vacols_date: created_in_vacols_date
+        )
       end
     end
   end
 
   private
 
-  def vacols_id
-    return Appeal.find(:appeal_id).vacols_id if appeal_id
-    task_id.split("-", 2).first if task_id
+  def validate!
+    fail ActiveRecord::RecordInvalid unless valid?
   end
 
   def created_in_vacols_date

--- a/app/models/judge_case_assignment.rb
+++ b/app/models/judge_case_assignment.rb
@@ -26,6 +26,7 @@ class JudgeCaseAssignment
   end
 
   def reassign_to_attorney!
+    fail ActiveRecord::RecordInvalid unless task_id
     validate!
     case appeal_type
     when "Legacy"

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -62,12 +62,11 @@ class QueueRepository
       update_location_to_attorney(vacols_id, attorney)
 
       decass_record = find_decass_record(vacols_id, created_in_vacols_date)
-      update_decass_record(decass_record, {
-        attorney_id: attorney.vacols_attorney_id,
-        group_name: attorney.vacols_group_id[0..2],
-        assigned_to_attorney_date: VacolsHelper.local_date_with_utc_timezone,
-        modifying_user: judge.vacols_uniq_id
-      })
+      update_decass_record(decass_record,
+                           attorney_id: attorney.vacols_attorney_id,
+                           group_name: attorney.vacols_group_id[0..2],
+                           assigned_to_attorney_date: VacolsHelper.local_date_with_utc_timezone,
+                           modifying_user: judge.vacols_uniq_id)
     end
   end
 

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -65,6 +65,12 @@ class QueueRepository
       vacols_case.update_vacols_location!(attorney.vacols_uniq_id)
       vacols_case.update(bfattid: attorney.vacols_attorney_id)
 
+      decass_record = find_decass_record(vacols_id, created_in_vacols_date)
+      update_decass_record(decass_record, {
+
+        })
+
+
       # VACOLS::Decass.create!(
       #   defolder: vacols_id,
       #   deatty: attorney.vacols_attorney_id,
@@ -85,13 +91,7 @@ class QueueRepository
   end
 
   def self.reassign_case_to_judge!(vacols_id:, created_in_vacols_date:, judge_vacols_user_id:, decass_attrs:)
-    # update DECASS table
-    decass_record = VACOLS::Decass.find_by(defolder: vacols_id, deadtim: created_in_vacols_date)
-    unless decass_record
-      msg = "Decass record does not exist for vacols_id: #{vacols_id} and date created: #{created_in_vacols_date}"
-      fail Caseflow::Error::QueueRepositoryError, msg
-    end
-
+    decass_record = find_decass_record(vacols_id, created_in_vacols_date)
     # In attorney checkout, we are automatically selecting the judge who
     # assigned the attorney the case. But we also have a drop down for the
     # attorney to select a different judge if they are checking it out to someone else
@@ -104,6 +104,15 @@ class QueueRepository
     # update location with the judge's slogid
     VACOLS::Case.find(vacols_id).update_vacols_location!(judge_vacols_user_id)
     true
+  end
+
+  def self.find_decass_record(vacols_id, created_in_vacols_date)
+    decass_record = VACOLS::Decass.find_by(defolder: vacols_id, deadtim: created_in_vacols_date)
+    unless decass_record
+      msg = "Decass record does not exist for vacols_id: #{vacols_id} and date created: #{created_in_vacols_date}"
+      fail Caseflow::Error::QueueRepositoryError, msg
+    end
+    decass_record
   end
 
   def self.update_decass_record(decass_record, decass_attrs)

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -59,6 +59,25 @@ class QueueRepository
     end
   end
 
+  def self.reassign_case_to_attorney!(judge:, attorney:, vacols_id:, created_in_vacols_date:)
+    transaction do
+      vacols_case = VACOLS::Case.find(vacols_id)
+      vacols_case.update_vacols_location!(attorney.vacols_uniq_id)
+      vacols_case.update(bfattid: attorney.vacols_attorney_id)
+
+      # VACOLS::Decass.create!(
+      #   defolder: vacols_id,
+      #   deatty: attorney.vacols_attorney_id,
+      #   deteam: attorney.vacols_group_id[0..2],
+      #   deadusr: judge.vacols_uniq_id,
+      #   deadtim: VacolsHelper.local_date_with_utc_timezone,
+      #   dedeadline: VacolsHelper.local_date_with_utc_timezone + 30.days,
+      #   deassign: VacolsHelper.local_date_with_utc_timezone,
+      #   deicr: decass_complexity_rating(vacols_id)
+      # )
+    end
+  end
+
   def self.decass_complexity_rating(vacols_id)
     VACOLS::Case.select("VACOLS.DECASS_COMPLEX(bfkey) as complexity_rating")
       .find_by(bfkey: vacols_id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,7 @@ Rails.application.routes.draw do
     get '/:user_id', to: 'queue#tasks'
     post '/tasks/:task_id/complete', to: 'queue#complete'
     post '/tasks', to: 'queue#create'
+    patch '/tasks/:task_id', to: 'queue#update'
   end
 
   get "health-check", to: "health_checks#show"

--- a/spec/controllers/queue_controller_spec.rb
+++ b/spec/controllers/queue_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe QueueController, type: :controller do
       end
 
       it "should not be successful" do
-        patch :update, params: { queue: params, task_id: "3615398-2018-04-18"}
+        patch :update, params: { queue: params, task_id: "3615398-2018-04-18" }
         expect(response.status).to eq 400
         response_body = JSON.parse(response.body)
         expect(response_body["errors"].first["title"]).to eq "Role is Invalid"
@@ -146,7 +146,7 @@ RSpec.describe QueueController, type: :controller do
     end
 
     context "when current user is a judge" do
-       let(:params) do
+      let(:params) do
         {
           "attorney_id": attorney.id,
           "appeal_type": "Legacy"
@@ -162,7 +162,7 @@ RSpec.describe QueueController, type: :controller do
           created_in_vacols_date: "2018-04-18".to_date
         ).and_return(true)
 
-        patch :update, params: { queue: params, task_id: "3615398-2018-04-18"}
+        patch :update, params: { queue: params, task_id: "3615398-2018-04-18" }
         expect(response.status).to eq 200
       end
 
@@ -176,7 +176,7 @@ RSpec.describe QueueController, type: :controller do
 
         it "should not be successful" do
           allow(Fakes::UserRepository).to receive(:vacols_role).and_return("Judge")
-          patch :update, params: { queue: params, task_id: "3615398-2018-04-18"}
+          patch :update, params: { queue: params, task_id: "3615398-2018-04-18" }
           expect(response.status).to eq 404
         end
       end

--- a/spec/controllers/queue_controller_spec.rb
+++ b/spec/controllers/queue_controller_spec.rb
@@ -82,23 +82,6 @@ RSpec.describe QueueController, type: :controller do
         expect(response.status).to eq 201
       end
 
-      context "when appeal type is invalid" do
-        let(:params) do
-          {
-            "appeal_id": appeal.id,
-            "attorney_id": attorney.id,
-            "appeal_type": "Unknown"
-          }
-        end
-
-        it "should not be successful" do
-          post :create, params: { queue: params }
-          expect(response.status).to eq 400
-          response_body = JSON.parse(response.body)
-          expect(response_body["errors"].first["title"]).to eq "Appeal Type is Invalid"
-        end
-      end
-
       context "when appeal is not found" do
         let(:params) do
           {
@@ -127,6 +110,73 @@ RSpec.describe QueueController, type: :controller do
         it "should not be successful" do
           allow(Fakes::UserRepository).to receive(:vacols_role).and_return("Judge")
           post :create, params: { queue: params }
+          expect(response.status).to eq 404
+        end
+      end
+    end
+  end
+
+  describe "PATCH queue/tasks" do
+    let(:attorney) { User.create(css_id: "CFS123", station_id: "101") }
+    let(:appeal) { Appeal.create(vacols_id: "1234C") }
+    let!(:current_user) { User.authenticate!(roles: ["System Admin"]) }
+
+    before do
+      FeatureToggle.enable!(:queue_phase_three)
+    end
+
+    after do
+      FeatureToggle.disable!(:queue_phase_three)
+    end
+
+    context "when current user is an attorney" do
+      let(:params) do
+        {
+          "attorney_id": attorney.id,
+          "appeal_type": "Legacy"
+        }
+      end
+
+      it "should not be successful" do
+        patch :update, params: { queue: params, task_id: "3615398-2018-04-18"}
+        expect(response.status).to eq 400
+        response_body = JSON.parse(response.body)
+        expect(response_body["errors"].first["title"]).to eq "Role is Invalid"
+      end
+    end
+
+    context "when current user is a judge" do
+       let(:params) do
+        {
+          "attorney_id": attorney.id,
+          "appeal_type": "Legacy"
+        }
+      end
+
+      it "should be successful" do
+        allow(Fakes::UserRepository).to receive(:vacols_role).and_return("Judge")
+        allow(QueueRepository).to receive(:reassign_case_to_attorney!).with(
+          judge: current_user,
+          attorney: attorney,
+          vacols_id: "3615398",
+          created_in_vacols_date: "2018-04-18".to_date
+        ).and_return(true)
+
+        patch :update, params: { queue: params, task_id: "3615398-2018-04-18"}
+        expect(response.status).to eq 200
+      end
+
+      context "when attorney is not found" do
+        let(:params) do
+          {
+            "attorney_id": 7_777_777_777,
+            "appeal_type": "Legacy"
+          }
+        end
+
+        it "should not be successful" do
+          allow(Fakes::UserRepository).to receive(:vacols_role).and_return("Judge")
+          patch :update, params: { queue: params, task_id: "3615398-2018-04-18"}
           expect(response.status).to eq 404
         end
       end

--- a/spec/mappers/queue_mapper_spec.rb
+++ b/spec/mappers/queue_mapper_spec.rb
@@ -12,7 +12,11 @@ describe QueueMapper do
           overtime: false,
           document_id: "123456789.1234",
           note: "Require action4",
-          modifying_user: "TESTSLOGID" }
+          modifying_user: "TESTSLOGID",
+          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
+          assigned_to_attorney_date: VacolsHelper.local_date_with_utc_timezone,
+          attorney_id: "123",
+          group_name: "DCS" }
       end
       let(:expected_result) do
         { deprod: :IME,
@@ -20,7 +24,10 @@ describe QueueMapper do
           deatcom: "Require action4",
           dereceive: VacolsHelper.local_date_with_utc_timezone,
           demdtim: VacolsHelper.local_date_with_utc_timezone,
-          demdusr: "TESTSLOGID" }
+          demdusr: "TESTSLOGID",
+          deassign: VacolsHelper.local_date_with_utc_timezone,
+          deatty: "123",
+          deteam: "DCS" }
       end
       it { is_expected.to eq expected_result }
     end
@@ -30,6 +37,7 @@ describe QueueMapper do
         { work_product: "OMO - IME",
           overtime: true,
           note: nil,
+          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
           document_id: "123456789.1234",
           modifying_user: "TESTSLOGID" }
       end
@@ -48,6 +56,7 @@ describe QueueMapper do
       let(:info) do
         { work_product: "OMO - IME",
           overtime: false,
+          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
           document_id: "123456789.1234",
           modifying_user: "TESTSLOGID" }
       end
@@ -59,29 +68,6 @@ describe QueueMapper do
           demdusr: "TESTSLOGID" }
       end
       it { is_expected.to eq expected_result }
-    end
-
-    context "when required document ID is missing" do
-      let(:info) do
-        { work_product: "OMO - IME",
-          overtime: true,
-          note: "Require action4" }
-      end
-      it "raises an error" do
-        expect { subject }.to raise_error(Caseflow::Error::MissingRequiredFieldError)
-      end
-    end
-
-    context "when required work product is missing" do
-      let(:info) do
-        { work_product: "Invalid",
-          overtime: true,
-          document_id: "1234",
-          note: "Require action4" }
-      end
-      it "raises an error" do
-        expect { subject }.to raise_error(Caseflow::Error::MissingRequiredFieldError)
-      end
     end
   end
 

--- a/spec/models/attorney_case_reviews/attorney_case_review_spec.rb
+++ b/spec/models/attorney_case_reviews/attorney_case_review_spec.rb
@@ -47,7 +47,8 @@ describe AttorneyCaseReview do
             document_id: "123456789.1234",
             overtime: true,
             modifying_user: "CFS456",
-            note: "something"
+            note: "something",
+            reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone
           }
         ).and_return(true)
 
@@ -89,7 +90,8 @@ describe AttorneyCaseReview do
             document_id: "123456789.1234",
             overtime: true,
             note: "something",
-            modifying_user: "CFS456"
+            modifying_user: "CFS456",
+            reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone
           }
         ).and_return(true)
 

--- a/spec/models/judge_case_assignment_spec.rb
+++ b/spec/models/judge_case_assignment_spec.rb
@@ -1,5 +1,140 @@
-describe JudgeCaseReview do
-  let(:judge) { User.create(css_id: "CFS123", station_id: User::BORAD_STATION_ID) }
-  let(:attorney) { User.create(css_id: "CFS456", station_id: User::BORAD_STATION_ID) }
+describe JudgeCaseAssignment do
+  let(:judge) { User.create(css_id: "CFS123", station_id: User::BOARD_STATION_ID) }
+  let(:attorney) { User.create(css_id: "CFS456", station_id: User::BOARD_STATION_ID) }
+  let(:appeal) { Appeal.create(vacols_id: "123456") }
 
+  context "#assign_to_attorney!" do
+
+    let(:record) do
+      JudgeCaseAssignment.new(
+        appeal_id: appeal_id,
+        assigned_by: assigned_by,
+        assigned_to: assigned_to,
+        appeal_type: appeal_type
+      )
+    end
+
+    subject { record.assign_to_attorney! }
+
+    context "when all required values are present" do
+      let(:appeal_id) { appeal.id }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "it is successful" do
+        expect(QueueRepository).to receive(:assign_case_to_attorney!).once
+        subject
+      end
+    end
+
+    context "when appeal id is not valid" do
+      let(:appeal_id) { 1234 }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect(QueueRepository).to_not receive(:assign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when appeal type is not valid" do
+      let(:appeal_id) { appeal.id }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Unknown" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect(QueueRepository).to_not receive(:assign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "when assigned by is missing" do
+      let(:appeal_id) { appeal.id }
+      let(:assigned_by) { nil }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect(QueueRepository).to_not receive(:assign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+
+  context "#reassign_to_attorney!" do
+    let(:record) do
+      JudgeCaseAssignment.new(
+        task_id: task_id,
+        assigned_by: assigned_by,
+        assigned_to: assigned_to,
+        appeal_type: appeal_type
+      )
+    end
+
+    subject { record.reassign_to_attorney! }
+
+    context "when all required values are present" do
+      let(:task_id) { "3615398-2018-04-18" }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "it is successful" do
+        expect(QueueRepository).to receive(:reassign_case_to_attorney!).once
+        subject
+      end
+    end
+
+    context "when task id is not valid" do
+      let(:task_id) { 1234 }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect(QueueRepository).to_not receive(:reassign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "when task id is missing" do
+      let(:task_id) { nil }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect(QueueRepository).to_not receive(:reassign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "when appeal type is not valid" do
+      let(:task_id) { "3615398-2018-04-18" }
+      let(:assigned_by) { judge }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Unknown" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect(QueueRepository).to_not receive(:reassign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+
+    context "when assigned by is missing" do
+      let(:task_id) { "3615398-2018-04-18" }
+      let(:assigned_by) { nil }
+      let(:assigned_to) { attorney }
+      let(:appeal_type) { "Legacy" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect(QueueRepository).to_not receive(:reassign_case_to_attorney!)
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
 end

--- a/spec/models/judge_case_assignment_spec.rb
+++ b/spec/models/judge_case_assignment_spec.rb
@@ -1,0 +1,5 @@
+describe JudgeCaseReview do
+  let(:judge) { User.create(css_id: "CFS123", station_id: User::BORAD_STATION_ID) }
+  let(:attorney) { User.create(css_id: "CFS456", station_id: User::BORAD_STATION_ID) }
+
+end

--- a/spec/models/judge_case_assignment_spec.rb
+++ b/spec/models/judge_case_assignment_spec.rb
@@ -4,7 +4,6 @@ describe JudgeCaseAssignment do
   let(:appeal) { Appeal.create(vacols_id: "123456") }
 
   context "#assign_to_attorney!" do
-
     let(:record) do
       JudgeCaseAssignment.new(
         appeal_id: appeal_id,


### PR DESCRIPTION
Resolves #5053 

### Description
Allow a judge to assign a case to another attorney


### Testing Plan
Through postman

```
curl -X PATCH 
  http://localhost:3000/queue/tasks/3615398-2018-04-18 
  -d '{ "appeal_id": 103,
  "appeal_type": "Legacy",
  "attorney_id": 1533
}'
```

Through command line:
```
params = { appeal_id: 103, appeal_type: "Legacy", assigned_to: User.find(1533), assigned_by: User.find(1278), task_id: "3615398-2018-04-18" }
JudgeCaseAssignment.new(params).reassign_to_attorney!
```
