### PR TITLE
Queue | Update Evaluate Decision screen layout, copy

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -69,7 +69,9 @@
   "JUDGE_EVALUATE_DECISION_CASE_COMPLEXITY_SUBHEAD": "How would you rate the complexity of this case?",
   "JUDGE_EVALUATE_DECISION_CASE_QUALITY_LABEL": "Quality of work",
   "JUDGE_EVALUATE_DECISION_CASE_QUALITY_SUBHEAD": "How would you rate the overall quality of this case?",
-  "JUDGE_EVALUATE_DECISION_IMPROVEMENT_LABEL": "Were there any areas of improvement?",
+  "JUDGE_EVALUATE_DECISION_IMPROVEMENT_LABEL": "Identify areas for improvement",
+  "JUDGE_EVALUATE_DECISION_IMPROVEMENT_NOT_CONSIDERED": "The attorney did not properly consider and apply:",
+  "JUDGE_EVALUATE_DECISION_IMPROVEMENT_AREAS_FOR_IMPROVEMENT": "Other areas for improvement:",
 
   "JUDGE_EVALUATE_DECISION_CASE_TIMELINESS_LABEL": "Case Timeliness",
   "JUDGE_EVALUATE_DECISION_CASE_TIMELINESS_ASSIGNED_DATE": "Date assigned to attorney",

--- a/client/app/components/CheckboxGroup.jsx
+++ b/client/app/components/CheckboxGroup.jsx
@@ -32,7 +32,8 @@ export default class CheckboxGroup extends React.Component {
       values,
       errorMessage,
       errorState,
-      getCheckbox
+      getCheckbox,
+      styling
     } = this.props;
 
     let fieldClasses = `checkbox-wrapper-${name} cf-form-checkboxes`;
@@ -47,7 +48,7 @@ export default class CheckboxGroup extends React.Component {
 
     let legendClasses = (hideLabel) ? 'hidden-field' : '';
 
-    return <fieldset className={fieldClasses}>
+    return <fieldset className={fieldClasses} {...styling}>
       <legend className={legendClasses}>
         {required && <span className="cf-required">Required</span>}
         {label || name}
@@ -80,5 +81,6 @@ CheckboxGroup.propTypes = {
   values: PropTypes.object,
   errorMessage: PropTypes.string,
   errorState: PropTypes.bool,
-  getCheckbox: PropTypes.func
+  getCheckbox: PropTypes.func,
+  styling: PropTypes.object
 };

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import CopyToClipboard from 'react-copy-to-clipboard';
 
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 
 import { CATEGORIES } from './constants';
 import { COLORS } from '../constants/AppConstants';
 import ReaderLink from './ReaderLink';
+import { ClipboardIcon } from '../components/RenderFunctions';
 
 import { toggleVeteranCaseList } from './uiReducer/uiActions';
 
@@ -46,6 +48,21 @@ const viewCasesStyling = css({
   cursor: 'pointer'
 });
 
+const clipboardButtonStyling = css({
+  borderColor: COLORS.GREY_LIGHT,
+  borderWidth: '1px',
+  color: COLORS.GREY_DARK,
+  padding: '0.75rem',
+  ':hover': {
+    backgroundColor: 'transparent',
+    color: COLORS.GREY_DARK,
+    borderColor: COLORS.PRIMARY,
+    borderBottomWidth: '1px'
+  },
+  '& > svg path': { fill: COLORS.GREY_LIGHT },
+  '&:hover > svg path': { fill: COLORS.PRIMARY }
+});
+
 class CaseTitle extends React.PureComponent {
   render = () => {
     const {
@@ -58,7 +75,19 @@ class CaseTitle extends React.PureComponent {
     } = this.props;
 
     return <CaseTitleScaffolding heading={appeal.attributes.veteran_full_name}>
-      <React.Fragment>Veteran ID: <b>{appeal.attributes.vbms_id}</b></React.Fragment>
+      <React.Fragment>
+        Veteran ID:&nbsp;
+        <CopyToClipboard text={appeal.attributes.vbms_id}>
+          <button type="submit"
+            title="Click to copy Veteran ID"
+            className="cf-apppeal-id"
+            {...clipboardButtonStyling} >
+            {appeal.attributes.vbms_id}&nbsp;
+            <ClipboardIcon />
+          </button>
+        </CopyToClipboard>
+      </React.Fragment>
+
       <ReaderLink
         appealId={appealId}
         analyticsSource={CATEGORIES[analyticsSource.toUpperCase()]}
@@ -66,6 +95,7 @@ class CaseTitle extends React.PureComponent {
         appeal={appeal}
         taskType={taskType}
         longMessage />
+
       <span {...viewCasesStyling}>
         <Link onClick={this.props.toggleVeteranCaseList}>
           { veteranCaseListIsVisible ? 'Hide' : 'View' } all cases

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -29,7 +29,10 @@ import {
   redText, PAGE_TITLES,
   ISSUE_DISPOSITIONS
 } from './constants';
-const setWidth = (width) => css({ width, maxWidth: width });
+const setWidth = (width) => css({
+  width,
+  maxWidth: width
+});
 const headerStyling = marginBottom(1.5);
 const inlineHeaderStyling = css(headerStyling, { float: 'left' });
 const hrStyling = css(marginTop(2), marginBottom(3));

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -25,27 +25,21 @@ import COPY from '../../COPY.json';
 import JUDGE_CASE_REVIEW_OPTIONS from '../../constants/JUDGE_CASE_REVIEW_OPTIONS.json';
 import {
   marginBottom, marginTop,
-  marginRight, paddingLeft,
-  fullWidth, redText, PAGE_TITLES,
+  paddingLeft, fullWidth,
+  redText, PAGE_TITLES,
   ISSUE_DISPOSITIONS
 } from './constants';
-const setWidth = (width) => css({ width });
+const setWidth = (width) => css({ width, maxWidth: width });
 const headerStyling = marginBottom(1.5);
 const inlineHeaderStyling = css(headerStyling, { float: 'left' });
 const hrStyling = css(marginTop(2), marginBottom(3));
 const qualityOfWorkAlertStyling = css({ borderLeft: '0.5rem solid #59BDE1' });
 const errorStylingNoTopMargin = css({ '&.usa-input-error': marginTop(0) });
-
-const twoColumnContainerStyling = css({
-  display: 'inline-flex',
-  width: '100%'
-});
-const leftColumnStyling = css({
-  '@media(min-width: 950px)': setWidth('calc(50% - 2rem)'),
-  '@media(max-width: 949px)': setWidth('calc(100% - 2rem)')
-});
 const subH2Styling = css(paddingLeft(1), { lineHeight: 2 });
 const subH3Styling = css(paddingLeft(1), { lineHeight: 1.75 });
+const fullWidthCheckboxLabels = css({
+  '& .question-label': setWidth('100%')
+});
 
 class EvaluateDecisionView extends React.PureComponent {
   constructor(props) {
@@ -243,24 +237,26 @@ class EvaluateDecisionView extends React.PureComponent {
         </h3>
         {this.qualityIsDeficient() && <span {...css(subH3Styling, redText)}>Choose at least one</span>}
       </div>
-      <div {...twoColumnContainerStyling}>
-        <div className="cf-push-left" {...css(marginRight(2), leftColumnStyling)}>
-          <CheckboxGroup
-            hideLabel vertical
-            name={COPY.JUDGE_EVALUATE_DECISION_IMPROVEMENT_LABEL}
-            onChange={this.setAreasOfImprovement}
-            errorState={highlight && this.qualityIsDeficient() && _.isEmpty(this.state.areas_for_improvement)}
-            value={this.state.areas_for_improvement}
-            options={this.getDisplayOptions('areas_for_improvement')} />
-        </div>
-        <div className="cf-push-left">
-          <CheckboxGroup
-            hideLabel vertical
-            name={COPY.JUDGE_EVALUATE_DECISION_IMPROVEMENT_LABEL}
-            onChange={this.setStateAttrList}
-            value={this.state.factors_not_considered}
-            options={this.getDisplayOptions('factors_not_considered')} />
-        </div>
+      <div className="cf-push-left" {...fullWidth}>
+        <h4>{COPY.JUDGE_EVALUATE_DECISION_IMPROVEMENT_NOT_CONSIDERED}</h4>
+        <CheckboxGroup
+          hideLabel vertical
+          name={COPY.JUDGE_EVALUATE_DECISION_IMPROVEMENT_LABEL}
+          onChange={this.setStateAttrList}
+          value={this.state.factors_not_considered}
+          options={this.getDisplayOptions('factors_not_considered')}
+          styling={fullWidthCheckboxLabels} />
+      </div>
+      <div className="cf-push-left" {...fullWidth}>
+        <h4>{COPY.JUDGE_EVALUATE_DECISION_IMPROVEMENT_AREAS_FOR_IMPROVEMENT}</h4>
+        <CheckboxGroup
+          hideLabel vertical
+          name={COPY.JUDGE_EVALUATE_DECISION_IMPROVEMENT_LABEL}
+          onChange={this.setAreasOfImprovement}
+          errorState={highlight && this.qualityIsDeficient() && _.isEmpty(this.state.areas_for_improvement)}
+          value={this.state.areas_for_improvement}
+          options={this.getDisplayOptions('areas_for_improvement')}
+          styling={fullWidthCheckboxLabels} />
       </div>
 
       <hr {...hrStyling} />


### PR DESCRIPTION
### Description
We received some feedback about the heirachy of content on Judge evaluation screen not making sense to a Judge. See conversation and rationale for the following changes in the [Judge checkout mural](https://app.mural.co/invitation/mural/workqueue2001/1525197080534?sender=phillipjo4517&key=83519e8e-200e-4b1b-bce7-0acc8bea0ef8). 

Updates the Evaluate Decision screen to match [mocks](https://dsva.slack.com/archives/C6E41RE92/p1533846896000118?thread_ts=1533832586.000417&cid=C6E41RE92).

<details><summary>mock</summary>
<img src="https://user-images.githubusercontent.com/8533004/43927320-1fb6dbd6-9bfb-11e8-9ecc-65905427a0d1.png">
</details>

<details><summary>screenshot</summary>
<img src="https://user-images.githubusercontent.com/8533004/43927298-14385500-9bfb-11e8-9955-d2fbb71e611d.png">
</details>

### Acceptance Criteria 
- [ ] Tests pass

