### PR TITLE
shorten wording when canceling intake edit

### DIFF
--- a/client/app/intakeEdit/pages/canceled.jsx
+++ b/client/app/intakeEdit/pages/canceled.jsx
@@ -13,7 +13,7 @@ class Canceled extends Component {
       formType
     } = this.props;
     const formName = _.find(FORM_TYPES, { key: formType }).name;
-    const message = `No changes were made to ${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName}.
+    const message = `No changes were made to ${veteran.name}'s (ID #${veteran.fileNumber}) ${formName}.
 Go to VBMS claim details and click the “Edit in Caseflow” button to return to edit.`;
 
     return <div>


### PR DESCRIPTION
Connects #7276

### Description
The wording for the form name when canceling an intake edit was awkward, so we've shortened it a bit by taking out 'Request For'.

before:
<img width="1417" alt="screen shot 2018-10-26 at 3 13 59 pm" src="https://user-images.githubusercontent.com/279406/47594817-ed243c80-d931-11e8-81de-4e2d3674643a.png">

after:
<img width="1408" alt="screen shot 2018-10-26 at 3 12 40 pm" src="https://user-images.githubusercontent.com/279406/47594808-e5649800-d931-11e8-864c-677419036104.png">

### Acceptance Criteria
N/A

### Testing Plan
N/A
