### PR TITLE
Ignore vulnerability for a week

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,10 @@ gem "redis-namespace"
 # catch problematic migrations at development/test time
 gem "zero_downtime_migrations"
 
+# nokogiri versions before 1.8.3 are affected by CVE-2018-8048. Explicitly define nokogiri version here to avoid that.
+# https://github.com/sparklemotion/nokogiri/pull/1746
+gem "nokogiri", ">= 1.8.3"
+
 group :production, :staging, :ssh_forwarding, :development, :test do
   # Oracle DB
   gem "activerecord-oracle_enhanced-adapter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,7 +264,7 @@ GEM
     newrelic_rpm (4.7.1.340)
     nio4r (2.3.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     octokit (4.8.0)
@@ -514,6 +514,7 @@ DEPENDENCIES
   launchy
   moment_timezone-rails
   newrelic_rpm
+  nokogiri (>= 1.8.3)
   paper_trail (= 8.1.2)
   parallel
   paranoia (~> 2.2)

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -11,8 +11,12 @@ task :security_caseflow do
   puts "running bundle-audit to check for insecure dependencies..."
   exit!(1) unless ShellCommand.run("bundle-audit update")
 
-  # TODO(lowell): Remove this ignore after we have upgraded rubocop.
-  audit_result = ShellCommand.run("bundle-audit check --ignore CVE-2017-8418")
+  # Only ignore this vulnerability for a week.
+  audit_cmd = "bundle-audit check --ignore CVE-2016-10545"
+  if Time.zone.local(2018, 7, 5) < Time.zone.today - 1.week
+    audit_cmd = "bundle-audit check"
+  end
+  audit_result = ShellCommand.run(audit_cmd)
 
   puts "\n"
   if brakeman_result && audit_result

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -11,6 +11,10 @@ task :security_caseflow do
   puts "running bundle-audit to check for insecure dependencies..."
   exit!(1) unless ShellCommand.run("bundle-audit update")
 
+  # Set time zone when running in Circle CI environment.
+  # TODO: Remove this when we stop calling Time.zone... below.
+  Time.zone = "Eastern Time (US & Canada)"
+
   # Only ignore this vulnerability for a week.
   audit_cmd = "bundle-audit check --ignore CVE-2016-10545"
   if Time.zone.local(2018, 7, 5) < Time.zone.today - 1.week


### PR DESCRIPTION
CI builds are currently failing due to a vulnerability in a third-party package we use. This PR ignores this vulnerability for a week. After a week `bundle-audit` will fail again and we will be reminded to look to see if a patch for the gem has been released.

![image](https://user-images.githubusercontent.com/32683958/42338120-c8e763f8-8056-11e8-915a-20c6bdc65c6a.png)

Link to issue on the Thor gem's github: https://github.com/erikhuda/thor/issues/514

I don't think it makes sense to try to get rid of our dependency on this gem since so many gems we rely on use it:
* bourbon
* bundler-audit
* foreman
* jquery-rails
* neat
* railties
* shoryuken