### PR TITLE
Navigate to Queue from Reader

### DIFF
--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -137,9 +137,11 @@ export class DecisionReviewer extends React.PureComponent {
   render() {
     const queueEnabled = this.props.featureToggles.queueWelcomeGate;
 
-    const { vacolsId } = this.props.match.params;
-    const defaultUrl = queueEnabled ? `/${vacolsId}/documents/` : '/';
     const claimsFolderBreadcrumb = queueEnabled ? '' : 'Claims Folder';
+    const defaultUrlProps = {};
+
+    // set Link's `to` vs `href`
+    defaultUrlProps[queueEnabled ? 'defaultHref' : 'defaultUrl'] = '/';
 
     return <React.Fragment>
       <NavigationBar
@@ -151,7 +153,7 @@ export class DecisionReviewer extends React.PureComponent {
         }}
         userDisplayName={this.props.userDisplayName}
         dropdownUrls={this.props.dropdownUrls}
-        defaultUrl={defaultUrl}>
+        {...defaultUrlProps}>
         <PageRoute
           exact
           title="Document Viewer | Caseflow Reader"

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "client/node_modules"
   ],
   "dependencies": {
-    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "^2.5.6",
+    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "^2.5.7",
     "babel-core": "^6.18.2",
     "babel-loader": "^7.1.2",
     "babel-polyfill": "^6.23.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -54,9 +54,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@^2.5.6":
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/caseflow-frontend-toolkit/-/caseflow-frontend-toolkit-2.5.6.tgz#cc97d2b8b4e78e6a2612737f41d2bbf21c4b44a8"
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/caseflow-frontend-toolkit/-/caseflow-frontend-toolkit-2.5.7.tgz#c5d389e9eef6a95ec8458d4777f30e0bae32adbc"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"

--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -514,6 +514,9 @@ RSpec.feature "Queue" do
         click_on "documents in Caseflow Reader"
 
         expect(page).to have_content("Back to #{appeal.veteran_full_name} (#{appeal.vbms_id})")
+
+        click_on "> Reader"
+        expect(page.current_path).to eq "/queue"
       end
     end
 

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -474,7 +474,7 @@ RSpec.feature "Reader" do
 
     scenario "Clicking outside pdf or next pdf removes annotation mode" do
       visit "/reader/appeal/#{appeal.vacols_id}/documents/2"
-      expect(page).to have_content("Caseflow Reader")
+      expect(page).to have_content("Caseflow > Reader")
 
       add_comment_without_clicking_save("text")
       page.find("body").click
@@ -525,7 +525,7 @@ RSpec.feature "Reader" do
       end
 
       visit "/reader/appeal/#{appeal.vacols_id}/documents/2"
-      expect(page).to have_content("Caseflow Reader")
+      expect(page).to have_content("Caseflow > Reader")
 
       add_comment(text: "comment text")
 
@@ -605,7 +605,7 @@ RSpec.feature "Reader" do
 
     scenario "Add, edit, and delete comments" do
       visit "/reader/appeal/#{appeal.vacols_id}/documents"
-      expect(page).to have_content("Caseflow Reader")
+      expect(page).to have_content("Caseflow > Reader")
 
       # Click on the link to the first file
       click_on documents[0].type


### PR DESCRIPTION
Connects #4894 

### Description
After a Queue user goes to Reader to view documents, they can navigate back to Queue from the Case Details page. However, once they load a document, there are only links back to Reader, none to Queue. This replaces the Caseflow logo / breadcrumb target within reader to `/` (`/queue`) for queue users.

### Acceptance Criteria 
- [ ] Within Reader, confirm `Caseflow` logo/breadcrumb in navbar links to `/` (which will redirect to `/queue` for queue users)

### Testing Plan
1. Within `caseflow-frontend-toolkit`, check out https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit/pull/29, and `yarn link` to Caseflow
2. Visit `/queue`, go to view case documents in Reader.
3. Confirm `Caseflow` logo/breadcrumb in navbar links to `/` (which will redirect to `/queue` for queue users)
4. Go to a document, confirm `Caseflow` logo/breadcrumb in navbar links to `/`.

![reader_queue_link](https://user-images.githubusercontent.com/8533004/40134498-8ffc2168-5910-11e8-8e91-09b7ee6775ba.gif)
