### PR TITLE
Case Details | Shows actions dropdown if the case is assigned to the user

### DIFF
--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -2,7 +2,7 @@ class LegacyTasksController < ApplicationController
   before_action :verify_queue_access
   before_action :verify_task_assignment_access, only: [:create, :update]
 
-  ROLES = %w[judge attorney].freeze
+  ROLES = %w[judge attorney colocated].freeze
 
   def set_application
     RequestStore.store[:application] = "queue"

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -27,11 +27,13 @@ class QueueLoadingScreen extends React.PureComponent {
   }
 
   loadRelevantCases = () => {
+    const promises = [];
     if (this.props.appealId) {
-      return this.loadActiveAppeal();
+      promises.push(this.loadActiveAppeal());
     }
 
-    return this.loadQueue();
+    promises.push(this.loadQueue());
+    return Promise.all(promises);
   }
 
   loadQueue = () => {

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -28,11 +28,12 @@ class QueueLoadingScreen extends React.PureComponent {
 
   loadRelevantCases = () => {
     const promises = [];
+
     if (this.props.appealId) {
       promises.push(this.loadActiveAppeal());
     }
-
     promises.push(this.loadQueue());
+
     return Promise.all(promises);
   }
 


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/caseflow/issues/6222

### Description
Shows actions dropdown on the case details page if the case is assigned to the current user.

### Testing Plan
- [x] Become BVAAABSHIRE.
- [x] View http://localhost:3000/queue/appeals/3449656
- [x] Confirm that the actions dropdown is visible.
- [x] Become BVARERDMAN.
- [x] Confirm that http://localhost:3000/queue/appeals/3449656 loads successfully.
- [x] Become BVALSPORER.
- [x] Confirm that http://localhost:3000/queue/appeals/3449656 loads successfully.
- [x] Become BVASCASPER1.
- [x] Confirm that http://localhost:3000/queue/appeals/3449656 loads successfully.
