### PR TITLE
Add appeal_type property to legacy task serializer

### DIFF
--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -32,6 +32,11 @@ class LegacyTask
     @appeal ||= LegacyAppeal.find(appeal_id)
   end
 
+  def appeal_type
+    appeal.class.name
+    # "LegacyAppeal"
+  end
+
   ### Serializer Methods End
 
   def self.from_vacols(record, appeal, user)

--- a/app/models/serializers/work_queue/legacy_task_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_task_serializer.rb
@@ -14,6 +14,7 @@ class WorkQueue::LegacyTaskSerializer < ActiveModel::Serializer
   attribute :assigned_by_first_name
   attribute :assigned_by_last_name
   attribute :work_product
+  attribute :appeal_type
   attribute :previous_task do
     {
       assigned_on: object.previous_task.try(:assigned_at)


### PR DESCRIPTION
Resolves an issue caused by the task serializer and the legacy task serializer having different properties and [not properly filtering the tasks](https://github.com/department-of-veterans-affairs/caseflow/blob/5156c1b9c97d5b58c24cbc7bb10736e4a685e265/client/app/queue/CaseDetailsLoadingScreen.jsx#L61) as a result.