### PR TITLE
update Redis version used by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:version_2
 
       # This is the circleci provided Redis container.
-      - image: circleci/redis:4.0.8
+      - image: circleci/redis:4.0.10
     parallelism: 5
     steps:
       - checkout
@@ -40,9 +40,9 @@ jobs:
       - restore_cache:
           keys:
             - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            
+
       - run: bundle install --path vendor/bundle
-      
+
       - save_cache:
           key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:


### PR DESCRIPTION
### Description
Addresses [multiple](https://circleci.com/gh/department-of-veterans-affairs/caseflow/5808) [CircleCI](https://circleci.com/gh/department-of-veterans-affairs/caseflow/5813) [build](https://circleci.com/gh/department-of-veterans-affairs/caseflow/5802) [failures](https://circleci.com/gh/department-of-veterans-affairs/caseflow/5809) due to not being able to find the correct version of Redis:

```
Starting container circleci/redis:4.0.8
  image cache not found on this host, downloading circleci/redis:4.0.8
Error response from daemon: manifest for circleci/redis:4.0.8 not found
```

### Acceptance Criteria 
- [ ] Tests pass in CircleCI

