### PR TITLE
Queue | Only set task to 'in_progress' if task exists

### DIFF
--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -15,21 +15,25 @@ import { prepareTasksForStore } from './utils';
 class CaseDetailsLink extends React.PureComponent {
   onClick = () => {
     const { task } = this.props;
-    const payload = {
-      data: {
-        task: {
-          status: 'in_progress'
+
+    // when searching for a case, we only load appeal info, no tasks
+    if (task) {
+      const payload = {
+        data: {
+          task: {
+            status: 'in_progress'
+          }
         }
-      }
-    };
+      };
 
-    ApiUtil.patch(`/tasks/${task.taskId}`, payload).
-      then((resp) => {
-        const response = JSON.parse(resp.text);
-        const preparedTasks = prepareTasksForStore(response.tasks.data);
+      ApiUtil.patch(`/tasks/${task.taskId}`, payload).
+        then((resp) => {
+          const response = JSON.parse(resp.text);
+          const preparedTasks = prepareTasksForStore(response.tasks.data);
 
-        this.props.setTaskAttrs(task.externalAppealId, preparedTasks[task.externalAppealId]);
-      });
+          this.props.setTaskAttrs(task.externalAppealId, preparedTasks[task.externalAppealId]);
+        });
+    }
 
     return this.props.onClick ? this.props.onClick(arguments) : true;
   }


### PR DESCRIPTION
### Description
In #6802, we changed CaseDetailsLink to PATCH to the server on click, to set the task's `status` to `in_progress`. However, when searching for a case, we only fetch appeal information, no tasks. So, the `task` prop of `CaseDetailsLink` would be undefined, throwing an error.

As per the 5 whys discussion team Foxtrot had earlier today, this was not a feature I added an automated test for, for two reasons: First, it's not clear that Capybara can inspect CSS for individual elements (beyond finding elements with CSS selectors). Glamor, which we use to set the font-weight, does assign a CSS class/id to the element it wraps, but I'm not sure it's possible to predict the id in advance. Second, in working on a test to check the task `status` before and after clicking on the link, there were issues with the initial task status not being set reliably, and, interestingly, although Chrome would have updated information, reloading the task in the rails console didn't always get the latest information. I've included the diff here for future reference.

<details><summary>diff of partially-completed test</summary>

```diff
diff --git a/spec/feature/queue/checkout_flows_spec.rb b/spec/feature/queue/checkout_flows_spec.rb
index 9c50323a3..239a848f9 100644
--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -531,6 +531,7 @@ RSpec.feature "Checkout flows" do
         )
       )
     end
+    let!(:ama_appeal) { FactoryBot.create(:appeal) }
     let!(:colocated_action) do
       FactoryBot.create(
         :colocated_task,
@@ -549,6 +550,24 @@ RSpec.feature "Checkout flows" do
         action: "translation"
       )
     end
+    let!(:ama_attorney_task) do
+      FactoryBot.create(
+        :ama_attorney_task,
+        assigned_to: attorney_user,
+        appeal: ama_appeal
+      )
+    end
+    let!(:ama_colocated_action) do
+      FactoryBot.create(
+        :colocated_task,
+        appeal: ama_appeal,
+        appeal_type: "Appeal",
+        assigned_to: colocated_user,
+        assigned_by: attorney_user,
+        parent: ama_attorney_task,
+        status: "assigned"
+      )
+    end
 
     before do
       FeatureToggle.enable!(:colocated_queue)
@@ -562,13 +581,16 @@ RSpec.feature "Checkout flows" do
     scenario "reassigns task to assigning attorney" do
       visit "/queue"
 
-      appeal = colocated_action.appeal
+      appeal = ama_colocated_action.appeal
 
       vet_name = appeal.veteran_full_name
-      attorney_name = colocated_action.assigned_by_display_name
+      attorney_name = ama_colocated_action.assigned_by_display_name
       attorney_name_display = "#{attorney_name.first[0]}. #{attorney_name.last}"
+      expect(ama_colocated_action.status).to eq "assigned"
 
-      click_on "#{vet_name.split(' ').first} #{vet_name.split(' ').last} (#{appeal.sanitized_vbms_id})"
+      click_on "#{vet_name.split(' ').first} #{vet_name.split(' ').last} (#{appeal.veteran_file_number})"
+
+      expect(ama_colocated_action.reload.status).to eq "in_progress"
       click_dropdown 0
       expect(page).to have_content(COPY::COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY_BUTTON)
       click_on COPY::COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY_BUTTON
@@ -577,8 +599,8 @@ RSpec.feature "Checkout flows" do
         format(COPY::COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY_CONFIRMATION, vet_name, attorney_name_display)
       )
 
-      expect(colocated_action.reload.status).to eq "completed"
-      expect(colocated_action.assigned_at.to_date).to eq Time.zone.today
+      expect(ama_colocated_action.reload.status).to eq "completed"
+      expect(ama_colocated_action.assigned_at.to_date).to eq Time.zone.today
     end
 
     scenario "places task on hold" do
```

</details>

### Acceptance Criteria
- [ ] Clicking into case details from case search view works

### Testing Plan
1. Go to `/queue`, search for 228081153
2. Confirm clicking into case details for any result works as expected

