### PR TITLE
Attorney Check out | Fix creating remand reasons

### DIFF
--- a/app/mappers/issue_mapper.rb
+++ b/app/mappers/issue_mapper.rb
@@ -63,7 +63,9 @@ module IssueMapper
     end
 
     def disposition_to_vacols_format(disposition)
-      inverted_dispositions = Constants::VACOLS_DISPOSITIONS_BY_ID.map { |k, v| [v.parameterize.underscore, k] }.to_h
+      inverted_dispositions = Constants::VACOLS_DISPOSITIONS_BY_ID.map { |k, v|
+        [v.parameterize.underscore.capitalize, k]
+      }.to_h
       code = inverted_dispositions[disposition]
 
       unless ALLOWED_DISPOSITION_CODES.include? code

--- a/app/mappers/issue_mapper.rb
+++ b/app/mappers/issue_mapper.rb
@@ -63,9 +63,9 @@ module IssueMapper
     end
 
     def disposition_to_vacols_format(disposition)
-      inverted_dispositions = Constants::VACOLS_DISPOSITIONS_BY_ID.map { |k, v|
+      inverted_dispositions = Constants::VACOLS_DISPOSITIONS_BY_ID.map do |k, v|
         [v.parameterize.underscore.capitalize, k]
-      }.to_h
+      end.to_h
       code = inverted_dispositions[disposition]
 
       unless ALLOWED_DISPOSITION_CODES.include? code

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -104,9 +104,10 @@ class SubmitDecisionView extends React.PureComponent {
       data: {
         tasks: {
           type: decision.type,
-          issues: getUndecidedIssues(issues).map((issue) => _.pick(issue,
-            ['disposition', 'vacols_sequence_id', 'remand_reasons', 'type', 'readjudication']
-          )),
+          issues: getUndecidedIssues(issues).map((issue) => _.extend({},
+            _.pick(issue, ['vacols_sequence_id', 'remand_reasons', 'type', 'readjudication']),
+            { disposition: _.capitalize(issue.disposition) })
+          ),
           ...decision.opts
         }
       }

--- a/spec/mappers/issue_mapper_spec.rb
+++ b/spec/mappers/issue_mapper_spec.rb
@@ -125,7 +125,7 @@ describe IssueMapper do
         context "when valid disposition" do
           let(:issue_attrs) do
             {
-              disposition: "withdrawn",
+              disposition: "Withdrawn",
               disposition_date: VacolsHelper.local_date_with_utc_timezone,
               vacols_user_id: "TEST1"
             }


### PR DESCRIPTION
Connects #5724

### Description
As of #5413 (merged 5/8/18), we have had a mismatch in how we send issue dispositions to the backend, resulting in remand reasons not being created.

### Acceptance Criteria 
- [ ] Issue disposition is sent from front-end as capitalized (as per [`IssueRepository. perform_actions_if_disposition_changes `](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/repositories/issue_repository.rb#L68))
- [ ] [`IssueMapper.disposition_to_vacols_format`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/mappers/issue_mapper.rb#L65) gets disposition code correctly / doesn't throw a "Not allowed disposition" error


### Testing Plan
1. Go to `/queue` as an attorney (`BVASCASPER1`), do Draft Decision checkout flow, set ≥ 1 issue to Remanded
2. After completing checkout, confirm `VACOLS::RemandReason`s created correctly.

![remand_reasons](https://user-images.githubusercontent.com/8533004/40742860-ca29db06-641d-11e8-8d14-feca8278af4e.gif)
