### PR TITLE
disable prepped checkbox until docket loads

### DIFF
--- a/client/app/hearings/components/WorksheetHeaderVeteranSelection.jsx
+++ b/client/app/hearings/components/WorksheetHeaderVeteranSelection.jsx
@@ -86,13 +86,15 @@ class WorksheetHeaderVeteranSelection extends React.PureComponent {
 
     currentDocket = orderTheDocket(currentDocket);
 
+    const docketNotLoaded = _.isEmpty(currentDocket);
+
     return <span className="worksheet-header" {...headerSelectionStyling}>
       <div className="cf-push-left" {...containerStyling}>
         <div {...selectVeteranStyling}>
           <SearchableDropdown
             label="Select Veteran"
             name="worksheet-veteran-selection"
-            placeholder={_.isEmpty(currentDocket) ? <SmallLoader spinnerColor={LOGO_COLORS.HEARINGS.ACCENT}
+            placeholder={docketNotLoaded ? <SmallLoader spinnerColor={LOGO_COLORS.HEARINGS.ACCENT}
               message="Loading..." /> : ''}
             options={this.getDocketVeteranOptions(currentDocket, worksheetIssues)}
             onChange={this.onDropdownChange}
@@ -107,6 +109,7 @@ class WorksheetHeaderVeteranSelection extends React.PureComponent {
           name={`prep-${currentHearing.id}`}
           label="Hearing Prepped"
           styling={hearingPreppedStyling}
+          disabled={docketNotLoaded}
         />
       </div>
       <div className="cf-push-right">


### PR DESCRIPTION
Connects #5883 

### Description
Disabled prepped checkbox until the docket loads in the Hearing worksheet Header

### Acceptance Criteria 
- [ ] Make sure the checkbox is disabled until the docket loads in the Hearing worksheet Header

