### PR TITLE
Fix reading VVA indicator

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -216,7 +216,7 @@ class AppealRepository
   def self.folder_type_from(folder_record)
     if %w[Y 1 0].include?(folder_record.tivbms)
       "VBMS"
-    elsif folder_record.tisubj == "Y"
+    elsif folder_record.tisubj2 == "Y"
       "VVA"
     else
       "Paper"

--- a/spec/services/appeals_repository_spec.rb
+++ b/spec/services/appeals_repository_spec.rb
@@ -178,12 +178,12 @@ describe AppealRepository do
     end
 
     context "detects VVA folder" do
-      let(:folder_record) { OpenStruct.new(tisubj: "Y") }
+      let(:folder_record) { OpenStruct.new(tisubj2: "Y") }
       it { is_expected.to eq("VVA") }
     end
 
     context "detects paper" do
-      let(:folder_record) { OpenStruct.new(tivbms: "other_val", tisubj: "other_val") }
+      let(:folder_record) { OpenStruct.new(tivbms: "other_val", tisubj2: "other_val") }
       it { is_expected.to eq("Paper") }
     end
   end


### PR DESCRIPTION
### Description
Within [`AppealRepository.folder_type_from`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/services/appeal_repository.rb#L216), we check wither the case is in VBMS, VVA, or Paper. However, we were previously checking the wrong attribute for VVA, `tisubj` vs `tisubj2`. Jed [pointed us towards](https://github.com/department-of-veterans-affairs/dsva-vacols/issues/11) a VACOLS function `PAPERLESS`, also found in [our VACOLS function dump](https://github.com/department-of-veterans-affairs/caseflow/blob/master/local/vacols/vacols_copy_5_functions.sql#L1556).

### Acceptance Criteria 
- [ ] VACOLS Folders with `tivbms` not in `%[Y 1 0]` and `tisubj2 != "Y"` should be "Paper".

### To do
There're no test cases matching these criteria in FACOLS (all have `tivbms == "Y"`).

