### PR TITLE
Fixing the broken send back to attorney

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -35,10 +35,6 @@ class ColocatedTask < Task
 
     actions = [
       {
-        label: COPY::COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY,
-        value: "modal/mark_task_complete"
-      },
-      {
         label: COPY::COLOCATED_ACTION_PLACE_HOLD,
         value: Constants::CO_LOCATED_ACTIONS["PLACE_HOLD"]
       }
@@ -48,6 +44,11 @@ class ColocatedTask < Task
       actions.unshift(
         label: format(COPY::COLOCATED_ACTION_SEND_TO_TEAM, Constants::CO_LOCATED_ADMIN_ACTIONS[action]),
         value: "modal/send_colocated_task"
+      )
+    else
+      actions.unshift(
+        label: COPY::COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY,
+        value: "modal/mark_task_complete"
       )
     end
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/7356

### Description
We're just removing the ability to send back to the attorney for co located tasks that are schedule hearing or translation.

### Testing Plan
1. Go to colocated and ensure for legacy tasks that they cannot select send back to attorney for translation/schedule hearing tasks. But can send back to attorney for other tasks.

