### PR TITLE
flush stdout before exiting process

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -87,7 +87,6 @@ namespace :ci do
     require "simplecov"
 
     api_url = "https://circleci.com/api/v1.1/project/github/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}/#{ENV['CIRCLE_BUILD_NUM']}/artifacts" # rubocop:disable Metrics/LineLength
-
     coverage_dir = "/tmp/coverage"
     SimpleCov.coverage_dir(coverage_dir)
     # Set the merge_timeout very large so that we don't exclude results

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -85,6 +85,7 @@ namespace :ci do
   desc "Verify code coverage on CircleCI "
   task :circleci_verify_code_coverage do
     require "simplecov"
+    $stdout.sync = true
 
     api_url = "https://circleci.com/api/v1.1/project/github/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}/#{ENV['CIRCLE_BUILD_NUM']}/artifacts" # rubocop:disable Metrics/LineLength
     coverage_dir = "/tmp/coverage"
@@ -110,7 +111,6 @@ namespace :ci do
     SimpleCov::ResultMerger.store_result(result)
     if result.covered_percentages.empty?
       puts Rainbow("No valid coverage results were found").red
-      $stdout.flush
       exit!(1)
     end
     # This prints code coverage statistics as a side effect, which we want
@@ -119,11 +119,9 @@ namespace :ci do
     if result.covered_percentages.any? { |c| c < CODE_COVERAGE_THRESHOLD }
       puts Rainbow("File #{result.least_covered_file} is only #{result.covered_percentages.min.to_i}% covered.\
                   This is below the expected minimum coverage per file of #{CODE_COVERAGE_THRESHOLD}%\n").red
-      $stdout.flush
       exit!(1)
     else
       puts Rainbow("Code coverage threshold met\n").green
-      $stdout.flush
       exit!(0)
     end
   end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -88,7 +88,6 @@ namespace :ci do
 
     api_url = "https://circleci.com/api/v1.1/project/github/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}/#{ENV['CIRCLE_BUILD_NUM']}/artifacts" # rubocop:disable Metrics/LineLength
 
-    https://circleci.com/api/v1.1/project/github/
     coverage_dir = "/tmp/coverage"
     SimpleCov.coverage_dir(coverage_dir)
     # Set the merge_timeout very large so that we don't exclude results

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -87,6 +87,8 @@ namespace :ci do
     require "simplecov"
 
     api_url = "https://circleci.com/api/v1.1/project/github/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}/#{ENV['CIRCLE_BUILD_NUM']}/artifacts" # rubocop:disable Metrics/LineLength
+
+    https://circleci.com/api/v1.1/project/github/
     coverage_dir = "/tmp/coverage"
     SimpleCov.coverage_dir(coverage_dir)
     # Set the merge_timeout very large so that we don't exclude results
@@ -110,6 +112,7 @@ namespace :ci do
     SimpleCov::ResultMerger.store_result(result)
     if result.covered_percentages.empty?
       puts Rainbow("No valid coverage results were found").red
+      $stdout.flush
       exit!(1)
     end
     # This prints code coverage statistics as a side effect, which we want
@@ -118,9 +121,11 @@ namespace :ci do
     if result.covered_percentages.any? { |c| c < CODE_COVERAGE_THRESHOLD }
       puts Rainbow("File #{result.least_covered_file} is only #{result.covered_percentages.min.to_i}% covered.\
                   This is below the expected minimum coverage per file of #{CODE_COVERAGE_THRESHOLD}%\n").red
+      $stdout.flush
       exit!(1)
     else
       puts Rainbow("Code coverage threshold met\n").green
+      $stdout.flush
       exit!(0)
     end
   end


### PR DESCRIPTION
### Description
When the code coverage check runs in CI, the process exits and we stop capturing logs before Ruby's stdout has a chance to flush. This leads to coverage output being lost, though the exit code is correct.

<img width="1004" alt="screen shot 2018-10-09 at 1 21 22 pm" src="https://user-images.githubusercontent.com/279406/46696442-fc338c80-cbc6-11e8-8217-ceafcda5a973.png">

Previously we'd just see:
<img width="695" alt="screen shot 2018-10-09 at 1 27 49 pm" src="https://user-images.githubusercontent.com/279406/46696506-2422f000-cbc7-11e8-9532-24dd4b52b2d4.png">

I don't have a screenshot, but a failure will start to show more useful text like
```
Warning: NLS_LANG is not set. fallback to US7ASCII.
Coverage report generated for RSpec0, RSpec1, RSpec2, RSpec3, RSpec4 to /tmp/coverage. 8023 / 8196 LOC (97.89%) covered.
File /home/circleci/project/app/models/hearing_day.rb is only 89% covered.                  This is below the expected minimum coverage per file of 90%
```

### Acceptance Criteria
N/A

### Testing Plan
N/A
