### PR TITLE
Judge Queue | Case details | Show document ID and attorney name

### DIFF
--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -57,9 +57,8 @@ class QueueApp extends React.PureComponent {
 
   routedQueueDetail = (props) => <QueueLoadingScreen {...this.props}>
     <Breadcrumbs />
-    <QueueDetailView
-      vacolsId={props.match.params.vacolsId}
-      featureToggles={this.props.featureToggles} />
+    <QueueDetailView {...this.props}
+      vacolsId={props.match.params.vacolsId} />
   </QueueLoadingScreen>;
 
   routedSubmitDecision = (props) => <SubmitDecisionView

--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -100,7 +100,7 @@ class QueueDetailView extends React.PureComponent {
       </React.Fragment>;
     } else {
       leadPgContent = <React.Fragment>
-        Assigned to you {task.added_by_name ? `by ${task.added_by_name}` : ''} on&nbsp;
+        Assigned to you {task.added_by_name && `by ${task.added_by_name}`} on&nbsp;
         <DateString date={task.assigned_on} dateFormat="MM/DD/YY" />.
         Due <DateString date={task.due_on} dateFormat="MM/DD/YY" />.
       </React.Fragment>;

--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -77,6 +77,7 @@ class QueueDetailView extends React.PureComponent {
 
   render = () => {
     const {
+      userRole,
       appeal: { attributes: appeal },
       task: { attributes: task }
     } = this.props;
@@ -87,15 +88,30 @@ class QueueDetailView extends React.PureComponent {
       label: `Appellant (${appeal.appellant_full_name || appeal.veteran_full_name})`,
       page: <AppellantDetail appeal={this.props.appeal} analyticsSource={CATEGORIES.QUEUE_TASK} />
     }];
+    let leadPgContent;
+
+    if (userRole === 'Judge') {
+      const firstInitial = String.fromCodePoint(task.assigned_by_first_name.codePointAt(0));
+      const nameAbbrev = `${firstInitial}. ${task.assigned_by_last_name}`;
+
+      leadPgContent = <React.Fragment>
+        Prepared by {nameAbbrev}<br />
+        Document ID: {task.document_id}
+      </React.Fragment>
+    } else {
+      leadPgContent = <React.Fragment>
+        Assigned to you {task.added_by_name ? `by ${task.added_by_name}` : ''} on&nbsp;
+        <DateString date={task.assigned_on} dateFormat="MM/DD/YY" />.
+        Due <DateString date={task.due_on} dateFormat="MM/DD/YY" />.
+      </React.Fragment>;
+    }
 
     return <AppSegment filledBackground>
       <h1 className="cf-push-left" {...css(headerStyling, fullWidth)}>
         {appeal.veteran_full_name} ({appeal.vbms_id})
       </h1>
       <p className="cf-lead-paragraph" {...subHeadStyling}>
-        Assigned to you {task.added_by_name ? `by ${task.added_by_name}` : ''} on&nbsp;
-        <DateString date={task.assigned_on} dateFormat="MM/DD/YY" />.
-        Due <DateString date={task.due_on} dateFormat="MM/DD/YY" />.
+        {leadPgContent}
       </p>
       <ReaderLink
         vacolsId={this.props.vacolsId}
@@ -119,7 +135,8 @@ class QueueDetailView extends React.PureComponent {
 }
 
 QueueDetailView.propTypes = {
-  vacolsId: PropTypes.string.isRequired
+  vacolsId: PropTypes.string.isRequired,
+  userRole: PropTypes.string
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -97,7 +97,7 @@ class QueueDetailView extends React.PureComponent {
       leadPgContent = <React.Fragment>
         Prepared by {nameAbbrev}<br />
         Document ID: {task.document_id}
-      </React.Fragment>
+      </React.Fragment>;
     } else {
       leadPgContent = <React.Fragment>
         Assigned to you {task.added_by_name ? `by ${task.added_by_name}` : ''} on&nbsp;

--- a/lib/fakes/user_repository.rb
+++ b/lib/fakes/user_repository.rb
@@ -3,8 +3,8 @@ class Fakes::UserRepository
     true
   end
 
-  def self.vacols_role(_css_id)
-    _css_id.eql?("BVAAABSHIRE") ? "Judge" : "Attorney"
+  def self.vacols_role(css_id)
+    css_id.eql?("BVAAABSHIRE") ? "Judge" : "Attorney"
   end
 
   def self.vacols_attorney_id(_css_id)

--- a/lib/fakes/user_repository.rb
+++ b/lib/fakes/user_repository.rb
@@ -4,7 +4,7 @@ class Fakes::UserRepository
   end
 
   def self.vacols_role(_css_id)
-    "Attorney"
+    _css_id.eql?("BVAAABSHIRE") ? "Judge" : "Attorney"
   end
 
   def self.vacols_attorney_id(_css_id)

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -527,7 +527,6 @@ RSpec.feature "Queue" do
       end
 
       def select_issue_level_options(opts)
-        puts "selecting #{opts}"
         Array.new(5).map.with_index do |*, row_idx|
           # Issue level 2 and diagnostic code dropdowns render based on earlier
           # values, so we have to re-get elements per loop. There are at most 5

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -50,11 +50,11 @@ RSpec.feature "Queue" do
     ]
   end
   let!(:issues) { [Generators::Issue.build] }
-  let!(:current_user) do
-    User.authenticate!(roles: ["System Admin"])
+  let! :attorney_user do
+    User.authenticate!
   end
 
-  let!(:vacols_tasks) { Fakes::QueueRepository.tasks_for_user(current_user.css_id) }
+  let!(:vacols_tasks) { Fakes::QueueRepository.tasks_for_user(attorney_user.css_id) }
   let!(:vacols_appeals) { Fakes::QueueRepository.appeals_from_tasks(vacols_tasks) }
 
   context "reader-style search for appeals using veteran id" do
@@ -249,7 +249,7 @@ RSpec.feature "Queue" do
     end
   end
 
-  context "loads task detail views" do
+  context "loads attorney task detail views" do
     context "displays who assigned task" do
       scenario "appeal has assigner" do
         appeal = vacols_appeals.select(&:added_by_first_name).first
@@ -383,6 +383,29 @@ RSpec.feature "Queue" do
         click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
         expect(page).to have_content("Disposition: 1 - Allowed")
       end
+    end
+  end
+
+  context "loads judge task detail views" do
+    scenario "displays who prepared task" do
+      User.unauthenticate!
+      User.authenticate!(css_id: "BVAAABSHIRE")
+
+      vacols_tasks = Fakes::QueueRepository.tasks_for_user current_user.css_id
+
+      task = vacols_tasks.select(&:assigned_by_first_name).first
+      visit "/queue"
+
+      click_on "#{task.veteran_full_name} (#{task.vbms_id})"
+
+      assigned_by_name = FullName.new(
+        task.assigned_by_first_name,
+        nil,
+        task.assigned_by_last_name
+      ).formatted(:readable_fi_last_formatted)
+
+      expect(page).to have_content("Prepared by #{assigned_by_name}")
+      expect(page).to have_content("Document ID: #{task.document_id}")
     end
   end
 

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Queue" do
   end
   let!(:issues) { [Generators::Issue.build] }
   let! :attorney_user do
-    User.authenticate!
+    User.authenticate!(roles: ["System Admin"])
   end
 
   let!(:vacols_tasks) { Fakes::QueueRepository.tasks_for_user(attorney_user.css_id) }


### PR DESCRIPTION
Resolves #4762 

### Description
For judges, display the document ID and attorney name in the appeal detail view

### Acceptance Criteria 
- [ ] Confirm document ID and attorney name are displayed in appeal detail view

### Testing Plan
1. Go to `/queue/tasks/${vacolsId}` as `BVAAABSHIRE`
2. Confirm "Prepared by ${assigner}" and "Document ID" labels appear

![screen shot 2018-05-01 at 11 22 11 am](https://user-images.githubusercontent.com/8533004/39479255-b0632ea4-4d32-11e8-9e01-ffbbc253d9b8.png)


