### PR TITLE
FACOLS | Sets the default station ID to the board's

### DIFF
--- a/lib/tasks/local/vacols.rake
+++ b/lib/tasks/local/vacols.rake
@@ -85,7 +85,7 @@ namespace :local do
         User.find_or_create_by(
           css_id: s.sdomainid
         ) do |user|
-          user.station_id = "283"
+          user.station_id = "101"
           user.full_name = "#{s.snamef} + #{s.snamel}"
         end.css_id
       end


### PR DESCRIPTION
### Description
Sets the station ID of the users that vacols.rake creates to 101, the board's station ID, to make the data more similar to Prod.

### Testing Plan
- [x] `rake db:setup`
- [x] `rake db:seed`
- [x] `rake db:vacols:setup`
- [x] `rake db:vacols:seed`
- [x] http://localhost:3000/test/users shows that most users have the station ID 101.
