### PR TITLE
Add tab for completed colocated tasks

### DIFF
--- a/app/models/queues/colocated_queue.rb
+++ b/app/models/queues/colocated_queue.rb
@@ -3,19 +3,29 @@ class ColocatedQueue
 
   attr_accessor :user
 
-  # rubocop:disable Rails/FindEach
   # rubocop:disable Style/SymbolProc
   def tasks
-    incomplete_tasks.where(assigned_to: user).each { |t| t.update_if_hold_expired! }
+    relevant_tasks.select { |t| t.assigned_to == user }.each { |t| t.update_if_hold_expired! }
   end
 
   def tasks_by_appeal_id(appeal_id, appeal_type)
-    incomplete_tasks.where(appeal_id: appeal_id, appeal_type: appeal_type).each { |t| t.update_if_hold_expired! }
+    tasks = relevant_tasks.select { |t| t.appeal_id == appeal_id && t.appeal_type == appeal_type }
+    tasks.each { |t| t.update_if_hold_expired! }
   end
   # rubocop:enable Style/SymbolProc
-  # rubocop:enable Rails/FindEach
 
   private
+
+  def relevant_tasks
+    [incomplete_tasks, recently_completed_tasks].flatten
+  end
+
+  def recently_completed_tasks
+    ColocatedTask.where(
+      status: Constants.TASK_STATUSES.completed,
+      completed_at: (Time.zone.now - 2.weeks)..Time.zone.now
+    )
+  end
 
   def incomplete_tasks
     ColocatedTask.where.not(status: Constants.TASK_STATUSES.completed)

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -79,9 +79,11 @@
   "COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE": "New (%d)",
   "COLOCATED_QUEUE_PAGE_PENDING_TAB_TITLE": "Pending action (%d)",
   "COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold (%d)",
+  "COLOCATED_QUEUE_PAGE_COMPLETE_TAB_TITLE": "Complete",
   "COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "These are new administrative actions that have been assigned to you.",
   "COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION": "When a hold is complete, the case will appear here. Cases with new documents will also appear here.",
   "COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, the case will automatically return to the Pending action tab.",
+  "COLOCATED_QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases with tasks that were marked complete in the last two weeks will appeal here.",
 
   "NO_CASES_FOR_JUDGE_REVIEW_TITLE": "Cases not found",
   "NO_CASES_FOR_JUDGE_REVIEW_MESSAGE": "Congratulations! You don't have any decisions to sign.",

--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -23,6 +23,7 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 
 import COPY from '../../COPY.json';
 import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 import { COLORS } from '../constants/AppConstants';
 import StringUtil from '../util/StringUtil';
@@ -244,7 +245,9 @@ export class CaseSnapshot extends React.PureComponent<Props> {
 
     // users can end up at case details for appeals with no DAS
     // record (!task.taskId). prevent starting checkout flows
-    return Boolean(tasks.length && _.every(tasks, (task) => task.taskId));
+    return Boolean(tasks.length && _.every(tasks, (task) => {
+      return task.taskId && (!task.status || task.status !== TASK_STATUSES.completed);
+    }));
   }
 
   render = () => {

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -10,7 +10,8 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import {
   newTasksByAssigneeCssIdSelector,
   pendingTasksByAssigneeCssIdSelector,
-  onHoldTasksByAssigneeCssIdSelector
+  onHoldTasksByAssigneeCssIdSelector,
+  completeTasksByAssigneeCssIdSelector
 } from './selectors';
 import { hideSuccessMessage } from './uiReducer/uiActions';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
@@ -65,6 +66,10 @@ class ColocatedTaskListView extends React.PureComponent<Props> {
       {
         label: sprintf(COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TAB_TITLE, numOnHoldTasks),
         page: <OnHoldTasksTab />
+      },
+      {
+        label: COPY.COLOCATED_QUEUE_PAGE_COMPLETE_TAB_TITLE,
+        page: <CompleteTasksTab />
       }
     ];
 
@@ -139,6 +144,22 @@ const OnHoldTasksTab = connect(
         includeType
         includeDocketNumber
         includeDaysOnHold
+        includeReaderLink
+        tasks={props.tasks}
+      />
+    </React.Fragment>;
+  });
+
+const CompleteTasksTab = connect(
+  (state: State) => ({ tasks: completeTasksByAssigneeCssIdSelector(state) }))(
+  (props: { tasks: Array<TaskWithAppeal> }) => {
+    return <React.Fragment>
+      <p>{COPY.COLOCATED_QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}</p>
+      <TaskTable
+        includeDetailsLink
+        includeTask
+        includeType
+        includeDocketNumber
         includeReaderLink
         tasks={props.tasks}
       />

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -21,6 +21,7 @@ import type {
   AppealDetails,
   User
 } from './types/models';
+import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
 
 export const selectedTasksSelector = (state: State, userId: string) => {
   return _.map(
@@ -115,7 +116,8 @@ export const appealsByCaseflowVeteranId = createSelector(
       appeal.caseflowVeteranId.toString() === caseflowVeteranId.toString())
 );
 
-const incompleteTasksSelector = (tasks: Tasks) => _.filter(tasks, (task) => task.status !== 'completed');
+const incompleteTasksSelector = (tasks: Tasks) => _.filter(tasks, (task) => task.status !== TASK_STATUSES.completed);
+const completeTasksSelector = (tasks: Tasks) => _.filter(tasks, (task) => task.status === TASK_STATUSES.completed);
 
 export const tasksByAssigneeCssIdSelector = createSelector(
   [tasksWithAppealSelector, getUserCssId],
@@ -126,6 +128,11 @@ export const tasksByAssigneeCssIdSelector = createSelector(
 export const incompleteTasksByAssigneeCssIdSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
   (tasks: Tasks) => incompleteTasksSelector(tasks)
+);
+
+export const completeTasksByAssigneeCssIdSelector = createSelector(
+  [tasksByAssigneeCssIdSelector],
+  (tasks: Tasks) => completeTasksSelector(tasks)
 );
 
 export const organizationTasksByAssigneeIdSelector = createSelector(
@@ -147,7 +154,7 @@ export const newTasksByAssigneeCssIdSelector = createSelector(
 export const workableTasksByAssigneeCssIdSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
   (tasks: Array<TaskWithAppeal>) => tasks.filter(
-    (task) => task.appeal.isLegacyAppeal || task.status !== 'on_hold'
+    (task) => task.appeal.isLegacyAppeal || task.status !== TASK_STATUSES.on_hold
   )
 );
 
@@ -174,7 +181,8 @@ export const judgeReviewTasksSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
   (tasks) => _.filter(tasks, (task: TaskWithAppeal) => {
     if (task.appealType === 'Appeal') {
-      return task.action === 'review' && (task.status === 'in_progress' || task.status === 'assigned');
+      return task.action === 'review' &&
+        (task.status === TASK_STATUSES.in_progress || task.status === TASK_STATUSES.assigned);
     }
 
     // eslint-disable-next-line no-undefined
@@ -186,7 +194,8 @@ export const judgeAssignTasksSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
   (tasks) => _.filter(tasks, (task: TaskWithAppeal) => {
     if (task.appealType === 'Appeal') {
-      return task.action === 'assign' && (task.status === 'in_progress' || task.status === 'assigned');
+      return task.action === 'assign' &&
+        (task.status === TASK_STATUSES.in_progress || task.status === TASK_STATUSES.assigned);
     }
 
     return task.action === 'assign';


### PR DESCRIPTION
Connects #7211. Returns recently completed tasks for co-located queues and adds a tab for those recently completed tasks.

### TODO:
* Write tests

![completed_tab](https://user-images.githubusercontent.com/32683958/46432713-e3d1f680-c71c-11e8-84c9-5ec49401cc5b.gif)