### PR TITLE
making hearing days immutable and fix error handling

### DIFF
--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -42,6 +42,7 @@ class HearingSchedule::AssignJudgesToHearingDays
             current_hearing_day = hearing_days[index]
             unless can_day_be_assigned(current_hearing_day, assigned_hearing_days, css_id)
               assigned_hearing_days.push(*assign_judge_to_hearing_day(current_hearing_day, css_id))
+              hearing_days.delete(current_hearing_day)
               hearing_days_assigned = (total_hearing_day_count == assigned_hearing_days.length)
               break
             end
@@ -49,7 +50,7 @@ class HearingSchedule::AssignJudgesToHearingDays
             throw :hearing_days_assigned if hearing_days_assigned
           end
         end
-        verify_assignments(num_days_assigned, assigned_hearing_days, hearing_days_assigned)
+        verify_assignments(num_days_assigned, assigned_hearing_days, hearing_days_assigned, hearing_days)
       end
     end
     assigned_hearing_days.sort_by { |day| day[:hearing_date] }
@@ -104,17 +105,16 @@ class HearingSchedule::AssignJudgesToHearingDays
     end
   end
 
-  def verify_assignments(num_days_assigned, assigned_hearing_days, hearing_days_assigned)
-    dates = @video_co_hearing_days.map(&:hearing_date)
-
-    if @algo_counter >= 20
-      fail HearingSchedule::Errors::CannotAssignJudges.new(
-        "Hearing days on these dates couldn't be assigned #{dates}.",
-        dates: dates
-      )
-    end
-
+  def verify_assignments(num_days_assigned, assigned_hearing_days, hearing_days_assigned, hearing_days)
     if (num_days_assigned == assigned_hearing_days.length) && !hearing_days_assigned
+      dates = hearing_days.map(&:hearing_date)
+
+      if @algo_counter >= 20
+        fail HearingSchedule::Errors::CannotAssignJudges.new(
+          "Hearing days on these dates couldn't be assigned #{dates}.",
+          dates: dates
+        )
+      end
       @algo_counter += 1
       match_hearing_days_to_judges
     end
@@ -148,7 +148,6 @@ class HearingSchedule::AssignJudgesToHearingDays
     hearing_days = is_central_hearing ? hearing_days_by_date(date) : [day]
 
     hearing_days.map do |hearing_day|
-      @video_co_hearing_days.delete(hearing_day)
 
       HearingDayMapper.hearing_day_field_validations(
         hearing_pkseq: hearing_day.hearing_pkseq,
@@ -193,7 +192,7 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def fetch_hearing_days_for_schedule_period
     hearing_days = HearingDay.load_days(@schedule_period.start_date, @schedule_period.end_date)
-    @video_co_hearing_days = filter_co_hearings(hearing_days[0].to_a)
+    @video_co_hearing_days = filter_co_hearings(hearing_days[0].to_a).freeze
 
     # raises an exception if hearing days have not already been allocated
     fail HearingDaysNotAllocated if @video_co_hearing_days.empty?

--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -107,7 +107,7 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def verify_assignments(unassigned_hearing_days, prior_iter_days_assigned, assigned_hearing_days)
     if (prior_iter_days_assigned == assigned_hearing_days.length) &&
-        !(assigned_hearing_days.length == @video_co_hearing_days.length)
+       assigned_hearing_days.length != @video_co_hearing_days.length
       dates = unassigned_hearing_days.map(&:hearing_date)
 
       if @algo_counter >= 20
@@ -149,7 +149,6 @@ class HearingSchedule::AssignJudgesToHearingDays
     hearing_days = is_central_hearing ? hearing_days_by_date(date) : [day]
 
     hearing_days.map do |hearing_day|
-
       HearingDayMapper.hearing_day_field_validations(
         hearing_pkseq: hearing_day.hearing_pkseq,
         hearing_type: get_hearing_type(is_central_hearing),


### PR DESCRIPTION
Resolves #6768

### Description
* Changed variable names for better redability
* Made `video_co_hearing_days` immutable after it's been assigned to hearing days
* Move the block of code where the errors are being thrown to the correct location

### Acceptance Criteria
- [ ] Error message with details are properly shown to users. 

### Testing Plan
1. Use 'ValidRoSpreadsheet` to upload additional RO days locally from (01/01 - 05/31)
2. Confirm those RO days
3. There should be 300 odd hearing days from periods (01/01 - 05/31)
4. Assign judges using the following spreadsheet attached to this issue
5. Notice error in the UI with dates that could not be assigned in the message

[sevenJudgesApril2018.xlsx](https://github.com/department-of-veterans-affairs/caseflow/files/2329088/sevenJudgesApril2018.xlsx)

