### PR TITLE
Replace nil docket numbers with label

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -182,7 +182,7 @@ class AppealRepository
       last_location_change_date: normalize_vacols_date(case_record.bfdloout),
       outcoding_date: normalize_vacols_date(folder_record.tioctime),
       private_attorney_or_agent: case_record.bfso == "T",
-      docket_number: folder_record.tinum,
+      docket_number: folder_record.tinum || "Missing Docket Number",
       docket_date: case_record.bfd19
     )
 


### PR DESCRIPTION
Resolves #7610.

Mirrors [what we do for AMA appeals](https://github.com/department-of-veterans-affairs/caseflow/blob/4ed9d4c43259c86c0429fba102d172a6aed8ade1/app/models/appeal.rb#L149) if we do not have a docket number.
