### PR TITLE
bump connect_vbms to support poa fields when establishing claims

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "therubyracer", platforms: :ruby
 
 gem "pg", platforms: :ruby
 
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "44a3aee470f3ddd0e42eb2d07b87ed776b0f9fab"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "446b1ad643607e49dd3cacff24f7039bb17f78b8"
 
 gem "redis-rails", "~> 5.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 44a3aee470f3ddd0e42eb2d07b87ed776b0f9fab
-  ref: 44a3aee470f3ddd0e42eb2d07b87ed776b0f9fab
+  revision: 446b1ad643607e49dd3cacff24f7039bb17f78b8
+  ref: 446b1ad643607e49dd3cacff24f7039bb17f78b8
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
Connects #204

### Description
Bumps connect_vbms to include https://github.com/department-of-veterans-affairs/connect_vbms/pull/205, which adds support for passing through claim-level POA fields when establishing claims.

### Acceptance Criteria
N/A we validated the connect_vbms client separately, and Caseflow does not currently send these POA fields

### Testing Plan
N/A