### PR TITLE
Fix enable_features_dev

### DIFF
--- a/scripts/enable_features_dev.rb
+++ b/scripts/enable_features_dev.rb
@@ -70,6 +70,7 @@ json_config = <<EOS.strip_heredoc
           feature: "queue_beaam_appeals",
           enable_all: true
         },
+        {
           feature: "judge_assign_cases",
           enable_all: true
         }


### PR DESCRIPTION
### Description
In d353617af8095491d15f241c653a10ef6d01586e, a change was made to `enable_features_dev.rb` to add an entry for the `:queue_beaam_appeals` FeatureToggle. A `{` was removed, causing the following error when loading the file:
```
/Users/danny/.rbenv/versions/2.2.4/lib/ruby/2.2.0/psych.rb:370:in `parse': (<unknown>): did not find expected ',' or ']' while parsing a flow sequence at line 1 column 1 (Psych::SyntaxError)
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/2.2.0/psych.rb:370:in `parse_stream'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/2.2.0/psych.rb:318:in `parse'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/2.2.0/psych.rb:284:in `safe_load'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bundler/gems/caseflow-commons-be1ad2d0cc70/app/services/feature_toggle.rb:198:in `validate_config'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/bundler/gems/caseflow-commons-be1ad2d0cc70/app/services/feature_toggle.rb:109:in `sync!'
	from scripts/enable_features_dev.rb:79:in `<top (required)>'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-5.1.6/lib/rails/commands/runner/runner_command.rb:34:in `load'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-5.1.6/lib/rails/commands/runner/runner_command.rb:34:in `perform'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-5.1.6/lib/rails/command/base.rb:63:in `perform'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-5.1.6/lib/rails/command.rb:44:in `invoke'
	from /Users/danny/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/railties-5.1.6/lib/rails/commands.rb:16:in `<top (required)>'
	from bin/rails:4:in `require'
	from bin/rails:4:in `<main>'
```

### Acceptance Criteria 
- [ ] `rails runner scripts/enable_features_dev.rb` works successfully

