### PR TITLE
Display basic subheading on case details page when task data incomplete

### DIFF
--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -44,10 +44,17 @@ class QueueDetailView extends React.PureComponent {
   }
 
   subHead = () => {
+    const appeal = this.props.appeal.attributes;
+    const basicSubHeading = `Docket Number: ${appeal.docket_number}, Assigned to ${appeal.location_code}`;
+
     if (this.props.task) {
       const task = this.props.task.attributes;
 
       if (this.props.userRole === 'Judge') {
+        if (!task.assigned_by_first_name || !task.assigned_by_last_name || !task.document_id) {
+          return basicSubHeading;
+        }
+
         const firstInitial = String.fromCodePoint(task.assigned_by_first_name.codePointAt(0));
         const nameAbbrev = `${firstInitial}. ${task.assigned_by_last_name}`;
 
@@ -64,9 +71,7 @@ class QueueDetailView extends React.PureComponent {
       </React.Fragment>;
     }
 
-    const appeal = this.props.appeal.attributes;
-
-    return `Docket Number: ${appeal.docket_number}, Assigned to ${appeal.location_code}`;
+    return basicSubHeading;
   }
 
   getCheckoutFlowDropdown = () => {


### PR DESCRIPTION
Connect #5669.

This fixes a bug where tasks with some null attributes (specifically the `assigned_by_first_name` attribute) would cause the case details page to load when reached via the case details link on the judge assignment page. Fixed by displaying a basis subheading if the task data is incomplete.