### PR TITLE
Modify query for CO and Video hearings

### DIFF
--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -137,14 +137,14 @@ class VACOLS::CaseHearing < VACOLS::Record
       select(:hearing_pkseq,
              :hearing_date,
              "CASE WHEN folder_nr LIKE 'VIDEO%' THEN 'V' ELSE hearing_type END AS hearing_type",
-             :folder_nr,
+             "CASE WHEN folder_nr LIKE 'VIDEO%' or folder_nr is null THEN folder_nr ELSE null END AS folder_nr",
              :room,
              :board_member,
              "snamef || ' ' || snamemi || ' ' || snamel as judge_name",
              :mduser,
              :mdtime)
         .joins("left outer join vacols.staff on staff.sattyid = board_member")
-        .where("folder_nr is null or folder_nr like ?", "VIDEO %")
+        .where("hearing_type = ? and (folder_nr != ? or folder_nr is null)", "C", "1779233")
     end
   end
 


### PR DESCRIPTION
Connects #6656 

### Description
Modify query for CO and Video hearings to include any central office hearing days where veterans have been already assigned to that day. This is indicated by the folder_nr having the veteran vacols id instead of being null.

### Acceptance Criteria 
- [ ] Code compiles correctly

### Testing Plan
1. Go to View Schedule page
2. Based on current FACOLS hearsched seeding, look for row you should now see hearing days for August 2 2018.

