### PR TITLE
updating hearing summary when fields change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: e6291950ddac59add73b9fb52ddb3b06c7e028d7
-  ref: e6291950ddac59add73b9fb52ddb3b06c7e028d7
+  revision: be1ad2d0cc70a55e7040ea193ad9f3f84c7b35cb
+  ref: be1ad2d0cc70a55e7040ea193ad9f3f84c7b35cb
   specs:
-    caseflow (0.3.6)
+    caseflow (0.3.7)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -206,10 +206,10 @@ class Hearing < ApplicationRecord
   def update_summary_field
     get_paragraph = ->(data) { data.blank? ? "<p></p><p></p><p></p>" : "<p>#{data}</p><p></p>" }
 
-    self.summary = "<p><strong>Contentions</strong></p>#{get_paragraph.call(self.contentions)}"\
-    "<p><strong>Evidence</strong></p> #{get_paragraph.call(self.evidence)}"\
+    self.summary = "<p><strong>Contentions</strong></p>#{get_paragraph.call(contentions)}"\
+    "<p><strong>Evidence</strong></p> #{get_paragraph.call(evidence)}"\
     "<p><strong>Comments and special instructions to attorneys</strong></p>"\
-    "#{get_paragraph.call(self.comments_for_attorney)}"
+    "#{get_paragraph.call(comments_for_attorney)}"
   end
 
   class << self

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -206,10 +206,10 @@ class Hearing < ApplicationRecord
   def update_summary_field
     get_paragraph = ->(data) { data.blank? ? "<p></p><p></p><p></p>" : "<p>#{data}</p><p></p>" }
 
-    self.summary = "<p><strong>Contentions</strong></p> #{get_paragraph.call(contentions)}
-      <p><strong>Evidence</strong></p> #{get_paragraph.call(evidence)}
-      <p><strong>Comments and special instructions to attorneys</strong></p>
-      #{get_paragraph.call(comments_for_attorney)}"
+    self.summary = "<p><strong>Contentions</strong></p>#{get_paragraph.call(self.contentions)}"\
+    "<p><strong>Evidence</strong></p> #{get_paragraph.call(self.evidence)}"\
+    "<p><strong>Comments and special instructions to attorneys</strong></p>"\
+    "#{get_paragraph.call(self.comments_for_attorney)}"
   end
 
   class << self

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -16,6 +16,7 @@ class Hearing < ApplicationRecord
   belongs_to :user # the judge
   has_many :hearing_views
   has_many :appeal_stream_snapshots
+  before_save :update_summary_field, if: :data_fields_changed
 
   # this is used to cache appeal stream for hearings
   # when fetched intially.
@@ -194,6 +195,21 @@ class Hearing < ApplicationRecord
       update_attributes(military_service: veteran.periods_of_service.join("\n")) if persisted? && veteran
       super
     end
+  end
+
+  private
+
+  def data_fields_changed
+    evidence_changed? || contentions_changed? || comments_for_attorney_changed?
+  end
+
+  def update_summary_field
+
+    get_paragraph = lambda {|data| data.nil? || data.empty? ? "<p></p><p></p><p></p>" : "<p>#{data}</p><p></p>" }
+
+    self.summary = "<p><strong>Contentions</strong></p> #{get_paragraph.call(self.contentions)}
+      <p><strong>Evidence</strong></p> #{get_paragraph.call(self.evidence)}
+      <p><strong>Comments and special instructions to attorneys</strong></p>#{get_paragraph.call(self.comments_for_attorney)}"
   end
 
   class << self

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -204,12 +204,12 @@ class Hearing < ApplicationRecord
   end
 
   def update_summary_field
+    get_paragraph = ->(data) { data.blank? ? "<p></p><p></p><p></p>" : "<p>#{data}</p><p></p>" }
 
-    get_paragraph = lambda {|data| data.nil? || data.empty? ? "<p></p><p></p><p></p>" : "<p>#{data}</p><p></p>" }
-
-    self.summary = "<p><strong>Contentions</strong></p> #{get_paragraph.call(self.contentions)}
-      <p><strong>Evidence</strong></p> #{get_paragraph.call(self.evidence)}
-      <p><strong>Comments and special instructions to attorneys</strong></p>#{get_paragraph.call(self.comments_for_attorney)}"
+    self.summary = "<p><strong>Contentions</strong></p> #{get_paragraph.call(contentions)}
+      <p><strong>Evidence</strong></p> #{get_paragraph.call(evidence)}
+      <p><strong>Comments and special instructions to attorneys</strong></p>
+      #{get_paragraph.call(comments_for_attorney)}"
   end
 
   class << self

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -12,6 +12,16 @@ describe Hearing do
     )
   end
 
+  let(:hearing2) do
+    Generators::Hearing.build(
+      date: date,
+      disposition: disposition,
+      hold_open: hold_open,
+      type: type,
+      contentions: "no treatment after service private or VA\n"
+    )
+  end
+
   let(:date) { 1.day.ago }
   let(:disposition) { nil }
   let(:hold_open) { nil }
@@ -26,6 +36,34 @@ describe Hearing do
       let(:type) { :central_office }
 
       it { is_expected.to eq("Board of Veterans' Appeals in Washington, DC") }
+    end
+  end
+
+  context "update_summary_field" do
+    subject { hearing2 }
+
+    it 'updates summary field after contentions is updated' do
+
+      extected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
+      "CS denied in 3/68 DX of C-spine issue</p><p></p><p><strong>Evidence</strong></p>"\
+      " <p></p><p></p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
+      "</p><p></p><p></p><p></p>"
+      subject.contentions = "no treatment after service private or VA\n"\
+      "CS denied in 3/68 DX of C-spine issue"
+      subject.save
+      expect(subject.summary).to eq extected_string
+    end
+
+    it 'updates summary field after evidence and comments updated' do
+
+      extected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
+      "</p><p></p><p><strong>Evidence</strong></p>"\
+      " <p>evidence</p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
+      "</p><p>here are the list of comments here</p><p></p>"
+      evidence = "evidence"
+      comments_for_attorney = "here are the list of comments here"
+      subject.update!(evidence: evidence, comments_for_attorney: comments_for_attorney)
+      expect(subject.summary).to eq extected_string
     end
   end
 

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -44,26 +44,26 @@ describe Hearing do
 
     it 'updates summary field after contentions is updated' do
 
-      extected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
+      expected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
       "CS denied in 3/68 DX of C-spine issue</p><p></p><p><strong>Evidence</strong></p>"\
       " <p></p><p></p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
       "</p><p></p><p></p><p></p>"
       subject.contentions = "no treatment after service private or VA\n"\
       "CS denied in 3/68 DX of C-spine issue"
       subject.save
-      expect(subject.summary).to eq extected_string
+      expect(subject.summary).to eq expected_string
     end
 
     it 'updates summary field after evidence and comments updated' do
 
-      extected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
+      expected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
       "</p><p></p><p><strong>Evidence</strong></p>"\
       " <p>evidence</p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
       "</p><p>here are the list of comments here</p><p></p>"
       evidence = "evidence"
       comments_for_attorney = "here are the list of comments here"
       subject.update!(evidence: evidence, comments_for_attorney: comments_for_attorney)
-      expect(subject.summary).to eq extected_string
+      expect(subject.summary).to eq expected_string
     end
   end
 

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -42,8 +42,7 @@ describe Hearing do
   context "update_summary_field" do
     subject { hearing2 }
 
-    it 'updates summary field after contentions is updated' do
-
+    it "updates summary field after contentions is updated" do
       expected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
       "CS denied in 3/68 DX of C-spine issue</p><p></p><p><strong>Evidence</strong></p>"\
       " <p></p><p></p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
@@ -54,8 +53,7 @@ describe Hearing do
       expect(subject.summary).to eq expected_string
     end
 
-    it 'updates summary field after evidence and comments updated' do
-
+    it "updates summary field after evidence and comments updated" do
       expected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
       "</p><p></p><p><strong>Evidence</strong></p>"\
       " <p>evidence</p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\


### PR DESCRIPTION
Resolves #3862 

### Description
This adds calls backs to update the summary field with valid html when evidence, contentions and comments_for_attorney fields change.

### Acceptance Criteria 
- [ ] Make sure the summary database column is updated with correct fields when other fields' text changes.


