### PR TITLE
Fixes assignment when a colocated admin is removed

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -41,6 +41,7 @@ class ColocatedTask < Task
 
     def next_assignee_index
       return 0 unless last_assignee_css_id
+      return 0 unless list_of_assignees.index(last_assignee_css_id)
       (list_of_assignees.index(last_assignee_css_id) + 1) % list_of_assignees.length
     end
 


### PR DESCRIPTION
### Description
Today, if an admin is removed from the list of colocated admins, assignment to colocated breaks. This fixes that. Unblocks testing in Preprod. Copied from https://github.com/department-of-veterans-affairs/caseflow/pull/6668 .