### PR TITLE
Enable marking tasks as complete when the task has no assigner

### DIFF
--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -9,9 +9,10 @@ import COPY from '../../../COPY.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 
 import {
-  tasksForAppealAssignedToUserSelector,
+  actionableTasksForAppeal,
+  appealWithDetailSelector,
   incompleteOrganizationTasksByAssigneeIdSelector,
-  appealWithDetailSelector
+  tasksForAppealAssignedToUserSelector
 } from '../selectors';
 import { setTaskAttrs } from '../QueueActions';
 import {
@@ -40,7 +41,7 @@ type Props = Params & {|
 const SEND_TO_LOCATION_MODAL_TYPE_ATTRS = {
   mark_task_complete: {
     buildSuccessMsg: (appeal: Appeal, { assignerName }: { assignerName: string}) => ({
-      title: sprintf(COPY.MARK_TASK_COMPLETE_CONFIRMATION, appeal.veteranFullName, assignerName),
+      title: sprintf(COPY.MARK_TASK_COMPLETE_CONFIRMATION, appeal.veteranFullName),
       detail: sprintf(COPY.MARK_TASK_COMPLETE_CONFIRMATION_DETAIL, assignerName)
     }),
     title: () => COPY.MARK_TASK_COMPLETE_TITLE,
@@ -68,6 +69,13 @@ const SEND_TO_LOCATION_MODAL_TYPE_ATTRS = {
 class CompleteTaskModal extends React.Component<Props> {
   getTaskAssignerName = () => {
     const { task: { assignedBy } } = this.props;
+
+    // Tasks created by the application (tasks for quality review or dispatch) will not have assigners.
+    // TODO: Amend copy to better explain what is going on instead of having a blank field where we expect
+    // to see somebody's name.
+    if (!assignedBy.firstName.codePointAt(0)) {
+      return '';
+    }
 
     return `${String.fromCodePoint(assignedBy.firstName.codePointAt(0))}. ${assignedBy.lastName}`;
   };
@@ -110,6 +118,7 @@ class CompleteTaskModal extends React.Component<Props> {
 
 const mapStateToProps = (state: State, ownProps: Params) => ({
   task: tasksForAppealAssignedToUserSelector(state, ownProps)[0] ||
+    actionableTasksForAppeal(state, { appealId: ownProps.appealId })[0] ||
     incompleteOrganizationTasksByAssigneeIdSelector(state, { appealId: ownProps.appealId })[0],
   appeal: appealWithDetailSelector(state, ownProps),
   saveState: state.ui.saveState.savePending

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -75,6 +75,14 @@ FactoryBot.define do
       parent { create(:root_task) }
     end
 
+    factory :qr_task do
+      type QualityReviewTask.name
+      appeal { create(:appeal) }
+      parent { create(:root_task) }
+      assigned_by { nil }
+      assigned_to { QualityReview.singleton }
+    end
+
     factory :bva_dispatch_task do
       type BvaDispatchTask.name
       appeal_type Appeal.name

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -379,4 +379,29 @@ RSpec.feature "Case details" do
       expect(Task.find(on_hold_task.id).status).to eq("on_hold")
     end
   end
+
+  describe "Marking organization task complete" do
+    context "when there is no assigner" do
+      let(:qr) { QualityReview.singleton }
+      let(:task) { FactoryBot.create(:qr_task) }
+      let(:user) { FactoryBot.create(:user) }
+
+      before do
+        StaffFieldForOrganization.create!(organization: qr, name: "sdept", values: %w[QR])
+        FactoryBot.create(:staff, user: user, sdept: "QR", sattyid: nil)
+        User.authenticate!(user: user)
+      end
+
+      it "marking task as complete works" do
+        visit "/queue/appeals/#{task.appeal.uuid}"
+
+        find(".Select-control", text: "Select an action").click
+        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.label).click
+
+        find("button", text: COPY::MARK_TASK_COMPLETE_BUTTON).click
+
+        expect(page).to have_content(format(COPY::MARK_TASK_COMPLETE_CONFIRMATION_DETAIL, ""))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #7539.

Tasks created automatically by the backed (quality review tasks, bva dispatch tasks to name two) will not have assigners. This change allows the frontend to handle marking those tasks as complete.

| Before | After | 
| --- | --- |
| ![qr_task_before](https://user-images.githubusercontent.com/32683958/47509117-65600480-d843-11e8-9ee1-680ffae4cd8f.gif) | ![qr_task_after](https://user-images.githubusercontent.com/32683958/47509130-6b55e580-d843-11e8-9dd6-64ab280cfc13.gif) |

### Steps to reproduce
On this branch, in the rails console create this situation:
* qr = QualityReview.singleton
* task = FactoryBot.create(:qr_task)
* StaffFieldForOrganization.create!(organization: qr, name: "sdept", values: %w[QR])
* u = User.create!(station_id: 101, css_id: "QUALITY_REVIEW", full_name: "Quality Reviewer")
* FactoryBot.create(:staff, user: u, sdept: "QR", sattyid: nil)

Related error in sentry: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2840/
> TypeError: app/queue/components/CompleteTaskModal in assignedBy
> Cannot read property 'assignedBy' of undefined