### PR TITLE
Add RatingIssue table, link contentions

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -71,6 +71,7 @@ class ClaimReview < AmaReview
   def on_sync(end_product_establishment)
     if end_product_establishment.status_cleared?
       sync_dispositions(end_product_establishment.reference_id)
+      sync_rating_issues(end_product_establishment.veteran_file_number)
       # allow higher level reviews to do additional logic on dta errors
       yield if block_given?
     end
@@ -93,6 +94,10 @@ class ClaimReview < AmaReview
         disposition: disposition.disposition
       )
     end
+  end
+
+  def sync_rating_issues(veteran_file_number)
+    Veteran.find_by!(file_number: veteran_file_number).sync_rating_issues!
   end
 
   def fetch_dispositions_from_vbms(reference_id)

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -71,7 +71,7 @@ class ClaimReview < AmaReview
   def on_sync(end_product_establishment)
     if end_product_establishment.status_cleared?
       sync_dispositions(end_product_establishment.reference_id)
-      sync_rating_issues(end_product_establishment.veteran_file_number)
+      veteran.sync_rating_issues!
       # allow higher level reviews to do additional logic on dta errors
       yield if block_given?
     end
@@ -94,10 +94,6 @@ class ClaimReview < AmaReview
         disposition: disposition.disposition
       )
     end
-  end
-
-  def sync_rating_issues(veteran_file_number)
-    Veteran.find_by!(file_number: veteran_file_number).sync_rating_issues!
   end
 
   def fetch_dispositions_from_vbms(reference_id)

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -220,7 +220,7 @@ class EndProductEstablishment < ApplicationRecord
 
   def rated_issue_contention_map(request_issues_to_associate)
     request_issues_to_associate.inject({}) do |contention_map, issue|
-      contention_map[issue.rating_issue_reference_id] = issue.contention_reference_id
+      contention_map[issue.rating_issue_reference_id] = issue.contention_reference_id.to_s
       contention_map
     end
   end
@@ -310,7 +310,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def contention_for_object(for_object)
-    contentions.find { |contention| contention.id == for_object.contention_reference_id }
+    contentions.find { |contention| contention.id == for_object.contention_reference_id.to_s }
   end
 
   # These are values that need to be determined based on the source right before the end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -220,7 +220,7 @@ class EndProductEstablishment < ApplicationRecord
 
   def rated_issue_contention_map(request_issues_to_associate)
     request_issues_to_associate.inject({}) do |contention_map, issue|
-      contention_map[issue.rating_issue_reference_id] = issue.contention_reference_id.to_s
+      contention_map[issue.rating_issue_reference_id] = issue.contention_reference_id
       contention_map
     end
   end
@@ -310,7 +310,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def contention_for_object(for_object)
-    contentions.find { |contention| contention.id == for_object.contention_reference_id.to_s }
+    contentions.find { |contention| contention.id.to_i == for_object.contention_reference_id.to_i }
   end
 
   # These are values that need to be determined based on the source right before the end

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -4,6 +4,17 @@ class RatingIssue < ApplicationRecord
   # this local attribute is used to resolve the related RequestIssue
   attr_accessor :contention_reference_id
 
+  def save_with_request_issue!
+    return unless related_request_issue
+    self.request_issue = related_request_issue
+    save!
+  end
+
+  def related_request_issue
+    return if contention_reference_id.nil?
+    @request_issue ||= RequestIssue.find_by(contention_reference_id: contention_reference_id)
+  end
+
   # If you change this method, you will need
   # to clear cache in prod for your changes to
   # take effect immediately.

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -1,6 +1,9 @@
 class RatingIssue < ApplicationRecord
   belongs_to :request_issue
 
+  # this local attribute is used to resolve the related RequestIssue
+  attr_accessor :contention_reference_id
+
   # If you change this method, you will need
   # to clear cache in prod for your changes to
   # take effect immediately.
@@ -15,6 +18,8 @@ class RatingIssue < ApplicationRecord
   def self.from_bgs_hash(data)
     new(
       reference_id: data[:rba_issue_id],
+      profile_date: data.dig(:rba_issue_contentions, :prfil_dt),
+      contention_reference_id: data.dig(:rba_issue_contentions, :cntntn_id),
       decision_text: data[:decn_txt]
     )
   end

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -10,11 +10,6 @@ class RatingIssue < ApplicationRecord
     save!
   end
 
-  def related_request_issue
-    return if contention_reference_id.nil?
-    @request_issue ||= RequestIssue.find_by(contention_reference_id: contention_reference_id)
-  end
-
   # If you change this method, you will need
   # to clear cache in prod for your changes to
   # take effect immediately.
@@ -33,5 +28,12 @@ class RatingIssue < ApplicationRecord
       contention_reference_id: data.dig(:rba_issue_contentions, :cntntn_id),
       decision_text: data[:decn_txt]
     )
+  end
+
+  private
+
+  def related_request_issue
+    return if contention_reference_id.nil?
+    @related_request_issue ||= RequestIssue.find_by(contention_reference_id: contention_reference_id)
   end
 end

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -1,7 +1,5 @@
-class RatingIssue
-  include ActiveModel::Model
-
-  attr_accessor :reference_id, :decision_text
+class RatingIssue < ApplicationRecord
+  belongs_to :request_issue
 
   # If you change this method, you will need
   # to clear cache in prod for your changes to

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -3,6 +3,7 @@ class RequestIssue < ApplicationRecord
   belongs_to :end_product_establishment
   has_many :decision_issues
   has_many :remand_reasons
+  has_many :rating_issues
 
   def self.rated
     where.not(rating_issue_reference_id: nil, rating_issue_profile_date: nil)

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -139,14 +139,7 @@ class Veteran < ApplicationRecord
 
   def sync_rating_issues!
     timely_ratings(from_date: Time.zone.today).each do |rating|
-      rating.issues.each do |rating_issue|
-        next unless rating_issue.contention_reference_id
-        request_issue = RequestIssue.find_by(contention_reference_id: rating_issue.contention_reference_id)
-        if request_issue
-          rating_issue.request_issue = request_issue
-          rating_issue.save!
-        end
-      end
+      rating.issues.select(&:contention_reference_id).each(&:save_with_request_issue!)
     end
   end
 

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -137,6 +137,19 @@ class Veteran < ApplicationRecord
     super || ptcpnt_id
   end
 
+  def sync_rating_issues!
+    timely_ratings(from_date: Time.zone.today).each do |rating|
+      rating.issues.each do |rating_issue|
+        next unless rating_issue.contention_reference_id
+        request_issue = RequestIssue.find_by(contention_reference_id: rating_issue.contention_reference_id)
+        if request_issue
+          rating_issue.request_issue = request_issue
+          rating_issue.save!
+        end
+      end
+    end
+  end
+
   class << self
     def find_or_create_by_file_number(file_number)
       find_and_maybe_backfill_name(file_number) || create_by_file_number(file_number)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -257,13 +257,14 @@ class ExternalApi::BGSService
     BGS::Services.new(
       env: Rails.application.config.bgs_environment,
       application: "CASEFLOW",
-      client_ip: Rails.application.secrets.user_ip_address,
+      client_ip: ENV.fetch("USER_IP_ADDRESS", Rails.application.secrets.user_ip_address),
       client_station_id: current_user.station_id,
       client_username: current_user.css_id,
       ssl_cert_key_file: ENV["BGS_KEY_LOCATION"],
       ssl_cert_file: ENV["BGS_CERT_LOCATION"],
       ssl_ca_cert: ENV["BGS_CA_CERT_LOCATION"],
       forward_proxy_url: forward_proxy_url,
+      jumpbox_url: ENV["RUBY_BGS_JUMPBOX_URL"],
       log: true
     )
   end

--- a/db/migrate/20181009214213_create_rating_issues.rb
+++ b/db/migrate/20181009214213_create_rating_issues.rb
@@ -1,0 +1,10 @@
+class CreateRatingIssues < ActiveRecord::Migration[5.1]
+  def change
+    create_table :rating_issues do |t|
+      t.belongs_to :request_issue, null: false, index: true
+      t.string     :reference_id, null: false
+      t.datetime   :profile_date, null: false
+      t.string     :decision_text
+    end
+  end
+end

--- a/db/migrate/20181010185251_change_contention_ref_id_to_integer.rb
+++ b/db/migrate/20181010185251_change_contention_ref_id_to_integer.rb
@@ -1,0 +1,11 @@
+class ChangeContentionRefIdToInteger < ActiveRecord::Migration[5.1]
+  def up
+    execute "alter table request_issues alter column contention_reference_id type integer using (contention_reference_id::integer)"
+    safety_assured { add_index(:request_issues, :contention_reference_id, unique: true) }
+  end
+
+  def down
+    execute "alter table request_issues alter column contention_reference_id type varchar using (contention_reference_id::varchar)"
+    remove_index(:request_issues, :contention_reference_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181004232948) do
+ActiveRecord::Schema.define(version: 20181009214213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 20181004232948) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "granted"
-    t.index ["person_id"], name: "index_advance_on_docket_grants_on_person_id"
-    t.index ["user_id"], name: "index_advance_on_docket_grants_on_user_id"
+    t.index ["person_id"], name: "index_advance_on_docket_motions_on_person_id"
+    t.index ["user_id"], name: "index_advance_on_docket_motions_on_user_id"
   end
 
   create_table "allocations", force: :cascade do |t|
@@ -568,6 +568,14 @@ ActiveRecord::Schema.define(version: 20181004232948) do
     t.datetime "establishment_attempted_at"
     t.string "establishment_error"
     t.index ["veteran_file_number"], name: "index_ramp_refilings_on_veteran_file_number"
+  end
+
+  create_table "rating_issues", force: :cascade do |t|
+    t.bigint "request_issue_id", null: false
+    t.string "reference_id", null: false
+    t.datetime "profile_date", null: false
+    t.string "decision_text"
+    t.index ["request_issue_id"], name: "index_rating_issues_on_request_issue_id"
   end
 
   create_table "reader_users", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181009214213) do
+ActiveRecord::Schema.define(version: 20181010185251) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -599,7 +599,7 @@ ActiveRecord::Schema.define(version: 20181009214213) do
     t.bigint "review_request_id"
     t.string "rating_issue_reference_id"
     t.datetime "rating_issue_profile_date"
-    t.string "contention_reference_id"
+    t.integer "contention_reference_id"
     t.string "description"
     t.string "issue_category"
     t.date "decision_date"
@@ -609,6 +609,7 @@ ActiveRecord::Schema.define(version: 20181009214213) do
     t.datetime "rating_issue_associated_at"
     t.integer "parent_request_issue_id"
     t.text "notes"
+    t.index ["contention_reference_id"], name: "index_request_issues_on_contention_reference_id", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["parent_request_issue_id"], name: "index_request_issues_on_parent_request_issue_id"
     t.index ["review_request_type", "review_request_id"], name: "index_request_issues_on_review_request"

--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -61,7 +61,11 @@ class Generators::Rating
       attrs[:issues].map do |issue_data|
         {
           rba_issue_id: issue_data[:reference_id] || generate_external_id,
-          decn_txt: issue_data[:decision_text]
+          decn_txt: issue_data[:decision_text],
+          rba_issue_contentions: {
+            prfil_dt: issue_data[:profile_date],
+            cntntn_id: issue_data[:contention_reference_id]
+          }
         }
       end
     end

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -370,7 +370,7 @@ describe EndProductEstablishment do
     end
 
     let(:reference_id) { "stevenasmith" }
-    let(:contention_ref_id) { SecureRandom.random_number(1_000_000) }
+    let(:contention_ref_id) { 1234 }
 
     let(:for_object) do
       RequestIssue.new(

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -262,7 +262,7 @@ describe EndProductEstablishment do
 
       expect(end_product_establishment.contentions.count).to eq(3)
       expect(end_product_establishment.contentions.map(&:id)).to contain_exactly(
-        *request_issues.map(&:reload).map(&:contention_reference_id)
+        *request_issues.map(&:reload).map(&:contention_reference_id).map(&:to_s)
       )
     end
 
@@ -370,6 +370,7 @@ describe EndProductEstablishment do
     end
 
     let(:reference_id) { "stevenasmith" }
+    let(:contention_ref_id) { SecureRandom.random_number(1_000_000) }
 
     let(:for_object) do
       RequestIssue.new(
@@ -377,12 +378,12 @@ describe EndProductEstablishment do
         rating_issue_reference_id: "reference-id",
         rating_issue_profile_date: Date.new(2018, 4, 30),
         description: "this is a big decision",
-        contention_reference_id: "skipbayless"
+        contention_reference_id: contention_ref_id
       )
     end
 
     let!(:contention) do
-      Generators::Contention.build(id: "skipbayless", claim_id: reference_id, text: "Left knee")
+      Generators::Contention.build(id: contention_ref_id, claim_id: reference_id, text: "Left knee")
     end
 
     subject { end_product_establishment.remove_contention!(for_object) }

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -30,4 +30,25 @@ describe RatingIssue do
       )
     end
   end
+
+  context "#save_with_request_issue!" do
+    let(:contention_ref_id) { 123 }
+
+    let!(:request_issue) { create(:request_issue, contention_reference_id: contention_ref_id) }
+
+    it "matches based on contention_reference_id" do
+      rating_issue = RatingIssue.new(
+        reference_id: "ref-id",
+        profile_date: Time.zone.today,
+        contention_reference_id: contention_ref_id
+      )
+
+      expect(rating_issue.id).to be_nil
+
+      rating_issue.save_with_request_issue!
+
+      expect(rating_issue.request_issue).to eq(request_issue)
+      expect(rating_issue.id).to_not be_nil
+    end
+  end
 end

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -415,4 +415,43 @@ describe Veteran do
       expect(veteran.valid?(:bgs)).to be false
     end
   end
+
+  context "#sync_rating_issues!" do
+    let(:rating) do
+      Generators::Rating.build(
+        issues: issues
+      )
+    end
+
+    let(:contention_ref_id) { "123456" }
+
+    let(:issues) do
+      [
+        {
+          reference_id: "Issue1",
+          decision_text: "Decision1",
+          contention_reference_id: contention_ref_id,
+          profile_date: Time.zone.today
+        },
+        { reference_id: "Issue2", decision_text: "Decision2" }
+      ]
+    end
+
+    let!(:request_issues) do
+      [create(:request_issue, contention_reference_id: contention_ref_id)]
+    end
+
+    subject { veteran.sync_rating_issues! }
+
+    it "connects rating issues with request issues based on contention_reference_id" do
+      allow(veteran).to receive(:timely_ratings).and_return([rating])
+
+      expect(request_issues.first.rating_issues.count).to eq(0)
+
+      subject
+
+      expect(request_issues.first.rating_issues.count).to eq(1)
+      expect(request_issues.first.rating_issues.first.reference_id).to eq("Issue1")
+    end
+  end
 end


### PR DESCRIPTION
connects #7178

### Description

* Add `rating_issues` table, re-use existing model class
* Sync `Veteran` rating issues based on matching `contention_reference_id`
* make `contention_reference_id` a unique integer

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Tests continue to pass

### Testing Plan
See the specific UAT examples in #7178

