### PR TITLE
Raises method length limit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,7 +67,7 @@ Rails/Present:
   UnlessBlank: false
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 40
 
 Metrics/ClassLength:
   Max: 400


### PR DESCRIPTION
### Description
We disable the method length limit 17 times in Caseflow today. To me, this is a sign that our method length limit is too low. This PR doubles the method length limit to 40 lines, about two screenfuls.

### Acceptance Criteria 
- [ ] Rubocop doesn't flag methods with less that 41 lines.

### Testing Plan
- [ ] Add lines to a method until it has 40 lines.
- [ ] Confirm that `bundle exec rake lint` succeeds.
- [ ] Add another line to the method.
- [ ] Confirm that `bundle exec rake lint` fails.