### PR TITLE
Remove mail task-specific logic from assign to component

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -158,6 +158,10 @@ class Task < ApplicationRecord
     }
   end
 
+  def mail_assign_to_organization_data
+    assign_to_organization_data.merge(type: MailTask.name)
+  end
+
   def assign_to_user_data
     users = if assigned_to.is_a?(Organization)
               assigned_to.members

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -32,7 +32,6 @@ import type { Appeal, Task } from './types/models';
 type Params = {|
   appealId: string,
   task: Task,
-  createsMailTask: boolean,
   isReassignAction: boolean,
   isTeamAssign: boolean,
   history: Object
@@ -83,22 +82,14 @@ class AssignToView extends React.Component<Props, ViewState> {
     const {
       appeal,
       task,
-      createsMailTask,
       isReassignAction,
       isTeamAssign
     } = this.props;
-    let type = 'GenericTask';
-
-    if (createsMailTask) {
-      type = 'MailTask';
-    } else if (this.taskActionData().type) {
-      type = this.taskActionData().type;
-    }
 
     const payload = {
       data: {
         tasks: [{
-          type,
+          type: this.taskActionData().type ? this.taskActionData().type : 'GenericTask',
           external_id: appeal.externalId,
           parent_id: task.taskId,
           assigned_to_id: this.state.selectedValue,

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -162,8 +162,6 @@ class QueueApp extends React.PureComponent<Props> {
 
   routedAssignToTeam = (props) => <AssignToView isTeamAssign {...props.match.params} />;
 
-  routedCreateMailTask = (props) => <AssignToView isTeamAssign createsMailTask {...props.match.params} />;
-
   routedAssignToUser = (props) => <AssignToView {...props.match.params} />;
 
   routedReassignToUser = (props) => <AssignToView isReassignAction {...props.match.params} />;
@@ -254,8 +252,8 @@ class QueueApp extends React.PureComponent<Props> {
             path={`/queue/appeals/:appealId/${TASK_ACTIONS.ASSIGN_TO_TEAM.value}`}
             render={this.routedAssignToTeam} />
           <Route
-            path="/queue/appeals/:appealId/modal/create_mail_task"
-            render={this.routedCreateMailTask} />
+            path={`/queue/appeals/:appealId/${TASK_ACTIONS.CREATE_MAIL_TASK.value}`}
+            render={this.routedAssignToTeam} />
           <Route
             path={`/queue/appeals/:appealId/${TASK_ACTIONS.ASSIGN_TO_PERSON.value}`}
             render={this.routedAssignToUser} />

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -1,7 +1,7 @@
 {
     "ASSIGN_TO_PERSON": { "label": "Assign to person", "value": "modal/assign_to_person", "func": "assign_to_user_data" },
     "ASSIGN_TO_TEAM": { "label": "Assign to team", "value": "modal/assign_to_team", "func": "assign_to_organization_data" },
-    "CREATE_MAIL_TASK": { "label": "Create mail task", "value": "modal/create_mail_task", "func": "assign_to_organization_data" },
+    "CREATE_MAIL_TASK": { "label": "Create mail task", "value": "modal/create_mail_task", "func": "mail_assign_to_organization_data" },
     "MARK_COMPLETE": { "label": "Mark task complete", "value": "modal/mark_task_complete" },
     "REASSIGN_TO_PERSON": { "label": "Re-assign to person", "value": "modal/reassign_to_person", "func": "assign_to_user_data" },
     "RETURN_TO_JUDGE": { "label": "Return to judge", "value": "modal/assign_to_person", "func": "assign_to_judge_data" }


### PR DESCRIPTION
Making the change suggested in a comment on a previous PR: https://github.com/department-of-veterans-affairs/caseflow/pull/7484#pullrequestreview-168570609