### PR TITLE
Video records should be type "C" in the VACOLS DB.

### DIFF
--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -97,7 +97,8 @@ class VACOLS::CaseHearing < VACOLS::Record
                             name: "create_hearing") do
         create(attrs.merge(addtime: VacolsHelper.local_time_with_utc_timezone,
                            adduser: current_user_slogid,
-                           folder_nr: hearing_info[:regional_office] ? "VIDEO #{hearing_info[:regional_office]}" : nil))
+                           folder_nr: hearing_info[:regional_office] ? "VIDEO #{hearing_info[:regional_office]}" : nil,
+                           hearing_type: "C"))
       end
     end
 
@@ -131,7 +132,7 @@ class VACOLS::CaseHearing < VACOLS::Record
     def select_schedule_days
       select(:hearing_pkseq,
              :hearing_date,
-             :hearing_type,
+             "CASE WHEN FOLDER_NR LIKE 'VIDEO%' THEN 'V' ELSE FOLDER_NR END AS hearing_type",
              :folder_nr,
              :room,
              :board_member,


### PR DESCRIPTION
Connects #6350 

### Description
Video records should be type "C" in the VACOLS DB. All changes in VACOLS model CaseHearings.

### Acceptance Criteria 
- [ ] Code compiles correctly

### Testing Plan
1. Run RO schedule creation. 
2. Check DB, all rows in hearsched have C for hearing_type
3. View current schedule in the UI and all hearings have proper hearing type, video or Central.

