### PR TITLE
Fix InvalidAuthenticityToken error when posting to IDT outcode endpoint

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -1,5 +1,4 @@
 class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
-  protect_from_forgery with: :exception
   before_action :verify_access
 
   rescue_from StandardError do |e|

--- a/app/controllers/idt/api/v1/base_controller.rb
+++ b/app/controllers/idt/api/v1/base_controller.rb
@@ -1,5 +1,4 @@
 class Idt::Api::V1::BaseController < ActionController::Base
-  protect_from_forgery with: :exception
   before_action :validate_token
 
   def validate_token


### PR DESCRIPTION
Related slack discussion with error: https://dsva.slack.com/archives/CD5DAQNCU/p1538505205000100. Authentication tokens only attempt to protect from CSRF attacks on `POST` requests, so we haven't seen this issue before because `/outcode` is the first endpoint that accepts `POST` requests. We use our own IDT auth tokens to authenticate these requests so we should be fine removing the `protect_from_forgery` filters here.

More details on Rails' `protect_from_forgery` method: https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html