### PR TITLE
VBMS benefit_type_code based on date_of_death

### DIFF
--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -58,15 +58,23 @@ class EndProduct
 
   DISPATCH_MODIFIERS = %w[070 071 072 073 074 075 076 077 078 079 170 171 175 176 177 178 179 172].freeze
 
+  # C&P Live = '1', C&P Death = '2'
+  BENEFIT_TYPE_CODE_LIVE = '1'.freeze
+  BENEFIT_TYPE_CODE_DEATH = '2'.freeze
+
   attr_accessor :claim_id, :claim_date, :claim_type_code, :modifier, :status_type_code,
                 :station_of_jurisdiction, :gulf_war_registry, :suppress_acknowledgement_letter
 
-  attr_writer :payee_code, :claimant_participant_id
+  attr_writer :payee_code, :claimant_participant_id, :benefit_type_code
 
   # Validators are used for validating the EP before we create it in VBMS
   validates :modifier, :claim_type_code, :station_of_jurisdiction, :claim_date, presence: true
   validates :claim_type_code, inclusion: { in: CODES.keys }
   validates :gulf_war_registry, :suppress_acknowledgement_letter, inclusion: { in: [true, false] }
+
+  def benefit_type_code
+    @benefit_type_code ||= BENEFIT_TYPE_CODE_LIVE
+  end
 
   def payee_code
     @payee_code ||= "00"
@@ -114,7 +122,7 @@ class EndProduct
 
   def to_vbms_hash
     {
-      benefit_type_code: "1",
+      benefit_type_code: benefit_type_code,
       payee_code: payee_code,
       predischarge: false,
       claim_type: "Claim",

--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -59,8 +59,8 @@ class EndProduct
   DISPATCH_MODIFIERS = %w[070 071 072 073 074 075 076 077 078 079 170 171 175 176 177 178 179 172].freeze
 
   # C&P Live = '1', C&P Death = '2'
-  BENEFIT_TYPE_CODE_LIVE = '1'.freeze
-  BENEFIT_TYPE_CODE_DEATH = '2'.freeze
+  BENEFIT_TYPE_CODE_LIVE = "1".freeze
+  BENEFIT_TYPE_CODE_DEATH = "2".freeze
 
   attr_accessor :claim_id, :claim_date, :claim_type_code, :modifier, :status_type_code,
                 :station_of_jurisdiction, :gulf_war_registry, :suppress_acknowledgement_letter

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -166,9 +166,13 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def benefit_type_code
-    @benefit_type_code ||= @veteran.date_of_death.nil?
-      ? EndProduct::BENEFIT_TYPE_CODE_LIVE
-      : EndProduct::BENEFIT_TYPE_CODE_DEATH
+    @benefit_type_code ||= begin
+      if veteran.date_of_death.nil?
+        EndProduct::BENEFIT_TYPE_CODE_LIVE
+      else
+        EndProduct::BENEFIT_TYPE_CODE_DEATH
+      end
+    end
   end
 
   def establish_claim_in_vbms(end_product)

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -165,6 +165,12 @@ class EndProductEstablishment < ApplicationRecord
     @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number)
   end
 
+  def benefit_type_code
+    @benefit_type_code ||= @veteran.date_of_death.nil?
+      ? EndProduct::BENEFIT_TYPE_CODE_LIVE
+      : EndProduct::BENEFIT_TYPE_CODE_DEATH
+  end
+
   def establish_claim_in_vbms(end_product)
     VBMSService.establish_claim!(
       claim_hash: end_product.to_vbms_hash,
@@ -177,6 +183,7 @@ class EndProductEstablishment < ApplicationRecord
       claim_id: reference_id,
       claim_date: claim_date,
       claim_type_code: code,
+      benefit_type_code: benefit_type_code,
       payee_code: payee_code,
       claimant_participant_id: claimant_participant_id,
       modifier: find_open_modifier,
@@ -196,6 +203,7 @@ class EndProductEstablishment < ApplicationRecord
       claim_date: claim_date,
       claim_type_code: code,
       payee_code: payee_code,
+      benefit_type_code: benefit_type_code,
       claimant_participant_id: claimant_participant_id,
       modifier: modifier,
       suppress_acknowledgement_letter: false,

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -15,7 +15,7 @@ describe EndProductEstablishment do
     Generators::Veteran.build(
       file_number: veteran_file_number,
       participant_id: veteran_participant_id,
-      date_of_death: "05/01/2016",
+      date_of_death: "05/01/2016"
     )
   end
   let(:living_veteran_file_number) { "12345678" }

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -3,15 +3,30 @@ describe EndProductEstablishment do
     Timecop.freeze(Time.utc(2018, 1, 1, 12, 0, 0))
 
     if source.is_a?(HigherLevelReview)
-      source.stub(:valid_modifiers).and_return(%w[030 031 032])
-      source.stub(:invalid_modifiers).and_return(invalid_modifiers)
-      source.stub(:special_issues).and_return(special_issues)
+      allow(source).to receive(:valid_modifiers).and_return(%w[030 031 032])
+      allow(source).to receive(:invalid_modifiers).and_return(invalid_modifiers)
+      allow(source).to receive(:special_issues).and_return(special_issues)
     end
   end
 
   let(:veteran_file_number) { "12341234" }
   let(:veteran_participant_id) { "11223344" }
-  let!(:veteran) { Generators::Veteran.build(file_number: veteran_file_number, participant_id: veteran_participant_id) }
+  let!(:veteran) do
+    Generators::Veteran.build(
+      file_number: veteran_file_number,
+      participant_id: veteran_participant_id,
+      date_of_death: "05/01/2016",
+    )
+  end
+  let(:living_veteran_file_number) { "12345678" }
+  let(:living_veteran_participant_id) { "55667788" }
+  let!(:living_veteran) do
+    Generators::Veteran.build(
+      file_number: living_veteran_file_number,
+      participant_id: living_veteran_participant_id,
+      date_of_death: nil, # default but explicit here for clarity
+    )
+  end
   let(:code) { "030HLRR" }
   let(:payee_code) { "00" }
   let(:reference_id) { nil }
@@ -20,6 +35,7 @@ describe EndProductEstablishment do
   let(:synced_status) { nil }
   let(:special_issues) { nil }
   let(:committed_at) { nil }
+  let(:fake_claim_id) { "FAKECLAIMID" }
 
   let(:end_product_establishment) do
     EndProductEstablishment.new(
@@ -36,8 +52,63 @@ describe EndProductEstablishment do
     )
   end
 
+  let(:living_end_product_establishment) do
+    EndProductEstablishment.new(
+      source: source,
+      veteran_file_number: living_veteran_file_number,
+      code: code,
+      payee_code: payee_code,
+      claim_date: 2.days.ago,
+      station: "397",
+      reference_id: reference_id,
+      claimant_participant_id: living_veteran_participant_id,
+      synced_status: synced_status,
+      committed_at: committed_at
+    )
+  end
+
   let(:vbms_error) do
     VBMS::HTTPError.new("500", "More EPs more problems")
+  end
+
+  context "when veteran has nil date_of_death (is alive)" do
+    subject { living_end_product_establishment.perform! }
+
+    before do
+      Fakes::VBMSService.end_product_claim_ids_by_file_number ||= {}
+      Fakes::VBMSService.end_product_claim_ids_by_file_number[living_veteran.file_number] = fake_claim_id
+      allow(Fakes::VBMSService).to receive(:establish_claim!).and_call_original
+    end
+
+    it "sends correct benefit_type_code" do
+      subject
+
+      expect(living_end_product_establishment.reload).to have_attributes(
+        reference_id: fake_claim_id,
+        veteran_file_number: living_veteran_file_number,
+        established_at: Time.zone.now,
+        committed_at: nil,
+        modifier: "030"
+      )
+
+      expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
+        claim_hash: {
+          benefit_type_code: EndProduct::BENEFIT_TYPE_CODE_LIVE,
+          payee_code: "00",
+          claimant_participant_id: living_veteran_participant_id,
+          predischarge: false,
+          claim_type: "Claim",
+          station_of_jurisdiction: "397",
+          date: 2.days.ago.to_date,
+          end_product_modifier: "030",
+          end_product_label: "Higher-Level Review Rating",
+          end_product_code: HigherLevelReview::END_PRODUCT_RATING_CODE,
+          gulf_war_registry: false,
+          suppress_acknowledgement_letter: false
+        },
+        veteran_hash: living_veteran.to_vbms_hash
+      )
+    end
   end
 
   context "#perform!" do
@@ -45,7 +116,7 @@ describe EndProductEstablishment do
 
     before do
       Fakes::VBMSService.end_product_claim_ids_by_file_number ||= {}
-      Fakes::VBMSService.end_product_claim_ids_by_file_number[veteran.file_number] = "FAKECLAIMID"
+      Fakes::VBMSService.end_product_claim_ids_by_file_number[veteran.file_number] = fake_claim_id
       allow(Fakes::VBMSService).to receive(:establish_claim!).and_call_original
     end
 
@@ -90,7 +161,7 @@ describe EndProductEstablishment do
         subject
         expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
           claim_hash: {
-            benefit_type_code: "1",
+            benefit_type_code: EndProduct::BENEFIT_TYPE_CODE_DEATH,
             payee_code: "00",
             predischarge: false,
             claim_type: "Claim",
@@ -117,7 +188,7 @@ describe EndProductEstablishment do
           subject
           expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
             claim_hash: {
-              benefit_type_code: "1",
+              benefit_type_code: EndProduct::BENEFIT_TYPE_CODE_DEATH,
               payee_code: "00",
               predischarge: false,
               claim_type: "Claim",
@@ -144,7 +215,7 @@ describe EndProductEstablishment do
         subject
 
         expect(end_product_establishment.reload).to have_attributes(
-          reference_id: "FAKECLAIMID",
+          reference_id: fake_claim_id,
           veteran_file_number: veteran_file_number,
           established_at: Time.zone.now,
           committed_at: nil,
@@ -153,7 +224,7 @@ describe EndProductEstablishment do
 
         expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
           claim_hash: {
-            benefit_type_code: "1",
+            benefit_type_code: EndProduct::BENEFIT_TYPE_CODE_DEATH,
             payee_code: "00",
             claimant_participant_id: veteran_participant_id,
             predischarge: false,

--- a/spec/models/end_product_spec.rb
+++ b/spec/models/end_product_spec.rb
@@ -7,6 +7,7 @@ describe EndProduct do
 
   let(:end_product) do
     EndProduct.new(
+      benefit_type_code: benefit_type_code,
       claim_date: claim_date,
       claim_type_code: claim_type_code,
       status_type_code: status_type_code,
@@ -28,6 +29,7 @@ describe EndProduct do
   let(:suppress_acknowledgement_letter) { true }
   let(:payee_code) { "00" }
   let(:claimant_participant_id) { nil }
+  let(:benefit_type_code) { "1" }
 
   context "#claim_type" do
     subject { end_product.claim_type }
@@ -241,6 +243,7 @@ describe EndProduct do
     let(:modifier) { "170" }
     let(:claim_type_code) { "930RC" }
     let(:payee_code) { "00" }
+    let(:benefit_type_code) { "1" }
     let(:station_of_jurisdiction) { "313" }
     let(:gulf_war_registry) { true }
     let(:suppress_acknowledgement_letter) { false }


### PR DESCRIPTION
connects #6205 

### Description
Rather than hardcoding the `benefit_type_code` and assuming all requests refer to living veterans, check for the `Veteran.date_of_death` and set the `benefit_type_code` appropriately.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Presence of `Veteran.date_of_death` triggers `benefit_type_code == 2`

### Testing Plan
1. Verify tests pass.

