### PR TITLE
Move common styling for dl into own component

### DIFF
--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -1,10 +1,11 @@
-import { after, css, merge } from 'glamor';
+import { css } from 'glamor';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 
+import CaseDetailsDescriptionList from './components/CaseDetailsDescriptionList';
 import SelectCheckoutFlowDropdown from './components/SelectCheckoutFlowDropdown';
 import JudgeStartCheckoutFlowDropdown from './components/JudgeStartCheckoutFlowDropdown';
 import COPY from '../../COPY.json';
@@ -25,20 +26,6 @@ const snapshotParentContainerStyling = css({
   '& > div:first-child': { paddingLeft: '3rem' },
 
   '& .Select': { maxWidth: '100%' }
-});
-
-const definitionListStyling = css({
-  margin: '0',
-  '& dt': merge(
-    after({ content: ':' }),
-    {
-      color: COLORS.GREY_MEDIUM,
-      float: 'left',
-      fontSize: '1.5rem',
-      marginRight: '0.5rem',
-      textTransform: 'uppercase'
-    }
-  )
 });
 
 const headingStyling = css({
@@ -125,19 +112,19 @@ export class CaseSnapshot extends React.PureComponent {
     return <div className="usa-grid" {...snapshotParentContainerStyling} {...snapshotChildResponsiveWrapFixStyling}>
       <div className="usa-width-one-fourth">
         <h3 {...headingStyling}>{COPY.CASE_SNAPSHOT_ABOUT_BOX_TITLE}</h3>
-        <dl {...definitionListStyling}>
+        <CaseDetailsDescriptionList>
           <dt>{COPY.CASE_SNAPSHOT_ABOUT_BOX_TYPE_LABEL}</dt>
           <dd>{renderAppealType(this.props.appeal)}</dd>
           <dt>{COPY.CASE_SNAPSHOT_ABOUT_BOX_DOCKET_NUMBER_LABEL}</dt>
           <dd>{appeal.docket_number}</dd>
           {this.daysSinceTaskAssignmentListItem()}
-        </dl>
+        </CaseDetailsDescriptionList>
       </div>
       <div className="usa-width-one-fourth">
         <h3 {...headingStyling}>{COPY.CASE_SNAPSHOT_TASK_ASSIGNMENT_BOX_TITLE}</h3>
-        <dl {...definitionListStyling}>
+        <CaseDetailsDescriptionList>
           {this.taskAssignmentListItems()}
-        </dl>
+        </CaseDetailsDescriptionList>
       </div>
       { this.props.featureToggles.phase_two &&
         this.props.loadedQueueAppealIds.includes(appeal.vacols_id) &&

--- a/client/app/queue/components/CaseDetailsDescriptionList.jsx
+++ b/client/app/queue/components/CaseDetailsDescriptionList.jsx
@@ -1,0 +1,22 @@
+import { after, css, merge } from 'glamor';
+import React from 'react';
+
+import { COLORS } from '../../constants/AppConstants';
+
+const definitionListStyling = css({
+  margin: '0',
+  '& dt': merge(
+    after({ content: ':' }),
+    {
+      color: COLORS.GREY_MEDIUM,
+      float: 'left',
+      fontSize: '1.5rem',
+      marginRight: '0.5rem',
+      textTransform: 'uppercase'
+    }
+  )
+});
+
+export default class CaseDetailsDescriptionList extends React.PureComponent {
+  render = () => <dl {...definitionListStyling}>{this.props.children}</dl>
+}


### PR DESCRIPTION
Connects #5735.

The rest of the #5735 ticket will redesign the way the issues section of the case details page appears. We will use the same list styling we already use for the two `dl`s in CaseSnapshot so this PR simply moves the styling on the `dl` element out to it's own component for easy reuse.

### Testing Plan
* Go to case details page
* Everything in the case snapshot section should look the same

