### PR TITLE
Validate veteran address line length on intake search

### DIFF
--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -170,8 +170,7 @@ class Intake < ApplicationRecord
 
     elsif !veteran.valid?(:bgs)
       self.error_code = :veteran_not_valid
-      errors = veteran.errors.messages.map { |(key, _value)| key }
-      @error_data = { veteran_missing_fields: errors }
+      @error_data = veteran_invalid_fields
 
     elsif duplicate_intake_in_progress
       self.error_code = :duplicate_intake_in_progress
@@ -241,5 +240,21 @@ class Intake < ApplicationRecord
 
   def build_issues(request_issues_data)
     request_issues_data.map { |data| detail.request_issues.from_intake_data(data) }
+  end
+
+  def veteran_invalid_fields
+    missing_fields = veteran.errors.details
+      .select { |_, errors| errors.any? { |e| e[:error] == :blank } }
+      .keys
+
+    address_too_long = veteran.errors.details.any? do |field_name, errors|
+      [:address_line1, :address_line2, :address_line3].include?(field_name) &&
+        errors.any? { |e| e[:error] == :too_long }
+    end
+
+    {
+      veteran_missing_fields: missing_fields,
+      veteran_address_too_long: address_too_long
+    }
   end
 end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -29,6 +29,7 @@ class Veteran < ApplicationRecord
   validates :zip_code, presence: true, if: :country_requires_zip?, on: :bgs
   validates :state, presence: true, if: :state_is_required?, on: :bgs
   validates :city, presence: true, unless: :military_address?, on: :bgs
+  validates :address_line1, :address_line2, :address_line3, length: { maximum: 20 }, on: :bgs
 
   # TODO: get middle initial from BGS
   def name

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import SearchBar from '../../components/SearchBar';
 import Alert from '../../components/Alert';
 import BareList from '../../components/BareList';
@@ -9,6 +9,7 @@ import { doFileNumberSearch, setFileNumberSearch } from '../actions/common';
 import { PAGE_PATHS, INTAKE_STATES } from '../constants';
 import { REQUEST_STATE } from '../../intakeCommon/constants';
 import { getIntakeStatus } from '../selectors';
+import _ from 'lodash';
 
 const steps = [
   <span>
@@ -37,6 +38,27 @@ const rampIneligibleInstructions = <div>
   <BareList items={stepFns} />
 </div>;
 
+const missingFieldsMessage = fields => <p>
+  Please fill in the following field(s) in the Veteran's profile in VBMS or the corporate database, then retry establishing the EP in Caseflow: {fields}.
+</p>;
+
+const addressTips = [
+  () => <Fragment>Do: move the last word(s) of the street address down to an another street address field</Fragment>,
+  () => <Fragment>Do: abbreviate to St. Ave. Rd. Blvd. Dr. Ter. Pl. Ct.</Fragment>,
+  () => <Fragment>Don't: edit street names or numbers</Fragment>
+];
+
+const addressTooLongMessage = <Fragment>
+  <p>This Veteran's address is too long. Please edit it in VBMS or SHARE so each address field is no longer than 20 characters (including spaces) then try again.</p>
+  <p>Tips:</p>
+  <BareList items={addressTips} ListElementComponent='ul' />
+</Fragment>;
+
+const invalidVeteranInstructions = searchErrorData => <Fragment>
+  { searchErrorData.veteranMissingFields && searchErrorData.veteranMissingFields.length && missingFieldsMessage(searchErrorData.veteranMissingFields) }
+  { searchErrorData.veteranAddressTooLong && addressTooLongMessage }
+</Fragment>;
+
 class Search extends React.PureComponent {
   handleSearchSubmit = () => (
     this.props.doFileNumberSearch(this.props.formType, this.props.fileNumberSearchInput)
@@ -62,9 +84,8 @@ class Search extends React.PureComponent {
           ' Please alert your manager so they can assign the form to someone else.'
       },
       veteran_not_valid: {
-        title: 'The Veteran\'s profile is missing information required to create an EP.',
-        body: 'Please fill in the following field(s) in the Veteran\'s profile in VBMS or the corporate database,' +
-          ` then retry establishing the EP in Caseflow: ${searchErrorData.veteranMissingFields}.`
+        title: 'The Veteran\'s profile has missing or invalid information required to create an EP.',
+        body: invalidVeteranInstructions(searchErrorData)
       },
       did_not_receive_ramp_election: {
         title: 'A RAMP Opt-in Notice Letter was not sent to this Veteran.',

--- a/client/app/intake/reducers/intake.js
+++ b/client/app/intake/reducers/intake.js
@@ -34,7 +34,8 @@ export const mapDataToInitialIntake = (data = { serverIntake: {} }) => (
     searchErrorData: {
       duplicateReceiptDate: null,
       duplicateProcessedBy: null,
-      veteranMissingFields: null
+      veteranMissingFields: null,
+      veteranAddressTooLong: null
     },
     cancelModalVisible: false,
     veteran: {
@@ -96,8 +97,11 @@ export const intakeReducer = (state = mapDataToInitialIntake(), action) => {
           $set: action.payload.errorData.processed_by
         },
         veteranMissingFields: {
-          $set: action.payload.errorData.veteran_missing_fields &&
+          $set: _.get(action.payload.errorData.veteran_missing_fields, 'length', 0) > 0 &&
             action.payload.errorData.veteran_missing_fields.join(', ')
+        },
+        veteranAddressTooLong: {
+          $set: action.payload.errorData.veteran_address_too_long
         }
       },
       requestStatus: {
@@ -119,6 +123,9 @@ export const intakeReducer = (state = mapDataToInitialIntake(), action) => {
           $set: null
         },
         veteranMissingFields: {
+          $set: null
+        },
+        veteranAddressTooLong: {
           $set: null
         }
       }

--- a/client/app/intakeManager/FlaggedForReview.jsx
+++ b/client/app/intakeManager/FlaggedForReview.jsx
@@ -8,7 +8,7 @@ const summary = 'Claims for manager review';
 const formatExplanation = (intake) => {
   const explanationCopy = {
     veteran_not_accessible: 'sensitivity',
-    veteran_not_valid: 'missing profile information',
+    veteran_not_valid: 'missing or invalid profile information',
     duplicate_ep: 'duplicate EP created outside Caseflow',
     system_error: 'system error',
     missing_signature: 'missing signature',

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -137,9 +137,15 @@ RSpec.feature "Intake" do
       end
     end
 
-    context "Veteran has missing information" do
+    context "Veteran has invalid information" do
       let(:veteran) do
-        Generators::Veteran.build(file_number: "12341234", sex: nil, ssn: nil, country: nil)
+        Generators::Veteran.build(
+          file_number: "12341234",
+          sex: nil,
+          ssn: nil,
+          country: nil,
+          address_line1: "this address is more than 20 chars"
+        )
       end
 
       scenario "Search for a veteran with a validation error" do
@@ -158,6 +164,7 @@ RSpec.feature "Intake" do
         expect(page).to have_content(
           "the corporate database, then retry establishing the EP in Caseflow: ssn, sex, country."
         )
+        expect(page).to have_content("This Veteran's address is too long. Please edit it in VBMS or SHARE")
       end
     end
 

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -300,7 +300,7 @@ describe Intake do
     context "country is null" do
       let(:country) { nil }
 
-      it "adds invalid_file_number and returns false" do
+      it "adds veteran_not_valid and returns false" do
         expect(subject).to eq(false)
         expect(intake.error_code).to eq("veteran_not_valid")
       end
@@ -362,12 +362,18 @@ describe Intake do
       end
     end
 
-    context "veteran address is too long", focus: true do
-      let(:veteran_file_number) { "12341234C" }
+    context "veteran address is too long" do
+      let!(:veteran) do
+        Generators::Veteran.build(
+          file_number: "64205050",
+          country: country,
+          address_line1: "this address is more than 20 characters long"
+        )
+      end
 
-      it "adds veteran_address_too_long and returns false" do
+      it "adds veteran_not_valid and returns false" do
         expect(subject).to eq(false)
-        expect(intake.error_code).to eq("veteran_address_too_long")
+        expect(intake.error_code).to eq("veteran_not_valid")
       end
     end
 

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -362,6 +362,15 @@ describe Intake do
       end
     end
 
+    context "veteran address is too long", focus: true do
+      let(:veteran_file_number) { "12341234C" }
+
+      it "adds veteran_address_too_long and returns false" do
+        expect(subject).to eq(false)
+        expect(intake.error_code).to eq("veteran_address_too_long")
+      end
+    end
+
     context "duplicate in progress intake already exists" do
       let!(:other_intake) do
         TestIntake.create!(

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -407,4 +407,12 @@ describe Veteran do
       expect(veteran.valid?(:bgs)).to be true
     end
   end
+
+  context "given a long address" do
+    let(:address_line3) { "this address is longer than 20 chars" }
+
+    it "is considered an invalid veteran from bgs" do
+      expect(veteran.valid?(:bgs)).to be false
+    end
+  end
 end


### PR DESCRIPTION



Connects #6947 



### Description
* Adds a max address line length validation of 20 characters to the Veteran model
* Adds support for displaying multiple kinds of validation errors on Veterans during Intake search (not just missing fields)
* Adds error messaging for address line lengths that are too long

three potential visual things to tweak, to my eyes:
* Our `cf-bare-list` style sets `list-style-type: none;` but I wonder if the tips would look better with visible bullets
* the spacing between bullets in the tips feels a bit too large
* should the missing fields vs long address messages be more distinct?

### Screenshots of possible Veteran validation errors

Error when address line length is over 20 chars:
<img width="881" alt="screen shot 2018-09-24 at 7 02 35 pm" src="https://user-images.githubusercontent.com/279406/45989569-1f8c0280-c031-11e8-969d-a9f07c6287e7.png">
Existing error when fields are missing:
<img width="863" alt="screen shot 2018-09-24 at 7 04 58 pm" src="https://user-images.githubusercontent.com/279406/45989570-1f8c0280-c031-11e8-89ce-0bf8c3649304.png">
When both errors are present:
<img width="877" alt="screen shot 2018-09-24 at 7 33 41 pm" src="https://user-images.githubusercontent.com/279406/45989571-1f8c0280-c031-11e8-9f05-42cfd5140dd4.png">

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Feature, unit tests

### Testing Plan
1. Edit bgs_service.rb#L31 to add a long address and/or missing field
    ```diff
    -# veteran = Generators::Veteran.build(file_number: row_hash["vbms_id"].chop)
    +veteran = Generators::Veteran.build(file_number: row_hash["vbms_id"].chop, address_line1: "super super long address blab blab blab", city: nil, state: nil)
    ```
1. Attempt to start an intake with any veteran
1. Validate that the error(s) show up correctly
