### PR TITLE
Moving to receipt date

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -56,7 +56,7 @@ class Appeal < AmaReview
   end
 
   def docket_number
-    return "Missing Docket Number" unless receipt_date 
+    return "Missing Docket Number" unless receipt_date
     "#{receipt_date.strftime('%y%m%d')}-#{id}"
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -56,7 +56,8 @@ class Appeal < AmaReview
   end
 
   def docket_number
-    "#{established_at.strftime('%y%m%d')}-#{id}"
+    return "Missing Docket Number" unless receipt_date 
+    "#{receipt_date.strftime('%y%m%d')}-#{id}"
   end
 
   def power_of_attorney

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
     end
 
     established_at { Time.zone.now }
+    receipt_date { Time.zone.yesterday }
 
     after(:create) do |appeal, _evaluator|
       appeal.request_issues.each do |issue|

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -19,10 +19,10 @@ describe Appeal do
     end
   end
 
-  context "#docket_number" do
+  context "#docket_number", focus: true do
     context "when receipt_date is defined" do
       let(:appeal) do
-        create(:appeal, receipt_date: Time.new("2018", "04", "05"))
+        create(:appeal, receipt_date: Time.new("2018", "04", "05").utc)
       end
 
       it "returns a docket number if receipt_date is defined" do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -19,7 +19,7 @@ describe Appeal do
     end
   end
 
-  context "#docket_number", focus: true do
+  context "#docket_number" do
     context "when receipt_date is defined" do
       let(:appeal) do
         create(:appeal, receipt_date: Time.new("2018", "04", "05").utc)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -19,6 +19,28 @@ describe Appeal do
     end
   end
 
+  context "#docket_number" do
+    context "when receipt_date is defined" do
+      let(:appeal) do
+        create(:appeal, receipt_date: Time.new("2018", "04", "05"))
+      end
+
+      it "returns a docket number if receipt_date is defined" do
+        expect(appeal.docket_number).to eq("180405-#{appeal.id}")
+      end
+    end
+
+    context "when receipt_date is nil" do
+      let(:appeal) do
+        create(:appeal, receipt_date: nil)
+      end
+
+      it "returns Missing Docket Number" do
+        expect(appeal.docket_number).to eq("Missing Docket Number")
+      end
+    end
+  end
+
   context "#find_appeal_by_id_or_find_or_create_legacy_appeal_by_vacols_id" do
     context "with a uuid (AMA appeal id)" do
       let(:veteran_file_number) { "64205050" }


### PR DESCRIPTION
### Description
We learned that we should be calculating the docket number based on the date on a veteran's form (receipt_date), not the date the form was intaked (established_at). This PR moves to using receipt_date in our docket number calculation.

### Testing Plan
1. Test manually by reseeding and going to the `queue/beaam` page to ensure the docket numbers are of yesterday's date.

