### PR TITLE
Add Appeals RAMP Opt-in Election doc to case summary filter

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -48,7 +48,8 @@ class Document < ApplicationRecord
     "VA 21-527EZ, Fully Developed Claim (Pension)",
     "VA 21-22 Appointment of Veterans Serv. Org. as Claimant Rep",
     "Power of Attorney (incl. VA 21-22, VA 22a)",
-    "Hearing Transcript"
+    "Hearing Transcript",
+    "RAMP Opt-in Election"
   ].freeze
 
   DECISION_TYPES = ["BVA Decision", "Remand BVA or CAVC"].freeze

--- a/lib/fakes/data/appeal_data.rb
+++ b/lib/fakes/data/appeal_data.rb
@@ -89,7 +89,8 @@ module Fakes::Data::AppealData
     "Correspondence",
     "VA 21-4142 Authorization to Disclose Information to VA",
     "VA 21-4138 Statement in Support of Claim",
-    "VA Memo"
+    "VA Memo",
+    "RAMP Opt-in Election"
   ].freeze
 
   def self.redacted_reader_documents


### PR DESCRIPTION
Resolves #5388
### Description
This PR shows that RAMP Opt-in Election in Reader Claim Folder in Document Type.
### Acceptance Criteria 
- [ ] Add document category/type: "RAMP Opt-in Election" document to case summary.

### Testing Plan
1. Go to Reader Claims Folder
2. Check if `RAMP Opt-in Election` exits in Document Type
