### PR TITLE
Queue | Remove unneeded css check in test

### DIFF
--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -664,7 +664,6 @@ RSpec.feature "Queue" do
           row = field_options[row_idx]
 
           next unless row
-          next if row.matches_css? ".is-disabled"
 
           row.find(".Select-control").click
 


### PR DESCRIPTION
### Description
Removes a CSS check in Queue test `"shows/hides diagnostic code option"`, speeding up the test

### Acceptance Criteria 
- [ ] Tests pass

Before:
```
real	1m58.422s
user	0m23.628s
sys	0m7.535s
```

After:
```
real	0m36.315s
user	0m14.672s
sys	0m4.892s
```