### PR TITLE
Queue | Filter undecided issues for all users

### DIFF
--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -143,11 +143,8 @@ export const buildCaseReviewPayload = (
       }
     }
   };
-  let issueList = issues;
 
   if (userRole === USER_ROLES.ATTORNEY) {
-    issueList = getUndecidedIssues(issues);
-
     _.extend(payload.data.tasks, { document_type: decision.type });
   } else {
     args.factors_not_considered = _.keys(args.factors_not_considered);
@@ -156,7 +153,7 @@ export const buildCaseReviewPayload = (
     _.extend(payload.data.tasks, args);
   }
 
-  payload.data.tasks.issues = issueList.map((issue) => _.extend({},
+  payload.data.tasks.issues = getUndecidedIssues(issues).map((issue) => _.extend({},
     _.pick(issue, ['vacols_sequence_id', 'remand_reasons', 'type', 'readjudication']),
     { disposition: _.capitalize(issue.disposition) }
   ));

--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -364,7 +364,10 @@ RSpec.feature "Checkout flows" do
           :assigned,
           user: judge_user,
           assigner: attorney_user,
-          case_issues: [FactoryBot.create(:case_issue, :disposition_allowed)],
+          case_issues: [
+            FactoryBot.create(:case_issue, :disposition_allowed),
+            FactoryBot.create(:case_issue, :disposition_granted_by_aoj)
+          ],
           work_product: work_product
         )
       )
@@ -392,6 +395,10 @@ RSpec.feature "Checkout flows" do
           expect(visible_options.length).to eq 1
           expect(visible_options.first.text).to eq COPY::JUDGE_CHECKOUT_DISPATCH_LABEL
         end
+
+        # one issue is decided, excluded from checkout flow
+        expect(appeal.issues.length).to eq 2
+        expect(page.find_all(".issue-disposition-dropdown").length).to eq 1
 
         click_on "Continue"
         expect(page).to have_content("Evaluate Decision")


### PR DESCRIPTION
### Description
During decision draft checkout flows, we [filter out all decided issues](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/queue/utils.js#L124). However, we were [only calling this function](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/queue/utils.js#L148) for Attorneys.

### Acceptance Criteria 
- [ ] Judge draft decision flow for appeal w/already-decided issues is successful

### Testing Plan
1. Go to `/queue` as BVAAABSHIRE
2. Go to Juana Z Ullrich's appeal (202708586), do checkout flow
3. Confirm only 3 issues appear in Review Dispositions screen (2 are already decided), confirm flow completes successfully

