### PR TITLE
Prohibit access to files in case search for VSO users when denied by BGS

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -79,6 +79,8 @@ class AppealsController < ApplicationController
   def get_appeals_for_file_number(file_number)
     return file_number_not_found_error unless file_number
 
+    return veteran_file_access_prohibited_error unless BGSService.new.can_access?(file_number)
+
     MetricsService.record("VACOLS: Get appeal information for file_number #{file_number}",
                           service: :queue,
                           name: "AppealsController.index") do
@@ -102,6 +104,15 @@ class AppealsController < ApplicationController
 
   def appeal
     @appeal ||= Appeal.find_appeal_by_id_or_find_or_create_legacy_appeal_by_vacols_id(params[:appeal_id])
+  end
+
+  def veteran_file_access_prohibited_error
+    render json: {
+      "errors": [
+        "title": "Access to Veteran file prohibited",
+        "detail": "User is prohibited from accessing files associated with provided Veteran ID"
+      ]
+    }, status: 403
   end
 
   def file_number_not_found_error

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -79,7 +79,7 @@ class AppealsController < ApplicationController
   def get_appeals_for_file_number(file_number)
     return file_number_not_found_error unless file_number
 
-    return veteran_file_access_prohibited_error if current_user.can?("VSO") && !BGSService.new.can_access?(file_number)
+    return file_access_prohibited_error if current_user.vso_employee? && !BGSService.new.can_access?(file_number)
 
     MetricsService.record("VACOLS: Get appeal information for file_number #{file_number}",
                           service: :queue,
@@ -106,7 +106,7 @@ class AppealsController < ApplicationController
     @appeal ||= Appeal.find_appeal_by_id_or_find_or_create_legacy_appeal_by_vacols_id(params[:appeal_id])
   end
 
-  def veteran_file_access_prohibited_error
+  def file_access_prohibited_error
     render json: {
       "errors": [
         "title": "Access to Veteran file prohibited",

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -79,7 +79,7 @@ class AppealsController < ApplicationController
   def get_appeals_for_file_number(file_number)
     return file_number_not_found_error unless file_number
 
-    return veteran_file_access_prohibited_error unless BGSService.new.can_access?(file_number)
+    return veteran_file_access_prohibited_error if current_user.can?("VSO") && !BGSService.new.can_access?(file_number)
 
     MetricsService.record("VACOLS: Get appeal information for file_number #{file_number}",
                           service: :queue,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,10 @@ class User < ApplicationRecord
     Functions.granted?("Global Admin", css_id)
   end
 
+  def vso_employee?
+    Functions.granted?("VSO", css_id)
+  end
+
   def granted?(thing)
     Functions.granted?(thing, css_id)
   end


### PR DESCRIPTION
Connects #6391.

Currently, we return all cases that match the provided Veteran ID without checking to see if the person searching for that ID is allowed access to that Veteran's case file in BGS. This PR changes that so we now return an error if the searcher is a VSO and is not allowed to access the Veteran's case file in BGS.