### PR TITLE
Remove appeal query for Org queues

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -5,11 +5,9 @@ class Organizations::TasksController < OrganizationsController
 
   def index
     tasks = GenericQueue.new(user: organization).tasks
-    appeals = tasks.map(&:appeal).uniq
 
     render json: {
-      tasks: json_tasks(tasks),
-      appeals: json_appeals(appeals)
+      tasks: json_tasks(tasks)
     }
   end
 
@@ -23,13 +21,6 @@ class Organizations::TasksController < OrganizationsController
     ActiveModelSerializers::SerializableResource.new(
       tasks,
       each_serializer: ::WorkQueue::TaskSerializer
-    ).as_json
-  end
-
-  def json_appeals(appeals)
-    ActiveModelSerializers::SerializableResource.new(
-      appeals,
-      each_serializer: ::WorkQueue::AppealSerializer
     ).as_json
   end
 end


### PR DESCRIPTION
### Description
VSO users have said that Caseflow is timing out. I'm pretty sure this is because we're returning all the appeals from the organization/tasks endpoint. This is something we've already fixed on the main tasks endpoint, but we missed changing here.

### Testing Plan
1. Load 20 appeals for a VSO user
1. Load the organization and ensure there are not a lot of requests to get Appeals

