### PR TITLE
Co-located table | Pending action tab

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -62,6 +62,7 @@
   "COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE": "Pending",
   "COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold",
   "COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "These are new administrative actions that have been assigned to you.",
+  "COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION": "When a hold is complete, the case will appear here.",
   "COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, the case will automatically return to the Pending action tab.",
 
   "NO_CASES_FOR_JUDGE_REVIEW_TITLE": "Cases not found",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -58,6 +58,9 @@
   "TASKS_NEED_ASSIGNMENT_ERROR_MESSAGE": "Cases marked with exclamation points need to be assigned to you through DAS. Please contact your judge or senior counsel to create preliminary DAS assignments.",
   "JUDGE_QUEUE_UNASSIGNED_CASES_PAGE_TITLE": "Cases to Assign",
 
+  "COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE": "New",
+  "COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE": "Pending",
+  "COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold",
   "COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "These are new administrative actions that have been assigned to you.",
   "COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, the case will automatically return to the Pending action tab.",
 

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -80,7 +80,7 @@ export default (connect(mapStateToProps, mapDispatchToProps)(ColocatedTaskListVi
 const NewTasksTab = connect(
   (state: State) => ({ tasks: newTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
-    return <div>
+    return <React.Fragment>
       <p>{COPY.COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
@@ -91,13 +91,13 @@ const NewTasksTab = connect(
         includeReaderLink
         tasks={props.tasks}
       />
-    </div>;
+    </React.Fragment>;
   });
 
 const PendingTasksTab = connect(
   (state: State) => ({ tasks: pendingTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
-    return <div>
+    return <React.Fragment>
       <p>{COPY.COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
@@ -108,13 +108,13 @@ const PendingTasksTab = connect(
         includeReaderLink
         tasks={props.tasks}
       />
-    </div>;
+    </React.Fragment>;
   });
 
 const OnHoldTasksTab = connect(
   (state: State) => ({ tasks: onHoldTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
-    return <div>
+    return <React.Fragment>
       <p>{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
@@ -125,5 +125,5 @@ const OnHoldTasksTab = connect(
         includeReaderLink
         tasks={props.tasks}
       />
-    </div>;
+    </React.Fragment>;
   });

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -39,13 +39,20 @@ class ColocatedTaskListView extends React.PureComponent<Props> {
 
   render = () => {
     const { success } = this.props;
-    const tabs = [{
-      label: 'New',
-      page: <NewTasksTab />
-    }, {
-      label: 'On hold',
-      page: <OnHoldTasksTab />
-    }];
+    const tabs = [
+      {
+        label: COPY.COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE,
+        page: <NewTasksTab />
+      },
+      {
+        label: COPY.COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE,
+        page: <PendingTasksTab />
+      },
+      {
+        label: COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE,
+        page: <OnHoldTasksTab />
+      }
+    ];
 
     return <AppSegment filledBackground>
       {success && <Alert type="success" title={success.title} message={success.detail} />}
@@ -80,6 +87,23 @@ const NewTasksTab = connect(
         includeType
         includeDocketNumber
         includeDaysWaiting
+        includeReaderLink
+        tasks={props.tasks}
+      />
+    </div>;
+  });
+
+const PendingTasksTab = connect(
+  (state: State) => ({ tasks: onHoldTasksByAssigneeCssIdSelector(state) }))(
+  (props: { tasks: Array<TaskWithAppeal> }) => {
+    return <div>
+      <p>{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
+      <TaskTable
+        includeDetailsLink
+        includeTask
+        includeType
+        includeDocketNumber
+        includeDaysOnHold
         includeReaderLink
         tasks={props.tasks}
       />

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -8,6 +8,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 
 import {
   newTasksByAssigneeCssIdSelector,
+  pendingTasksByAssigneeCssIdSelector,
   onHoldTasksByAssigneeCssIdSelector
 } from './selectors';
 import { hideSuccessMessage } from './uiReducer/uiActions';
@@ -94,7 +95,7 @@ const NewTasksTab = connect(
   });
 
 const PendingTasksTab = connect(
-  (state: State) => ({ tasks: onHoldTasksByAssigneeCssIdSelector(state) }))(
+  (state: State) => ({ tasks: pendingTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
     return <div>
       <p>{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -98,7 +98,7 @@ const PendingTasksTab = connect(
   (state: State) => ({ tasks: pendingTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
     return <div>
-      <p>{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
+      <p>{COPY.COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
         includeTask

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -110,13 +110,24 @@ const hasNewDocuments = (newDocsForAppeal: NewDocsForAppeal, task: Task) => {
   return newDocsForAppeal[task.externalAppealId].docs.length > 0;
 };
 
+export const pendingTasksByAssigneeCssIdSelector: (State) => Array<Task> = createSelector(
+  [tasksByAssigneeCssIdSelector, getNewDocsForAppeal],
+  (tasks: Array<Task>, newDocsForAppeal: NewDocsForAppeal) =>
+    tasks.filter(
+      (task) =>
+        task.placedOnHoldAt &&
+          (moment().diff(moment(task.placedOnHoldAt), 'days') >= task.onHoldDuration ||
+            hasNewDocuments(newDocsForAppeal, task)))
+);
+
 export const onHoldTasksByAssigneeCssIdSelector: (State) => Array<Task> = createSelector(
   [tasksByAssigneeCssIdSelector, getNewDocsForAppeal],
   (tasks: Array<Task>, newDocsForAppeal: NewDocsForAppeal) =>
     tasks.filter(
       (task) =>
-        moment().diff(moment(task.placedOnHoldAt), 'days') < task.onHoldDuration &&
-          !hasNewDocuments(newDocsForAppeal, task))
+        task.placedOnHoldAt &&
+          (moment().diff(moment(task.placedOnHoldAt), 'days') < task.onHoldDuration &&
+            !hasNewDocuments(newDocsForAppeal, task)))
 );
 
 export const judgeReviewTasksSelector = createSelector(

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -211,7 +211,7 @@ describe('ColocatedTaskListView', () => {
         expect(documents.html()).to.include(`/reader/appeal/${task.externalAppealId}/documents`);
       }
       {
-        const [caseDetails, columnTasks, types, docketNumber, daysOnHold, documents] = wrappers.slice(6);
+        const [daysOnHold, documents] = wrappers.slice(10);
 
         expect(daysOnHold.text()).to.equal('2 of 30');
         expect(documents.html()).to.include(`/reader/appeal/${taskWithNewDocs.externalAppealId}/documents`);


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/6079

### Description
Adds a tab for pending tasks, including on-hold tasks with new documents.

### Testing Plan
- [x] Become BVALSPORER.
- [x] Go to /queue.
- [x] Switch to the pending tab.
- [x] Confirm that one task is visible.
