### PR TITLE
Moving power of attorney to abide by the test_facols feature toggle.

### DIFF
--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -88,6 +88,7 @@ class PowerOfAttorney
     attr_writer :repository
 
     def repository
+      return PowerOfAttorneyRepository if FeatureToggle.enabled?(:test_facols)
       @repository ||= PowerOfAttorneyRepository
     end
   end

--- a/spec/feature/certification/save_certification_spec.rb
+++ b/spec/feature/certification/save_certification_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature "Save Certification" do
     Form8.pdf_service = FakePdfService
     Timecop.freeze(Time.utc(2017, 2, 2, 20, 59, 0))
     FeatureToggle.enable!(:test_facols)
-    PowerOfAttorney.repository = PowerOfAttorneyRepository
   end
 
   after do

--- a/spec/models/judge_case_review_spec.rb
+++ b/spec/models/judge_case_review_spec.rb
@@ -38,8 +38,8 @@ describe JudgeCaseReview do
         end
         let(:issues) do
           [
-            { disposition: "5", vacols_sequence_id: 1, readjudication: true },
-            { disposition: "3", vacols_sequence_id: 2,
+            { disposition: "5", vacols_sequence_id: vacols_issue1.issseq, readjudication: true },
+            { disposition: "3", vacols_sequence_id: vacols_issue2.issseq,
               remand_reasons: [{ code: "AB", after_certification: true }] }
           ]
         end

--- a/spec/models/judge_case_review_spec.rb
+++ b/spec/models/judge_case_review_spec.rb
@@ -82,9 +82,9 @@ describe JudgeCaseReview do
           expect(vacols_issues.third.issseq).to eq(vacols_issue2.issseq + 1)
           expect(vacols_issues.third.issaduser).to eq "CFS456"
 
-          remand_reasons = VACOLS::RemandReason.where(rmdkey: "123456", rmdissseq: "2")
+          remand_reasons = VACOLS::RemandReason.where(rmdkey: "123456", rmdissseq: vacols_issue2.issseq)
           expect(remand_reasons.size).to eq 1
-          expect(remand_reasons.first.rmdissseq).to eq 2
+          expect(remand_reasons.first.rmdissseq).to eq vacols_issue2.issseq
           expect(remand_reasons.first.rmdmdusr).to eq "CFS456"
         end
       end

--- a/spec/models/judge_case_review_spec.rb
+++ b/spec/models/judge_case_review_spec.rb
@@ -71,15 +71,15 @@ describe JudgeCaseReview do
           expect(vacols_issues.size).to eq 3
 
           expect(vacols_issues.first.issdc).to eq "5"
-          expect(vacols_issues.first.issseq).to eq 1
+          expect(vacols_issues.first.issseq).to eq vacols_issue1.issseq
           expect(vacols_issues.first.issmduser).to eq "CFS456"
 
           expect(vacols_issues.second.issdc).to eq "3"
-          expect(vacols_issues.second.issseq).to eq 2
+          expect(vacols_issues.second.issseq).to eq vacols_issue2.issseq
           expect(vacols_issues.second.issmduser).to eq "CFS456"
 
           expect(vacols_issues.third.issdc).to eq nil
-          expect(vacols_issues.third.issseq).to eq 3
+          expect(vacols_issues.third.issseq).to eq (vacols_issue2.issseq + 1)
           expect(vacols_issues.third.issaduser).to eq "CFS456"
 
           remand_reasons = VACOLS::RemandReason.where(rmdkey: "123456", rmdissseq: "2")

--- a/spec/models/judge_case_review_spec.rb
+++ b/spec/models/judge_case_review_spec.rb
@@ -79,7 +79,7 @@ describe JudgeCaseReview do
           expect(vacols_issues.second.issmduser).to eq "CFS456"
 
           expect(vacols_issues.third.issdc).to eq nil
-          expect(vacols_issues.third.issseq).to eq (vacols_issue2.issseq + 1)
+          expect(vacols_issues.third.issseq).to eq(vacols_issue2.issseq + 1)
           expect(vacols_issues.third.issaduser).to eq "CFS456"
 
           remand_reasons = VACOLS::RemandReason.where(rmdkey: "123456", rmdissseq: "2")


### PR DESCRIPTION
### Description
Our test suite is currently broken because:

1) We set `PowerOfAttorney.repository = PowerOfAttorneyRepository` in a before block, but don't unset it in an after block.
2) Our tests run in a non-deterministic order so the suite will only sometimes fail if tests after this one required `PowerOfAttorney.repository` to be the fake version of `PowerOfAttorneyRepository`. This is how the change got to master.

### Testing Plan
1. Ensure test suite passes.

