### PR TITLE
Remove Organizations' reliance on staff table for membership

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -20,23 +20,6 @@ class Organization < ApplicationRecord
   end
 
   def user_has_access?(user)
-    members.pluck(:id).include?(user.id)
-  end
-
-  def members
-    @members ||= User.where(css_id: member_css_ids.uniq)
-  end
-
-  private
-
-  def member_css_ids
-    return [] if staff_field_for_organization.empty?
-
-    staff_records = VACOLS::Staff.where(sactive: "A")
-    staff_field_for_organization.each do |sfo|
-      staff_records = sfo.filter_staff_records(staff_records)
-    end
-
-    staff_records.pluck(:sdomainid)
+    users.pluck(:id).include?(user.id)
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -164,9 +164,9 @@ class Task < ApplicationRecord
 
   def assign_to_user_data
     users = if assigned_to.is_a?(Organization)
-              assigned_to.members
+              assigned_to.users
             elsif parent && parent.assigned_to.is_a?(Organization)
-              parent.assigned_to.members.reject { |member| member == assigned_to }
+              parent.assigned_to.users.reject { |u| u == assigned_to }
             else
               []
             end


### PR DESCRIPTION
Connects #7596. Replaces the `Organization` models reliance on the `vacols.staff` table for membership with the caseflow `organizations_users` table.

I added the members of the QR team to the new table by running the following in the prod rails console:
```
rails c> org = QualityReview.singleton
rails c> org.members.each { |u| OrganizationsUser.add_user_to_organization(u, org) }
```

### TODO:
* Make tests pass