### PR TITLE
bump nokogiri to 1.8.5 for sec fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem "zero_downtime_migrations"
 
 # nokogiri versions before 1.8.3 are affected by CVE-2018-8048. Explicitly define nokogiri version here to avoid that.
 # https://github.com/sparklemotion/nokogiri/pull/1746
-gem "nokogiri", ">= 1.8.3"
+gem "nokogiri", "1.8.5"
 
 group :production, :staging, :ssh_forwarding, :development, :test do
   # Oracle DB

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
     newrelic_rpm (4.7.1.340)
     nio4r (2.3.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     nori (2.6.0)
     notiffany (0.1.1)
@@ -536,7 +536,7 @@ DEPENDENCIES
   launchy
   moment_timezone-rails
   newrelic_rpm
-  nokogiri (>= 1.8.3)
+  nokogiri (= 1.8.5)
   paper_trail (= 8.1.2)
   parallel
   paranoia (~> 2.2)


### PR DESCRIPTION
### Description
the nokogiri folks released 1.8.5 which includes fixes for known vulnerabilities that are causing brakeman to fail our build. This upgrades our version of nokogiri from 1.8.4 to 1.8.5 (and pins to 1.8.5 instead of >= 1.8.3)

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
N/A
