### PR TITLE
Queue | Add tooltip to days waiting column

### DIFF
--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -70,19 +70,15 @@ class TaskTable extends React.PureComponent<Props> {
   caseSelectColumn = () => {
     return this.props.includeSelect ? {
       header: COPY.CASE_LIST_TABLE_SELECT_COLUMN_TITLE,
-      valueFunction:
-        (task) => {
-          return <Checkbox
-            name={task.externalAppealId}
-            hideLabel
-            value={this.isTaskSelected(task.externalAppealId)}
-            onChange={
-              (checked) => this.props.setSelectionOfTaskOfUser(
-                { userId: this.props.userId,
-                  taskId: task.externalAppealId,
-                  selected: checked })
-            } />;
-        }
+      valueFunction: (task) => <Checkbox
+        name={task.externalAppealId}
+        hideLabel
+        value={this.isTaskSelected(task.externalAppealId)}
+        onChange={(selected) => this.props.setSelectionOfTaskOfUser({
+          userId: this.props.userId,
+          taskId: task.externalAppealId,
+          selected
+        })} />
     } : null;
   }
 
@@ -186,24 +182,17 @@ class TaskTable extends React.PureComponent<Props> {
         </React.Fragment>;
       },
       span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => {
-        return moment().diff(moment(task.assignedOn), 'days');
-      }
+      getSortValue: (task) => moment().diff(moment(task.assignedOn), 'days')
     } : null;
   }
 
   caseDaysWaitingColumn = () => {
     return this.props.includeDaysWaiting ? {
       header: COPY.CASE_LIST_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
-      valueFunction: (task) => {
-        return moment().startOf('day').
-          diff(moment(task.assignedOn), 'days');
-      },
       span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => {
-        return moment().startOf('day').
-          diff(moment(task.assignedOn), 'days');
-      }
+      tooltip: <React.Fragment>Calendar days since <br /> this case was assigned</React.Fragment>,
+      valueFunction: (task) => moment().startOf('day').diff(moment(task.assignedOn), 'days'),
+      getSortValue: (task) => moment().startOf('day').diff(moment(task.assignedOn), 'days')
     } : null;
   }
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -191,8 +191,10 @@ class TaskTable extends React.PureComponent<Props> {
       header: COPY.CASE_LIST_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
       span: this.collapseColumnIfNoDASRecord,
       tooltip: <React.Fragment>Calendar days since <br /> this case was assigned</React.Fragment>,
-      valueFunction: (task) => moment().startOf('day').diff(moment(task.assignedOn), 'days'),
-      getSortValue: (task) => moment().startOf('day').diff(moment(task.assignedOn), 'days')
+      valueFunction: (task) => moment().startOf('day').
+        diff(moment(task.assignedOn), 'days'),
+      getSortValue: (task) => moment().startOf('day').
+        diff(moment(task.assignedOn), 'days')
     } : null;
   }
 


### PR DESCRIPTION
Resolves #6294

### Description
Adds a tooltip to the Days Waiting column in TaskTable (used for judge views)

### Acceptance Criteria
- [ ] Tests pass, tooltip appears as expected

### Testing Plan
1. Go to `/queue` as `BVAAABSHIRE`, mouse over Days Waiting column header, confirm tooltip

![screen shot 2018-09-14 at 11 42 40 am](https://user-images.githubusercontent.com/8533004/45560637-b2e45d00-b813-11e8-8a3a-7bd8a30b5238.png)


