### PR TITLE
Fix Vacols timeliness during judge checkout

### DIFF
--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -13,7 +13,8 @@ module QueueMapper
     complexity: :defdiff,
     quality: :deoq,
     comment: :debmcom,
-    completion_date: :decomp
+    completion_date: :decomp,
+    timeliness: :detrem
   }.freeze
 
   DEFICIENCIES = {

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -174,7 +174,11 @@ class QueueRepository
         msg = "The work product is not decision"
         fail Caseflow::Error::QueueRepositoryError, msg
       end
-      update_decass_record(decass_record, decass_attrs)
+      if decass_record.dereceive && decass_record.dedeadline
+        timeliness = decass_record.dereceive > decass_record.dedeadline ? "N" : "Y"
+      end
+
+      update_decass_record(decass_record, decass_attrs.merge(timeliness: timeliness))
       # When the DAS final review is done by the VLJ and the case is charged to 4E the VLJ,
       # Attorney and Team get updated in the BRIEFF table
       decass_record.reload.case.update(

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -175,7 +175,7 @@ class QueueRepository
         fail Caseflow::Error::QueueRepositoryError, msg
       end
       if decass_record.dereceive && decass_record.dedeadline
-        timeliness = decass_record.dereceive > decass_record.dedeadline ? "N" : "Y"
+        timeliness = (decass_record.dereceive > decass_record.dedeadline) ? "N" : "Y"
       end
 
       update_decass_record(decass_record, decass_attrs.merge(timeliness: timeliness))

--- a/spec/models/judge_case_review_spec.rb
+++ b/spec/models/judge_case_review_spec.rb
@@ -43,7 +43,9 @@ describe JudgeCaseReview do
              defolder: "123456",
              deprod: work_product,
              deatty: "102",
-             deteam: "BB")
+             deteam: "BB",
+             dereceive: 4.days.ago,
+             dedeadline: 6.days.ago)
     end
     let!(:vacols_case) { create(:case, bfkey: "123456") }
     let!(:vacols_issue1) { create(:case_issue, isskey: "123456") }
@@ -109,6 +111,7 @@ describe JudgeCaseReview do
           expect(decass.deqr4).to eq nil
           expect(decass.dememid).to eq "AA"
           expect(decass.decomp).to eq VacolsHelper.local_date_with_utc_timezone
+          expect(decass.detrem).to eq "N"
 
           expect(vacols_case.reload.bfcurloc).to eq "48"
           expect(vacols_case.bfmemid).to eq "AA"
@@ -189,6 +192,7 @@ describe JudgeCaseReview do
           expect(decass.deqr3).to eq nil
           expect(decass.deqr4).to eq nil
           expect(decass.decomp).to eq VacolsHelper.local_date_with_utc_timezone
+          expect(decass.detrem).to eq "N"
 
           expect(vacols_case.reload.bfcurloc).to eq "4E"
 


### PR DESCRIPTION
Turns out timeliness is not really calculated at runtime in Vacols :)