### PR TITLE
Use consistent metrics naming

### DIFF
--- a/app/services/prometheus_service.rb
+++ b/app/services/prometheus_service.rb
@@ -172,14 +172,14 @@ class PrometheusService
       @background_jobs_attempt_counter ||=
         find_or_register_metric(:counter,
                                 :background_jobs_attempt_counter,
-                                "counter of all shoryuken background jobs attempted (fail or succeed)")
+                                "counter of all background jobs attempted (fail or succeed)")
     end
 
     def background_jobs_error_counter
       @background_jobs_error_counter ||=
         find_or_register_metric(:counter,
                                 :background_jobs_error_counter,
-                                "counter of all shoryuken background jobs that errored")
+                                "counter of all background jobs that errored")
     end
 
     # This method pushes all registered metrics to the prometheus pushgateway


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/6089

### Description
Use the metrics `help` naming from [efolder](https://github.com/department-of-veterans-affairs/caseflow-efolder/blob/master/app/services/prometheus_service.rb), which is more generic.

These metrics have the same `name` but different `help` description. `pushgateway` emits a warning when this happens.

The pushgateway has de-dupe logic that will arbitrarily pick the latter one.

### Acceptance Criteria 
Changed documentation of a metric

### Testing Plan
Check for `pushgateway` warning logs in staging after push
