### PR TITLE
Unset VACOLS upload

### DIFF
--- a/client/app/hearingSchedule/reducers.js
+++ b/client/app/hearingSchedule/reducers.js
@@ -158,7 +158,8 @@ const reducers = (state = initialState, action = {}) => {
     return update(state, {
       $unset: [
         'displaySuccessMessage',
-        'schedulePeriod'
+        'schedulePeriod',
+        'vacolsUpload'
       ]
     });
   default:


### PR DESCRIPTION
Connects #6773 

### Testing Plan
1. Add a backend error in the schedule_periods_controller update function
1. Attempt to confirm a schedule period VACOLS upload
1. Confirm an error is displayed
1. When navigating away from the resulting page, confirm vacolsUpload is unset

