### PR TITLE
Converting offending test to FACOLS

### DIFF
--- a/spec/models/queues/work_queue_spec.rb
+++ b/spec/models/queues/work_queue_spec.rb
@@ -1,27 +1,19 @@
 describe WorkQueue do
-  before { WorkQueue.repository = Fakes::QueueRepository }
+  before do
+    FeatureToggle.enable!(:test_facols)
+  end
+
+  after do
+    FeatureToggle.disable!(:test_facols)
+  end
 
   context ".tasks_with_appeals" do
     let(:user) { User.find_or_create_by(css_id: "DNYGLVR", station_id: "LANCASTER") }
 
-    before do
-      Fakes::QueueRepository.appeal_records = [
-        Generators::LegacyAppeal.build(
-          vacols_id: "2222",
-          assigned_to_attorney_date: "2013-05-17 00:00:00 UTC".to_datetime,
-          assigned_to_location_date: "2013-05-15 00:00:00 UTC".to_datetime,
-          created_at: "2013-05-15 00:00:00 UTC".to_datetime,
-          date_due: "2018-02-13 00:00:00 UTC".to_datetime,
-          docket_date: "2014-03-25 00:00:00 UTC".to_datetime
-        ),
-        Generators::LegacyAppeal.build(
-          vacols_id: "3333",
-          assigned_to_attorney_date: "2013-05-17 00:00:00 UTC".to_datetime,
-          assigned_to_location_date: "2013-05-15 00:00:00 UTC".to_datetime,
-          created_at: "2013-05-15 00:00:00 UTC".to_datetime,
-          date_due: "2018-02-13 00:00:00 UTC".to_datetime,
-          docket_date: "2014-03-25 00:00:00 UTC".to_datetime
-        )
+    let!(:appeals) do
+      [
+        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user)),
+        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user))
       ]
     end
 


### PR DESCRIPTION
Connects #5688

### Description
Currently running the `work_queue_spec` and then the `queue_spec` will cause tests in queue_spec to fail. The reason is how we setup fake data. In `Fakes::QueueRepository` (https://github.com/department-of-veterans-affairs/caseflow-certification/blob/master/lib/fakes/queue_repository.rb#L6) we have a line: `appeal_records || Fakes::Data::AppealData.default_queue_records.map do |record|`. Some of our tests in queue_repository rely on data in `Fakes::Data::AppealData.default_queue_records`. Our tests in `work_queue_spec` set `appeal_records`. When queue_spec runs first, all is good. When work_queue_spec runs first, it messes up the data setup for `queue_spec`.

We could fix this problem, but since we're moving to FACOLS anyway which will resolve this, we opt to just convert this test to FACOLS.

### Acceptance Criteria 
- [ ] Tests pass when running work_queue_spec.rb and then queue_spec.rb


