### PR TITLE
Ignore rubyzip vulnerability one week

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -16,7 +16,7 @@ task :security_caseflow do
   Time.zone = "Eastern Time (US & Canada)"
 
   # Only ignore this vulnerability for a week.
-  audit_cmd = "bundle-audit check --ignore CVE-2016-10545"
+  audit_cmd = "bundle-audit check --ignore CVE-2018-1000544"
   if Time.zone.local(2018, 8, 26) < Time.zone.today - 1.week
     audit_cmd = "bundle-audit check"
   end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -17,7 +17,7 @@ task :security_caseflow do
 
   # Only ignore this vulnerability for a week.
   audit_cmd = "bundle-audit check --ignore CVE-2016-10545"
-  if Time.zone.local(2018, 7, 5) < Time.zone.today - 1.week
+  if Time.zone.local(2018, 8, 26) < Time.zone.today - 1.week
     audit_cmd = "bundle-audit check"
   end
   audit_result = ShellCommand.run(audit_cmd)


### PR DESCRIPTION

### Description
Our security linter is blocking merges right now due to a vulnerability discovered in rubyzip.

This PR ignores the vulnerability for one week. It will only be merged if we determine that this vulnerability only affects our test runs and not application code.

In a week, we'll need to ignore it again or bump our version of rubyzip to a version where the vulnerability is fixed.

### Testing Plan
CircleCI tests pass

