### PR TITLE
Use assigned to location date for attorney

### DIFF
--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -1,7 +1,7 @@
 class AttorneyLegacyTask < LegacyTask
   def self.from_vacols(case_assignment, appeal, user_id)
     task = super
-    task.assigned_at = case_assignment.assigned_to_attorney_date.try(:to_date)
+    task.assigned_at = case_assignment.assigned_to_location_date.try(:to_date)
     task
   end
 end

--- a/spec/models/legacy_tasks/attorney_legacy_task_spec.rb
+++ b/spec/models/legacy_tasks/attorney_legacy_task_spec.rb
@@ -21,7 +21,7 @@ describe AttorneyLegacyTask do
         OpenStruct.new(
           vacols_id: vacols_id,
           date_due: 1.day.ago,
-          assigned_to_attorney_date: 5.days.ago,
+          assigned_to_location_date: 5.days.ago,
           created_at: 6.days.ago,
           docket_date: nil
         )


### PR DESCRIPTION
When a colocated use completes their task, the task gets assigned back to an attorney and days waiting should be reset. We cannot update decass.deassign because Jed said "the DECASS.DEASSIGN date does not change, it should reflect the date the VLJ originally assigned the case to the attorney." so we have to use `brieff.bfdloout` to get the new date