### PR TITLE
Change of home page

### DIFF
--- a/app/controllers/test/users_controller.rb
+++ b/app/controllers/test/users_controller.rb
@@ -55,7 +55,7 @@ class Test::UsersController < ApplicationController
     {
       name: "Hearing Schedule",
       links: {
-        current_schedule: "/hearings/schedule/build"
+        current_schedule: "/hearings/schedule"
       }
     },
     {

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -87,7 +87,6 @@
   "JUDGE_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL": "If you need to make any changes, please manage this case in DAS.",
   "JUDGE_CHECKOUT_DISPATCH_SUCCESS_MESSAGE_TITLE": "Thank you for reviewing %s's decision.",
 
-  "HEARING_SCHEDULE_BUILD_WELCOME_PAGE_HEADER": "Welcome to Caseflow Hearing Schedule!",
   "HEARING_SCHEDULE_BUILD_WELCOME_PAGE_BUILD_HEADER": "Build Schedule",
   "HEARING_SCHEDULE_BUILD_WELCOME_PAGE_BUILD_DESCRIPTION": "To build the schedule, please download one of the templates and fill it with the appropriate data. Then, click the \"Upload files\" button to import your completed .xlsx file.",
   "HEARING_SCHEDULE_BUILD_WELCOME_PAGE_DOWNLOAD_LINK": "Download templates",

--- a/client/app/hearingSchedule/HearingScheduleApp.jsx
+++ b/client/app/hearingSchedule/HearingScheduleApp.jsx
@@ -18,6 +18,7 @@ class HearingScheduleApp extends React.PureComponent {
   render = () => <BrowserRouter basename="/hearings">
     <NavigationBar
       wideApp
+      defaultUrl="/schedule"
       userDisplayName={this.props.userDisplayName}
       dropdownUrls={this.props.dropdownUrls}
       logoProps={{
@@ -30,26 +31,29 @@ class HearingScheduleApp extends React.PureComponent {
         <div className="cf-wide-app">
           <PageRoute
             exact
-            path="/schedule/build"
-            title="Caseflow Hearing Schedule"
-            component={BuildScheduleContainer}
-          />
-          <PageRoute
-            exact
             path="/schedule"
             title="Scheduled Hearings"
             component={ListScheduleContainer}
           />
           <PageRoute
             exact
+            path="/schedule/build"
+            title="Caseflow Hearing Schedule"
+            breadcrumb="Build"
+            component={BuildScheduleContainer}
+          />
+          <PageRoute
+            exact
             path="/schedule/build/upload"
             title="Upload Files"
+            breadcrumb="Upload"
             component={BuildScheduleUploadContainer}
           />
           <PageRoute
             exact
             path="/schedule/build/upload/:schedulePeriodId"
-            title="Upload Files"
+            title="Review Assignments"
+            breadcrumb="Review"
             component={ReviewAssignmentsContainer}
           />
         </div>

--- a/client/app/hearingSchedule/components/BuildSchedule.jsx
+++ b/client/app/hearingSchedule/components/BuildSchedule.jsx
@@ -109,8 +109,7 @@ export default class BuildSchedule extends React.Component {
         message={successMessage}
         styling={alertStyling}
       />}
-      <h1>{COPY.HEARING_SCHEDULE_BUILD_WELCOME_PAGE_HEADER}</h1>
-      <h2>{COPY.HEARING_SCHEDULE_BUILD_WELCOME_PAGE_BUILD_HEADER}</h2>
+      <h1>{COPY.HEARING_SCHEDULE_BUILD_WELCOME_PAGE_BUILD_HEADER}</h1>
       <p>{COPY.HEARING_SCHEDULE_BUILD_WELCOME_PAGE_BUILD_DESCRIPTION}</p>
       <DropdownButton
         lists={downloadOptions}

--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -14,7 +14,9 @@ const hearingSchedStyling = css({
   marginTop: '70px'
 });
 
-const fullWidth = css({ width: '100%' });
+const inlineFormStyling = css({
+  marginTop: '80px'
+});
 
 export default class ListSchedule extends React.Component {
 
@@ -61,28 +63,30 @@ export default class ListSchedule extends React.Component {
 
     return <AppSegment filledBackground>
       <h1 className="cf-push-left">{COPY.HEARING_SCHEDULE_VIEW_PAGE_HEADER}</h1>
-      <span className="cf-push-right"><Link button="primary">Build Schedule</Link></span>
-      <InlineForm>
-        <BasicDateRangeSelector
-          startDateName="fromDate"
-          startDateValue={this.props.startDateValue}
-          startDateLabel={COPY.HEARING_SCHEDULE_VIEW_START_DATE_LABEL}
-          endDateName="toDate"
-          endDateValue={this.props.endDateValue}
-          endDateLabel={COPY.HEARING_SCHEDULE_VIEW_END_DATE_LABEL}
-          onStartDateChange={this.props.startDateChange}
-          onEndDateChange={this.props.endDateChange}
-        />
-        &nbsp;&nbsp;&nbsp;&nbsp;
-        <div {...hearingSchedStyling}>
-          <Link
-            name="apply"
-            to="/schedule"
-            onClick={this.props.onApply}>
-            {COPY.HEARING_SCHEDULE_VIEW_PAGE_APPLY_LINK}
-          </Link>
-        </div>
-      </InlineForm>
+      <span className="cf-push-right"><Link button="primary" to="/schedule/build">Build Schedule</Link></span>
+      <div {...inlineFormStyling} >
+        <InlineForm>
+          <BasicDateRangeSelector
+            startDateName="fromDate"
+            startDateValue={this.props.startDateValue}
+            startDateLabel={COPY.HEARING_SCHEDULE_VIEW_START_DATE_LABEL}
+            endDateName="toDate"
+            endDateValue={this.props.endDateValue}
+            endDateLabel={COPY.HEARING_SCHEDULE_VIEW_END_DATE_LABEL}
+            onStartDateChange={this.props.startDateChange}
+            onEndDateChange={this.props.endDateChange}
+          />
+          &nbsp;&nbsp;&nbsp;&nbsp;
+          <div {...hearingSchedStyling}>
+            <Link
+              name="apply"
+              to="/schedule"
+              onClick={this.props.onApply}>
+              {COPY.HEARING_SCHEDULE_VIEW_PAGE_APPLY_LINK}
+            </Link>
+          </div>
+        </InlineForm>
+      </div>
       <Table
         columns={hearingScheduleColumns}
         rowObjects={hearingScheduleRows}

--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -14,6 +14,8 @@ const hearingSchedStyling = css({
   marginTop: '70px'
 });
 
+const fullWidth = css({ width: '100%' });
+
 export default class ListSchedule extends React.Component {
 
   render() {
@@ -58,7 +60,8 @@ export default class ListSchedule extends React.Component {
     }));
 
     return <AppSegment filledBackground>
-      <h1>{COPY.HEARING_SCHEDULE_VIEW_PAGE_HEADER}</h1>
+      <h1 className="cf-push-left">{COPY.HEARING_SCHEDULE_VIEW_PAGE_HEADER}</h1>
+      <span className="cf-push-right"><Link button="primary">Build Schedule</Link></span>
       <InlineForm>
         <BasicDateRangeSelector
           startDateName="fromDate"

--- a/spec/feature/out_of_service_spec.rb
+++ b/spec/feature/out_of_service_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature "Out of Service" do
 
     scenario "When out of service is disabled, it shows hearing schedule page" do
       visit "/hearings/schedule/build"
-      expect(page).to have_content("Welcome to Caseflow Hearing Schedule!")
+      expect(page).to have_content("Build Schedule")
       expect(page).to_not have_content("Technical Difficulties")
     end
 
@@ -142,7 +142,7 @@ RSpec.feature "Out of Service" do
       Rails.cache.write("hearing_schedule_out_of_service", true)
       visit "/hearings/schedule/build"
       expect(page).to have_content("Technical Difficulties")
-      expect(page).to_not have_content("Welcome to Caseflow Hearing Schedule!")
+      expect(page).to_not have_content("Build Schedule")
     end
   end
 


### PR DESCRIPTION
Connects #6321 

### Description
This PR updates Hearing Scheduling's homepage to be /schedule. It also updates the breadcrumbs.

### Testing Plan
1. Go to /test/users
1. Click on the hearing scheduling link
1. Confirm the 'View Schedule' page renders correctly
1. Confirm clicking 'Build Schedule' takes you to 'hearings/schedule/build'
1. Confirm breadcrumbs / links work

