### PR TITLE
Pass BGS timeout through to API

### DIFF
--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -6,6 +6,8 @@ class Api::V2::AppealsController < Api::ApplicationController
     veteran_not_found
   rescue Caseflow::Error::InvalidSSN
     invalid_ssn
+  rescue Errno::ETIMEDOUT
+    upstream_timeout
   end
 
   private
@@ -63,5 +65,15 @@ class Api::V2::AppealsController < Api::ApplicationController
         "detail": "Please enter a valid 9 digit SSN in the 'ssn' header"
       ]
     }, status: 422
+  end
+
+  def upstream_timeout
+    render json: {
+      "errors": [
+        "status": "504",
+        "title": "Gateway Timeout",
+        "detail": "Upstream service timed out"
+      ]
+    }, status: 504
   end
 end

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -209,6 +209,18 @@ describe "Appeals API v2", type: :request do
       expect(ApiView.count).to eq(0)
     end
 
+    it "returns 504 when BGS times out" do
+      allow_any_instance_of(BGSService).to receive(:fetch_file_number_by_ssn).and_raise(Errno::ETIMEDOUT)
+
+      headers = {
+        "ssn": "111223333",
+        "Authorization": "Token token=#{api_key.key_string}"
+      }
+      get "/api/v2/appeals", headers: headers
+
+      expect(response.code).to eq("504")
+    end
+
     it "returns list of appeals for veteran with SSN" do
       headers = {
         "ssn": "111223333",


### PR DESCRIPTION
Connects #5771.

Respond to API requests when our BGS requests time out with a 504, and do not send those timeouts to Slack as Sentry errors.