### PR TITLE
Queue | Fix preserving issue dispositions on add/edit issue

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -41,10 +41,6 @@ class Appeal < AmaReview
     { decision_issues: decision_issues, request_issues: request_issues }
   end
 
-  def issue_count
-    request_issues.count
-  end
-
   def docket_name
     docket_type
   end

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -57,7 +57,7 @@ class WorkQueue::TaskSerializer < ActiveModel::Serializer
   end
 
   attribute :issue_count do
-    object.appeal.issue_count
+    object.appeal.number_of_issues
   end
 
   attribute :previous_task do

--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -166,10 +166,10 @@ class AddEditIssueView extends React.Component<Params> {
     const { appeal } = this.props;
     const serverIssues = response.issues;
 
-    const issues = _.map(serverIssues, (issue) => {
+    const issues = _.map(serverIssues, (issue: { vacols_sequence_id: string }) => {
       // preserve locally-updated dispositions
       const disposition = _.get(
-        _.find(appeal.issues, (iss) => iss.id === issue.id),
+        _.find(appeal.issues, (iss) => iss.id === issue.vacols_sequence_id),
         'disposition'
       );
 

--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -166,10 +166,10 @@ class AddEditIssueView extends React.Component<Params> {
     const { appeal } = this.props;
     const serverIssues = response.issues;
 
-    const issues = _.map(serverIssues, (issue: { vacols_sequence_id: string }) => {
+    const issues = _.map(serverIssues, (issue) => {
       // preserve locally-updated dispositions
       const disposition = _.get(
-        _.find(appeal.issues, (iss) => iss.id === issue.vacols_sequence_id),
+        _.find(appeal.issues, (iss) => iss.id === (issue.id || issue.vacols_sequence_id)),
         'disposition'
       );
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/appeals-support/issues/3157

### Description
When updating Attorney checkout to support AMA appeals, we standardized Issues to have only `id`, which for legacy appeal issues was `vacols_sequence_id`. In doing this find/replace, we stopped preserving issue dispositions when updating issues from the server.

Original fix: https://github.com/department-of-veterans-affairs/caseflow/pull/5441
Bug introduced: https://github.com/department-of-veterans-affairs/caseflow/pull/6819

This PR also removes a duplicate method on `Appeal`: [`issue_count`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/appeal.rb#L44). I had added this recently (#7021), failing to notice that `Appeal` already had [`number_of_issues`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/appeal.rb#L91). Its only usage was within `TaskSerializer`.

<details><summary>Appeal.issue_count usage</summary>
<img src="https://user-images.githubusercontent.com/8533004/46369091-da2e8d00-c64f-11e8-925e-88218e22abad.png">
</details>

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to `/queue` as `BVASCASPER1`, draft decision
2. Set issue dispositions, add/edit issue, confirm dispositions are not reset

<details><summary>gif</summary>
<img src="https://user-images.githubusercontent.com/8533004/46365825-920b6c80-c647-11e8-8d45-9b273817692e.gif">
</details>