### PR TITLE
add flag for unidentified issues

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -83,7 +83,7 @@ class ClaimReview < AmaReview
   end
 
   def end_product_establishment_for_issue(issue)
-    ep_code = issue_code(issue.rated? || issue.unidentified?)
+    ep_code = issue_code(issue.rated? || issue.is_unidentified?)
     end_product_establishments.find_by(code: ep_code) || new_end_product_establishment(ep_code)
   end
 

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -83,7 +83,7 @@ class ClaimReview < AmaReview
   end
 
   def end_product_establishment_for_issue(issue)
-    ep_code = issue_code(issue.rated?)
+    ep_code = issue_code(issue.rated? || issue.unidentified?)
     end_product_establishments.find_by(code: ep_code) || new_end_product_establishment(ep_code)
   end
 

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -10,8 +10,8 @@ class RequestIssue < ApplicationRecord
   end
 
   def self.nonrated
-    where(rating_issue_reference_id: nil, rating_issue_profile_date: nil)
-      .where.not(issue_category: nil, is_unidentified: true)
+    where(rating_issue_reference_id: nil, rating_issue_profile_date: nil, is_unidentified: [nil, false])
+      .where.not(issue_category: nil)
   end
 
   def self.unidentified
@@ -24,10 +24,6 @@ class RequestIssue < ApplicationRecord
 
   def rated?
     rating_issue_reference_id && rating_issue_profile_date
-  end
-
-  def unidentified?
-    is_unidentified
   end
 
   def self.from_intake_data(data)

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -6,12 +6,16 @@ class RequestIssue < ApplicationRecord
 
   def self.rated
     where.not(rating_issue_reference_id: nil, rating_issue_profile_date: nil)
-      .or(where(issue_category: "Unknown issue category"))
+      .or(where(is_unidentified: true))
   end
 
   def self.nonrated
     where(rating_issue_reference_id: nil, rating_issue_profile_date: nil)
-      .where.not(issue_category: [nil, "Unknown issue category"])
+      .where.not(issue_category: nil, is_unidentified: true)
+  end
+
+  def self.unidentified
+    where(rating_issue_reference_id: nil, rating_issue_profile_date: nil, is_unidentified: true)
   end
 
   def self.no_follow_up_issues
@@ -22,6 +26,10 @@ class RequestIssue < ApplicationRecord
     rating_issue_reference_id && rating_issue_profile_date
   end
 
+  def unidentified?
+    is_unidentified
+  end
+
   def self.from_intake_data(data)
     new(
       rating_issue_reference_id: data[:reference_id],
@@ -29,7 +37,8 @@ class RequestIssue < ApplicationRecord
       description: data[:decision_text],
       decision_date: data[:decision_date],
       issue_category: data[:issue_category],
-      notes: data[:notes]
+      notes: data[:notes],
+      is_unidentified: data[:is_unidentified]
     )
   end
 

--- a/client/app/intake/actions/ama.js
+++ b/client/app/intake/actions/ama.js
@@ -152,7 +152,6 @@ export const addUnidentifiedIssue = (description, notes) => (dispatch) => {
   dispatch({
     type: ACTIONS.ADD_ISSUE,
     payload: {
-      category: 'Unknown issue category',
       isUnidentified: true,
       description,
       notes

--- a/client/app/intakeCommon/constants.js
+++ b/client/app/intakeCommon/constants.js
@@ -29,7 +29,6 @@ export const FORM_TYPES = {
 };
 
 const issueCategoriesArray = [
-  'Unknown issue category',
   'Apportionment',
   'Incarceration Adjustments',
   'Audit Error Worksheet (DFAS)',
@@ -56,10 +55,8 @@ export const ISSUE_CATEGORIES = issueCategoriesArray.map((category) => {
   };
 });
 
-// Removes the "Unknown issue category"
-// which is temporary until we activate the new "Add issues" flow
 export const NON_RATED_ISSUE_CATEGORIES = issueCategoriesArray.
-  filter((category) => category !== 'Unknown issue category').map((category) => {
+  .map((category) => {
     return {
       value: category,
       label: category

--- a/client/app/intakeCommon/constants.js
+++ b/client/app/intakeCommon/constants.js
@@ -55,7 +55,7 @@ export const ISSUE_CATEGORIES = issueCategoriesArray.map((category) => {
   };
 });
 
-export const NON_RATED_ISSUE_CATEGORIES = issueCategoriesArray.
+export const NON_RATED_ISSUE_CATEGORIES = issueCategoriesArray
   .map((category) => {
     return {
       value: category,

--- a/client/app/intakeCommon/constants.js
+++ b/client/app/intakeCommon/constants.js
@@ -55,8 +55,8 @@ export const ISSUE_CATEGORIES = issueCategoriesArray.map((category) => {
   };
 });
 
-export const NON_RATED_ISSUE_CATEGORIES = issueCategoriesArray
-  .map((category) => {
+export const NON_RATED_ISSUE_CATEGORIES = issueCategoriesArray.
+  map((category) => {
     return {
       value: category,
       label: category

--- a/client/app/intakeCommon/constants.js
+++ b/client/app/intakeCommon/constants.js
@@ -29,6 +29,8 @@ export const FORM_TYPES = {
 };
 
 const issueCategoriesArray = [
+  // Unknown issue category should be removed in the new add issues flow
+  'Unknown issue category',
   'Apportionment',
   'Incarceration Adjustments',
   'Audit Error Worksheet (DFAS)',
@@ -55,8 +57,10 @@ export const ISSUE_CATEGORIES = issueCategoriesArray.map((category) => {
   };
 });
 
+// Removes the "Unknown issue category"
+// which is temporary until we activate the new "Add issues" flow
 export const NON_RATED_ISSUE_CATEGORIES = issueCategoriesArray.
-  map((category) => {
+  filter((category) => category !== 'Unknown issue category').map((category) => {
     return {
       value: category,
       label: category

--- a/client/app/intakeCommon/util/index.js
+++ b/client/app/intakeCommon/util/index.js
@@ -57,11 +57,22 @@ export const validNonRatedIssue = (issue) => {
 };
 
 const formatRatedIssues = (state) => {
+  // unidentified issues are counted as rated issues
   if (state.addedIssues && state.addedIssues.length > 0) {
     // we're using the new add issues page
     return state.addedIssues.
-      filter((issue) => issue.isRated).
+      filter((issue) => issue.isRated || issue.isUnidentified).
       map((issue) => {
+        // for unidentified issues
+        if (issue.isUnidentified) {
+          return {
+            decision_text: issue.description,
+            notes: issue.notes,
+            is_unidentified: true
+          };
+        }
+
+        // otherwise return for rated issue
         let originalIssue = state.ratings[issue.profileDate].issues[issue.id];
 
         return _.merge(originalIssue, { profile_date: issue.profileDate,
@@ -84,7 +95,7 @@ const formatRatedIssues = (state) => {
 const formatNonRatedIssues = (state) => {
   if (state.addedIssues && state.addedIssues.length > 0) {
     // we're using the new add issues page
-    return state.addedIssues.filter((issue) => !issue.isRated).map((issue) => {
+    return state.addedIssues.filter((issue) => !issue.isRated && !issue.isUnidentified).map((issue) => {
       return {
         issue_category: issue.category,
         decision_text: issue.description,

--- a/client/app/intakeCommon/util/index.js
+++ b/client/app/intakeCommon/util/index.js
@@ -56,23 +56,29 @@ export const validNonRatedIssue = (issue) => {
   return true;
 };
 
+const formatUnidentifiedIssues = (state) => {
+  // only used for the new add intake flow
+  if (state.addedIssues && state.addedIssues.length > 0) {
+    return state.addedIssues.
+      filter((issue) => issue.isUnidentified).
+      map((issue) => {
+        return {
+          decision_text: issue.description,
+          notes: issue.notes,
+          is_unidentified: true
+        };
+      });
+  }
+
+  return [];
+};
+
 const formatRatedIssues = (state) => {
-  // unidentified issues are counted as rated issues
   if (state.addedIssues && state.addedIssues.length > 0) {
     // we're using the new add issues page
     return state.addedIssues.
-      filter((issue) => issue.isRated || issue.isUnidentified).
+      filter((issue) => issue.isRated).
       map((issue) => {
-        // for unidentified issues
-        if (issue.isUnidentified) {
-          return {
-            decision_text: issue.description,
-            notes: issue.notes,
-            is_unidentified: true
-          };
-        }
-
-        // otherwise return for rated issue
         let originalIssue = state.ratings[issue.profileDate].issues[issue.id];
 
         return _.merge(originalIssue, { profile_date: issue.profileDate,
@@ -122,9 +128,10 @@ const formatNonRatedIssues = (state) => {
 export const formatIssues = (state) => {
   const ratingData = formatRatedIssues(state);
   const nonRatingData = formatNonRatedIssues(state);
+  const unidentifiedData = formatUnidentifiedIssues(state);
 
   const data = {
-    request_issues: _.concat(ratingData, nonRatingData)
+    request_issues: _.concat(ratingData, nonRatingData, unidentifiedData)
   };
 
   return data;

--- a/db/migrate/20181010220548_add_is_unidentified_to_request_issues.rb
+++ b/db/migrate/20181010220548_add_is_unidentified_to_request_issues.rb
@@ -1,0 +1,5 @@
+class AddIsUnidentifiedToRequestIssues < ActiveRecord::Migration[5.1]
+  def change
+    add_column :request_issues, :is_unidentified, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181010220548) do
+ActiveRecord::Schema.define(version: 20181012204811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181004232948) do
+ActiveRecord::Schema.define(version: 20181010220548) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 20181004232948) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "granted"
-    t.index ["person_id"], name: "index_advance_on_docket_grants_on_person_id"
-    t.index ["user_id"], name: "index_advance_on_docket_grants_on_user_id"
+    t.index ["person_id"], name: "index_advance_on_docket_motions_on_person_id"
+    t.index ["user_id"], name: "index_advance_on_docket_motions_on_user_id"
   end
 
   create_table "allocations", force: :cascade do |t|
@@ -601,6 +601,7 @@ ActiveRecord::Schema.define(version: 20181004232948) do
     t.datetime "rating_issue_associated_at"
     t.integer "parent_request_issue_id"
     t.text "notes"
+    t.boolean "is_unidentified"
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["parent_request_issue_id"], name: "index_request_issues_on_parent_request_issue_id"
     t.index ["review_request_type", "review_request_id"], name: "index_request_issues_on_review_request"

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -374,5 +374,11 @@ RSpec.feature "Appeal Intake" do
              description: "Description for Active Duty Adjustments",
              decision_date: 1.month.ago
     )).to_not be_nil
+
+    expect(RequestIssue.find_by(
+             review_request: appeal,
+             description: "This is an unidentified issue",
+             is_unidentified: true
+    )).to_not be_nil
   end
 end

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -652,6 +652,13 @@ RSpec.feature "Higher-Level Review" do
                decision_date: 1.month.ago.to_date,
                end_product_establishment_id: non_rating_end_product_establishment.id
       )).to_not be_nil
+
+      expect(RequestIssue.find_by(
+               review_request: higher_level_review,
+               description: "This is an unidentified issue",
+               is_unidentified: true,
+               end_product_establishment_id: end_product_establishment.id
+      )).to_not be_nil
     end
 
     scenario "Non-compensation" do

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -532,6 +532,13 @@ RSpec.feature "Supplemental Claim Intake" do
                decision_date: 1.month.ago.to_date,
                end_product_establishment_id: non_rating_end_product_establishment.id
       )).to_not be_nil
+
+      expect(RequestIssue.find_by(
+               review_request: supplemental_claim,
+               description: "This is an unidentified issue",
+               is_unidentified: true,
+               end_product_establishment_id: end_product_establishment.id
+      )).to_not be_nil
     end
 
     scenario "Non-compensation" do

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe RequestIssue do
+  let(:review) { create(:higher_level_review, veteran_file_number: veteran.file_number) }
+  let!(:veteran) { Generators::Veteran.build(file_number: "789987789") }
+
+  let!(:rated_issue) do
+    RequestIssue.create(
+      review_request: review,
+      rating_issue_reference_id: "abc123",
+      rating_issue_profile_date: Time.zone.now,
+      description: "a rated issue"
+    )
+  end
+
+  let!(:unrated_issue) do
+    RequestIssue.create(
+      review_request: review,
+      description: "an unrated rated issue",
+      issue_category: "a thing"
+    )
+  end
+
+  let!(:unidentified_issue) do
+    RequestIssue.create(
+      review_request: review,
+      description: "an unidentified issue",
+      is_unidentified: true
+    )
+  end
+
+  context "finds issues" do
+    it "filters by rated issues" do
+      rated_issues = RequestIssue.rated
+      expect(rated_issues.length).to eq(2)
+      expect(rated_issues.find_by(id: rated_issue.id)).to_not be_nil
+      expect(rated_issues.find_by(id: unidentified_issue.id)).to_not be_nil
+    end
+
+    it "filters by nonrated issues" do
+      nonrated_issues = RequestIssue.nonrated
+      expect(nonrated_issues.length).to eq(1)
+      expect(nonrated_issues.find_by(id: unrated_issue.id)).to_not be_nil
+    end
+
+    it "filters by unidentified issues" do
+      unidentified_issues = RequestIssue.unidentified
+      expect(unidentified_issues.length).to eq(1)
+      expect(unidentified_issues.find_by(id: unidentified_issue.id)).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
Backend portion of #6990

### Description
- Adds an `is_unidentified` column to request issues. Unidentified issues have this column set to true
- Removes `Unknown issue category` from being saved in the issue category column for unidentified issues
- Changes unidentified issues from being on a nonrated EP to a rated EP

### Todo
- [ ] verify that we do not need a further migration to migrate issues with "unknown issue category" to use the boolean flag