### PR TITLE
Add back feature toggle to limit who can create colocated tasks

### DIFF
--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -2,7 +2,7 @@ class AttorneyLegacyTask < LegacyTask
   def allowed_actions(role)
     return [] if role != "attorney"
 
-    [
+    actions = [
       {
         label: "Decision Ready for Review",
         value: "draft_decision/dispositions"
@@ -10,12 +10,14 @@ class AttorneyLegacyTask < LegacyTask
       {
         label: "Medical Request Ready for Review",
         value: "omo_request/submit"
-      },
-      {
-        label: "Add admin action",
-        value: "colocated_task"
       }
     ]
+
+    if FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: assigned_to)
+      actions.push(label: "Add admin action", value: "colocated_task")
+    end
+
+    actions
   end
 
   def self.from_vacols(case_assignment, appeal, user_id)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -96,8 +96,7 @@ class Task < ApplicationRecord
   end
 
   def self.verify_user_can_assign(user)
-    unless (user.attorney_in_vacols? &&
-              (appeal.type == Appeal.name || FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: user))) ||
+    unless (user.attorney_in_vacols? && FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: user)) ||
            (user.judge_in_vacols? && FeatureToggle.enabled?(:judge_assignment_to_attorney, user: user))
       fail Caseflow::Error::ActionForbiddenError, message: "Current user cannot assign this task"
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -96,7 +96,8 @@ class Task < ApplicationRecord
   end
 
   def self.verify_user_can_assign(user)
-    unless (user.attorney_in_vacols? && FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: user)) ||
+    unless (user.attorney_in_vacols? &&
+              (appeal.type == Appeal.name || FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: user))) ||
            (user.judge_in_vacols? && FeatureToggle.enabled?(:judge_assignment_to_attorney, user: user))
       fail Caseflow::Error::ActionForbiddenError, message: "Current user cannot assign this task"
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -96,7 +96,7 @@ class Task < ApplicationRecord
   end
 
   def self.verify_user_can_assign(user)
-    unless (user.attorney_in_vacols?) ||
+    unless user.attorney_in_vacols? ||
            (user.judge_in_vacols? && FeatureToggle.enabled?(:judge_assignment_to_attorney, user: user))
       fail Caseflow::Error::ActionForbiddenError, message: "Current user cannot assign this task"
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -96,7 +96,7 @@ class Task < ApplicationRecord
   end
 
   def self.verify_user_can_assign(user)
-    unless (user.attorney_in_vacols? && FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: user)) ||
+    unless (user.attorney_in_vacols?) ||
            (user.judge_in_vacols? && FeatureToggle.enabled?(:judge_assignment_to_attorney, user: user))
       fail Caseflow::Error::ActionForbiddenError, message: "Current user cannot assign this task"
     end


### PR DESCRIPTION
This hides the admin action option for all legacy tasks unless the attorney has the `attorney_assignment_to_colocated` feature toggle and allows all attorneys to assign non-legacy tasks.