### PR TITLE
Fixes veteran-is-appellant logic

### DIFF
--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -18,7 +18,7 @@ const CaseDetailsLink = (props) => {
     <Link to={`/tasks/${props.task.vacolsId}`} disabled={!props.task.attributes.task_id}>
       {props.appeal.attributes.veteran_full_name} ({props.appeal.attributes.vbms_id})
     </Link>
-    {!_.isNull(props.appeal) && <React.Fragment>
+    {!_.isNull(_.get(props.appeal.attributes, 'appellant_full_name')) && <React.Fragment>
       <br />
       <span {...subHeadStyle}>Veteran is not the appellant</span>
     </React.Fragment>}


### PR DESCRIPTION
### Description
Fixes logic for determining whether to show a note that the appellant isn't the veteran.

### Acceptance Criteria 
- [ ] "Veteran is not the appellant" should only appear on appeals to which it applies.

### Testing Plan
- [x] Log in as BVAAABSHIRE.
- [x] On /queue, confirm that:
  - [x] Grover E Kerluke doesn't have the note.
  - [x] Kelley Y Schinner has the note.
