### PR TITLE
sets button into loading state when waiting

### DIFF
--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -122,7 +122,6 @@ class AssignWidget extends React.PureComponent<Props> {
   }
 
   render = () => {
-
     const {
       attorneysOfJudge,
       selectedAssignee,

--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -97,10 +97,7 @@ class AssignWidget extends React.PureComponent<Props> {
   assignTasks = (selectedTasks: Array<Task>, assigneeId: string) => {
     const { previousAssigneeId } = this.props;
 
-    if (!this.props.savePending) {
-      this.props.setSavePending();
-    }
-
+    this.props.setSavePending();
     this.props.onTaskAssignment(
       { tasks: selectedTasks,
         assigneeId,

--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -42,13 +42,16 @@ type Props = Params & {|
   selectedAssignee: string,
   selectedAssigneeSecondary: string,
   attorneys: Attorneys,
+  savePending: boolean,
   // Action creators
   setSelectedAssignee: typeof setSelectedAssignee,
   setSelectedAssigneeSecondary: typeof setSelectedAssigneeSecondary,
   showErrorMessage: typeof showErrorMessage,
   resetErrorMessages: typeof resetErrorMessages,
   showSuccessMessage: typeof showSuccessMessage,
-  resetSuccessMessages: typeof resetSuccessMessages
+  resetSuccessMessages: typeof resetSuccessMessages,
+  setSavePending: typeof setSavePending,
+  resetSaveState: typeof resetSaveState
 |};
 
 class AssignWidget extends React.PureComponent<Props> {

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -98,6 +98,10 @@ export const requestUpdate = (url: string, params: Object, successMessage: UiSta
 export const requestDelete = (url: string, params: Object, successMessage: UiStateMessage) =>
   requestSave(url, params, successMessage, 'delete');
 
+export const setSavePending = () => ({
+  type: ACTIONS.REQUEST_SAVE
+});
+
 export const resetSaveState = () => ({
   type: ACTIONS.RESET_SAVE_STATE
 });


### PR DESCRIPTION
After a judge clicked the "Assign N Cases" button, when waiting for the VACOLS judge assignment to attorney query to finish, we were not putting the button into a disabled "loading" state. This resulted in a case where multiple clicks on the button could result in erroneous duplicate DECASS records.

This PR fixes that issue by preventing multiple clicks from triggering multiple assignments.

# Testing

- added `sleep 10`in the transaction block of `QueueRepository.assign_case_to_attorney!`

![assignment](https://user-images.githubusercontent.com/3781835/46489165-ae87e000-c7d2-11e8-9064-1d774e21a8d8.gif)
