### PR TITLE
Add endpoint for completing BvaDispatchTasks through the IDT API

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -2,6 +2,12 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
   protect_from_forgery with: :exception
   before_action :verify_access
 
+  rescue_from StandardError do |e|
+    fail e unless e.class.method_defined?(:serialize_response)
+    Raven.capture_exception(e)
+    render(e.serialize_response)
+  end
+
   def list
     appeals = file_number ? appeals_by_file_number : appeals_assigned_to_user
 
@@ -10,6 +16,11 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
 
   def details
     return render json: { message: "Appeal not found" }, status: 404 unless appeal
+    render json: json_appeal_details
+  end
+
+  def outcode
+    BvaDispatchTask.outcode(appeal, user)
     render json: json_appeal_details
   end
 

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -22,7 +22,7 @@ class BvaDispatchTask < GenericTask
     private
 
     def list_of_assignees
-      @list_of_assignees || Constants::BvaDispatchTeams::USERS[Rails.current_env]
+      Constants::BvaDispatchTeams::USERS[Rails.current_env]
     end
   end
 end

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -11,10 +11,18 @@ class BvaDispatchTask < GenericTask
       )
     end
 
+    def outcode(appeal, user)
+      tasks = where(appeal: appeal, assigned_to: user)
+      if tasks.count != 1
+        fail Caseflow::Error::BvaDispatchTaskCountMismatch, appeal_id: appeal.id, user_id: user.id, tasks: tasks
+      end
+      tasks[0].mark_as_complete!
+    end
+
     private
 
     def list_of_assignees
-      Constants::BvaDispatchTeams::USERS[Rails.current_env]
+      @list_of_assignees || Constants::BvaDispatchTeams::USERS[Rails.current_env]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
         get 'token', to: 'tokens#generate_token'
         get 'appeals', to: 'appeals#list'
         get 'appeals/:appeal_id', to: 'appeals#details'
+        post 'appeals/:appeal_id/outcode', to: 'appeals#outcode'
         get 'judges', to: 'judges#index'
         get 'user', to: 'users#index'
       end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -32,6 +32,20 @@ module Caseflow::Error
     end
   end
 
+  class BvaDispatchTaskCountMismatch < SerializableError
+    # Add attr_accessors for testing
+    attr_accessor :user_id, :appeal_id, :tasks
+
+    def initialize(args)
+      @user_id = args[:user_id]
+      @appeal_id = args[:appeal_id]
+      @tasks = args[:tasks]
+      @code = args[:code] || 500
+      @message = args[:message] || "Expected 1 BvaDispatchTask received #{@tasks.count} tasks for"\
+                                   " appeal #{@appeal_id}, user #{@user_id}"
+    end
+  end
+
   class MultipleAppealsByVBMSID < StandardError; end
   class CertificationMissingData < StandardError; end
   class InvalidSSN < StandardError; end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -40,7 +40,7 @@ module Caseflow::Error
       @user_id = args[:user_id]
       @appeal_id = args[:appeal_id]
       @tasks = args[:tasks]
-      @code = args[:code] || 500
+      @code = args[:code] || 400
       @message = args[:message] || "Expected 1 BvaDispatchTask received #{@tasks.count} tasks for"\
                                    " appeal #{@appeal_id}, user #{@user_id}"
     end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -249,4 +249,56 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       end
     end
   end
+
+  describe "POST /idt/api/v1/appeals/:appeal_id/outcode" do
+    let(:user) { FactoryBot.create(:user) }
+    let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: user.css_id) }
+    let(:root_task) { FactoryBot.create(:root_task) }
+    let(:params) { { appeal_id: root_task.appeal.external_id } }
+
+    before do
+      allow(BvaDispatchTask).to receive(:list_of_assignees).and_return([user.css_id])
+
+      key, t = Idt::Token.generate_one_time_key_and_proposed_token
+      Idt::Token.activate_proposed_token(key, user.css_id)
+      request.headers["TOKEN"] = t
+    end
+
+    context "when single BvaDispatchTask exists for user and appeal combination" do
+      before { BvaDispatchTask.create_and_assign(root_task) }
+
+      it "should complete the BvaDispatchTask assigned to the User and the task assigned to the BvaDispatch org" do
+        post :outcode, params: params
+        tasks = BvaDispatchTask.where(appeal: root_task.appeal, assigned_to: user)
+        expect(tasks.length).to eq(1)
+        task = tasks[0]
+        expect(task.status).to eq("completed")
+        expect(task.parent.status).to eq("completed")
+      end
+    end
+
+    context "when multiple BvaDispatchTasks exists for user and appeal combination" do
+      let(:task_count) { 4 }
+      before { task_count.times { BvaDispatchTask.create_and_assign(root_task) } }
+
+      it "should throw an error" do
+        post :outcode, params: params
+        expect(response.status).to eq(500)
+        response_detail = JSON.parse(response.body)["errors"][0]["detail"]
+        expect(response_detail).to eq("Expected 1 BvaDispatchTask received #{task_count} tasks for appeal "\
+                                      "#{root_task.appeal.id}, user #{user.id}")
+      end
+    end
+
+    context "when no BvaDispatchTasks exists for user and appeal combination" do
+      let(:task_count) { 0 }
+      it "should throw an error" do
+        post :outcode, params: params
+        expect(response.status).to eq(500)
+        response_detail = JSON.parse(response.body)["errors"][0]["detail"]
+        expect(response_detail).to eq("Expected 1 BvaDispatchTask received #{task_count} tasks for appeal "\
+                                      "#{root_task.appeal.id}, user #{user.id}")
+      end
+    end
+  end
 end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
       it "should throw an error" do
         post :outcode, params: params
-        expect(response.status).to eq(500)
+        expect(response.status).to eq(400)
         response_detail = JSON.parse(response.body)["errors"][0]["detail"]
         expect(response_detail).to eq("Expected 1 BvaDispatchTask received #{task_count} tasks for appeal "\
                                       "#{root_task.appeal.id}, user #{user.id}")
@@ -294,7 +294,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       let(:task_count) { 0 }
       it "should throw an error" do
         post :outcode, params: params
-        expect(response.status).to eq(500)
+        expect(response.status).to eq(400)
         response_detail = JSON.parse(response.body)["errors"][0]["detail"]
         expect(response_detail).to eq("Expected 1 BvaDispatchTask received #{task_count} tasks for appeal "\
                                       "#{root_task.appeal.id}, user #{user.id}")

--- a/spec/models/tasks/bva_dispatch_task_spec.rb
+++ b/spec/models/tasks/bva_dispatch_task_spec.rb
@@ -18,4 +18,48 @@ describe BvaDispatchTask do
       end
     end
   end
+
+  describe ".outcode" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:root_task) { FactoryBot.create(:root_task) }
+    before { allow(BvaDispatchTask).to receive(:list_of_assignees).and_return([user.css_id]) }
+
+    context "when single BvaDispatchTask exists for user and appeal combination" do
+      before { BvaDispatchTask.create_and_assign(root_task) }
+
+      it "should complete the BvaDispatchTask assigned to the User and the task assigned to the BvaDispatch org" do
+        BvaDispatchTask.outcode(root_task.appeal, user)
+        tasks = BvaDispatchTask.where(appeal: root_task.appeal, assigned_to: user)
+        expect(tasks.length).to eq(1)
+        task = tasks[0]
+        expect(task.status).to eq("completed")
+        expect(task.parent.status).to eq("completed")
+      end
+    end
+
+    context "when multiple BvaDispatchTasks exists for user and appeal combination" do
+      let(:task_count) { 4 }
+      before { task_count.times { BvaDispatchTask.create_and_assign(root_task) } }
+
+      it "should throw an error" do
+        expect { BvaDispatchTask.outcode(root_task.appeal, user) }.to(raise_error) do |e|
+          expect(e.class).to eq(Caseflow::Error::BvaDispatchTaskCountMismatch)
+          expect(e.tasks.count).to eq(task_count)
+          expect(e.user_id).to eq(user.id)
+          expect(e.appeal_id).to eq(root_task.appeal.id)
+        end
+      end
+    end
+
+    context "when no BvaDispatchTasks exists for user and appeal combination" do
+      it "should throw an error" do
+        expect { BvaDispatchTask.outcode(root_task.appeal, user) }.to(raise_error) do |e|
+          expect(e.class).to eq(Caseflow::Error::BvaDispatchTaskCountMismatch)
+          expect(e.tasks.count).to eq(0)
+          expect(e.user_id).to eq(user.id)
+          expect(e.appeal_id).to eq(root_task.appeal.id)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #6888. Adds `/idt/api/v1/appeals/:appeal_id/outcode` endpoint to allow folks to complete `BvaDispatchTask`s through the IDT API.