### PR TITLE
Generate IDs that more closely mirror SSNs

### DIFF
--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :case, class: VACOLS::Case do
     sequence(:bfkey)
     sequence(:bfcorkey)
-    sequence(:bfcorlid, 10_000) { |n| "#{n}S" }
+    sequence(:bfcorlid, 100_000_000) { |n| "#{n}S" }
 
     association :representative, factory: :representative, repkey: :bfkey
     association :correspondent, factory: :correspondent

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       end
     end
 
-    sequence(:file_number, 10_000)
+    sequence(:file_number, 100_000_000)
 
     after(:build) do |veteran, evaluator|
       Fakes::BGSService.veteran_records ||= {}


### PR DESCRIPTION
We expect file_number and vmbs_id to contain SSNs or claims file number. This PR changes those generators so we create IDs that more closely resemble SSNs (same number of digits).