### PR TITLE
Fix document list scroll bug

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -46,26 +46,7 @@ export const getRowObjects = (documents, annotationsPerDocument) => {
 
 class DocumentsTable extends React.Component {
   componentDidMount() {
-    this.hasSetScrollPosition = false;
-  }
-
-  componentWillUnmount() {
-    this.props.setDocListScrollPosition(this.tbodyElem.scrollTop);
-  }
-
-  getTbodyRef = (elem) => this.tbodyElem = elem
-  getLastReadIndicatorRef = (elem) => this.lastReadIndicatorElem = elem
-  getCategoryFilterIconRef = (categoryFilterIcon) => this.categoryFilterIcon = categoryFilterIcon
-  getTagFilterIconRef = (tagFilterIcon) => this.tagFilterIcon = tagFilterIcon
-  toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisibility('category')
-  toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisibility('tag')
-
-  getKeyForRow = (index, { isComment, id }) => {
-    return isComment ? `${id}-comment` : id;
-  }
-
-  componentDidUpdate() {
-    if (!this.hasSetScrollPosition) {
+    if (this.props.pdfList.scrollTop) {
       this.tbodyElem.scrollTop = this.props.pdfList.scrollTop;
 
       if (this.lastReadIndicatorElem) {
@@ -83,9 +64,22 @@ class DocumentsTable extends React.Component {
           this.tbodyElem.scrollTop += rowWithLastRead.getBoundingClientRect().top - tbodyBoundingRect.top;
         }
       }
-
-      this.hasSetScrollPosition = true;
     }
+  }
+
+  componentWillUnmount() {
+    this.props.setDocListScrollPosition(this.tbodyElem.scrollTop);
+  }
+
+  getTbodyRef = (elem) => this.tbodyElem = elem
+  getLastReadIndicatorRef = (elem) => this.lastReadIndicatorElem = elem
+  getCategoryFilterIconRef = (categoryFilterIcon) => this.categoryFilterIcon = categoryFilterIcon
+  getTagFilterIconRef = (tagFilterIcon) => this.tagFilterIcon = tagFilterIcon
+  toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisibility('category')
+  toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisibility('tag')
+
+  getKeyForRow = (index, { isComment, id }) => {
+    return isComment ? `${id}-comment` : id;
   }
 
   // eslint-disable-next-line max-statements


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/5492

### Description
We had code to scroll to the most recent location of a user on the document list page. However, this code was inside componentDidUpdate. Until this change: https://github.com/department-of-veterans-affairs/caseflow/commit/c9ec40973bb745a93a933ff45e7f4d8dacd91253, we erroneously called componentDidUpdate very frequently because the state was always changing with coordinates for the dropdowns. Now we rarely call it.

The solution is to move the scrolling code into componentDidMount. It's where it always belonged. We only need to scroll when we return to this page and it mounts.
![documentlistscrolls](https://user-images.githubusercontent.com/3885236/39890711-99a6d8ee-5469-11e8-81eb-1fe085bf48d5.gif)

### Acceptance Criteria 
- [ ] Returning to the document list from a document scrolls to the document the user just visited.

