### PR TITLE
If BGS does not return rating_profile_list structure, raise exception

### DIFF
--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -1,6 +1,8 @@
 class Rating
   include ActiveModel::Model
 
+  class NilRatingProfileListError < StandardError; end
+
   # WARNING: profile_date is a misnomer adopted from BGS terminology.
   # It is a datetime, not a date.
   attr_accessor :participant_id, :profile_date, :promulgation_date
@@ -70,6 +72,9 @@ class Rating
     private
 
     def ratings_from_bgs_response(response)
+      if response.dig(:rating_profile_list, :rating_profile).nil?
+        fail NilRatingProfileListError
+      end
       # If only one rating is returned, we need to convert it to an array
       [response[:rating_profile_list][:rating_profile]].flatten.map do |rating_data|
         Rating.from_bgs_hash(rating_data)

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -73,7 +73,7 @@ class Rating
 
     def ratings_from_bgs_response(response)
       if response.dig(:rating_profile_list, :rating_profile).nil?
-        fail NilRatingProfileListError
+        fail NilRatingProfileListError, message: response
       end
       # If only one rating is returned, we need to convert it to an array
       [response[:rating_profile_list][:rating_profile]].flatten.map do |rating_data|

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -127,5 +127,14 @@ describe Rating do
         )
       end
     end
+
+    context "when a rating is locked" do
+      it "throws NilRatingProfileListError" do
+        allow_any_instance_of(Fakes::BGSService).to receive(:fetch_ratings_in_range).and_return({})
+        expect do
+          Rating.fetch_timely(participant_id: "DRAYMOND", from_date: receipt_date)
+        end.to raise_error(Rating::NilRatingProfileListError)
+      end
+    end
   end
 end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -130,7 +130,7 @@ describe Rating do
 
     context "when a rating is locked" do
       it "throws NilRatingProfileListError" do
-        allow_any_instance_of(Fakes::BGSService).to receive(:fetch_ratings_in_range).and_return({})
+        allow_any_instance_of(Fakes::BGSService).to receive(:fetch_ratings_in_range).and_return(error: "Oops")
         expect do
           Rating.fetch_timely(participant_id: "DRAYMOND", from_date: receipt_date)
         end.to raise_error(Rating::NilRatingProfileListError)


### PR DESCRIPTION
connects #7323 

### Description
When a Rating is locked, we fail with Ruby exception about no method for `[]`. Catch that case and throw an error of our own instead.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Tests continue to pass

### Testing Plan
Wait for a locked rating?

