### PR TITLE
Schedule date format in mm/dd/yy

### DIFF
--- a/client/app/hearingSchedule/components/BuildSchedule.jsx
+++ b/client/app/hearingSchedule/components/BuildSchedule.jsx
@@ -114,14 +114,14 @@ export default class BuildSchedule extends React.Component {
       {displayJudgeSuccessMessage && <Alert
         type="success"
         title={`You have successfully assigned judges to hearings between
-          ${schedulePeriod.startDate} and ${schedulePeriod.endDate}`}
+          ${formatDateStr(schedulePeriod.startDate)} and ${formatDateStr(schedulePeriod.endDate)}`}
         message={successMessage}
         styling={alertStyling}
       />}
       {displayRoCoSuccessMessage && <Alert
         type="success"
         title={`You have successfully assigned hearings between
-          ${schedulePeriod.startDate} and ${schedulePeriod.endDate}`}
+          ${formatDateStr(schedulePeriod.startDate)} and ${formatDateStr(schedulePeriod.endDate)}`}
         message={successMessage}
         styling={alertStyling}
       />}


### PR DESCRIPTION
Connects #6551

### Description
This PR changes the date format for the buils schedule success page.

### Acceptance Criteria 
- [x]  The dates should be in mm/dd/yyyy format.

### Testing Plan
1. Go to Build schedule.
2. Upload a spreadsheet and complete the process. 
3. Check if date format is in mm/dd/yy
<img width="1463" alt="screen shot 2018-08-09 at 10 44 16 pm" src="https://user-images.githubusercontent.com/23080951/43936495-be01854a-9c26-11e8-846d-f1952c009cb4.png">


