### PR TITLE
Colocated Queue | Add task counts to tabs

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -58,9 +58,9 @@
   "TASKS_NEED_ASSIGNMENT_ERROR_MESSAGE": "Cases marked with exclamation points need to be assigned to you through DAS. Please contact your judge or senior counsel to create preliminary DAS assignments.",
   "JUDGE_QUEUE_UNASSIGNED_CASES_PAGE_TITLE": "Cases to Assign",
 
-  "COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE": "New",
-  "COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE": "Pending",
-  "COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold",
+  "COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE": "New (%(numNewTasks)d)",
+  "COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE": "Pending (%(numPendingTasks)d)",
+  "COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold (%(numOnHoldTasks)d)",
   "COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "These are new administrative actions that have been assigned to you.",
   "COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION": "When a hold is complete, the case will appear here.",
   "COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, the case will automatically return to the Pending action tab.",

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -25,6 +25,9 @@ type Params = {||};
 type Props = Params & {|
   // store
   success: UiStateMessage,
+  numNewTasks: number,
+  numPendingTasks: number,
+  numOnHoldTasks: number,
   // Action creators
   clearCaseSelectSearch: typeof clearCaseSelectSearch,
   hideSuccessMessage: typeof hideSuccessMessage
@@ -58,7 +61,10 @@ const mapStateToProps = (state) => {
   const { success } = state.ui.messages;
 
   return {
-    success
+    success,
+    numNewTasks: newTasksByAssigneeCssIdSelector(state).length,
+    numPendingTasks: pendingTasksByAssigneeCssIdSelector(state).length,
+    numOnHoldTasks: onHoldTasksByAssigneeCssIdSelector(state).length
   };
 };
 

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { sprintf } from 'sprintf-js';
 
 import TaskTable from './components/TaskTable';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
@@ -42,18 +43,23 @@ class ColocatedTaskListView extends React.PureComponent<Props> {
   componentWillUnmount = () => this.props.hideSuccessMessage();
 
   render = () => {
-    const { success } = this.props;
+    const {
+      success,
+      numNewTasks,
+      numPendingTasks,
+      numOnHoldTasks
+    } = this.props;
     const tabs = [
       {
-        label: COPY.COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE,
+        label: sprintf(COPY.COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE, { numNewTasks }),
         page: <NewTasksTab />
       },
       {
-        label: COPY.COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE,
+        label: sprintf(COPY.COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE, { numPendingTasks }),
         page: <PendingTasksTab />
       },
       {
-        label: COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE,
+        label: sprintf(COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE, { numOnHoldTasks }),
         page: <OnHoldTasksTab />
       }
     ];

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -189,7 +189,7 @@ describe('ColocatedTaskListView', () => {
 
       const wrapper = getWrapperColocatedTaskListView(store);
 
-      wrapper.find('[aria-label="Pending tab window"]').simulate('click');
+      wrapper.find('[aria-label="Pending (2) tab window"]').simulate('click');
 
       const cells = wrapper.find('td');
 
@@ -272,7 +272,7 @@ describe('ColocatedTaskListView', () => {
 
       const wrapper = getWrapperColocatedTaskListView(store);
 
-      wrapper.find('[aria-label="On hold tab window"]').simulate('click');
+      wrapper.find('[aria-label="On hold (1) tab window"]').simulate('click');
 
       const cells = wrapper.find('td');
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/6720

### Description
Adds task counts to the tabs on the colocated queue.

<img width="615" alt="screen shot 2018-08-23 at 5 50 31 pm" src="https://user-images.githubusercontent.com/357369/44553900-0d9b0500-a6fd-11e8-82b9-9738072794fe.png">

### Testing Plan
- [ ] Become bvalsporer.
- [ ] Go to /queue.
- [ ] Confirm that tab labels include task counts.
