### PR TITLE
Display special issues for legacy cases

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -12,6 +12,7 @@ class LegacyAppeal < ApplicationRecord
   has_many :appeal_views, as: :appeal
   has_many :claims_folder_searches, as: :appeal
   has_many :tasks, as: :appeal
+  has_one :special_issue_list, as: :appeal
   accepts_nested_attributes_for :worksheet_issues, allow_destroy: true
 
   class UnknownLocationError < StandardError; end

--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -10,7 +10,7 @@ class AttorneyLegacyTask < LegacyTask
     actions = [
       {
         label: COPY::ATTORNEY_CHECKOUT_DRAFT_DECISION_LABEL,
-        value: "draft_decision/dispositions"
+        value: "draft_decision/special_issues"
       },
       {
         label: COPY::ATTORNEY_CHECKOUT_OMO_LABEL,

--- a/app/models/legacy_tasks/judge_legacy_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_task.rb
@@ -8,7 +8,7 @@ class JudgeLegacyTask < LegacyTask
     else
       {
         label: COPY::JUDGE_CHECKOUT_DISPATCH_LABEL,
-        value: "dispatch_decision/dispositions"
+        value: "draft_decision/special_issues"
       }
     end
   end

--- a/app/models/legacy_tasks/judge_legacy_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_task.rb
@@ -8,7 +8,7 @@ class JudgeLegacyTask < LegacyTask
     else
       {
         label: COPY::JUDGE_CHECKOUT_DISPATCH_LABEL,
-        value: "draft_decision/special_issues"
+        value: "dispatch_decision/special_issues"
       }
     end
   end

--- a/app/models/special_issue_list.rb
+++ b/app/models/special_issue_list.rb
@@ -1,3 +1,3 @@
 class SpecialIssueList < ApplicationRecord
-  belongs_to :appeal
+  belongs_to :appeal, polymorphic: true
 end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -247,7 +247,8 @@
   "MODAL_CANCEL_ATTORNEY_CHECKOUT_PROMPT": "Are you sure you want to cancel?",
   "MODAL_CANCEL_ATTORNEY_CHECKOUT": "All changes made to this page will be lost, except for the adding, editing, and deleting of issues.",
 
-  "SPECIAL_ISSUES_PAGE_TITLE": "Select special issue(s)",
+  "SPECIAL_ISSUES_PAGE_TITLE": "Select special issues (optional)",
+  "SPECIAL_ISSUES_PAGE_NOTE": "Select the special issues that pertain to this case. Cases with special issues are routed to specific groups who are in charge of adjusting the case.",
 
   "ADVANCE_ON_DOCKET_MOTION_PAGE_TITLE": "Update Advanced on Docket (AOD) Status",
   "ADVANCE_ON_DOCKET_MOTION_DISPOSITION_DROPDOWN": "AOD Motion Disposition",

--- a/client/app/queue/SelectSpecialIssuesView.jsx
+++ b/client/app/queue/SelectSpecialIssuesView.jsx
@@ -36,11 +36,12 @@ class SelectSpecialIssuesView extends React.PureComponent {
   render = () => {
     const {
       specialIssues,
+      appeal,
       error
     } = this.props;
 
     const specialIssueCheckboxes = SPECIAL_ISSUES.map((issue) => {
-      if (issue.nonCompensation) {
+      if (issue.nonCompensation && !appeal.isLegacyAppeal) {
         return null;
       }
 

--- a/client/app/queue/SelectSpecialIssuesView.jsx
+++ b/client/app/queue/SelectSpecialIssuesView.jsx
@@ -15,6 +15,7 @@ import ApiUtil from '../util/ApiUtil';
 
 class SelectSpecialIssuesView extends React.PureComponent {
   getPageName = () => COPY.SPECIAL_ISSUES_PAGE_TITLE;
+  getPageNote = () => COPY.SPECIAL_ISSUES_PAGE_NOTE;
 
   onChangeSpecialIssue = (issue) => (value) => {
     this.props.setSpecialIssues({
@@ -58,6 +59,9 @@ class SelectSpecialIssuesView extends React.PureComponent {
       <h1>
         {this.getPageName()}
       </h1>
+      <p>
+        {this.getPageNote()}
+      </p>
       {error && <Alert type="error" title={error.title} message={error.detail} />}
       <div className="cf-multiple-columns">
         {specialIssueCheckboxes}

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -453,7 +453,7 @@ RSpec.feature "AmaQueue" do
       find(".Select-control", text: "Select an action").click
       find("div", class: "Select-option", text: "Decision ready for review").click
 
-      expect(page).to have_content("Select special issue(s)")
+      expect(page).to have_content("Select special issues (optional)")
 
       click_on "Continue"
 

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -360,6 +360,23 @@ RSpec.feature "Attorney checkout flow" do
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
 
+        click_label "vamc"
+
+        click_on "Continue"
+
+        # Ensure we can reload the flow and the special issue is saved
+        click_on "Cancel"
+        click_on "Yes, cancel"
+
+        click_dropdown(index: 0)
+
+        # Vamc should still be checked
+        expect(page).to have_field("vamc", checked: true, visible: false)
+
+        # Vamc should also be marked in the database
+        expect(appeal.special_issue_list.vamc).to eq(true)
+        click_on "Continue"
+
         expect(page).to have_content "Select disposition"
 
         cancel_button = page.find "#button-cancel-button"
@@ -404,6 +421,8 @@ RSpec.feature "Attorney checkout flow" do
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
 
+        click_on "Continue"
+
         expect(page).to have_content("Select disposition")
 
         table_rows = page.find_all("tr[id^='table-row-']")
@@ -431,6 +450,8 @@ RSpec.feature "Attorney checkout flow" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
+
+        click_on "Continue"
 
         issue_dispositions = page.find_all(".Select-control", text: "Select disposition", count: appeal.issues.length)
 
@@ -492,6 +513,8 @@ RSpec.feature "Attorney checkout flow" do
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 1)
 
+        click_on "Continue"
+
         expect(page).to have_content("Submit OMO for Review")
 
         click_label("omo-type_OMO - VHA")
@@ -524,6 +547,8 @@ RSpec.feature "Attorney checkout flow" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
+
+        click_on "Continue"
 
         expect(page).to have_content("Select disposition")
 
@@ -581,6 +606,8 @@ RSpec.feature "Attorney checkout flow" do
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
 
+        click_on "Continue"
+
         expect(page).to have_content("Select disposition")
 
         first("a", text: "Edit Issue").click
@@ -611,6 +638,8 @@ RSpec.feature "Attorney checkout flow" do
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
 
+        click_on "Continue"
+
         expect(page).to have_content "Select disposition"
 
         diag_code_no_l2 = %w[4 5 0 *]
@@ -632,6 +661,8 @@ RSpec.feature "Attorney checkout flow" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
         click_dropdown(index: 0)
+
+        click_on "Continue"
 
         expect(page).to have_content "Select disposition"
 

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -123,8 +123,27 @@ RSpec.feature "Judge checkout flow" do
           expect(visible_options.first.text).to eq COPY::JUDGE_CHECKOUT_DISPATCH_LABEL
         end
 
+        click_label "vamc"
+
+        click_on "Continue"
+
+        # Ensure we can reload the flow and the special issue is saved
+        click_on "Cancel"
+        click_on "Yes, cancel"
+
+        click_dropdown(index: 0)
+
+        # Vamc should still be checked
+        expect(page).to have_field("vamc", checked: true, visible: false)
+
+        # Vamc should also be marked in the database
+        expect(appeal.special_issue_list.vamc).to eq(true)
+        click_on "Continue"
+
         # one issue is decided, excluded from checkout flow
         expect(appeal.issues.length).to eq 2
+
+        expect(page).to have_content("Review Dispositions")
         expect(page.find_all(".issue-disposition-dropdown").length).to eq 1
 
         click_on "Continue"


### PR DESCRIPTION
### Description
Allow attorneys and judges to select special issues for legacy cases

Once this PR is deployed, I will write a migration to update existing SpecialssueList records to have `Appeal` appeal_type as currently this is not being populated (due to missing `polymorphic: true`)
