### PR TITLE
Removing resolves because of unintended issue closing

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Resolves #{github issue number}
+Connects #{github issue number}
 
 ### Description
 Please explain the changes you made here.


### PR DESCRIPTION
We're accidentally closing issues because of the 'resolves' functionality. This update it to 'connects' so the PR still displays correctly on Waffle but doesn't close the associated issue.
