### PR TITLE
Store raven extra application context as string

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,6 +1,6 @@
 class ApplicationJob < ActiveJob::Base
   def self.application_attr(app_name)
     # setup debug context
-    Raven.extra_context(application: app_name)
+    Raven.extra_context(application: app_name.to_s)
   end
 end


### PR DESCRIPTION
@shanear @sharonwarner,

So in debugging why the RampElection::BGSEndProductSyncError did not appear to be routing to the right channels, I noticed that the 'application' Raven extra context was not being sent to sentry.  

I believe this is because I did not properly convert the symbol to a string. 