### PR TITLE
Reading form_8s from their new location

### DIFF
--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -3,6 +3,8 @@
 class Form8 < ApplicationRecord
   include UploadableDocument
 
+  FORM8_S3_SUB_BUCKET = "form_8".freeze
+
   FORM_FIELDS = [
     :vacols_id,
     :appellant_name,
@@ -198,7 +200,7 @@ class Form8 < ApplicationRecord
   end
 
   def fetch_from_s3_and_save(destination_path)
-    S3Service.fetch_file(pdf_filename, destination_path)
+    S3Service.fetch_file(FORM8_S3_SUB_BUCKET + "/" + pdf_filename, destination_path)
   end
 
   def pdf_filename

--- a/app/services/form8_pdf_service.rb
+++ b/app/services/form8_pdf_service.rb
@@ -6,8 +6,6 @@ class Form8PdfService
   PDF_PAGE_1 = "form1[0].#subform[0].#area[0].".freeze
   PDF_PAGE_2 = "form1[0].#subform[1].".freeze
 
-  FORM8_S3_SUB_BUCKET = "form_8".freeze
-
   # Currently, the only thing on Page 2 of the VA Form 8 is the continued
   # remarks. As a result, we'll just say anything except for that is actually
   # on Page 1.
@@ -106,8 +104,7 @@ class Form8PdfService
       final_location
     )
 
-    S3Service.store_file(form8.pdf_filename, final_location, :filepath)
-    S3Service.store_file(FORM8_S3_SUB_BUCKET + "/" + form8.pdf_filename, final_location, :filepath)
+    S3Service.store_file(Form8::FORM8_S3_SUB_BUCKET + "/" + form8.pdf_filename, final_location, :filepath)
 
     # Remove it from the tmp_location, leaving it only in final_location
     File.delete(tmp_location)

--- a/spec/services/form8_pdf_service_spec.rb
+++ b/spec/services/form8_pdf_service_spec.rb
@@ -50,7 +50,7 @@ describe Form8PdfService do
     end
 
     it "should save a file in s3" do
-      file_content = S3Service.files[form8.pdf_filename]
+      file_content = S3Service.files[Form8::FORM8_S3_SUB_BUCKET + "/" + form8.pdf_filename]
       expect(file_content).to_not be nil
     end
 


### PR DESCRIPTION
Resolves #6813 

### Description
This PR updates certification to read the form 8 from their new location in S3. After this is merged, I'll manually go through the production S3 bucket and delete files that aren't in either the hearing_schedule or form_8 folders.

### Testing Plan
1. Certify a case, and confirm there are new errors

