### PR TITLE
Improve display of case snapshot at slimmer widths

### DIFF
--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -49,7 +49,7 @@ const snapshotChildResponsiveWrapFixStyling = css({
       margin: '2rem 3rem 0 3rem',
       marginRight: '3rem !important',
       paddingTop: '2rem',
-      width: '100% !important'
+      width: '100%'
     },
     '& > div:nth-child(2)': { borderRight: 'none' }
   }

--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -13,6 +13,7 @@ import { DateString } from '../util/DateUtil';
 const snapshotParentContainerStyling = css({
   backgroundColor: COLORS.GREY_BACKGROUND,
   display: 'flex',
+  flexWrap: 'wrap',
   lineHeight: '3rem',
   marginTop: '3rem',
   padding: '2rem 0',
@@ -39,6 +40,19 @@ const definitionListStyling = css({
 
 const headingStyling = css({
   marginBottom: '0.5rem'
+});
+
+const snapshotChildResponsiveWrapFixStyling = css({
+  '@media(max-width: 1200px)': {
+    '& > .usa-width-one-half': {
+      borderTop: `1px solid ${COLORS.GREY_LIGHT}`,
+      margin: '2rem 3rem 0 3rem',
+      marginRight: '3rem !important',
+      paddingTop: '2rem',
+      width: '100% !important'
+    },
+    '& > div:nth-child(2)': { borderRight: 'none' }
+  }
 });
 
 export default class CaseSnapshot extends React.PureComponent {
@@ -94,7 +108,7 @@ export default class CaseSnapshot extends React.PureComponent {
   };
 
   render = () => {
-    return <div className="usa-grid" {...snapshotParentContainerStyling}>
+    return <div className="usa-grid" {...snapshotParentContainerStyling} {...snapshotChildResponsiveWrapFixStyling}>
       <div className="usa-width-one-fourth">
         <h3 {...headingStyling}>{COPY.CASE_SNAPSHOT_ABOUT_BOX_TITLE}</h3>
         <dl {...definitionListStyling}>


### PR DESCRIPTION
This change improves the display of the case snapshot element at widths narrower than 1201 pixels, since more than 30% of folks who use caseflow have a screen width of 900 or fewer pixels. [Initial Slack discussion here](https://dsva.slack.com/archives/C6E41RE92/p1529009595000136).

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/32683958/41542047-02ac52d8-72e2-11e8-888f-4ae471853491.png) | ![image](https://user-images.githubusercontent.com/32683958/41542056-07c32986-72e2-11e8-842a-a7ff33d0fce6.png) |

