### PR TITLE
Queue | Respect sys admin privileges

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,6 +88,7 @@ class ApplicationController < ApplicationBaseController
   helper_method :certification_header
 
   def can_access_queue?
+    return true if current_user.admin?
     role = current_user.vacols_role
     return true if role == "Attorney"
     return true if role == "Judge" && feature_enabled?(:judge_queue)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,7 +88,7 @@ class ApplicationController < ApplicationBaseController
   helper_method :certification_header
 
   def can_access_queue?
-    return true if current_user.admin?
+    return true if current_user.admin? && Rails.env.production?
     role = current_user.vacols_role
     return true if role == "Attorney"
     return true if role == "Judge" && feature_enabled?(:judge_queue)

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -2,7 +2,7 @@
   <%= react_component("Queue", props: {
     userDisplayName: current_user.display_name,
     userId: current_user.id,
-    userRole: current_user.vacols_role,
+    userRole: current_user.admin? ? "Attorney" : current_user.vacols_role,
     userCssId: current_user.css_id,
     userCanAccessQueue: can_access_queue?,
     dropdownUrls: dropdown_urls,

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -2,7 +2,7 @@
   <%= react_component("Queue", props: {
     userDisplayName: current_user.display_name,
     userId: current_user.id,
-    userRole: current_user.admin? ? "Attorney" : current_user.vacols_role,
+    userRole: (current_user.admin? && Rails.env.production?) ? "Attorney" : current_user.vacols_role,
     userCssId: current_user.css_id,
     userCanAccessQueue: can_access_queue?,
     dropdownUrls: dropdown_urls,


### PR DESCRIPTION
### Description
Currently within Queue, we use the [`can_access_queue?`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/controllers/application_controller.rb#L90) helper method to grant access. However, this function only consider's a users VACOLS role, disregarding any permissions set with caseflow-commons' Functions.

In FACOLS environments, we give [all users System Admin privileges](https://github.com/department-of-veterans-affairs/caseflow/blob/master/lib/tasks/local/vacols.rake#L100), so we restrict this check to the production environment.

### Acceptance Criteria 
- [ ] System Admin user who is not an Attorney can access Queue as an Attorney

### Testing Plan
1. Go to Caseflow production as an admin user, confirm Attorney table view appears

TODO: Link the Acting Judge role toggle (#5385) with this functionality
