### PR TITLE
Queue | Make success message an object

### DIFF
--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -114,11 +114,11 @@ class AddEditIssueView extends React.Component {
     let requestPromise;
 
     if (this.props.action === 'add') {
-      requestPromise = this.props.requestSave(url, params, 'You created a new issue.');
+      requestPromise = this.props.requestSave(url, params, { title: 'You created a new issue.' });
     } else {
       requestPromise = this.props.requestUpdate(
         `${url}/${issue.vacols_sequence_id}`, params,
-        `You updated issue ${issueIndex + 1}.`
+        { title: `You updated issue ${issueIndex + 1}.` }
       );
     }
 
@@ -159,7 +159,7 @@ class AddEditIssueView extends React.Component {
 
     this.props.requestDelete(
       `/appeals/${appeal.id}/issues/${issue.vacols_sequence_id}`, {},
-      `You deleted issue ${issueIndex + 1}.`
+      { title: `You deleted issue ${issueIndex + 1}.` }
     ).then((resp) => this.props.deleteEditingAppealIssue(appealId, issueId, JSON.parse(resp.text)));
   };
 

--- a/client/app/queue/AssignedCasesPage.jsx
+++ b/client/app/queue/AssignedCasesPage.jsx
@@ -15,7 +15,7 @@ import {
 } from './uiReducer/uiActions';
 import Alert from '../components/Alert';
 import type { Task, LegacyAppeals } from './types/models';
-import type { AttorneysOfJudge, AttorneyAppealsLoadingState, UiStateError, State } from './types/state';
+import type { AttorneysOfJudge, AttorneyAppealsLoadingState, UiStateMessage, State } from './types/state';
 
 type Params = {|
   match: Object
@@ -28,8 +28,8 @@ type Props = Params & {|
   featureToggles: Object,
   selectedTasks: Array<Task>,
   attorneyAppealsLoadingState: AttorneyAppealsLoadingState,
-  success: string,
-  error: ?UiStateError,
+  success: ?UiStateMessage,
+  error: ?UiStateMessage,
   // Action creators
   resetSuccessMessages: typeof resetSuccessMessages,
   resetErrorMessages: typeof resetErrorMessages,
@@ -78,7 +78,7 @@ class AssignedCasesPage extends React.Component<Props> {
     return <React.Fragment>
       <h2>{attorneyName}'s Cases</h2>
       {error && <Alert type="error" title={error.title} message={error.detail} scrollOnAlert={false} />}
-      {success && <Alert type="success" title={success} scrollOnAlert={false} />}
+      {success && <Alert type="success" title={success.title} message={success.detail} scrollOnAlert={false} />}
       {featureToggles.judge_assignment_to_attorney &&
         <AssignWidget
           previousAssigneeId={attorneyId}

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -58,8 +58,8 @@ class AttorneyTaskListView extends React.PureComponent {
         {messages.error && <Alert type="error" title={messages.error.title}>
           {messages.error.detail}
         </Alert>}
-        {messages.success && <Alert type="success" title={messages.success}>
-          {COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
+        {messages.success && <Alert type="success" title={messages.success.title}>
+          {messages.success.detail || COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
         </Alert>}
         <TaskTable
           includeDetailsLink

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -51,7 +51,9 @@ class CaseDetailsView extends React.PureComponent {
       {error && <Alert title={error.title} type="error">
         {error.detail}
       </Alert>}
-      {success && <Alert type="success" title={success.title} message={success.detail} scrollOnAlert={false} />}
+      {success && <Alert type="success" title={success.title} scrollOnAlert={false}>
+        {success.detail}
+      </Alert>}
       <CaseSnapshot appeal={appeal} task={task} />
       <hr {...horizontalRuleStyling} />
       <StickyNavContentArea>

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -33,32 +33,42 @@ const PowerOfAttorneyDetail = ({ poa }) => <p>{poa.representative_type} - {poa.r
 class CaseDetailsView extends React.PureComponent {
   componentWillUnmount = () => {
     this.props.clearActiveAppealAndTask();
-  }
+  };
 
   componentDidMount = () => window.analyticsEvent(CATEGORIES.QUEUE_TASK, TASK_ACTIONS.VIEW_APPEAL_INFO);
 
-  render = () => <AppSegment filledBackground>
-    <CaseTitle appeal={this.props.appeal} appealId={this.props.appealId} redirectUrl={window.location.pathname} />
-    {this.props.error && <Alert title={this.props.error.title} type="error">
-      {this.props.error.detail}
-    </Alert>}
-    {this.props.success && <Alert type="success" title={this.props.success} scrollOnAlert={false} />}
-    <CaseSnapshot appeal={this.props.appeal} task={this.props.task} />
-    <hr {...horizontalRuleStyling} />
-    <StickyNavContentArea>
-      <CaseDetailsIssueList
-        title="Issues"
-        isLegacyAppeal={this.props.appeal.attributes.is_legacy_appeal}
-        issues={this.props.appeal.attributes.issues}
-      />
-      <PowerOfAttorneyDetail title="Power of Attorney" poa={this.props.appeal.attributes.power_of_attorney} />
-      { this.props.appeal.attributes.hearings.length &&
-        <CaseHearingsDetail title="Hearings" appeal={this.props.appeal} /> }
-      <VeteranDetail title="About the Veteran" appeal={this.props.appeal} />
-      { !_.isNull(this.props.appeal.attributes.appellant_full_name) &&
-        <AppellantDetail title="About the Appellant" appeal={this.props.appeal} /> }
-    </StickyNavContentArea>
-  </AppSegment>;
+  render = () => {
+    const {
+      appealId,
+      appeal,
+      task,
+      error,
+      success
+    } = this.props;
+
+    return <AppSegment filledBackground>
+      <CaseTitle appeal={appeal} appealId={appealId} redirectUrl={window.location.pathname} />
+      {error && <Alert title={error.title} type="error">
+        {error.detail}
+      </Alert>}
+      {success && <Alert type="success" title={success.title} message={success.detail} scrollOnAlert={false} />}
+      <CaseSnapshot appeal={appeal} task={task} />
+      <hr {...horizontalRuleStyling} />
+      <StickyNavContentArea>
+        <CaseDetailsIssueList
+          title="Issues"
+          isLegacyAppeal={appeal.attributes.is_legacy_appeal}
+          issues={appeal.attributes.issues}
+        />
+        <PowerOfAttorneyDetail title="Power of Attorney" poa={appeal.attributes.power_of_attorney} />
+        {appeal.attributes.hearings.length &&
+        <CaseHearingsDetail title="Hearings" appeal={appeal} />}
+        <VeteranDetail title="About the Veteran" appeal={appeal} />
+        {!_.isNull(appeal.attributes.appellant_full_name) &&
+        <AppellantDetail title="About the Appellant" appeal={appeal} />}
+      </StickyNavContentArea>
+    </AppSegment>;
+  };
 }
 
 CaseDetailsView.propTypes = {

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -133,7 +133,7 @@ class EvaluateDecisionView extends React.PureComponent {
     });
     const successMsg = sprintf(COPY.JUDGE_CHECKOUT_DISPATCH_SUCCESS_MESSAGE_TITLE, appeal.veteran_full_name);
 
-    this.props.requestSave(`/case_reviews/${task.task_id}/complete`, payload, successMsg).
+    this.props.requestSave(`/case_reviews/${task.task_id}/complete`, payload, { title: successMsg }).
       then(() => this.props.deleteAppeal(appealId));
   }
 

--- a/client/app/queue/JudgeReviewTaskListView.jsx
+++ b/client/app/queue/JudgeReviewTaskListView.jsx
@@ -64,8 +64,8 @@ class JudgeReviewTaskListView extends React.PureComponent {
       {messages.error && <Alert type="error" title={messages.error.title}>
         {messages.error.detail}
       </Alert>}
-      {messages.success && <Alert type="success" title={messages.success}>
-        {COPY.JUDGE_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
+      {messages.success && <Alert type="success" title={messages.success.title}>
+        {messages.success.detail || COPY.JUDGE_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
       </Alert>}
       {tableContent}
     </AppSegment>;

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -119,7 +119,7 @@ class SelectDispositionsView extends React.PureComponent {
 
   render = () => {
     const {
-      saveResult,
+      success,
       appealId,
       appeal: { attributes: { issues } }
     } = this.props;
@@ -131,7 +131,7 @@ class SelectDispositionsView extends React.PureComponent {
       <p className="cf-lead-paragraph" {...marginBottom(2)}>
         Review each issue and assign the appropriate dispositions.
       </p>
-      {saveResult && <Alert type="success" title={saveResult} styling={smallTopMargin} />}
+      {success && <Alert type="success" title={success.title} message={success.detail} styling={smallTopMargin} />}
       <hr />
       <Table
         columns={this.getColumns}
@@ -154,7 +154,7 @@ SelectDispositionsView.propTypes = {
 
 const mapStateToProps = (state, ownProps) => ({
   appeal: state.queue.stagedChanges.appeals[ownProps.appealId],
-  saveResult: state.ui.messages.success,
+  success: state.ui.messages.success,
   ..._.pick(state.ui, 'userRole')
 });
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -50,8 +50,7 @@ import type { UiStateMessage } from './types/state';
 
 type Params = {|
   appealId: string,
-  nextStep: string,
-  requestSave: typeof requestSave
+  nextStep: string
 |};
 
 type Props = Params & {|
@@ -66,7 +65,7 @@ type Props = Params & {|
   // dispatch
   setDecisionOptions: typeof setDecisionOptions,
   resetDecisionOptions: typeof resetDecisionOptions,
-  requestSave: typeof requestSave,
+  requestSave: Function,
   deleteAppeal: typeof deleteAppeal
 |};
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -50,7 +50,8 @@ import type { UiStateMessage } from './types/state';
 
 type Params = {|
   appealId: string,
-  nextStep: string
+  nextStep: string,
+  requestSave: typeof requestSave
 |};
 
 type Props = Params & {|

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -134,7 +134,7 @@ class SubmitDecisionView extends React.PureComponent<Props> {
     const successMsg = `Thank you for drafting ${fields.veteran}'s ${fields.type}. It's
     been sent to ${fields.judge} for review.`;
 
-    this.props.requestSave(`/case_reviews/${taskId}/complete`, payload, successMsg).
+    this.props.requestSave(`/case_reviews/${taskId}/complete`, payload, { title: successMsg }).
       then(() => this.props.deleteAppeal(appealId));
   };
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -65,7 +65,7 @@ type Props = Params & {|
   // dispatch
   setDecisionOptions: typeof setDecisionOptions,
   resetDecisionOptions: typeof resetDecisionOptions,
-  requestSave: Function,
+  requestSave: typeof requestSave,
   deleteAppeal: typeof deleteAppeal
 |};
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -46,7 +46,7 @@ import type {
   LegacyAppeal,
   Judges
 } from './types/models';
-import type { UiStateError } from './types/state';
+import type { UiStateMessage } from './types/state';
 
 type Params = {|
   appealId: string,
@@ -61,7 +61,7 @@ type Props = Params & {|
   task: Task,
   highlightFormItems: Boolean,
   userRole: string,
-  error: ?UiStateError,
+  error: ?UiStateMessage,
   // dispatch
   setDecisionOptions: typeof setDecisionOptions,
   resetDecisionOptions: typeof resetDecisionOptions,

--- a/client/app/queue/UnassignedCasesPage.jsx
+++ b/client/app/queue/UnassignedCasesPage.jsx
@@ -15,7 +15,7 @@ import {
 import { judgeAssignAppealsSelector, selectedTasksSelector } from './selectors';
 import type { Task, LegacyAppeals } from './types/models';
 import Alert from '../components/Alert';
-import type { UiStateError } from './types/state';
+import type { UiStateMessage } from './types/state';
 
 type Params = {|
   userId: string,
@@ -25,8 +25,8 @@ type Props = Params & {|
   // Props
   featureToggles: Object,
   selectedTasks: Array<Task>,
-  error: ?UiStateError,
-  success: string,
+  error: ?UiStateMessage,
+  success: ?UiStateMessage,
   appeals: LegacyAppeals,
   // Action creators
   initialAssignTasksToUser: typeof initialAssignTasksToUser,
@@ -46,7 +46,7 @@ class UnassignedCasesPage extends React.PureComponent<Props> {
     return <React.Fragment>
       <h2>{JUDGE_QUEUE_UNASSIGNED_CASES_PAGE_TITLE}</h2>
       {error && <Alert type="error" title={error.title} message={error.detail} scrollOnAlert={false} />}
-      {success && <Alert type="success" title={success} scrollOnAlert={false} />}
+      {success && <Alert type="success" title={success.title} message={success.detail} scrollOnAlert={false} />}
       {featureToggles.judge_assignment_to_attorney &&
         <AssignWidget
           previousAssigneeId={userId}

--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -96,11 +96,12 @@ class AssignWidget extends React.PureComponent<Props> {
       { tasks: selectedTasks,
         assigneeId,
         previousAssigneeId }).
-      then(() => this.props.showSuccessMessage(
-        sprintf(
-          COPY.ASSIGN_WIDGET_SUCCESS,
-          { numCases: selectedTasks.length,
-            casePlural: pluralize('case', selectedTasks.length) }))).
+      then(() => this.props.showSuccessMessage({
+        title: sprintf(COPY.ASSIGN_WIDGET_SUCCESS, {
+          numCases: selectedTasks.length,
+          casePlural: pluralize('case', selectedTasks.length)
+        })
+      })).
       catch(() => this.props.showErrorMessage(
         { title: COPY.ASSIGN_WIDGET_ASSIGNMENT_ERROR_TITLE,
           detail: COPY.ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL }));

--- a/client/app/queue/components/JudgeActionsDropdown.jsx
+++ b/client/app/queue/components/JudgeActionsDropdown.jsx
@@ -32,7 +32,7 @@ import type { State } from '../types/state';
 const ASSIGN = 'ASSIGN';
 
 type Params = {|
-  appealId: string,
+  appealId: string
 |};
 
 type Props = Params & {|

--- a/client/app/queue/components/JudgeActionsDropdown.jsx
+++ b/client/app/queue/components/JudgeActionsDropdown.jsx
@@ -35,7 +35,8 @@ import type { State } from '../types/state';
 const ASSIGN = 'ASSIGN';
 
 type Params = {|
-  appealId: string
+  appealId: string,
+  requestSave: typeof requestSave
 |};
 
 type Props = Params & {|

--- a/client/app/queue/components/JudgeActionsDropdown.jsx
+++ b/client/app/queue/components/JudgeActionsDropdown.jsx
@@ -43,7 +43,7 @@ type Props = Params & {|
   decision: Object,
   userRole: string,
   // Action creators
-  requestSave: Function,
+  requestSave: typeof requestSave,
   deleteAppeal: typeof deleteAppeal,
   checkoutStagedAppeal: typeof checkoutStagedAppeal,
   stageAppeal: typeof stageAppeal,

--- a/client/app/queue/components/JudgeActionsDropdown.jsx
+++ b/client/app/queue/components/JudgeActionsDropdown.jsx
@@ -12,10 +12,7 @@ import DECASS_WORK_PRODUCT_TYPES from '../../../constants/DECASS_WORK_PRODUCT_TY
 import SearchableDropdown from '../../components/SearchableDropdown';
 
 import { buildCaseReviewPayload } from '../utils';
-import {
-  requestSave,
-  saveSuccess
-} from '../uiReducer/uiActions';
+import { requestSave } from '../uiReducer/uiActions';
 import {
   deleteAppeal,
   checkoutStagedAppeal,
@@ -36,7 +33,6 @@ const ASSIGN = 'ASSIGN';
 
 type Params = {|
   appealId: string,
-  requestSave: typeof requestSave
 |};
 
 type Props = Params & {|
@@ -47,8 +43,7 @@ type Props = Params & {|
   decision: Object,
   userRole: string,
   // Action creators
-  requestSave: typeof requestSave,
-  saveSuccess: typeof saveSuccess,
+  requestSave: Function,
   deleteAppeal: typeof deleteAppeal,
   checkoutStagedAppeal: typeof checkoutStagedAppeal,
   stageAppeal: typeof stageAppeal,
@@ -189,7 +184,6 @@ const mapStateToProps = (state: State, ownProps: Params) => ({
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   requestSave,
-  saveSuccess,
   deleteAppeal,
   checkoutStagedAppeal,
   stageAppeal,

--- a/client/app/queue/components/JudgeActionsDropdown.jsx
+++ b/client/app/queue/components/JudgeActionsDropdown.jsx
@@ -92,7 +92,7 @@ class JudgeActionsDropdown extends React.PureComponent<Props, ComponentState> {
       const payload = buildCaseReviewPayload(decision, userRole, appeal.issues, { location: 'omo_office' });
       const successMsg = sprintf(COPY.JUDGE_CHECKOUT_OMO_SUCCESS_MESSAGE_TITLE, appeal.veteran_full_name);
 
-      this.props.requestSave(`/case_reviews/${task.attributes.task_id}/complete`, payload, successMsg).
+      this.props.requestSave(`/case_reviews/${task.attributes.task_id}/complete`, payload, { title: successMsg }).
         then(() => {
           history.push('');
           history.replace('/queue');

--- a/client/app/queue/components/JudgeStartCheckoutFlowDropdown.jsx
+++ b/client/app/queue/components/JudgeStartCheckoutFlowDropdown.jsx
@@ -11,10 +11,7 @@ import DECASS_WORK_PRODUCT_TYPES from '../../../constants/DECASS_WORK_PRODUCT_TY
 import SearchableDropdown from '../../components/SearchableDropdown';
 
 import { buildCaseReviewPayload } from '../utils';
-import {
-  requestSave,
-  saveSuccess
-} from '../uiReducer/uiActions';
+import { requestSave } from '../uiReducer/uiActions';
 import {
   deleteAppeal,
   checkoutStagedAppeal,
@@ -101,7 +98,6 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   requestSave,
-  saveSuccess,
   deleteAppeal,
   checkoutStagedAppeal,
   stageAppeal,

--- a/client/app/queue/components/JudgeStartCheckoutFlowDropdown.jsx
+++ b/client/app/queue/components/JudgeStartCheckoutFlowDropdown.jsx
@@ -42,7 +42,7 @@ class JudgeStartCheckoutFlowDropdown extends React.PureComponent {
       const payload = buildCaseReviewPayload(decision, userRole, appeal.issues, { location: 'omo_office' });
       const successMsg = sprintf(COPY.JUDGE_CHECKOUT_OMO_SUCCESS_MESSAGE_TITLE, appeal.veteran_full_name);
 
-      this.props.requestSave(`/case_reviews/${task.attributes.task_id}/complete`, payload, successMsg).
+      this.props.requestSave(`/case_reviews/${task.attributes.task_id}/complete`, payload, { title: successMsg }).
         then(() => {
           this.props.deleteAppeal(appealId);
           history.push('');

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -78,7 +78,7 @@ export type State = {
   ui: UiState
 };
 
-type Action = { type: string, payload: Object };
+type Action = { type: string, payload?: Object };
 
 /* eslint-disable no-use-before-define */
 

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -22,14 +22,14 @@ export type CaseDetailState = {|
   activeTask: ?Task
 |};
 
-export type UiStateError = {title: string, detail: string}
+export type UiStateMessage = {title: string, detail: string}
 
 export type UiState = {
   selectingJudge: boolean,
   highlightFormItems: boolean,
   messages: {
-    success: ?string,
-    error: ?UiStateError
+    success: ?UiStateMessage,
+    error: ?UiStateMessage
   },
   saveState: {
     savePending: boolean,

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -22,7 +22,7 @@ export type CaseDetailState = {|
   activeTask: ?Task
 |};
 
-export type UiStateMessage = {title: string, detail: string}
+export type UiStateMessage = {title: string, detail?: string}
 
 export type UiState = {
   selectingJudge: boolean,

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -22,7 +22,7 @@ export type CaseDetailState = {|
   activeTask: ?Task
 |};
 
-export type UiStateMessage = {title: string, detail?: string}
+export type UiStateMessage = { title: string, detail?: string };
 
 export type UiState = {
   selectingJudge: boolean,

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -1,15 +1,17 @@
 // @flow
 import { ACTIONS } from './uiConstants';
 import ApiUtil from '../../util/ApiUtil';
-import _ from 'lodash';
 
-import type { Dispatch } from '../types/state';
+import type {
+  UiStateMessage,
+  Dispatch
+} from '../types/state';
 
 export const resetErrorMessages = () => ({
   type: ACTIONS.RESET_ERROR_MESSAGES
 });
 
-export const showErrorMessage = (errorMessage: Object) => ({
+export const showErrorMessage = (errorMessage: UiStateMessage) => ({
   type: ACTIONS.SHOW_ERROR_MESSAGE,
   payload: {
     errorMessage
@@ -24,7 +26,7 @@ export const resetSuccessMessages = () => ({
   type: ACTIONS.RESET_SUCCESS_MESSAGES
 });
 
-export const showSuccessMessage = (message: Object | string) => ({
+export const showSuccessMessage = (message: UiStateMessage) => ({
   type: ACTIONS.SHOW_SUCCESS_MESSAGE,
   payload: {
     message
@@ -49,8 +51,8 @@ export const setSelectingJudge = (selectingJudge: boolean) => ({
   }
 });
 
-const saveSuccess = (message: Object | string, response: Object) => (dispatch: Dispatch) => {
-  dispatch(showSuccessMessage(_.isObject(message) ? message : { title: message }));
+const saveSuccess = (message: UiStateMessage, response: Object) => (dispatch: Dispatch) => {
+  dispatch(showSuccessMessage(message));
   dispatch({ type: ACTIONS.SAVE_SUCCESS });
 
   return Promise.resolve(response);
@@ -76,7 +78,7 @@ const saveFailure = (resp: Object) => (dispatch: Dispatch) => {
 };
 
 export const requestSave = (
-  url: string, params: Object, successMessage: Object | string, verb: string = 'post'
+  url: string, params: Object, successMessage: UiStateMessage, verb: string = 'post'
 ): Function => (dispatch: Dispatch) => {
   dispatch(hideErrorMessage());
   dispatch(hideSuccessMessage());
@@ -88,9 +90,9 @@ export const requestSave = (
   );
 };
 
-export const requestUpdate = (url: string, params: Object, successMessage: Object | string) =>
+export const requestUpdate = (url: string, params: Object, successMessage: UiStateMessage) =>
   requestSave(url, params, successMessage, 'put');
-export const requestDelete = (url: string, params: Object, successMessage: Object | string) =>
+export const requestDelete = (url: string, params: Object, successMessage: UiStateMessage) =>
   requestSave(url, params, successMessage, 'delete');
 
 export const resetSaveState = () => ({
@@ -122,14 +124,16 @@ export const setUserCssId = (cssId: string) => ({
   payload: { cssId }
 });
 
-export const setSelectedAssignee = ({ assigneeId }: Object) => ({
+type targetAssignee = { assigneeId: string };
+
+export const setSelectedAssignee = ({ assigneeId }: targetAssignee) => ({
   type: ACTIONS.SET_SELECTED_ASSIGNEE,
   payload: {
     assigneeId
   }
 });
 
-export const setSelectedAssigneeSecondary = ({ assigneeId }: Object) => ({
+export const setSelectedAssigneeSecondary = ({ assigneeId }: targetAssignee) => ({
   type: ACTIONS.SET_SELECTED_ASSIGNEE_SECONDARY,
   payload: {
     assigneeId

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -1,12 +1,15 @@
+// @flow
 import { ACTIONS } from './uiConstants';
 import ApiUtil from '../../util/ApiUtil';
 import _ from 'lodash';
+
+import type { Dispatch } from '../types/state';
 
 export const resetErrorMessages = () => ({
   type: ACTIONS.RESET_ERROR_MESSAGES
 });
 
-export const showErrorMessage = (errorMessage) => ({
+export const showErrorMessage = (errorMessage: Object) => ({
   type: ACTIONS.SHOW_ERROR_MESSAGE,
   payload: {
     errorMessage
@@ -21,7 +24,7 @@ export const resetSuccessMessages = () => ({
   type: ACTIONS.RESET_SUCCESS_MESSAGES
 });
 
-export const showSuccessMessage = (message) => ({
+export const showSuccessMessage = (message: Object | string) => ({
   type: ACTIONS.SHOW_SUCCESS_MESSAGE,
   payload: {
     message
@@ -32,28 +35,28 @@ export const hideSuccessMessage = () => ({
   type: ACTIONS.HIDE_SUCCESS_MESSAGE
 });
 
-export const highlightInvalidFormItems = (highlight) => ({
+export const highlightInvalidFormItems = (highlight: boolean) => ({
   type: ACTIONS.HIGHLIGHT_INVALID_FORM_ITEMS,
   payload: {
     highlight
   }
 });
 
-export const setSelectingJudge = (selectingJudge) => ({
+export const setSelectingJudge = (selectingJudge: boolean) => ({
   type: ACTIONS.SET_SELECTING_JUDGE,
   payload: {
     selectingJudge
   }
 });
 
-export const saveSuccess = (message, response) => (dispatch) => {
+export const saveSuccess = (message: Object | string, response: Object) => (dispatch: Dispatch) => {
   dispatch(showSuccessMessage(_.isObject(message) ? message : { title: message }));
   dispatch({ type: ACTIONS.SAVE_SUCCESS });
 
   return Promise.resolve(response);
 };
 
-export const saveFailure = (resp) => (dispatch) => {
+export const saveFailure = (resp: Object) => (dispatch: Dispatch) => {
   const { response } = resp;
   let responseObject = {
     errors: [{
@@ -72,7 +75,9 @@ export const saveFailure = (resp) => (dispatch) => {
   return Promise.reject(responseObject.errors[0]);
 };
 
-export const requestSave = (url, params, successMessage, verb = 'post') => (dispatch) => {
+export const requestSave = (
+  url: string, params: Object, successMessage: Object | string, verb: string = 'post'
+) => (dispatch: Dispatch) => {
   dispatch(hideErrorMessage());
   dispatch(hideSuccessMessage());
   dispatch({ type: ACTIONS.REQUEST_SAVE });
@@ -83,46 +88,48 @@ export const requestSave = (url, params, successMessage, verb = 'post') => (disp
   );
 };
 
-export const requestUpdate = (url, params, successMessage) => requestSave(url, params, successMessage, 'put');
-export const requestDelete = (url, params, successMessage) => requestSave(url, params, successMessage, 'delete');
+export const requestUpdate = (url: string, params: Object, successMessage: Object | string) =>
+  requestSave(url, params, successMessage, 'put');
+export const requestDelete = (url: string, params: Object, successMessage: Object | string) =>
+  requestSave(url, params, successMessage, 'delete');
 
 export const resetSaveState = () => ({
   type: ACTIONS.RESET_SAVE_STATE
 });
 
-export const showModal = (modalType) => ({
+export const showModal = (modalType: string) => ({
   type: ACTIONS.SHOW_MODAL,
   payload: { modalType }
 });
 
-export const hideModal = (modalType) => ({
+export const hideModal = (modalType: string) => ({
   type: ACTIONS.HIDE_MODAL,
   payload: { modalType }
 });
 
-export const setFeatureToggles = (featureToggles) => ({
+export const setFeatureToggles = (featureToggles: Object) => ({
   type: ACTIONS.SET_FEATURE_TOGGLES,
   payload: { featureToggles }
 });
 
-export const setUserRole = (userRole) => ({
+export const setUserRole = (userRole: string) => ({
   type: ACTIONS.SET_USER_ROLE,
   payload: { userRole }
 });
 
-export const setUserCssId = (cssId) => ({
+export const setUserCssId = (cssId: string) => ({
   type: ACTIONS.SET_USER_CSS_ID,
   payload: { cssId }
 });
 
-export const setSelectedAssignee = ({ assigneeId }) => ({
+export const setSelectedAssignee = ({ assigneeId }: Object) => ({
   type: ACTIONS.SET_SELECTED_ASSIGNEE,
   payload: {
     assigneeId
   }
 });
 
-export const setSelectedAssigneeSecondary = ({ assigneeId }) => ({
+export const setSelectedAssigneeSecondary = ({ assigneeId }: Object) => ({
   type: ACTIONS.SET_SELECTED_ASSIGNEE_SECONDARY,
   payload: {
     assigneeId

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -1,5 +1,6 @@
 import { ACTIONS } from './uiConstants';
 import ApiUtil from '../../util/ApiUtil';
+import _ from 'lodash';
 
 export const resetErrorMessages = () => ({
   type: ACTIONS.RESET_ERROR_MESSAGES
@@ -46,7 +47,7 @@ export const setSelectingJudge = (selectingJudge) => ({
 });
 
 export const saveSuccess = (message, response) => (dispatch) => {
-  dispatch(showSuccessMessage(message));
+  dispatch(showSuccessMessage(_.isObject(message) ? message : { title: message }));
   dispatch({ type: ACTIONS.SAVE_SUCCESS });
 
   return Promise.resolve(response);

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -77,7 +77,7 @@ const saveFailure = (resp: Object) => (dispatch: Dispatch) => {
 
 export const requestSave = (
   url: string, params: Object, successMessage: Object | string, verb: string = 'post'
-) => (dispatch: Dispatch) => {
+): Function => (dispatch: Dispatch) => {
   dispatch(hideErrorMessage());
   dispatch(hideSuccessMessage());
   dispatch({ type: ACTIONS.REQUEST_SAVE });

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -49,14 +49,14 @@ export const setSelectingJudge = (selectingJudge: boolean) => ({
   }
 });
 
-export const saveSuccess = (message: Object | string, response: Object) => (dispatch: Dispatch) => {
+const saveSuccess = (message: Object | string, response: Object) => (dispatch: Dispatch) => {
   dispatch(showSuccessMessage(_.isObject(message) ? message : { title: message }));
   dispatch({ type: ACTIONS.SAVE_SUCCESS });
 
   return Promise.resolve(response);
 };
 
-export const saveFailure = (resp: Object) => (dispatch: Dispatch) => {
+const saveFailure = (resp: Object) => (dispatch: Dispatch) => {
   const { response } = resp;
   let responseObject = {
     errors: [{

--- a/client/app/queue/uiReducer/uiReducer.js
+++ b/client/app/queue/uiReducer/uiReducer.js
@@ -39,11 +39,11 @@ const setMessageState = (state, message, msgType) => update(state, {
 
 const setErrorMessageState = (state, message) => setMessageState(state, message, 'error');
 const hideErrorMessage = (state) => setErrorMessageState(state, null);
-const showErrorMessage = (state, errorMsg = 'Error') => setErrorMessageState(state, errorMsg);
+const showErrorMessage = (state, errorMsg = { title: 'Error' }) => setErrorMessageState(state, errorMsg);
 
 const setSuccessMessageState = (state, message) => setMessageState(state, message, 'success');
 const hideSuccessMessage = (state) => setSuccessMessageState(state, null);
-const showSuccessMessage = (state, message = 'Success') => setSuccessMessageState(state, message);
+const showSuccessMessage = (state, message = { title: 'Success' }) => setSuccessMessageState(state, message);
 
 const setModalState = (state, visibility, modalType) => update(state, {
   modal: {


### PR DESCRIPTION
### Description
#5440 (#6414) calls for message detail text that varies by task type. This turns `state.ui.messages.success` into an object with `title` and `detail` (identical to `messages.error`). This also adds Flow typing to `uiActions.js`

Usage:
```javascript
const successMsg = {
  title: `Your IHP has been successfully submitted to ${teamName}`,
  detail: 'If you need to make any changes, please manage this case in DAS.'
};

this.props.requestSave('/tasks', payload, successMsg).
  then(() => this.props.deleteAppeal(this.props.appealId));
```

This will display on `AttorneyTaskListView`, where the [current detail message](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/queue/AttorneyTaskListView.jsx#L62) is `COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL`: `"If you made a mistake please email your judge to resolve the issue."`

### Acceptance Criteria 
- [ ] Tests pass (no user-facing effect until #6414)

### Testing Plan
1. ~Go to ...~

