### PR TITLE
fix no ratings for dev

### DIFF
--- a/lib/generators/veteran.rb
+++ b/lib/generators/veteran.rb
@@ -4,6 +4,7 @@ class Generators::Veteran
   class << self
     # rubocop:disable Metrics/MethodLength
     def default_attrs(seed = nil)
+      seed_int = Random.new(seed.to_i).rand(5_000_000_000)
       {
         address_line1: "1234 FAKE ST",
         address_line2: nil,
@@ -32,9 +33,9 @@ class Generators::Veteran
         fiduciary_decision_category_type_code: nil,
         fiduciary_folder_location: nil,
         file_number: "111223334",
-        first_name: generate_first_name(seed),
+        first_name: generate_first_name(seed_int),
         foreign_code: nil,
-        last_name: generate_last_name(seed),
+        last_name: generate_last_name(seed_int),
         middle_name: "E",
         military_post_office_type_code: nil,
         military_postal_type_code: nil,
@@ -47,7 +48,7 @@ class Generators::Veteran
         phone_type_name_two: nil,
         prep_phrase_type: nil,
         province_name: nil,
-        ptcpnt_id: generate_external_id(seed),
+        ptcpnt_id: generate_external_id(seed_int),
         ptcpnt_relationship: nil,
         return_code: "SHAR 9999",
         return_message: "Records found.",
@@ -88,7 +89,7 @@ class Generators::Veteran
 
     def build(attrs = {})
       Fakes::BGSService.veteran_records ||= {}
-      Fakes::BGSService.veteran_records[attrs[:file_number]] = default_attrs(attrs[:file_number].hash).merge(attrs)
+      Fakes::BGSService.veteran_records[attrs[:file_number]] = default_attrs(attrs[:file_number]).merge(attrs)
       Veteran.new(file_number: attrs[:file_number])
     end
   end

--- a/lib/generators/veteran.rb
+++ b/lib/generators/veteran.rb
@@ -4,7 +4,9 @@ class Generators::Veteran
   class << self
     # rubocop:disable Metrics/MethodLength
     def default_attrs(seed = nil)
-      seed_int = Random.new(seed.to_i).rand(5_000_000_000)
+      # We need to convert to a string as some generators use
+      # a symbol :default for veteran file number
+      seed_int = Random.new(seed.to_s.to_i).rand(5_000_000_000)
       {
         address_line1: "1234 FAKE ST",
         address_line2: nil,


### PR DESCRIPTION
Resolves #6691 

Hash is only consistent in a single run. Since we rerun creating veteran records for Facols regularly, even within the same run, sometimes veterans have multiple participant_ids, which leads to not being able to find things like ratings issues. This uses the file number unhashed as the seed. Since that way it'll be consistent, even between runs.
