### PR TITLE
Fixing appeal factory

### DIFF
--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -32,7 +32,6 @@ FactoryBot.define do
     after(:build) do |appeal, evaluator|
       if evaluator.veteran
         appeal.veteran_file_number = evaluator.veteran.file_number
-        appeal.save
       end
 
       Fakes::VBMSService.document_records ||= {}

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -18,14 +18,10 @@ FactoryBot.define do
 
     established_at { Time.zone.now }
 
-    after(:create) do |appeal, evaluator|
+    after(:create) do |appeal, _evaluator|
       appeal.request_issues.each do |issue|
         issue.review_request = appeal
         issue.save
-      end
-      if evaluator.veteran
-        appeal.veteran_file_number = evaluator.veteran.file_number
-        appeal.save
       end
     end
 
@@ -34,6 +30,11 @@ FactoryBot.define do
     end
 
     after(:build) do |appeal, evaluator|
+      if evaluator.veteran
+        appeal.veteran_file_number = evaluator.veteran.file_number
+        appeal.save
+      end
+
       Fakes::VBMSService.document_records ||= {}
       Fakes::VBMSService.document_records[appeal.veteran_file_number] = evaluator.documents
     end


### PR DESCRIPTION
### Description
This test regularly fails because in a recent change we updated the factory to change the veteran file number after setting documents for the old file number. We move setting the file number into the build part instead of the create part of the factory.

### Acceptance Criteria 
- [ ] The failing test in ama_queue_spec passes

