### PR TITLE
Remove queue from tasks - FE

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -51,7 +51,7 @@ class TasksController < ApplicationController
 
   def update
     return invalid_role_error if current_user.vacols_role != "Judge"
-    JudgeCaseAssignment.new(task_params.merge(task_id: params[:task_id])).reassign_to_attorney!
+    JudgeCaseAssignment.new(task_params.merge(task_id: params[:id])).reassign_to_attorney!
     render json: {}, status: 200
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -139,14 +139,6 @@ class LegacyAppeal < ApplicationRecord
     documents.size
   end
 
-  def number_of_documents_url
-    if document_service == ExternalApi::EfolderService
-      ExternalApi::EfolderService.efolder_files_url
-    else
-      "/queue/docs_for_dev"
-    end
-  end
-
   def number_of_documents_after_certification
     return 0 unless certification_date
     documents.count { |d| d.received_at && d.received_at > certification_date }

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -118,7 +118,7 @@ class SubmitDecisionView extends React.PureComponent {
     const successMsg = `Thank you for drafting ${fields.veteran}'s ${fields.type}. It's
     been sent to ${fields.judge} for review.`;
 
-    this.props.requestSave(`/queue/appeals/${taskId}/complete`, params, successMsg).
+    this.props.requestSave(`/tasks/${taskId}/complete`, params, successMsg).
       then(() => this.props.deleteAppeal(vacolsId));
   };
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,9 @@ Rails.application.routes.draw do
     get '/appeals/:vacols_id', to: 'queue#index'
     get '/appeals/:vacols_id/*all', to: redirect('/queue/appeals/%{vacols_id}')
     get '/:user_id', to: 'tasks#index'
+
+    # Remove this route
+    post '/appeals/:task_id/complete', to: 'tasks#complete'
   end
 
   resources :tasks, only: [:create, :update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,22 +127,12 @@ Rails.application.routes.draw do
     get '/appeals/:vacols_id', to: 'queue#index'
     get '/appeals/:vacols_id/*all', to: redirect('/queue/appeals/%{vacols_id}')
     get '/:user_id', to: 'tasks#index'
-
-    post '/appeals/:task_id/complete', to: 'tasks#complete'
-    post '/appeals', to: 'tasks#create'
-    patch '/appeals/:task_id', to: 'tasks#update'
-
-    # Our single page app requires us to keep the old routes around for a while since we are not guaranteed that
-    # everybody who uses our app will have the latest version of the app. Remove these legacy routes after PR related
-    # to caseflow issue #5309 is deployed.
-    # -------------
-    get '/tasks/:vacols_id', to: 'queue#index'
-    get '/tasks/:vacols_id/*all', to: redirect('/queue/appeals/%{vacols_id}')
-    # -------------
-
-    post '/tasks/:task_id/complete', to: 'tasks#complete'
-    resources :tasks, only: [:create, :update]
   end
+
+  resources :tasks, only: [:create, :update] do
+    post :complete
+  end
+
 
   get "health-check", to: "health_checks#show"
   get "dependencies-check", to: "dependencies_checks#show"

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe TasksController, type: :controller do
     end
   end
 
-  describe "PATCH tasks/:task_id" do
+  describe "PATCH tasks/:id" do
     let(:attorney) { User.create(css_id: "CFS123", station_id: "101") }
     let(:appeal) { LegacyAppeal.create(vacols_id: "1234C") }
     let!(:current_user) { User.authenticate!(roles: ["System Admin"]) }
@@ -138,7 +138,7 @@ RSpec.describe TasksController, type: :controller do
       end
 
       it "should not be successful" do
-        patch :update, params: { tasks: params, task_id: "3615398-2018-04-18" }
+        patch :update, params: { tasks: params, id: "3615398-2018-04-18" }
         expect(response.status).to eq 400
         response_body = JSON.parse(response.body)
         expect(response_body["errors"].first["title"]).to eq "Role is Invalid"
@@ -162,7 +162,7 @@ RSpec.describe TasksController, type: :controller do
           created_in_vacols_date: "2018-04-18".to_date
         ).and_return(true)
 
-        patch :update, params: { tasks: params, task_id: "3615398-2018-04-18" }
+        patch :update, params: { tasks: params, id: "3615398-2018-04-18" }
         expect(response.status).to eq 200
       end
 
@@ -176,7 +176,7 @@ RSpec.describe TasksController, type: :controller do
 
         it "should not be successful" do
           allow(Fakes::UserRepository).to receive(:vacols_role).and_return("Judge")
-          patch :update, params: { tasks: params, task_id: "3615398-2018-04-18" }
+          patch :update, params: { tasks: params, id: "3615398-2018-04-18" }
           expect(response.status).to eq 404
         end
       end


### PR DESCRIPTION
Resolves #5404

Remove `/queue` from the tasks route.

### Testing Plan
1. Automated testing

