### PR TITLE
Queue | Prevent overlapping modals when deleting an issue

### DIFF
--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -137,7 +137,7 @@ class AddEditIssueView extends React.Component {
     } = this.props;
     const issueIndex = _.map(issues, 'vacols_sequence_id').indexOf(issue.vacols_sequence_id);
 
-    this.props.hideModal();
+    this.props.hideModal('deleteIssue');
 
     this.props.requestDelete(
       `/appeals/${appeal.id}/issues/${issue.vacols_sequence_id}`, {},
@@ -205,13 +205,13 @@ class AddEditIssueView extends React.Component {
           buttons={[{
             classNames: ['usa-button', 'cf-btn-link'],
             name: 'Close',
-            onClick: this.props.hideModal
+            onClick: () => this.props.hideModal('deleteIssue')
           }, {
             classNames: ['usa-button', 'usa-button-secondary'],
             name: 'Delete issue',
             onClick: this.deleteIssue
           }]}
-          closeHandler={this.props.hideModal}>
+          closeHandler={() => this.props.hideModal('deleteIssue')}>
           You are about to permanently delete this issue. To delete please
           click the <strong>"Delete issue"</strong> button or click&nbsp;
           <strong>"Close"</strong> to return to the previous screen.
@@ -228,7 +228,7 @@ class AddEditIssueView extends React.Component {
         linkStyling
         disabled={!issue.vacols_sequence_id}
         styling={noLeftPadding}
-        onClick={this.props.showModal}>
+        onClick={() => this.props.showModal('deleteIssue')}>
         Delete Issue
       </Button>
       <div {...dropdownMarginTop}>
@@ -323,7 +323,7 @@ const mapStateToProps = (state, ownProps) => ({
   task: state.queue.loadedQueue.tasks[ownProps.vacolsId],
   issue: state.queue.editingIssue,
   error: state.ui.messages.error,
-  modal: state.ui.modal
+  modal: state.ui.modal.deleteIssue
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/app/queue/components/DecisionViewBase.jsx
+++ b/client/app/queue/components/DecisionViewBase.jsx
@@ -60,7 +60,7 @@ export default function decisionViewBase(ComponentToWrap) {
     getFooterButtons = () => {
       const cancelButton = {
         classNames: ['cf-btn-link'],
-        callback: this.props.showModal,
+        callback: () => this.props.showModal('cancelCheckout'),
         name: 'cancel-button',
         displayText: 'Cancel',
         willNeverBeLoading: true
@@ -91,7 +91,7 @@ export default function decisionViewBase(ComponentToWrap) {
         stagedAppeals
       } = this.props;
 
-      this.props.hideModal();
+      this.props.hideModal('cancelCheckout');
       this.props.resetDecisionOptions();
       _.each(stagedAppeals, this.props.checkoutStagedAppeal);
 
@@ -163,19 +163,19 @@ export default function decisionViewBase(ComponentToWrap) {
 
     render = () => <React.Fragment>
       <Breadcrumbs />
-      {this.props.modal && <div className="cf-modal-scroll">
+      {this.props.cancelCheckoutModal && <div className="cf-modal-scroll">
         <Modal
           title="Are you sure you want to cancel?"
           buttons={[{
             classNames: ['usa-button', 'cf-btn-link'],
             name: 'Return to editing',
-            onClick: this.props.hideModal
+            onClick: () => this.props.hideModal('cancelCheckout')
           }, {
             classNames: ['usa-button-secondary', 'usa-button-hover', 'usa-button-warning'],
             name: 'Yes, cancel',
             onClick: this.cancelCheckoutFlow
           }]}
-          closeHandler={this.props.hideModal}>
+          closeHandler={() => this.props.hideModal('cancelCheckout')}>
           All changes made to this page will be lost, except for the adding,
           editing, and deleting of issues.
         </Modal>
@@ -190,7 +190,8 @@ export default function decisionViewBase(ComponentToWrap) {
   WrappedComponent.displayName = `DecisionViewBase(${getDisplayName(WrappedComponent)})`;
 
   const mapStateToProps = (state) => ({
-    ..._.pick(state.ui, 'breadcrumbs', 'modal'),
+    cancelCheckoutModal: state.ui.modal.cancelCheckout,
+    ..._.pick(state.ui, 'breadcrumbs'),
     ..._.pick(state.ui.saveState, 'savePending', 'saveSuccessful'),
     stagedAppeals: _.keys(state.queue.stagedChanges.appeals)
   });

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -117,10 +117,12 @@ export const resetSaveState = () => ({
   type: ACTIONS.RESET_SAVE_STATE
 });
 
-export const showModal = () => ({
-  type: ACTIONS.SHOW_MODAL
+export const showModal = (modalType) => ({
+  type: ACTIONS.SHOW_MODAL,
+  payload: { modalType }
 });
 
-export const hideModal = () => ({
-  type: ACTIONS.HIDE_MODAL
+export const hideModal = (modalType) => ({
+  type: ACTIONS.HIDE_MODAL,
+  payload: { modalType }
 });

--- a/client/app/queue/uiReducer/uiReducer.js
+++ b/client/app/queue/uiReducer/uiReducer.js
@@ -16,7 +16,10 @@ export const initialState = {
     error: null
   },
   saveState: initialSaveState,
-  modal: false
+  modal: {
+    cancelCheckout: false,
+    deleteIssue: false
+  }
 };
 
 const setMessageState = (state, message, msgType) => update(state, {
@@ -35,14 +38,16 @@ const setSuccessMessageState = (state, message) => setMessageState(state, messag
 const hideSuccessMessage = (state) => setSuccessMessageState(state, null);
 const showSuccessMessage = (state, message = 'Success') => setSuccessMessageState(state, message);
 
-const setModalState = (state, visibility) => update(state, {
+const setModalState = (state, visibility, modalType) => update(state, {
   modal: {
-    $set: visibility
+    [modalType]: {
+      $set: visibility
+    }
   }
 });
 
-const showModal = (state) => setModalState(state, true);
-const hideModal = (state) => setModalState(state, false);
+const showModal = (state, modalType) => setModalState(state, true, modalType);
+const hideModal = (state, modalType) => setModalState(state, false, modalType);
 
 const workQueueUiReducer = (state = initialState, action = {}) => {
   switch (action.type) {
@@ -120,9 +125,9 @@ const workQueueUiReducer = (state = initialState, action = {}) => {
   case ACTIONS.HIDE_SUCCESS_MESSAGE:
     return hideSuccessMessage(state);
   case ACTIONS.SHOW_MODAL:
-    return showModal(state);
+    return showModal(state, action.payload.modalType);
   case ACTIONS.HIDE_MODAL:
-    return hideModal(state);
+    return hideModal(state, action.payload.modalType);
   default:
     return state;
   }


### PR DESCRIPTION
Resolves #5469 

### Description
Within the Add/Edit Issue view, the Delete Issue button triggers displaying a modal, as does the Cancel button in the footer. However, both modals are triggered by `state.ui.modal`, resulting in both displaying at the same time.

### Acceptance Criteria 
- [ ] Delete Issue modal appears independent of Cancel Checkout modal

### Testing Plan
1. Go to Draft Decision checkout flow, Edit Issue
2. Click Delete Issue, confirm there's no modal visible behind the delete issue modal

Before:
![overlapping_modals](https://user-images.githubusercontent.com/8533004/39825819-d853b574-5380-11e8-9b8f-89f29e5fcfcd.gif)

After:
![single_modal](https://user-images.githubusercontent.com/8533004/39835491-4bebccfc-539e-11e8-8130-41ea2fff89f9.gif)


