### PR TITLE
Removing migration

### DIFF
--- a/db/migrate/201809112051441_index_claimants_on_date_of_birth.rb
+++ b/db/migrate/201809112051441_index_claimants_on_date_of_birth.rb
@@ -1,7 +1,0 @@
-class IndexClaimantsOnDateOfBirth < ActiveRecord::Migration[5.1]
-  disable_ddl_transaction!
-
-  def change
-    add_index :claimants, :date_of_birth, algorithm: :concurrently
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -381,7 +381,6 @@ ActiveRecord::Schema.define(version: 20180912224413) do
     t.date "receipt_date"
     t.boolean "informal_conference"
     t.boolean "same_office"
-    t.datetime "established_at"
     t.datetime "establishment_submitted_at"
     t.datetime "establishment_processed_at"
     t.string "benefit_type"
@@ -612,7 +611,6 @@ ActiveRecord::Schema.define(version: 20180912224413) do
   create_table "supplemental_claims", force: :cascade do |t|
     t.string "veteran_file_number", null: false
     t.date "receipt_date"
-    t.datetime "established_at"
     t.datetime "establishment_submitted_at"
     t.datetime "establishment_processed_at"
     t.string "benefit_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 201809112051441) do
+ActiveRecord::Schema.define(version: 20180912224413) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,7 +169,6 @@ ActiveRecord::Schema.define(version: 201809112051441) do
     t.string "participant_id", null: false
     t.string "payee_code"
     t.date "date_of_birth"
-    t.index ["date_of_birth"], name: "index_claimants_on_date_of_birth"
     t.index ["review_request_type", "review_request_id"], name: "index_claimants_on_review_request"
   end
 


### PR DESCRIPTION
### Description
When I merged the `201809112051441_index_claimants_on_date_of_birth.rb` migration I accidentally put an extra digit in the timestamp 🤦‍♂️ . This messes up the schema file, as this migration will always have the largest timestamp and the schema file will always use it. In order to fix it, we need to rename this file, but we can't do that since the name is already stored in Rails' schema migrations table. I think the easiest way to fix this is to rollback this particular change with `rake db:rollback VERSION=201809112051441` on prod, uat, preprod, and demo. And asking all developers to run it as well. Then I can remove the file in this PR and deploy. We're going to rearchitect this column a little bit anyway--so instead of recreating it, I'm just going to delete it. It's not currently in use.

### Acceptance Criteria
- [ ] Schema.rb stores the timestamp of the most recent migration, not always `201809112051441`

### Testing Plan
1. Run `rake db:rollback VERSION=201809112051441` and ensure the schema file is updated properly.

