### PR TITLE
Display data correctly if veteran does not exist in BGS

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -193,7 +193,14 @@ class LegacyAppeal < ApplicationRecord
   end
 
   delegate :age, :sex, to: :veteran, prefix: true
-  delegate :address_line_1, :address_line_2, :address_line_3, :city, :state, :zip, :country, to: :veteran, prefix: true
+  delegate :address_line_1,
+           :address_line_2,
+           :address_line_3,
+           :city,
+           :state,
+           :zip,
+           :country,
+           to: :veteran, prefix: true, allow_nil: true
 
   # NOTE: we cannot currently match end products to a specific appeal.
   delegate :end_products, to: :veteran

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -192,7 +192,6 @@ class LegacyAppeal < ApplicationRecord
     vbms_id.ends_with?("C") ? (veteran && veteran.ssn) : sanitized_vbms_id
   end
 
-  delegate :age, :sex, to: :veteran, prefix: true
   delegate :address_line_1,
            :address_line_2,
            :address_line_3,
@@ -200,6 +199,8 @@ class LegacyAppeal < ApplicationRecord
            :state,
            :zip,
            :country,
+           :age,
+           :sex,
            to: :veteran, prefix: true, allow_nil: true
 
   # NOTE: we cannot currently match end products to a specific appeal.

--- a/app/models/serializers/work_queue/veteran_serializer.rb
+++ b/app/models/serializers/work_queue/veteran_serializer.rb
@@ -6,10 +6,10 @@ class WorkQueue::VeteranSerializer < ActiveModel::Serializer
     object.veteran_gender
   end
   attribute :date_of_birth do
-    object.veteran.try(:date_of_birth)
+    object.veteran ? object.veteran.date_of_birth : nil
   end
   attribute :date_of_death do
-    object.veteran.try(:date_of_death)
+    object.veteran ? object.veteran.date_of_death : nil
   end
   attribute :address do
     if object.veteran_address_line_1

--- a/app/models/serializers/work_queue/veteran_serializer.rb
+++ b/app/models/serializers/work_queue/veteran_serializer.rb
@@ -12,14 +12,16 @@ class WorkQueue::VeteranSerializer < ActiveModel::Serializer
     object.veteran.try(:date_of_death)
   end
   attribute :address do
-    {
-      address_line_1: object.veteran_address_line_1,
-      address_line_2: object.veteran_address_line_2,
-      city: object.veteran_city,
-      state: object.veteran_state,
-      zip: object.veteran_zip,
-      country: object.veteran_country
-    }
+    if object.veteran_address_line_1
+      {
+        address_line_1: object.veteran_address_line_1,
+        address_line_2: object.veteran_address_line_2,
+        city: object.veteran_city,
+        state: object.veteran_state,
+        zip: object.veteran_zip,
+        country: object.veteran_country
+      }
+    end
   end
   attribute :regional_office do
     if object.regional_office

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -169,6 +169,36 @@ RSpec.feature "Case details" do
       end
     end
 
+    context "when veteran is not in BGS" do
+      let!(:appeal) do
+        FactoryBot.create(
+          :legacy_appeal,
+          :with_veteran,
+          vacols_case: FactoryBot.create(
+            :case,
+            :assigned,
+            user: attorney_user,
+            correspondent: FactoryBot.create(:correspondent, sgender: "F")
+          )
+        )
+      end
+
+      before do
+        allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_return(nil)
+      end
+
+      scenario "details view informs us that the Veteran is the appellant" do
+        visit "/queue"
+        click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+
+        expect(page).to have_content("About the Veteran")
+        expect(page).to have_content(COPY::CASE_DETAILS_GENDER_FIELD_VALUE_FEMALE)
+        expect(page).to_not have_content("1/10/1935")
+        expect(page).to_not have_content("5/25/2016")
+        expect(page).to have_content(appeal.regional_office.city)
+      end
+    end
+
     context "when Veteran is not the appellant" do
       let!(:appeal) do
         FactoryBot.create(


### PR DESCRIPTION
For legacy cases, veteran info might not be present in BGS. 

![image](https://user-images.githubusercontent.com/3811786/47434376-6ffd9980-d770-11e8-9a5d-7e00c0be3c8b.png)

