### PR TITLE
Checking for CO master records

### DIFF
--- a/app/helpers/master_record_helper.rb
+++ b/app/helpers/master_record_helper.rb
@@ -5,7 +5,7 @@ module MasterRecordHelper
     # and children records
     def remove_master_records_with_children(records)
       children_vdkeys = records.map(&:vdkey).compact
-      records.reject { |record| children?(record, children_vdkeys) }
+      records.reject { |record| record.folder_nr.nil? || children?(record, children_vdkeys) }
     end
 
     # Fields such as 'type', 'regional_office_key', 'date' are stored in different places

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -149,6 +149,7 @@ class VACOLS::CaseHearing < VACOLS::Record
 
   def master_record_type
     return :video if folder_nr =~ /VIDEO/
+    return :central if folder_nr.nil?
   end
 
   def update_hearing!(hearing_info)

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -149,7 +149,6 @@ class VACOLS::CaseHearing < VACOLS::Record
 
   def master_record_type
     return :video if folder_nr =~ /VIDEO/
-    return :central if folder_nr.nil?
   end
 
   def update_hearing!(hearing_info)

--- a/app/models/vacols/travel_board_schedule.rb
+++ b/app/models/vacols/travel_board_schedule.rb
@@ -63,4 +63,8 @@ class VACOLS::TravelBoardSchedule < VACOLS::Record
   def vdkey
     nil
   end
+
+  def folder_nr
+    :fake_folder_nr
+  end
 end


### PR DESCRIPTION
We are getting Sentry errors that we're unable to create appeals because folder_nr is nil. This is because for hearing scheduling, we've assigned judges to central office hearings that don't have veterans assigned. Previously, judges were only assigned when a veteran was assigned. We need to define central office records that have blank folder_nrs as master records so that we don't try to create appeals for them.

To test:
1) Confirm that the only hearing records with blank folder_nrs are CO hearings that haven't yet been assigned a veteran
1) Confirm that the CO records are still displayed correctly in the UI

https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2343/