### PR TITLE
Schedule assign room information

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -16,6 +16,18 @@ export default class AssignHearings extends React.Component {
     this.props.onSelectedHearingDayChange(hearingDay);
   };
 
+  roomInfo = (hearingDay) => {
+    let room = hearingDay.roomInfo;
+
+    if (hearingDay.regionalOffice === 'St. Petersburg, FL') {
+      return room;
+    } else if (hearingDay.regionalOffice === 'Winston-Salem, NC') {
+      return room;
+    }
+
+    return room = '';
+
+  }
   formatAvailableHearingDays = () => {
     return <div className="usa-width-one-fourth">
       <h3>Hearings to Schedule</h3>
@@ -31,7 +43,7 @@ export default class AssignHearings extends React.Component {
                 linkStyling
               >
                 {`${moment(hearingDay.hearingDate).format('ddd M/DD/YYYY')}
-                ${hearingDay.roomInfo} (${availableSlots} slots)`}
+                ${this.roomInfo(hearingDay)} (${availableSlots} slots)`}
               </Button>
             </li>;
           })}
@@ -86,7 +98,7 @@ export default class AssignHearings extends React.Component {
     return <div className="usa-width-three-fourths">
       <h1>
         {moment(selectedHearingDay.hearingDate).format('ddd M/DD/YYYY')}
-        {selectedHearingDay.roomInfo} ({availableSlots} slots remaining)
+        {this.roomInfo(selectedHearingDay)} ({availableSlots} slots remaining)
       </h1>
       <TabWindow
         name="scheduledHearings-tabwindow"


### PR DESCRIPTION
Resolves #7135

### Description
This Pr shows the room info for St Petersburg and Winston-Salem
### Acceptance Criteria
- [ ] The room information in the left hand date table and the header for the centered tab should only be displayed if the RO has multiple hearing rooms (St Petersburg and Winston-Salem).

### Testing Plan
1. Go to Schedule/Assign
**Central Office**
<img width="1533" alt="screen shot 2018-09-28 at 12 02 22 pm" src="https://user-images.githubusercontent.com/23080951/46220058-075d0180-c317-11e8-9cdf-d1ecb55e6738.png">

**St Peterburg, FL**
<img width="1386" alt="screen shot 2018-09-28 at 12 02 37 pm" src="https://user-images.githubusercontent.com/23080951/46220107-2bb8de00-c317-11e8-9001-015a10e20c54.png">


