### PR TITLE
Clicking Caseflow logo in Reader links to Queue

### DIFF
--- a/client/app/reader/DecisionReviewer.jsx
+++ b/client/app/reader/DecisionReviewer.jsx
@@ -144,7 +144,7 @@ export class DecisionReviewer extends React.PureComponent {
       }}
       userDisplayName={this.props.userDisplayName}
       dropdownUrls={this.props.dropdownUrls}
-      defaultUrl="/"
+      defaultUrl="/queue"
       outsideCurrentRouter>
       <PageRoute
         exact


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/appeals-support/issues/3067#issuecomment-423214771.

This change was made in #6967 but overwritten by a related change in #6932, so it worked as expected from Friday until Tuesday morning. When we released on Tuesday the code was changed so that the logo pointed to the base path. This PR fixes that.