### PR TITLE
Rails hangs

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
   config.cache_classes = false
 
   # Do not eager load code on boot.
-  config.eager_load = false
+  config.eager_load = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
### Description
Since upgrading Ruby, [people have experienced](https://dsva.slack.com/archives/C2ZAMLK88/p1536169620000100) slowness / hanging when running the Rails server locally. 

Some issues suggest it may be due to Rails' module loader, and can be solved by setting [`config.eager_load = true`](https://github.com/rails/rails/issues/27455#issuecomment-269262124) in the development environment. Downgrading Ruby to 2.2.4 [fixes the issue](https://dsva.slack.com/archives/C2ZAMLK88/p1536176223000100?thread_ts=1536169620.000100&cid=C2ZAMLK88) too.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

### TODO
- Figure out how to reproduce hanging