### PR TITLE
bump circleci to 2.1 to use build processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 jobs:
   rspec:
     docker:

--- a/local/vacols/bgs_setup.csv
+++ b/local/vacols/bgs_setup.csv
@@ -1,6 +1,6 @@
 vbms_id,bgs_key
 701305078S,
-783740847S,
+783740847S,test
 963360019S,
 604969679S,
 662643660S,veteran_exists

--- a/local/vacols/bgs_setup.csv
+++ b/local/vacols/bgs_setup.csv
@@ -1,6 +1,6 @@
 vbms_id,bgs_key
 701305078S,
-783740847S,test
+783740847S,
 963360019S,
 604969679S,
 662643660S,veteran_exists


### PR DESCRIPTION
### Description
CircleCI 2.1 adds the 'build processing' feature, which includes the option to cancel a workflow if a later commit on that branch is pushed. This bumps the CircleCI version from 2.0 to 2.1 to take advantage of this new feature.

2.1 is technically in preview but I don't think the [outstanding caveats](https://github.com/CircleCI-Public/config-preview-sdk/blob/master/README.md#important-preview-caveats) affect us. I've confirmed using this branch that subsequent pushes cancel earlier workflows.

### Acceptance Criteria
N/A

### Testing Plan
N/A
