### PR TITLE
add --parallel to speed up rubocop

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -9,7 +9,7 @@ task :lint do
 
   opts = ENV["CI"] ? "" : "--auto-correct"
   puts "running rubocop..."
-  rubocop_result = ShellCommand.run("rubocop #{opts} --color")
+  rubocop_result = ShellCommand.run("rubocop #{opts} --color --parallel")
 
   puts "\nrunning eslint..."
   eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"


### PR DESCRIPTION
### Description
I noticed that builds spend a lot of time linting (2 minutes total, about 1m30 of that is rubocop). I tried adding the --parallel flag when running rubocop locally on my 4 core laptop and I get a great speedup:
```
kenshiro15:caseflow kencheeto$ time rubocop --parallel
...
real	0m21.356s
```
vs
```
kenshiro15:caseflow kencheeto$ time rubocop
...
real	1m10.200s
```
I'm not sure how many CPUs each CircleCI container has (I get 404s when I try to look at project configs) but testing it out here. Looks like we save just under a minute off of each container's step:

before:
<img width="333" alt="screen shot 2018-09-18 at 4 35 33 pm" src="https://user-images.githubusercontent.com/279406/45722417-15659200-bb61-11e8-84c1-7e0d33997992.png">
after:
<img width="303" alt="screen shot 2018-09-18 at 4 35 02 pm" src="https://user-images.githubusercontent.com/279406/45722416-15659200-bb61-11e8-8596-8dfc8a82b389.png">

Seems like a cheap free win for build times! Should take us from ~16 minute to ~15 minute builds in CI.

### Acceptance Criteria
- [x] Tests pass

### Testing Plan
None, internal CI change