### PR TITLE
Queue | Rename 'OMO Ready for Review' 'Medical Request Ready for Review'

### DIFF
--- a/COPY.json
+++ b/COPY.json
@@ -44,5 +44,8 @@
 
   "IS_PAPER_CASE": "This is a paper case",
   "CASE_DIFF_VETERAN_AND_APPELLANT": "Veteran is not the appellant.",
-  "CASE_SAME_VETERAN_AND_APPELLANT": "The veteran is the appellant."
+  "CASE_SAME_VETERAN_AND_APPELLANT": "The veteran is the appellant.",
+
+  "ATTORNEY_CHECKOUT_OMO_LABEL": "OMO Ready for Review",
+  "ATTORNEY_CHECKOUT_DRAFT_DECISION_LABEL": "Decision Ready for Review"
 }

--- a/COPY.json
+++ b/COPY.json
@@ -46,6 +46,6 @@
   "CASE_DIFF_VETERAN_AND_APPELLANT": "Veteran is not the appellant.",
   "CASE_SAME_VETERAN_AND_APPELLANT": "The veteran is the appellant.",
 
-  "ATTORNEY_CHECKOUT_OMO_LABEL": "OMO Ready for Review",
+  "ATTORNEY_CHECKOUT_OMO_LABEL": "Medical Request Ready for Review",
   "ATTORNEY_CHECKOUT_DRAFT_DECISION_LABEL": "Decision Ready for Review"
 }

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -5,6 +5,7 @@ import VACOLS_DISPOSITIONS_BY_ID from '../../../constants/VACOLS_DISPOSITIONS_BY
 import REMAND_REASONS_BY_ID from '../../../constants/ACTIVE_REMAND_REASONS_BY_ID.json';
 import StringUtil from '../util/StringUtil';
 import { COLORS as COMMON_COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
+import COPY from '../../../COPY.json';
 
 export const COLORS = {
   QUEUE_LOGO_PRIMARY: '#11598D',
@@ -68,10 +69,10 @@ export const DECISION_TYPES = {
 };
 
 export const DRAFT_DECISION_OPTIONS = [{
-  label: 'Decision Ready for Review',
+  label: COPY.ATTORNEY_CHECKOUT_DRAFT_DECISION_LABEL,
   value: DECISION_TYPES.DRAFT_DECISION
 }, {
-  label: 'OMO Ready for Review',
+  label: COPY.ATTORNEY_CHECKOUT_OMO_LABEL,
   value: DECISION_TYPES.OMO_REQUEST
 }];
 


### PR DESCRIPTION
Connects #5491 

### Description
Renames attorney checkout flow dropdown label.

### Acceptance Criteria 
- [ ] Confirm Attorney checkout flow dropdown label "OMO Ready for Review" -> "Medical Request Ready for Review"

### Testing Plan
1. Go to `/queue` as attorney with `:queue_phase_two` featuretoggle enabled
2. Confirm OMO checkout label reads "Medical Request Ready for Review"

<img width="789" alt="screen shot 2018-05-16 at 5 01 39 pm" src="https://user-images.githubusercontent.com/8533004/40143932-d77bdb0e-592a-11e8-859d-cab5601b2883.png">

<img width="547" alt="screen shot 2018-05-16 at 5 02 35 pm" src="https://user-images.githubusercontent.com/8533004/40143970-f4d5f162-592a-11e8-92b8-4e0e1fafa874.png">
