### PR TITLE
Alert for finalized schedule periods

### DIFF
--- a/client/app/components/StatusMessage.jsx
+++ b/client/app/components/StatusMessage.jsx
@@ -68,7 +68,10 @@ StatusMessage.defaultProps = {
 StatusMessage.props = {
   checklist: PropTypes.array,
   leadMessageList: PropTypes.array,
-  messageText: PropTypes.string,
+  messageText: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node
+  ]),
   title: PropTypes.string,
   type: PropTypes.string
 };

--- a/client/app/hearingSchedule/components/ReviewAssignments.jsx
+++ b/client/app/hearingSchedule/components/ReviewAssignments.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Redirect } from 'react-router-dom';
 import _ from 'lodash';
 import { css } from 'glamor';
 import COPY from '../../../COPY.json';
@@ -83,7 +82,7 @@ export default class ReviewAssignments extends React.Component {
       return <StatusMessage
         type="status"
         title="This page has expired."
-        leadMessageList={["Please return to the homepage", <Link>Go back to home</Link>]}
+        messageText={<Link to="/schedule">Go back to home</Link>}
       />;
     }
 

--- a/client/app/hearingSchedule/components/ReviewAssignments.jsx
+++ b/client/app/hearingSchedule/components/ReviewAssignments.jsx
@@ -10,6 +10,7 @@ import Alert from '../../components/Alert';
 import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import Table from '../../components/Table';
+import StatusMessage from '../../components/StatusMessage';
 import { formatDate } from '../../util/DateUtil';
 import { SPREADSHEET_TYPES } from '../constants';
 
@@ -79,7 +80,11 @@ export default class ReviewAssignments extends React.Component {
   render() {
 
     if (this.props.schedulePeriod.finalized) {
-      return <Redirect to="/schedule/build" />;
+      return <StatusMessage
+        type="status"
+        title="This page has expired."
+        leadMessageList={["Please return to the homepage", <Link>Go back to home</Link>]}
+      />;
     }
 
     let hearingAssignmentColumns = [

--- a/client/app/hearingSchedule/containers/BuildScheduleContainer.jsx
+++ b/client/app/hearingSchedule/containers/BuildScheduleContainer.jsx
@@ -28,7 +28,7 @@ class BuildScheduleContainer extends React.PureComponent {
   };
 
   sendAssignments = () => {
-    if (_.isEmpty(this.props.schedulePeriod)) {
+    if (_.isEmpty(this.props.schedulePeriod) || this.props.schedulePeriod.finalized === true) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
Connects #6345 

### Description
Instead of immediately redirecting to the homepage, we display a StatusPage alerting the user the page has expired. We also added a requirement that the schedulePeriod is not finalized to the VACOLS upload backend request.

### Testing Plan
1. Create a schedule period
1. Go to hearings/schedule/build/upload/${id} and confirm the page renders correctly
1. Update the schedule period so finalized = true
1. Go to hearings/schedule/build/upload/${id} and confirm the StatusPage renders correctly
1. Go to hearings/schedule/build and confirm we don't send a request to the VACOLS upload and the success message is not displayed
