### PR TITLE
Set current_user for sync reviews job

### DIFF
--- a/app/jobs/sync_reviews_job.rb
+++ b/app/jobs/sync_reviews_job.rb
@@ -7,6 +7,7 @@ class SyncReviewsJob < CaseflowJob
 
   def perform(args = {})
     RequestStore.store[:application] = "intake"
+    RequestStore.store[:current_user] = User.system_user
 
     # specified limit of end products that will be synced
     limit = args["limit"] || DEFAULT_EP_LIMIT


### PR DESCRIPTION
This previously wasn't needed, but now that we are reprocessing ramp reviews in this job, we will need this.
