### PR TITLE
Allow VSO users access to switch user screen

### DIFF
--- a/app/controllers/test/users_controller.rb
+++ b/app/controllers/test/users_controller.rb
@@ -6,7 +6,7 @@ CaseflowCertification::Application.load_tasks
 class Test::UsersController < ApplicationController
   before_action :require_demo, only: [:set_user, :set_end_products, :reseed, :toggle_feature]
   before_action :require_global_admin, only: :log_in_as_user
-  skip_before_action :deny_vso_access, only: :index
+  skip_before_action :deny_vso_access, only: [:index, :set_user]
 
   APPS = [
     {

--- a/app/controllers/test/users_controller.rb
+++ b/app/controllers/test/users_controller.rb
@@ -6,6 +6,7 @@ CaseflowCertification::Application.load_tasks
 class Test::UsersController < ApplicationController
   before_action :require_demo, only: [:set_user, :set_end_products, :reseed, :toggle_feature]
   before_action :require_global_admin, only: :log_in_as_user
+  skip_before_action :deny_vso_access, only: :index
 
   APPS = [
     {


### PR DESCRIPTION
### Test plan:
* Log in as VSO User
* Go to your queue (notice the redirect! How cool!)
* Select "Switch User" from the dropdown in the top right
* It works. Marvel at the majesty of web development in the 21st century