### PR TITLE
Queue | fix ime / vha document id validation

### DIFF
--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -172,7 +172,7 @@ export const validateWorkProductTypeAndId = (decision: {opts: Object}) => {
     return newFormat.test(documentId);
   }
 
-  const initialChar = workProduct.includes('IME') ? 'V' : 'M';
+  const initialChar = workProduct.includes('IME') ? 'M' : 'V';
   const regex = `^${initialChar}\\d{7}\\.\\d{3,4}$`;
   const oldFormat = new RegExp(regex);
 

--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -182,7 +182,7 @@ RSpec.feature "Checkout flows" do
 
         click_on "Continue"
         expect(page).to have_content(COPY::FORM_ERROR_FIELD_INVALID)
-        fill_in "document_id", with: "M1234567.1234"
+        fill_in "document_id", with: "V1234567.1234"
         click_on "Continue"
         expect(page).not_to have_content(COPY::FORM_ERROR_FIELD_INVALID)
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/appeals-support/issues/2562

### Description
This fixes an issue in #6193, which reversed the document id formats for OMO VHA and IME work products

### Acceptance Criteria 
- [ ] IME work products require "M##..."
- [ ] VHA work products require "V##..."

### Testing Plan
1. Go to `/queue` as attorney (`BVASCASPER1`), case detail view, Medical Request Ready for Review
2. Confirm Document ID validates correctly

