### PR TITLE
Fixing up VSO queues and search -> case details page

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -15,8 +15,8 @@ class WorkQueue::TaskSerializer < ActiveModel::Serializer
     {
       first_name: object.assigned_by_display_name.first,
       last_name: object.assigned_by_display_name.last,
-      css_id: object.assigned_by.css_id,
-      pg_id: object.assigned_by.id
+      css_id: object.assigned_by.try(:css_id),
+      pg_id: object.assigned_by.try(:id)
     }
   end
 

--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -109,6 +109,11 @@ export class CaseSnapshot extends React.PureComponent<Props> {
     const {
       taskAssignedToUser
     } = this.props;
+
+    if (!taskAssignedToUser) {
+      return null;
+    }
+
     const assignedByAbbrev = taskAssignedToUser.assignedBy.firstName ?
       this.getAbbrevName(taskAssignedToUser.assignedBy) : null;
 
@@ -240,7 +245,7 @@ export class CaseSnapshot extends React.PureComponent<Props> {
           <dt>{COPY.CASE_SNAPSHOT_ABOUT_BOX_DOCKET_NUMBER_LABEL}</dt>
           <dd>{appeal.docketNumber}</dd>
           {this.daysSinceTaskAssignmentListItem()}
-          { taskAssignedToUser.documentId &&
+          { taskAssignedToUser && taskAssignedToUser.documentId &&
             <React.Fragment>
               <dt>{COPY.CASE_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL}</dt>
               <dd><CopyTextButton text={taskAssignedToUser.documentId} /></dd>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,10 +47,10 @@ class SeedDB
     u = User.create(
       css_id: "VSO",
       station_id: 101,
-      full_name: "VSO user associated with american-legion",
+      full_name: "VSO user associated with PVA",
       roles: ["VSO"]
     )
-    FeatureToggle.enable!(:vso_queue_aml, users: [u.css_id])
+    FeatureToggle.enable!(:vso_queue_pva, users: [u.css_id])
 
     q = User.create!(station_id: 101, css_id: "ORG_QUEUE_USER", full_name: "Org Q User")
     FeatureToggle.enable!(:org_queue_translation, users: [q.css_id])


### PR DESCRIPTION
### Description
Fixing some minor bugs with tasks showing up in the VSO queue (our VSO user needs to be a part of PVA not American Legion) and viewing the case details as a VSO or from case search.

### Testing Plan
1. Intake a case, choose appellant Bob Vance
1. Log in as VSO user
1. Go to `/organizations/paralyzed-veterans-of-america`
1. Ensure there is the appeal that was intook
1. Click on the case details link and ensure the page loads properly

