### PR TITLE
Ensure all codes are present when updating code in issues

### DIFF
--- a/app/mappers/issue_mapper.rb
+++ b/app/mappers/issue_mapper.rb
@@ -37,6 +37,11 @@ module IssueMapper
 
     def validate!(issue_attrs)
       return if (issue_attrs.keys & [:issprog, :isscode, :isslev1, :isslev2, :isslev3]).empty?
+
+      if issue_attrs.slice(:issprog, :isscode, :isslev1, :isslev2, :isslev3).size != 5
+        fail Caseflow::Error::IssueRepositoryError, "All keys must be present: program, issue, level_1, level_2, level_3"
+      end
+
       if IssueRepository.find_issue_reference(program: issue_attrs[:issprog],
                                               issue: issue_attrs[:isscode],
                                               level_1: issue_attrs[:isslev1],

--- a/spec/mappers/issue_mapper_spec.rb
+++ b/spec/mappers/issue_mapper_spec.rb
@@ -8,6 +8,7 @@ describe IssueMapper do
       {
         program: "02",
         issue: "18",
+        level_1: "01",
         level_2: "03",
         level_3: nil,
         note: "another one",
@@ -24,6 +25,7 @@ describe IssueMapper do
         {
           issprog: "02",
           isscode: "18",
+          isslev1: "01",
           isslev2: "03",
           isslev3: nil,
           issdesc: "another one",
@@ -54,6 +56,7 @@ describe IssueMapper do
         {
           issprog: "02",
           isscode: "18",
+          isslev1: "01",
           isslev2: "03",
           isslev3: nil,
           issdesc: "another one",
@@ -88,6 +91,15 @@ describe IssueMapper do
       context "when codes are not valid" do
         it "raises Caseflow::Error::IssueRepositoryError" do
           allow(IssueRepository).to receive(:find_issue_reference).and_return([])
+          expect { subject }.to raise_error(Caseflow::Error::IssueRepositoryError)
+        end
+      end
+
+      context "when codes are not complete" do
+        let(:issue_attrs) { { note: "another one", vacols_user_id: "TEST1", program: "02", issue: "01", level_1: "03" } }
+
+        it "raises Caseflow::Error::IssueRepositoryError" do
+          expect(IssueRepository).to_not receive(:find_issue_reference)
           expect { subject }.to raise_error(Caseflow::Error::IssueRepositoryError)
         end
       end


### PR DESCRIPTION
This will validate that all code keys are present when updating issue codes. 

