### PR TITLE
Remove gunzip deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,7 +460,7 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.3)
       execjs (>= 0.3.0, < 3)
-    unicode-display_width (1.3.0)
+    unicode-display_width (1.3.3)
     wannabe_bool (0.7.0)
     wasabi (3.5.0)
       httpi (~> 2.0)


### PR DESCRIPTION
Eliminates the following deprecation warning that has been bugging me whenever I run tests/rails console/rubocop:
```
NOTE: Gem.gunzip is deprecated; use Gem::Util.gunzip instead. It will be removed on or after 2018-12-01.
Gem.gunzip called from /Users/lowell/.rvm/gems/ruby-2.5.1/gems/unicode-display_width-1.3.0/lib/unicode/display_width/index.rb:5.
```

We only upgrade unicode-display_width to the latest patch version, [not the most recent version](https://github.com/janlelis/unicode-display_width/blob/master/CHANGELOG.md) overall in an attempt to avoid any unintended side effects.