### PR TITLE
fix dropdown focus

### DIFF
--- a/app/assets/stylesheets/react/_select-dropdown.scss
+++ b/app/assets/stylesheets/react/_select-dropdown.scss
@@ -316,7 +316,7 @@
 }
 
 .Select-option.is-focused {
-  background-color: $color-primary-alt-lightest;
+  background-color: $color-gray;
   color: $color-white;
 }
 


### PR DESCRIPTION
Dropdown focus color should be gray

### Testing Plan
1. Go to test/user to see ui
<img width="573" alt="screen shot 2018-05-07 at 6 07 15 pm" src="https://user-images.githubusercontent.com/1745984/39727632-860795fc-5221-11e8-9029-31f78b8921d3.png">

