### PR TITLE
Generate unique index for stafkey to abide by uniqueness constraint in database.

### DIFF
--- a/lib/generators/vacols/case.rb
+++ b/lib/generators/vacols/case.rb
@@ -1,11 +1,15 @@
 class Generators::Vacols::Case
   class << self
+    def generate_pkseq
+      SecureRandom.random_number(99_999_999)
+    end
+
     # rubocop:disable Metrics/MethodLength
     def case_attrs
       {
         bfkey: "877483",
         bfddec: "2017-11-28 00:00:00 UTC",
-        bfcorkey: "CK168505",
+        bfcorkey: generate_pkseq,
         bfcorlid: "626343664S",
         bfdcn: nil,
         bfdocind: nil,

--- a/lib/generators/vacols/correspondent.rb
+++ b/lib/generators/vacols/correspondent.rb
@@ -1,9 +1,13 @@
 class Generators::Vacols::Correspondent
   class << self
+    def generate_pkseq
+      SecureRandom.random_number(99_999_999)
+    end
+
     # rubocop:disable Metrics/MethodLength
     def correspondent_attrs
       {
-        stafkey: "CK168505",
+        stafkey: generate_pkseq,
         susrpw: nil,
         susrsec: nil,
         susrtyp: "VETERAN",


### PR DESCRIPTION

Connects #{5450}

### Description
Added unique number generator to ensure column complies with uniqueness constraint in VACOLS table.

### Acceptance Criteria 
- [ ] Code compiles correctly
- [ ] Reader and Hearing tests pass against docker container.

### Testing Plan
1. Test locally to ensure no db errors occur when inserting to CORRES table in VACOLS.

