### PR TITLE
Fixing appeal detail load

### DIFF
--- a/client/app/queue/reducers.js
+++ b/client/app/queue/reducers.js
@@ -398,11 +398,14 @@ export const workQueueReducer = (state: QueueState = initialState, action: Objec
         }
       }
     });
-  case ACTIONS.RECEIVE_APPEAL_VALUE:
+  case ACTIONS.RECEIVE_APPEAL_VALUE: {
+    const existingState = state.loadingAppealDetail[action.payload.appealId] || {};
+
     return update(state, {
       loadingAppealDetail: {
         $merge: {
           [action.payload.appealId]: {
+            ...existingState,
             [action.payload.name]: {
               loading: false
             }
@@ -417,11 +420,15 @@ export const workQueueReducer = (state: QueueState = initialState, action: Objec
         }
       }
     });
-  case ACTIONS.ERROR_ON_RECEIVE_APPEAL_VALUE:
+  }
+  case ACTIONS.ERROR_ON_RECEIVE_APPEAL_VALUE: {
+    const existingState = state.loadingAppealDetail[action.payload.appealId] || {};
+
     return update(state, {
       loadingAppealDetail: {
         $merge: {
           [action.payload.appealId]: {
+            ...existingState,
             [action.payload.name]: {
               loading: false,
               error: action.payload.error
@@ -430,6 +437,7 @@ export const workQueueReducer = (state: QueueState = initialState, action: Objec
         }
       }
     });
+  }
   default:
     return state;
   }


### PR DESCRIPTION
https://circleci.com/gh/department-of-veterans-affairs/caseflow/17636#tests/containers/0

### Description
When I wrote the reducer for the new async appeals detail load I messed up the immutability helper, such that when Anya added a new property (veteranInfo), it introduced a race condition. Whichever  finished second, veteranInfo or POA, would override whatever was written first. This caused this test to fail non-deterministically.

### Testing Plan
1. Run the failing test with ensure stable and ensure it passes every time.

