### PR TITLE
Add RequestIssuesUpdate model

### DIFF
--- a/app/models/ama_review.rb
+++ b/app/models/ama_review.rb
@@ -111,30 +111,10 @@ class AmaReview < ApplicationRecord
     @rated_issue_contention_map ||= create_rated_issue_contention_map
   end
 
-  # VBMS will return ALL contentions on a end product when you create contentions,
-  # not just the ones that were just created. This method assumes there are no
-  # pre-existing contentions on the end product. Since it was also just created.
   def create_contentions_on_new_end_product!(rated: true)
-    issues_to_create = rated ? rated_issues_to_create : nonrated_issues_to_create
-    # Load all the issues so we can match them in memory
-    issues_to_create.all.tap do |issues|
-      # Currently not making any assumptions about the order in which VBMS returns
-      # the created contentions. Instead find the issue by matching text.
-      create_contentions_in_vbms(rated: rated).each do |contention|
-        matching_issue = issues.find { |issue| issue.description == contention.text }
-        matching_issue && matching_issue.update!(contention_reference_id: contention.id)
-      end
+    issues_to_create = (rated ? rated_issues_to_create : nonrated_issues_to_create).all
 
-      fail ContentionCreationFailed if issues.any? { |issue| !issue.contention_reference_id }
-    end
-  end
-
-  def create_contentions_in_vbms(rated: true)
-    VBMSService.create_contentions!(
-      veteran_file_number: veteran_file_number,
-      claim_id: end_product_establishment(rated: rated).reference_id,
-      contention_descriptions: issue_descriptions_to_create(rated: rated)
-    )
+    end_product_establishment(rated: rated).create_contentions!(from_objects: issues_to_create)
   end
 
   def create_associated_rated_issues_in_vbms!

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -1,0 +1,21 @@
+# A claim review is a short hand term to refer to either a supplemental claim or
+# higher level review as defined in the Appeals Modernization Act of 2017
+
+class ClaimReview < AmaReview
+  self.abstract_class = true
+
+  # NOTE: Choosing not to test this method because it is fully tested in RequestIssuesUpdate.perform!
+  # hoping to refactor this, so it can be a private method inside request issues update, but that requires
+  # request issues to know about their own end_product_establishments
+  def on_request_issues_update!(request_issues_update)
+    # TODO: what should happen if one of these requests fails? retry? rollback?
+
+    end_product_establishment(rated: true).create_contentions!(
+      request_issues_update.created_issues
+    )
+
+    request_issues_update.removed_issues.each do |request_issue|
+      end_product_establishment(rated: true).remove_contention!(request_issue)
+    end
+  end
+end

--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -1,4 +1,4 @@
-class HigherLevelReview < AmaReview
+class HigherLevelReview < ClaimReview
   with_options if: :saving_review do
     validates :receipt_date, presence: { message: "blank" }
     validates :informal_conference, :same_office, inclusion: { in: [true, false], message: "blank" }
@@ -39,15 +39,6 @@ class HigherLevelReview < AmaReview
     [{ code: "SSR", narrative: "Same Station Review" }]
   end
 
-  def create_contentions_in_vbms(rated: true)
-    VBMSService.create_contentions!(
-      veteran_file_number: veteran_file_number,
-      claim_id: end_product_establishment(rated: rated).reference_id,
-      contention_descriptions: issue_descriptions_to_create(rated: rated),
-      special_issues: special_issues
-    )
-  end
-
   private
 
   def find_end_product_establishment(ep_code)
@@ -65,7 +56,8 @@ class HigherLevelReview < AmaReview
       invalid_modifiers: invalid_modifiers,
       claimant_participant_id: claimant_participant_id,
       source: self,
-      station: "397" # AMC
+      station: "397", # AMC
+      special_issues: special_issues
     )
   end
 

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -1,0 +1,99 @@
+# Represents the action where a Caseflow user updates the request issues on
+# a review, typically to make a correction.
+
+class RequestIssuesUpdate < ApplicationRecord
+  belongs_to :user
+  belongs_to :review, polymorphic: true
+
+  attr_writer :request_issues_data
+  attr_reader :error_code
+
+  def perform!
+    return false unless validate_before_perform
+
+    transaction do
+      # TODO: Investigate making each request issue responsible for determining its own
+      # end product establishment. This will remove the need for the review to be responsible
+      # for creating and removing the appropriate contentions
+      new_issues.each(&:save!)
+
+      strip_removed_issues!
+
+      update!(
+        before_request_issue_ids: before_issues.map(&:id),
+        after_request_issue_ids: after_issues.map(&:id)
+      )
+    end
+
+    review.on_request_issues_update!(self)
+
+    true
+  end
+
+  def created_issues
+    after_issues - before_issues
+  end
+
+  def removed_issues
+    before_issues - after_issues
+  end
+
+  private
+
+  def changes?
+    review.request_issues.count != @request_issues_data.count || !new_issues.empty?
+  end
+
+  def new_issues
+    after_issues.reject(&:persisted?)
+  end
+
+  def before_issues
+    @before_issues ||= before_request_issue_ids ? fetch_before_issues : calculate_before_issues
+  end
+
+  def after_issues
+    @after_issues ||= after_request_issue_ids ? fetch_after_issues : calculate_after_issues
+  end
+
+  def calculate_after_issues
+    # need to calculate and store before issues before we add new request issues
+    before_issues
+
+    @request_issues_data.map do |issue_data|
+      review.request_issues.find_or_initialize_by(
+        rating_issue_profile_date: issue_data[:profile_date],
+        rating_issue_reference_id: issue_data[:reference_id],
+        description: issue_data[:description]
+      )
+    end
+  end
+
+  def calculate_before_issues
+    review.request_issues.select(&:persisted?)
+  end
+
+  def validate_before_perform
+    if !@request_issues_data || @request_issues_data.empty?
+      @error_code = :request_issues_data_empty 
+    elsif !changes?
+      @error_code = :no_changes 
+    end
+
+    !@error_code
+  end
+
+  def fetch_before_issues
+    RequestIssue.where(id: before_request_issue_ids)
+  end
+
+  def fetch_after_issues
+    RequestIssue.where(id: after_request_issue_ids)
+  end
+
+  # Instead of fully deleting removed issues, we instead strip them from the review so we can
+  # maintain a record of the other data that was on them incase we need to revert the update.
+  def strip_removed_issues!
+    removed_issues.each { |issue| issue.update!(review_request: nil) }
+  end
+end

--- a/app/models/supplemental_claim.rb
+++ b/app/models/supplemental_claim.rb
@@ -1,4 +1,4 @@
-class SupplementalClaim < AmaReview
+class SupplementalClaim < ClaimReview
   validates :receipt_date, presence: { message: "blank" }, if: :saving_review
 
   END_PRODUCT_RATING_CODE = "040SCR".freeze

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -130,6 +130,17 @@ class ExternalApi::VBMSService
     send_and_log_request(claim_id, request)
   end
 
+  def self.remove_contention!(contention)
+    @vbms_client ||= init_vbms_client
+
+    request = VBMS::Requests::RemoveContention.new(
+      contention: contention,
+      v5: FeatureToggle.enabled?(:claims_service_v5)
+    )
+
+    send_and_log_request(claim_id, request)
+  end
+
   def self.associate_rated_issues!(claim_id:, rated_issue_contention_map:)
     # rated_issue_contention_map format: { issue_id: contention_id, issue_id2: contention_id2 }
     @vbms_client ||= init_vbms_client

--- a/db/migrate/20180824172906_create_request_issues_updates.rb
+++ b/db/migrate/20180824172906_create_request_issues_updates.rb
@@ -1,0 +1,11 @@
+class CreateRequestIssuesUpdates < ActiveRecord::Migration[5.1]
+  def change
+    create_table :request_issues_updates do |t|
+      t.belongs_to :user, null: false
+      t.belongs_to :review, polymorphic: true, null: false
+      t.integer :before_request_issue_ids, array: true, null: false
+      t.integer :after_request_issue_ids, array: true, null: false
+      t.datetime :processed_at
+    end
+  end
+end

--- a/db/migrate/20180824224113_allow_nil_review_on_request_issues.rb
+++ b/db/migrate/20180824224113_allow_nil_review_on_request_issues.rb
@@ -1,0 +1,6 @@
+class AllowNilReviewOnRequestIssues < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :request_issues, :review_request_id, true
+    change_column_null :request_issues, :review_request_type, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180817195432) do
+ActiveRecord::Schema.define(version: 20180824224113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -524,8 +524,8 @@ ActiveRecord::Schema.define(version: 20180817195432) do
   end
 
   create_table "request_issues", force: :cascade do |t|
-    t.string "review_request_type", null: false
-    t.bigint "review_request_id", null: false
+    t.string "review_request_type"
+    t.bigint "review_request_id"
     t.string "rating_issue_reference_id"
     t.date "rating_issue_profile_date"
     t.string "contention_reference_id"
@@ -533,6 +533,17 @@ ActiveRecord::Schema.define(version: 20180817195432) do
     t.string "issue_category"
     t.date "decision_date"
     t.index ["review_request_type", "review_request_id"], name: "index_request_issues_on_review_request"
+  end
+
+  create_table "request_issues_updates", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "review_type", null: false
+    t.bigint "review_id", null: false
+    t.integer "before_request_issue_ids", null: false, array: true
+    t.integer "after_request_issue_ids", null: false, array: true
+    t.datetime "processed_at"
+    t.index ["review_type", "review_id"], name: "index_request_issues_updates_on_review_type_and_review_id"
+    t.index ["user_id"], name: "index_request_issues_updates_on_user_id"
   end
 
   create_table "schedule_periods", force: :cascade do |t|

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -160,4 +160,11 @@ class Fakes::VBMSService
 
     true
   end
+
+  def self.remove_contention!(contention)
+    Rails.logger.info("Submitting remove contention request to VBMS...")
+    Rails.logger.info("Contention: #{contention.inspect}")
+
+    true
+  end
 end

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -1,0 +1,207 @@
+require "rails_helper"
+
+describe RequestIssuesUpdate do
+  before do
+    FeatureToggle.enable!(:test_facols)
+
+    rated_end_product_establishment.update!(reference_id: end_product.claim_id)
+  end
+
+  after do
+    FeatureToggle.disable!(:test_facols)
+  end
+
+  # TODO: make it simpler to set up a completed claim review, with end product data
+  # and contention data stubbed out properly
+  let(:review) { create(:higher_level_review) }
+
+  let(:rated_end_product_establishment) do
+    review.send(:end_product_establishment, rated: true)
+  end
+
+  let(:end_product) { Generators::EndProduct.build }
+
+  let(:request_issue_contentions) do
+    [
+      Generators::Contention.build(
+        claim_id: end_product.claim_id,
+        text: "Service connection for PTSD was granted at 10 percent"
+      ),
+      Generators::Contention.build(
+        claim_id: end_product.claim_id,
+        text: "Service connection for left knee immobility was denied"
+      )
+    ]
+  end
+
+  let!(:existing_request_issues) do
+    [
+      RequestIssue.create!(
+        review_request: review,
+        rating_issue_profile_date: Date.new(2017, 4, 5),
+        rating_issue_reference_id: "issue1",
+        contention_reference_id: request_issue_contentions[0].id,
+        description: request_issue_contentions[0].text,
+      ),
+      RequestIssue.create!(
+        review_request: review,
+        rating_issue_profile_date: Date.new(2017, 4, 6),
+        rating_issue_reference_id: "issue2",
+        contention_reference_id: request_issue_contentions[1].id,
+        description: request_issue_contentions[1].text,
+      )
+    ]
+  end
+
+  let(:request_issues_update) do
+    RequestIssuesUpdate.new(
+      user: user,
+      review: review,
+      request_issues_data: request_issues_data
+    )
+  end
+
+  let(:user) { create(:user) }
+
+  let(:request_issues_data) { [] }
+
+  let(:existing_request_issues_data) do
+    existing_request_issues.map do |issue|
+      {
+        reference_id: issue.rating_issue_reference_id,
+        # TODO: validate the string format this comes in
+        profile_date: issue.rating_issue_profile_date, 
+        description: issue.description
+      }
+    end
+  end
+
+  let(:request_issues_data_with_new_issue) do
+    existing_request_issues_data + [{
+      reference_id: "issue3",
+      profile_date: Date.new(2017, 4, 7),
+      description: "Service connection for cancer was denied"
+    }]
+  end
+
+  context "#created_issues" do
+    subject { request_issues_update.created_issues }
+    before { request_issues_update.perform! }
+
+    context "when new issues were added as part of the update" do
+      let(:request_issues_data) { request_issues_data_with_new_issue }
+      let(:new_request_issue) { RequestIssue.find_by(rating_issue_reference_id: "issue3") }
+
+      it { is_expected.to contain_exactly(new_request_issue) }
+    end
+
+    context "when new issues were added as part of the update" do
+      let(:request_issues_data) { existing_request_issues_data[0...1] }
+
+      it { is_expected.to eq([]) }
+    end
+  end
+
+  context "#removed_issues" do
+    subject { request_issues_update.removed_issues }
+    before { request_issues_update.perform! }
+
+    context "when new issues were removed as part of the update" do
+      let(:request_issues_data) { existing_request_issues_data[0...1] }
+
+      it { is_expected.to contain_exactly(existing_request_issues.last) }
+    end
+
+    context "when new issues were added as part of the update" do
+      let(:request_issues_data) { request_issues_data_with_new_issue }
+
+      it { is_expected.to eq([]) }
+    end
+  end
+
+  context "#perform!" do
+    subject { request_issues_update.perform! }
+
+    context "when request issues are empty" do
+      it "fails and adds to errors" do
+        expect(subject).to be_falsey
+
+        expect(request_issues_update.error_code).to eq(:request_issues_data_empty)
+      end
+    end
+
+    context "when issues are exactly the same as existing issues" do
+      let(:request_issues_data) { existing_request_issues_data }
+
+      it "fails and adds to errors" do
+        expect(subject).to be_falsey
+
+        expect(request_issues_update.error_code).to eq(:no_changes)
+      end
+    end
+
+    context "when issues contain new issues not in existing issues" do
+      let(:request_issues_data) { request_issues_data_with_new_issue }
+
+      it "saves update, adds issues, and calls create contentions" do
+        allow(Fakes::VBMSService).to receive(:create_contentions!).and_call_original
+
+        expect(subject).to be_truthy
+
+        request_issues_update.reload
+
+        expect(request_issues_update.before_request_issue_ids).to contain_exactly(
+          *existing_request_issues.map(&:id)
+        )
+
+        expect(request_issues_update.after_request_issue_ids).to contain_exactly(
+          *(existing_request_issues.map(&:id) + [ review.request_issues.last.id ])
+        )
+
+        expect(Fakes::VBMSService).to have_received(:create_contentions!).with(
+          hash_including(
+            veteran_file_number: review.veteran_file_number,
+            contention_descriptions: ["Service connection for cancer was denied"],
+            special_issues: []
+          )
+        )
+
+        expect(review.request_issues.count).to eq(3)
+
+        created_issue = review.request_issues.find_by(rating_issue_reference_id: "issue3")
+        expect(created_issue).to have_attributes(
+          rating_issue_profile_date: Date.new(2017, 4, 7),
+          description: "Service connection for cancer was denied"
+        )
+        expect(created_issue.contention_reference_id).to_not be_nil
+      end
+    end
+
+    context "when issues contain a subset of existing issues" do
+      let(:request_issues_data) { existing_request_issues_data[0...1] }
+
+      it "saves update, removes issues, and calls remove contentions" do
+        allow(Fakes::VBMSService).to receive(:remove_contention!).and_call_original
+
+        expect(subject).to be_truthy
+
+        request_issues_update.reload
+
+        expect(request_issues_update.before_request_issue_ids).to contain_exactly(
+          *existing_request_issues.map(&:id)
+        )
+
+        expect(request_issues_update.after_request_issue_ids).to contain_exactly(
+          existing_request_issues.first.id
+        )
+
+        removed_issue = existing_request_issues.last.reload
+        expect(removed_issue).to have_attributes(
+          review_request: nil,
+        )
+
+        expect(Fakes::VBMSService).to have_received(:remove_contention!).with(request_issue_contentions.last)
+      end
+    end
+  end
+end


### PR DESCRIPTION
connects #6212
connects #6357

### Description
Added `RequestIssuesUpdate` class to capture an instance of a user updating the issues on the case. It is stored in the database to make the operation fully auditable, retryable, and able to be rolled back.

Also added a few more things:
- Begun moving create contentions functionality into the End Product Establishment
- Added `ClaimReview` abstract class
- Added some top level description comments for some of our classes