### PR TITLE
Add decisions table

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -5,6 +5,7 @@ class Appeal < AmaReview
   has_many :claims_folder_searches, as: :appeal
   has_many :tasks, as: :appeal
   has_many :decision_issues, through: :request_issues
+  has_many :decisions
   has_one :special_issue_list
 
   validates :receipt_date, :docket_type, presence: { message: "blank" }, on: :intake_review

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -1,0 +1,3 @@
+class Decision < ApplicationRecord
+  belongs_to :appeal
+end

--- a/db/migrate/20180926143801_create_decisions.rb
+++ b/db/migrate/20180926143801_create_decisions.rb
@@ -1,7 +1,7 @@
 class CreateDecisions < ActiveRecord::Migration[5.1]
   def change
     create_table :decisions do |t|
-      t.belongs_to :request_issue
+      t.belongs_to :appeal
       t.string :citation_number
       t.date :decision_date
       t.string :redacted_document_location

--- a/db/migrate/20180926143801_create_decisions.rb
+++ b/db/migrate/20180926143801_create_decisions.rb
@@ -7,5 +7,7 @@ class CreateDecisions < ActiveRecord::Migration[5.1]
       t.string :redacted_document_location
       t.timestamps null: false
     end
+
+    add_index(:decisions, :citation_number, unique: true)
   end
 end

--- a/db/migrate/20180926143801_create_decisions.rb
+++ b/db/migrate/20180926143801_create_decisions.rb
@@ -1,0 +1,11 @@
+class CreateDecisions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :decisions do |t|
+      t.belongs_to :request_issue
+      t.string :citation_number
+      t.date :decision_date
+      t.string :redacted_document_location
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,6 +195,7 @@ ActiveRecord::Schema.define(version: 20180926143801) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["appeal_id"], name: "index_decisions_on_appeal_id"
+    t.index ["citation_number"], name: "index_decisions_on_citation_number", unique: true
   end
 
   create_table "dispatch_tasks", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180924131352) do
+ActiveRecord::Schema.define(version: 20180926143801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -185,6 +185,16 @@ ActiveRecord::Schema.define(version: 20180924131352) do
     t.string "disposition_date"
     t.string "description"
     t.integer "request_issue_id"
+  end
+
+  create_table "decisions", force: :cascade do |t|
+    t.bigint "request_issue_id"
+    t.string "citation_number"
+    t.date "decision_date"
+    t.string "redacted_document_location"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["request_issue_id"], name: "index_decisions_on_request_issue_id"
   end
 
   create_table "dispatch_tasks", id: :serial, force: :cascade do |t|
@@ -635,6 +645,13 @@ ActiveRecord::Schema.define(version: 20180924131352) do
     t.boolean "us_territory_claim_american_samoa_guam_northern_mariana_isla", default: false
     t.boolean "us_territory_claim_puerto_rico_and_virgin_islands", default: false
     t.index ["appeal_type", "appeal_id"], name: "index_special_issue_lists_on_appeal_type_and_appeal_id"
+  end
+
+  create_table "staff_field_for_organizations", force: :cascade do |t|
+    t.bigint "organization_id", null: false
+    t.string "name", null: false
+    t.string "values", default: [], null: false, array: true
+    t.index ["organization_id"], name: "index_staff_field_for_organizations_on_organization_id"
   end
 
   create_table "supplemental_claims", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -647,13 +647,6 @@ ActiveRecord::Schema.define(version: 20180926143801) do
     t.index ["appeal_type", "appeal_id"], name: "index_special_issue_lists_on_appeal_type_and_appeal_id"
   end
 
-  create_table "staff_field_for_organizations", force: :cascade do |t|
-    t.bigint "organization_id", null: false
-    t.string "name", null: false
-    t.string "values", default: [], null: false, array: true
-    t.index ["organization_id"], name: "index_staff_field_for_organizations_on_organization_id"
-  end
-
   create_table "supplemental_claims", force: :cascade do |t|
     t.string "veteran_file_number", null: false
     t.date "receipt_date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -188,13 +188,13 @@ ActiveRecord::Schema.define(version: 20180926143801) do
   end
 
   create_table "decisions", force: :cascade do |t|
-    t.bigint "request_issue_id"
+    t.bigint "appeal_id"
     t.string "citation_number"
     t.date "decision_date"
     t.string "redacted_document_location"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["request_issue_id"], name: "index_decisions_on_request_issue_id"
+    t.index ["appeal_id"], name: "index_decisions_on_appeal_id"
   end
 
   create_table "dispatch_tasks", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Connects #7148.

We will be needing the `decisions` table to hold information for AMA appeals we will be getting from the IDT API. This PR creates that table but does not yet include any logic around putting things into that table.