### PR TITLE
Any judge should have permissions to modify task info

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -72,7 +72,7 @@ class TasksController < ApplicationController
   #   on_hold_duration: "something"
   # }
   def update
-    redirect_to("/unauthorized") && return unless task.can_user_access?(current_user)
+    redirect_to("/unauthorized") && return unless task.can_be_accessed_by_user?(current_user)
 
     task.update_from_params(update_params, current_user)
 
@@ -99,7 +99,7 @@ class TasksController < ApplicationController
 
   def can_act_on_task?
     return true if can_assign_task?
-    true if task.can_user_access?(current_user)
+    true if task.can_be_accessed_by_user?(current_user)
   rescue ActiveRecord::RecordNotFound
     return false
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -39,7 +39,7 @@ class Task < ApplicationRecord
   end
 
   def self.create_from_params(params, current_user)
-    verify_user_can_assign(current_user)
+    verify_user_can_assign!(current_user)
     params = params.each { |p| p["instructions"] = [p["instructions"]] if p.key?("instructions") }
     create(params)
   end
@@ -88,18 +88,22 @@ class Task < ApplicationRecord
     update_status_if_children_tasks_are_complete
   end
 
-  def can_user_access?(user)
-    return true if assigned_to == user || assigned_by == user
+  def can_be_accessed_by_user?(user)
+    if assigned_to == user || 
+      (parent && parent.assigned_to == user) || 
+      Constants::AttorneyJudgeTeams::JUDGES[Rails.current_env].keys.include?(user.css_id)
+      return true 
+    end
     false
   end
 
-  def verify_user_access(user)
-    unless can_user_access?(user)
+  def verify_user_access!(user)
+    unless can_be_accessed_by_user?(user)
       fail Caseflow::Error::ActionForbiddenError, message: "Current user cannot access this task"
     end
   end
 
-  def self.verify_user_can_assign(user)
+  def self.verify_user_can_assign!(user)
     unless user.attorney_in_vacols? ||
            (user.judge_in_vacols? && FeatureToggle.enabled?(:judge_assignment_to_attorney, user: user))
       fail Caseflow::Error::ActionForbiddenError, message: "Current user cannot assign this task"

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -19,7 +19,7 @@ class GenericTask < Task
   end
 
   def update_from_params(params, current_user)
-    verify_user_access(current_user)
+    verify_user_access!(current_user)
 
     new_status = params[:status]
     if new_status == Constants.TASK_STATUSES.completed
@@ -29,7 +29,7 @@ class GenericTask < Task
     end
   end
 
-  def can_user_access?(user)
+  def can_be_accessed_by_user?(user)
     return true if assigned_to && assigned_to == user
     return true if user && assigned_to.is_a?(Organization) && assigned_to.user_has_access?(user)
     false
@@ -42,7 +42,7 @@ class GenericTask < Task
         fail Caseflow::Error::ChildTaskAssignedToSameUser if parent.assigned_to_id == params[:assigned_to_id] &&
                                                              parent.assigned_to_type == params[:assigned_to_type]
 
-        parent.verify_user_access(current_user)
+        parent.verify_user_access!(current_user)
 
         child = create_child_task(parent, current_user, params)
         update_status(parent, params[:status])

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -99,6 +99,40 @@ describe Task do
     end
   end
 
+  context "#can_be_accessed_by_user?" do
+    
+    subject { task.can_be_accessed_by_user?(user) }
+
+    context "when user is an assignee" do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, type: "Task", assigned_to: user) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when user is a task parent assignee" do
+      let(:user) { create(:user) }
+      let(:parent) { create(:task, type: "Task", assigned_to: user) }
+      let(:task) { create(:task, type: "Task", parent: parent) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when user is any judge" do
+      let(:user) { create(:user, css_id: "BVABDANIEL") }
+      let(:task) { create(:task, type: "Task", assigned_to: user) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context "when user does not have access" do
+      let(:user) { create(:user) }
+      let(:task) { create(:task, type: "Task", assigned_to: create(:user)) }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
   context "#prepared_by_display_name" do
     let(:task) { create(:task, type: "Task") }
 

--- a/spec/models/tasks/generic_task_spec.rb
+++ b/spec/models/tasks/generic_task_spec.rb
@@ -1,5 +1,5 @@
 describe GenericTask do
-  describe ".verify_user_access" do
+  describe ".verify_user_access!" do
     let(:user) { FactoryBot.create(:user) }
     let(:other_user) { FactoryBot.create(:user) }
 
@@ -26,28 +26,28 @@ describe GenericTask do
     context "task assignee is current user" do
       let(:assignee) { user }
       it "should not raise an error" do
-        expect { task.verify_user_access(user) }.to_not raise_error
+        expect { task.verify_user_access!(user) }.to_not raise_error
       end
     end
 
     context "task assignee is organization to which current user belongs" do
       let(:assignee) { org }
       it "should not raise an error" do
-        expect { task.verify_user_access(user) }.to_not raise_error
+        expect { task.verify_user_access!(user) }.to_not raise_error
       end
     end
 
     context "task assignee is a different person" do
       let(:assignee) { other_user }
       it "should raise an error" do
-        expect { task.verify_user_access(user) }.to raise_error(Caseflow::Error::ActionForbiddenError)
+        expect { task.verify_user_access!(user) }.to raise_error(Caseflow::Error::ActionForbiddenError)
       end
     end
 
     context "task assignee is organization to which current user does not belong" do
       let(:assignee) { other_org }
       it "should raise an error" do
-        expect { task.verify_user_access(user) }.to raise_error(Caseflow::Error::ActionForbiddenError)
+        expect { task.verify_user_access!(user) }.to raise_error(Caseflow::Error::ActionForbiddenError)
       end
     end
   end


### PR DESCRIPTION
Scenario: assign task to BVAEERDMAN and then move BVAEERDMAN from judge BVAAABSHIRE to judge BVARZIEMANN1. Task's assigned by will still have judge BVAAABSHIRE. However, now BVARZIEMANN1 should be able to modify task. 

I talked to LP and we made a decision that all judges should have permissions to modify tasks.

