### PR TITLE
Ineligibility reasons not showing up correctly on Edit page

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -74,6 +74,12 @@ class RequestIssue < ApplicationRecord
     review_request_type.try(:constantize).try(:review_title)
   end
 
+  def in_active_review
+    return unless rating_issue_reference_id
+    request_issue = self.class.find_active_by_reference_id(rating_issue_reference_id)
+    request_issue.review_title if request_issue
+  end
+
   def eligible?
     ineligible_reason.nil?
   end
@@ -86,7 +92,9 @@ class RequestIssue < ApplicationRecord
       decision_date: decision_date,
       category: issue_category,
       notes: notes,
-      is_unidentified: is_unidentified
+      is_unidentified: is_unidentified,
+      ineligible_reason: ineligible_reason,
+      in_active_review: in_active_review
     }
   end
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -47,9 +47,11 @@ export class AddIssuesPage extends React.Component {
   checkIfEligible = (issue, formType) => {
     if (issue.isUnidentified) {
       return false;
-    } else if (issue.inActiveReview) {
-      return INELIGIBLE_REQUEST_ISSUES.in_active_review.replace('{review_title}', issue.inActiveReview);
-    } else if (!issue.timely && formType !== 'supplemental_claim') {
+    } else if (issue.inActiveReview || issue.ineligibleReason === 'duplicate_of_issue_in_active_review') {
+      return INELIGIBLE_REQUEST_ISSUES.duplicate_of_issue_in_active_review.replace('{review_title}', issue.inActiveReview);
+    } else if (issue.ineligibleReason) {
+      return INELIGIBLE_REQUEST_ISSUES[ineligibleReason];
+    } else if (issue.timely === false && formType !== 'supplemental_claim') {
       return INELIGIBLE_REQUEST_ISSUES.untimely;
     } else if (issue.sourceHigherLevelReview && formType === 'higher_level_review') {
       return INELIGIBLE_REQUEST_ISSUES.previous_higher_level_review;

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -79,12 +79,14 @@ export const validNonRatedIssue = (issue) => {
 
 export const formatRequestIssues = (requestIssues) => {
   return requestIssues.map((issue) => {
+    console.log("issue::", issue)
     if (issue.category) {
       return {
         isRated: false,
         category: issue.category,
         description: issue.description,
-        decisionDate: issue.decision_date
+        decisionDate: issue.decision_date,
+        ineligibleReason: issue.ineligible_reason
       };
     }
 
@@ -105,7 +107,9 @@ export const formatRequestIssues = (requestIssues) => {
       id: issue.reference_id,
       profileDate: issueDate.toISOString(),
       notes: issue.notes,
-      description: issue.description
+      description: issue.description,
+      ineligibleReason: issue.ineligible_reason,
+      inActiveReview: issue.in_active_review
     };
   });
 };
@@ -261,7 +265,8 @@ export const formatAddedIssues = (intakeData) => {
         inActiveReview: issue.inActiveReview,
         sourceHigherLevelReview: issue.sourceHigherLevelReview,
         promulgationDate: issue.promulgationDate,
-        timely: issue.timely
+        timely: issue.timely,
+        ineligibleReason: issue.ineligibleReason
       };
     }
 
@@ -276,7 +281,8 @@ export const formatAddedIssues = (intakeData) => {
       referenceId: issue.id,
       text: `${issue.category} - ${issue.description}`,
       date: formatDate(issue.decisionDate),
-      timely: isTimely
+      timely: isTimely,
+      ineligibleReason: issue.ineligibleReason
     };
   });
 };

--- a/client/constants/INELIGIBLE_REQUEST_ISSUES.json
+++ b/client/constants/INELIGIBLE_REQUEST_ISSUES.json
@@ -1,5 +1,5 @@
 {
-  "in_active_review": "is ineligible because it's already under review as a {review_title}",
+  "duplicate_of_issue_in_active_review": "is ineligible because it's already under review as a {review_title}",
   "untimely": "is ineligible because it has a prior decision date that’s older than 1 year",
   "previous_higher_level_review": "is ineligible because it was last processed as a Higher-Level Review and this can't be done twice in a row"
 }


### PR DESCRIPTION
connects #7587

Originally this bug was just for ineligibility due to timeliness on the edit page, but I noticed that it would affect the other ineligibility reasons as well so there is code for those too.