### PR TITLE
Queue Colocated | Format veteran names as first name last name

### DIFF
--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -25,12 +25,22 @@ type Props = Params;
 class AmaTaskTable extends React.PureComponent<Props> {
   getKeyForRow = (rowNumber, task) => task.id
 
+  formattedVetNameOfTask = (task: AmaTask) => {
+    if (!task.attributes.veteran_name) {
+      return '';
+    }
+
+    const [ln, fn, mi] = task.attributes.veteran_name.split(', ')
+
+    return _.compact([fn, mi, ln]).join(' ');
+  }
+
   caseDetailsColumn = () => {
     return {
       header: COPY.CASE_LIST_TABLE_VETERAN_NAME_COLUMN_TITLE,
       valueFunction:
         (task: AmaTask) => <a href={`/queue/appeals/${task.attributes.external_id}`}>
-          {task.attributes.veteran_name} ({task.attributes.veteran_file_number})</a>
+          {this.formattedVetNameOfTask(task)} ({task.attributes.veteran_file_number})</a>
     };
   }
 

--- a/client/app/queue/components/AmaTaskTable.jsx
+++ b/client/app/queue/components/AmaTaskTable.jsx
@@ -30,7 +30,7 @@ class AmaTaskTable extends React.PureComponent<Props> {
       return '';
     }
 
-    const [ln, fn, mi] = task.attributes.veteran_name.split(', ')
+    const [ln, fn, mi] = task.attributes.veteran_name.split(', ');
 
     return _.compact([fn, mi, ln]).join(' ');
   }


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/caseflow/issues/6509

### Description
Formats veteran names as "first name middle initial last name".

### Testing Plan
- [ ] Become BVALSPORER.
- [ ] Go to /queue.
- [ ] Confirm that veteran names have the form "first name middle initial last name".
