### PR TITLE
--parallel and --auto-correct are incompatible so unbreak local linting

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -7,9 +7,9 @@ task :lint do
   puts "running scss-lint..."
   scss_result = ShellCommand.run("scss-lint --color")
 
-  opts = ENV["CI"] ? "" : "--auto-correct"
+  opts = ENV["CI"] ? "--parallel" : "--auto-correct"
   puts "running rubocop..."
-  rubocop_result = ShellCommand.run("rubocop #{opts} --color --parallel")
+  rubocop_result = ShellCommand.run("rubocop #{opts} --color")
 
   puts "\nrunning eslint..."
   eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"


### PR DESCRIPTION
### Description
@mdbenjam brought up that rubocop prints an error when run with both --parallel and --auto-correct. Since the time savings is valuable on CI and autocorrection is valuable locally, we can just pass --parallel only on CI so that `rake lint` is unbroken for folks using it locally.

### Acceptance Criteria
- [x] `bundle exec rake lint` auto-corrects locally

### Testing Plan
N/A
