### PR TITLE
Fixing a nil error

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -99,7 +99,7 @@ class ExternalApi::BGSService
                                        name: "org.find_poas_by_participant_id") do
         client.org.find_poas_by_ptcpnt_id(participant_id)
       end
-      @poa_by_participant_ids[participant_id] = bgs_poas.map { |poa| get_poa_from_bgs_poa(poa) }
+      @poa_by_participant_ids[participant_id] = (bgs_poas || []).map { |poa| get_poa_from_bgs_poa(poa) }
     end
 
     @poa_by_participant_ids[participant_id]


### PR DESCRIPTION
We saw the following error in production: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2556/

We need to check if the response from BGS is nil

### Testing Plan
1. Ensure that
```
[5] pry(main)> (nil || []).map { |a| a + 1 }
=> []
```

