### PR TITLE
Improve appearance of case title at narrow widths

### DIFF
--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -27,7 +27,7 @@ const headerStyling = css({
 const listStyling = css({
   listStyleType: 'none',
   verticalAlign: 'super',
-  padding: '0'
+  padding: '1rem 0 0 0'
 });
 
 const listItemStyling = css({

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -7,32 +7,34 @@ import { CATEGORIES } from './constants';
 import { COLORS } from '../constants/AppConstants';
 import ReaderLink from './ReaderLink';
 
+const containingDivStyling = css({
+  borderBottom: `1px solid ${COLORS.GREY_LIGHT}`,
+  display: 'block',
+  // Offsets the padding from .cf-app-segment--alt to make the bottom border full width.
+  margin: '-2rem -4rem 0 -4rem',
+  padding: '0 0 1.5rem 4rem',
+
+  '& > *': {
+    display: 'inline-block',
+    margin: '0'
+  }
+});
+
 const headerStyling = css({
-  float: 'left',
-  listStyleType: 'none',
-  margin: 0,
-  marginTop: '-2rem'
+  paddingRight: '2.5rem'
 });
 
 const listStyling = css({
-  float: 'left',
   listStyleType: 'none',
-  margin: '-1.5rem 0 0 1rem',
-  padding: 0
+  verticalAlign: 'super',
+  padding: '0'
 });
 
 const listItemStyling = css({
-  float: 'left',
-  padding: '0.5rem 1.5rem',
-  ':not(:last-child)': { borderRight: `1px solid ${COLORS.GREY_LIGHT}` }
-});
-
-const horizontalRuleStyling = css({
-  border: 0,
-  borderTop: `1px solid ${COLORS.GREY_LIGHT}`,
-  clear: 'both',
-  // Offsets the padding from .cf-app-segment--alt to make the hr full width.
-  margin: '4rem -4rem 0 -4rem'
+  display: 'inline',
+  padding: '0.5rem 1.5rem 0.5rem 0',
+  ':not(:last-child)': { borderRight: `1px solid ${COLORS.GREY_LIGHT}` },
+  ':not(:first-child)': { paddingLeft: '1.5rem' }
 });
 
 export default class CaseTitle extends React.PureComponent {
@@ -59,11 +61,10 @@ CaseTitle.propTypes = {
 };
 
 class CaseTitleScaffolding extends React.PureComponent {
-  render = () => <React.Fragment>
+  render = () => <div {...containingDivStyling}>
     <h1 {...headerStyling}>{this.props.heading}</h1>
     <ul {...listStyling}>
       {this.props.children.map((child, i) => <li key={i} {...listItemStyling}>{child}</li>)}
     </ul>
-    <hr {...horizontalRuleStyling} />
-  </React.Fragment>;
+  </div>;
 }


### PR DESCRIPTION
Related to goal of making case details page look nice at narrow screen widths, first discussed in #5939.

## 760px wide
| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/32683958/41550500-f454593c-72f6-11e8-9fb2-951a7bd37475.png) | ![image](https://user-images.githubusercontent.com/32683958/41550343-75f42a36-72f6-11e8-9820-0e16cea9a817.png) |

## 1000px wide
| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/32683958/41550472-dca05278-72f6-11e8-838e-394090442955.png) | ![image](https://user-images.githubusercontent.com/32683958/41550442-c759dd58-72f6-11e8-805b-b76180ad2f95.png) |
