### PR TITLE
Queue | limit document id field length

### DIFF
--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -34,6 +34,7 @@ import {
   marginBottom,
   marginTop,
   ATTORNEY_COMMENTS_MAX_LENGTH,
+  DOCUMENT_ID_MAX_LENGTH,
   OMO_ATTORNEY_CASE_REVIEW_WORK_PRODUCT_TYPES,
   ISSUE_DISPOSITIONS
 } from './constants';
@@ -264,6 +265,7 @@ class SubmitDecisionView extends React.PureComponent<Props> {
         errorMessage={highlightFormItems ? documentIdErrorMessage : null}
         onChange={(value) => this.props.setDecisionOptions({ document_id: value })}
         value={decisionOpts.document_id}
+        maxLength={DOCUMENT_ID_MAX_LENGTH}
       />
       {this.getJudgeSelectComponent()}
       <TextareaField

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -130,10 +130,12 @@ export const ISSUE_DISPOSITIONS = _.fromPairs(_.zip(
   Object.keys(VACOLS_DISPOSITIONS_BY_ID)
 ));
 
-// max length of VACOLS issue description field `ISSDESC`
+// max length of VACOLS issue description field `ISSUES.ISSDESC`
 export const ISSUE_DESCRIPTION_MAX_LENGTH = 100;
 // max length for Attorney comments `DECASS.DEATCOM`
 export const ATTORNEY_COMMENTS_MAX_LENGTH = 350;
+// max length for document id `DECASS.DEDOCID`
+export const DOCUMENT_ID_MAX_LENGTH = 30;
 
 export const USER_ROLES = {
   ATTORNEY: USER_ROLE_TYPES.attorney,

--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -153,7 +153,10 @@ RSpec.feature "Checkout flows" do
         click_on "Continue"
         expect(page).to have_content("Submit Draft Decision for Review")
 
-        fill_in "document_id", with: "12345"
+        document_id = Array.new(35).map { rand(10) }.join
+        fill_in "document_id", with: document_id
+        expect(page.find("#document_id").value.length).to eq 30
+
         fill_in "notes", with: "this is a decision note"
 
         # Expect this to be populated with all judge_staff we've created


### PR DESCRIPTION
Fixes #6371

### Description
Limits the document id field length during attorney checkout ([Sentry error](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/1909/)).

### Acceptance Criteria 
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

