### PR TITLE
Add RatingIssue promulgation_date

### DIFF
--- a/app/models/ama_review.rb
+++ b/app/models/ama_review.rb
@@ -15,7 +15,7 @@ class AmaReview < ApplicationRecord
   before_destroy :remove_issues!
 
   cache_attribute :cached_serialized_ratings, cache_key: :timely_ratings_cache_key, expires_in: 1.day do
-    ratings_with_issues.map(&:ui_hash)
+    receipt_date && ratings_with_issues.map(&:ui_hash)
   end
 
   def self.review_title
@@ -60,6 +60,8 @@ class AmaReview < ApplicationRecord
   private
 
   def ratings_with_issues
+    return unless receipt_date
+
     veteran.ratings(receipt_date: receipt_date).reject { |rating| rating.issues.empty? }
   end
 

--- a/app/models/ama_review.rb
+++ b/app/models/ama_review.rb
@@ -64,7 +64,7 @@ class AmaReview < ApplicationRecord
   private
 
   def ratings_with_issues
-    veteran.ratings.reject { |rating| rating.issues.empty? }
+    veteran.ratings(receipt_date: receipt_date).reject { |rating| rating.issues.empty? }
   end
 
   # disabled for simplecov sake

--- a/app/models/ama_review.rb
+++ b/app/models/ama_review.rb
@@ -14,11 +14,7 @@ class AmaReview < ApplicationRecord
 
   before_destroy :remove_issues!
 
-  # cache_attribute :cached_serialized_timely_ratings, cache_key: :timely_ratings_cache_key, expires_in: 1.day do
-  #   receipt_date && timely_ratings_with_issues.map(&:ui_hash)
-  # end
-
-  cache_attribute :cached_serialized_ratings, cache_key: :ratings_cache_key, expires_in: 1.day do
+  cache_attribute :cached_serialized_ratings, cache_key: :timely_ratings_cache_key, expires_in: 1.day do
     ratings_with_issues.map(&:ui_hash)
   end
 
@@ -67,24 +63,13 @@ class AmaReview < ApplicationRecord
     veteran.ratings(receipt_date: receipt_date).reject { |rating| rating.issues.empty? }
   end
 
-  # disabled for simplecov sake
-  # def timely_ratings_with_issues
-  #  return unless receipt_date
-  #
-  #  veteran.timely_ratings(from_date: receipt_date).reject { |rating| rating.issues.empty? }
-  # end
-
-  def ratings_cache_key
-    "#{veteran_file_number}-ratings"
+  def timely_ratings_cache_key
+    "#{veteran_file_number}-#{formatted_receipt_date}"
   end
 
-  # def timely_ratings_cache_key
-  #  "#{veteran_file_number}-#{formatted_receipt_date}"
-  # end
-
-  # def formatted_receipt_date
-  #  receipt_date ? receipt_date.to_formatted_s(:short_date) : ""
-  # end
+  def formatted_receipt_date
+    receipt_date ? receipt_date.to_formatted_s(:short_date) : ""
+  end
 
   def end_product_station
     "499" # National Work Queue

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -5,7 +5,7 @@ class Rating
 
   # WARNING: profile_date is a misnomer adopted from BGS terminology.
   # It is a datetime, not a date.
-  attr_accessor :participant_id, :profile_date, :promulgation_date
+  attr_accessor :participant_id, :profile_date, :promulgation_date, :receipt_date
 
   ONE_YEAR_PLUS_DAYS = 372.days
   TWO_LIFETIMES_DAYS = 250.years
@@ -38,7 +38,7 @@ class Rating
     return [] if response[:rating_issues].nil?
 
     [response[:rating_issues]].flatten.map do |issue_data|
-      RatingIssue.from_bgs_hash(issue_data.merge(promulgation_date: promulgation_date))
+      RatingIssue.from_bgs_hash(issue_data.merge(promulgation_date: promulgation_date, receipt_date: receipt_date))
     end
   rescue Savon::Error
     []

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -38,7 +38,7 @@ class Rating
     return [] if response[:rating_issues].nil?
 
     [response[:rating_issues]].flatten.map do |issue_data|
-      RatingIssue.from_bgs_hash(issue_data)
+      RatingIssue.from_bgs_hash(issue_data.merge(promulgation_date: response[:prmlgn_dt]))
     end
   rescue Savon::Error
     []

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -38,7 +38,7 @@ class Rating
     return [] if response[:rating_issues].nil?
 
     [response[:rating_issues]].flatten.map do |issue_data|
-      RatingIssue.from_bgs_hash(issue_data.merge(promulgation_date: response[:prmlgn_dt]))
+      RatingIssue.from_bgs_hash(issue_data.merge(promulgation_date: promulgation_date))
     end
   rescue Savon::Error
     []

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -48,7 +48,7 @@ class RatingIssue < ApplicationRecord
   private
 
   def less_than_one_year_old?
-    promulgation_date < (Time.zone.today - Rating::ONE_YEAR_PLUS_DAYS)
+    promulgation_date >= (Time.zone.today - Rating::ONE_YEAR_PLUS_DAYS)
   end
 
   def related_request_issue

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -18,6 +18,8 @@ class RatingIssue < ApplicationRecord
     {
       reference_id: reference_id,
       decision_text: decision_text,
+      promulgation_date: promulgation_date,
+      timely: timely?,
       in_active_review: in_active_review
     }
   end
@@ -28,7 +30,8 @@ class RatingIssue < ApplicationRecord
       reference_id: data[:rba_issue_id],
       profile_date: rba_contentions.first.dig(:prfil_dt),
       contention_reference_id: rba_contentions.first.dig(:cntntn_id),
-      decision_text: data[:decn_txt]
+      decision_text: data[:decn_txt],
+      promulgation_date: data[:promulgation_date]
     )
   end
 
@@ -38,7 +41,15 @@ class RatingIssue < ApplicationRecord
     request_issue.review_title if request_issue
   end
 
+  def timely?
+    less_than_one_year_old?
+  end
+
   private
+
+  def less_than_one_year_old?
+    promulgation_date < (Time.zone.today - Rating::ONE_YEAR_PLUS_DAYS)
+  end
 
   def related_request_issue
     return if contention_reference_id.nil?

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -4,6 +4,9 @@ class RatingIssue < ApplicationRecord
   # this local attribute is used to resolve the related RequestIssue
   attr_accessor :contention_reference_id
 
+  # this local attribute used to calculate timeliness
+  attr_accessor :receipt_date
+
   def save_with_request_issue!
     return unless related_request_issue
     self.request_issue = related_request_issue
@@ -31,7 +34,8 @@ class RatingIssue < ApplicationRecord
       profile_date: rba_contentions.first.dig(:prfil_dt),
       contention_reference_id: rba_contentions.first.dig(:cntntn_id),
       decision_text: data[:decn_txt],
-      promulgation_date: data[:promulgation_date]
+      promulgation_date: data[:promulgation_date],
+      receipt_date: data[:receipt_date]
     )
   end
 
@@ -48,7 +52,7 @@ class RatingIssue < ApplicationRecord
   private
 
   def less_than_one_year_old?
-    promulgation_date >= (Time.zone.today - Rating::ONE_YEAR_PLUS_DAYS)
+    promulgation_date >= (receipt_date - Rating::ONE_YEAR_PLUS_DAYS)
   end
 
   def related_request_issue

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -121,11 +121,13 @@ class Veteran < ApplicationRecord
   alias gender sex
 
   def timely_ratings(from_date:)
-    @timely_ratings ||= Rating.fetch_timely(participant_id: participant_id, from_date: from_date)
+    @timely_ratings ||= Rating.fetch_timely(participant_id: participant_id, from_date: from_date).each do |rating|
+      rating.receipt_date = from_date
+    end
   end
 
-  def ratings
-    @ratings ||= Rating.fetch_all(participant_id)
+  def ratings(receipt_date:)
+    @ratings ||= Rating.fetch_all(participant_id).each { |rating| rating.receipt_date = receipt_date }
   end
 
   def accessible_appeals_for_poa(poa_participant_ids)

--- a/db/migrate/20181018191048_add_promulgation_date_to_rating_issue.rb
+++ b/db/migrate/20181018191048_add_promulgation_date_to_rating_issue.rb
@@ -1,0 +1,5 @@
+class AddPromulgationDateToRatingIssue < ActiveRecord::Migration[5.1]
+  def change
+    add_column :rating_issues, :promulgation_date, :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181018143032) do
+ActiveRecord::Schema.define(version: 20181018191048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -582,6 +582,7 @@ ActiveRecord::Schema.define(version: 20181018143032) do
     t.string "reference_id", null: false
     t.datetime "profile_date", null: false
     t.string "decision_text"
+    t.datetime "promulgation_date", null: false
     t.index ["request_issue_id"], name: "index_rating_issues_on_request_issue_id"
   end
 

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -157,14 +157,22 @@ describe RatingIssue do
   end
 
   context "#timely?" do
-    it "considers within the last year timely" do
-      rating_issue = RatingIssue.new(promulgation_date: promulgation_date)
-      expect(rating_issue.timely?).to eq(true)
+    let(:receipt_date) { Time.zone.today - 30.days }
+
+    subject { RatingIssue.new(promulgation_date: promulgation_date, receipt_date: receipt_date) }
+
+    context "received in the last year" do
+      it "considers it timely" do
+        expect(subject.timely?).to eq(true)
+      end
     end
 
-    it "considers older than a year-ish untimely" do
-      rating_issue = RatingIssue.new(promulgation_date: promulgation_date - 373.days)
-      expect(rating_issue.timely?).to eq(false)
+    context "received more than a year ago" do
+      let(:promulgation_date) { receipt_date - 373.days }
+
+      it "considers it untimely" do
+        expect(subject.timely?).to eq(false)
+      end
     end
   end
 end

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -10,13 +10,16 @@ describe RatingIssue do
     FeatureToggle.disable!(:test_facols)
   end
 
+  let(:promulgation_date) { Time.zone.today - 30 }
+
   context ".from_bgs_hash" do
     subject { RatingIssue.from_bgs_hash(bgs_record) }
 
     let(:bgs_record) do
       {
         rba_issue_id: "NBA",
-        decn_txt: "This broadcast may not be reproduced"
+        decn_txt: "This broadcast may not be reproduced",
+        promulgation_date: promulgation_date
       }
     end
 
@@ -140,7 +143,8 @@ describe RatingIssue do
       rating_issue = RatingIssue.new(
         reference_id: "ref-id",
         profile_date: Time.zone.today,
-        contention_reference_id: contention_ref_id
+        contention_reference_id: contention_ref_id,
+        promulgation_date: promulgation_date
       )
 
       expect(rating_issue.id).to be_nil
@@ -149,6 +153,18 @@ describe RatingIssue do
 
       expect(rating_issue.request_issue).to eq(request_issue)
       expect(rating_issue.id).to_not be_nil
+    end
+  end
+
+  context "#timely?" do
+    it "considers within the last year timely" do
+      rating_issue = RatingIssue.new(promulgation_date: promulgation_date)
+      expect(rating_issue.timely?).to eq(true)
+    end
+
+    it "considers older than a year-ish untimely" do
+      rating_issue = RatingIssue.new(promulgation_date: promulgation_date - 373.days)
+      expect(rating_issue.timely?).to eq(false)
     end
   end
 end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -5,8 +5,11 @@ describe Rating do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end
 
+  let(:receipt_date) { Time.zone.today }
+
   let(:rating) do
     Generators::Rating.build(
+      promulgation_date: receipt_date,
       issues: issues
     )
   end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -7,7 +7,7 @@ describe Rating do
 
   let(:receipt_date) { Time.zone.today }
 
-  let(:promulgation_date) { receipt_date - 30.days }
+  let(:promulgation_date) { (receipt_date - 30.days).to_datetime }
 
   let(:rating) do
     Generators::Rating.build(

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -7,18 +7,27 @@ describe Rating do
 
   let(:receipt_date) { Time.zone.today }
 
+  let(:promulgation_date) { receipt_date - 30 }
+
   let(:rating) do
     Generators::Rating.build(
-      promulgation_date: receipt_date,
-      issues: issues
+      issues: issues,
+      promulgation_date: promulgation_date
     )
   end
 
+  def build_issue(num)
+    {
+      reference_id: "Issue#{num}",
+      decision_text: "Decision#{num}",
+      in_active_review: nil,
+      promulgation_date: promulgation_date,
+      timely: false
+    }
+  end
+
   let(:issues) do
-    [
-      { reference_id: "Issue1", decision_text: "Decision1", in_active_review: nil },
-      { reference_id: "Issue2", decision_text: "Decision2", in_active_review: nil }
-    ]
+    [build_issue(1), build_issue(2)]
   end
 
   context "#issues" do

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -7,7 +7,7 @@ describe Rating do
 
   let(:receipt_date) { Time.zone.today }
 
-  let(:promulgation_date) { receipt_date - 30 }
+  let(:promulgation_date) { receipt_date - 30.days }
 
   let(:rating) do
     Generators::Rating.build(
@@ -22,7 +22,7 @@ describe Rating do
       decision_text: "Decision#{num}",
       in_active_review: nil,
       promulgation_date: promulgation_date,
-      timely: false
+      timely: true
     }
   end
 

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -12,7 +12,8 @@ describe Rating do
   let(:rating) do
     Generators::Rating.build(
       issues: issues,
-      promulgation_date: promulgation_date
+      promulgation_date: promulgation_date,
+      receipt_date: receipt_date
     )
   end
 


### PR DESCRIPTION
connects #7300 

### Description
The promulgation_date is on the VBMS Rating, but we need it to evaluate timeliness on all the children RatingIssue. So store it in the database so we can always perform timeliness calculation locally.

This the first of multiple PRs to implement the timeliness check.

### Acceptance Criteria
- [x] Code compiles correctly
