### PR TITLE
Improve build local dev env script

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,7 @@ To rapidly set up your local development (and testing) environment, you can run:
 bundle exec rake local:build
 ```
 
-In order to rebuild your local development run that command after tearing down your existing environment with this command:
-```
-bundle exec rake local:destroy
-```
-
-Both of the above shortcuts run a set of commands in sequence that should build (or destroy) your local environment. If you need to troubleshoot the process, you can copy each individual step out of these tasks and run them independently.
+The above shortcut runs a set of commands in sequence that should build your local environment. If you need to troubleshoot the process, you can copy each individual step out of the task and run them independently.
 
 ## Debugging FACOLS setup
 Sometimes the above setup fails, or the app cannot connect to the DB. Here are some frequently encountered scenarios.
@@ -141,6 +136,12 @@ Sometimes the above setup fails, or the app cannot connect to the DB. Here are s
 Try running `docker-compose down --rmi all -v --remove-orphans` and then running the setup again.
 
 2) The app is failing to connect to the DB and you get timeout errors. Try restarting your docker containers. `docker-compose restart`.
+
+If all else fails you can rebuild your local development environment by running the two rake tasks in sequence:
+```
+bundle exec rake local:destroy
+bundle exec rake local:build
+```
 
 ## Manually seeding your local VACOLS container
 To seed the VACOLS container with data you'll need to generate the data for the CSVs first.

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ RAILS_ENV=development rake local:vacols:seed
 
 Note you'll need to setup both the test and development databases, but only need to seed the development database.
 
+## Setup shortcuts
+
+To rapidly set up your local development (and testing) environment, you can run `bundle exec rake local:build`. In order to rebuild your local development run that command after tearing down your existing environment with this command: `bundle exec rake local:destroy`.
+
 ## Debugging FACOLS setup
 Sometimes the above setup fails, or the app cannot connect to the DB. Here are some frequently encountered scenarios.
 

--- a/README.md
+++ b/README.md
@@ -115,45 +115,19 @@ brew services stop postgresql
 brew services stop redis
 ```
 
-Start all containers
-```
-docker-compose up -d
-# run without -d to start your environment and view container logging in the foreground
-
-docker-compose ps
-# this shows you the status of all of your dependencies
-```
-
-Turning off dependencies
-```
-# this stops all containers
-docker-compose down
-
-# this will reset your setup back to scratch. You will need to setup your database schema again if you do this (see below)
-docker-compose down -v
-```
-
-Enable features
-```
-bundle exec rails runner scripts/enable_features_dev.rb
-```
-
-## Setup your Database Schema
-```
-rake [RAILS_ENV=<test|development|stubbed>] db:setup
-rake [RAILS_ENV=<test|development|stubbed>] db:seed
-
-# setup local VACOLS (FACOLS)
-RAILS_ENV=test rake local:vacols:setup
-RAILS_ENV=development rake local:vacols:setup
-RAILS_ENV=development rake local:vacols:seed
-```
-
-Note you'll need to setup both the test and development databases, but only need to seed the development database.
-
 ## Setup shortcuts
 
-To rapidly set up your local development (and testing) environment, you can run `bundle exec rake local:build`. In order to rebuild your local development run that command after tearing down your existing environment with this command: `bundle exec rake local:destroy`.
+To rapidly set up your local development (and testing) environment, you can run:
+```
+bundle exec rake local:build
+```
+
+In order to rebuild your local development run that command after tearing down your existing environment with this command:
+```
+bundle exec rake local:destroy
+```
+
+Both of the above shortcuts run a set of commands in sequence that should build (or destroy) your local environment. If you need to troubleshoot the process, you can copy each individual step out of these tasks and run them independently.
 
 ## Debugging FACOLS setup
 Sometimes the above setup fails, or the app cannot connect to the DB. Here are some frequently encountered scenarios.


### PR DESCRIPTION
Continuation of the work initiated in #5787.

Three major changes here:
1. Added step to set up the FACOLS container that our local tests run against.
2. Added logic to wait for FACOLS containers to be ready in this script instead of only relying on other rake tasks's logic to do that for us (that approach failed occasionally).
3. Call rake tasks by way of backticked system commands instead of ruby interface. This allows us to set the environment variables inside the script instead of when we call this task. This has the side benefit of allowing us to copy and paste individual lines into the command line to easily troubleshoot finicky steps.

Prior to this change, to rebuild the local development we would have to run the following sequence of commands:
```
caseflow $ bundle exec rake local:destroy
caseflow $ RAILS_ENV=development bundle exec rake local:build
caseflow $ RAILS_ENV=test bundle exec rake local:vacols:setup
```

After this change, we will be able to rebuild with the following steps:
```
caseflow $ bundle exec rake local:destroy
caseflow $ bundle exec rake local:build
```