### PR TITLE
Use participant ID to check if claimant is appellant

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -76,10 +76,6 @@ class Appeal < AmaReview
 
   delegate :first_name, :last_name, :middle_initial, :name_suffix, to: :appellant, prefix: true
 
-  def appellant_is_not_veteran
-    appellant ? appellant.relationship.present? : false
-  end
-
   # TODO: implement for AMA
   def citation_number
     "not implemented"

--- a/app/models/serializers/idt/v1/appeal_details_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_details_serializer.rb
@@ -11,7 +11,9 @@ class Idt::V1::AppealDetailsSerializer < ActiveModel::Serializer
   attribute :veteran_gender
   attribute :veteran_is_deceased
 
-  attribute :appellant_is_not_veteran
+  attribute :appellant_is_not_veteran do
+    object.is_a?(LegacyAppeal) ? object.appellant_is_not_veteran : object.claimant_not_veteran
+  end
   attribute :appellant_first_name
   attribute :appellant_middle_name do
     object.appellant_middle_initial

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -78,8 +78,8 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
         let!(:ama_appeals) do
           [
-            create(:appeal, veteran: veteran1),
-            create(:appeal, veteran: veteran2)
+            create(:appeal, veteran: veteran1, number_of_claimants: 2),
+            create(:appeal, veteran: veteran2, number_of_claimants: 1)
           ]
         end
 


### PR DESCRIPTION
Use code from AmaRevew to determine if claimant is a veteran. It is more accurate because it uses a participant ID. 
