### PR TITLE
Assign Hearings | Room information(St Petersburg and Winston-Salem)

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -44,9 +44,9 @@ export default class AssignHearings extends React.Component {
   roomInfo = (hearingDay) => {
     let room = hearingDay.roomInfo;
 
-    if (hearingDay.regionalOffice === 'St. Petersburg, FL') {
+    if (this.props.selectedRegionalOffice.label === 'St. Petersburg, FL') {
       return room;
-    } else if (hearingDay.regionalOffice === 'Winston-Salem, NC') {
+    } else if (this.props.selectedRegionalOffice.label === 'Winston-Salem, NC') {
       return room;
     }
 


### PR DESCRIPTION
Resolves #7297

### Description
Currently we are showing two boxes for each day and both of them get highlighted together in St Petersburg and Winston-Salem . Remove one box and show room-information for these Ros.

### Acceptance Criteria
- [ ] This Pr shows room-info for St Petersburg and Winston-Salem

### Testing Plan
1. Go to Assign hearings
<img width="1407" alt="screen shot 2018-10-16 at 2 00 34 pm" src="https://user-images.githubusercontent.com/23080951/47037059-edf7ea00-d14b-11e8-95d6-76c2bed024c7.png">


