### PR TITLE
Add static is_legacy_appeal attribute to Appeal serializers

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -1,4 +1,8 @@
 class WorkQueue::AppealSerializer < ActiveModel::Serializer
+  attribute :is_legacy_appeal do
+    false
+  end
+
   attribute :issues do
     object.request_issues
   end

--- a/app/models/serializers/work_queue/legacy_appeal_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_serializer.rb
@@ -1,4 +1,8 @@
 class WorkQueue::LegacyAppealSerializer < ActiveModel::Serializer
+  attribute :is_legacy_appeal do
+    true
+  end
+
   attribute :issues do
     object.issues.map do |issue|
       ActiveModelSerializers::SerializableResource.new(


### PR DESCRIPTION
Don't know the most Rails-y way of adding a static attribute to model serializers, so happy to change course if there is a better way to accomplish this (move these to functions in the models themselves?).