### PR TITLE
Queue | Fix sorting tasks by docket date

### DIFF
--- a/client/app/queue/types.js
+++ b/client/app/queue/types.js
@@ -22,7 +22,8 @@ export type Task = {
     due_on: string,
     task_id: string,
     task_type: string,
-    user_id: string
+    user_id: string,
+    work_product: string
   }
 };
 

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -40,15 +40,12 @@ export const associateTasksWithAppeals = (serverData: Object = {}) => {
 *  Sort by docket date (form 9 date) oldest to
 *  newest within each group
 */
-export const sortTasks = ({ tasks = {}, appeals = {} }: {tasks: Tasks, appeals: {[string]: Object}}) => {
-  const partitionedTasks = _.partition(tasks, (task) =>
+export const sortTasks = ({ tasks = {}, appeals = {} }: {tasks: Tasks, appeals: {[string]: Object}}) => _(tasks).
+  partition((task) =>
     appeals[task.vacolsId].attributes.aod || appeals[task.vacolsId].attributes.type === 'Court Remand'
-  );
-
-  _.each(partitionedTasks, _.reverse);
-
-  return partitionedTasks[0].concat(partitionedTasks[1]);
-};
+  ).
+  flatMap((taskList) => _.sortBy(taskList, (task) => new Date(task.attributes.docket_date))).
+  value()
 
 export const renderAppealType = (appeal: {attributes: {aod: string, type: string}}) => {
   const {

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -45,7 +45,7 @@ export const sortTasks = ({ tasks = {}, appeals = {} }: {tasks: Tasks, appeals: 
     appeals[task.vacolsId].attributes.aod || appeals[task.vacolsId].attributes.type === 'Court Remand'
   ).
   flatMap((taskList) => _.sortBy(taskList, (task) => new Date(task.attributes.docket_date))).
-  value()
+  value();
 
 export const renderAppealType = (appeal: {attributes: {aod: string, type: string}}) => {
   const {


### PR DESCRIPTION
Resolves #6101 

### Description
Fixes sorting attorney/judge tasks by `docket_date`. This PR also updates the `Task` flow type, adding `work_product`.

### Acceptance Criteria 
- [ ] Tasks are properly sorted by type (AOD/CAVC) and then by docket date

### Testing Plan
1. Go to `/queue`, confirm case sort order

<details><summary>Screenshot with added docket date column</summary>
<img src="https://user-images.githubusercontent.com/8533004/42341041-ba4c6740-805f-11e8-905d-545a53393097.png">
</details>


