### PR TITLE
Add Germany to list of countries that gives user Postal Code error

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -21,7 +21,7 @@ class Veteran < ApplicationRecord
     "DIS" => "Discharge"
   }.freeze
 
-  COUNTRIES_REQUIRING_ZIP = %w[USA CANADA].freeze
+  COUNTRIES_REQUIRING_ZIP = %w[USA CANADA GERMANY].freeze
 
   validates :ssn, :sex, :first_name, :last_name, :city,
             :address_line1, :country, presence: true, on: :bgs


### PR DESCRIPTION
Connects #6285 

Temporarily add Germany to the list of countries that requires a Postal Code, so that users get the error and can go add it in VBMS, allowing them to proceed with the intake.

VBMS has a bug which we expect to be deployed around August 18th, after which we can remove Germany from this list (because they aren't really required to have a postal code).
