### PR TITLE
Add rake tasks to rebuild local dev env in consolidated steps

### DIFF
--- a/lib/tasks/local/build.rake
+++ b/lib/tasks/local/build.rake
@@ -1,0 +1,25 @@
+namespace :local do
+  desc "build local development environment"
+  task :build do
+    puts "Building docker services from configuration"
+    `docker-compose build --no-cache`
+
+    puts "Starting docker containers in the background"
+    `docker-compose up -d`
+
+    puts "Setting up FACOLS"
+    Rake::Task["local:vacols:setup"].invoke
+
+    puts "Enabling feature flags"
+    `bundle exec rails runner scripts/enable_features_dev.rb`
+
+    puts "Setting up local caseflow database"
+    Rake::Task["db:setup"].invoke
+
+    puts "Seeding local caseflow database"
+    Rake::Task["db:seed"].invoke
+
+    puts "Seeding FACOLS"
+    Rake::Task["local:vacols:seed"].invoke
+  end
+end

--- a/lib/tasks/local/destroy.rake
+++ b/lib/tasks/local/destroy.rake
@@ -1,0 +1,7 @@
+namespace :local do
+  desc "destroy local development environment to have a clean slate when rebuilding"
+  task :destroy do
+    puts "Tearing down docker volumes"
+    `docker-compose down --rmi all -v --remove-orphans`
+  end
+end

--- a/lib/tasks/local/destroy.rake
+++ b/lib/tasks/local/destroy.rake
@@ -2,6 +2,6 @@ namespace :local do
   desc "destroy local development environment to have a clean slate when rebuilding"
   task :destroy do
     puts "Tearing down docker volumes"
-    `docker-compose down --rmi all -v --remove-orphans`
+    `docker-compose down -v --remove-orphans`
   end
 end


### PR DESCRIPTION
To make it easier to rebuild our local development environments I created two rake tasks to destroy and build those environments. We still need to set a local variable but otherwise this pair of commands will rebuild your local development environment when run within the caseflow directory:
```
caseflow $ RAILS_ENV=development bundle exec rake local:destroy
caseflow $ RAILS_ENV=development bundle exec rake local:build
```