### PR TITLE
fix mismatched SHA (bug introduced in #5415)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
-  ref: 1728de8d71ac9d7b3948aa8b6e2fa4e165b16810
+  revision: fd9771bafc48d98b56909c4466721da312a22739
+  ref: fd9771bafc48d98b56909c4466721da312a22739
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
### Description
In #5415 I did not use the right SHA for connect_vbms - there was a mismatch between the Gemfile and the Gemfile.lock.

As a consequence, Jenkins builds fail on `TASK [rails-build : bundle install]`. 

sample:
```
TASK [rails-build : bundle install] ********************************************
Monday 07 May 2018  11:44:45 -0400 (0:00:00.535)       0:01:54.449 ************ 
fatal: [52.222.111.206]: FAILED! => [...] "You are trying to install in deployment mode after changing", "your Gemfile. Run `bundle install` elsewhere and add the", "updated Gemfile.lock to version control.", "", "The list of sources changed", "", "You have added to the Gemfile:", "* source: https://github.com/department-of-veterans-affairs/connect_vbms.git (at", "fd9771b)", "", "You have deleted from the Gemfile:", "* source: https://github.com/department-of-veterans-affairs/connect_vbms.git (at", "1728de8@1728de8)"]}
```

### Acceptance Criteria 
Jenkins build should not fail.
