### PR TITLE
Add dep on immutable to resolve peer dependency from react-draft-wysiwyg

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "glamor": "^2.20.40",
     "history": "^4.5.1",
     "immutability-helper": "^2.4.0",
+    "immutable": "^3.8.2",
     "imports-loader": "^0.7.1",
     "jsdom": "9.8.3",
     "lodash": "^4.17.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3387,6 +3387,10 @@ immutability-helper@^2.4.0:
   dependencies:
     invariant "^2.2.0"
 
+immutable@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
 immutable@~3.7.4:
   version "3.7.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"


### PR DESCRIPTION
### Description
Adds an explicit dependency on immutable so that a fresh yarn install doesn't fail with an unmet peerDependency from react-draft-wysiwyg

### Acceptance Criteria 
- [ ] Code compiles correctly
- [ ] yarn install runs with no warnings or errors.

### Testing Plan
1. rm -rf client/node_modules
2. cd client && yarn install

