### PR TITLE
Judge can reassign AMA case to another attorney

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,6 +28,16 @@ class TasksController < ApplicationController
     render json: { tasks: json_tasks(tasks) }
   end
 
+  # e.g, for legacy appeal => POST /tasks,
+  # { type: ColocatedTask, external_id: 123423, title: "poa_clarification", instructions: "poa is missing" }
+  #
+  # e.g, for ama appeal => POST /tasks,
+  # { type: AttorneyTask,
+  #   external_id: "2CE3BEB0-FA7D-4ACA-A8D2-1F7D2BDFB1E7",
+  #   title: "something",
+  #   parent_id: 2,
+  #   assigned_to_id: 23
+  #  }
   def create
     return invalid_type_error unless task_class
 
@@ -37,8 +47,12 @@ class TasksController < ApplicationController
     render json: { tasks: json_tasks(tasks) }, status: :created
   end
 
+  # e.g, for ama appeal => PATCH /tasks/:id,
+  # { type: AttorneyTask,
+  #   assigned_to_id: 23
+  # }
   def update
-    if task.assigned_to != current_user
+    if task.assigned_to != current_user && task.assigned_by != current_user
       redirect_to "/unauthorized"
       return
     end
@@ -87,7 +101,7 @@ class TasksController < ApplicationController
 
   def update_params
     params.require("task")
-      .permit(:status, :on_hold_duration)
+      .permit(:status, :on_hold_duration, :assigned_to_id)
   end
 
   def json_tasks(tasks)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -51,6 +51,11 @@ class TasksController < ApplicationController
   # { type: AttorneyTask,
   #   assigned_to_id: 23
   # }
+  # e.g, for ama appeal => PATCH /tasks/:id,
+  # { type: ColocatedtTask,
+  #   status: :on_hold,
+  #   on_hold_duration: "something"
+  # }
   def update
     if task.assigned_to != current_user && task.assigned_by != current_user
       redirect_to "/unauthorized"

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -47,11 +47,11 @@ class TasksController < ApplicationController
     render json: { tasks: json_tasks(tasks) }, status: :created
   end
 
-  # e.g, for ama appeal => PATCH /tasks/:id,
+  # e.g, for ama/legacy appeal => PATCH /tasks/:id,
   # { type: AttorneyTask,
   #   assigned_to_id: 23
   # }
-  # e.g, for ama appeal => PATCH /tasks/:id,
+  # e.g, for ama/legacy appeal => PATCH /tasks/:id,
   # { type: ColocatedtTask,
   #   status: :on_hold,
   #   on_hold_duration: "something"

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -28,9 +28,21 @@ class TasksController < ApplicationController
     render json: { tasks: json_tasks(tasks) }
   end
 
+  # To create colocated task
   # e.g, for legacy appeal => POST /tasks,
-  # { type: ColocatedTask, external_id: 123423, title: "poa_clarification", instructions: "poa is missing" }
+  # { type: ColocatedTask,
+  #   external_id: 123423,
+  #   title: "poa_clarification",
+  #   instructions: "poa is missing"
+  # }
+  # for ama appeal = POST /tasks,
+  # { type: ColocatedTask,
+  #   external_id: "2CE3BEB0-FA7D-4ACA-A8D2-1F7D2BDFB1E7",
+  #   title: "something",
+  #   parent_id: 2
+  #  }
   #
+  # To create attorney task
   # e.g, for ama appeal => POST /tasks,
   # { type: AttorneyTask,
   #   external_id: "2CE3BEB0-FA7D-4ACA-A8D2-1F7D2BDFB1E7",
@@ -47,10 +59,12 @@ class TasksController < ApplicationController
     render json: { tasks: json_tasks(tasks) }, status: :created
   end
 
+  # To update attorney task
   # e.g, for ama/legacy appeal => PATCH /tasks/:id,
   # { type: AttorneyTask,
   #   assigned_to_id: 23
   # }
+  # To update colocated task
   # e.g, for ama/legacy appeal => PATCH /tasks/:id,
   # { type: ColocatedtTask,
   #   status: :on_hold,

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -1,4 +1,17 @@
 class AttorneyTask < Task
   validates :assigned_by, presence: true
   validates :parent, presence: true, if: :ama?
+
+  validate :assigned_by_role_is_valid
+  validate :assigned_to_role_is_valid
+
+  private
+
+  def assigned_to_role_is_valid
+    errors.add(:assigned_to, "has to be an attorney") if assigned_to && !assigned_to.attorney_in_vacols?
+  end
+
+  def assigned_by_role_is_valid
+    errors.add(:assigned_by, "has to be a judge") if assigned_by && !assigned_by.judge_in_vacols?
+  end
 end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -260,18 +260,21 @@ RSpec.describe TasksController, type: :controller do
   end
 
   describe "PATCH /task/:id" do
-    let(:user) { create(:user) }
+    let(:colocated) { create(:user) }
     let(:attorney) { create(:user) }
+    let(:judge) { create(:user) }
+
     before do
-      User.stub = user
-      create(:staff, :colocated_role, sdomainid: user.css_id)
+      create(:staff, :colocated_role, sdomainid: colocated.css_id)
       create(:staff, :attorney_role, sdomainid: attorney.css_id)
+      create(:staff, :judge_role, sdomainid: judge.css_id)
     end
 
     context "when updating status to in-progress and on-hold" do
-      let(:admin_action) { create(:colocated_task, assigned_by: attorney, assigned_to: user) }
+      let(:admin_action) { create(:colocated_task, assigned_by: attorney, assigned_to: colocated) }
 
       it "should update successfully" do
+        User.stub = colocated
         patch :update, params: { task: { status: "in_progress" }, id: admin_action.id }
         expect(response.status).to eq 200
         response_body = JSON.parse(response.body)["tasks"]["data"]
@@ -287,9 +290,10 @@ RSpec.describe TasksController, type: :controller do
     end
 
     context "when updating status to completed" do
-      let(:admin_action) { create(:colocated_task, assigned_by: attorney, assigned_to: user) }
+      let(:admin_action) { create(:colocated_task, assigned_by: attorney, assigned_to: colocated) }
 
       it "should update successfully" do
+        User.stub = colocated
         patch :update, params: { task: { status: "completed" }, id: admin_action.id }
         expect(response.status).to eq 200
         response_body = JSON.parse(response.body)["tasks"]["data"]
@@ -298,10 +302,25 @@ RSpec.describe TasksController, type: :controller do
       end
     end
 
+    context "when updating assignee" do
+      let(:attorney_task) { create(:ama_attorney_task, assigned_by: judge, assigned_to: attorney) }
+      let(:new_attorney) { create(:user) }
+
+      it "should update successfully" do
+        User.stub = judge
+        create(:staff, :attorney_role, sdomainid: new_attorney.css_id)
+        patch :update, params: { task: { assigned_to_id: new_attorney.id }, id: attorney_task.id }
+        expect(response.status).to eq 200
+        response_body = JSON.parse(response.body)["tasks"]["data"]
+        expect(response_body.first["attributes"]["assigned_to"]["id"]).to eq new_attorney.id
+      end
+    end
+
     context "when some other user updates another user's task" do
       let(:admin_action) { create(:colocated_task, assigned_by: attorney, assigned_to: create(:user)) }
 
       it "should return not be successful" do
+        User.stub = colocated
         patch :update, params: { task: { status: "in_progress" }, id: admin_action.id }
         expect(response.status).to eq 302
       end


### PR DESCRIPTION
Fixes #6312 

### Description
Ability for a judge to reassign a case to another attorney
