### PR TITLE
Hearing Scheduling | Fix filtering hearing days by null values

### DIFF
--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -66,7 +66,7 @@ const populateFilterDropDowns = (resultSet, filterName) => {
       });
     } else {
       uniqueOptions.push({
-        value: '<<blank>>',
+        value: 'null',
         displayText: `<<blank>> (${countByFilterName[key]})`
       });
     }
@@ -79,7 +79,7 @@ const filterSchedule = (scheduleToFilter, filterName, value) => {
   let filteredSchedule = {};
 
   for (let key in scheduleToFilter) {
-    if (scheduleToFilter[key][filterName] === value) {
+    if (String(scheduleToFilter[key][filterName]) === String(value)) {
       filteredSchedule[key] = scheduleToFilter[key];
     }
   }


### PR DESCRIPTION
### Description
This fixes filtering hearing days by blank values. Previously, we were setting the filter value to `<<blank>>`, matching its display text, but this caused all rows to disappear. This PR sets the null option value to `'null'` and compares values based on `String(value)`.

### Acceptance Criteria
- [ ] Hearing day table filters work for null and non-null values

### Testing Plan
1. Go to `/hearings/schedule`, confirm setting any filter to `<<blank>>` shows correct rows

<details><summary>before</summary>
<img src="https://user-images.githubusercontent.com/8533004/46692697-cee1e100-cbbc-11e8-9112-815580594ca4.gif">
</details>

<details><summary>after</summary>
<img src="https://user-images.githubusercontent.com/8533004/46692636-aeb22200-cbbc-11e8-9fc1-f59fa8b5efa9.gif">
</details>