### PR TITLE
Fix seed data to not create vacols case that is already there

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -484,23 +484,12 @@ class SeedDB
 
   def create_previously_held_hearing_data
     user = User.find_by_css_id("BVAAABSHIRE")
-    veteran_file_number = "994806951S"
-    appeals = LegacyAppeal.where(vbms_id: veteran_file_number)
+    appeal = LegacyAppeal.find_or_create_by(vacols_id: "3617215", vbms_id: "994806951S")
 
-    return if (appeals.map(&:type) - ["Post Remand", "Original"]).empty? &&
-              appeals.flat_map(&:hearings).map(&:disposition).include?(:held)
+    return if ([appeal.type] - ["Post Remand", "Original"]).empty? &&
+              appeal.hearings.map(&:disposition).include?(:held)
 
-    FactoryBot.create(
-      :legacy_appeal,
-      vacols_case: FactoryBot.create(
-        :case,
-        :assigned,
-        :type_original,
-        user: user,
-        bfcorlid: veteran_file_number,
-        case_hearings: [FactoryBot.create(:case_hearing, :disposition_held, user: user)]
-      )
-    )
+    FactoryBot.create(:case_hearing, :disposition_held, user: user, folder_nr: appeal.vacols_id)
   end
 
   def seed


### PR DESCRIPTION
Turns out that the case that we were trying to create in Facols is already there from the Facols seed data. Take a looky here: https://github.com/department-of-veterans-affairs/caseflow/blob/master/local/vacols/VACOLS::Case_dump.csv#L226

So do not create it!

