### PR TITLE
Mwf support ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,19 @@ jobs:
 
       - restore_cache:
           keys:
+            - rbenv-cache-v1-{{ arch }}-{{ checksum ".ruby-version" }}
+
+      - run:
+          name: Setup Ruby
+          command: rbenv install --skip-existing $(cat ~/project/.ruby-version)
+
+      - save_cache:
+          key: rbenv-cache-v1-{{ arch }}-{{ checksum ".ruby-version" }}
+          paths:
+            - .rbenv
+
+      - restore_cache:
+          keys:
             - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
 
       - run: bundle install --path vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
       # The first image listed is the image that all steps run inside of.
       # This can be modified by steps, or can be built as a separate
       # customized container.
-      - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/circleci:latest
+      - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/circleci:mwftest
         environment:
           - DBUS_SESSION_BUS_ADDRESS: /dev/null
           - RAILS_ENV: test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - rbenv-cache-v1-{{ arch }}-{{ checksum ".ruby-version" }}
+            - rbenv-cache-v2-{{ arch }}-{{ checksum ".ruby-version" }}
 
       - run:
           name: Setup Ruby
@@ -50,7 +50,7 @@ jobs:
           command: gem install bundler
 
       - save_cache:
-          key: rbenv-cache-v1-{{ arch }}-{{ checksum ".ruby-version" }}
+          key: rbenv-cache-v2-{{ arch }}-{{ checksum ".ruby-version" }}
           paths:
             - .rbenv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - rbenv-cache-v2-{{ arch }}-{{ checksum ".ruby-version" }}
+            - rbenv-cache-v3-{{ arch }}-{{ checksum ".ruby-version" }}
 
       - run:
           name: Setup Ruby
@@ -50,9 +50,9 @@ jobs:
           command: gem install bundler
 
       - save_cache:
-          key: rbenv-cache-v2-{{ arch }}-{{ checksum ".ruby-version" }}
+          key: rbenv-cache-v3-{{ arch }}-{{ checksum ".ruby-version" }}
           paths:
-            - .rbenv
+            - ~/.rbenv
 
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ jobs:
           name: Setup Ruby
           command: rbenv install --skip-existing $(cat ~/project/.ruby-version)
 
+      - run:
+          name: Setup Bundler
+          command: gem install bundler
+
       - save_cache:
           key: rbenv-cache-v1-{{ arch }}-{{ checksum ".ruby-version" }}
           paths:
@@ -54,7 +58,13 @@ jobs:
           keys:
             - gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
 
-      - run: bundle install --path vendor/bundle
+      - run:
+          name: Ruby version
+          command: ruby -v
+
+      - run:
+          name: Bundle install
+          command: bundle install --path vendor/bundle
 
       - save_cache:
           key: gem-cache-v1-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}

--- a/ci-bin/circle_docker_container/Dockerfile
+++ b/ci-bin/circle_docker_container/Dockerfile
@@ -8,5 +8,11 @@ RUN apt-get install pdftk libaio1 libaio-dev
 ADD instantclient_12_1 /opt/oracle/instantclient_12_1
 ENV LD_LIBRARY_PATH=/opt/oracle/instantclient_12_1
 RUN ln -s /opt/oracle/instantclient_12_1/libclntsh.so.12.1 /opt/oracle/instantclient_12_1/libclntsh.so
+# The default permissions here break rbenv. I'm not sure why. Since the CircleCI
+# user is the only user of this container, hammer the permissions.
+RUN chown -R circleci /usr/local/bundle
 
 USER circleci
+# Explicitly set the rbenv PATHs here so the installation script doesn't error.
+ENV PATH=/home/circleci/.rbenv/bin:/home/circleci/.rbenv/shims:/usr/local/bundle/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+RUN curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer | bash

--- a/ci-bin/circle_docker_container/Dockerfile
+++ b/ci-bin/circle_docker_container/Dockerfile
@@ -1,3 +1,5 @@
+# NOTE: Once we are no longer using the default Ruby environment, we should upgrade
+# our base container to something more recent.
 FROM circleci/ruby:2.2-node-browsers
 
 USER root


### PR DESCRIPTION
Connects #6068 

### Description
Modified the CircleCI container to support .ruby-version by installing rbenv.
Modified the CircleCI config to use .ruby-version.

### Acceptance Criteria 
- [ ] Code compiles correctly
- [ ] Tests pass
- [ ] Ruby versions are used and installed correctly.

### Testing Plan
1. Submit job to CircleCI using existing config. Tests should pass.
2. Use .ruby-version 2.2.4. Tests should pass.
3. Try a different ruby version (2.5.1). Tests should run with new ruby version, may not pass.

