### PR TITLE
Queue | Limit judge case review comment length

### DIFF
--- a/app/models/attorney_case_review.rb
+++ b/app/models/attorney_case_review.rb
@@ -8,7 +8,7 @@ class AttorneyCaseReview < ApplicationRecord
   validates :attorney, :document_type, :task_id, :reviewing_judge, :document_id, :work_product, presence: true
   validates :overtime, inclusion: { in: [true, false] }
   validates :work_product, inclusion: { in: QueueMapper::WORK_PRODUCTS.values }
-  validates :note, length: { maximum: 350 }
+  validates :note, length: { maximum: Constants::VACOLS_COLUMN_MAX_LENGTHS["DECASS"]["DEATCOM"] }
 
   enum document_type: {
     omo_request: Constants::APPEAL_DECISION_TYPES["OMO_REQUEST"],

--- a/app/models/judge_case_review.rb
+++ b/app/models/judge_case_review.rb
@@ -7,6 +7,7 @@ class JudgeCaseReview < ApplicationRecord
 
   validates :task_id, :location, :judge, :attorney, presence: true
   validates :complexity, :quality, presence: true, if: :bva_dispatch?
+  validates :comment, length: { maximum: 600 }
 
   after_create :select_case_for_quality_review
 

--- a/app/models/judge_case_review.rb
+++ b/app/models/judge_case_review.rb
@@ -7,7 +7,7 @@ class JudgeCaseReview < ApplicationRecord
 
   validates :task_id, :location, :judge, :attorney, presence: true
   validates :complexity, :quality, presence: true, if: :bva_dispatch?
-  validates :comment, length: { maximum: 600 }
+  validates :comment, length: { maximum: Constants::VACOLS_COLUMN_MAX_LENGTHS["DECASS"]["DEBMCOM"] }
 
   after_create :select_case_for_quality_review
 

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -27,7 +27,8 @@ import {
   marginBottom, marginTop,
   paddingLeft, fullWidth,
   redText, PAGE_TITLES,
-  ISSUE_DISPOSITIONS
+  ISSUE_DISPOSITIONS,
+  JUDGE_CASE_REVIEW_COMMENT_MAX_LENGTH
 } from './constants';
 const setWidth = (width) => css({
   width,
@@ -273,6 +274,7 @@ class EvaluateDecisionView extends React.PureComponent {
         name="additional-factors"
         label={COPY.JUDGE_EVALUATE_DECISION_ADDITIONAL_FACTORS_SUBHEAD}
         hideLabel
+        maxlength={JUDGE_CASE_REVIEW_COMMENT_MAX_LENGTH}
         value={this.state.comment}
         onChange={(comment) => this.setState({ comment })} />
     </React.Fragment>;

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -145,6 +145,8 @@ export const ISSUE_DESCRIPTION_MAX_LENGTH = 100;
 export const ATTORNEY_COMMENTS_MAX_LENGTH = 350;
 // max length for document id `DECASS.DEDOCID`
 export const DOCUMENT_ID_MAX_LENGTH = 30;
+// max length for VLJ comment `DECASS.DEBMCOM`
+export const JUDGE_CASE_REVIEW_COMMENT_MAX_LENGTH = 600;
 
 export const PAGE_TITLES = {
   DISPOSITIONS: {

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -8,6 +8,7 @@ import StringUtil from '../util/StringUtil';
 import { COLORS as COMMON_COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
 import COPY from '../../COPY.json';
 import CO_LOCATED_ACTIONS from '../../constants/CO_LOCATED_ACTIONS.json';
+import VACOLS_COLUMN_MAX_LENGTHS from '../../constants/VACOLS_COLUMN_MAX_LENGTHS.json';
 
 export const COLORS = {
   QUEUE_LOGO_PRIMARY: '#11598D',
@@ -139,14 +140,10 @@ export const ISSUE_DISPOSITIONS = _.fromPairs(_.zip(
   Object.keys(VACOLS_DISPOSITIONS_BY_ID)
 ));
 
-// max length of VACOLS issue description field `ISSUES.ISSDESC`
-export const ISSUE_DESCRIPTION_MAX_LENGTH = 100;
-// max length for Attorney comments `DECASS.DEATCOM`
-export const ATTORNEY_COMMENTS_MAX_LENGTH = 350;
-// max length for document id `DECASS.DEDOCID`
-export const DOCUMENT_ID_MAX_LENGTH = 30;
-// max length for VLJ comment `DECASS.DEBMCOM`
-export const JUDGE_CASE_REVIEW_COMMENT_MAX_LENGTH = 600;
+export const ISSUE_DESCRIPTION_MAX_LENGTH = VACOLS_COLUMN_MAX_LENGTHS.ISSUES.ISSDESC;
+export const ATTORNEY_COMMENTS_MAX_LENGTH = VACOLS_COLUMN_MAX_LENGTHS.DECASS.DEATCOM;
+export const DOCUMENT_ID_MAX_LENGTH = VACOLS_COLUMN_MAX_LENGTHS.DECASS.DEDOCID;
+export const JUDGE_CASE_REVIEW_COMMENT_MAX_LENGTH = VACOLS_COLUMN_MAX_LENGTHS.DECASS.DEBMCOM;
 
 export const PAGE_TITLES = {
   DISPOSITIONS: {

--- a/client/constants/VACOLS_COLUMN_MAX_LENGTHS.json
+++ b/client/constants/VACOLS_COLUMN_MAX_LENGTHS.json
@@ -1,0 +1,10 @@
+{
+  "ISSUES": {
+    "ISSDESC": 100
+  },
+  "DECASS": {
+    "DEATCOM": 350,
+    "DEDOCID": 30,
+    "DEBMCOM": 600
+  }
+}

--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -425,7 +425,9 @@ RSpec.feature "Checkout flows" do
         # areas of improvement
         page.find_all(".question-label").sample(2).each(&:double_click)
 
-        fill_in "additional-factors", with: "this is the note"
+        dummy_note = generate_words 200
+        fill_in "additional-factors", with: dummy_note
+        expect(page).to have_content(dummy_note[0..599])
 
         click_on "Continue"
 


### PR DESCRIPTION
Resolves https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2300/

### Description
In the DECASS table, `DEBMCOM` (VLJ comments), comment field on Evaluate Decision view, has a max length of 600 characters

### Acceptance Criteria 
- [ ] character limit imposed in comment field on Evaluate Decision view

### Testing Plan
1. Go to ...

