### PR TITLE
Add Australia to list of countries requiring zip (temporary)

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -21,7 +21,7 @@ class Veteran < ApplicationRecord
     "DIS" => "Discharge"
   }.freeze
 
-  COUNTRIES_REQUIRING_ZIP = %w[USA CANADA GERMANY].freeze
+  COUNTRIES_REQUIRING_ZIP = %w[USA CANADA GERMANY AUSTRALIA].freeze
 
   validates :ssn, :sex, :first_name, :last_name, :city,
             :address_line1, :country, presence: true, on: :bgs

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -21,6 +21,7 @@ class Veteran < ApplicationRecord
     "DIS" => "Discharge"
   }.freeze
 
+  # Germany and Australia should be temporary additions until VBMS bug is fixed
   COUNTRIES_REQUIRING_ZIP = %w[USA CANADA GERMANY AUSTRALIA].freeze
 
   validates :ssn, :sex, :first_name, :last_name, :city,


### PR DESCRIPTION
Connects #6285 

We are adding Australia to the list of countries requiring zip.  VBMS should have a fix for this on August 18th, but we have made this a temporary fix until that is confirmed.  This should give the user an error to go into the system and add a zip code, which will allow them to finish processing the intake.
