### PR TITLE
Update status to assigned for parent when child is completed

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -39,7 +39,7 @@ class Task < ApplicationRecord
 
   def update_parent_status
     if saved_change_to_status? && completed? && parent
-      parent.update(status: :in_progress)
+      parent.update(status: :assigned)
     end
   end
 
@@ -61,6 +61,7 @@ class Task < ApplicationRecord
 
   def set_timestamps
     if will_save_change_to_status?
+      self.assigned_at = updated_at if assigned?
       self.started_at = updated_at if in_progress?
       self.placed_on_hold_at = updated_at if on_hold?
       self.completed_at = updated_at if completed?

--- a/spec/controllers/case_reviews_controller_spec.rb
+++ b/spec/controllers/case_reviews_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CaseReviewsController, type: :controller do
             expect(decision_issue2.reload.disposition).to eq "remanded"
             expect(task.reload.status).to eq "completed"
             expect(task.completed_at).to_not eq nil
-            expect(task.parent.status).to eq "in_progress"
+            expect(task.parent.status).to eq "assigned"
           end
         end
       end

--- a/spec/models/colocated_task_spec.rb
+++ b/spec/models/colocated_task_spec.rb
@@ -210,6 +210,14 @@ describe ColocatedTask do
         expect(colocated_admin_action.reload.started_at).to eq time5
         expect(colocated_admin_action.placed_on_hold_at).to eq time3
         expect(colocated_admin_action.completed_at).to eq time6
+
+        time7 = Time.utc(2015, 1, 9, 12, 0, 0)
+        Timecop.freeze(time7)
+        colocated_admin_action.update(status: "assigned")
+        # go back to in-progres - should reset date
+        expect(colocated_admin_action.reload.started_at).to eq time5
+        expect(colocated_admin_action.placed_on_hold_at).to eq time3
+        expect(colocated_admin_action.completed_at).to eq time6
       end
     end
   end


### PR DESCRIPTION
When a child task is completed, a parent's status should be reset to `assigned` and `assigned_at` must be reset