### PR TITLE
Add QR team and task

### DIFF
--- a/app/controllers/case_reviews_controller.rb
+++ b/app/controllers/case_reviews_controller.rb
@@ -25,7 +25,7 @@ class CaseReviewsController < ApplicationController
 
   def create_bva_dispatch_task(record)
     return if record.appeal.class == LegacyAppeal
-    BvaDispatchTask.create_and_assign(record.task.root_task)
+    QualityReviewTask.create_from_root_task(record.task.root_task)
   end
 
   def case_review_class

--- a/app/controllers/case_reviews_controller.rb
+++ b/app/controllers/case_reviews_controller.rb
@@ -14,7 +14,7 @@ class CaseReviewsController < ApplicationController
     record = case_review_class.complete(complete_params)
     return invalid_record_error(record) unless record.valid?
 
-    create_bva_dispatch_task(record) if case_review_class == JudgeCaseReview
+    create_quality_review_task(record) if case_review_class == JudgeCaseReview
 
     response = { task: record }
     response[:issues] = record.appeal.issues
@@ -23,7 +23,7 @@ class CaseReviewsController < ApplicationController
 
   private
 
-  def create_bva_dispatch_task(record)
+  def create_quality_review_task(record)
     return if record.appeal.class == LegacyAppeal
     QualityReviewTask.create_from_root_task(record.task.root_task)
   end

--- a/app/models/organizations/quality_review.rb
+++ b/app/models/organizations/quality_review.rb
@@ -1,5 +1,5 @@
 class QualityReview < Organization
   def self.singleton
-    QualityReview.first || QualityReview.create(name: "Quality Review")
+    QualityReview.first || QualityReview.create(name: "Quality Review", url: "quality-review")
   end
 end

--- a/app/models/organizations/quality_review.rb
+++ b/app/models/organizations/quality_review.rb
@@ -1,0 +1,5 @@
+class QualityReview < Organization
+  def self.singleton
+    QualityReview.first || QualityReview.create(name: "Quality Review")
+  end
+end

--- a/app/models/tasks/quality_review_task.rb
+++ b/app/models/tasks/quality_review_task.rb
@@ -1,0 +1,10 @@
+class QualityReviewTask < GenericTask
+  def create_from_root_task(root_task)
+    create!(assigned_to: QualityReview.singleton, parent_id: root_task.id, appeal: root_task.appeal)
+  end
+
+  def mark_as_complete!
+    BvaDispatchTask.create_and_assign(root_task)
+    super
+  end
+end

--- a/app/models/tasks/quality_review_task.rb
+++ b/app/models/tasks/quality_review_task.rb
@@ -1,5 +1,5 @@
 class QualityReviewTask < GenericTask
-  def create_from_root_task(root_task)
+  def self.create_from_root_task(root_task)
     create!(assigned_to: QualityReview.singleton, parent_id: root_task.id, appeal: root_task.appeal)
   end
 

--- a/db/migrate/20181004221403_add_quality_review_org_row.rb
+++ b/db/migrate/20181004221403_add_quality_review_org_row.rb
@@ -1,0 +1,9 @@
+class AddQualityReviewOrgRow < ActiveRecord::Migration[5.1]
+  def up
+    QualityReview.singleton
+  end
+
+  def down
+    QualityReview.delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181001214125) do
+ActiveRecord::Schema.define(version: 20181004221403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/case_reviews_controller_spec.rb
+++ b/spec/controllers/case_reviews_controller_spec.rb
@@ -117,9 +117,8 @@ RSpec.describe CaseReviewsController, type: :controller do
             expect(task.reload.status).to eq "completed"
             expect(task.completed_at).to_not eq nil
 
-            bva_dispatch_task = BvaDispatchTask.find_by(parent_id: root_task.id)
-            expect(bva_dispatch_task.assigned_to).to eq(BvaDispatch.singleton)
-            expect(bva_dispatch_task.children.length).to eq(1)
+            quality_review_task = QualityReviewTask.find_by(parent_id: root_task.id)
+            expect(quality_review_task.assigned_to).to eq(QualityReview.singleton)
           end
         end
       end

--- a/spec/models/tasks/quality_review_task_spec.rb
+++ b/spec/models/tasks/quality_review_task_spec.rb
@@ -1,0 +1,16 @@
+describe QualityReviewTask do
+  before { FeatureToggle.enable!(:test_facols) }
+  after { FeatureToggle.disable!(:test_facols) }
+
+  describe ".mark_as_complete!" do
+    let(:root_task) { FactoryBot.create(:root_task) }
+
+    it "should create a task for BVA dispatch and close the current task" do
+      qr_task = QualityReviewTask.create_from_root_task(root_task)
+      qr_task.mark_as_complete!
+
+      expect(qr_task.status).to eq(Constants.TASK_STATUSES.completed)
+      expect(root_task.children.select { |t| t.type == BvaDispatchTask.name }.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Creates a QR organization, QR-specific task, and creates a task for QR instead of BVA dispatch when a judge completes case review. Related slack discussion: https://dsva.slack.com/archives/C6E41RE92/p1538686092000100