### PR TITLE
Some manifests take longer than 3 minutes to fetch - upping the time …

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -1,7 +1,7 @@
 require "json"
 
 class ExternalApi::EfolderService
-  TRIES = 180
+  TRIES = 300
 
   def self.fetch_documents_for(appeal, user)
     # Makes a GET request to https://<efolder_url>/files/<file_number>


### PR DESCRIPTION
Fixes https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1236/
Checked that this manifest took 4 minutes to fetch so upping to 5 min.

