### PR TITLE
If VACOLS update failes, ensure to rollback

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,17 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 end
+
+# Helper for multi-database transactions
+# http://technology.customink.com/blog/2015/06/22/rails-multi-database-best-practices-roundup/
+ActiveRecord::Base.class_eval do
+  def self.multi_transaction
+    ActiveRecord::Base.transaction do
+      VACOLS::Record.transaction { yield }
+    end
+  end
+
+  def multi_transaction
+    self.class.multi_transaction { yield }
+  end
+end

--- a/app/models/attorney_case_reviews/attorney_case_review.rb
+++ b/app/models/attorney_case_reviews/attorney_case_review.rb
@@ -62,7 +62,7 @@ class AttorneyCaseReview < ApplicationRecord
     attr_writer :repository
 
     def complete!(params)
-      transaction do
+      ActiveRecord::Base.multi_transaction do
         record = create!(params)
         MetricsService.record("VACOLS: reassign_case_to_judge #{record.task_id}",
                               service: :vacols,

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -1,7 +1,7 @@
 class QueueRepository
   # :nocov:
   def self.transaction
-    VACOLS::Case.transaction do
+    VACOLS::Record.transaction do
       yield
     end
   end


### PR DESCRIPTION
We've noticed that if VACOLS update fails, only changes in Postgres DB are rollbacked. Turns out 
we need to handle it differently for multi database connections.

