### PR TITLE
Ramp Election Sync | Calls application_attr from the job thread

### DIFF
--- a/app/jobs/ramp_election_sync_job.rb
+++ b/app/jobs/ramp_election_sync_job.rb
@@ -1,9 +1,9 @@
 # This job syncs a RampElection with up to date BGS and VBMS data
 class RampElectionSyncJob < CaseflowJob
   queue_as :low_priority
-  application_attr :intake
 
   def perform(ramp_election_id)
+    self.class.application_attr :intake
     RequestStore.store[:current_user] = User.system_user
 
     RampElection.find(ramp_election_id).sync!


### PR DESCRIPTION
### Description
For some reason, [errors from the ramp election sync job](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2246/) aren't being routed to the #appeals-intake channel. When I looked at the raw data sent to Sentry, I noticed that the application field wasn't being sent. I think this is happening because the call to application_attr in ramp_election_sync_job.rb isn't running in the same thread as the rest of the job.

This PR moves the call to application_attr to the same thread as the rest of the job.

### Testing Plan
- [ ] Merge PR.
- [ ] Deploy Caseflow.
- [ ] Confirm that RampElection::BGSEndProductSyncError errors are now being routed to #appeals-intake.