### PR TITLE
Increase queue request timeout

### DIFF
--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -48,10 +48,11 @@ class QueueLoadingScreen extends React.PureComponent {
       return Promise.resolve();
     }
 
-    return ApiUtil.get(urlToLoad).then((response) => this.props.onReceiveQueue({
-      ...associateTasksWithAppeals(JSON.parse(response.text)),
-      userId
-    }));
+    return ApiUtil.get(urlToLoad, { timeout: { response: 5 * 60 * 1000 } }).then((response) =>
+      this.props.onReceiveQueue({
+        ...associateTasksWithAppeals(JSON.parse(response.text)),
+        userId
+      }));
   };
 
   loadActiveAppeal = () => {

--- a/client/app/util/ApiUtil.js
+++ b/client/app/util/ApiUtil.js
@@ -8,7 +8,7 @@ import { timeFunctionPromise } from '../util/PerfDebug';
 export const STANDARD_API_TIMEOUT_MILLISECONDS = 60 * 1000;
 export const RESPONSE_COMPLETE_LIMIT_MILLISECONDS = 5 * 60 * 1000;
 
-const timeoutSettings = {
+const defaultTimeoutSettings = {
   response: STANDARD_API_TIMEOUT_MILLISECONDS,
   deadline: RESPONSE_COMPLETE_LIMIT_MILLISECONDS
 };
@@ -50,6 +50,8 @@ const httpMethods = {
   },
 
   get(url, options = {}) {
+    const timeoutSettings = Object.assign({}, defaultTimeoutSettings, _.get(options, 'timeout', {}));
+
     let promise = request.
       get(url).
       set(getHeadersObject(options.headers)).


### PR DESCRIPTION
Increases timeout for requests to API endpoint which returns attorney queue from 60 seconds to 5 minutes to resolve this support issue: https://github.com/department-of-veterans-affairs/appeals-support/issues/2284. This appears to have been caused by requests taking 70 seconds to respond. Related [slack discussion](https://dsva.slack.com/archives/C6E41RE92/p1528222476000465).

Long term fix is to reduce the amount of time it takes us to serve this response.