### PR TITLE
Unify tooltip appearance and add to new docs icon and Veteran ID copy button

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -40,6 +40,10 @@
   "CASE_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL": "Document ID",
   "CASE_SNAPSHOT_ACTION_BOX_TITLE": "Actions",
 
+  "CASE_TITLE_VETERAN_ID_BUTTON_TOOLTIP": "Click to copy Veteran ID",
+
+  "NEW_FILE_ICON_TOOLTIP": "This case has new documents",
+
   "NO_TASKS_IN_ATTORNEY_QUEUE_TITLE": "Cases not found",
   "NO_TASKS_IN_ATTORNEY_QUEUE_MESSAGE": "Sorry! We couldn't find any cases for you.",
   "ATTORNEY_QUEUE_TABLE_TITLE": "Your Queue",

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import _ from 'lodash';
-import ReactTooltip from 'react-tooltip';
 
+import Tooltip from './Tooltip';
 import {
   SortArrowDown,
   SortArrowUp,
@@ -47,28 +47,24 @@ const HeaderRow = (props) => {
   return <thead className={props.headerClassName}>
     <tr>
       {getColumns(props).map((column, columnNumber) => {
-        const tooltipProps = {
-          'data-tip': true,
-          'data-for': `${columnNumber}-tooltip`
-        };
-        let columnContent = <span {...tooltipProps}>{column.header || ''}</span>;
+        let columnContent = <span>{column.header || ''}</span>;
 
         if (column.getSortValue) {
           const sortIndicator = props.sortAscending ? <SortArrowUp /> : <SortArrowDown />;
           const notSortedIndicator = <DoubleArrow />;
 
           columnContent = <span
-            {...sortableHeaderStyle} {...tooltipProps}
+            {...sortableHeaderStyle}
             onClick={() => props.setSortOrder(columnNumber)}>
             {column.header || ''} {props.sortColIdx === columnNumber ? sortIndicator : notSortedIndicator}
           </span>;
         }
 
         return <th scope="col" key={columnNumber} className={cellClasses(column)}>
-          {column.tooltip && <ReactTooltip id={`${columnNumber}-tooltip`} effect="solid" multiline>
-            {column.tooltip}
-          </ReactTooltip>}
-          {columnContent}
+          { column.tooltip ?
+            <Tooltip id={`tooltip-${columnNumber}`} text={column.tooltip}>{columnContent}</Tooltip> :
+            <React.Fragment>{columnContent}</React.Fragment>
+          }
         </th>;
       })}
     </tr>

--- a/client/app/components/Tooltip.jsx
+++ b/client/app/components/Tooltip.jsx
@@ -1,0 +1,35 @@
+import { css } from 'glamor';
+import * as React from 'react';
+import ReactTooltip from 'react-tooltip';
+
+import { COLORS } from '../constants/AppConstants';
+
+const Tooltip = (props) => {
+  const {
+    text,
+    id = 'tooltip-id',
+    position = 'top',
+    offset = {}
+  } = props;
+
+  const borderToColor = position.charAt(0).toUpperCase() + position.slice(1);
+  const tooltipStyling = css({
+    display: 'inline-block',
+    [`& #${id}`]: {
+      backgroundColor: COLORS.GREY_DARK,
+      fontWeight: 'normal',
+      padding: '0.5rem 1rem',
+      textAlign: 'center'
+    },
+    [`& #${id}:after`]: { [`border${borderToColor}Color`]: COLORS.GREY_DARK }
+  });
+
+  return <React.Fragment>
+    <span data-tip data-for={id}>{props.children}</span>
+    <span {...tooltipStyling} >
+      <ReactTooltip effect="solid" id={id} offset={offset} place={position} multiline>{text}</ReactTooltip>
+    </span>
+  </React.Fragment>;
+};
+
+export default Tooltip;

--- a/client/app/hearings/components/WorksheetHeader.jsx
+++ b/client/app/hearings/components/WorksheetHeader.jsx
@@ -10,7 +10,7 @@ import { onRepNameChange, onWitnessChange, onMilitaryServiceChange } from '../ac
 import { css } from 'glamor';
 import _ from 'lodash';
 import { DISPOSITION_OPTIONS } from '../constants/constants';
-import ReactTooltip from 'react-tooltip';
+import Tooltip from '../../components/Tooltip';
 
 class WorksheetFormEntry extends React.PureComponent {
   render() {
@@ -137,22 +137,20 @@ class WorksheetHeader extends React.PureComponent {
           <div className="cf-hearings-headers"><b>{worksheet.veteran_mi_formatted}</b></div>
         </div>
 
-        <ReactTooltip place="top" className="copy-paste-button" effect="solid" id="copy-vbms-id" />
-
         <div className="cf-hearings-worksheet-data-cell">
           <h5>VETERAN ID</h5>
           {!this.props.print &&
           <div {...copyButtonStyling}>
-            <CopyToClipboard text={worksheet.sanitized_vbms_id}>
-              <button
-                data-for="copy-vbms-id"
-                data-tip="Click to copy to clipboard"
-                name="Copy Veteran ID"
-                className={['usa-button-outline cf-copy-to-clipboard']}>
-                {worksheet.sanitized_vbms_id}
-                <ClipboardIcon />
-              </button>
-            </CopyToClipboard>
+            <Tooltip text="Click to copy to clipboard">
+              <CopyToClipboard text={worksheet.sanitized_vbms_id}>
+                <button
+                  name="Copy Veteran ID"
+                  className={['usa-button-outline cf-copy-to-clipboard']}>
+                  {worksheet.sanitized_vbms_id}
+                  <ClipboardIcon />
+                </button>
+              </CopyToClipboard>
+            </Tooltip>
           </div>
           }
           {this.props.print &&

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -79,16 +79,16 @@ class CaseTitle extends React.PureComponent {
     return <CaseTitleScaffolding heading={appeal.attributes.veteran_full_name}>
       <React.Fragment>
         Veteran ID:&nbsp;
-        <CopyToClipboard text={appeal.attributes.vbms_id}>
-          <Tooltip text={COPY.CASE_TITLE_VETERAN_ID_BUTTON_TOOLTIP} position="bottom">
+        <Tooltip text={COPY.CASE_TITLE_VETERAN_ID_BUTTON_TOOLTIP} position="bottom">
+          <CopyToClipboard text={appeal.attributes.vbms_id}>
             <button type="submit"
               className="cf-apppeal-id"
               {...clipboardButtonStyling} >
               {appeal.attributes.vbms_id}&nbsp;
               <ClipboardIcon />
             </button>
-          </Tooltip>
-        </CopyToClipboard>
+          </CopyToClipboard>
+        </Tooltip>
       </React.Fragment>
 
       <ReaderLink

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -11,6 +11,8 @@ import { CATEGORIES } from './constants';
 import { COLORS } from '../constants/AppConstants';
 import ReaderLink from './ReaderLink';
 import { ClipboardIcon } from '../components/RenderFunctions';
+import Tooltip from '../components/Tooltip';
+import COPY from '../../COPY.json';
 
 import { toggleVeteranCaseList } from './uiReducer/uiActions';
 
@@ -78,13 +80,14 @@ class CaseTitle extends React.PureComponent {
       <React.Fragment>
         Veteran ID:&nbsp;
         <CopyToClipboard text={appeal.attributes.vbms_id}>
-          <button type="submit"
-            title="Click to copy Veteran ID"
-            className="cf-apppeal-id"
-            {...clipboardButtonStyling} >
-            {appeal.attributes.vbms_id}&nbsp;
-            <ClipboardIcon />
-          </button>
+          <Tooltip text={COPY.CASE_TITLE_VETERAN_ID_BUTTON_TOOLTIP} position="bottom">
+            <button type="submit"
+              className="cf-apppeal-id"
+              {...clipboardButtonStyling} >
+              {appeal.attributes.vbms_id}&nbsp;
+              <ClipboardIcon />
+            </button>
+          </Tooltip>
         </CopyToClipboard>
       </React.Fragment>
 

--- a/client/app/queue/components/NewFile.jsx
+++ b/client/app/queue/components/NewFile.jsx
@@ -1,15 +1,14 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { css } from 'glamor';
-import ReactTooltip from 'react-tooltip';
 import { NewFileIcon } from '../../components/RenderFunctions';
-import { COLORS } from '../../constants/AppConstants';
+import Tooltip from '../../components/Tooltip';
 import { bindActionCreators } from 'redux';
 import { getNewDocuments } from '../QueueActions';
 import type {
   BasicAppeal
 } from '../types/models';
+import COPY from '../../../COPY.json';
 
 type Params = {|
   appeal: BasicAppeal
@@ -22,17 +21,6 @@ type Props = Params & {|
   getNewDocuments: Function
 |};
 
-const tooltipID = 'newfile-tip';
-
-const tooltipStyling = css({
-  [`& > #${tooltipID}`]: {
-    backgroundColor: COLORS.GREY_DARK,
-    padding: '0.5rem 1rem',
-    textAlign: 'center'
-  },
-  [`& > #${tooltipID}:after`]: { display: 'none' }
-});
-
 class NewFile extends React.Component<Props> {
   componentDidMount = () => {
     if (!this.props.docs) {
@@ -42,20 +30,9 @@ class NewFile extends React.Component<Props> {
 
   render = () => {
     if (this.props.docs && this.props.docs.length > 0) {
-      return <React.Fragment>
-        <span data-tip data-for={tooltipID}>
-          <NewFileIcon />
-        </span>
-        <span {...tooltipStyling} >
-          <ReactTooltip
-            effect="solid"
-            id={tooltipID}
-            multiline
-            offset={{ top: '-10px' }} >
-            This case has new <br />documents
-          </ReactTooltip>
-        </span>
-      </React.Fragment>;
+      return <Tooltip id="newfile-tip" text={COPY.NEW_FILE_ICON_TOOLTIP} offset={{ top: '-10px' }}>
+        <NewFileIcon />
+      </Tooltip>;
     }
 
     return null;

--- a/client/app/queue/components/NewFile.jsx
+++ b/client/app/queue/components/NewFile.jsx
@@ -1,7 +1,10 @@
 // @flow
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { css } from 'glamor';
+import ReactTooltip from 'react-tooltip';
 import { NewFileIcon } from '../../components/RenderFunctions';
+import { COLORS } from '../../constants/AppConstants';
 import { bindActionCreators } from 'redux';
 import { getNewDocuments } from '../QueueActions';
 import type {
@@ -19,6 +22,17 @@ type Props = Params & {|
   getNewDocuments: Function
 |};
 
+const tooltipID = 'newfile-tip';
+
+const tooltipStyling = css({
+  [`& > #${tooltipID}`]: {
+    backgroundColor: COLORS.GREY_DARK,
+    padding: '0.5rem 1rem',
+    textAlign: 'center'
+  },
+  [`& > #${tooltipID}:after`]: { display: 'none' }
+});
+
 class NewFile extends React.Component<Props> {
   componentDidMount = () => {
     if (!this.props.docs) {
@@ -28,7 +42,20 @@ class NewFile extends React.Component<Props> {
 
   render = () => {
     if (this.props.docs && this.props.docs.length > 0) {
-      return <NewFileIcon />;
+      return <React.Fragment>
+        <span data-tip data-for={tooltipID}>
+          <NewFileIcon />
+        </span>
+        <span {...tooltipStyling} >
+          <ReactTooltip
+            effect="solid"
+            id={tooltipID}
+            multiline
+            offset={{ top: '-10px' }} >
+            This case has new <br />documents
+          </ReactTooltip>
+        </span>
+      </React.Fragment>;
     }
 
     return null;


### PR DESCRIPTION
Connects #6370.

* Unifies the styling of tooltips
* Adds tooltip to new documents icon
* Adds tooltip to Veteran ID copy button

Additionally, this PR creates a new `Tooltip` component which wraps `ReactTooltip`, requires a text attribute (the text of the tooltip) and a child element (the element that triggers the tooltip to appear when it is hovered).

### New documents tooltip
| Table view | Case details title |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/32683958/43928093-af3d0bca-9bfd-11e8-8a5c-414b232cecbd.png) | ![image](https://user-images.githubusercontent.com/32683958/43928193-022bc402-9bfe-11e8-9d8f-5e399c502dc8.png) |

### Column header tooltip
| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/32683958/43928278-55735512-9bfe-11e8-9f8f-e32fc0b4b494.png) | ![image](https://user-images.githubusercontent.com/32683958/43928105-ba370fa8-9bfd-11e8-8077-a69249caa2c0.png) |

### Veteran ID copy button tooltip
![image](https://user-images.githubusercontent.com/32683958/43928185-fbf252ae-9bfd-11e8-8c4f-e24975328063.png)
