### PR TITLE
makes vbms fake use random ids

### DIFF
--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -128,7 +128,7 @@ class Fakes::VBMSService
     # A randomly generated id
     claim_id = end_product_claim_ids_by_file_number[veteran_hash[:file_number]] ||
                @end_product_claim_id ||
-               Generators::LegacyAppeal.generate_external_id
+               Generators::Random.external_id
 
     # return fake end product
     OpenStruct.new(claim_id: claim_id)

--- a/lib/generators/random.rb
+++ b/lib/generators/random.rb
@@ -26,5 +26,9 @@ class Generators::Random
       @unique_ssns[my_ssn] = 1
       my_ssn
     end
+
+    def external_id
+      Random.rand(1_000_000).to_s
+    end
   end
 end


### PR DESCRIPTION
`Generators::LegacyAppeal.generate_external_id` is deterministic which results in end products being created with the same ids in dev if you stop/restart your server.
