### PR TITLE
Adding fake judge for demo

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -228,6 +228,13 @@ class User < ApplicationRecord
       UserRepository.css_ids_by_vlj_ids(vlj_ids)
     end
 
+    # This method is only used in dev/demo mode to test the judge spreadsheet functionality in hearing scheduling
+    def create_judge_in_vacols(first_name, last_name, vlj_id)
+      return unless Rails.env.development? || Rails.env.demo?
+
+      UserRepository.create_judge_in_vacols(first_name, last_name, vlj_id)
+    end
+
     def system_user
       new(
         station_id: "283",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -229,11 +229,13 @@ class User < ApplicationRecord
     end
 
     # This method is only used in dev/demo mode to test the judge spreadsheet functionality in hearing scheduling
+    # :nocov:
     def create_judge_in_vacols(first_name, last_name, vlj_id)
       return unless Rails.env.development? || Rails.env.demo?
 
       UserRepository.create_judge_in_vacols(first_name, last_name, vlj_id)
     end
+    # :nocov:
 
     def system_user
       new(

--- a/app/repositories/user_repository.rb
+++ b/app/repositories/user_repository.rb
@@ -45,6 +45,7 @@ class UserRepository
     end
 
     # This method is only used in dev/demo mode to test the judge spreadsheet functionality in hearing scheduling
+    # :nocov:
     def create_judge_in_vacols(first_name, last_name, vlj_id)
       return unless Rails.env.development? || Rails.env.demo?
 
@@ -52,7 +53,6 @@ class UserRepository
       VACOLS::Staff.create(snamef: first_name, snamel: last_name, sdomainid: css_id, sattyid: vlj_id)
     end
 
-    # :nocov:
     def css_id_by_full_name(full_name)
       name = full_name.split(" ")
       first_name = name.first

--- a/app/repositories/user_repository.rb
+++ b/app/repositories/user_repository.rb
@@ -44,6 +44,14 @@ class UserRepository
       results
     end
 
+    # This method is only used in dev/demo mode to test the judge spreadsheet functionality in hearing scheduling
+    def create_judge_in_vacols(first_name, last_name, vlj_id)
+      return unless Rails.env.development? || Rails.env.demo?
+
+      css_id = ["BVA", first_name.first, last_name].join
+      VACOLS::Staff.create(snamef: first_name, snamel: last_name, sdomainid: css_id, sattyid: vlj_id)
+    end
+
     # :nocov:
     def css_id_by_full_name(full_name)
       name = full_name.split(" ")

--- a/app/services/hearing_schedule/validate_judge_spreadsheet.rb
+++ b/app/services/hearing_schedule/validate_judge_spreadsheet.rb
@@ -26,10 +26,25 @@ class HearingSchedule::ValidateJudgeSpreadsheet
     end
   end
 
+  # This method is only used in dev/demo mode to test the judge spreadsheet functionality
+  def find_or_create_judges_in_vacols(vacols_judges, name, vlj_id)
+    return unless Rails.env.development? || Rails.env.demo?
+
+    if vacols_judges[vlj_id] &&
+       vacols_judges[vlj_id][:first_name] == name.split(", ")[1].strip &&
+       vacols_judges[vlj_id][:last_name] == name.split(", ")[0].strip
+      true
+    else
+      User.create_judge_in_vacols(name.split(", ")[1].strip, name.split(", ")[0].strip, vlj_id)
+    end
+  end
+
   def judge_in_vacols?(vacols_judges, name, vlj_id)
+    return find_or_create_judges_in_vacols(vacols_judges, name, vlj_id) if Rails.env.development? || Rails.env.demo?
+
     vacols_judges[vlj_id] &&
-      vacols_judges[vlj_id][:first_name] == name.split(", ")[1] &&
-      vacols_judges[vlj_id][:last_name] == name.split(", ")[0]
+      vacols_judges[vlj_id][:first_name] == name.split(", ")[1].strip &&
+      vacols_judges[vlj_id][:last_name] == name.split(", ")[0].strip
   end
 
   def check_range_of_dates(date)

--- a/app/services/hearing_schedule/validate_judge_spreadsheet.rb
+++ b/app/services/hearing_schedule/validate_judge_spreadsheet.rb
@@ -27,6 +27,7 @@ class HearingSchedule::ValidateJudgeSpreadsheet
   end
 
   # This method is only used in dev/demo mode to test the judge spreadsheet functionality
+  # :nocov:
   def find_or_create_judges_in_vacols(vacols_judges, name, vlj_id)
     return unless Rails.env.development? || Rails.env.demo?
 
@@ -38,6 +39,7 @@ class HearingSchedule::ValidateJudgeSpreadsheet
       User.create_judge_in_vacols(name.split(", ")[1].strip, name.split(", ")[0].strip, vlj_id)
     end
   end
+  # :nocov:
 
   def judge_in_vacols?(vacols_judges, name, vlj_id)
     return find_or_create_judges_in_vacols(vacols_judges, name, vlj_id) if Rails.env.development? || Rails.env.demo?


### PR DESCRIPTION
### Description
Because FACOLS randomizes the attorney information when we reseed, there's no way to test the judge non-availability spreadsheet consistently. I added new functionality just for dev and demo that will add any judge in the spreadsheet to FACOLS.

### Testing Plan
1. Try to upload the attached spreadsheet
1. Confirm new users are created in FACOLS and the algorithm runs successfully

[demoJudge.xlsx](https://github.com/department-of-veterans-affairs/caseflow/files/2253528/demoJudge.xlsx)


