### PR TITLE
Queue | Update colocated actions

### DIFF
--- a/client/app/queue/components/ColocatedActionsDropdown.jsx
+++ b/client/app/queue/components/ColocatedActionsDropdown.jsx
@@ -71,24 +71,20 @@ class ColocatedActionsDropdown extends React.PureComponent<Props> {
       task,
       appeal
     } = this.props;
-    const options = [];
+    const options = [{
+      label: COPY.COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY,
+      value: CO_LOCATED_ACTIONS.SEND_BACK_TO_ATTORNEY
+    }, {
+      label: COPY.COLOCATED_ACTION_PLACE_HOLD,
+      value: CO_LOCATED_ACTIONS.PLACE_HOLD
+    }];
 
     if (['translation', 'schedule_hearing'].includes(task.action) && appeal.isLegacyAppeal) {
-      options.push({
+      options.unshift({
         label: sprintf(COPY.COLOCATED_ACTION_SEND_TO_TEAM, CO_LOCATED_ADMIN_ACTIONS[task.action]),
         value: CO_LOCATED_ACTIONS.SEND_TO_TEAM
       });
-    } else {
-      options.push({
-        label: COPY.COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY,
-        value: CO_LOCATED_ACTIONS.SEND_BACK_TO_ATTORNEY
-      });
     }
-
-    options.push({
-      label: COPY.COLOCATED_ACTION_PLACE_HOLD,
-      value: CO_LOCATED_ACTIONS.PLACE_HOLD
-    });
 
     return options;
   }


### PR DESCRIPTION
Connects #7090 

### Description
This updates the available Colocated admin actions as described [here](https://github.com/department-of-veterans-affairs/caseflow/issues/7090#issuecomment-424323713)

### Acceptance Criteria
- [ ] Schedule Hearing and Translation AMA tasks cannot be sent to team, legacy tasks can
- [ ] All task types support sending back to attorney and placing hold

### Testing Plan
1. Go to `/queue` as `BVASCASPER1`, add multiple admin actions
2. Go to `/queue` as `BVALSPORER`, confirm available actions

