### PR TITLE
Blank disposition fix

### DIFF
--- a/client/app/hearings/components/WorksheetHeader.jsx
+++ b/client/app/hearings/components/WorksheetHeader.jsx
@@ -92,7 +92,11 @@ class WorksheetHeader extends React.PureComponent {
 
     const dispositionClassNames = classNames({ 'cf-red-text': negativeDispositions });
 
-    const getDisposition = (dispositionSymbol) => _.find(DISPOSITION_OPTIONS, { value: dispositionSymbol }).label;
+    const getDisposition = (dispositionSymbol) => {
+      const disposition = _.find(DISPOSITION_OPTIONS, { value: dispositionSymbol });
+
+      return disposition ? disposition.label : '';
+    };
 
     return <div>
       <div className="cf-hearings-worksheet-data">


### PR DESCRIPTION
### Description
There's a bug on the hearing worksheet where if we call the hearing disposition, and it's blank, we get an error, 'Can't read label of nil'. This PR fixes that bug

### Testing Plan
1. Go to a past hearing's worksheet
1. Confirm that the disposition loads correctly for both nil cases and non-nil cases

