### PR TITLE
Queue | Update Remand Reasons screen

### DIFF
--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -11,6 +11,7 @@ import IssueRemandReasonsOptions from './components/IssueRemandReasonsOptions';
 import { fullWidth } from './constants';
 const subHeadStyling = css({ marginBottom: '2rem' });
 const smallBottomMargin = css({ marginBottom: '1rem' });
+const floatRight = css({ float: 'right' });
 
 class SelectRemandReasonsView extends React.Component {
   constructor(props) {
@@ -24,11 +25,21 @@ class SelectRemandReasonsView extends React.Component {
     path: `/tasks/${this.props.appealId}/remands`
   });
 
-  getFooterButtons = () => [{
-    displayText: 'Go back to Select Dispositions'
-  }, {
-    displayText: 'Review Draft Decision'
-  }];
+  getFooterButtons = () => {
+    const { issues } = this.props;
+    const { issuesRendered } = this.state;
+    const buttons = [{
+      displayText: 'Go back to Select Dispositions'
+    }];
+
+    if (issuesRendered === issues.length) {
+      buttons.push({
+        displayText: 'Continue'
+      });
+    }
+
+    return buttons;
+  }
 
   validateForm = () => true;
 
@@ -48,10 +59,10 @@ class SelectRemandReasonsView extends React.Component {
       renderedOptions.push(
         <Button
           willNeverBeLoading
-          linkStyling
+          styling={floatRight}
           key="show-more"
-          onClick={() => this.setState({ issuesRendered: Math.min(this.state.issuesRendered + 2, issues.length) })}>
-          Show more
+          onClick={() => this.setState({ issuesRendered: Math.min(this.state.issuesRendered + 1, issues.length) })}>
+          Next Issue
         </Button>
       );
     }

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -28,47 +28,37 @@ class SelectRemandReasonsView extends React.Component {
   getFooterButtons = () => {
     const { issues } = this.props;
     const { issuesRendered } = this.state;
-    const buttons = [{
-      displayText: 'Go back to Select Dispositions'
-    }];
 
-    if (issuesRendered === issues.length) {
-      buttons.push({
-        displayText: 'Continue'
-      });
+    return [{
+      displayText: 'Go back to Select Dispositions'
+    }, {
+      displayText: issuesRendered < issues.length ? 'Next Issue' : 'Continue'
+    }];
+  }
+
+  goToNextStep = () => {
+    const { issues } = this.props;
+    const { issuesRendered } = this.state;
+
+    if (issuesRendered < issues.length) {
+      this.setState({ issuesRendered: Math.min(issuesRendered + 1, issues.length) });
+      return false;
     }
 
-    return buttons;
+    return true;
   }
 
   validateForm = () => true;
 
-  renderIssueOptions = () => {
-    const { issues, appealId } = this.props;
-    const renderedOptions = _.map(_.range(this.state.issuesRendered), (idx) => {
-      const { vacols_sequence_id: issueId } = issues[idx];
+  renderIssueOptions = () => _.map(_.range(this.state.issuesRendered), (idx) => {
+    const { vacols_sequence_id: issueId } = this.props.issues[idx];
 
-      return <IssueRemandReasonsOptions
-        appealId={appealId}
-        issueId={issueId}
-        key={`remand-reasons-options-${issueId}`}
-        idx={idx} />;
-    });
-
-    if (issues.length > 1 && renderedOptions.length < issues.length) {
-      renderedOptions.push(
-        <Button
-          willNeverBeLoading
-          styling={floatRight}
-          key="show-more"
-          onClick={() => this.setState({ issuesRendered: Math.min(this.state.issuesRendered + 1, issues.length) })}>
-          Next Issue
-        </Button>
-      );
-    }
-
-    return renderedOptions;
-  };
+    return <IssueRemandReasonsOptions
+      appealId={this.props.appealId}
+      issueId={issueId}
+      key={`remand-reasons-options-${issueId}`}
+      idx={idx} />;
+  });
 
   render = () => <React.Fragment>
     <h1 className="cf-push-left" {...css(fullWidth, smallBottomMargin)}>

--- a/client/app/queue/components/DecisionViewBase.jsx
+++ b/client/app/queue/components/DecisionViewBase.jsx
@@ -58,21 +58,25 @@ export default function decisionViewBase(ComponentToWrap) {
 
       const [backButton, nextButton] = getButtons();
 
-      _.defaults(nextButton, {
-        classNames: ['cf-right-side', 'cf-next-step'],
-        callback: this.goToNextStep,
-        loading: this.props.savePending,
-        name: 'next-button'
-      });
       _.defaults(backButton, {
         classNames: ['cf-btn-link', 'cf-prev-step'],
         callback: this.goToPrevStep,
         name: 'back-button'
       });
-
       backButton.displayText = `< ${backButton.displayText}`;
 
-      return [backButton, nextButton];
+      if (nextButton) {
+        _.defaults(nextButton, {
+          classNames: ['cf-right-side', 'cf-next-step'],
+          callback: this.goToNextStep,
+          loading: this.props.savePending,
+          name: 'next-button'
+        });
+
+        return [backButton, nextButton];
+      }
+
+      return [backButton];
     };
 
     goToStep = (url) => {

--- a/client/app/queue/components/DecisionViewBase.jsx
+++ b/client/app/queue/components/DecisionViewBase.jsx
@@ -58,25 +58,21 @@ export default function decisionViewBase(ComponentToWrap) {
 
       const [backButton, nextButton] = getButtons();
 
+      _.defaults(nextButton, {
+        classNames: ['cf-right-side', 'cf-next-step'],
+        callback: this.goToNextStep,
+        loading: this.props.savePending,
+        name: 'next-button'
+      });
       _.defaults(backButton, {
         classNames: ['cf-btn-link', 'cf-prev-step'],
         callback: this.goToPrevStep,
         name: 'back-button'
       });
+
       backButton.displayText = `< ${backButton.displayText}`;
 
-      if (nextButton) {
-        _.defaults(nextButton, {
-          classNames: ['cf-right-side', 'cf-next-step'],
-          callback: this.goToNextStep,
-          loading: this.props.savePending,
-          name: 'next-button'
-        });
-
-        return [backButton, nextButton];
-      }
-
-      return [backButton];
+      return [backButton, nextButton];
     };
 
     goToStep = (url) => {

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -129,6 +129,7 @@ class IssueRemandReasonsOptions extends React.PureComponent {
   render = () => {
     const {
       issue,
+      issues,
       idx,
       appeal: { attributes: appeal }
     } = this.props;
@@ -139,7 +140,9 @@ class IssueRemandReasonsOptions extends React.PureComponent {
     };
 
     return <div key={`remand-reasons-${issue.vacols_sequence_id}`}>
-      <h2 className="cf-push-left" {...css(fullWidth, smallBottomMargin)}>Issue {idx + 1}</h2>
+      <h2 className="cf-push-left" {...css(fullWidth, smallBottomMargin)}>
+        Issue {idx + 1} {issues.length > 1 ? ` of ${issues.length}` : ''}
+      </h2>
       <div {...smallBottomMargin}>Program: {getIssueProgramDescription(issue)}</div>
       <div {...smallBottomMargin}>Issue: {getIssueTypeDescription(issue)}</div>
       <div {...smallBottomMargin}>Code: {_.last(issue.description)}</div>
@@ -187,6 +190,7 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     appeal,
+    issues: _.filter(issues, (issue) => issue.disposition === 'Remanded'),
     issue: _.find(issues, (issue) => issue.vacols_sequence_id === ownProps.issueId)
   };
 };

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { css } from 'glamor';
 import { formatDateStr } from '../../util/DateUtil';
+import scrollToComponent from 'react-scroll-to-component';
 
 import Checkbox from '../../components/Checkbox';
 import CheckboxGroup from '../../components/CheckboxGroup';
@@ -58,12 +59,28 @@ class IssueRemandReasonsOptions extends React.PureComponent {
     this.props.saveEditedAppealIssue(appealId);
   };
 
-  componentDidMount = () => _.each(this.props.issue.remand_reasons, (reason) => this.setState({
-    [reason.code]: {
-      checked: true,
-      after_certification: reason.after_certification
+  componentDidMount = () => {
+    const {
+      issue: { vacols_sequence_id: issueId },
+      issues
+    } = this.props;
+
+    _.each(this.props.issue.remand_reasons, (reason) => this.setState({
+      [reason.code]: {
+        checked: true,
+        after_certification: reason.after_certification
+      }
+    }));
+
+    if (_.map(issues, 'vacols_sequence_id').indexOf(issueId) > 0) {
+      scrollToComponent(this, {
+        align: 'top',
+        duration: 1500,
+        ease: 'outCube',
+        offset: -35
+      });
     }
-  }));
+  }
 
   componentWillUnmount = () => {
     // on unmount, update issue attrs from state

--- a/client/package.json
+++ b/client/package.json
@@ -60,6 +60,7 @@
     "react-redux": "^5.0.5",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1",
+    "react-scroll-to-component": "^1.0.2",
     "react-select": "^1.0.0-rc.4",
     "react-textarea-autosize": "^5.1.0",
     "react-virtualized": "^9.10.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1534,9 +1534,19 @@ component-classes@^1.2.5:
   dependencies:
     component-indexof "0.0.3"
 
+component-clone@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/component-clone/-/component-clone-0.2.2.tgz#c7f5979822880fad8cfb0962ba29186d061ee04f"
+  dependencies:
+    component-type "*"
+
 component-emitter@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.1.2.tgz#296594f2753daa63996d2af08d15a95116c9aec3"
+
+component-emitter@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.0.tgz#ccd113a86388d06482d03de3fc7df98526ba8efe"
 
 component-emitter@1.2.1, component-emitter@^1.2.0:
   version "1.2.1"
@@ -1553,6 +1563,27 @@ component-indexof@0.0.3:
 component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
+
+component-raf@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/component-raf/-/component-raf-1.2.0.tgz#b2bc72d43f1b014fde7a4b3c447c764bc73ccbaa"
+
+component-tween@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/component-tween/-/component-tween-1.2.0.tgz#cc39ce5dbab05b52825f41d1947638a0b01b2b8a"
+  dependencies:
+    component-clone "0.2.2"
+    component-emitter "1.2.0"
+    component-type "1.1.0"
+    ease-component "1.0.0"
+
+component-type@*:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-type/-/component-type-1.2.1.tgz#8a47901700238e4fc32269771230226f24b415a9"
+
+component-type@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/component-type/-/component-type-1.1.0.tgz#95b666aad53e5c8d1f2be135c45b5d499197c0c5"
 
 compressible@~2.0.11:
   version "2.0.11"
@@ -2034,6 +2065,10 @@ domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+ease-component@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ease-component/-/ease-component-1.0.0.tgz#b375726db0b5b04595b77440396fec7daa5d77c9"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"
@@ -4900,6 +4935,12 @@ react-router@^4.1.1, react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
+react-scroll-to-component@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/react-scroll-to-component/-/react-scroll-to-component-1.0.2.tgz#f260dc936c62a53e772786d7832fe0884e195354"
+  dependencies:
+    scroll-to "0.0.2"
+
 react-select@^1.0.0-rc.4:
   version "1.0.0-rc.10"
   resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.0.0-rc.10.tgz#f137346250f9255c979fbfa21860899928772350"
@@ -5294,6 +5335,13 @@ schema-utils@^0.4.0:
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
+
+scroll-to@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/scroll-to/-/scroll-to-0.0.2.tgz#936d398a9133660a2492145c2c0081dfcb0728f3"
+  dependencies:
+    component-raf "1.2.0"
+    component-tween "1.2.0"
 
 select-hose@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Resolves #4484

### Description
Please explain the changes you made here.

### Acceptance Criteria 
- [x] When a user selects a remand reason as a disposition, they are taken to the Remand Reasons screen
- [x] Verify that the bread crumbs for this page are called Select Remand Reasons 
- [x] The title of this page is called Select Remand Reasons
- [x] There is a horizontal line underneath the copy 
- [x] The remand reasons behaves as an embedded page for single and multi issues (see mocks)
- [x] Each Issue on this page is labeled:  
   - Issue 1 - for single issues
   - Issue 1 of x - for multi issues
- [x] There is a section called Issue with the following categories: 
   - Program
   - Issue
   - Code
   - Certified date 
- [x] Verify that the list of reasons appear 
   - look at the mock for the reasons (not writing since we already have those)
- [x] Verify that there is a link at the bottom left called < Go back to [previous page title]
- [ ] Verify the following error states: 
   - When a user does not select a remand reason we mirror a form error with the text below 
      "Choose at least one" 
   - When a user selects a remand reason but not a before or after cert designation that we render the error seen in the mock with the following copy: "Chose one" 

**Single Remand Reason**
- [x] Verify that there is a button on the bottom right called "Continue" through the flow of Remand Reasons

**Multi remand reasons**
- [x] For pages with multiple remand reasons - show a button called "Next Issue"
- [x] This pattern continues until the last issue is shown, where the above button disappears and a continue shows at the bottom.  

### Testing Plan
1. Go to ...

