### PR TITLE
This will fix sensitive errors for eX v2

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -43,7 +43,9 @@ class ExternalApi::EfolderService
       response_body = JSON.parse(response.body)
 
       if response.error?
-        msg = "Failed for #{vbms_id}, user_id: #{user.id}, error: #{response_body}"
+        fail Caseflow::Error::EfolderAccessForbidden, "403" if response.code == 403
+        fail Caseflow::Error::DocumentRetrievalError, "502" if response.code == 500
+        msg = "Failed for #{vbms_id}, user_id: #{user.id}, error: #{response_body}, HTTP code: #{response.code}"
         fail Caseflow::Error::DocumentRetrievalError, msg
       end
 

--- a/spec/services/external_api/efolder_service_spec.rb
+++ b/spec/services/external_api/efolder_service_spec.rb
@@ -254,7 +254,8 @@ describe ExternalApi::EfolderService do
 
         it "throws Caseflow::Error::DocumentRetrievalError" do
           expect { subject }
-            .to raise_error(Caseflow::Error::DocumentRetrievalError, "Failed for #{vbms_id}, user_id: #{user.id}, error: {}, HTTP code: 404")
+            .to raise_error(Caseflow::Error::DocumentRetrievalError,
+                            "Failed for #{vbms_id}, user_id: #{user.id}, error: {}, HTTP code: 404")
         end
       end
 


### PR DESCRIPTION
Fixes this alert: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1237/events/50914/

For v2 efolder service, we didn't include the check for 403/500 statuses. 
We do catch Caseflow::Error::DocumentRetrievalError in the controller: https://github.com/department-of-veterans-affairs/caseflow/blob/17015700d4a9ad50ede994c871db6e7712effe2a/app/controllers/reader/documents_controller.rb#L2

But in the job we only catch AccessForbiddenError: https://github.com/department-of-veterans-affairs/caseflow/blob/0b19e04ac43bb054292c3e65458946318f60e00b/app/jobs/fetch_documents_for_reader_user_job.rb#L54

I think the decision was made NOT to catch DocumentRetrievalError in jobs so we can investigate. 

