### PR TITLE
Facols hearing prep fix

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -21,9 +21,7 @@ class Fakes::BGSService
 
     CSV.foreach(file_path, headers: true) do |row|
       row_hash = row.to_h
-      if %w[veteran_exists].include?(row_hash["bgs_key"])
-        Generators::Veteran.build(file_number: row_hash["vbms_id"].chop)
-      end
+      Generators::Veteran.build(file_number: row_hash["vbms_id"].chop)
     end
   end
 

--- a/local/vacols/cases.csv
+++ b/local/vacols/cases.csv
@@ -3,16 +3,16 @@ vacols_id,vbms_key,bgs_key,used_in_app,comments
 2774535,fuzzy_match_documents,,certification,Appeal with fuzzy matching docs
 2771149,mismatched_documents,,certification,Appeal with mismatched docs
 3242524,,,certification,Appeal already certified
-3306315,amc_full_grants,veteran_exists,dispatch,AMC full grants appeals
-2096907,amc_full_grants,veteran_exists,dispatch,AMC full grants appeals
-3642997,amc_full_grants,veteran_exists,dispatch,AMC full grants appeals
-2430857,amc_full_grants,veteran_exists,dispatch,AMC full grants appeals
-3363848,amc_full_grants,veteran_exists,dispatch,AMC full grants appeals
-3085659,remands_ready_for_claims_establishment,veteran_exists,dispatch,Remands ready
-3436456,remands_ready_for_claims_establishment,veteran_exists,dispatch,Remands ready
-2214968,remands_ready_for_claims_establishment,veteran_exists,dispatch,Remands ready
-3310775,remands_ready_for_claims_establishment,veteran_exists,dispatch,Remands ready
-2537880,remands_ready_for_claims_establishment,veteran_exists,dispatch,Remands ready
+3306315,amc_full_grants,,dispatch,AMC full grants appeals
+2096907,amc_full_grants,,dispatch,AMC full grants appeals
+3642997,amc_full_grants,,dispatch,AMC full grants appeals
+2430857,amc_full_grants,,dispatch,AMC full grants appeals
+3363848,amc_full_grants,,dispatch,AMC full grants appeals
+3085659,remands_ready_for_claims_establishment,,dispatch,Remands ready
+3436456,remands_ready_for_claims_establishment,,dispatch,Remands ready
+2214968,remands_ready_for_claims_establishment,,dispatch,Remands ready
+3310775,remands_ready_for_claims_establishment,,dispatch,Remands ready
+2537880,remands_ready_for_claims_establishment,,dispatch,Remands ready
 3575931,static_documents,,reader queue,Case assigned to ZZHU
 3619838,no_categories,,reader queue,Case assigned to ZZHU
 3625593,random_documents,,reader queue,Case assigned to ZZHU


### PR DESCRIPTION
We added BGS attributes to all veterans. This fixed the hearing worksheet's calls to veteran_sex and veteran_age.