### PR TITLE
Set application to queue to ensure to use efolder service instead of …

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -1,5 +1,6 @@
 class AppealsController < ApplicationController
   before_action :react_routed
+  before_action :set_application, only: :document_count
 
   def index
     return veteran_id_not_found_error unless veteran_id
@@ -44,6 +45,10 @@ class AppealsController < ApplicationController
   end
 
   private
+
+  def set_application
+    RequestStore.store[:application] = "queue"
+  end
 
   # https://stackoverflow.com/a/748646
   def no_cache


### PR DESCRIPTION
…quering vbms directly

Connects #5638 

### Description
In the appeals controller, we need to set the application to queue to ensure it uses Efolder service instead of querying VBMS directly. Efolder service has better error handling, etc
https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/legacy_appeal.rb#L125
