### PR TITLE
Queue | Fix sending `after_certification` as boolean

### DIFF
--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -79,7 +79,7 @@ class IssueRemandReasonsOptions extends React.PureComponent {
 
         return {
           code: key,
-          ..._.pick(val, 'after_certification')
+          after_certification: val.after_certification === 'true'
         };
       }).
       compact().


### PR DESCRIPTION
Resolves #5290

### Description
When setting Remand Reasons, we provide an option for before or after certification. The component we use for this, `<RadioField/>`, requires that option values [be strings](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/components/RadioField.jsx#L98), so we used `"true"` and `"false"` to track before/after certification. When the backend went to process this, though, the [ternary](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/mappers/remand_reason_mapper.rb#L7) would fail because strings are truthy. This converts `after_certification` to boolean when it updates redux.

### Acceptance Criteria 
- [x] Before and After Certification options (chosen in Remand Reasons screen) are saved to VACOLS correctly

### Testing Plan
1. Begin Draft Decision checkout flow, set ≥ 1 issue dispositions to Remanded. Set ≥ 2 remand reasons, with before and after certification. Submit draft decision.
2. Confirm remand reason `after_certification`s were sent as booleans.

#### Before
Incorrect payload
```bash
[bdc6def4-8920-432a-a968-f64fa65fee39] [localhost] [BVAAABSHIRE ] [2018-04-24 17:37:13 -0400]
Parameters: {"queue"=>
  {"type"=>"DraftDecision",
   "issues"=>
    [{"disposition"=>"Remanded",
      "vacols_sequence_id"=>1,
      "remand_reasons"=>
       [{"code"=>"AC", "after_certification"=>"false"},
        {"code"=>"DB", "after_certification"=>"true"},
        {"code"=>"EH", "after_certification"=>"true"}],
      "type"=>"15",
      "readjudication"=>false}],
   "work_product"=>"Decision",
   "document_id"=>"123",
   "reviewing_judge_id"=>"3"},
 "task_id"=>"3618770-2017-12-06"}
```

#### After
Frontend payload
<img width="572" alt="screen shot 2018-04-24 at 5 33 52 pm" src="https://user-images.githubusercontent.com/8533004/39215416-bc974766-47e5-11e8-8e40-a6e57e985dd2.png">

Backend parsing successfully
<img width="813" alt="screen shot 2018-04-24 at 5 33 00 pm" src="https://user-images.githubusercontent.com/8533004/39215429-c3312880-47e5-11e8-9cac-dfe9e168c525.png">

