### PR TITLE
Queue | Fix sending remand reasons for legacy issues in case review

### DIFF
--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -5,7 +5,8 @@ import moment from 'moment';
 import StringUtil from '../util/StringUtil';
 import {
   redText,
-  ISSUE_DISPOSITIONS
+  ISSUE_DISPOSITIONS,
+  VACOLS_DISPOSITIONS
 } from './constants';
 
 import type {
@@ -344,7 +345,7 @@ export const buildCaseReviewPayload = (
     payload.data.tasks.issues = getUndecidedIssues(issues).map((issue) => {
       const issueAttrs = ['type', 'readjudication', 'id'];
 
-      if (issue.disposition === VACOLS_DISPOSITIONS_BY_ID.REMANDED) {
+      if (issue.disposition === VACOLS_DISPOSITIONS.REMANDED) {
         issueAttrs.push('remand_reasons');
       }
 


### PR DESCRIPTION
### Description
Testing [issue dispositions being set correctly](https://github.com/department-of-veterans-affairs/appeals-support/issues/3148#issuecomment-425996933) revealed that remand reasons were not being sent correcly during case reviews. This was due to us checking the issue disposition against `VACOLS_DISPOSITIONS_BY_ID` (`{ '1': 'Allowed', ... }`), rather than `queue/constants/VACOLS_DISPOSITIONS` (`{ ALLOWED: '1', ... }`). 

### Acceptance Criteria
- [ ] Remand reasons are included in case review payload

### Testing Plan
1. Go to `/queue` as attorney, check out case setting ≥ 1 issue to remanded w/remand reasons
2. Go to `/queue` as the recipient judge, confirm issue dispositions and remand reasons are set correctly

