### PR TITLE
Redirect VSO users to organizational queue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,6 +94,7 @@ class ApplicationController < ApplicationBaseController
   helper_method :certification_header
 
   def can_access_queue?
+    return true if current_user.vso_employee?
     return true if current_user.attorney_in_vacols? || current_user.judge_in_vacols?
     return true if current_user.colocated_in_vacols? && feature_enabled?(:colocated_queue)
     false

--- a/app/controllers/queue_controller.rb
+++ b/app/controllers/queue_controller.rb
@@ -1,6 +1,7 @@
 class QueueController < ApplicationController
   before_action :react_routed, :check_queue_out_of_service
   before_action :verify_queue_access
+  before_action :redirect_vso_queue_requests
 
   def set_application
     RequestStore.store[:application] = "queue"
@@ -12,5 +13,15 @@ class QueueController < ApplicationController
 
   def check_queue_out_of_service
     render "out_of_service", layout: "application" if Rails.cache.read("queue_out_of_service")
+  end
+
+  private
+
+  def redirect_vso_queue_requests
+    return unless current_user.vso_employee?
+
+    Vso.where.not(feature: nil).each do |vso|
+      return redirect_to vso.path if FeatureToggle.enabled?(vso.feature.to_sym, user: current_user)
+    end
   end
 end

--- a/app/controllers/queue_controller.rb
+++ b/app/controllers/queue_controller.rb
@@ -23,5 +23,7 @@ class QueueController < ApplicationController
     Vso.where.not(feature: nil).each do |vso|
       return redirect_to vso.path if FeatureToggle.enabled?(vso.feature.to_sym, user: current_user)
     end
+
+    redirect_to "/unauthorized"
   end
 end

--- a/app/models/organizations/vso.rb
+++ b/app/models/organizations/vso.rb
@@ -5,6 +5,10 @@ class Vso < Organization
     participant_ids.include?(participant_id)
   end
 
+  def path
+    "/queue/organization/#{url}"
+  end
+
   private
 
   def bgs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,10 @@ class User < ApplicationRecord
     Functions.granted?("Global Admin", css_id)
   end
 
+  def vso_employee?
+    Functions.granted?("VSO", css_id)
+  end
+
   def granted?(thing)
     Functions.granted?(thing, css_id)
   end

--- a/spec/controllers/queue_controller_spec.rb
+++ b/spec/controllers/queue_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe QueueController, type: :controller do
       let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
 
       before { User.authenticate!(user: attorney_user) }
+      after { User.unauthenticate! }
 
       it "should return the queue landing page" do
         get :index
@@ -21,14 +22,28 @@ RSpec.describe QueueController, type: :controller do
 
       before do
         Functions.grant!("VSO", users: [vso_user.css_id])
-        FeatureToggle.enable!(feature.to_sym, users: [vso_user.css_id])
         User.authenticate!(user: vso_user)
       end
 
-      it "should redirect to VSO's organizational queue" do
-        get :index
-        expect(response.status).to eq 302
-        expect(response.redirect_url).to match(/#{vso.path}$/)
+      after { User.unauthenticate! }
+
+      context "but user does not have feature toggle for any organization" do
+        it "should redirect to unauthorized page" do
+          get :index
+          expect(response.status).to eq 302
+          expect(response.redirect_url).to match(/unauthorized$/)
+        end
+      end
+
+      context "and user has feature toggle for one VSO" do
+        before { FeatureToggle.enable!(feature.to_sym, users: [vso_user.css_id]) }
+        after { FeatureToggle.disable!(feature.to_sym, users: [vso_user.css_id]) }
+
+        it "should redirect to VSO's organizational queue" do
+          get :index
+          expect(response.status).to eq 302
+          expect(response.redirect_url).to match(/#{vso.path}$/)
+        end
       end
     end
   end

--- a/spec/controllers/queue_controller_spec.rb
+++ b/spec/controllers/queue_controller_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe QueueController, type: :controller do
+  describe "GET /queue" do
+    context "when user has access to queue" do
+      let(:attorney_user) { FactoryBot.create(:user) }
+      let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
+
+      before { User.authenticate!(user: attorney_user) }
+
+      it "should return the queue landing page" do
+        get :index
+        expect(response.status).to eq 200
+      end
+    end
+
+    context "when user is a VSO employee" do
+      let(:vso_user) { FactoryBot.create(:user) }
+
+      let(:url) { "american-legion" }
+      let(:feature) { "org_queue_american_legion" }
+      let!(:vso) { Vso.create(url: url, feature: feature) }
+
+      before do
+        Functions.grant!("VSO", users: [vso_user.css_id])
+        FeatureToggle.enable!(feature.to_sym, users: [vso_user.css_id])
+        User.authenticate!(user: vso_user)
+      end
+
+      it "should redirect to VSO's organizational queue" do
+        get :index
+        expect(response.status).to eq 302
+        expect(response.redirect_url).to match(/#{vso.path}$/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR makes it so requests to `/queue` from VSO users will redirect them to the URL of the organizational queue for the VSO they are associated with. This enables us to point all VSO users to the `/queue` endpoint in training so we don't have to remember the URLs for each VSO. Additionally, this prevents VSO users from accessing personalized task queues until (if?) those are enabled.