### PR TITLE
Fixing reader link

### DIFF
--- a/app/models/serializers/idt/v1/appeal_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_serializer.rb
@@ -1,3 +1,4 @@
+# :nocov
 class Idt::V1::AppealSerializer < ActiveModel::Serializer
   # TODO: serialize AMA appeals with this serializer
   def id
@@ -17,3 +18,4 @@ class Idt::V1::AppealSerializer < ActiveModel::Serializer
     object.issues.length
   end
 end
+# :nocov

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -256,7 +256,7 @@ class TaskTable extends React.PureComponent<Props> {
           return null;
         }
 
-        return <ReaderLink appealId={appeal.id}
+        return <ReaderLink appealId={appeal.attributes.vacols_id}
           analyticsSource={CATEGORIES.QUEUE_TABLE}
           redirectUrl={window.location.pathname}
           appeal={appeal} />;


### PR DESCRIPTION
In our refactor we accidentally moved from using the PG appeal id instead of the vacols_id for our reader link.

### Testing Plan
1. Locally try to access a case in reader from Queue.

