### PR TITLE
Adding fake and real find relationships endpoint to BGS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem "wannabe_bool"
 gem "uswds-rails", git: "https://github.com/18F/uswds-rails-gem.git"
 
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "07a398fb0102ad93684f5423e73be68ba97c74d2"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "bc9c89591ac5830939476bd6eb96c1a2b415fdcb"
 
 # PDF Tools
 gem "pdf-forms"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 07a398fb0102ad93684f5423e73be68ba97c74d2
-  ref: 07a398fb0102ad93684f5423e73be68ba97c74d2
+  revision: bc9c89591ac5830939476bd6eb96c1a2b415fdcb
+  ref: bc9c89591ac5830939476bd6eb96c1a2b415fdcb
   specs:
     bgs (0.2)
       nokogiri (~> 1.8.2)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -130,6 +130,17 @@ class ExternalApi::BGSService
     end
   end
 
+  def find_all_relationships(participant_id:)
+    DBService.release_db_connections
+
+    MetricsService.record("BGS: find all relationships: \
+                           participant_id = #{participant_id}",
+                          service: :bgs,
+                          name: "claimants.find_all_relationships") do
+      client.claimants.find_all_relationships(participant_id)
+    end
+  end
+
   private
 
   def init_client

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -296,6 +296,67 @@ class Fakes::BGSService
     { rating_issues: rating_issues }
   end
 
+  def find_all_relationships(participant_id:)
+    [
+      {
+        authzn_change_clmant_addrs_ind: nil,
+        authzn_poa_access_ind: "Y",
+        award_begin_date: nil,
+        award_end_date: nil,
+        award_ind: "N",
+        award_type: "CPL",
+        date_of_birth: "02171972",
+        date_of_death: "03072014",
+        dependent_reason: nil,
+        dependent_terminate_date: nil,
+        email_address: nil,
+        fiduciary: nil,
+        file_number: "123456789",
+        first_name: "BOB",
+        gender: "M",
+        last_name: "VANCE",
+        middle_name: "D",
+        poa: "DISABLED AMERICAN VETERANS",
+        proof_of_dependecy_ind: nil,
+        ptcpnt_id: "5382910292",
+        relationship_begin_date: nil,
+        relationship_end_date: nil,
+        relationship_type: "Spouse",
+        ssn: "123456789",
+        ssn_verified_ind: "Unverified",
+        terminate_reason: nil
+      },
+      {
+        authzn_change_clmant_addrs_ind: nil,
+        authzn_poa_access_ind: nil,
+        award_begin_date: nil,
+        award_end_date: nil,
+        award_ind: "N",
+        award_type: "CPL",
+        date_of_birth: "04121995",
+        date_of_death: nil,
+        dependent_reason: nil,
+        dependent_terminate_date: nil,
+        email_address: "cathy@gmail.com",
+        fiduciary: nil,
+        file_number: nil,
+        first_name: "CATHY",
+        gender: nil,
+        last_name: "SMITH",
+        middle_name: nil,
+        poa: nil,
+        proof_of_dependecy_ind: nil,
+        ptcpnt_id: "1129318238",
+        relationship_begin_date: "08121999",
+        relationship_end_date: nil,
+        relationship_type: "Child",
+        ssn: nil,
+        ssn_verified_ind: nil,
+        terminate_reason: nil
+      }
+    ]
+  end
+
   private
 
   def default_power_of_attorney_record


### PR DESCRIPTION
### Description
We need to have relationship info for veterans to be able to identify appellants. This adds a fake and real version to the `find_all_relationships` BGS endpoint.

### Acceptance Criteria 
- [ ] Has fake version of `find_all_relationships`
- [ ] Has a real version of `find_all_relationships`

### Testing Plan
1. Run locally and test the fake version returns stubbed data.
1. Run in UAT and test the real version returns data for the participant id: `600051520`

