### PR TITLE
Fix typo that causes reader to fail to load documents

### DIFF
--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -213,7 +213,7 @@ class TaskTable extends React.PureComponent<Props> {
           return null;
         }
 
-        return <ReaderLink appealId={task.externaAppeallId}
+        return <ReaderLink appealId={task.externalAppealId}
           analyticsSource={CATEGORIES.QUEUE_TABLE}
           redirectUrl={window.location.pathname}
           appeal={task.appeal} />;


### PR DESCRIPTION
Fixes a typo that caused Reader pages to fail to load properly for attorneys navigating to Reader from the task table. Related slack discussions: [Support channel](https://dsva.slack.com/archives/C2ZBKPMND/p1534275540000100), [app alerts channel](https://dsva.slack.com/archives/C4JECDLSE/p1534275668000100).

### Steps to reproduce before change
1. Log in to queue as BVASCASPER1
2. Navigate to your personalized task queue
3. Click the "View docs" link for any case in the table
4. Notice the "Information cannot be found" error message when arriving at the linked page


