### PR TITLE
add bootsnap gem for faster rails boot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,6 +170,6 @@ gem "rubyzip", "~> 1.2.2"
 gem "business_time", "~> 0.9.3"
 
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
-gem 'bootsnap', require: false
+gem "bootsnap", require: false
 
 # rubocop:enable Metrics/LineLength

--- a/Gemfile
+++ b/Gemfile
@@ -143,8 +143,6 @@ group :stubbed, :test, :development, :demo do
   # Added at 2018-05-16 22:09:10 -0400 by mdbenjam:
   gem "factory_bot_rails", "~> 4.8"
 
-  # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
-  gem 'bootsnap', require: false
 end
 
 group :stubbed, :development do
@@ -170,4 +168,8 @@ gem "roo", "~> 2.7"
 gem "rubyzip", "~> 1.2.2"
 
 gem "business_time", "~> 0.9.3"
+
+# Bootsnap speeds up app boot (and started to be a default gem in 5.2).
+gem 'bootsnap', require: false
+
 # rubocop:enable Metrics/LineLength

--- a/Gemfile
+++ b/Gemfile
@@ -142,7 +142,6 @@ group :stubbed, :test, :development, :demo do
 
   # Added at 2018-05-16 22:09:10 -0400 by mdbenjam:
   gem "factory_bot_rails", "~> 4.8"
-
 end
 
 group :stubbed, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,9 @@ group :stubbed, :test, :development, :demo do
 
   # Added at 2018-05-16 22:09:10 -0400 by mdbenjam:
   gem "factory_bot_rails", "~> 4.8"
+
+  # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
+  gem 'bootsnap', require: false
 end
 
 group :stubbed, :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,8 @@ GEM
     aws-sdk-resources (2.10.112)
       aws-sdk-core (= 2.10.112)
     aws-sigv4 (1.0.2)
+    bootsnap (1.3.2)
+      msgpack (~> 1.0)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -250,6 +252,7 @@ GEM
     moment_timezone-rails (0.5.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
+    msgpack (1.2.4)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     nap (1.1.0)
@@ -483,6 +486,7 @@ DEPENDENCIES
   activerecord-oracle_enhanced-adapter
   acts_as_tree
   bgs!
+  bootsnap
   brakeman
   bundler-audit
   business_time (~> 0.9.3)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
### Description
Rails 5.2 ships with a new default gem called `bootsnap`, which [speeds up Rails boot time by 50%](https://github.com/rails/rails/pull/29313). I've added it here to see if it'll work for Caseflow. Faster boot times mean a shorter development loop, less CI contention, and faster boot/restart during deploys.

[How it works](https://github.com/Shopify/bootsnap#how-does-this-work)
tl;dr avoiding slow scanning of $LOAD_PATH and caching of yaml files (both are slow parts of Rails boot)

Results for caseflow, locally testing a couple results of `time bundle exec rails s` until the 'Ctrl-C' prompt appears:

before:
real  0m8.811s
real  0m8.325s

after:
real  0m3.939s
real  0m4.098s

~53% decrease in bootup time, seems legit.

### Potential risks
* This gem does affect how files are loaded during app boot, so there is some risk that app boot in a non-dev environment goes awry. A test deploy should alleviate those concerns.
* It's possible that bootsnap negatively affects development by caching filepaths too aggressively (see 'stable entries' under https://github.com/Shopify/bootsnap#path-pre-scanning). I don't know of a use case where those paths need to be uncached.

I'm adding this gem to every group, since there's nothing development-specific about it and it seems better to both take advantage of speed gains in other envs and run as similar of a setup in dev and prod as possible. Shopify uses this gem in every environment and it's the new Rails default.

Tangentially, I'm also curious if we've tried upgrading to Rails 5.2 outright.

### Acceptance Criteria
- [x] Tests pass

### Testing Plan
In addition to working with this gem enabled locally for development, I'd like to do a test deploy to an AWS environment and restart to confirm that both of these succeed.