### PR TITLE
Add safety_assured to migration

### DIFF
--- a/db/migrate/20180926143801_create_decisions.rb
+++ b/db/migrate/20180926143801_create_decisions.rb
@@ -1,4 +1,6 @@
 class CreateDecisions < ActiveRecord::Migration[5.1]
+  safety_assured
+
   def change
     create_table :decisions do |t|
       t.belongs_to :appeal


### PR DESCRIPTION
The lack of the `safety_assured` call caused a deploy to prod to fail this morning: https://appealsjenkins.ds.va.gov/job/deploys/job/prod/job/certification/81/console. This PR adds that function call