### PR TITLE
Change AMA date

### DIFF
--- a/app/models/ama_review.rb
+++ b/app/models/ama_review.rb
@@ -3,7 +3,7 @@ class AmaReview < ApplicationRecord
 
   validate :validate_receipt_date
 
-  AMA_BEGIN_DATE = Date.new(2018, 4, 17).freeze
+  AMA_BEGIN_DATE = Date.new(2018, 4, 1).freeze
 
   self.abstract_class = true
 


### PR DESCRIPTION
Connects #5927 

Changing the AMA date to something more intuitive, also because it will help us validate a ticket that has taken us a while to set up data for.

Some background on the original AMA date in the code, we set it to the current day when the variable was created, so it is somewhat arbitrary.  We need an AMA date in there in order to prevent dates that are too far in the past, like if someone fat fingered a date from last year.

I think April 1st will also be more intuitive to communicate to others when we are explaining our data needs (as compared to a random day in April).