### PR TITLE
don't need to specify workflow version with circleci 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,6 @@ jobs:
           path: ~/all_logs.log
 
 workflows:
-  version: 2
   build:
     jobs:
       - rspec


### PR DESCRIPTION
### Description
in CircleCI 2.1 you no longer need to specify the workflow version separately, so removing it here.

### Acceptance Criteria
N/A

### Testing Plan
N/A
