### PR TITLE
Queue | Replace/update attorney checkout flow tests

### DIFF
--- a/spec/feature/queue/queue_spec.rb
+++ b/spec/feature/queue/queue_spec.rb
@@ -510,6 +510,319 @@ RSpec.feature "Queue" do
     end
   end
 
+  context "loads attorney checkout views" do
+    scenario "starts checkout flow from case detail view" do
+      appeal = vacols_appeals.first
+      visit "/queue"
+
+      click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+
+      click_dropdown 0
+
+      expect(page).to have_content "Select Dispositions"
+
+      cancel_button = page.find "#button-cancel-button"
+      expect(cancel_button.text).to eql "Cancel"
+      cancel_button.click
+
+      cancel_modal = page.find ".cf-modal"
+      expect(cancel_modal.matches_css?(".active")).to eq true
+      cancel_modal.find(".usa-button-warning").click
+
+      click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+
+      click_dropdown 1
+
+      expect(page).to have_content "Submit OMO for Review"
+
+      cancel_button = page.find "#button-cancel-button"
+      expect(cancel_button.text).to eql "Cancel"
+
+      back_button = page.find "#button-back-button"
+      expect(back_button.text).to eql "Back"
+    end
+
+    context "prepares/fails to submit decision" do
+      scenario "fails to submit omo decision" do
+        appeal = vacols_appeals.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 1
+
+        expect(page).to have_link("Your Queue", href: "/queue")
+        expect(page).to have_link(appeal.veteran_full_name, href: "/queue/appeals/#{appeal.vacols_id}")
+        expect(page).to have_link("Submit OMO", href: "/queue/appeals/#{appeal.vacols_id}/submit")
+
+        expect(page).to have_content "Back"
+
+        click_on "Continue"
+
+        expect(page).to have_content("This field is required")
+        expect(page.find_all(".usa-input-error-message").length).to eq(3)
+      end
+
+      scenario "selects issue dispositions" do
+        appeal = vacols_appeals.select { |a| a.issues.length > 1 }.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 0
+
+        expect(page).to have_content("Select Dispositions")
+
+        table_rows = page.find_all("tr[id^='table-row-']")
+        expect(table_rows.length).to eq(appeal.issues.length)
+
+        # do not select all dispositions
+        table_rows[0..0].each { |row| click_dropdown 1, row }
+
+        click_on "Continue"
+
+        table_rows[1..-1].each do |row|
+          dropdown_border = row.find(".issue-disposition-dropdown").native.css_value("border-left")
+          expect(dropdown_border).to eq("4px solid rgb(205, 32, 38)")
+        end
+
+        # select all dispositions
+        table_rows.each { |row| click_dropdown 2, row }
+
+        click_on "Continue"
+
+        expect(page.current_path).to eq("/queue/appeals/#{appeal.vacols_id}/submit")
+      end
+
+      scenario "edits issue information" do
+        appeal = vacols_appeals.select { |a| a.issues.map(&:disposition).uniq.eql? [nil] }.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 0
+
+        expect(page).to have_content("Select Dispositions")
+
+        safe_click("a[href='/queue/appeals/#{appeal.vacols_id}/dispositions/edit/1']")
+        expect(page).to have_content("Edit Issue")
+
+        enabled_fields = page.find_all(".Select--single:not(.is-disabled)")
+
+        field_values = enabled_fields.map do |row|
+          # changing options at the top of the form affects what options are enabled further down
+          next if row.matches_css? ".is-disabled"
+
+          click_dropdown 1, row
+          row.find(".Select-value-label").text
+        end
+        fill_in "Notes:", with: "this is the note"
+
+        click_on "Continue"
+
+        expect(page).to have_content "You updated issue 1."
+        expect(page).to have_content "Program: #{field_values.first}"
+        expect(page).to have_content "Issue: #{field_values.second}"
+        expect(page).to have_content field_values.last # diagnostic code
+        expect(page).to have_content "Note: this is the note"
+      end
+
+      scenario "shows/hides diagnostic code option" do
+        appeal = vacols_appeals.select { |a| a.issues.map(&:disposition).uniq.eql? [nil] }.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 0
+
+        expect(page).to have_content "Select Dispositions"
+
+        diag_code_no_l2 = %w[4 5 0 *]
+        no_diag_code_no_l2 = %w[4 5 1]
+        diag_code_w_l2 = %w[4 8 0 1 *]
+        no_diag_code_w_l2 = %w[4 8 0 2]
+
+        [diag_code_no_l2, no_diag_code_no_l2, diag_code_w_l2, no_diag_code_w_l2].each do |opt_set|
+          safe_click "a[href='/queue/appeals/#{appeal.vacols_id}/dispositions/edit/1']"
+          expect(page).to have_content "Edit Issue"
+          selected_vals = select_issue_level_options(opt_set)
+          click_on "Continue"
+          selected_vals.each { |v| expect(page).to have_content v }
+        end
+      end
+
+      def select_issue_level_options(opts)
+        Array.new(5).map.with_index do |*, row_idx|
+          # Issue level 2 and diagnostic code dropdowns render based on earlier
+          # values, so we have to re-get elements per loop. There are at most 5
+          # dropdowns rendered: Program, Type, Levels 1, 2, Diagnostic Code
+          field_options = page.find_all ".Select--single"
+          row = field_options[row_idx]
+
+          next unless row
+
+          row.find(".Select-control").click
+
+          if opts[row_idx].eql? "*"
+            # there're about 800 diagnostic code options, but getting the count
+            # of '.Select-option's from the DOM takes a while
+            row.find("div[id$='--option-#{rand(800)}']").click
+          elsif opts[row_idx].is_a? String
+            row.find("div[id$='--option-#{opts[row_idx]}']").click
+          end
+          row.find(".Select-value-label").text
+        end
+      end
+
+      scenario "adds issue" do
+        appeal = vacols_appeals.reject { |a| a.issues.empty? }.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 0
+
+        expect(page).to have_content "Select Dispositions"
+
+        click_on "Add Issue"
+        expect(page).to have_content "Add Issue"
+
+        delete_btn = find("button", text: "Delete Issue")
+        expect(delete_btn.disabled?).to eq true
+
+        fields = page.find_all ".Select--single"
+
+        field_values = fields.map do |row|
+          next if row.matches_css? ".is-disabled"
+
+          click_dropdown 0, row
+          row.find(".Select-value-label").text
+        end
+        fill_in "Notes:", with: "added issue"
+
+        click_on "Continue"
+
+        expect(page).to have_content "You created a new issue."
+        expect(page).to have_content "Program: #{field_values.first}"
+        expect(page).to have_content "Issue: #{field_values.second}"
+        expect(page).to have_content field_values.last
+        expect(page).to have_content "Note: added issue"
+
+        click_on "Your Queue"
+
+        issue_count = find(:xpath, "//tbody/tr[@id='table-row-#{appeal.vacols_id}']/td[4]").text
+        expect(issue_count).to eq "2"
+      end
+
+      scenario "deletes issue" do
+        appeal = vacols_appeals.select { |a| a.issues.length > 1 }.first
+        old_issues = appeal.issues
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 0
+
+        expect(page).to have_content("Select Dispositions")
+
+        issue_rows = page.find_all("tr[id^='table-row-']")
+        expect(issue_rows.length).to eq(appeal.issues.length)
+
+        safe_click("a[href='/queue/appeals/#{appeal.vacols_id}/dispositions/edit/1']")
+        expect(page).to have_content("Edit Issue")
+
+        issue_idx = appeal.issues.index { |i| i.vacols_sequence_id.eql? 1 }
+
+        click_on "Delete Issue"
+        expect(page).to have_content "Delete Issue?"
+        click_on "Delete issue"
+
+        expect(page).to have_content("You deleted issue #{issue_idx + 1}.")
+
+        issue_rows = page.find_all("tr[id^='table-row-']")
+        expect(issue_rows.length).to eq(old_issues.length - 1)
+
+        click_on "Your Queue"
+
+        issue_count = find(:xpath, "//tbody/tr[@id='table-row-#{appeal.vacols_id}']/td[4]").text
+        expect(issue_count).to eq "4"
+      end
+    end
+
+    context "submits decision" do
+      scenario "submits omo decision" do
+        appeal = vacols_appeals.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 1
+
+        expect(page).to have_content("Submit OMO for Review")
+
+        click_label("omo-type_OMO - VHA")
+        click_label("overtime")
+        fill_in "document_id", with: "12345"
+        fill_in "notes", with: "notes"
+
+        safe_click("#select-judge")
+        click_dropdown 1
+        expect(page).to have_content("Andrew Mackenzie")
+
+        click_on "Continue"
+        sleep 1
+        expect(page).to(
+          have_content(
+            "Thank you for drafting #{appeal.veteran_full_name}'s outside medical
+            opinion (OMO) request. It's been sent to Andrew Mackenzie for review."
+          )
+        )
+        expect(page.current_path).to eq("/queue")
+      end
+
+      scenario "submits draft decision" do
+        appeal = vacols_appeals.select { |a| a.issues.length > 1 }.first
+        visit "/queue"
+
+        click_on "#{appeal.veteran_full_name} (#{appeal.vbms_id})"
+        click_dropdown 0
+
+        issue_rows = page.find_all("tr[id^='table-row-']")
+        expect(issue_rows.length).to eq(appeal.issues.length)
+
+        issue_rows.each do |row|
+          row.find(".Select-control").click
+          row.find("div[id$='--option-#{issue_rows.index(row) % 7}']").click
+        end
+
+        click_on "Continue"
+        expect(page).to have_content("Select Remand Reasons")
+        expect(page).to have_content(appeal.issues.first.note)
+
+        page.execute_script("return document.querySelectorAll('div[class^=\"checkbox-wrapper-\"]')")
+          .sample(4)
+          .each(&:click)
+
+        page.find_all("input[type='radio'] + label").to_a.each_with_index do |label, idx|
+          label.click unless (idx % 2).eql? 0
+        end
+
+        click_on "Continue"
+        expect(page).to have_content("Submit Draft Decision for Review")
+
+        fill_in "document_id", with: "12345"
+        fill_in "notes", with: "this is a decision note"
+
+        safe_click "#select-judge"
+        click_dropdown 1
+        expect(page).to have_content("Andrew Mackenzie")
+
+        click_on "Continue"
+        sleep 1
+        expect(page).to(
+          have_content(
+            "Thank you for drafting #{appeal.veteran_full_name}'s decision.
+            It's been sent to Andrew Mackenzie for review."
+          )
+        )
+        expect(page.current_path).to eq("/queue")
+      end
+    end
+  end
+
   context "loads judge checkout views" do
     before do
       FeatureToggle.enable!(:test_facols)


### PR DESCRIPTION
### Description
When the start attorney checkout flow dropdown was removed from `AttorneyTaskTable`, tests were removed as well. This restores and updates them to navigate into the case detail view first

### Acceptance Criteria 
- [ ] Attorney checkout flow tests pass

### Testing Plan
1. `REACT_ON_RAILS_ENV=HOT bundle exec rake spec ./spec/feature/queue/queue_spec:513`
