### PR TITLE
Create TaskAction model and table

### DIFF
--- a/app/models/task_action.rb
+++ b/app/models/task_action.rb
@@ -1,0 +1,37 @@
+class TaskAction < ApplicationRecord
+  enum status_after: {
+    assigned: "assigned",
+    in_progress: "in_progress",
+    on_hold: "on_hold",
+    completed: "completed"
+  }
+
+  def act(task, child_task_owner)
+    update_task_status(task)
+    create_child_task(task, child_task_owner)
+  end
+
+  def update_task_status(task)
+    return unless status_after
+
+    case status_after
+    when "completed"
+      task.mark_complete!
+    when "on_hold"
+      task.update(status: :on_hold)
+    end
+  end
+
+  def create_child_task(task, child_task_owner)
+    return unless child_task_type
+
+    Task.create!(
+      appeal_id: task.appeal_id,
+      assigned_by_id: task.assigned_to_id,
+      appeal_type: task.appeal_type,
+      parent_id: task.id,
+      assigned_to_id: child_task_owner,
+      assigned_to_type: child_task_owner_type
+    )
+  end
+end

--- a/db/migrate/20180820170206_add_task_actions_table.rb
+++ b/db/migrate/20180820170206_add_task_actions_table.rb
@@ -1,0 +1,11 @@
+class AddTaskActionsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :task_actions do |t|
+      t.string "name", null: false
+      t.string "status_after"
+      t.string "child_task_owner_type"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+    end
+  end
+end


### PR DESCRIPTION
Connects #6683.

Creates `TaskAction` model and table. Three generic task actions would be created with the following commands in the rails console:
```
TaskAction.create!(name: 'Mark task complete', status_after: 'completed')
TaskAction.create!(name: 'Assign to team', status_after: 'on_hold', child_task_owner_type: 'Organization')
TaskAction.create!(name: 'Assign to individual', status_after: 'on_hold', child_task_owner_type: 'User')
```

TaskActions can be called from a controller in the following way:
```
task = Task.find(params[:task_id])
a = TaskAction.find(params[:task_action_id])
a.act(task, params[:child_task_owner_id])
```