### PR TITLE
Properly update GenericTask status

### DIFF
--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -1,8 +1,13 @@
 class GenericTask < Task
-  # Only request to PATCH /tasks/:id we expect for GenericTasks is to mark the task complete.
-  def update_from_params(_params, current_user)
+  def update_from_params(params, current_user)
     verify_user_access(current_user)
-    mark_as_complete!
+
+    new_status = params[:status]
+    if new_status == "completed"
+      mark_as_complete!
+    else
+      update!(status: new_status)
+    end
   end
 
   def can_user_access?(user)

--- a/spec/models/tasks/generic_task_spec.rb
+++ b/spec/models/tasks/generic_task_spec.rb
@@ -68,7 +68,9 @@ describe GenericTask do
 
       context "and current user does not belong to that organization" do
         it "should raise an error when trying to call Task.mark_as_complete!" do
-          expect { task.update_from_params({}, user) }.to raise_error(Caseflow::Error::ActionForbiddenError)
+          expect do
+            task.update_from_params({ status: "completed" }, user)
+          end.to raise_error(Caseflow::Error::ActionForbiddenError)
         end
       end
 
@@ -80,7 +82,7 @@ describe GenericTask do
 
         it "should call Task.mark_as_complete!" do
           expect_any_instance_of(GenericTask).to receive(:mark_as_complete!)
-          task.update_from_params({}, user)
+          task.update_from_params({ status: "completed" }, user)
         end
       end
     end
@@ -98,7 +100,7 @@ describe GenericTask do
       context "who is the current user" do
         it "should call Task.mark_as_complete!" do
           expect_any_instance_of(GenericTask).to receive(:mark_as_complete!)
-          task.update_from_params({}, user)
+          task.update_from_params({ status: "completed" }, user)
         end
       end
     end


### PR DESCRIPTION
`CaseDetailsLink` updates "assigned" tasks to "in_progress" when the link is clicked by [making a request to the backend](https://github.com/department-of-veterans-affairs/caseflow/blob/a3627bf31314eeaf065916b61015db9da0059d1f/client/app/queue/CaseDetailsLink.jsx#L29). `GenericTask` [interprets all updates](https://github.com/department-of-veterans-affairs/caseflow/blob/a3627bf31314eeaf065916b61015db9da0059d1f/app/models/tasks/generic_task.rb#L2) to mean that the task should be marked as complete. As a result, when navigating from the queue page to the case details page, we would incorrectly mark these tasks as "completed" instead of "in_progress". This PR fixes this bug.