### PR TITLE
Judge queue | Adds document ID to judge review table

### DIFF
--- a/client/app/queue/JudgeReviewTaskTable.jsx
+++ b/client/app/queue/JudgeReviewTaskTable.jsx
@@ -26,6 +26,10 @@ class JudgeReviewTaskTable extends React.PureComponent {
       valueFunction: this.getCaseDetailsLink
     },
     {
+      header: 'Document ID',
+      valueFunction: (task) => task.attributes.document_id
+    },
+    {
       header: 'Type(s)',
       valueFunction: (task) => renderAppealType(this.getAppealForTask(task))
     },


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/5260.

### Description
Adds a document ID column to the judge review task table.

<img width="1194" alt="screen shot 2018-04-20 at 2 23 56 pm" src="https://user-images.githubusercontent.com/357369/39067407-8793a92a-44a6-11e8-8436-5feba1c7608c.png">

### Acceptance Criteria 
- [x] Judge review table has a document ID column.

### Testing Plan
- [x] Log in as BVAAABSHIRE.
- [x] On http://localhost:3000/queue, check that the table has a document ID column with document IDs.
- [x] Log in as BVASRITCHIE.
- [x] On http://localhost:3000/queue, check that the table displays the tasks assigned to the attorney.
