### PR TITLE
Queue | Only update remand reasons in redux on go to next page

### DIFF
--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -37,6 +37,8 @@ class SelectRemandReasonsView extends React.Component {
     return `${baseUrl}/${userRole === USER_ROLES.JUDGE ? 'evaluate' : 'submit'}`;
   }
 
+  goToPrevStep = () => _.each(this.state.renderedChildren, (child) => child.updateStoreIssue());
+
   goToNextStep = () => {
     const { issues } = this.props;
     const {

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -39,7 +39,10 @@ class SelectRemandReasonsView extends React.Component {
 
   goToNextStep = () => {
     const { issues } = this.props;
-    const { issuesRendered } = this.state;
+    const {
+      issuesRendered,
+      renderedChildren
+    } = this.state;
 
     if (issuesRendered < issues.length) {
       this.setState({ issuesRendered: Math.min(issuesRendered + 1, issues.length) });
@@ -47,6 +50,7 @@ class SelectRemandReasonsView extends React.Component {
       return false;
     }
 
+    _.each(renderedChildren, (child) => child.updateStoreIssue());
     return true;
   }
 

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -53,6 +53,7 @@ class SelectRemandReasonsView extends React.Component {
     }
 
     _.each(renderedChildren, (child) => child.updateStoreIssue());
+
     return true;
   }
 

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -109,7 +109,7 @@ class IssueRemandReasonsOptions extends React.PureComponent {
   };
 
   updateStoreIssue = () => {
-    // on going to the next page, update issue attrs from state
+    // on going to the next or previous page, update issue attrs from state
     // "remand_reasons": [
     //   {"code": "AB", "after_certification": true},
     //   {"code": "AC", "after_certification": false}

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -108,8 +108,8 @@ class IssueRemandReasonsOptions extends React.PureComponent {
     }
   };
 
-  componentWillUnmount = () => {
-    // on unmount, update issue attrs from state
+  updateStoreIssue = () => {
+    // on going to the next page, update issue attrs from state
     // "remand_reasons": [
     //   {"code": "AB", "after_certification": true},
     //   {"code": "AC", "after_certification": false}


### PR DESCRIPTION
Resolves https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2113/

### Description
Previously, we would update issues' remand reasons in Redux as soon as `IssueRemandReasonsOptions` unmounted, regardless of intent. As a result, when the user would cancel a checkout flow from the Remand Reasons screen, we would attempt to update issues on an appeal that was no longer in `state.queue.stagedChanges`.

This only updates Redux issue remand reasons on going backwards or forwards within the checkout flow, not when canceling it.

### Acceptance Criteria 
- [ ] Remand Reasons screen does not attempt to update Redux issue reasons on canceling checkout flow

### Testing Plan
1. Go to `/queue` as Attorney, Draft Decision checkout flow
2. Set remand reasons for ≥ 1 issue, go forwards and backwards, confirm selected remand reasons display when you return to the screen
3. From Remand Reasons screen, cancel checkout flow, confirm return to `/queue/appeals/${appeal_id}`

