### PR TITLE
Stop creating duplicate BvaDispatchTasks

### DIFF
--- a/app/models/tasks/quality_review_task.rb
+++ b/app/models/tasks/quality_review_task.rb
@@ -13,7 +13,10 @@ class QualityReviewTask < GenericTask
   end
 
   def mark_as_complete!
-    BvaDispatchTask.create_and_assign(root_task)
+    # QualityReviewTasks may be assigned to organizations or individuals. However, for each appeal that goes through
+    # quality review the a task assigned to the organization will exist (even if there is none assigned to an
+    # individual). To prevent creating duplicate BvaDispatchTasks only create one for the organization task.
+    BvaDispatchTask.create_and_assign(root_task) if assigned_to == QualityReview.singleton
     super
   end
 end


### PR DESCRIPTION
Currently we are creating BvaDispatchTasks every time a QualityReviewTask is marked complete. Doing so creates duplicate BvaDispatchTasks when QualityReviewTasks are assigned to members of the QR team as well as the organizational QualityReviewTask. This PR fixes that.

Related slack conversation: https://dsva.slack.com/archives/C6E41RE92/p1540909625107100