### PR TITLE
Return all documement IDs to IDT api

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -538,11 +538,11 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def das_assignments
-    @das_assignments ||= QueueRepository.tasks_for_appeal(vacols_id)
+    @das_assignments ||= VACOLS::CaseAssignment.tasks_for_appeal(vacols_id)
   end
 
   def reviewing_judge_name
-    das_assignments.last.try(:assigned_by_name)
+    das_assignments.sort_by(&:created_at).last.try(:assigned_by_name)
   end
 
   attr_writer :issues

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -127,7 +127,13 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
         let(:assigner2) { create(:user, css_id: "ANOTHER_TEST_ID2", full_name: "Grey White") }
 
         let(:vacols_case1) do
-          create(:case, :assigned, user: user, assigner: assigner1, document_id: "1234", bfdloout: 2.days.ago.to_date)
+          create(:case,
+                 :assigned,
+                 user: user,
+                 assigner: assigner1,
+                 decass_count: 2,
+                 document_id: "1234",
+                 bfdloout: 2.days.ago.to_date)
         end
         let(:vacols_case2) do
           create(:case, :assigned, user: user, assigner: assigner2, document_id: "5678", bfdloout: 4.days.ago.to_date)
@@ -240,8 +246,9 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
             expect(response_body.first["attributes"]["days_waiting"]).to eq 2
             expect(response_body.first["attributes"]["assigned_by"]).to eq "Lyor Cohen"
-            expect(response_body.first["attributes"]["documents"].size).to eq 1
+            expect(response_body.first["attributes"]["documents"].size).to eq 2
             expect(response_body.first["attributes"]["documents"].first["document_id"]).to eq "1234"
+            expect(response_body.first["attributes"]["documents"].second["document_id"]).to eq "1234"
 
             expect(response_body.second["attributes"]["days_waiting"]).to eq 4
             expect(response_body.second["attributes"]["assigned_by"]).to eq "Grey White"

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -57,6 +57,20 @@ describe LegacyAppeal do
     end
   end
 
+  context "#attorney_case_reviews" do
+    subject { appeal.attorney_case_reviews }
+
+    let(:vacols_case) do
+      create(:case, :assigned, decass_count: 1, user: create(:user), document_id: "02255-00000002")
+    end
+    let!(:decass1) { create(:decass, defolder: vacols_case.bfkey, dedocid: nil) }
+    let!(:decass2) { create(:decass, defolder: vacols_case.bfkey, dedocid: "02255-00000002") }
+
+    it "returns all documents associated with the case" do
+      expect(subject.size).to eq 2
+    end
+  end
+
   context "#nod" do
     let(:vacols_case) do
       create(:case_with_nod)


### PR DESCRIPTION
Previously, we were only returning latest decass records.  Paul asked me to return all document IDs associated with the case. 

