### PR TITLE
Fix veteran DB creation race condition

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -121,7 +121,15 @@ class Veteran < ApplicationRecord
 
       return nil unless veteran.found?
 
+      before_create_veteran_by_file_number # Used to simulate race conditions
       veteran.tap { |v| v.update!(participant_id: v.ptcpnt_id) }
+
+    rescue ActiveRecord::RecordNotUnique
+      find_by(file_number: file_number)
+    end
+
+    def before_create_veteran_by_file_number
+      # noop - used to simulate race conditions
     end
   end
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -64,6 +64,20 @@ describe Veteran do
             participant_id: "123123"
           )
         end
+
+        context "when duplicate veteran is saved while fetching BGS data (race condition)" do
+          let(:saved_veteran) do
+            Veteran.new(file_number: file_number, participant_id: "123123")
+          end
+
+          before do
+            allow(Veteran).to receive(:before_create_veteran_by_file_number) do
+              saved_veteran.save!
+            end
+          end
+
+          it { is_expected.to eq(saved_veteran) }
+        end
       end
 
       context "when veteran isn't found in BGS" do


### PR DESCRIPTION
connects #5311

Validated that the unit test produces the [error found in sentry](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1281/):

<img width="1294" alt="screen shot 2018-05-02 at 10 30 58 am" src="https://user-images.githubusercontent.com/1596259/39529362-7b75e840-4df4-11e8-8a22-c7ab1d5597dd.png">
