### PR TITLE
upgrades connect_vbms version to support SHA256

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem "therubyracer", platforms: :ruby
 
 gem "pg", platforms: :ruby
 
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "1728de8d71ac9d7b3948aa8b6e2fa4e165b16810"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "fd9771bafc48d98b56909c4466721da312a22739"
 
 gem "redis-rails", "~> 5.0.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem "therubyracer", platforms: :ruby
 
 gem "pg", platforms: :ruby
 
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "783200ca61b57fc75f818334838181993535229a"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "1728de8d71ac9d7b3948aa8b6e2fa4e165b16810"
 
 gem "redis-rails", "~> 5.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,10 +30,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 783200ca61b57fc75f818334838181993535229a
-  ref: 783200ca61b57fc75f818334838181993535229a
+  revision: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
+  ref: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
   specs:
-    connect_vbms (1.0.1)
+    connect_vbms (1.2.0)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail


### PR DESCRIPTION
Resolves [appeals-deployment#1408](https://github.com/department-of-veterans-affairs/appeals-deployment/issues/1408).

### Description
Installs a newer version of the `connect_vbms` gem - this one supports SHA256 digests, which is critical for the upgraded certs VBMS is using in their uat environment. 

(the changes in `connect_vbms`: see [connect_vbms#178](https://github.com/department-of-veterans-affairs/connect_vbms/pull/178))

### Testing Plan

Caseflow should display data retrieved from VBMS. In uat, this has been broken since April 30.

This is how the devops team has been testing out the gem from an app server:
```
require 'vbms'
client = VBMS::Client.from_env_vars(env_name: ENV["CONNECT_VBMS_ENV"], use_forward_proxy:true)
request = VBMS::Requests::FindDocumentSeriesReference.new("<id>")
res = client.send_request(request)
```
Before the fix, we had been observing 503s on uat. After deploying this fix, we are seeing success responses.
