### PR TITLE
Queue | Fix issue count in TaskTable

### DIFF
--- a/app/models/serializers/work_queue/legacy_task_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_task_serializer.rb
@@ -60,7 +60,8 @@ class WorkQueue::LegacyTaskSerializer < ActiveModel::Serializer
   end
 
   attribute :issue_count do
-    object.appeal.issues.count
+    # this is used in TaskTable before appeal issues are loaded, replicates queue/utils.getUndecidedIssues logic
+    object.appeal.issues.select { |issue| issue.disposition.nil? || issue.disposition.to_i.between?(1, 9) }.count
   end
 
   attribute :paper_case do

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -14,10 +14,7 @@ import ReaderLink from '../ReaderLink';
 import CaseDetailsLink from '../CaseDetailsLink';
 
 import { setSelectionOfTaskOfUser } from '../QueueActions';
-import {
-  renderAppealType,
-  getUndecidedIssues
-} from '../utils';
+import { renderAppealType } from '../utils';
 import { DateString } from '../../util/DateUtil';
 import { CATEGORIES, redText } from '../constants';
 import COPY from '../../../COPY.json';
@@ -179,9 +176,9 @@ class TaskTable extends React.PureComponent<Props> {
   caseIssueCountColumn = () => {
     return this.props.includeIssueCount ? {
       header: COPY.CASE_LIST_TABLE_APPEAL_ISSUE_COUNT_COLUMN_TITLE,
-      valueFunction: (task) => this.taskHasDASRecord(task) ? getUndecidedIssues(task.appeal.issues).length : null,
+      valueFunction: (task) => this.taskHasDASRecord(task) ? task.appeal.issueCount : null,
       span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => this.taskHasDASRecord(task) ? getUndecidedIssues(task.appeal.issues).length : null
+      getSortValue: (task) => this.taskHasDASRecord(task) ? task.appeal.issueCount : null
     } : null;
   }
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -14,7 +14,10 @@ import ReaderLink from '../ReaderLink';
 import CaseDetailsLink from '../CaseDetailsLink';
 
 import { setSelectionOfTaskOfUser } from '../QueueActions';
-import { renderAppealType } from '../utils';
+import {
+  renderAppealType,
+  getUndecidedIssues
+} from '../utils';
 import { DateString } from '../../util/DateUtil';
 import { CATEGORIES, redText } from '../constants';
 import COPY from '../../../COPY.json';
@@ -176,9 +179,9 @@ class TaskTable extends React.PureComponent<Props> {
   caseIssueCountColumn = () => {
     return this.props.includeIssueCount ? {
       header: COPY.CASE_LIST_TABLE_APPEAL_ISSUE_COUNT_COLUMN_TITLE,
-      valueFunction: (task) => this.taskHasDASRecord(task) ? task.appeal.issueCount : null,
+      valueFunction: (task) => this.taskHasDASRecord(task) ? getUndecidedIssues(task.appeal.issues).length : null,
       span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => this.taskHasDASRecord(task) ? task.appeal.issueCount : null
+      getSortValue: (task) => this.taskHasDASRecord(task) ? getUndecidedIssues(task.appeal.issues).length : null
     } : null;
   }
 

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -57,21 +57,19 @@ export const tasksWithAppealSelector = createSelector(
   (tasks: Tasks, amaTasks: Tasks, appeals: BasicAppeals, appealDetails: AppealDetails) : Array<TaskWithAppeal> => {
     return [
       ..._.map(tasks, (task) => ({
-          ...task,
-          appeal: {
-            ..._.find(appeals, (appeal) => task.externalAppealId === appeal.externalId),
-            ..._.find(appealDetails, (appealDetail) => task.externalAppealId === appealDetail.externalId)
-          }
-        })
-      ),
+        ...task,
+        appeal: {
+          ..._.find(appeals, (appeal) => task.externalAppealId === appeal.externalId),
+          ..._.find(appealDetails, (appealDetail) => task.externalAppealId === appealDetail.externalId)
+        }
+      })),
       ..._.map(amaTasks, (amaTask) => ({
-          ...amaTask,
-          appeal: {
-            ..._.find(appeals, (appeal) => amaTask.externalAppealId === appeal.externalId),
-            ..._.find(appealDetails, (appealDetail) => amaTask.externalAppealId === appealDetail.externalId)
-          }
-        })
-      )
+        ...amaTask,
+        appeal: {
+          ..._.find(appeals, (appeal) => amaTask.externalAppealId === appeal.externalId),
+          ..._.find(appealDetails, (appealDetail) => amaTask.externalAppealId === appealDetail.externalId)
+        }
+      }))
     ];
   }
 );

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -6,7 +6,11 @@ import {
   taskIsOnHold
 } from './utils';
 
-import type { State, NewDocsForAppeal } from './types/state';
+import type {
+  State,
+  NewDocsForAppeal,
+  AttorneysOfJudge, UiStateModals
+} from './types/state';
 import type {
   Task,
   Tasks,
@@ -14,6 +18,7 @@ import type {
   Appeal,
   Appeals,
   BasicAppeals,
+  AppealDetails,
   User
 } from './types/models';
 
@@ -30,17 +35,17 @@ export const selectedTasksSelector = (state: State, userId: string) => {
   ).filter(Boolean);
 };
 
-const getTasks = (state: State) => state.queue.tasks;
-const getAmaTasks = (state: State) => state.queue.amaTasks;
-const getAppeals = (state: State) => state.queue.appeals;
-const getAppealDetails = (state: State) => state.queue.appealDetails;
-const getUserCssId = (state: State) => state.ui.userCssId;
-const getOrganizationId = (state: State) => state.queue.organizationId;
-const getAppealId = (state: State, props: Object) => props.appealId;
-const getAttorneys = (state: State) => state.queue.attorneysOfJudge;
-const getCaseflowVeteranId = (state: State, props: Object) => props.caseflowVeteranId;
-const getModals = (state: State) => state.ui.modals;
-const getNewDocsForAppeal = (state: State) => state.queue.newDocsForAppeal;
+const getTasks = (state: State): Tasks => state.queue.tasks;
+const getAmaTasks = (state: State): Tasks => state.queue.amaTasks;
+const getAppeals = (state: State): BasicAppeals => state.queue.appeals;
+const getAppealDetails = (state: State): AppealDetails => state.queue.appealDetails;
+const getUserCssId = (state: State): string => state.ui.userCssId;
+const getOrganizationId = (state: State): ?number => state.queue.organizationId;
+const getAppealId = (state: State, props: Object): string => props.appealId;
+const getAttorneys = (state: State): AttorneysOfJudge => state.queue.attorneysOfJudge;
+const getCaseflowVeteranId = (state: State, props: Object): string => props.caseflowVeteranId;
+const getModals = (state: State): UiStateModals => state.ui.modals;
+const getNewDocsForAppeal = (state: State): NewDocsForAppeal => state.queue.newDocsForAppeal;
 
 export const getActiveModalType = createSelector(
   [getModals],
@@ -48,19 +53,25 @@ export const getActiveModalType = createSelector(
 );
 
 export const tasksWithAppealSelector = createSelector(
-  [getTasks, getAmaTasks, getAppeals],
-  (tasks: Tasks, amaTasks: Tasks, appeals: Appeals) : Array<TaskWithAppeal> => {
+  [getTasks, getAmaTasks, getAppeals, getAppealDetails],
+  (tasks: Tasks, amaTasks: Tasks, appeals: BasicAppeals, appealDetails: AppealDetails) : Array<TaskWithAppeal> => {
     return [
-      ..._.map(tasks, (task) => {
-        return { ...task,
-          appeal: _.find(appeals, (appeal) => task.externalAppealId === appeal.externalId)
-        };
-      }),
-      ..._.map(amaTasks, (amaTask) => {
-        return { ...amaTask,
-          appeal: _.find(appeals, (appeal) => amaTask.externalAppealId === appeal.externalId)
-        };
-      })
+      ..._.map(tasks, (task) => ({
+          ...task,
+          appeal: {
+            ..._.find(appeals, (appeal) => task.externalAppealId === appeal.externalId),
+            ..._.find(appealDetails, (appealDetail) => task.externalAppealId === appealDetail.externalId)
+          }
+        })
+      ),
+      ..._.map(amaTasks, (amaTask) => ({
+          ...amaTask,
+          appeal: {
+            ..._.find(appeals, (appeal) => amaTask.externalAppealId === appeal.externalId),
+            ..._.find(appealDetails, (appealDetail) => amaTask.externalAppealId === appealDetail.externalId)
+          }
+        })
+      )
     ];
   }
 );

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -123,7 +123,8 @@ export type BasicAppeal = {
   veteranFullName: string,
   veteranFileNumber: string,
   isPaperCase: ?boolean,
-  tasks?: Array<Task>
+  tasks?: Array<Task>,
+  issueCount: number
 };
 
 export type BasicAppeals = { [string]: BasicAppeal };

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -5,6 +5,7 @@ import type {
   Tasks,
   Appeals,
   BasicAppeals,
+  AppealDetails,
   User,
   Attorneys
 } from './models';
@@ -24,6 +25,13 @@ export type CaseDetailState = {|
   activeTask: ?Task
 |};
 
+export type UiStateModals = {|
+  deleteIssue?: boolean,
+  cancelCheckout?: boolean,
+  sendToAttorney?: boolean,
+  sendToTeam?: boolean
+|};
+
 export type UiStateMessage = { title: string, detail?: React.Node };
 
 export type UiState = {
@@ -37,12 +45,7 @@ export type UiState = {
     savePending: boolean,
     saveSuccessful: ?boolean
   },
-  modals: {|
-    deleteIssue?: boolean,
-    cancelCheckout?: boolean,
-    sendToAttorney?: boolean,
-    sendToTeam?: boolean
-  |},
+  modals: UiStateModals,
   featureToggles: Object,
   selectedAssignee: ?string,
   selectedAssigneeSecondary: ?string,
@@ -64,7 +67,7 @@ export type QueueState = {|
   judges: UsersById,
   tasks: Tasks,
   appeals: BasicAppeals,
-  appealDetails: Appeals,
+  appealDetails: AppealDetails,
   amaTasks: Tasks,
   editingIssue: Object,
   docCountForAppeal: {[string]: Object},


### PR DESCRIPTION
Connects https://github.com/department-of-veterans-affairs/appeals-support/issues/3148

### Description
This fixes an issue with the issue count reported in `TaskTable`, which sometimes caused us to display too high a number. Before `TaskTable` / the `BasicAppeal`/`AppealDetail` refactor, we would load tasks and appeals and filter appeal issues by disposition to display a count of [only undecided issues](https://github.com/department-of-veterans-affairs/caseflow/blob/master/client/app/queue/utils.js#L296). However, since the refactor, we no longer load appeal detail information until the user navigates to Case Details view, instead relying on the task serializers to return an `issue_count` attr. For [`LegacyTaskSerializer`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/serializers/work_queue/legacy_task_serializer.rb#L62), this was just `task.appeal.issues.count`, which would include already-decided issues.

### Acceptance Criteria
- [ ] Legacy appeal issue count in `TaskTable` reflects count of undecided issues

### Testing Plan
1. Go to `/queue` as `BVASCASPER1`
2. Confirm 

