### PR TITLE
Queue | Only show View Hearing Worksheet link if a judge used it for a hearing

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -12,7 +12,7 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
     object.hearings.map do |hearing|
       {
         held_by: hearing.user.present? ? hearing.user.full_name : "",
-        viewed_by_judge: hearing.user.present? && !hearing.hearing_views.empty?,
+        viewed_by_judge: !hearing.hearing_views.empty?,
         date: hearing.date,
         type: hearing.type,
         id: hearing.id,

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -12,6 +12,8 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
     object.hearings.map do |hearing|
       {
         held_by: hearing.user.present? ? hearing.user.full_name : "",
+        # this assumes only the assigned judge will view the hearing worksheet. otherwise,
+        # we should check `hearing.hearing_views.map(&:user_id).include? judge.css_id`
         viewed_by_judge: !hearing.hearing_views.empty?,
         date: hearing.date,
         type: hearing.type,

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -12,6 +12,7 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
     object.hearings.map do |hearing|
       {
         held_by: hearing.user.present? ? hearing.user.full_name : "",
+        viewed_by_judge: hearing.user.present? && !hearing.hearing_views.empty?,
         date: hearing.date,
         type: hearing.type,
         id: hearing.id,

--- a/client/app/queue/AppealDetail.jsx
+++ b/client/app/queue/AppealDetail.jsx
@@ -40,9 +40,10 @@ export default class AppealDetail extends React.PureComponent {
       label: 'Disposition',
       value: <React.Fragment>
         {StringUtil.snakeCaseToCapitalized(hearing.disposition)}&nbsp;&nbsp;
-        <Link rel="noopener" target="_blank" href={`/hearings/${hearing.id}/worksheet/print`}>
+        {hearing.viewed_by_judge && <Link rel="noopener" target="_blank"
+          href={`/hearings/${hearing.id}/worksheet/print`}>
           View Hearing Worksheet
-        </Link>
+        </Link>}
       </React.Fragment>
     });
 

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -266,14 +266,15 @@ RSpec.feature "Queue" do
         expect(page).to have_content("Type: #{hearing_preference}")
 
         if hearing.disposition.eql? :cancelled
-          expect(page).not_to have_content("Date")
-          expect(page).not_to have_content("Judge")
+          expect(page).to have_content("Disposition: Cancelled")
         else
           expect(page).to have_content("Date: #{hearing.date.strftime('%-m/%-e/%y')}")
           expect(page).to have_content("Judge: #{hearing.user.full_name}")
 
-          worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet/print']")
-          expect(worksheet_link.text).to eq("View Hearing Worksheet")
+          if hearing.user.present? && !hearing.hearing_views.empty?
+            worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet/print']")
+            expect(worksheet_link.text).to eq("View Hearing Worksheet")
+          end
         end
       end
 

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -271,7 +271,7 @@ RSpec.feature "Queue" do
           expect(page).to have_content("Date: #{hearing.date.strftime('%-m/%-e/%y')}")
           expect(page).to have_content("Judge: #{hearing.user.full_name}")
 
-          if hearing.user.present? && !hearing.hearing_views.empty?
+          unless hearing.hearing_views.empty?
             worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet/print']")
             expect(worksheet_link.text).to eq("View Hearing Worksheet")
           end


### PR DESCRIPTION
Resolves #5391

### Description
Previously, we would display a link to the hearing worksheet regardless of hearing status, and regardless of whether the worksheet had been prepared or not. This change only displays the link after the assigned judge has viewed the worksheet

### Acceptance Criteria 
- [ ] 'View Hearing Worksheet' link visible/enabled for hearings where the judge has viewed the worksheet

### Testing Plan
1. Go to `/hearings/dockets/${day}` as `BVAAABSHIRE` (a judge), open a hearing's worksheet and set its disposition if needed
2. Copy veteran id from worksheet, search for it in `/queue`, navigate to appeal detail view
3. Confirm judge is Anjali Abshire, disposition persisted, `View Hearing Worksheet` link visible

Screenshot shows view hearing worksheet link for hearing held by `BVAAABSHIRE` (which we viewed), but not for other judges
![screen shot 2018-05-15 at 11 51 24 am](https://user-images.githubusercontent.com/8533004/40068319-569af55a-5836-11e8-8c6c-a554c834746b.png)

