### PR TITLE
AppealView read without appeal type, write with appeal type

### DIFF
--- a/app/controllers/reader/documents_controller.rb
+++ b/app/controllers/reader/documents_controller.rb
@@ -4,10 +4,14 @@ class Reader::DocumentsController < Reader::ApplicationController
     respond_to do |format|
       format.html { return render "reader/appeal/index" }
       format.json do
-        AppealView.find_or_create_by(
+        appeal_view = AppealView.find_by(
+          appeal_id: appeal.id,
+          user_id: current_user.id
+        ) || AppealView.create(
           appeal: appeal,
           user_id: current_user.id
-        ).tap do |t|
+        )
+        appeal_view.tap do |t|
           t.update!(last_viewed_at: Time.zone.now)
         end
         MetricsService.record "Get appeal #{appeal_id} document data" do


### PR DESCRIPTION
Connects #5753

### Description
We caused a brief production outage this morning when we deployed a change that tried to find_or_create appeals by appeal id and appeal type instead of just appeal id. However, since we haven't yet backfilled all of our old AppealView's to have a type, when an existing AppealView was searched for, it wouldn't be found because the appeal_type in the DB was nil, but the search was expecting it to be "LegacyAppeal".

This change makes it so we can read just appeal id and write both appeal id and appeal type.

### Testing Plan
1. Ensure locally that it can read AppealViews without appeal_type, but specifies appeal_type when writing AppealViews.

