### PR TITLE
Vacols IDs can contain letters

### DIFF
--- a/app/models/attorney_case_reviews/attorney_case_review.rb
+++ b/app/models/attorney_case_reviews/attorney_case_review.rb
@@ -9,7 +9,7 @@ class AttorneyCaseReview < ApplicationRecord
   attr_accessor :issues
 
   # task ID is vacols_id concatenated with the date assigned
-  validates :task_id, format: { with: /\A[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}\Z/i }
+  validates :task_id, format: { with: /\A[0-9A-Z]+-[0-9]{4}-[0-9]{2}-[0-9]{2}\Z/i }
 
   def appeal
     @appeal ||= LegacyAppeal.find_or_create_by(vacols_id: vacols_id)

--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -1,6 +1,6 @@
 class AttorneyLegacyTask < LegacyTask
   # task ID is vacols_id concatenated with the date assigned
-  validates :task_id, format: { with: /\A[0-9]+-[0-9]{4}-[0-9]{2}-[0-9]{2}\Z/i }, allow_blank: true
+  validates :task_id, format: { with: /\A[0-9A-Z]+-[0-9]{4}-[0-9]{2}-[0-9]{2}\Z/i }, allow_blank: true
   validates :assigned_by, :assigned_to, presence: true
   validate :assigned_by_role_is_valid
 

--- a/spec/models/attorney_case_reviews/attorney_case_review_spec.rb
+++ b/spec/models/attorney_case_reviews/attorney_case_review_spec.rb
@@ -26,6 +26,11 @@ describe AttorneyCaseReview do
         it { is_expected.to be_valid }
       end
 
+      context "when correct format with letters" do
+        let(:task_id) { "123456L-2013-12-06" }
+        it { is_expected.to be_valid }
+      end
+
       context "when incorrect format" do
         let(:task_id) { "123456-2013/12/06" }
         it { is_expected.to_not be_valid }

--- a/spec/models/legacy_tasks/attorney_legacy_task_spec.rb
+++ b/spec/models/legacy_tasks/attorney_legacy_task_spec.rb
@@ -64,7 +64,7 @@ describe AttorneyLegacyTask do
       )
     end
     context "when all required values are present" do
-      let(:task_id) { "3615398-2018-04-18" }
+      let(:task_id) { "361539D8-2018-04-18" }
       let(:assigned_by) { judge }
       let(:assigned_to) { attorney }
 


### PR DESCRIPTION
Fixes https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1494/

Turns out bfkeys can contain letters.