### PR TITLE
Queue | Prevent user from starting checkout flow for cases w/no DAS record

### DIFF
--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -3,6 +3,7 @@ import { css } from 'glamor';
 import moment from 'moment';
 import React from 'react';
 import { connect } from 'react-redux';
+import _ from 'lodash';
 
 import {
   appealWithDetailSelector,
@@ -212,17 +213,17 @@ export class CaseSnapshot extends React.PureComponent<Props> {
     if (this.props.hideDropdown) {
       return false;
     }
-    if (this.props.taskAssignedToUser) {
-      return true;
-    }
-    if (this.props.taskAssignedToAttorney) {
-      return true;
-    }
-    if (this.props.taskAssignedToOrganization) {
-      return true;
-    }
 
-    return false;
+    const {
+      taskAssignedToUser,
+      taskAssignedToAttorney,
+      taskAssignedToOrganization
+    } = this.props;
+    const tasks = _.compact([taskAssignedToUser, taskAssignedToAttorney, taskAssignedToOrganization]);
+
+    // users can end up at case details for appeals with no DAS
+    // record (!task.taskId). prevent starting checkout flows
+    return tasks.length && _.every(tasks, (task) => task.taskId);
   }
 
   render = () => {


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/appeals-support/issues/3090

### Description
This change prevents users from starting checkout flows for cases with no DAS record / `task.taskId`. We already prevent attorneys from entering the case details screen, but when searching for a case we use a different table component which did not have this logic. Ultimately, when the user went to submit a case review, they POSTed to `/case_reviews/null/complete`, getting a "Task cannot be blank" error.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

