### PR TITLE
Fixing org members function

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -28,7 +28,7 @@ class Organization < ApplicationRecord
   private
 
   def member_css_ids
-    return [] unless staff_field_for_organization.length > 0
+    return [] if staff_field_for_organization.empty?
 
     staff_records = VACOLS::Staff.where(sactive: "A")
     staff_field_for_organization.each do |sfo|

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -22,13 +22,13 @@ class Organization < ApplicationRecord
   end
 
   def members
-    @members ||= member_css_ids.uniq.map { |css_id| User.find_by(css_id: css_id) }.compact
+    @members ||= User.where(css_id: member_css_ids.uniq)
   end
 
   private
 
   def member_css_ids
-    return [] unless staff_field_for_organization
+    return [] unless staff_field_for_organization.length > 0
 
     staff_records = VACOLS::Staff.where(sactive: "A")
     staff_field_for_organization.each do |sfo|

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -194,6 +194,9 @@ RSpec.feature "AmaQueue" do
       let!(:staff) { FactoryBot.create(:staff, user: user, sdept: "TRANS", sattyid: nil) }
       let!(:translation_organization) { Organization.create!(name: "Translation", url: "translation") }
       let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
+      let!(:staff_field) do
+        StaffFieldForOrganization.create!(organization: translation_organization, name: "sdept", values: %w[TRANS])
+      end
 
       let!(:translation_task) do
         create(

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -22,6 +22,13 @@ describe Organization do
   end
 
   describe ".members" do
+    let(:field) { "sdept" }
+    let(:fld_val) { "ORG" }
+    let(:member_cnt) { 5 }
+
+    let(:users) { create_list(:user, member_cnt) }
+    before { users.each { |u| FactoryBot.create(:staff, user: u, "#{field}": fld_val) } }
+
     context "when organization has no members" do
       let(:org) { create(:organization) }
       it "should return an empty list" do
@@ -30,15 +37,8 @@ describe Organization do
     end
 
     context "when organization has members" do
-      let(:field) { "sdept" }
-      let(:fld_val) { "ORG" }
-
       let(:org) { create(:organization) }
       let!(:sfo) { StaffFieldForOrganization.create!(organization: org, name: field, values: [fld_val]) }
-      let(:member_cnt) { 5 }
-      let(:users) { create_list(:user, member_cnt) }
-
-      before { users.each { |u| FactoryBot.create(:staff, user: u, "#{field}": fld_val) } }
 
       it "should return a non-empty list of members" do
         expect(org.members.length).to eq(member_cnt)


### PR DESCRIPTION
### Description
A VSO was saying caseflow isn't loading for them. I think the problem is when they try to access the page we get all tasks, and all the members they can assign those tasks to. However we have two bugs in the membership code. The first is that we look up each member individually using finds, rather than running one where statement. The second is that when there are no records in the `staff_field_for_organization` we return every member of the staff table.

Combined these result in hundreds of queries, which causes us to timeout.

### Testing Plan
1. Tested in prod with the user who brought it to our attention.

