### PR TITLE
Show all errors when manipulating annotations.

### DIFF
--- a/client/app/reader/AnnotationLayer/AnnotationActions.js
+++ b/client/app/reader/AnnotationLayer/AnnotationActions.js
@@ -273,9 +273,10 @@ export const requestEditAnnotation = (annotation) => (dispatch) => {
         });
       },
       (response) => {
-        const responseObject = JSON.parse(response.response.text);
+        const errors = response.response.type === 'application/json' ?
+          JSON.parse(response.response.text).errors[0].detail : null;
 
-        dispatch(showErrorMessage('annotation', responseObject.errors[0].detail));
+        dispatch(showErrorMessage('annotation', errors));
         dispatch({
           type: Constants.REQUEST_EDIT_ANNOTATION_FAILURE,
           payload: {
@@ -319,9 +320,10 @@ export const createAnnotation = (annotation) => (dispatch) => {
         });
       },
       (response) => {
-        const responseObject = JSON.parse(response.response.text);
+        const errors = response.response.type === 'application/json' ?
+          JSON.parse(response.response.text).errors[0].detail : null;
 
-        dispatch(showErrorMessage('annotation', responseObject.errors[0].detail));
+        dispatch(showErrorMessage('annotation', errors));
         dispatch({
           type: Constants.REQUEST_CREATE_ANNOTATION_FAILURE,
           payload: {


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/appeals-support/issues/2090#issuecomment-388972800

### Description
It's unclear why this happened, and I'm not sure this really addresses the problem, but I found that if there is a 500, we fail to parse the error on the frontend because the response is not JSON. The frontend won't show an error to the user and they'll think the annotation was saved.

### Acceptance Criteria 
- [ ] Frontend shows errors when annotations fail to save because of 500 error.

### Testing Plan
1. Add a `raise "TEST"` to the annotation controller's create method.
1. Try to create an annotation.
1. Ensure an error message appears.

