### PR TITLE
Fix disposition sync

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -89,8 +89,9 @@ class ClaimReview < AmaReview
 
   def sync_dispositions(reference_id)
     fetch_dispositions_from_vbms(reference_id).each do |disposition|
-      request_issue = matching_request_issue(disposition[:contention_id])
-      request_issue.update!(disposition: disposition[:disposition])
+      request_issue = matching_request_issue(disposition.contention_id)
+      request_issue.update!(disposition: disposition.disposition)
+
       # allow higher level reviews to do additional logic on dta errors
       yield(disposition, request_issue) if block_given?
     end

--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -90,7 +90,7 @@ class HigherLevelReview < ClaimReview
 
   def sync_dispositions(reference_id)
     super do |disposition, request_issue|
-      if DTA_ERRORS.include?(disposition[:disposition])
+      if DTA_ERRORS.include?(disposition.disposition)
         dta_issues << request_issue
       end
     end

--- a/lib/generators/contention.rb
+++ b/lib/generators/contention.rb
@@ -25,11 +25,11 @@ class Generators::Contention
         if disposition
           Fakes::VBMSService.disposition_records ||= {}
           Fakes::VBMSService.disposition_records[claim_id] ||= []
-          Fakes::VBMSService.disposition_records[claim_id] << {
+          Fakes::VBMSService.disposition_records[claim_id] << OpenStruct.new(
             claim_id: contention.claim_id,
             contention_id: contention.id,
             disposition: disposition
-          }
+          )
         end
       end
     end


### PR DESCRIPTION
This was happening because we were not correctly mocking connectVBMS. ConnectVBMS
returns a list of `Disposition` objects, not contentions.

connects #6186