### PR TITLE
Queue Colocated | Add sorting

### DIFF
--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -37,7 +37,8 @@ class AmaTaskTable extends React.PureComponent<Props> {
 
   caseTaskColumn = () => ({
     header: COPY.CASE_LIST_TABLE_TASKS_COLUMN_TITLE,
-    valueFunction: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title]
+    valueFunction: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title],
+    getSortValue: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title]
   })
 
   caseTypeColumn = () => ({

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -35,6 +35,11 @@ class AmaTaskTable extends React.PureComponent<Props> {
     };
   }
 
+  caseTaskColumn = () => ({
+    header: COPY.CASE_LIST_TABLE_TASKS_COLUMN_TITLE,
+    valueFunction: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title]
+  })
+
   caseTypeColumn = () => ({
     header: COPY.CASE_LIST_TABLE_APPEAL_TYPE_COLUMN_TITLE,
     valueFunction: (task: AmaTask) => renderAppealType({ aod: task.attributes.aod,
@@ -48,11 +53,6 @@ class AmaTaskTable extends React.PureComponent<Props> {
 
       return task.attributes.docket_number;
     }
-  })
-
-  caseTaskColumn = () => ({
-    header: COPY.CASE_LIST_TABLE_TASKS_COLUMN_TITLE,
-    valueFunction: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title]
   })
 
   caseDocketNumberColumn = () => ({
@@ -82,8 +82,8 @@ class AmaTaskTable extends React.PureComponent<Props> {
   getQueueColumns = () : Array<{ header: string, span?: Function, valueFunction: Function, getSortValue?: Function }> =>
     _.compact([
       this.caseDetailsColumn(),
-      this.caseTypeColumn(),
       this.caseTaskColumn(),
+      this.caseTypeColumn(),
       this.caseDocketNumberColumn(),
       this.caseDaysWaitingColumn(),
       this.caseReaderLinkColumn()
@@ -96,7 +96,7 @@ class AmaTaskTable extends React.PureComponent<Props> {
       columns={this.getQueueColumns}
       rowObjects={tasks}
       getKeyForRow={this.getKeyForRow}
-      defaultSort={{sortColIdx: 1}} />;
+      defaultSort={{sortColIdx: 2}} />;
   }
 }
 

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -62,12 +62,12 @@ class AmaTaskTable extends React.PureComponent<Props> {
     getSortValue: (task: AmaTask) => task.attributes.docket_number
   })
 
+  daysWaitingOfTask = (task: AmaTask) => moment().startOf('day').diff(moment(task.attributes.assigned_at), 'days')
+
   caseDaysWaitingColumn = () => ({
     header: COPY.CASE_LIST_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
-    valueFunction: (task) => {
-      return moment().startOf('day').
-        diff(moment(task.attributes.assigned_at), 'days');
-    }
+    valueFunction: (task: AmaTask) => this.daysWaitingOfTask(task),
+    getSortValue: (task: AmaTask) => this.daysWaitingOfTask(task)
   })
 
   caseReaderLinkColumn = () => ({

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -58,7 +58,8 @@ class AmaTaskTable extends React.PureComponent<Props> {
 
   caseDocketNumberColumn = () => ({
     header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
-    valueFunction: (task) => task.attributes.docket_number
+    valueFunction: (task: AmaTask) => task.attributes.docket_number,
+    getSortValue: (task: AmaTask) => task.attributes.docket_number
   })
 
   caseDaysWaitingColumn = () => ({

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -35,10 +35,12 @@ class AmaTaskTable extends React.PureComponent<Props> {
     };
   }
 
+  actionNameOfTask = (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.action]
+
   caseTaskColumn = () => ({
     header: COPY.CASE_LIST_TABLE_TASKS_COLUMN_TITLE,
-    valueFunction: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title],
-    getSortValue: (task: AmaTask) => CO_LOCATED_ADMIN_ACTIONS[task.attributes.title]
+    valueFunction: (task) => this.actionNameOfTask(task),
+    getSortValue: (task) => this.actionNameOfTask(task)
   })
 
   caseTypeColumn = () => ({

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -62,7 +62,8 @@ class AmaTaskTable extends React.PureComponent<Props> {
     getSortValue: (task: AmaTask) => task.attributes.docket_number
   })
 
-  daysWaitingOfTask = (task: AmaTask) => moment().startOf('day').diff(moment(task.attributes.assigned_at), 'days')
+  daysWaitingOfTask = (task: AmaTask) => moment().startOf('day').
+    diff(moment(task.attributes.assigned_at), 'days')
 
   caseDaysWaitingColumn = () => ({
     header: COPY.CASE_LIST_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
@@ -98,7 +99,7 @@ class AmaTaskTable extends React.PureComponent<Props> {
       columns={this.getQueueColumns}
       rowObjects={tasks}
       getKeyForRow={this.getKeyForRow}
-      defaultSort={{sortColIdx: 2}} />;
+      defaultSort={{ sortColIdx: 2 }} />;
   }
 }
 

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -30,14 +30,24 @@ class AmaTaskTable extends React.PureComponent<Props> {
       header: COPY.CASE_LIST_TABLE_VETERAN_NAME_COLUMN_TITLE,
       valueFunction:
         (task: AmaTask) => <a href={`/queue/appeals/${task.attributes.external_id}`}>
-          {task.attributes.veteran_name} ({task.attributes.veteran_file_number})</a>
+          {task.attributes.veteran_name} ({task.attributes.veteran_file_number})</a>,
+      getSortValue: (task) => task.attributes.veteran_name
     };
   }
 
   caseTypeColumn = () => ({
     header: COPY.CASE_LIST_TABLE_APPEAL_TYPE_COLUMN_TITLE,
     valueFunction: (task: AmaTask) => renderAppealType({ aod: task.attributes.aod,
-      type: task.attributes.case_type })
+      type: task.attributes.case_type }),
+    getSortValue: (task: AmaTask) => {
+      // We prepend a * to the docket number if it's a priority case since * comes before
+      // numbers in sort order, this forces these cases to the top of the sort.
+      if (task.attributes.aod || task.attributes.case_type === 'Court Remand') {
+        return `*${task.attributes.docket_number}`;
+      }
+
+      return task.attributes.docket_number;
+    }
   })
 
   caseTaskColumn = () => ({
@@ -85,7 +95,8 @@ class AmaTaskTable extends React.PureComponent<Props> {
     return <Table
       columns={this.getQueueColumns}
       rowObjects={tasks}
-      getKeyForRow={this.getKeyForRow} />;
+      getKeyForRow={this.getKeyForRow}
+      defaultSort={{sortColIdx: 1}} />;
   }
 }
 

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -69,6 +69,7 @@ export type AmaTask = {
   attributes: {
     aod: boolean,
     appeal_id: string,
+    assigned_at: string,
     assigned_by: User,
     assigned_to: User,
     case_type: string,

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -67,6 +67,7 @@ export type AmaTask = {
   id: string,
   type: string,
   attributes: {
+    action: string,
     aod: boolean,
     appeal_id: string,
     assigned_at: string,
@@ -81,7 +82,6 @@ export type AmaTask = {
     placed_on_hold_at: ?string,
     started_at: ?string,
     status: string,
-    title: string,
     type: string,
     veteran_file_number: string,
     veteran_name: ?string


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/caseflow/issues/6470

## Description
Makes the columns of the colocated queue table sortable.

## Testing Plan
- [x] Become BVALSPORER.
- [x] View their queue.
- [x] Confirm that the AOD case is the first case in the table.
- [x] Sort the column "Type(s)".
- [x] Confirm that the AOD case is now last.
- [x] Sort the column "Case Details" by ascending.
- [x] Confirm that the veteran names are in ascending alphabetical order.

