### PR TITLE
Revert "Queue | Ignores Decass records with deprod = "REA"  (#7121)"

### DIFF
--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -19,4 +19,8 @@ class AttorneyLegacyTask < LegacyTask
 
     actions
   end
+
+  def self.from_vacols(case_assignment, appeal, user_id)
+    super
+  end
 end

--- a/app/models/vacols/case_assignment.rb
+++ b/app/models/vacols/case_assignment.rb
@@ -116,7 +116,7 @@ class VACOLS::CaseAssignment < VACOLS::Record
              "s4.snamel as written_by_last_name")
         .joins(<<-SQL)
           LEFT JOIN decass
-            ON brieff.bfkey = decass.defolder and (decass.deprod is null or decass.deprod != 'REA')
+            ON brieff.bfkey = decass.defolder
           LEFT JOIN staff s1
             ON decass.deadusr = s1.slogid
           JOIN staff s2

--- a/spec/factories/vacols/decass.rb
+++ b/spec/factories/vacols/decass.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     end
 
     trait :draft_decision do
-      deprod Constants::DECASS_WORK_PRODUCT_TYPES["DRAFT_DECISION"].reject { |e| e == "REA" }.sample
+      deprod Constants::DECASS_WORK_PRODUCT_TYPES["DRAFT_DECISION"].sample
     end
   end
 end

--- a/spec/models/queues/legacy_work_queue_spec.rb
+++ b/spec/models/queues/legacy_work_queue_spec.rb
@@ -17,28 +17,19 @@ describe LegacyWorkQueue do
       ]
     end
 
-    let!(:decass) do
-      [
-        create(:decass, defolder: appeals[0].vacols_id, dereceive: Date.new(2018, 9, 24), deprod: "DEC"),
-        create(:decass, defolder: appeals[1].vacols_id, dereceive: Date.new(2018, 9, 24), deprod: "REA")
-      ]
-    end
+    subject { LegacyWorkQueue.tasks_with_appeals(user, role) }
 
     context "when it is an attorney" do
       let(:role) { "Attorney" }
 
       it "returns tasks" do
-        tasks, = LegacyWorkQueue.tasks_with_appeals(user, role)
-
-        expect(tasks.length).to eq(2)
-        expect(tasks[0].class).to eq(AttorneyLegacyTask)
+        expect(subject[0].length).to eq(2)
+        expect(subject[0][0].class).to eq(AttorneyLegacyTask)
       end
 
       it "returns appeals" do
-        _, appeals = LegacyWorkQueue.tasks_with_appeals(user, role)
-
-        expect(appeals.length).to eq(2)
-        expect(appeals[0].class).to eq(LegacyAppeal)
+        expect(subject[1].length).to eq(2)
+        expect(subject[1][0].class).to eq(LegacyAppeal)
       end
     end
 
@@ -46,24 +37,13 @@ describe LegacyWorkQueue do
       let(:role) { "Judge" }
 
       it "returns tasks" do
-        tasks, = LegacyWorkQueue.tasks_with_appeals(user, role)
-
-        expect(tasks.length).to eq(2)
-        if tasks[0].action == "assign"
-          assign, review = tasks
-        else
-          review, assign = tasks
-        end
-        expect(assign.class).to eq(JudgeLegacyTask)
-        expect(assign.action).to eq("assign")
-        expect(review.action).to eq("review")
+        expect(subject[0].length).to eq(2)
+        expect(subject[0][0].class).to eq(JudgeLegacyTask)
       end
 
       it "returns appeals" do
-        _, appeals = LegacyWorkQueue.tasks_with_appeals(user, role)
-
-        expect(appeals.length).to eq(2)
-        expect(appeals[0].class).to eq(LegacyAppeal)
+        expect(subject[1].length).to eq(2)
+        expect(subject[1][0].class).to eq(LegacyAppeal)
       end
     end
   end
@@ -79,21 +59,19 @@ describe LegacyWorkQueue do
     end
     let!(:appeal) { appeals[0] }
 
+    subject { LegacyWorkQueue.tasks_with_appeals_by_appeal_id(appeal.vacols_id, role) }
+
     context "when the user is an attorney" do
       let(:role) { "attorney" }
 
       it "returns a task" do
-        tasks, = LegacyWorkQueue.tasks_with_appeals_by_appeal_id(appeal.vacols_id, role)
-
-        expect(tasks.length).to eq(1)
-        expect(tasks[0].class).to eq(AttorneyLegacyTask)
+        expect(subject[0].length).to eq(1)
+        expect(subject[0][0].class).to eq(AttorneyLegacyTask)
       end
 
       it "returns an appeal" do
-        _, appeals = LegacyWorkQueue.tasks_with_appeals_by_appeal_id(appeal.vacols_id, role)
-
-        expect(appeals.length).to eq(1)
-        expect(appeals[0].class).to eq(LegacyAppeal)
+        expect(subject[1].length).to eq(1)
+        expect(subject[1][0].class).to eq(LegacyAppeal)
       end
     end
   end
@@ -109,12 +87,13 @@ describe LegacyWorkQueue do
     end
     let!(:appeal) { appeals[0] }
 
+    subject { LegacyWorkQueue.tasks_with_appeals_by_appeal_id(appeal.vacols_id, role) }
+
     context "when the user is an attorney" do
       let(:role) { "attorney" }
 
       it "returns a task and an appeal" do
-        tasks, appeals = LegacyWorkQueue.tasks_with_appeals_by_appeal_id(appeal.vacols_id, role)
-
+        tasks, appeals = subject
         expect(tasks.length).to eq(1)
         task = tasks[0]
         expect(task.class).to eq(AttorneyLegacyTask)


### PR DESCRIPTION
This reverts commit 1fc77dec3aa00dcabbbfb272cf0576ac734ef5b0.

Resolves https://github.com/department-of-veterans-affairs/appeals-support/issues/3191

### Description
It turns out that REA Decass records are used in ways that I didn't anticipate. They can't be ignored.
