### PR TITLE
Remove vso queue redirect

### DIFF
--- a/app/controllers/queue_controller.rb
+++ b/app/controllers/queue_controller.rb
@@ -7,25 +7,10 @@ class QueueController < ApplicationController
   end
 
   def index
-    path = vso_organization_queue_path
-    redirect_to(path) && return if path
-
     render "queue/index"
   end
 
   def check_queue_out_of_service
     render "out_of_service", layout: "application" if Rails.cache.read("queue_out_of_service")
-  end
-
-  private
-
-  def vso_organization_queue_path
-    return unless current_user.vso_employee?
-
-    Vso.where.not(feature: nil).each do |vso|
-      return vso.path if FeatureToggle.enabled?(vso.feature.to_sym, user: current_user)
-    end
-
-    "/unauthorized"
   end
 end


### PR DESCRIPTION
Prior to this change we redirected `/queue` to the appropriate `Vso.path()` by looping through every Vso organization and checking whether the user has access in BGS. This change removes those calls to BGS and will land VSO employees in a blank `/queue` screen if they navigate to that URL. They will have to go to their organization's URL directly to access that queue.