### PR TITLE
Create mapping table between vacols.staff and caseflow.organizations

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,7 +12,7 @@ class Organization < ApplicationRecord
   private
 
   def member_css_ids
-    details = FeatureToggle.details_for(feature.to_sym)
-    details && details[:users] || []
+    return [] unless staff_field_for_organization
+    VACOLS::Staff.where("#{staff_field_for_organization.name}": staff_field_for_organization.values).pluck(:sdomainid)
   end
 end

--- a/db/migrate/20180924231015_create_staff_field_for_organization.rb
+++ b/db/migrate/20180924231015_create_staff_field_for_organization.rb
@@ -1,0 +1,9 @@
+class CreateStaffFieldForOrganization < ActiveRecord::Migration[5.1]
+  def change
+    create_table :staff_field_for_organizations do |t|
+      t.belongs_to :organization, null: false
+      t.string :name, null: false
+      t.string :values, default: [], array: true, null: false
+    end
+  end
+end


### PR DESCRIPTION
Connect #6724.

Current implementation of `Organzation.members()` relies on a unique feature toggle for each organization. Since this is not how we will actually be rolling out organizational (and VSO) task queues, we need to go to VACOLS for that information. This PR implements the required changes to make that happen.

## TODO:
* Update test data to include vacols.staff entries for organizational and VSO queue users
* Add entries in the new table for all organizations (test and prod databases)
* Update tests to reflect this change