### PR TITLE
Co-located table | Hide tasks with new documents from on-hold tab

### DIFF
--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -59,17 +59,22 @@ export const fetchJudges = () => (dispatch: Dispatch) => {
   });
 };
 
+export const receiveNewDocuments = ({ appealId, newDocuments }: { appealId: string, newDocuments: Array<Object> }) => ({
+  type: ACTIONS.RECEIVE_NEW_FILES,
+  payload: {
+    appealId,
+    newDocuments
+  }
+});
+
 export const getNewDocuments = (appealId: string) => (dispatch: Dispatch) => {
   ApiUtil.get(`/appeals/${appealId}/new_documents`).then((response) => {
     const resp = JSON.parse(response.text);
 
-    dispatch({
-      type: ACTIONS.RECEIVE_NEW_FILES,
-      payload: {
-        appealId,
-        newDocuments: resp.new_documents
-      }
-    });
+    dispatch(receiveNewDocuments({
+      appealId,
+      newDocuments: resp.new_documents
+    }));
   }, (error) => {
     dispatch({
       type: ACTIONS.ERROR_ON_RECEIVE_NEW_FILES,

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -9,7 +9,13 @@ import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
 import { associateTasksWithAppeals } from './utils';
 
-import { onReceiveQueue, setAttorneysOfJudge, fetchAllAttorneys, fetchAmaTasksOfUser, getNewDocuments } from './QueueActions';
+import {
+  onReceiveQueue,
+  setAttorneysOfJudge,
+  fetchAllAttorneys,
+  fetchAmaTasksOfUser,
+  getNewDocuments
+} from './QueueActions';
 import { setUserId } from './uiReducer/uiActions';
 import type { BasicAppeals, Tasks } from './types/models';
 import type { State, UsersById } from './types/state';
@@ -37,7 +43,8 @@ type Props = Params & {|
   setAttorneysOfJudge: typeof setAttorneysOfJudge,
   fetchAllAttorneys: typeof fetchAllAttorneys,
   fetchAmaTasksOfUser: (number, string) => Promise<{ payload: { amaTasks: Tasks, appeals: BasicAppeals } }>,
-  setUserId: typeof setUserId
+  setUserId: typeof setUserId,
+  getNewDocuments: typeof getNewDocuments
 |};
 
 class QueueLoadingScreen extends React.PureComponent<Props> {

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -100,10 +100,12 @@ export const newTasksByAssigneeCssIdSelector = createSelector(
   (tasks: Array<Task>) => tasks.filter((task) => !task.placedOnHoldAt)
 );
 
+const getNewDocsForAppeal = (state: State) => state.queue.newDocsForAppeal;
+
 export const onHoldTasksByAssigneeCssIdSelector: (State) => Array<Task> = createSelector(
-  [tasksByAssigneeCssIdSelector],
-  (tasks: Array<Task>) =>
-    tasks.filter((task) => moment().diff(moment(task.placedOnHoldAt), 'days') < task.onHoldDuration)
+  [tasksByAssigneeCssIdSelector, getNewDocsForAppeal],
+  (tasks: Array<Task>, newDocsForAppeal: {[string]: Array<Object>}) =>
+    tasks.filter((task) => moment().diff(moment(task.placedOnHoldAt), 'days') < task.onHoldDuration && (!newDocsForAppeal[task.externalAppealId] || newDocsForAppeal[task.externalAppealId].length == 0))
 );
 
 export const judgeReviewTasksSelector = createSelector(

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -3,7 +3,7 @@ import { createSelector } from 'reselect';
 import _ from 'lodash';
 import moment from 'moment';
 
-import type { State } from './types/state';
+import type { State, NewDocsForAppeal } from './types/state';
 import type {
   Task,
   Tasks,
@@ -104,7 +104,7 @@ const getNewDocsForAppeal = (state: State) => state.queue.newDocsForAppeal;
 
 export const onHoldTasksByAssigneeCssIdSelector: (State) => Array<Task> = createSelector(
   [tasksByAssigneeCssIdSelector, getNewDocsForAppeal],
-  (tasks: Array<Task>, newDocsForAppeal: {[string]: Array<Object>}) =>
+  (tasks: Array<Task>, newDocsForAppeal: NewDocsForAppeal) =>
     tasks.filter((task) => moment().diff(moment(task.placedOnHoldAt), 'days') < task.onHoldDuration && (!newDocsForAppeal[task.externalAppealId] || newDocsForAppeal[task.externalAppealId].length == 0))
 );
 

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -50,6 +50,8 @@ export type UsersById = { [number]: ?User };
 
 export type IsTaskAssignedToUserSelected = {[string]: ?{[string]: ?boolean}};
 
+export type NewDocsForAppeal = {[string]: Array<Object>}
+
 export type QueueState = {
   judges: UsersById,
   tasks: Tasks,
@@ -68,7 +70,8 @@ export type QueueState = {
   attorneysOfJudge: AttorneysOfJudge,
   attorneyAppealsLoadingState: AttorneyAppealsLoadingState,
   isTaskAssignedToUserSelected: IsTaskAssignedToUserSelected,
-  attorneys: Attorneys
+  attorneys: Attorneys,
+  newDocsForAppeal: NewDocsForAppeal
 };
 
 export type State = {

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -9,7 +9,7 @@ import moment from 'moment';
 import thunk from 'redux-thunk';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 import rootReducer from '../../../app/queue/reducers';
-import { onReceiveQueue } from '../../../app/queue/QueueActions';
+import { onReceiveQueue, receiveNewDocuments } from '../../../app/queue/QueueActions';
 import { setUserCssId } from '../../../app/queue/uiReducer/uiActions';
 import { BrowserRouter } from 'react-router-dom';
 import type { Task, BasicAppeal } from '../../../app/queue/types/models';
@@ -140,25 +140,39 @@ describe('ColocatedTaskListView', () => {
         id: '1',
         cssIdAssignee: 'BVALSPORER',
         placedOnHoldAt: moment().subtract(2, 'days'),
-        onHoldDuration: 30 });
+        onHoldDuration: 30
+      });
       const taskNotAssigned = amaTaskWith({
+        ...task,
         id: '5',
-        cssIdAssignee: 'NOTBVALSPORER',
-        placedOnHoldAt: moment().subtract(2, 'days'),
-        onHoldDuration: 30 });
+        cssIdAssignee: 'NOTBVALSPORER'
+      });
+      const taskWithNewDocs = {
+        ...task,
+        id: '4',
+        externalAppealId: '44'
+      };
       const taskNew = amaTaskWith({
         id: '6',
-        cssIdAssignee: task.assignedTo.cssId });
+        cssIdAssignee: task.assignedTo.cssId
+      });
       const appeal = appealTemplate;
+      const appealWithNewDocs = {
+        ...appeal,
+        id: '6',
+        externalId: taskWithNewDocs.externalAppealId
+      };
 
       const tasks = {};
       const amaTasks = {
         [task.id]: task,
         [taskNotAssigned.id]: taskNotAssigned,
+        [taskWithNewDocs.id]: taskWithNewDocs,
         [taskNew.id]: taskNew
       };
       const appeals = {
-        [appeal.id]: appeal
+        [appeal.id]: appeal,
+        [appealWithNewDocs.id]: appealWithNewDocs
       };
       const store = getStore();
 
@@ -166,6 +180,10 @@ describe('ColocatedTaskListView', () => {
         amaTasks,
         appeals }));
       store.dispatch(setUserCssId(task.assignedTo.cssId));
+      store.dispatch(receiveNewDocuments({
+        appealId: appealWithNewDocs.externalId,
+        newDocuments: [{}]
+      }));
 
       const wrapper = getWrapperColocatedTaskListView(store);
 


### PR DESCRIPTION
Blocks https://github.com/department-of-veterans-affairs/caseflow/issues/6079

### Description
Hides tasks with new documents from the on-hold tab. (They'll be on the pending tab, instead.)

### Testing Plan
- [ ] Become BVALSPORER.
- [ ] Go to /queue.
- [ ] Open the on-hold tab.
- [ ] Confirm that there aren't any tasks on the tab.
