### PR TITLE
Add uuid pg extension and column to appeals

### DIFF
--- a/db/migrate/20180524173201_enable_uuid_extension.rb
+++ b/db/migrate/20180524173201_enable_uuid_extension.rb
@@ -1,0 +1,5 @@
+class EnableUuidExtension < ActiveRecord::Migration[5.1]
+  def change
+    enable_extension 'uuid-ossp'
+  end
+end

--- a/db/migrate/20180524174054_add_uuid_to_appeals.rb
+++ b/db/migrate/20180524174054_add_uuid_to_appeals.rb
@@ -1,0 +1,7 @@
+class AddUuidToAppeals < ActiveRecord::Migration[5.1]
+  def change
+    safety_assured do
+      add_column :appeals, :uuid, :uuid, null: false, default: 'uuid_generate_v4()'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180523171432) do
+ActiveRecord::Schema.define(version: 20180524173201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "annotations", id: :serial, force: :cascade do |t|
     t.integer "document_id", null: false
@@ -61,6 +62,7 @@ ActiveRecord::Schema.define(version: 20180523171432) do
     t.date "receipt_date"
     t.string "docket_type"
     t.datetime "established_at"
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["veteran_file_number"], name: "index_appeals_on_veteran_file_number"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180524173201) do
+ActiveRecord::Schema.define(version: 20180524174054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Connects #5626 
### Description
First migration to enable uuid postgres helpers.
Second migration to add uuid column to appeals table with a default.

