### PR TITLE
Preloads remand reasons for all appeals.

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -181,8 +181,9 @@ class Issue
     }
   end
 
+  attr_writer :remand_reasons
   def remand_reasons
-    self.class.repository.load_remands_from_vacols(id, vacols_sequence_id)
+    @remand_reasons ||= self.class.repository.load_remands_from_vacols(id, vacols_sequence_id)
   end
 
   private

--- a/app/repositories/issue_repository.rb
+++ b/app/repositories/issue_repository.rb
@@ -63,12 +63,56 @@ class IssueRepository
     VACOLS::RemandReason.create_remand_reasons!(vacols_id, vacols_sequence_id, remand_reasons)
   end
 
-  def self.load_remands_from_vacols(vacols_id, vacols_sequence_id)
-    VACOLS::RemandReason.where(rmdkey: vacols_id, rmdissseq: vacols_sequence_id).map do |reason|
+  def self.remand_reason_from_vacols_remand_reason(reason)
       {
         code: reason.rmdval,
         after_certification: reason.rmddev.eql?("R2")
       }
+  end
+
+  def self.load_remands_from_vacols(vacols_id, vacols_sequence_id)
+    VACOLS::RemandReason.where(rmdkey: vacols_id, rmdissseq: vacols_sequence_id).map do |reason|
+      self.remand_reason_from_vacols_remand_reason(reason)
+    end
+  end
+
+
+# Returns remand reasons grouped by brieff.bfkey and the issue sequence id. For example:
+# {"465400"=>{},
+#  "1074694"=>
+#   {6=>
+#     [{:code=>"1E", :after_certification=>false},
+#      {:code=>"1B", :after_certification=>false}],
+#    8=>
+#     [{:code=>"1B", :after_certification=>false},
+#      {:code=>"1C", :after_certification=>false},
+#      {:code=>"1E", :after_certification=>false}],
+#   },
+#  "1014716"=>
+#   {1=>
+#     [{:code=>"1A", :after_certification=>true},
+#      {:code=>"3D", :after_certification=>true}]}
+#  }
+  def self.load_remands_for_multiple_appeals(vacols_ids)
+    # `rmdissseq` will be null for remand reasons on appeals before 1999.
+    # See https://github.com/department-of-veterans-affairs/dsva-vacols/issues/13
+    # If we ever want to display remand reasons for appeals before then,
+    # we'll need to refactor to pass remand reasons down at the appeal level on the frontend.
+    reason_groups = VACOLS::RemandReason.where(rmdkey: vacols_ids).where("rmdissseq IS NOT NULL").group_by(&:rmdkey)
+
+    vacols_ids.each_with_object({}) do |vacols_id, obj|
+      obj[vacols_id] ||= {}
+
+      next unless reason_groups[vacols_id]
+
+      reason_group = reason_groups[vacols_id].group_by(&:rmdissseq)
+      reason_group.each do |issue_sequence_id, reasons|
+        formatted_reasons = reasons.map do |reason|
+          self.remand_reason_from_vacols_remand_reason(reason)
+        end
+
+        obj[vacols_id][issue_sequence_id] = formatted_reasons
+      end
     end
   end
   # :nocov:


### PR DESCRIPTION
Connects #

### Description
Preloads remand reasons

### Testing plan
- In rails console, visit the queue of a user with some appeals in their queue
- See that one query is made for remand reasons, not a series of queries
