### PR TITLE
Do not create contentions for ineligible issues

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -79,7 +79,7 @@ class EndProductEstablishment < ApplicationRecord
   # VBMS will return ALL contentions on a end product when you create contentions,
   # not just the ones that were just created.
   def create_contentions!
-    issues_without_contentions = request_issues_without_contentions
+    issues_without_contentions = request_issues_ready_for_contentions
     return if issues_without_contentions.empty?
 
     set_establishment_values_from_source
@@ -218,8 +218,8 @@ class EndProductEstablishment < ApplicationRecord
     rated_request_issues.select { |ri| ri.rating_issue_associated_at.nil? }
   end
 
-  def request_issues_without_contentions
-    request_issues.select { |ri| ri.contention_reference_id.nil? }
+  def request_issues_ready_for_contentions
+    request_issues.select { |ri| ri.contention_reference_id.nil? && ri.eligible? }
   end
 
   def rated_issue_contention_map(request_issues_to_associate)

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -34,8 +34,8 @@ class RatingIssue < ApplicationRecord
 
   def in_active_review
     return unless reference_id
-    request_issue = RequestIssue.in_review_for_rating_issue(self)
-    request_issue.review_title if request_issue && request_issue.status_active?
+    request_issue = RequestIssue.find_active_by_reference_id(reference_id)
+    request_issue.review_title if request_issue
   end
 
   private

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -4,9 +4,8 @@ class RequestIssue < ApplicationRecord
   has_many :decision_issues
   has_many :remand_reasons
   has_many :rating_issues
-  belongs_to :ineligible_request_issue, class_name: "RequestIssue"
 
-  enum ineligible_reason: { in_active_review: 0, untimely: 1 }
+  enum ineligible_reason: { duplicate_of_issue_in_active_review: 0, untimely: 1 }
 
   UNIDENTIFIED_ISSUE_MSG = "UNIDENTIFIED ISSUE - Please click \"Edit in Caseflow\" button to fix".freeze
 
@@ -43,19 +42,14 @@ class RequestIssue < ApplicationRecord
         notes: data[:notes],
         is_unidentified: data[:is_unidentified]
       )
-      if data[:reference_id]
-        existing_request_issue = in_review_for_rating_issue(data[:reference_id])
-        if existing_request_issue
-          request_issue.ineligible_request_issue = existing_request_issue
-          request_issue.ineligible_reason = :in_active_review
-        end
-      end
+      request_issue.check_for_existing_request_issue!
       request_issue
     end
 
-    def in_review_for_rating_issue(rating_issue)
-      reference_id = rating_issue.is_a?(RatingIssue) ? rating_issue.reference_id : rating_issue
-      unscoped.find_by(rating_issue_reference_id: reference_id, removed_at: nil, ineligible_reason: nil)
+    def find_active_by_reference_id(reference_id)
+      request_issue = unscoped.find_by(rating_issue_reference_id: reference_id, removed_at: nil, ineligible_reason: nil)
+      return unless request_issue && request_issue.status_active?
+      request_issue
     end
   end
 
@@ -78,10 +72,6 @@ class RequestIssue < ApplicationRecord
     description
   end
 
-  def update_as_ineligible!(other_request_issue:, reason:)
-    update!(ineligible_request_issue_id: other_request_issue.id, ineligible_reason: reason)
-  end
-
   def review_title
     review_request_type.try(:constantize).try(:review_title)
   end
@@ -100,5 +90,13 @@ class RequestIssue < ApplicationRecord
       notes: notes,
       is_unidentified: is_unidentified
     }
+  end
+
+  def check_for_existing_request_issue!
+    return unless rating_issue_reference_id
+    existing_request_issue = self.class.find_active_by_reference_id(rating_issue_reference_id)
+    if existing_request_issue
+      self.ineligible_reason = :duplicate_of_issue_in_active_review
+    end
   end
 end

--- a/spec/factories/end_product_establishment.rb
+++ b/spec/factories/end_product_establishment.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
       synced_status "CAN"
     end
 
+    trait :active do
+      synced_status "PEND"
+    end
+
     after(:build) do |end_product_establishment, _evaluator|
       Generators::EndProduct.build(
         veteran_file_number: end_product_establishment.veteran_file_number,

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -271,7 +271,7 @@ RSpec.feature "Appeal Intake" do
   end
 
   scenario "For new Add / Remove Issues page" do
-    in_active_review_rating_issue_reference_id = "xyz789"
+    duplicate_reference_id = "xyz789"
     Generators::Rating.build(
       participant_id: veteran.participant_id,
       promulgation_date: receipt_date - 40.days,
@@ -279,14 +279,14 @@ RSpec.feature "Appeal Intake" do
       issues: [
         { reference_id: "xyz123", decision_text: "Left knee granted" },
         { reference_id: "xyz456", decision_text: "PTSD denied" },
-        { reference_id: in_active_review_rating_issue_reference_id, decision_text: "Old injury in review" }
+        { reference_id: duplicate_reference_id, decision_text: "Old injury in review" }
       ]
     )
     epe = create(:end_product_establishment, :active)
     request_issue_in_progress = create(
       :request_issue,
       end_product_establishment: epe,
-      rating_issue_reference_id: in_active_review_rating_issue_reference_id,
+      rating_issue_reference_id: duplicate_reference_id,
       description: "Old injury"
     )
 
@@ -400,11 +400,11 @@ RSpec.feature "Appeal Intake" do
              is_unidentified: true
     )).to_not be_nil
 
-    xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
-    ineligible_issue = xyz789_request_issues.select(&:duplicate_of_issue_in_active_review?).first
+    duplicate_request_issues = RequestIssue.where(rating_issue_reference_id: duplicate_reference_id)
+    ineligible_issue = duplicate_request_issues.select(&:duplicate_of_issue_in_active_review?).first
 
-    expect(xyz789_request_issues.count).to eq(2)
-    expect(xyz789_request_issues).to include(request_issue_in_progress)
+    expect(duplicate_request_issues.count).to eq(2)
+    expect(duplicate_request_issues).to include(request_issue_in_progress)
     expect(ineligible_issue).to_not eq(request_issue_in_progress)
   end
 

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -367,7 +367,7 @@ RSpec.feature "Appeal Intake" do
     safe_click ".add-issue"
 
     expect(page).to have_content("4 issues")
-    expect(page).to have_content("4. Old injury in review is ineligible")
+    expect(page).to have_content("4. Old injury in review is ineligible because it's already under review as a Appeal")
 
     safe_click "#button-finish-intake"
 

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -401,13 +401,11 @@ RSpec.feature "Appeal Intake" do
     )).to_not be_nil
 
     xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
+    ineligible_issue = xyz789_request_issues.select(&:duplicate_of_issue_in_active_review?).first
 
     expect(xyz789_request_issues.count).to eq(2)
-
-    ineligible_issue = xyz789_request_issues.select(&:in_active_review?).first
-
-    expect(ineligible_issue).to be_in_active_review
-    expect(ineligible_issue.ineligible_request_issue).to eq(request_issue_in_progress)
+    expect(xyz789_request_issues).to include(request_issue_in_progress)
+    expect(ineligible_issue).to_not eq(request_issue_in_progress)
   end
 
   scenario "canceling an appeal intake" do

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -679,9 +679,8 @@ RSpec.feature "Higher-Level Review" do
       xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
       expect(xyz789_request_issues.count).to eq(2)
 
-      ineligible_issue = xyz789_request_issues.select(&:in_active_review?).first
-      expect(ineligible_issue).to be_in_active_review
-      expect(ineligible_issue.ineligible_request_issue).to eq(request_issue_in_progress)
+      ineligible_issue = xyz789_request_issues.select(&:duplicate_of_issue_in_active_review?).first
+      expect(ineligible_issue).to_not eq(request_issue_in_progress)
       expect(ineligible_issue.contention_reference_id).to be_nil
 
       expect(Fakes::VBMSService).to_not have_received(:create_contentions!).with(

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -509,7 +509,7 @@ RSpec.feature "Higher-Level Review" do
       expect(row).to have_text(text)
     end
 
-    let(:in_active_review_rating_issue_reference_id) { "xyz789" }
+    let(:duplicate_reference_id) { "xyz789" }
     let(:active_epe) { create(:end_product_establishment, :active) }
 
     let!(:timely_ratings) do
@@ -520,7 +520,7 @@ RSpec.feature "Higher-Level Review" do
         issues: [
           { reference_id: "xyz123", decision_text: "Left knee granted" },
           { reference_id: "xyz456", decision_text: "PTSD denied" },
-          { reference_id: in_active_review_rating_issue_reference_id, decision_text: "Old injury" }
+          { reference_id: duplicate_reference_id, decision_text: "Old injury" }
         ]
       )
     end
@@ -529,7 +529,7 @@ RSpec.feature "Higher-Level Review" do
       create(
         :request_issue,
         end_product_establishment: active_epe,
-        rating_issue_reference_id: in_active_review_rating_issue_reference_id,
+        rating_issue_reference_id: duplicate_reference_id,
         description: "Old injury"
       )
     end
@@ -676,10 +676,11 @@ RSpec.feature "Higher-Level Review" do
                end_product_establishment_id: end_product_establishment.id
       )).to_not be_nil
 
-      xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
-      expect(xyz789_request_issues.count).to eq(2)
+      duplicate_request_issues = RequestIssue.where(rating_issue_reference_id: duplicate_reference_id)
+      expect(duplicate_request_issues.count).to eq(2)
 
-      ineligible_issue = xyz789_request_issues.select(&:duplicate_of_issue_in_active_review?).first
+      ineligible_issue = duplicate_request_issues.select(&:duplicate_of_issue_in_active_review?).first
+      expect(duplicate_request_issues).to include(request_issue_in_progress)
       expect(ineligible_issue).to_not eq(request_issue_in_progress)
       expect(ineligible_issue.contention_reference_id).to be_nil
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -616,7 +616,7 @@ RSpec.feature "Higher-Level Review" do
       find_all("label", text: "Old injury").first.click
       safe_click ".add-issue"
       expect(page).to have_content("4 issues")
-      expect(page).to have_content("4. Old injury is ineligible")
+      expect(page).to have_content("4. Old injury is ineligible because it's already under review as a Appeal")
 
       safe_click "#button-finish-intake"
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -509,6 +509,9 @@ RSpec.feature "Higher-Level Review" do
       expect(row).to have_text(text)
     end
 
+    let(:in_active_review_rating_issue_reference_id) { "xyz789" }
+    let(:active_epe) { create(:end_product_establishment, :active) }
+
     let!(:timely_ratings) do
       Generators::Rating.build(
         participant_id: veteran.participant_id,
@@ -516,8 +519,18 @@ RSpec.feature "Higher-Level Review" do
         profile_date: receipt_date - 50.days,
         issues: [
           { reference_id: "xyz123", decision_text: "Left knee granted" },
-          { reference_id: "xyz456", decision_text: "PTSD denied" }
+          { reference_id: "xyz456", decision_text: "PTSD denied" },
+          { reference_id: in_active_review_rating_issue_reference_id, decision_text: "Old injury" }
         ]
+      )
+    end
+
+    let!(:request_issue_in_progress) do
+      create(
+        :request_issue,
+        end_product_establishment: active_epe,
+        rating_issue_reference_id: in_active_review_rating_issue_reference_id,
+        description: "Old injury"
       )
     end
 
@@ -544,6 +557,7 @@ RSpec.feature "Higher-Level Review" do
       expect(page).to have_content("Does issue 1 match any of these issues")
       expect(page).to have_content("Left knee granted")
       expect(page).to have_content("PTSD denied")
+      expect(page).to have_content("Old injury")
 
       # test canceling adding an issue by closing the modal
       safe_click ".close-modal"
@@ -596,6 +610,13 @@ RSpec.feature "Higher-Level Review" do
       safe_click ".add-issue"
       expect(page).to have_content("3 issues")
       expect(page).to have_content("This is an unidentified issue")
+
+      # add ineligible issue
+      safe_click "#button-add-issue"
+      find_all("label", text: "Old injury").first.click
+      safe_click ".add-issue"
+      expect(page).to have_content("4 issues")
+      expect(page).to have_content("4. Old injury is ineligible")
 
       safe_click "#button-finish-intake"
 
@@ -654,6 +675,26 @@ RSpec.feature "Higher-Level Review" do
                is_unidentified: true,
                end_product_establishment_id: end_product_establishment.id
       )).to_not be_nil
+
+      xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
+      expect(xyz789_request_issues.count).to eq(2)
+
+      ineligible_issue = xyz789_request_issues.select(&:in_active_review?).first
+      expect(ineligible_issue).to be_in_active_review
+      expect(ineligible_issue.ineligible_request_issue).to eq(request_issue_in_progress)
+      expect(ineligible_issue.contention_reference_id).to be_nil
+
+      expect(Fakes::VBMSService).to_not have_received(:create_contentions!).with(
+        hash_including(
+          contention_descriptions: array_including("Old injury")
+        )
+      )
+
+      expect(Fakes::VBMSService).to have_received(:create_contentions!).with(
+        hash_including(
+          contention_descriptions: array_including("Left knee granted")
+        )
+      )
     end
 
     scenario "Non-compensation" do

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -175,7 +175,7 @@ RSpec.feature "Intake" do
       end
     end
 
-    scenario "Search for a veteran who's form is already being processed" do
+    scenario "Search for a veteran whose form is already being processed" do
       create(:ramp_election, veteran_file_number: "12341234", notice_date: Date.new(2017, 8, 7))
 
       RampElectionIntake.new(

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -498,7 +498,7 @@ RSpec.feature "Supplemental Claim Intake" do
       find_all("label", text: "Old injury").first.click
       safe_click ".add-issue"
       expect(page).to have_content("4 issues")
-      expect(page).to have_content("4. Old injury is ineligible")
+      expect(page).to have_content("4. Old injury is ineligible because it's already under review as a Appeal")
 
       safe_click "#button-finish-intake"
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -398,7 +398,7 @@ RSpec.feature "Supplemental Claim Intake" do
       expect(row).to have_text(text)
     end
 
-    let(:in_active_review_rating_issue_reference_id) { "xyz789" }
+    let(:duplicate_reference_id) { "xyz789" }
     let(:active_epe) { create(:end_product_establishment, :active) }
 
     let!(:timely_ratings) do
@@ -409,7 +409,7 @@ RSpec.feature "Supplemental Claim Intake" do
         issues: [
           { reference_id: "xyz123", decision_text: "Left knee granted" },
           { reference_id: "xyz456", decision_text: "PTSD denied" },
-          { reference_id: in_active_review_rating_issue_reference_id, decision_text: "Old injury" }
+          { reference_id: duplicate_reference_id, decision_text: "Old injury" }
         ]
       )
     end
@@ -418,7 +418,7 @@ RSpec.feature "Supplemental Claim Intake" do
       create(
         :request_issue,
         end_product_establishment: active_epe,
-        rating_issue_reference_id: in_active_review_rating_issue_reference_id,
+        rating_issue_reference_id: duplicate_reference_id,
         description: "Old injury"
       )
     end
@@ -555,10 +555,10 @@ RSpec.feature "Supplemental Claim Intake" do
                end_product_establishment_id: end_product_establishment.id
       )).to_not be_nil
 
-      xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
-      expect(xyz789_request_issues.count).to eq(2)
+      duplicate_request_issues = RequestIssue.where(rating_issue_reference_id: duplicate_reference_id)
+      expect(duplicate_request_issues.count).to eq(2)
 
-      ineligible_issue = xyz789_request_issues.select(&:duplicate_of_issue_in_active_review?).first
+      ineligible_issue = duplicate_request_issues.select(&:duplicate_of_issue_in_active_review?).first
       expect(ineligible_issue).to_not eq(request_issue_in_progress)
       expect(ineligible_issue.contention_reference_id).to be_nil
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -558,9 +558,8 @@ RSpec.feature "Supplemental Claim Intake" do
       xyz789_request_issues = RequestIssue.where(rating_issue_reference_id: in_active_review_rating_issue_reference_id)
       expect(xyz789_request_issues.count).to eq(2)
 
-      ineligible_issue = xyz789_request_issues.select(&:in_active_review?).first
-      expect(ineligible_issue).to be_in_active_review
-      expect(ineligible_issue.ineligible_request_issue).to eq(request_issue_in_progress)
+      ineligible_issue = xyz789_request_issues.select(&:duplicate_of_issue_in_active_review?).first
+      expect(ineligible_issue).to_not eq(request_issue_in_progress)
       expect(ineligible_issue.contention_reference_id).to be_nil
 
       expect(Fakes::VBMSService).to_not have_received(:create_contentions!).with(

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -78,7 +78,7 @@ describe RatingIssue do
     let(:reference_id) { "abc123" }
     let(:review_request_type) { "SupplementalClaim" }
     let(:inactive_end_product_establishment) { create(:end_product_establishment, :cleared) }
-    let(:active_end_product_establishment) { create(:end_product_establishment, synced_status: "PEND") }
+    let(:active_end_product_establishment) { create(:end_product_establishment, :active) }
 
     let(:request_issue) do
       create(

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -58,6 +58,11 @@ describe RequestIssue do
         expect(request_issue_in_review).to eq(rated_issue)
       end
 
+      it "accepts string or RatingIssue" do
+        request_issue_in_review = RequestIssue.in_review_for_rating_issue("abc123")
+        expect(request_issue_in_review).to eq(rated_issue)
+      end
+
       it "ignores request issues that are already ineligible" do
         request_issue = create(:request_issue, rating_issue_reference_id: rated_issue.rating_issue_reference_id)
         request_issue.update_as_ineligible!(other_request_issue: rated_issue, reason: :in_active_review)


### PR DESCRIPTION
connects #7291 

### Description
Adds feature tests and prevents ineligible issues from generating contentions.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] No contentions are created for ineligible issues

### Testing Plan

see #7291 

