### PR TITLE
Change request_issues unique index to respect removed_at

### DIFF
--- a/db/migrate/20181012204811_unique_request_issue_contention_index.rb
+++ b/db/migrate/20181012204811_unique_request_issue_contention_index.rb
@@ -1,0 +1,17 @@
+class UniqueRequestIssueContentionIndex < ActiveRecord::Migration[5.1]
+  safety_assured
+
+  def up
+    safety_assured do
+      add_index(:request_issues, [:contention_reference_id, :removed_at], unique: true)
+      remove_index(:request_issues, :contention_reference_id)
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_index(:request_issues, [:contention_reference_id, :removed_at])
+      add_index(:request_issues, :contention_reference_id, unique: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181010185251) do
+ActiveRecord::Schema.define(version: 20181012204811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -609,7 +609,7 @@ ActiveRecord::Schema.define(version: 20181010185251) do
     t.datetime "rating_issue_associated_at"
     t.integer "parent_request_issue_id"
     t.text "notes"
-    t.index ["contention_reference_id"], name: "index_request_issues_on_contention_reference_id", unique: true
+    t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["parent_request_issue_id"], name: "index_request_issues_on_parent_request_issue_id"
     t.index ["review_request_type", "review_request_id"], name: "index_request_issues_on_review_request"


### PR DESCRIPTION
see 74dcf303721149319d94f3759b91be465e0f9902

### Description
There are duplicate contention_reference_id values in UAT (at least) because the id is re-used when contentions are removed.

### Acceptance Criteria
- [x] Code compiles correctly


