### PR TITLE
canceling intake from add_issues should redirect

### DIFF
--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { Redirect } from 'react-router-dom';
 import React from 'react';
 
 import AddIssuesModal from '../components/AddIssuesModal';
@@ -9,6 +10,7 @@ import UnidentifiedIssuesModal from '../components/UnidentifiedIssuesModal';
 import Button from '../../components/Button';
 import RequestIssuesUpdateErrorAlert from '../../intakeEdit/components/RequestIssuesUpdateErrorAlert';
 import { FORM_TYPES } from '../constants';
+import { PAGE_PATHS } from '../constants';
 import { formatDate } from '../../util/DateUtil';
 import { formatAddedIssues, getAddIssuesFields } from '../util/issues';
 import Table from '../../components/Table';
@@ -19,7 +21,7 @@ import {
   toggleUnidentifiedIssuesModal
 } from '../actions/addIssues';
 
-class AddIssuesPage extends React.PureComponent {
+export class AddIssues extends React.PureComponent {
   render() {
     const {
       intakeForms,
@@ -27,6 +29,10 @@ class AddIssuesPage extends React.PureComponent {
       veteran,
       responseErrorCode
     } = this.props;
+
+    if (!formType) {
+      return <Redirect to={PAGE_PATHS.BEGIN} />;
+    }
 
     const selectedForm = _.find(FORM_TYPES, { key: formType });
     const intakeData = intakeForms[selectedForm.key];

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -9,8 +9,7 @@ import NonRatedIssueModal from '../components/NonRatedIssueModal';
 import UnidentifiedIssuesModal from '../components/UnidentifiedIssuesModal';
 import Button from '../../components/Button';
 import RequestIssuesUpdateErrorAlert from '../../intakeEdit/components/RequestIssuesUpdateErrorAlert';
-import { FORM_TYPES } from '../constants';
-import { PAGE_PATHS } from '../constants';
+import { FORM_TYPES, PAGE_PATHS } from '../constants';
 import { formatDate } from '../../util/DateUtil';
 import { formatAddedIssues, getAddIssuesFields } from '../util/issues';
 import Table from '../../components/Table';
@@ -21,7 +20,7 @@ import {
   toggleUnidentifiedIssuesModal
 } from '../actions/addIssues';
 
-export class AddIssues extends React.PureComponent {
+export class AddIssuesPage extends React.PureComponent {
   render() {
     const {
       intakeForms,

--- a/client/test/karma/intake/addIssues-test.js
+++ b/client/test/karma/intake/addIssues-test.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { AddIssues } from '../../../app/intake/pages/AddIssues';
+import { AddIssues } from '../../../app/intake/pages/addIssues';
 import { Redirect } from 'react-router-dom';
 
 describe('AddIssues', () => {
   it('renders Redirect when formType is undefined', () => {
-    const wrapper = shallow(<AddIssues formType={undefined}/>);
+    const wrapper = shallow(<AddIssues />);
+
     expect(wrapper.find(Redirect)).to.have.lengthOf(1);
   });
 });

--- a/client/test/karma/intake/addIssues-test.js
+++ b/client/test/karma/intake/addIssues-test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { expect } from 'chai';
+import { assert } from 'chai';
 import { shallow } from 'enzyme';
 import { AddIssues } from '../../../app/intake/pages/addIssues';
 import { Redirect } from 'react-router-dom';
@@ -8,6 +8,7 @@ import { PAGE_PATHS } from '../../../app/intake/constants';
 describe('AddIssues', () => {
   it('redirects to intake start when formType is undefined, like after canceling an intake', () => {
     const wrapper = shallow(<AddIssues />);
-    expect(wrapper.contains(<Redirect to={PAGE_PATHS.BEGIN} />)).to.be.true;
+
+    assert.isTrue(wrapper.contains(<Redirect to={PAGE_PATHS.BEGIN} />));
   });
 });

--- a/client/test/karma/intake/addIssues-test.js
+++ b/client/test/karma/intake/addIssues-test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { AddIssues } from '../../../app/intake/pages/AddIssues';
 import { Redirect } from 'react-router-dom';
 
-describe.only('AddIssues', () => {
+describe('AddIssues', () => {
   it('renders Redirect when formType is undefined', () => {
     const wrapper = shallow(<AddIssues formType={undefined}/>);
     expect(wrapper.find(Redirect)).to.have.lengthOf(1);

--- a/client/test/karma/intake/addIssues-test.js
+++ b/client/test/karma/intake/addIssues-test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import { assert } from 'chai';
 import { shallow } from 'enzyme';
-import { AddIssues } from '../../../app/intake/pages/addIssues';
+import { AddIssuesPage } from '../../../app/intake/pages/addIssues';
 import { Redirect } from 'react-router-dom';
 import { PAGE_PATHS } from '../../../app/intake/constants';
 
-describe('AddIssues', () => {
+describe('AddIssuesPage', () => {
   it('redirects to intake start when formType is undefined, like after canceling an intake', () => {
-    const wrapper = shallow(<AddIssues />);
+    const wrapper = shallow(<AddIssuesPage />);
 
     assert.isTrue(wrapper.contains(<Redirect to={PAGE_PATHS.BEGIN} />));
   });

--- a/client/test/karma/intake/addIssues-test.js
+++ b/client/test/karma/intake/addIssues-test.js
@@ -3,11 +3,11 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { AddIssues } from '../../../app/intake/pages/addIssues';
 import { Redirect } from 'react-router-dom';
+import { PAGE_PATHS } from '../../../app/intake/constants';
 
 describe('AddIssues', () => {
-  it('renders Redirect when formType is undefined', () => {
+  it('redirects to intake start when formType is undefined, like after canceling an intake', () => {
     const wrapper = shallow(<AddIssues />);
-
-    expect(wrapper.find(Redirect)).to.have.lengthOf(1);
+    expect(wrapper.contains(<Redirect to={PAGE_PATHS.BEGIN} />)).to.be.true;
   });
 });

--- a/client/test/karma/intake/addIssues-test.js
+++ b/client/test/karma/intake/addIssues-test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { AddIssues } from '../../../app/intake/pages/AddIssues';
+import { Redirect } from 'react-router-dom';
+
+describe.only('AddIssues', () => {
+  it('renders Redirect when formType is undefined', () => {
+    const wrapper = shallow(<AddIssues formType={undefined}/>);
+    expect(wrapper.find(Redirect)).to.have.lengthOf(1);
+  });
+});

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -271,6 +271,15 @@ RSpec.feature "Appeal Intake", focus: true do
   end
 
   scenario "For new Add Issues page" do
+    Generators::Rating.build(
+      participant_id: veteran.participant_id,
+      promulgation_date: receipt_date - 40.days,
+      profile_date: receipt_date - 50.days,
+      issues: [
+        { reference_id: "xyz123", decision_text: "Left knee granted" },
+        { reference_id: "xyz456", decision_text: "PTSD denied" }
+      ]
+    )
     appeal, = start_appeal(veteran)
     visit "/intake/add_issues"
 

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Appeal Intake" do
+RSpec.feature "Appeal Intake", focus: true do
   before do
     FeatureToggle.enable!(:intake)
     # Test that this works when only enabled on the current user
@@ -269,7 +269,7 @@ RSpec.feature "Appeal Intake" do
     expect(row).to have_text(text)
   end
 
-  scenario "adding issues and completing an appeal intake", focus: true do
+  scenario "adding issues and completing an appeal intake" do
     appeal = start_appeal(veteran)
     visit "/intake/add_issues"
 
@@ -373,7 +373,7 @@ RSpec.feature "Appeal Intake" do
     )).to_not be_nil
   end
 
-  scenario "canceling an appeal intake", focus: true do
+  scenario "canceling an appeal intake" do
     appeal = Appeal.create!(
       veteran_file_number: veteran.file_number,
       receipt_date: 2.days.ago,

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -223,7 +223,7 @@ RSpec.feature "Appeal Intake", focus: true do
       docket_type: "evidence_submission"
     )
 
-    AppealIntake.create!(
+    intake = AppealIntake.create!(
       veteran_file_number: test_veteran.file_number,
       user: current_user,
       started_at: 5.minutes.ago,
@@ -236,7 +236,8 @@ RSpec.feature "Appeal Intake", focus: true do
     )
 
     appeal.start_review!
-    appeal
+
+    [appeal, intake]
   end
 
   it "Allows a Veteran without ratings to create an intake" do
@@ -269,8 +270,8 @@ RSpec.feature "Appeal Intake", focus: true do
     expect(row).to have_text(text)
   end
 
-  scenario "adding issues and completing an appeal intake" do
-    appeal = start_appeal(veteran)
+  scenario "For new Add Issues page" do
+    appeal, = start_appeal(veteran)
     visit "/intake/add_issues"
 
     expect(page).to have_content("Add Issues")
@@ -373,27 +374,8 @@ RSpec.feature "Appeal Intake", focus: true do
     )).to_not be_nil
   end
 
-  scenario "canceling an appeal intake" do
-    appeal = Appeal.create!(
-      veteran_file_number: veteran.file_number,
-      receipt_date: 2.days.ago,
-      docket_type: "evidence_submission"
-    )
-
-    intake = AppealIntake.create!(
-      veteran_file_number: veteran.file_number,
-      user: current_user,
-      started_at: 5.minutes.ago,
-      detail: appeal
-    )
-
-    Claimant.create!(
-      review_request: appeal,
-      participant_id: veteran.participant_id
-    )
-
-    appeal.start_review!
-
+  scenario "canceling an appeal intake", focus: true do
+    _, intake = start_appeal(veteran)
     visit "/intake/add_issues"
 
     expect(page).to have_content("Add Issues")

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.feature "Appeal Intake", focus: true do
+RSpec.feature "Appeal Intake" do
   before do
     FeatureToggle.enable!(:intake)
     # Test that this works when only enabled on the current user
@@ -383,7 +383,7 @@ RSpec.feature "Appeal Intake", focus: true do
     )).to_not be_nil
   end
 
-  scenario "canceling an appeal intake", focus: true do
+  scenario "canceling an appeal intake" do
     _, intake = start_appeal(veteran)
     visit "/intake/add_issues"
 
@@ -400,6 +400,10 @@ RSpec.feature "Appeal Intake", focus: true do
       find("label", text: "Other").click
     end
     safe_click ".confirm-cancel"
+    expect(page).to have_content("Make sure you’ve filled out the comment box below.")
+    fill_in "Tell us more about your situation.", with: "blue!"
+    safe_click ".confirm-cancel"
+
     expect(page).to have_content("Welcome to Caseflow Intake!")
     expect(page).to_not have_css(".cf-modal-title")
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -460,7 +460,7 @@ RSpec.feature "Higher-Level Review" do
       benefit_type: is_comp ? "compensation" : "education"
     )
 
-    HigherLevelReviewIntake.create!(
+    intake = HigherLevelReviewIntake.create!(
       veteran_file_number: test_veteran.file_number,
       user: current_user,
       started_at: 5.minutes.ago,
@@ -475,7 +475,7 @@ RSpec.feature "Higher-Level Review" do
 
     higher_level_review.start_review!
 
-    higher_level_review
+    [higher_level_review, intake]
   end
 
   it "Allows a Veteran without ratings to create an intake" do
@@ -529,7 +529,7 @@ RSpec.feature "Higher-Level Review" do
         relationship_type: "Spouse"
       )
 
-      higher_level_review = start_higher_level_review(veteran, claim_participant_id: "5382910292")
+      higher_level_review, = start_higher_level_review(veteran, claim_participant_id: "5382910292")
       visit "/intake/add_issues"
 
       expect(page).to have_content("Add Issues")
@@ -664,6 +664,32 @@ RSpec.feature "Higher-Level Review" do
       check_row("Form", Constants.INTAKE_FORM_NAMES.higher_level_review)
       check_row("Benefit type", "Education")
       expect(page).to_not have_content("Claimant")
+    end
+
+    scenario "canceling", focus: true do
+      _, intake = start_higher_level_review(veteran)
+      visit "/intake/add_issues"
+
+      expect(page).to have_content("Add Issues")
+      safe_click "#cancel-intake"
+      expect(find("#modal_id-title")).to have_content("Cancel Intake?")
+      safe_click ".close-modal"
+      expect(page).to_not have_css("#modal_id-title")
+      safe_click "#cancel-intake"
+
+      safe_click ".confirm-cancel"
+      expect(page).to have_content("Make sure you’ve selected an option below.")
+      within_fieldset("Please select the reason you are canceling this intake.") do
+        find("label", text: "Other").click
+      end
+      safe_click ".confirm-cancel"
+      expect(page).to have_content("Welcome to Caseflow Intake!")
+      expect(page).to_not have_css(".cf-modal-title")
+
+      intake.reload
+      expect(intake.completed_at).to eq(Time.zone.now)
+      expect(intake.cancel_reason).to eq("other")
+      expect(intake).to be_canceled
     end
   end
 end

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -666,7 +666,7 @@ RSpec.feature "Higher-Level Review" do
       expect(page).to_not have_content("Claimant")
     end
 
-    scenario "canceling", focus: true do
+    scenario "canceling" do
       _, intake = start_higher_level_review(veteran)
       visit "/intake/add_issues"
 
@@ -683,6 +683,10 @@ RSpec.feature "Higher-Level Review" do
         find("label", text: "Other").click
       end
       safe_click ".confirm-cancel"
+      expect(page).to have_content("Make sure you’ve filled out the comment box below.")
+      fill_in "Tell us more about your situation.", with: "blue!"
+      safe_click ".confirm-cancel"
+
       expect(page).to have_content("Welcome to Caseflow Intake!")
       expect(page).to_not have_css(".cf-modal-title")
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -545,7 +545,7 @@ RSpec.feature "Supplemental Claim Intake" do
       expect(page).to_not have_content("Claimant")
     end
 
-    scenario "canceling", focus: true do
+    scenario "canceling" do
       _, intake = start_supplemental_claim(veteran)
       visit "/intake/add_issues"
 
@@ -562,6 +562,10 @@ RSpec.feature "Supplemental Claim Intake" do
         find("label", text: "Other").click
       end
       safe_click ".confirm-cancel"
+      expect(page).to have_content("Make sure you’ve filled out the comment box below.")
+      fill_in "Tell us more about your situation.", with: "blue!"
+      safe_click ".confirm-cancel"
+
       expect(page).to have_content("Welcome to Caseflow Intake!")
       expect(page).to_not have_css(".cf-modal-title")
 


### PR DESCRIPTION
Connects #7312 

### Description
The current Finish page will redirect back to intake start (`/intake`) if the formType is undefined, which is cleared when canceling an intake. The new AddIssues page should be consistent with that behavior.

I'm not really sold on using a falsy `formType` to redirect since this is navigation by side effect, but this is simple for now. I think once we switch over to the new AddIssues page by default we can edit the `submitCancel` action to do the redirection.

![demo](https://user-images.githubusercontent.com/279406/46788827-df46a880-ccef-11e8-8986-5cf2576b6171.gif)

### Acceptance Criteria
- [x] Canceling any intake from the AddIssues page will redirect back to `/intake` as the current Finish page does

### Testing Plan
1. Start any intake, get to the review screen
2. Visit /intake/add_issues
3. Cancel the intake and verify that you are redirected back to /intake (currently there is a blank screen)
