### PR TITLE
Ignore CVE-2018-1000201 for a week

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -16,8 +16,8 @@ task :security_caseflow do
   Time.zone = "Eastern Time (US & Canada)"
 
   # Only ignore this vulnerability for a week.
-  audit_cmd = "bundle-audit check --ignore CVE-2018-1000544"
-  if Time.zone.local(2018, 8, 26) < Time.zone.today - 1.week
+  audit_cmd = "bundle-audit check --ignore CVE-2018-1000201"
+  if Time.zone.local(2018, 9, 10) < Time.zone.today - 1.week
     audit_cmd = "bundle-audit check"
   end
   audit_result = ShellCommand.run(audit_cmd)


### PR DESCRIPTION
`ruby-ffi` is a dependency of ours by way of `sniffybara` ( -> [`selenium-webdriver`](https://rubygems.org/gems/selenium-webdriver/versions/3.14.0) -> `childprocess` -> `ruby-ffi`) and [`sass-rails`](https://rubygems.org/gems/sass-rails/versions/5.0.4) ( -> `sass` -> `sass-listen` -> `rb-inotify` -> `ruby-ffi`). @[CVE-2018-1000201 only affects Windows machines](https://nvd.nist.gov/vuln/detail/CVE-2018-1000201), and since we aren't running Caseflow on any Windows machines, then I propose we should ignore this vulnerability for a week to give `selenium-webdriver` and `sass-rails` some time to release patches instead of explicitly setting the version of `ruby-ffi` (a dependency of a dependency) we want to use in the main Gemfile.