### PR TITLE
Don't call relationships unless ama is enabled

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -196,7 +196,7 @@ class Intake < ApplicationRecord
       veteran_name: veteran && veteran.name.formatted(:readable_short),
       veteran_form_name: veteran && veteran.name.formatted(:form),
       completed_at: completed_at,
-      relationships: veteran && veteran.relationships
+      relationships: FeatureToggle.enabled?(:intakeAma, user: current_user) && veteran && veteran.relationships
     }
   end
 


### PR DESCRIPTION
We shouldn't be loading relationships for RAMP since that endpoint hasn't been thoroughly tested.

It's causing this issue:
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1559/

<img width="1021" alt="screen shot 2018-06-08 at 12 50 47 pm" src="https://user-images.githubusercontent.com/1596259/41170516-969f9b78-6b1a-11e8-8aff-46249d783163.png">
