### PR TITLE
Schedule CAVC/AOD formatting

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -15,8 +15,6 @@ const colorAOD = css({
   color: 'red'
 });
 
-
-
 export default class AssignHearings extends React.Component {
 
   onSelectedHearingDayChange = (hearingDay) => () => {

--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -38,6 +38,18 @@ export default class AssignHearings extends React.Component {
     </div>;
   };
 
+  // const color = veteran.type === 'CAVC';
+  //
+  // const veteranClassNames = classNames({ 'cf-red-text': color });
+
+  colors = () => {
+    let type = ''
+    if (veteran.type === 'CAVC' && 'AOD') {
+     type.push('cf-red-text');
+    }
+    return type;
+  }
+
   tableRows = (veterans) => {
     return _.map(veterans, (veteran) => ({
       caseDetails: veteran.name,
@@ -77,6 +89,7 @@ export default class AssignHearings extends React.Component {
         valueName: 'time'
       }
     ];
+
 
     const selectedHearingDay = this.props.selectedHearingDay;
 

--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -11,7 +11,7 @@ import { formatDateStr } from '../../util/DateUtil';
 import RoSelectorDropdown from './RoSelectorDropdown';
 import { css } from 'glamor';
 
-const bottomMargin = css({
+const colorAOD = css({
   color: 'red'
 });
 
@@ -47,9 +47,9 @@ export default class AssignHearings extends React.Component {
     let veteranType;
 
     if (type === 'CAVC') {
-      veteranType = <span {...bottomMargin}>CAVC</span>;
+      veteranType = <span {...colorAOD}>CAVC</span>;
     } else if (type === 'AOD') {
-      veteranType = <span {...bottomMargin}>AOD</span>;
+      veteranType = <span {...colorAOD}>AOD</span>;
     }
 
     return veteranType;

--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -10,7 +10,6 @@ import Table from '../../components/Table';
 import { formatDateStr } from '../../util/DateUtil';
 import RoSelectorDropdown from './RoSelectorDropdown';
 import { css } from 'glamor';
-import classnames from 'classnames';
 
 const bottomMargin = css({
   color: 'red'
@@ -46,13 +45,15 @@ export default class AssignHearings extends React.Component {
 
   veteranTypeColor = (type) => {
     let veteranType;
-     if (type  === 'CAVC') {
+
+    if (type === 'CAVC') {
       veteranType = <span {...bottomMargin}>CAVC</span>;
-     } else if (type === 'AOD') {
-       veteranType = <span {...bottomMargin}>AOD</span>;
-   }
-     return veteranType;
-   }
+    } else if (type === 'AOD') {
+      veteranType = <span {...bottomMargin}>AOD</span>;
+    }
+
+    return veteranType;
+  }
 
   tableRows = (veterans) => {
     return _.map(veterans, (veteran) => ({

--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -9,6 +9,12 @@ import TabWindow from '../../components/TabWindow';
 import Table from '../../components/Table';
 import { formatDateStr } from '../../util/DateUtil';
 import RoSelectorDropdown from './RoSelectorDropdown';
+import { css } from 'glamor';
+import classnames from 'classnames';
+
+const bottomMargin = css({
+  color: 'red'
+});
 
 export default class AssignHearings extends React.Component {
 
@@ -38,22 +44,20 @@ export default class AssignHearings extends React.Component {
     </div>;
   };
 
-  // const color = veteran.type === 'CAVC';
-  //
-  // const veteranClassNames = classNames({ 'cf-red-text': color });
-
-  colors = () => {
-    let type = ''
-    if (veteran.type === 'CAVC' && 'AOD') {
-     type.push('cf-red-text');
-    }
-    return type;
-  }
+  veteranTypeColor = (type) => {
+    let veteranType;
+     if (type  === 'CAVC') {
+      veteranType = <span {...bottomMargin}>CAVC</span>;
+     } else if (type === 'AOD') {
+       veteranType = <span {...bottomMargin}>AOD</span>;
+   }
+     return veteranType;
+   }
 
   tableRows = (veterans) => {
     return _.map(veterans, (veteran) => ({
       caseDetails: veteran.name,
-      type: veteran.type,
+      type: this.veteranTypeColor(veteran.type),
       docketNumber: veteran.docketNumber,
       location: veteran.location,
       time: veteran.time
@@ -89,7 +93,6 @@ export default class AssignHearings extends React.Component {
         valueName: 'time'
       }
     ];
-
 
     const selectedHearingDay = this.props.selectedHearingDay;
 


### PR DESCRIPTION
Resolves #7137 
 This PR shows that  'AOD' or 'CAV,  text is red.

### Acceptance Criteria
- [ ] In the 'Scheduled' and 'Assign Hearings' tabs in the center of the page, if the appeal type is either 'AOD' or 'CAVC, the text should be red.

### Testing Plan
1. Go to schedule/assign page
<img width="1579" alt="screen shot 2018-09-27 at 7 39 58 pm" src="https://user-images.githubusercontent.com/23080951/46181047-c1118f00-c291-11e8-9495-48b37f764b16.png">

