### PR TITLE
Set open timeout and read timout to longer time

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -116,6 +116,8 @@ class ExternalApi::EfolderService
 
     url = URI.escape(efolder_base_url + endpoint)
     request = HTTPI::Request.new(url)
+    request.open_timeout = 600 # seconds
+    request.read_timeout = 600 # seconds
     request.auth.ssl.ssl_version  = :TLSv1_2
     request.auth.ssl.ca_cert_file = ENV["SSL_CERT_FILE"]
 

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -111,6 +111,7 @@ class ExternalApi::EfolderService
     Rails.application.config.efolder_key.to_s
   end
 
+  # rubocop:disable Metrics/MethodLength
   def self.send_efolder_request(endpoint, user, headers = {}, method: :get)
     DBService.release_db_connections
 
@@ -136,4 +137,5 @@ class ExternalApi::EfolderService
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
Fixes https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1536/

We've been seeing a lot of HTTPClient::ReceiveTimeoutError alerts. 

:open_timeout is the timeout for opening the connection. This is useful if you are calling servers with slow or shaky response times.
:read_timeout is the timeout for reading the answer. 

I set the timeout options to the same value we set for connect_vbms and connect_vva

