### PR TITLE
Queue | Disable Delete Issue button before finishing its creation

### DIFF
--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -232,6 +232,7 @@ class AddEditIssueView extends React.Component {
       <Button
         willNeverBeLoading
         linkStyling
+        disabled={!issue.vacols_sequence_id}
         styling={noLeftPadding}
         onClick={this.props.showModal}>
         Delete Issue

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -563,6 +563,9 @@ RSpec.feature "Queue" do
         click_on "Add Issue"
         expect(page).to have_content "Add Issue"
 
+        delete_btn = find("button", text: "Delete Issue")
+        expect(delete_btn.disabled?).to eq true
+
         fields = page.find_all ".Select--single"
 
         field_values = fields.map do |row|


### PR DESCRIPTION
Resolves https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1308/

### Description
When creating an Issue, the Delete Issue button was enabled. Attempting to delete the new issue would attempt to `DELETE /queue/appeals/#{vacolsId}/issues/undefined`.

### Acceptance Criteria 
- [ ] When creating an issue, the Delete Issue link is disabled

### Testing Plan
1. Go to Draft Decision checkout flow, Add Issue
2. Confirm Delete Issue link is disabled

