### PR TITLE
Fixing extra vacols calls

### DIFF
--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -45,7 +45,8 @@ class LegacyTask
       assigned_to: user,
       task_id: record.created_at ? record.vacols_id + "-" + record.created_at.strftime("%Y-%m-%d") : nil,
       document_id: record.document_id,
-      assigned_by: record.assigned_by
+      assigned_by: record.assigned_by,
+      appeal: appeal
     )
   end
 

--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -6,6 +6,7 @@ class LegacyTask
            :docket_date, :added_by, :task_id, :type, :document_id, :assigned_by, :work_product].freeze
 
   attr_accessor(*ATTRS)
+  attr_writer :appeal
 
   ### Serializer Methods Start
   def assigned_on
@@ -28,7 +29,7 @@ class LegacyTask
   end
 
   def appeal
-    LegacyAppeal.find(appeal_id)
+    @appeal ||= LegacyAppeal.find(appeal_id)
   end
 
   ### Serializer Methods End

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -37,8 +37,11 @@ class LegacyWorkQueue
       vacols_appeals = repository.appeals_from_tasks(vacols_tasks)
 
       tasks = vacols_tasks.zip(vacols_appeals).map do |task, appeal|
-        MODEL_CLASS_OF_ROLE[role.capitalize].from_vacols(task, appeal, user)
+        return_task = MODEL_CLASS_OF_ROLE[role.capitalize].from_vacols(task, appeal, user)
+        return_task.appeal = appeal
+        return_task
       end
+
       [tasks, vacols_appeals]
     end
   end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -39,7 +39,6 @@ class LegacyWorkQueue
       tasks = vacols_tasks.zip(vacols_appeals).map do |task, appeal|
         MODEL_CLASS_OF_ROLE[role.capitalize].from_vacols(task, appeal, user)
       end
-
       [tasks, vacols_appeals]
     end
   end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -37,9 +37,7 @@ class LegacyWorkQueue
       vacols_appeals = repository.appeals_from_tasks(vacols_tasks)
 
       tasks = vacols_tasks.zip(vacols_appeals).map do |task, appeal|
-        return_task = MODEL_CLASS_OF_ROLE[role.capitalize].from_vacols(task, appeal, user)
-        return_task.appeal = appeal
-        return_task
+        MODEL_CLASS_OF_ROLE[role.capitalize].from_vacols(task, appeal, user)
       end
 
       [tasks, vacols_appeals]


### PR DESCRIPTION
### Description
The frontend refactor started making a lot of VACOLS requests. This is because the legacy_task does not memoize its relationship with appeal. And while we grab appeals in bulk we need to assign them to the task model preemptively.

### Acceptance Criteria 
- [ ] Should not see any `load_vacols_data` calls when loading a Queue.
