### PR TITLE
Change tasks controller create action to allow creation of multiple t…

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -22,10 +22,9 @@ class TasksController < ApplicationController
   end
 
   def create
-    return required_parameters_missing([:titles]) if task_params[:titles].blank?
-
     return invalid_type_error unless task_class
-    tasks = task_class.create(task_params.merge(appeal_type: "LegacyAppeal"))
+
+    tasks = task_class.create(tasks_params)
 
     tasks.each { |task| return invalid_record_error(task) unless task.valid? }
     render json: { tasks: tasks }, status: :created
@@ -63,7 +62,7 @@ class TasksController < ApplicationController
   end
 
   def task_class
-    TASK_CLASSES[params["tasks"][:type].try(:to_sym)]
+    TASK_CLASSES[tasks_params.first[:type].try(:to_sym)]
   end
 
   def invalid_type_error
@@ -79,11 +78,12 @@ class TasksController < ApplicationController
     @task ||= Task.find(params[:id])
   end
 
-  def task_params
-    params.require("tasks")
-      .permit(:appeal_id, :type, :instructions, titles: [])
-      .merge(assigned_by: current_user)
-      .merge(assigned_to: User.find_by(id: params[:tasks][:assigned_to_id]))
+  def tasks_params
+    [params.require("tasks")].flatten.map do |task|
+      task.permit(:appeal_id, :type, :instructions, :title)
+        .merge(assigned_by: current_user)
+        .merge(appeal_type: "LegacyAppeal")
+    end
   end
 
   def update_params

--- a/app/models/tasks/co_located_admin_action.rb
+++ b/app/models/tasks/co_located_admin_action.rb
@@ -3,11 +3,11 @@ class CoLocatedAdminAction < Task
   validate :assigned_by_role_is_valid
 
   class << self
-    def create(params)
+    def create(tasks)
       ActiveRecord::Base.multi_transaction do
-        params[:assigned_to] = next_assignee
-        records = params.delete(:titles).each_with_object([]) do |title, result|
-          result << super(params.merge(title: title))
+        assignee = next_assignee
+        records = [tasks].flatten.each_with_object([]) do |task, result|
+          result << super(task.merge(assigned_to: assignee))
           result
         end
         if records.map(&:valid?).uniq == [true]

--- a/spec/models/co_located_admin_action_spec.rb
+++ b/spec/models/co_located_admin_action_spec.rb
@@ -16,11 +16,14 @@ describe CoLocatedAdminAction do
   context ".create" do
     context "when all fields are present" do
       subject do
-        CoLocatedAdminAction.create(
-          assigned_by: attorney,
-          titles: [:aoj, :poa_clarification],
-          appeal: appeal
-        )
+        CoLocatedAdminAction.create([{
+                                      assigned_by: attorney,
+                                      title: :aoj,
+                                      appeal: appeal
+                                    },
+                                     { assigned_by: attorney,
+                                       title: :poa_clarification,
+                                       appeal: appeal }])
       end
 
       it "creates a co-located task successfully" do
@@ -40,14 +43,14 @@ describe CoLocatedAdminAction do
 
         expect(vacols_case.reload.bfcurloc).to eq "CASEFLOW"
 
-        record = CoLocatedAdminAction.create(assigned_by: attorney, titles: [:aoj], appeal: appeal)
+        record = CoLocatedAdminAction.create(assigned_by: attorney, title: :aoj, appeal: appeal)
         expect(record.first.assigned_to).to eq User.find_by(css_id: "BVATEST2")
 
-        record = CoLocatedAdminAction.create(assigned_by: attorney, titles: [:aoj], appeal: appeal)
+        record = CoLocatedAdminAction.create(assigned_by: attorney, title: :aoj, appeal: appeal)
         expect(record.first.assigned_to).to eq User.find_by(css_id: "BVATEST3")
 
         # should start from index 0
-        record = CoLocatedAdminAction.create(assigned_by: attorney, titles: [:aoj], appeal: appeal)
+        record = CoLocatedAdminAction.create(assigned_by: attorney, title: :aoj, appeal: appeal)
         expect(record.first.assigned_to).to eq User.find_by(css_id: "BVATEST1")
       end
     end
@@ -56,7 +59,7 @@ describe CoLocatedAdminAction do
       subject do
         CoLocatedAdminAction.create(
           assigned_by: attorney,
-          titles: [:aoj]
+          title: :aoj
         )
       end
       it "does not create a co-located task" do
@@ -73,7 +76,7 @@ describe CoLocatedAdminAction do
       subject do
         CoLocatedAdminAction.create(
           assigned_by: attorney,
-          titles: [:aoj],
+          title: :aoj,
           appeal: appeal
         )
       end
@@ -87,7 +90,7 @@ describe CoLocatedAdminAction do
       subject do
         CoLocatedAdminAction.create(
           assigned_by: attorney,
-          titles: [:test],
+          title: :test,
           appeal: appeal
         )
       end


### PR DESCRIPTION
…asks

Closes #6152 

### Description
Create multiple admin actions at once. The controller `create` action accepts both forms now: one task to create and an array of tasks

