### PR TITLE
CircleCI: Configures Rspec to fail fast

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
             mkdir -p ~/test-results/rspec
             testfiles=$(circleci tests glob "spec/**/*spec.rb" | circleci tests split --split-by timings)
             echo $testfiles > ~/project/tmp/testfiles/rspec_testfiles.txt
-            ~/project/ci-bin/capture-log "bundle exec rspec --no-color --format progress --format RspecJunitFormatter -o ~/test-results/rspec/rspec.xml -- ${testfiles}"
+            ~/project/ci-bin/capture-log "bundle exec rspec --no-color --format progress --format RspecJunitFormatter --fail-fast -o ~/test-results/rspec/rspec.xml -- ${testfiles}"
 
       - store_test_results:
           name: Store test results as summary


### PR DESCRIPTION
### Description
Configures Rspec to fail as soon as the first test fails. This should speed up failed builds. On the other hand, it will make it much harder to use CircleCI as a development tool.