### PR TITLE
ignoring CVE-2018-1000201 until rails fixes it

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -20,6 +20,10 @@ task :security_caseflow do
   if Time.zone.local(2018, 9, 10) < Time.zone.today - 1.week
     audit_cmd = "bundle-audit check"
   end
+
+  # ignore CVE-2018-1000201 (awaiting on https://github.com/rails/rails-html-sanitizer/pull/73)
+  audit_cmd += " --ignore CVE-2018-16468"
+
   audit_result = ShellCommand.run(audit_cmd)
 
   puts "\n"


### PR DESCRIPTION
ruby advisory fails on

```
Name: loofah
Version: 2.2.2
Advisory: CVE-2018-16468
Criticality: Unknown
URL: https://github.com/flavorjones/loofah/issues/154
Title: Loofah XSS Vulnerability
Solution: upgrade to >= 2.2.3
```

Once https://github.com/rails/rails-html-sanitizer/pull/73 is merged, we can remove this exception.