### PR TITLE
Disables CaseDetailsLink only for attorneys

### DIFF
--- a/client/app/queue/AttorneyTaskTable.jsx
+++ b/client/app/queue/AttorneyTaskTable.jsx
@@ -22,7 +22,7 @@ class AttorneyTaskTable extends React.PureComponent {
     return attr ? _.get(appeal.attributes, attr) : appeal;
   };
 
-  getCaseDetailsLink = (task) => <CaseDetailsLink task={task} appeal={this.getAppealForTask(task)} />;
+  getCaseDetailsLink = (task) => <CaseDetailsLink task={task} appeal={this.getAppealForTask(task)} disabled={!task.attributes.task_id} />;
 
   tableStyle = css({
     '& > tr > td': {

--- a/client/app/queue/AttorneyTaskTable.jsx
+++ b/client/app/queue/AttorneyTaskTable.jsx
@@ -22,7 +22,8 @@ class AttorneyTaskTable extends React.PureComponent {
     return attr ? _.get(appeal.attributes, attr) : appeal;
   };
 
-  getCaseDetailsLink = (task) => <CaseDetailsLink task={task} appeal={this.getAppealForTask(task)} disabled={!task.attributes.task_id} />;
+  getCaseDetailsLink = (task) =>
+    <CaseDetailsLink task={task} appeal={this.getAppealForTask(task)} disabled={!task.attributes.task_id} />;
 
   tableStyle = css({
     '& > tr > td': {

--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -25,7 +25,7 @@ class CaseDetailsLink extends React.PureComponent {
     return <React.Fragment>
       <Link
         to={`/queue/appeals/${this.props.task.vacolsId}`}
-        disabled={!task.task_id || appeal.paper_case}
+        disabled={appeal.paper_case}
         onClick={this.setActiveAppealAndTask}
       >
         {appeal.veteran_full_name} ({appeal.vbms_id})

--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -26,7 +26,7 @@ class CaseDetailsLink extends React.PureComponent {
     return <React.Fragment>
       <Link
         to={`/queue/appeals/${this.props.task.vacolsId}`}
-        disabled={disabled || this.appeal.paper_case}
+        disabled={disabled || appeal.paper_case}
         onClick={this.setActiveAppealAndTask}
       >
         {appeal.veteran_full_name} ({appeal.vbms_id})

--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -19,13 +19,14 @@ class CaseDetailsLink extends React.PureComponent {
   render() {
     const {
       appeal: { attributes: appeal },
-      task: { attributes: task }
+      task: { attributes: task },
+      disabled
     } = this.props;
 
     return <React.Fragment>
       <Link
         to={`/queue/appeals/${this.props.task.vacolsId}`}
-        disabled={appeal.paper_case}
+        disabled={disabled || this.appeal.paper_case}
         onClick={this.setActiveAppealAndTask}
       >
         {appeal.veteran_full_name} ({appeal.vbms_id})
@@ -44,7 +45,8 @@ class CaseDetailsLink extends React.PureComponent {
 
 CaseDetailsLink.propTypes = {
   task: PropTypes.object.isRequired,
-  appeal: PropTypes.object.isRequired
+  appeal: PropTypes.object.isRequired,
+  disabled: PropTypes.bool
 };
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -19,7 +19,6 @@ class CaseDetailsLink extends React.PureComponent {
   render() {
     const {
       appeal: { attributes: appeal },
-      task: { attributes: task },
       disabled
     } = this.props;
 


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/caseflow/issues/5619 .

## Description
Stops disabling the case details link when the task doesn't have a task id.

## Test Plan
- [ ] Deploy to Prod.
- [ ] Ask the judge to see if the page works now.