### PR TITLE
Throw error if accessing non-existent Constant

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -2,5 +2,20 @@ Constants = Module.new
 
 Dir.glob(File.join(Rails.root, "client", "constants", "*")).each do |filepath|
   constant_name = filepath.split("/").last.split(".").first
-  Constants.const_set(constant_name.to_s, JSON.parse(File.read(filepath)))
+  file_contents = JSON.parse(File.read(filepath))
+
+  # Access Constants through hash: Constants::BENEFIT_TYPES["compensation"]
+  Constants.const_set(constant_name.to_s, file_contents)
+
+  # Access Constants through object: Constants.BENEFIT_TYPES.compensation
+  Constants.define_singleton_method(constant_name) { Subconstant.new(file_contents) }
+end
+
+# https://stackoverflow.com/questions/26809848/convert-hash-to-object
+class Subconstant
+  def initialize(hash)
+    hash.each do |k, v|
+      define_singleton_method(k) { v.is_a?(Hash) ? Subconstant.new(v) : v }
+    end
+  end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -4,10 +4,10 @@ Dir.glob(File.join(Rails.root, "client", "constants", "*")).each do |filepath|
   constant_name = filepath.split("/").last.split(".").first
   file_contents = JSON.parse(File.read(filepath))
 
-  # Access Constants through hash: Constants::BENEFIT_TYPES["compensation"]
+  # Access via hash (Constants::BENEFIT_TYPES["compensation"]) to access keys.
   Constants.const_set(constant_name.to_s, file_contents)
 
-  # Access Constants through object: Constants.BENEFIT_TYPES.compensation
+  # Access via methods (Constants.BENEFIT_TYPES.compensation) to throw errors when incorrectly addressing constants.
   Constants.define_singleton_method(constant_name) { Subconstant.new(file_contents) }
 end
 


### PR DESCRIPTION
Addresses deficiency with our shared Constants [identified in a recent PR](https://github.com/department-of-veterans-affairs/caseflow/pull/7091#discussion_r221095536). Constants can still be accessed as members of a hash `Constants::BENEFIT_TYPES["compensation"]`, but can also now be accessed through methods on singletons `Constants.BENEFIT_TYPES.compensation`.

This second way throws an error if we attempt to access a non-existing constant:
```
# Existing way of accessing Constants as hashes:
rails> Constants::BENEFIT_TYPES["compesation"]
nil

# New way of accessing Constants as methods:
rails> Constants::BENEFIT_TYPES.compesation.
NoMethodError: undefined method `compesation' for #<Subconstant:0x00007fc121278668>
Did you mean?  compensation
```

We still need to maintain the hash way of accessing Constants for compatibility with existing code and to enable easy access to the keys of those hashes, but we should probably start using the method-based way of accessing Constants going forward.