### PR TITLE
API | Adds Postgresql ID of assignee to tasks

### DIFF
--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -19,6 +19,10 @@ class LegacyTask
     assigned_to.css_id
   end
 
+  def assigned_to_pg_id
+    assigned_to.id
+  end
+
   def task_type
     type
   end

--- a/app/models/serializers/work_queue/legacy_task_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_task_serializer.rb
@@ -5,6 +5,7 @@ class WorkQueue::LegacyTaskSerializer < ActiveModel::Serializer
   attribute :docket_date
   attribute :appeal_id
   attribute :user_id
+  attribute :assigned_to_pg_id
   attribute :added_by_name
   attribute :added_by_css_id
   attribute :task_id


### PR DESCRIPTION
Part of https://github.com/department-of-veterans-affairs/caseflow/issues/5303

### Description
Adds the Postgresql ID of the assignee to each task.

### Testing Plan
- [x] http://localhost:3000/queue/<Postgresql ID of judge>.json includes assigned_to_pg_id
- [x] http://localhost:3000/queue/<Postgresql ID of attorney>.json includes assigned_to_pg_id