### PR TITLE
Clear local cache before recreating veteran records

### DIFF
--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -69,6 +69,8 @@ class Fakes::Initializer
 
       # FACOLS needs to match veteran records through Fakes::BGSService for Dispatch(EPs)
       if rails_env.development?
+        Fakes::BGSService.rating_issue_records = {}
+        Fakes::BGSService.rating_records = {}
         Fakes::BGSService.create_veteran_records
         return
       end

--- a/lib/fakes/initializer.rb
+++ b/lib/fakes/initializer.rb
@@ -54,9 +54,7 @@ class Fakes::Initializer
     def load_fakes_and_seed!(rails_env:, app_name: nil)
       load!(rails_env: rails_env)
 
-      User.authentication_service.vacols_regional_offices = {
-        "DSUSER" => "DSUSER", "RO13" => "RO13"
-      }
+      User.authentication_service.vacols_regional_offices = { "DSUSER" => "DSUSER", "RO13" => "RO13" }
 
       User.authentication_service.user_session = {
         "id" => "Fake User", "css_id" => "FAKEUSER",


### PR DESCRIPTION
Resolves #6691 It appears that the intent was to rerun creating veteran records even though it's meant to be cached in memory. Because of this, I've cleared the in memory cache every time it's run through again for ratings.