### PR TITLE
Display Veteran date of birth correctly for BEAAM appeals

### DIFF
--- a/app/models/serializers/work_queue/legacy_appeal_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_serializer.rb
@@ -45,7 +45,9 @@ class WorkQueue::LegacyAppealSerializer < ActiveModel::Serializer
   attribute :appellant_relationship
   attribute :location_code
   attribute :veteran_full_name
-  attribute :veteran_date_of_birth
+  attribute :veteran_date_of_birth do
+    object.veteran_date_of_birth ? object.veteran_date_of_birth.strftime("%m/%d/%Y") : nil
+  end
   attribute :veteran_gender
   attribute :vbms_id do
     object.sanitized_vbms_id

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -53,7 +53,7 @@ export default class VeteranDetail extends React.PureComponent {
     if (dobField && this.getAppealAttr(dobField)) {
       details.push({
         label: 'Date of birth',
-        value: <DateString date={this.getAppealAttr(dobField)} dateFormat="M/D/YYYY" />
+        value: <DateString date={this.getAppealAttr(dobField)} inputFormat="MM/DD/YYYY" dateFormat="M/D/YYYY" />
       });
     }
     if (relationField && this.getAppealAttr(relationField)) {

--- a/client/app/util/DateUtil.js
+++ b/client/app/util/DateUtil.js
@@ -36,8 +36,8 @@ export const formatDateStr = (dateString, dateFormat = 'YYYY-MM-DD', expectedFor
   return moment(dateString, dateFormat).format(expectedFormat);
 };
 
-export const DateString = ({ date, dateFormat = 'MM/DD/YY', style }) => <span {...style}>
-  {formatDateStr(date, 'YYYY-MM-DD', dateFormat)}
+export const DateString = ({ date, dateFormat = 'MM/DD/YY', inputFormat = 'YYYY-MM-DD', style }) => <span {...style}>
+  {formatDateStr(date, inputFormat, dateFormat)}
 </span>;
 
 export const formatDateStringForApi = (dateString) => (


### PR DESCRIPTION
Connects #6550.

When we display the Veteran's date of birth in case details, we use the `veteranDateOfBirth` field from the appeal which comes from the `veteran_date_of_birth` field in the appeal serializers. For `LegacyAppeals` the `veteran_date_of_birth` field comes from VACOLS as a datetime object (I think), and was serialized in the `legacy_appeal_serializer` in the format "1989-11-23". The `veteran_date_of_birth` for BEAAM `Appeals` comes from the `Veteran` object's call to BGS for that value where it is returned in the format "11/23/1989", which is the value the `appeal_serializer` passed to the frontend. On the frontend the `DateString` component assumed the `veteranDateOfBirth` was always in the format "1989-11-23", and made a best guess at what the value should be for the values in the format "11/23/1989"... that best guess was never correct and resulted in incorrect birthdates.

This PR changes 1) the `DateString` component to expect Veteran birthdates in the format "11/23/1989", and 2) the `LegacyAppeal` serializer to return birthdates to match the format returned by BGS ("11/23/1989").