### PR TITLE
Respond with 404 when appeal is not found

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -17,6 +17,10 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
     render(json: { message: e.message }, status: 400)
   end
 
+  rescue_from ActiveRecord::RecordNotFound do |_e|
+    render(json: { message: "Record not found" }, status: 404)
+  end
+
   def list
     if file_number.present?
       render json: json_appeals(appeals_by_file_number)
@@ -26,7 +30,6 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
   end
 
   def details
-    return render json: { message: "Appeal not found" }, status: 404 unless appeal
     render json: json_appeal_details
   end
 

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -351,6 +351,15 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
           end
         end
 
+        context "and appeal id URL parameter is not valid" do
+          let(:params) { { appeal_id: "invalid" } }
+
+          it "responds with not found" do
+            get :details, params: params
+            expect(response.status).to eq 404
+          end
+        end
+
         context "and legacy appeal id URL parameter is passed" do
           let(:params) { { appeal_id: appeal.vacols_id } }
           let!(:vacols_case) do


### PR DESCRIPTION
It appears that `Appeal.find_appeal_by_id_or_find_or_create_legacy_appeal_by_vacols_id(params[:appeal_id])` throws an exception instead of returning nil. We should name all methods with `!` to indicate exception throwing. 

