### PR TITLE
persist appeals when searching by vbms id

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -37,7 +37,7 @@ class AppealRepository
       VACOLS::Case.where(bfcorlid: vbms_id).includes(:folder, :correspondent, :representatives)
     end
 
-    cases.map { |case_record| build_appeal(case_record) }
+    cases.map { |case_record| build_appeal(case_record, true) }
   end
 
   # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/7579

### Description
If multiple appeals are passed with `nil` values for id to our serializers, the serializer drops all but one appeal (it treats `nil` as a unique id even though it's not). As a result, if more than one appeal without a LegacyAppeal row in our DB was found in case search, all but one would be dropped by the serializer and not shown in case search results.

We need to save appeals before passing them to the serializer.
