### PR TITLE
Too many VLJ ids being sent to VACOLS

### DIFF
--- a/app/models/hearings/judge_non_availability.rb
+++ b/app/models/hearings/judge_non_availability.rb
@@ -3,7 +3,7 @@ class JudgeNonAvailability < NonAvailability
     def import_judge_non_availability(schedule_period)
       dates = HearingSchedule::GetSpreadsheetData.new(schedule_period.spreadsheet).judge_non_availability_data
       judge_non_availability = []
-      judges = User.css_ids_by_vlj_ids(dates.pluck("vlj_id"))
+      judges = User.css_ids_by_vlj_ids(dates.pluck("vlj_id").uniq)
       transaction do
         dates.each do |date|
           css_id = judges[date["vlj_id"]][:css_id]

--- a/app/services/hearing_schedule/validate_judge_spreadsheet.rb
+++ b/app/services/hearing_schedule/validate_judge_spreadsheet.rb
@@ -54,7 +54,7 @@ class HearingSchedule::ValidateJudgeSpreadsheet
   end
 
   def validate_judge_non_availability_dates
-    vacols_judges = User.css_ids_by_vlj_ids(@spreadsheet_data.pluck("vlj_id"))
+    vacols_judges = User.css_ids_by_vlj_ids(@spreadsheet_data.pluck("vlj_id").uniq)
     unless @spreadsheet_data.all? { |row| row["date"].instance_of?(Date) }
       @errors << JudgeDatesNotCorrectFormat
     end


### PR DESCRIPTION
### Description
While uploading the judge spreadsheet, we were getting 'Invalid spreadsheet' errors. This is because we were sending ~1200 VLJ ids to VACOLS to see if the judges were in the database. We are now checking for unique VLJ ids only, so the request has ~80 VLJ ids.

### Testing Plan
1. Upload the spreadsheet from the hearing coordinators.

