### PR TITLE
Limit list of organization members to only active folks

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,7 +19,7 @@ class Organization < ApplicationRecord
   def member_css_ids
     return [] unless staff_field_for_organization
 
-    staff_records = VACOLS::Staff
+    staff_records = VACOLS::Staff.where(sactive: "A")
     staff_field_for_organization.each do |sfo|
       staff_records = sfo.filter_staff_records(staff_records)
     end


### PR DESCRIPTION
[Jed highlighted](https://github.com/department-of-veterans-affairs/dsva-vacols/issues/42#issuecomment-426415435) that we should only be returning active employees as members of organizations. This is an issue I overlooked when initially implementing the organization member method. This PR changes that.