### PR TITLE
Queue | Set issue description max length

### DIFF
--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -33,7 +33,8 @@ import Alert from '../components/Alert';
 
 import {
   fullWidth,
-  ERROR_FIELD_REQUIRED
+  ERROR_FIELD_REQUIRED,
+  ISSUE_DESCRIPTION_MAX_LENGTH
 } from './constants';
 import ISSUE_INFO from '../../constants/ISSUE_INFO.json';
 import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json';
@@ -320,6 +321,7 @@ class AddEditIssueView extends React.Component {
       <TextField
         name="Notes:"
         value={_.get(this.props.issue, 'note', '')}
+        maxLength={ISSUE_DESCRIPTION_MAX_LENGTH}
         onChange={(value) => this.updateIssue({ note: value })} />
     </React.Fragment>;
   };

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -114,6 +114,9 @@ export const ISSUE_DISPOSITIONS = _.fromPairs(_.zip(
   Object.keys(VACOLS_DISPOSITIONS_BY_ID)
 ));
 
+// max length of VACOLS issue description field `ISSDESC`
+export const ISSUE_DESCRIPTION_MAX_LENGTH = 100;
+
 export const USER_ROLES = {
   ATTORNEY: 'Attorney',
   JUDGE: 'Judge'


### PR DESCRIPTION
### Description
Set max character limit on issue description `VACOLS.ISSUE.ISSDESC`
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1600/

### Acceptance Criteria 
- [ ] Issue description max field length is 100

### Testing Plan
1. Go to Draft Decision checkout flow, Add/Edit issue
2. Confirm Description field supports max of 100 characters

![issue_description_max_length](https://user-images.githubusercontent.com/8533004/41432064-e2387114-6fe2-11e8-99a9-65f72ed0cf8c.gif)
