### PR TITLE
Queue | Add ability to sort by days waiting for Judge queues

### DIFF
--- a/client/app/queue/JudgeAssignTaskTable.jsx
+++ b/client/app/queue/JudgeAssignTaskTable.jsx
@@ -6,10 +6,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Table from '../components/Table';
 import _ from 'lodash';
-import moment from 'moment';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { renderAppealType } from './utils';
+import { renderAppealType, getTaskDaysWaiting } from './utils';
 import { setSelectionOfTaskOfUser } from './QueueActions';
 
 class JudgeAssignTaskTable extends React.PureComponent {
@@ -60,10 +59,8 @@ class JudgeAssignTaskTable extends React.PureComponent {
     },
     {
       header: COPY.JUDGE_QUEUE_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
-      valueFunction: ({ task }) => (
-        moment().
-          startOf('day').
-          diff(moment(task.attributes.assigned_on), 'days'))
+      valueFunction: ({ task }) => getTaskDaysWaiting(task),
+      getSortValue: ({ task }) => getTaskDaysWaiting(task)
     }
   ];
 

--- a/client/app/queue/JudgeReviewTaskTable.jsx
+++ b/client/app/queue/JudgeReviewTaskTable.jsx
@@ -2,13 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import _ from 'lodash';
-import moment from 'moment';
 
 import Table from '../components/Table';
 import CaseDetailsLink from './CaseDetailsLink';
 
 import { judgeReviewTasksSelector } from './selectors';
-import { sortTasks, renderAppealType } from './utils';
+import { sortTasks, renderAppealType, getTaskDaysWaiting } from './utils';
 import COPY from '../../COPY.json';
 
 class JudgeReviewTaskTable extends React.PureComponent {
@@ -47,8 +46,8 @@ class JudgeReviewTaskTable extends React.PureComponent {
     valueFunction: (task) => this.getAppealForTask(task, 'issues.length')
   }, {
     header: COPY.JUDGE_QUEUE_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
-    valueFunction: (task) => moment().startOf('day').
-      diff(moment(task.attributes.assigned_on), 'days')
+    valueFunction: getTaskDaysWaiting,
+    getSortValue: getTaskDaysWaiting
   }];
 
   render = () => <Table

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -181,6 +181,4 @@ export const validateWorkProductTypeAndId = (decision: {opts: Object}) => {
 };
 
 export const getTaskDaysWaiting = (task: Task) => moment().startOf('day').
-  diff(
-    moment(task.attributes.assigned_on), 'days'
-  );
+  diff(moment(task.attributes.assigned_on), 'days');

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -1,12 +1,14 @@
 // @flow
 import React from 'react';
 import _ from 'lodash';
+import moment from 'moment';
 import StringUtil from '../util/StringUtil';
 import {
   redText,
   USER_ROLES
 } from './constants';
 import type {
+  Task,
   Tasks,
   LegacyAppeal,
   LegacyAppeals,
@@ -177,3 +179,8 @@ export const validateWorkProductTypeAndId = (decision: {opts: Object}) => {
 
   return oldFormat.test(documentId) || newFormat.test(documentId);
 };
+
+export const getTaskDaysWaiting = (task: Task) => moment().startOf('day').
+  diff(
+    moment(task.attributes.assigned_on), 'days'
+  );


### PR DESCRIPTION
Resolves #6299

### Description
Enables sorting by Days Waiting column for Judge Assign and Review tables

### Acceptance Criteria 
- [ ] Judge Review and Assign tables support sorting by days waiting

### Testing Plan
1. Go to `/queue` as judge, confirm table sorts as expected

<img width="884" alt="screen shot 2018-07-24 at 2 25 14 pm" src="https://user-images.githubusercontent.com/8533004/43158465-bd9f3678-8f4d-11e8-99b7-0300f64cabfd.png">
<img width="900" alt="screen shot 2018-07-24 at 2 25 19 pm" src="https://user-images.githubusercontent.com/8533004/43158466-bdb0a1b0-8f4d-11e8-8e81-261c1543a206.png">

