### PR TITLE
Queue | Days waiting calculation, AppealSerializer type updates

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -59,7 +59,7 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
   end
 
   attribute :type do
-    "BEAAM"
+    "Original"
   end
 
   attribute :aod do

--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -77,7 +77,7 @@ type Props = Params & {|
 export class CaseSnapshot extends React.PureComponent<Props> {
   daysSinceTaskAssignmentListItem = () => {
     if (this.props.taskAssignedToUser) {
-      const today = moment();
+      const today = moment().startOf('day');
       const dateAssigned = moment(this.props.taskAssignedToUser.assignedOn);
       const dayCountSinceAssignment = today.diff(dateAssigned, 'days');
 


### PR DESCRIPTION
Resolves #7103 

### Description
This updates the `:type` attribute in `AppealSerializer` from `BEAAM` to `Original`. It also fixes the days waiting calculation in `CaseSnapshot` to match the calculation in `TaskTable`

### Acceptance Criteria
- [ ] AMA appeal type listed as "Original"
- [ ] Days waiting values match in TaskTable and CaseSnapshot

### Testing Plan
1. Go to `/queue` as `BVAAABSHIRE`
2. Confirm above criteria

<details><summary>table view</summary>
<img src="https://user-images.githubusercontent.com/8533004/45968862-15054500-c000-11e8-9bea-cd2096ac9e9e.png">
</details>
<details><summary>case snapshot before</summary>
<img src="https://user-images.githubusercontent.com/8533004/45968945-539aff80-c000-11e8-9c6a-72bdae78cb3c.png">
</details>
<details><summary>case snapshot after</summary>
<img src="https://user-images.githubusercontent.com/8533004/45968897-36663100-c000-11e8-8b3f-0b418c8f0476.png">
</details>
