### PR TITLE
removing columns that are not needed for HP

### DIFF
--- a/app/controllers/hearings/worksheets_controller.rb
+++ b/app/controllers/hearings/worksheets_controller.rb
@@ -35,10 +35,7 @@ class Hearings::WorksheetsController < HearingsController
   def worksheet_params
     params.require("worksheet").permit(:representative_name,
                                        :witness,
-                                       :contentions,
                                        :military_service,
-                                       :evidence,
-                                       :comments_for_attorney,
                                        :prepped,
                                        :summary)
   end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -16,7 +16,6 @@ class Hearing < ApplicationRecord
   belongs_to :user # the judge
   has_many :hearing_views
   has_many :appeal_stream_snapshots
-  before_save :update_summary_field, if: :data_fields_changed
 
   # this is used to cache appeal stream for hearings
   # when fetched intially.
@@ -211,21 +210,6 @@ class Hearing < ApplicationRecord
       update_attributes(military_service: veteran.periods_of_service.join("\n")) if persisted? && veteran
       super
     end
-  end
-
-  private
-
-  def data_fields_changed
-    evidence_changed? || contentions_changed? || comments_for_attorney_changed?
-  end
-
-  def update_summary_field
-    get_paragraph = ->(data) { data.blank? ? "<p></p><p></p><p></p>" : "<p>#{data}</p><p></p>" }
-
-    self.summary = "<p><strong>Contentions</strong></p>#{get_paragraph.call(contentions)}"\
-    "<p><strong>Evidence</strong></p> #{get_paragraph.call(evidence)}"\
-    "<p><strong>Comments and special instructions to attorneys</strong></p>"\
-    "#{get_paragraph.call(comments_for_attorney)}"
   end
 
   class << self

--- a/db/migrate/20180517204250_remove_hearing_data_columns.rb
+++ b/db/migrate/20180517204250_remove_hearing_data_columns.rb
@@ -1,0 +1,7 @@
+class RemoveHearingDataColumns < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :hearings, :contentions
+    remove_column :hearings, :evidence
+    remove_column :hearings, :comments_for_attorney
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180517204321) do
+ActiveRecord::Schema.define(version: 20180517204250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -313,10 +313,7 @@ ActiveRecord::Schema.define(version: 20180517204321) do
     t.integer "appeal_id"
     t.string "vacols_id", null: false
     t.string "witness"
-    t.string "contentions"
-    t.string "evidence"
     t.string "military_service"
-    t.string "comments_for_attorney"
     t.boolean "prepped"
     t.text "summary"
   end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -17,8 +17,7 @@ describe Hearing do
       date: date,
       disposition: disposition,
       hold_open: hold_open,
-      type: type,
-      contentions: "no treatment after service private or VA\n"
+      type: type
     )
   end
 
@@ -36,32 +35,6 @@ describe Hearing do
       let(:type) { :central_office }
 
       it { is_expected.to eq("Board of Veterans' Appeals in Washington, DC") }
-    end
-  end
-
-  context "update_summary_field" do
-    subject { hearing2 }
-
-    it "updates summary field after contentions is updated" do
-      expected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
-      "CS denied in 3/68 DX of C-spine issue</p><p></p><p><strong>Evidence</strong></p>"\
-      " <p></p><p></p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
-      "</p><p></p><p></p><p></p>"
-      subject.contentions = "no treatment after service private or VA\n"\
-      "CS denied in 3/68 DX of C-spine issue"
-      subject.save
-      expect(subject.summary).to eq expected_string
-    end
-
-    it "updates summary field after evidence and comments updated" do
-      expected_string = "<p><strong>Contentions</strong></p><p>no treatment after service private or VA\n"\
-      "</p><p></p><p><strong>Evidence</strong></p>"\
-      " <p>evidence</p><p></p><p><strong>Comments and special instructions to attorneys</strong>"\
-      "</p><p>here are the list of comments here</p><p></p>"
-      evidence = "evidence"
-      comments_for_attorney = "here are the list of comments here"
-      subject.update!(evidence: evidence, comments_for_attorney: comments_for_attorney)
-      expect(subject.summary).to eq expected_string
     end
   end
 
@@ -266,10 +239,7 @@ describe Hearing do
       let(:hearing_hash) do
         {
           military_service: "Vietnam 1968 - 1970",
-          evidence: "Medical exam done on 10/10/2003",
           witness: "Jane Smith attended",
-          contentions: "The veteran believes their neck is hurt",
-          comments_for_attorney: "Look for neck-related records",
           prepped: true
         }
       end
@@ -277,10 +247,7 @@ describe Hearing do
       it "updates hearing columns" do
         subject
         expect(hearing.military_service).to eq "Vietnam 1968 - 1970"
-        expect(hearing.evidence).to eq "Medical exam done on 10/10/2003"
         expect(hearing.witness).to eq "Jane Smith attended"
-        expect(hearing.contentions).to eq "The veteran believes their neck is hurt"
-        expect(hearing.comments_for_attorney).to eq "Look for neck-related records"
         expect(hearing.prepped).to be_truthy
       end
     end


### PR DESCRIPTION
Connects #3862

### Description
Removing the columns not being used in HP

### Acceptance Criteria 
- [ ] Run the migration and make sure HP loads and summary field still works

