### PR TITLE
Queue | Fix backwards navigation in checkout flow

### DIFF
--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -25,7 +25,8 @@ import JUDGE_CASE_REVIEW_OPTIONS from '../../constants/JUDGE_CASE_REVIEW_OPTIONS
 import {
   marginBottom, marginTop,
   marginRight, paddingLeft,
-  fullWidth, redText, PAGE_TITLES
+  fullWidth, redText, PAGE_TITLES,
+  ISSUE_DISPOSITIONS
 } from './constants';
 const setWidth = (width) => css({ width });
 const headerStyling = marginBottom(1.5);
@@ -104,6 +105,19 @@ class EvaluateDecisionView extends React.PureComponent {
 
     return true;
   };
+
+  getPrevStepUrl = () => {
+    const {
+      appealId,
+      appeal: { attributes: appeal }
+    } = this.props;
+    const dispositions = _.map(appeal.issues, (issue) => issue.disposition);
+    const prevUrl = `/queue/appeals/${appealId}`;
+
+    return dispositions.includes(ISSUE_DISPOSITIONS.REMANDED) ?
+      `${prevUrl}/remands` :
+      `${prevUrl}/dispositions`;
+  }
 
   goToNextStep = () => {
     const {

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -79,14 +79,18 @@ class QueueApp extends React.PureComponent {
     appealId={props.match.params.appealId}
     nextStep="/queue" />;
 
-  routedSelectDispositions = (props) => <SelectDispositionsView appealId={props.match.params.appealId} />;
+  routedSelectDispositions = (props) => <SelectDispositionsView
+    prevStep={`/queue/appeals/${props.match.params.appealId}`}
+    appealId={props.match.params.appealId} />;
 
   routedAddEditIssue = (props) => <AddEditIssueView
     nextStep={`/queue/appeals/${props.match.params.appealId}/dispositions`}
     prevStep={`/queue/appeals/${props.match.params.appealId}/dispositions`}
     {...props.match.params} />;
 
-  routedSetIssueRemandReasons = (props) => <SelectRemandReasonsView {...props.match.params} />;
+  routedSetIssueRemandReasons = (props) => <SelectRemandReasonsView
+    prevStep={`/queue/appeals/${props.match.params.appealId}/dispositions`}
+    {...props.match.params} />;
 
   routedEvaluateDecision = (props) => <EvaluateDecisionView nextStep="/queue" {...props.match.params} />;
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -34,7 +34,8 @@ import {
   marginBottom,
   marginTop,
   ATTORNEY_COMMENTS_MAX_LENGTH,
-  OMO_ATTORNEY_CASE_REVIEW_WORK_PRODUCT_TYPES
+  OMO_ATTORNEY_CASE_REVIEW_WORK_PRODUCT_TYPES,
+  ISSUE_DISPOSITIONS
 } from './constants';
 import SearchableDropdown from '../components/SearchableDropdown';
 import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
@@ -109,6 +110,24 @@ class SubmitDecisionView extends React.PureComponent<Props> {
 
     return !missingParams.length;
   };
+
+  getPrevStepUrl = () => {
+    const {
+      decision: { type: decisionType },
+      appeal: { attributes: appeal },
+      appealId
+    } = this.props;
+    const dispositions = _.map(appeal.issues, (issue) => issue.disposition);
+    const prevUrl = `/queue/appeals/${appealId}`;
+
+    if (decisionType === DECISION_TYPES.DRAFT_DECISION) {
+      return dispositions.includes(ISSUE_DISPOSITIONS.REMANDED) ?
+        `${prevUrl}/remands` :
+        `${prevUrl}/dispositions`;
+    }
+
+    return prevUrl;
+  }
 
   goToNextStep = () => {
     const {

--- a/client/app/queue/components/DecisionViewBase.jsx
+++ b/client/app/queue/components/DecisionViewBase.jsx
@@ -77,15 +77,16 @@ export default function decisionViewBase(ComponentToWrap) {
       history.push(`/queue/appeals/${appealId}`);
     }
 
+    getPrevStepUrl = () => _.invoke(this.state.wrapped, 'getPrevStepUrl') || this.props.prevStep;
+    getNextStepUrl = () => _.invoke(this.state.wrapped, 'getNextStepUrl') || this.props.nextStep;
+
     goToPrevStep = () => {
       const prevStepHook = _.get(this.state.wrapped, 'goToPrevStep');
 
       if (!prevStepHook || prevStepHook()) {
-        return this.props.history.push(this.props.prevStep);
+        return this.props.history.push(this.getPrevStepUrl());
       }
     };
-
-    getNextStepUrl = () => _.invoke(this.state.wrapped, 'getNextStepUrl') || this.props.nextStep;
 
     goToNextStep = () => {
       // This handles moving to the next step in the flow. The wrapped


### PR DESCRIPTION
### Description
#6201 removed breadcrumbs from Queue, removing behavior to [get the previous page's route automatically](https://github.com/department-of-veterans-affairs/caseflow/pull/6201/files#diff-089965c96187789b52b3c00906d0f5faL110). As a result, the user could not navigate backwards from any page which did not have a `prevStep` property. This restores this behavior

### Acceptance Criteria 
- [ ] Confirm Back button behaves as expected for
  - EvaluateDecisionView (returns to `/remands`/`/dispositions` depending on issue dispositions)
  - SubmitDecisionView (returns to `/remands`, `/dispositions`, or case detail view depending on work product & dispositions)
  - SelectDispositionsView (returns to case detail)
  - SelectRemandReasonsView (returns to select dispositions)

### Testing Plan
1. Go to ...

<details><summary>before</summary>
<img src="https://user-images.githubusercontent.com/8533004/43167822-0f03e048-8f69-11e8-9bf2-7d4feffa3958.gif">
</details>

<details><summary>after</summary>
<img src="https://user-images.githubusercontent.com/8533004/43168039-c5b14b82-8f69-11e8-9e1c-95bedb7a4a63.gif">
</details>