### PR TITLE
Enable access to VSO organizational queue for VSO users

### DIFF
--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -23,10 +23,10 @@ class OrganizationQueue extends React.PureComponent {
   }
 
   render = () => {
-    const noAppeals = !_.size(this.props.appeals);
+    const noTasks = !_.size(this.props.tasks);
     let tableContent;
 
-    if (noAppeals) {
+    if (noTasks) {
       tableContent = <StatusMessage title={COPY.NO_TASKS_IN_ATTORNEY_QUEUE_TITLE}>
         {COPY.NO_TASKS_IN_ATTORNEY_QUEUE_MESSAGE}
       </StatusMessage>;

--- a/client/app/queue/OrganizationQueueLoadingScreen.jsx
+++ b/client/app/queue/OrganizationQueueLoadingScreen.jsx
@@ -1,0 +1,64 @@
+// @flow
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import LoadingDataDisplay from '../components/LoadingDataDisplay';
+import { LOGO_COLORS } from '../constants/AppConstants';
+import ApiUtil from '../util/ApiUtil';
+import { extractAppealsAndAmaTasks } from './utils';
+
+import { onReceiveQueue } from './QueueActions';
+
+type Params = {|
+  children: React.Node,
+  urlToLoad: string
+|};
+
+type Props = Params & {|
+  // Action creators
+  onReceiveQueue: typeof onReceiveQueue
+|};
+
+class OrganizationQueueLoadingScreen extends React.PureComponent<Props> {
+  // TODO: Short-circuit this request if we already have the tasks for this organization's queue.
+  createLoadPromise = () => ApiUtil.get(this.props.urlToLoad, { timeout: { response: 5 * 60 * 1000 } }).then(
+    (response) => {
+      const { tasks: { data: tasks } } = JSON.parse(response.text);
+
+      this.props.onReceiveQueue(extractAppealsAndAmaTasks(tasks));
+    }
+  );
+
+  reload = () => window.location.reload();
+
+  render = () => {
+    const failStatusMessageChildren = <div>
+      It looks like Caseflow was unable to load your cases.<br />
+      Please <a onClick={this.reload}>refresh the page</a> and try again.
+    </div>;
+
+    const loadingDataDisplay = <LoadingDataDisplay
+      createLoadPromise={this.createLoadPromise}
+      loadingComponentProps={{
+        spinnerColor: LOGO_COLORS.QUEUE.ACCENT,
+        message: 'Loading cases...'
+      }}
+      failStatusMessageProps={{
+        title: 'Unable to load cases'
+      }}
+      failStatusMessageChildren={failStatusMessageChildren}>
+      {this.props.children}
+    </LoadingDataDisplay>;
+
+    return <div className="usa-grid">
+      {loadingDataDisplay}
+    </div>;
+  };
+}
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  onReceiveQueue
+}, dispatch);
+
+export default (connect(null, mapDispatchToProps)(OrganizationQueueLoadingScreen): React.ComponentType<Params>);

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -37,6 +37,7 @@ import SelectRemandReasonsView from './SelectRemandReasonsView';
 import SearchBar from './SearchBar';
 import BeaamAppealListView from './BeaamAppealListView';
 import OrganizationQueue from './OrganizationQueue';
+import OrganizationQueueLoadingScreen from './OrganizationQueueLoadingScreen';
 
 import { LOGO_COLORS } from '../constants/AppConstants';
 import { PAGE_TITLES, USER_ROLES } from './constants';
@@ -130,12 +131,11 @@ class QueueApp extends React.PureComponent<Props> {
 
   routedAddColocatedTask = (props) => <AddColocatedTaskView nextStep="/queue" {...props.match.params} />;
 
-  routedOrganization = (props) => <QueueLoadingScreen
-    {...this.propsForQueueLoadingScreen()}
+  routedOrganization = (props) => <OrganizationQueueLoadingScreen
     urlToLoad={`${props.location.pathname}/tasks`}>
     <SearchBar feedbackUrl={this.props.feedbackUrl} />
     <OrganizationQueue {...this.props} />
-  </QueueLoadingScreen>
+  </OrganizationQueueLoadingScreen>
 
   queueName = () => this.props.userRole === USER_ROLES.ATTORNEY ? 'Your Queue' : 'Review Cases';
 


### PR DESCRIPTION
Connects #6622.

Enables access to VSO organizational queues for VSO users by avoiding API calls that fail.

### Testing Plan
1. Log in as `VSO` user
2. In local dev env, set feature flag for the American Legion organization `psql -W -h 0.0.0.0 -p 5432 -U postgres -d caseflow_certification_development -c "update organizations set feature = 'org_queue_for_american-legion' where id = 1 and url = 'american-legion';"`
3. In local rails console, enable the American Legion organizational queue feature toggle for the VSO user `org = Vso.where(url: 'american-legion').first; u = User.where(css_id: 'VSO').first; FeatureToggle.enable!(org.feature.to_sym, users: [u.css_id])`
4. Navigate to `http://localhost:3000/organizations/american-legion`
5. Marvel at the beauty of the organizational task queue.

