### PR TITLE
Assign Hearings | Remove slots from navigation

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -60,8 +60,9 @@ export default class AssignHearings extends React.Component {
         {Object.values(this.props.upcomingHearingDays).slice(0, 9).
           map((hearingDay) => {
             const { selectedHearingDay } = this.props;
-            const availableSlots = hearingDay.totalSlots - Object.keys(hearingDay.hearings).length;
-            const dateSelected = selectedHearingDay && selectedHearingDay.hearingDate === hearingDay.hearingDate;
+            const dateSelected = selectedHearingDay &&
+            (selectedHearingDay.hearingDate === hearingDay.hearingDate &&
+               selectedHearingDay.roomInfo === hearingDay.roomInfo);
             const buttonColorSelected = css({
               backgroundColor: COLORS.GREY_DARK,
               color: COLORS.WHITE,
@@ -80,7 +81,7 @@ export default class AssignHearings extends React.Component {
                 linkStyling
               >
                 {`${moment(hearingDay.hearingDate).format('ddd M/DD/YYYY')}
-                ${this.roomInfo(hearingDay)} (${availableSlots} slots)`}
+                ${this.roomInfo(hearingDay)}`}
               </Button>
             </li>;
           })}
@@ -145,8 +146,8 @@ export default class AssignHearings extends React.Component {
 
     return <div className="usa-width-three-fourths">
       <h1>
-        {moment(selectedHearingDay.hearingDate).format('ddd M/DD/YYYY')}
-        {this.roomInfo(selectedHearingDay)} ({availableSlots} slots remaining)
+        {`${moment(selectedHearingDay.hearingDate).format('ddd M/DD/YYYY')}
+       ${this.roomInfo(selectedHearingDay)} (${availableSlots} slots remaining)`}
       </h1>
       <TabWindow
         name="scheduledHearings-tabwindow"


### PR DESCRIPTION
Resolves #7296
Resolves #7298

### Description
This pr removes slots in the navigation and also highlights one date at a time  in the navigation if dates are the same. It also adds a space to between room info and date header.

### Acceptance Criteria
- [ ]  We should remove the number of slots from the navigation panel on the lefthand side.


### Testing Plan
1. Go to  Assign Hearings

<img width="1042" alt="screen shot 2018-10-09 at 2 22 51 pm" src="https://user-images.githubusercontent.com/23080951/46689937-0a85a680-cbcf-11e8-9d32-8b3ea775568a.png">