### PR TITLE
Raise error when there are no available modifiers

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -17,6 +17,7 @@ class EndProductEstablishment < ApplicationRecord
   belongs_to :source, polymorphic: true
 
   class InvalidEndProductError < StandardError; end
+  class NoAvailableModifiers < StandardError; end
 
   class BGSSyncError < RuntimeError
     def initialize(error, end_product_establishment)
@@ -234,6 +235,8 @@ class EndProductEstablishment < ApplicationRecord
         return modifier
       end
     end
+
+    fail NoAvailableModifiers
   end
 
   def sync_source!

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -210,6 +210,21 @@ describe EndProductEstablishment do
       end
     end
 
+    context "when there are no open modifiers" do
+      before do
+        %w[030 031 032].each do |modifier|
+          Generators::EndProduct.build(
+            veteran_file_number: "12341234",
+            bgs_attrs: { end_product_type_code: modifier }
+          )
+        end
+      end
+
+      it "returns NoAvailableModifiers error" do
+        expect { subject }.to raise_error(EndProductEstablishment::NoAvailableModifiers)
+      end
+    end
+
     context "when all goes well" do
       it "creates end product and sets reference_id" do
         subject


### PR DESCRIPTION
This was happening in UAT, and it was very painful to debug. Putting this in as a stand in right now.

connects #7108