### PR TITLE
Refresh schedule periods on page load

### DIFF
--- a/client/app/hearingSchedule/containers/BuildScheduleContainer.jsx
+++ b/client/app/hearingSchedule/containers/BuildScheduleContainer.jsx
@@ -15,10 +15,6 @@ class BuildScheduleContainer extends React.PureComponent {
   }
 
   loadPastUploads = () => {
-    if (!_.isEmpty(this.props.pastUploads)) {
-      return Promise.resolve();
-    }
-
     return ApiUtil.get('/hearings/schedule_periods.json').then((response) => {
       const resp = ApiUtil.convertToCamelCase(JSON.parse(response.text));
       const schedulePeriods = _.keyBy(resp.schedulePeriods, 'id');


### PR DESCRIPTION
Connects #6479 

### Testing Plan
1. Create a judge schedule period 
1. Confirm it's displayed on the build schedule homepage without refreshing the page

