### PR TITLE
Remove search flag

### DIFF
--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -107,7 +107,6 @@ end
 RSpec.feature "Reader" do
   before do
     Fakes::Initializer.load!
-    FeatureToggle.enable!(:search)
     FeatureToggle.enable!(:test_facols)
     Time.zone = "America/New_York"
 


### PR DESCRIPTION
```
vhaisaroltsa@VACOLTROLTSA5 ~/dev/caseflow (master) $ grep -Rn "(:reader)" *
vhaisaroltsa@VACOLTROLTSA5 ~/dev/caseflow (master) $ grep -Rn "(:search)" *
spec/feature/reader/reader_spec.rb:110:    FeatureToggle.enable!(:search)
```