### PR TITLE
Show all AMA appeals in case search

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -85,10 +85,7 @@ class AppealsController < ApplicationController
                           service: :queue,
                           name: "AppealsController.index") do
 
-      appeals = []
-      if FeatureToggle.enabled?(:queue_beaam_appeals, user: current_user)
-        appeals.concat(Appeal.where(veteran_file_number: file_number).to_a)
-      end
+      appeals = Appeal.where(veteran_file_number: file_number).to_a
       # rubocop:disable Lint/HandleExceptions
       begin
         appeals.concat(LegacyAppeal.fetch_appeals_by_file_number(file_number))


### PR DESCRIPTION
Resolves #6742.

### Manual test plan
* Find a pre-existing legacy appeal (Veteran ID 884668527, for example)
* Create an AMA appeal for it in our database `v = Veteran.find_by(file_number: 884668527); FactoryBot.create(:appeal, veteran: v)`
* Turn off the feature toggle for your current user `u = User.find_by(css_id: "BVASCASPER1"); FeatureToggle.disable!(:queue_beaam_appeals, users: [u.css_id])`
* Search for that Veteran ID in the case search box, see both appeals (before this change only the legacy appeal would appear).