### PR TITLE
First step of case details redesign

### DIFF
--- a/client/app/constants/AppConstants.js
+++ b/client/app/constants/AppConstants.js
@@ -10,7 +10,8 @@ export const COLORS = {
   ...COMMON_COLORS,
   GOLD_LIGHTEST: '#FFF1D2',
   GOLD_LIGHT: '#F9C642',
-  GREY_BACKGROUND: '#f9f9f9'
+  GREY_BACKGROUND: '#f9f9f9',
+  PRIMARY: '#0071bc'
 };
 
 export const LOGO_COLORS = {

--- a/client/app/queue/AppellantDetail.jsx
+++ b/client/app/queue/AppellantDetail.jsx
@@ -4,7 +4,7 @@ import { css } from 'glamor';
 import _ from 'lodash';
 
 import BareList from '../components/BareList';
-import { boldText, TASK_ACTIONS } from './constants';
+import { boldText } from './constants';
 import COPY from '../../COPY.json';
 import { DateString } from '../util/DateUtil';
 
@@ -44,7 +44,7 @@ export default class AppellantDetail extends React.PureComponent {
 
   veteranIsAppellant = () => _.isNull(this.getAppealAttr('appellant_full_name'));
 
-  getDetails = ({ nameField, genderField, dobField, addressField, relationField }) => {
+  getDetails = ({ nameField, genderField, dobField, addressField, relationField, regionalOfficeField }) => {
     const details = [{
       label: 'Name',
       value: this.getAppealAttr(nameField)
@@ -74,6 +74,14 @@ export default class AppellantDetail extends React.PureComponent {
         value: this.formatAddress(addressField)
       });
     }
+    if (regionalOfficeField && this.getAppealAttr(regionalOfficeField)) {
+      const { city, key } = this.getAppealAttr(regionalOfficeField);
+
+      details.push({
+        label: 'Regional Office',
+        value: `${city} (${key.replace('RO', '')})`
+      });
+    }
 
     const getDetailField = ({ label, value }) => () => <React.Fragment>
       <span {...boldText}>{label}:</span> {value}
@@ -81,10 +89,6 @@ export default class AppellantDetail extends React.PureComponent {
 
     return <BareList ListElementComponent="ul" items={details.map(getDetailField)} />;
   };
-
-  componentDidMount = () => {
-    window.analyticsEvent(this.props.analyticsSource, TASK_ACTIONS.VIEW_APPELLANT_INFO);
-  }
 
   render = () => {
     let appellantDetails;
@@ -99,7 +103,8 @@ export default class AppellantDetail extends React.PureComponent {
             nameField: 'veteran_full_name',
             genderField: 'veteran_gender',
             dobField: 'veteran_date_of_birth',
-            addressField: 'appellant_address'
+            addressField: 'appellant_address',
+            regionalOfficeField: 'regional_office'
           })}
         </ul>
       </React.Fragment>;
@@ -122,7 +127,8 @@ export default class AppellantDetail extends React.PureComponent {
           {this.getDetails({
             nameField: 'veteran_full_name',
             genderField: 'veteran_gender',
-            dobField: 'veteran_date_of_birth'
+            dobField: 'veteran_date_of_birth',
+            regionalOfficeField: 'regional_office'
           })}
         </ul>
       </React.Fragment>;
@@ -136,6 +142,5 @@ export default class AppellantDetail extends React.PureComponent {
 }
 
 AppellantDetail.propTypes = {
-  analyticsSource: PropTypes.string.isRequired,
   appeal: PropTypes.object.isRequired
 };

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import _ from 'lodash';
 
-import IssueList from './components/IssueList';
 import BareList from '../components/BareList';
 import { boldText } from './constants';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
@@ -22,7 +21,7 @@ const noTopBottomMargin = css({
   marginBottom: '1rem'
 });
 
-export default class AppealDetail extends React.PureComponent {
+export default class CaseHearingsDetail extends React.PureComponent {
   getAppealAttr = (attr) => _.get(this.props.appeal.attributes, attr);
 
   getHearingAttrs = (hearing) => {
@@ -89,28 +88,11 @@ export default class AppealDetail extends React.PureComponent {
     {label && <span {...boldText}>{label}:</span>} {value || valueFunction()}
   </React.Fragment>;
 
-  getListElements = () => {
+  render = () => {
     const listElements = [{
-      label: 'Power of Attorney',
-      value: this.getAppealAttr('power_of_attorney')
-    }, {
-      label: 'Regional Office',
-      valueFunction: () => {
-        const {
-          city,
-          key
-        } = this.getAppealAttr('regional_office');
-
-        return `${city} (${key.replace('RO', '')})`;
-      }
+      label: this.getAppealAttr('hearings').length > 1 ? 'Hearings (Oldest to Newest)' : '',
+      valueFunction: this.getHearingInfo
     }];
-
-    if (this.getAppealAttr('hearings').length) {
-      listElements.splice(2, 0, {
-        label: this.getAppealAttr('hearings').length > 1 ? 'Hearings (Oldest to Newest)' : '',
-        valueFunction: this.getHearingInfo
-      });
-    }
 
     return <BareList
       ListElementComponent="ul"
@@ -120,13 +102,14 @@ export default class AppealDetail extends React.PureComponent {
           paddingBottom: '1.5rem',
           paddingTop: '1rem',
           borderBottom: '1px solid grey'
+        },
+        '> li:last-child': {
+          borderBottom: 0
         }
       })} />;
   };
-
-  render = () => <IssueList appeal={_.pick(this.props.appeal.attributes, 'issues')} />;
 }
 
-AppealDetail.propTypes = {
+CaseHearingsDetail.propTypes = {
   appeal: PropTypes.object.isRequired
 };

--- a/client/app/queue/QueueDetailView.jsx
+++ b/client/app/queue/QueueDetailView.jsx
@@ -1,3 +1,4 @@
+import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -8,13 +9,26 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 
 import AppealDetail from './AppealDetail';
 import AppellantDetail from './AppellantDetail';
+import CaseHearingsDetail from './CaseHearingsDetail';
 import CaseTitle from './CaseTitle';
 import CaseSnapshot from './CaseSnapshot';
-import TabWindow from '../components/TabWindow';
-import { CATEGORIES } from './constants';
+import StickyNavContentArea from './StickyNavContentArea';
+import { CATEGORIES, TASK_ACTIONS } from './constants';
+import { COLORS } from '../constants/AppConstants';
 
 import { clearActiveAppealAndTask } from './CaseDetail/CaseDetailActions';
 import { pushBreadcrumb, resetBreadcrumbs } from './uiReducer/uiActions';
+
+// TODO: Pull this horizontal rule styling out somewhere.
+const horizontalRuleStyling = css({
+  border: 0,
+  borderTop: `1px solid ${COLORS.GREY_LIGHT}`,
+  marginTop: '3rem',
+  marginBottom: '3rem'
+});
+
+// TODO: Move this out to its own component when it gets complex.
+const PowerOfAttorneyDetail = ({ appeal }) => <p>{appeal.attributes.power_of_attorney}</p>;
 
 class QueueDetailView extends React.PureComponent {
   componentWillUnmount = () => {
@@ -22,21 +36,11 @@ class QueueDetailView extends React.PureComponent {
   }
 
   componentDidMount = () => {
+    window.analyticsEvent(CATEGORIES.QUEUE_TASK, TASK_ACTIONS.VIEW_APPEAL_INFO);
+
     if (!this.props.breadcrumbs.length) {
       this.props.resetBreadcrumbs(this.props.appeal.attributes.veteran_full_name, this.props.vacolsId);
     }
-  }
-
-  tabs = () => {
-    const appeal = this.props.appeal;
-
-    return [{
-      label: 'Appeal',
-      page: <AppealDetail appeal={appeal} analyticsSource={CATEGORIES.QUEUE_TASK} />
-    }, {
-      label: `Appellant (${appeal.attributes.appellant_full_name || appeal.attributes.veteran_full_name})`,
-      page: <AppellantDetail appeal={appeal} analyticsSource={CATEGORIES.QUEUE_TASK} />
-    }];
   }
 
   render = () => <AppSegment filledBackground>
@@ -48,9 +52,14 @@ class QueueDetailView extends React.PureComponent {
       task={this.props.task}
       userRole={this.props.userRole}
     />
-    <TabWindow
-      name="queue-tabwindow"
-      tabs={this.tabs()} />
+    <hr {...horizontalRuleStyling} />
+    <StickyNavContentArea>
+      <AppealDetail title="Issues" appeal={this.props.appeal} />
+      <PowerOfAttorneyDetail title="Power of Attorney" appeal={this.props.appeal} />
+      { this.props.appeal.attributes.hearings.length &&
+        <CaseHearingsDetail title="Hearings" appeal={this.props.appeal} /> }
+      <AppellantDetail title="About the Veteran" appeal={this.props.appeal} />
+    </StickyNavContentArea>
   </AppSegment>;
 }
 

--- a/client/app/queue/StickyNavContentArea.jsx
+++ b/client/app/queue/StickyNavContentArea.jsx
@@ -1,0 +1,83 @@
+import { css } from 'glamor';
+import React from 'react';
+
+import StringUtil from '../util/StringUtil';
+import { COLORS } from '../constants/AppConstants';
+
+const sectionNavigationContainerStyling = css({
+  float: 'left',
+  paddingRight: '3rem',
+  position: 'sticky',
+  top: '3rem',
+  width: '20%'
+});
+
+const sectionNavigationListStyling = css({
+  '& > li': {
+    backgroundColor: COLORS.GREY_BACKGROUND,
+    color: COLORS.PRIMARY,
+    borderWidth: 0
+  },
+  '& > li:hover': {
+    backgroundColor: COLORS.GREY_DARK,
+    color: COLORS.WHITE
+  },
+  '& > li > a': { color: COLORS.PRIMARY },
+  '& > li:hover > a': {
+    background: 'none',
+    color: COLORS.WHITE
+  },
+  '& > li > a:after': {
+    content: '〉',
+    float: 'right'
+  }
+});
+
+const sectionBodyStyling = css({
+  float: 'left',
+  width: '80%'
+});
+
+const getIdForElement = (elem) => `${StringUtil.parameterize(elem.props.title)}-section`;
+
+export default class StickyNavContentArea extends React.PureComponent {
+  render = () => {
+    // Ignore undefined child elements.
+    const childElements = this.props.children.filter((child) => typeof child === 'object');
+
+    return <React.Fragment>
+      <aside {...sectionNavigationContainerStyling}>
+        <ul className="usa-sidenav-list" {...sectionNavigationListStyling}>
+          {childElements.map((child, i) =>
+            <li key={i}><a href={`#${getIdForElement(child)}`}>{child.props.title}</a></li>)}
+        </ul>
+      </aside>
+
+      <div {...sectionBodyStyling}>
+        {childElements.map((child, i) => <ContentSection key={i} element={child} />)}
+      </div>
+    </React.Fragment>;
+  };
+}
+
+const sectionSegmentStyling = css({
+  border: `1px solid ${COLORS.GREY_LIGHT}`,
+  borderTop: '0px',
+  marginBottom: '3rem',
+  padding: '1rem 2rem'
+});
+
+const sectionHeadingStyling = css({
+  backgroundColor: COLORS.GREY_BACKGROUND,
+  border: `1px solid ${COLORS.GREY_LIGHT}`,
+  borderBottom: 0,
+  borderRadius: '0.5rem 0.5rem 0 0',
+  margin: 0,
+  padding: '1rem 2rem'
+});
+
+const ContentSection = ({element}) => <React.Fragment>
+    <h2 id={`${getIdForElement(element)}`} {...sectionHeadingStyling}>{element.props.title}</h2>
+    <div {...sectionSegmentStyling}>{element}</div>
+  </React.Fragment>;
+


### PR DESCRIPTION
Connects #5735.

There will be a later PR to clean up the loose ends and make the live app agree with [the mocks](https://app.mural.co/t/workqueue2001/m/workqueue2001/1525112874684/5765d285f568b5f631990e2c8e514a39d9b6b570), but I wanted to get these changes out to door in order to validate this approach for constructing the case details page.

| Before | After | 
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/32683958/41302177-d5a0f55e-6e37-11e8-8c06-84183aa1a362.png) | ![image](https://user-images.githubusercontent.com/32683958/41302139-bb1b5972-6e37-11e8-9540-fac69df65b40.png) |

cc @mkhandekar 
