### PR TITLE
SyncIntakeJob | Calls application_attr from the job thread

### DIFF
--- a/app/jobs/sync_intake_job.rb
+++ b/app/jobs/sync_intake_job.rb
@@ -2,9 +2,9 @@
 # EP known to Intake
 class SyncIntakeJob < CaseflowJob
   queue_as :low_priority
-  application_attr :intake
 
   def perform
+    self.class.application_attr :intake
     # Set user to system_user to avoid sensitivity errors
     RequestStore.store[:current_user] = User.system_user
 


### PR DESCRIPTION
## Description
I think errors from this job are being misrouted for the same reason that errors from RampElectionsSync: https://github.com/department-of-veterans-affairs/caseflow/pull/6624