### PR TITLE
do not create vbms client with user if there is no user

### DIFF
--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -103,7 +103,7 @@ class ExternalApi::VBMSService
       send_userid: FeatureToggle.enabled?(:vbms_include_user)
     )
 
-    send_and_log_request(veteran_hash[:file_number], request, user ? vbms_client_with_user(user) : nil)
+    send_and_log_request(veteran_hash[:file_number], request, vbms_client_with_user(user))
   end
 
   def self.fetch_contentions(claim_id:)
@@ -129,7 +129,7 @@ class ExternalApi::VBMSService
       send_userid: FeatureToggle.enabled?(:vbms_include_user)
     )
 
-    send_and_log_request(claim_id, request, user ? vbms_client_with_user(user) : nil)
+    send_and_log_request(claim_id, request, vbms_client_with_user(user))
   end
 
   def self.remove_contention!(contention)
@@ -165,6 +165,8 @@ class ExternalApi::VBMSService
   end
 
   def self.vbms_client_with_user(user)
+    return @vbms_client if user.nil?
+
     VBMS::Client.from_env_vars(
       logger: VBMSCaseflowLogger.new,
       env_name: ENV["CONNECT_VBMS_ENV"],

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -103,8 +103,7 @@ class ExternalApi::VBMSService
       send_userid: FeatureToggle.enabled?(:vbms_include_user)
     )
 
-    client = FeatureToggle.enabled?(:vbms_include_user) ? vbms_client_with_user(user) : @vbms_client
-    send_and_log_request(veteran_hash[:file_number], request, client)
+    send_and_log_request(veteran_hash[:file_number], request, user ? vbms_client_with_user(user) : nil)
   end
 
   def self.fetch_contentions(claim_id:)
@@ -130,7 +129,7 @@ class ExternalApi::VBMSService
       send_userid: FeatureToggle.enabled?(:vbms_include_user)
     )
 
-    send_and_log_request(claim_id, request, vbms_client_with_user(user))
+    send_and_log_request(claim_id, request, user ? vbms_client_with_user(user) : nil)
   end
 
   def self.remove_contention!(contention)


### PR DESCRIPTION
Existing EPs that were created previously do not have their user ids populated. This means that `vbms_client_with_user(user)` will always error out.