### PR TITLE
Allow system admin roles access to queue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,13 +110,16 @@ class ApplicationController < ApplicationBaseController
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def can_access_queue?
+    return true if current_user.admin?
     return true if current_user.organization_queue_user? || current_user.vso_employee?
     return true if current_user.attorney_in_vacols? || current_user.judge_in_vacols?
     return true if current_user.colocated_in_vacols? && feature_enabled?(:colocated_queue)
     false
   end
   helper_method :can_access_queue?
+  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def verify_queue_access


### PR DESCRIPTION
## Test plan
* Log in as CSS ID `BVATWARNER` on master (system admin role that does not match any other `can_access_queue?()` conditions)
* Navigate to `/queue`
* See "Drat!" unauthorized screen
* Check out this branch
* Navigate to `/queue`
* See "Unable to load your cases" message on queue screen indicating success!