### PR TITLE
Make CaseTitle self contained

### DIFF
--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -1,7 +1,11 @@
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
 import React from 'react';
 
+import AppealDocumentCount from './AppealDocumentCount';
+import { CATEGORIES } from './constants';
 import { COLORS } from '../constants/AppConstants';
+import ReaderLink from './ReaderLink';
 
 const headerStyling = css({
   float: 'left',
@@ -32,6 +36,29 @@ const horizontalRuleStyling = css({
 });
 
 export default class CaseTitle extends React.PureComponent {
+  render = () => {
+    const { appeal, vacolsId, redirectUrl } = this.props;
+
+    return <CaseTitleScaffolding heading={appeal.attributes.veteran_full_name}>
+      <React.Fragment>Veteran ID: <b>{appeal.attributes.vbms_id}</b></React.Fragment>
+      <ReaderLink
+        vacolsId={vacolsId}
+        analyticsSource={CATEGORIES.QUEUE_TASK}
+        redirectUrl={redirectUrl}
+        appeal={appeal}
+        taskType="Draft Decision"
+        message={<React.Fragment>View <AppealDocumentCount appeal={appeal} /> documents</React.Fragment>} />
+    </CaseTitleScaffolding>;
+  }
+}
+
+CaseTitle.propTypes = {
+  appeal: PropTypes.object.isRequired,
+  redirectUrl: PropTypes.string.isRequired,
+  vacolsId: PropTypes.string.isRequired
+};
+
+class CaseTitleScaffolding extends React.PureComponent {
   render = () => <React.Fragment>
     <h1 {...headerStyling}>{this.props.heading}</h1>
     <ul {...listStyling}>

--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -8,13 +8,11 @@ import _ from 'lodash';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
 import AppealDetail from './AppealDetail';
-import AppealDocumentCount from './AppealDocumentCount';
 import AppellantDetail from './AppellantDetail';
 import CaseTitle from './CaseTitle';
 import SelectCheckoutFlowDropdown from './components/SelectCheckoutFlowDropdown';
 import TabWindow from '../components/TabWindow';
 import { CATEGORIES, USER_ROLES } from './constants';
-import ReaderLink from './ReaderLink';
 import { DateString } from '../util/DateUtil';
 
 import { clearActiveAppealAndTask } from './CaseDetail/CaseDetailActions';
@@ -92,18 +90,7 @@ class QueueDetailView extends React.PureComponent {
   }
 
   render = () => <AppSegment filledBackground>
-    <CaseTitle heading={this.props.appeal.attributes.veteran_full_name}>
-      <React.Fragment>Veteran ID: <b>{this.props.appeal.attributes.vbms_id}</b></React.Fragment>
-      <ReaderLink
-        vacolsId={this.props.vacolsId}
-        analyticsSource={CATEGORIES.QUEUE_TASK}
-        redirectUrl={window.location.pathname}
-        appeal={this.props.appeal}
-        taskType="Draft Decision"
-        message={
-          <React.Fragment>View <AppealDocumentCount appeal={this.props.appeal} /> documents</React.Fragment>
-        } />
-    </CaseTitle>
+    <CaseTitle appeal={this.props.appeal} vacolsId={this.props.vacolsId} redirectUrl={window.location.pathname} />
     <p className="cf-lead-paragraph" {...subHeadStyling}>{this.subHead()}</p>
     {this.getCheckoutFlowDropdown()}
     <TabWindow


### PR DESCRIPTION
As we start using CaseTitle in more places in the code it becomes increasingly clear that we pass the same components into CaseTitle. This PR moves those elements inside the CaseTitle component (and create a new CaseTitleScaffolding component) so we only have to pass the bare minimum set of elements to the component for it to display correctly.