### PR TITLE
Fix caseflow help link bug

### DIFF
--- a/client/app/queue/CaseListView.jsx
+++ b/client/app/queue/CaseListView.jsx
@@ -40,7 +40,7 @@ class CaseListView extends React.PureComponent {
         <p>{COPY.CASE_SEARCH_INPUT_INSTRUCTION}</p>
         <CaseListSearch elementId="searchBarEmptyList" />
         <hr {...horizontalRuleStyling} />
-        <p><Link to="/help">Caseflow Help</Link></p>
+        <p><Link href="/help">Caseflow Help</Link></p>
       </React.Fragment>
     };
 


### PR DESCRIPTION
This fixes a bug where clicking the help link on the caseflow search homepage sent you to an empty page. This change makes that link work properly.