### PR TITLE
Queue | Fix sorting attorney tasks by type

### DIFF
--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -182,7 +182,7 @@ export default class Table extends React.PureComponent {
     const builtColumns = getColumns(this.props);
 
     return _.orderBy(rowObjects,
-      (row) => builtColumns[sortColIdx].getSortValue(row),
+      (row) => builtColumns[sortColIdx].getSortValue(row, rowObjects),
       sortAscending ? 'desc' : 'asc'
     );
   }

--- a/client/app/queue/AttorneyTaskTable.jsx
+++ b/client/app/queue/AttorneyTaskTable.jsx
@@ -59,7 +59,10 @@ class AttorneyTaskTable extends React.PureComponent<Props> {
     span: (task) => task.attributes.task_id ? 1 : 5,
     getSortValue: (task, tasks) => {
       const { appeals } = this.props;
-      const sortedTasks = sortTasks({ tasks, appeals });
+      const sortedTasks = sortTasks({
+        tasks,
+        appeals
+      });
 
       return sortedTasks.indexOf(task);
     }

--- a/client/app/queue/AttorneyTaskTable.jsx
+++ b/client/app/queue/AttorneyTaskTable.jsx
@@ -56,7 +56,13 @@ class AttorneyTaskTable extends React.PureComponent<Props> {
     valueFunction: (task) => task.attributes.task_id ?
       renderAppealType(this.getAppealForTask(task)) :
       <span {...redText}>{COPY.ATTORNEY_QUEUE_TABLE_TASK_NEEDS_ASSIGNMENT_ERROR_MESSAGE}</span>,
-    span: (task) => task.attributes.task_id ? 1 : 5
+    span: (task) => task.attributes.task_id ? 1 : 5,
+    getSortValue: (task, tasks) => {
+      const { appeals } = this.props;
+      const sortedTasks = sortTasks({ tasks, appeals });
+
+      return sortedTasks.indexOf(task);
+    }
   }, {
     header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
     valueFunction: (task) => task.attributes.task_id ? this.getAppealForTask(task, 'docket_number') : null,
@@ -99,19 +105,15 @@ class AttorneyTaskTable extends React.PureComponent<Props> {
     }
   }];
 
-  render = () => {
-    const { appeals, tasks } = this.props;
-
-    return <Table
-      columns={this.getQueueColumns}
-      rowObjects={sortTasks({
-        appeals,
-        tasks
-      })}
-      getKeyForRow={this.getKeyForRow}
-      defaultSort={{ sortColIdx: 0 }}
-      rowClassNames={(task) => task.attributes.task_id ? null : 'usa-input-error'} />;
-  }
+  render = () => <Table
+    columns={this.getQueueColumns}
+    rowObjects={Object.values(this.props.tasks)}
+    getKeyForRow={this.getKeyForRow}
+    defaultSort={{
+      sortColIdx: 1,
+      sortAscending: false
+    }}
+    rowClassNames={(task) => task.attributes.task_id ? null : 'usa-input-error'} />;
 }
 
 const mapStateToProps = (state) => {

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -67,9 +67,9 @@ RSpec.feature "Task queue" do
       docket_number_column_header = page.find(:xpath, "//thead/tr/th[3]/span")
       docket_number_column_header.click
       docket_number_column_vals = page.find_all(:xpath, "//tbody/tr/td[3]")
-      expect(docket_number_column_vals.map(&:text)).to eq vacols_tasks.map(&:docket_number).sort
+      expect(docket_number_column_vals.map(&:text)).to eq vacols_tasks.map(&:docket_number).sort.reverse
       docket_number_column_header.click
-      expect(docket_number_column_vals.map(&:text)).to eq vacols_tasks.map(&:docket_number).sort
+      expect(docket_number_column_vals.map(&:text)).to eq vacols_tasks.map(&:docket_number).sort.reverse
     end
 
     it "displays special text indicating an assigned case has a claimant who is not the Veteran" do


### PR DESCRIPTION
### Description
After custom sorting was added to AttorneyTaskTable, we set a different default sort order, rather than preserving sorting by type.

### Acceptance Criteria 
- [ ] AttorneyTaskTable allows sorting based on Type

### Testing Plan
1. Go to `/queue` as attorney, confirm sorting works

<img width="712" alt="screen shot 2018-07-24 at 2 54 05 pm" src="https://user-images.githubusercontent.com/8533004/43159998-eb2dbb24-8f51-11e8-949f-84134f46dd14.png">

