### PR TITLE
Update rubyzip (CVE-2018-1000544)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,6 +170,7 @@ gem "paper_trail", "8.1.2"
 gem "holidays", "~> 6.4"
 
 gem "roo", "~> 2.7"
+gem "rubyzip", "~> 1.2.2"
 
 gem "business_time", "~> 0.9.3"
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -398,7 +398,7 @@ GEM
     ruby-oci8 (2.2.5.1)
     ruby-plsql (0.6.0)
     ruby-progressbar (1.9.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_shell (1.1.0)
     sass (3.5.5)
       sass-listen (~> 4.0.0)
@@ -546,6 +546,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.52.1)
   ruby-oci8
+  rubyzip (~> 1.2.2)
   sass-rails (~> 5.0)
   scss_lint
   sdoc (~> 0.4.0)
@@ -564,4 +565,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
Updates `rubyzip` (dependency of `roo`) due to https://github.com/rubyzip/rubyzip/pull/376