### PR TITLE
Jobs | Sets Sentry context on the worker thread

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,10 +1,14 @@
 class ApplicationJob < ActiveJob::Base
-  def self.application_attr(app_name)
-    @app_name = app_name
+  class << self
+    def application_attr(app_name)
+      @app_name = app_name
+    end
+    
+    attr_reader :app_name
   end
 
   before_perform do
     # setup debug context
-    Raven.extra_context(application: @app_name.to_s)
+    Raven.extra_context(application: self.class.app_name.to_s)
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,7 +3,7 @@ class ApplicationJob < ActiveJob::Base
     def application_attr(app_name)
       @app_name = app_name
     end
-    
+
     attr_reader :app_name
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,6 +1,10 @@
 class ApplicationJob < ActiveJob::Base
   def self.application_attr(app_name)
+    @app_name = app_name
+  end
+
+  before_perform do
     # setup debug context
-    Raven.extra_context(application: app_name.to_s)
+    Raven.extra_context(application: @app_name.to_s)
   end
 end

--- a/app/jobs/ramp_election_sync_job.rb
+++ b/app/jobs/ramp_election_sync_job.rb
@@ -1,9 +1,9 @@
 # This job syncs a RampElection with up to date BGS and VBMS data
 class RampElectionSyncJob < CaseflowJob
   queue_as :low_priority
+  application_attr :intake
 
   def perform(ramp_election_id)
-    self.class.application_attr :intake
     RequestStore.store[:current_user] = User.system_user
 
     RampElection.find(ramp_election_id).sync!

--- a/app/jobs/sync_intake_job.rb
+++ b/app/jobs/sync_intake_job.rb
@@ -2,9 +2,9 @@
 # EP known to Intake
 class SyncIntakeJob < CaseflowJob
   queue_as :low_priority
+  application_attr :intake
 
   def perform
-    self.class.application_attr :intake
     # Set user to system_user to avoid sensitivity errors
     RequestStore.store[:current_user] = User.system_user
 

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -11,8 +11,9 @@ end
 describe "ApplicationJob" do
   context ".application_attr" do
     it "sets extra context" do
-      allow()
-      expect(true).to be false
+      allow(Raven).to receive(:extra_context)
+      TestJob.perform_now
+      expect(Raven).to have_received(:extra_context).with(application: "fake")
     end
   end
 end

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+class TestJob < ApplicationJob
+  application_attr :fake
+
+  def perform
+    "Hello"
+  end
+end
+
+describe "ApplicationJob" do
+  context ".application_attr" do
+    it "sets extra context" do
+      allow()
+      expect(true).to be false
+    end
+  end
+end


### PR DESCRIPTION
### Description
Changes ApplicationJob to add the app name to the Sentry context from the job's worker thread. This ensures that job errors are routed to the right channel. See also https://github.com/department-of-veterans-affairs/caseflow/pull/6649 and https://github.com/department-of-veterans-affairs/caseflow/pull/6624.

### Testing Plan
- [ ] Merge this PR.
- [ ] Deploy Caseflow.
- [ ] Confirm that BGSEndProductSyncError doesn't start showing up in #appeals-app-alerts.

