### PR TITLE
Render unidentified issues on intake confirmation page

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -83,6 +83,7 @@ class RequestIssue < ApplicationRecord
       reference_id: rating_issue_reference_id,
       profile_date: rating_issue_profile_date,
       description: description,
+      contention_text: contention_text,
       decision_date: decision_date,
       category: issue_category,
       notes: notes,

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -15,21 +15,21 @@ const getAppealChecklistItems = (requestIssues) => [<Fragment>
 // higher level reviews & supplemental claims
 const getClaimReviewChecklistItems = (formType, requestIssues, isInformalConferenceRequested) => {
   const checklist = [];
-  const ratedIssues = requestIssues.filter((ri) => ri.isRated || ri.isUnidentified);
-  const nonRatedIssues = requestIssues.filter((ri) => ri.isRated === false);
+  const ratingIssues = requestIssues.filter((ri) => ri.isRated || ri.isUnidentified);
+  const nonratingIssues = requestIssues.filter((ri) => ri.isRated === false);
   const claimReviewName = _.find(FORM_TYPES, { key: formType }).shortName;
 
-  if (ratedIssues.length > 0) {
+  if (ratingIssues.length > 0) {
     checklist.push(<Fragment>
       <strong>A {claimReviewName} Rating EP is being established:</strong>
-      {ratedIssues.map((ri, i) => <p key={i}>Contention: {ri.description}</p>)}
+      {ratingIssues.map((ri, i) => <p key={`rating-issue-${i}`}>Contention: {ri.description}</p>)}
     </Fragment>);
   }
 
-  if (nonRatedIssues.length > 0) {
+  if (nonratingIssues.length > 0) {
     checklist.push(<Fragment>
       <strong>A {claimReviewName} Nonrating EP is being established:</strong>
-      {nonRatedIssues.map((nri, i) => <p key={i}>Contention: {nri.contentionText}</p>)}
+      {nonratingIssues.map((nri, i) => <p key={`nonrating-issue-${i}`}>Contention: {nri.contentionText}</p>)}
     </Fragment>);
   }
 

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -15,8 +15,7 @@ const getAppealChecklistItems = (requestIssues) => [<Fragment>
 // higher level reviews & supplemental claims
 const getClaimReviewChecklistItems = (formType, requestIssues, isInformalConferenceRequested) => {
   const checklist = [];
-  const ratedIssues = requestIssues.filter((ri) => ri.isRated);
-  // unidentified issues have undefined isRated
+  const ratedIssues = requestIssues.filter((ri) => ri.isRated || ri.isUnidentified);
   const nonRatedIssues = requestIssues.filter((ri) => ri.isRated === false);
   const claimReviewName = _.find(FORM_TYPES, { key: formType }).shortName;
 
@@ -30,7 +29,7 @@ const getClaimReviewChecklistItems = (formType, requestIssues, isInformalConfere
   if (nonRatedIssues.length > 0) {
     checklist.push(<Fragment>
       <strong>A {claimReviewName} Nonrating EP is being established:</strong>
-      {nonRatedIssues.map((nri, i) => <p key={i}>Contention: {nri.description}</p>)}
+      {nonRatedIssues.map((nri, i) => <p key={i}>Contention: {nri.contentionText}</p>)}
     </Fragment>);
   }
 

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -71,6 +71,8 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       <strong>Edit the notice letter to reflect the status of requested issues.</strong>
     ];
 
+    const checklistClassNames = ['cf-intake-statusmessage-checklist', 'cf-success-checklist', 'cf-left-padding'];
+
     return <StatusMessage
       title="Intake completed"
       type="success"
@@ -78,6 +80,7 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       checklist={formType === 'appeal' ?
         getAppealChecklistItems(requestIssues) :
         getClaimReviewChecklistItems(formType, requestIssues, informalConference)}
+      checklistClassNames={checklistClassNames}
       wrapInAppSegment={false}
     />;
   }

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -77,6 +77,8 @@ export const validNonRatedIssue = (issue) => {
   return true;
 };
 
+// formatRequestIssues takes an array of requestIssues in the server ui_hash format
+// and returns objects useful for displaying in UI
 export const formatRequestIssues = (requestIssues) => {
   return requestIssues.map((issue) => {
     if (issue.category) {
@@ -84,6 +86,7 @@ export const formatRequestIssues = (requestIssues) => {
         isRated: false,
         category: issue.category,
         description: issue.description,
+        contentionText: issue.contention_text,
         decisionDate: issue.decision_date
       };
     }
@@ -92,6 +95,7 @@ export const formatRequestIssues = (requestIssues) => {
     if (issue.is_unidentified) {
       return {
         description: issue.description,
+        contentionText: issue.contention_text,
         notes: issue.notes,
         isUnidentified: issue.is_unidentified
       };
@@ -105,7 +109,8 @@ export const formatRequestIssues = (requestIssues) => {
       id: issue.reference_id,
       profileDate: issueDate.toISOString(),
       notes: issue.notes,
-      description: issue.description
+      description: issue.description,
+      contentionText: issue.contention_text
     };
   });
 };

--- a/client/app/styles/_intake.scss
+++ b/client/app/styles/_intake.scss
@@ -3,6 +3,8 @@
   padding-left: 0.5em;
 }
 
+// the .cf-app-segment is needed in this rule so .cf-intake-statusmessage-checklist has a higher
+// specificity than the existing .cf-success-checklist class.
 .cf-app-segment .cf-intake-statusmessage-checklist {
   max-width: 800px;
   margin: 50px auto 65px;

--- a/client/app/styles/_intake.scss
+++ b/client/app/styles/_intake.scss
@@ -3,9 +3,9 @@
   padding-left: 0.5em;
 }
 
-ul.cf-intake-statusmessage-checklist {
+.cf-app-segment .cf-intake-statusmessage-checklist {
   max-width: 800px;
-  margin: 50px auto 65px auto;
+  margin: 50px auto 65px;
 }
 
 .cf-intake-substeps {

--- a/client/app/styles/_intake.scss
+++ b/client/app/styles/_intake.scss
@@ -3,6 +3,11 @@
   padding-left: 0.5em;
 }
 
+ul.cf-intake-statusmessage-checklist {
+  max-width: 800px;
+  margin: 50px auto 65px auto;
+}
+
 .cf-intake-substeps {
   padding-left: 1em;
 }

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -420,6 +420,7 @@ RSpec.feature "Appeal Intake" do
     safe_click "#button-finish-intake"
 
     expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
+    expect(page).to have_content("This is an unidentified issue")
 
     expect(Appeal.find_by(
              id: appeal.id,

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -228,7 +228,7 @@ RSpec.feature "Higher-Level Review" do
     expect(page).to have_content(
       "A #{Constants.INTAKE_FORM_NAMES_SHORT.higher_level_review} Nonrating EP is being established:"
     )
-    expect(page).to have_content("Contention: Description for Active Duty Adjustments")
+    expect(page).to have_content("Contention: Active Duty Adjustments - Description for Active Duty Adjustments")
     expect(page).to have_content("Informal Conference Tracked Item")
 
     # ratings end product

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -692,6 +692,7 @@ RSpec.feature "Higher-Level Review" do
       safe_click "#button-finish-intake"
 
       expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+      expect(page).to have_content("This is an unidentified issue")
 
       # make sure that database is populated
       expect(HigherLevelReview.find_by(

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -532,6 +532,7 @@ RSpec.feature "Supplemental Claim Intake" do
       safe_click "#button-finish-intake"
 
       expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
+      expect(page).to have_content("This is an unidentified issue")
 
       expect(SupplementalClaim.find_by(
                id: supplemental_claim.id,

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -222,7 +222,7 @@ RSpec.feature "Supplemental Claim Intake" do
     expect(page).to have_content(
       "A #{Constants.INTAKE_FORM_NAMES_SHORT.supplemental_claim} Nonrating EP is being established:"
     )
-    expect(page).to have_content("Contention: Description for Active Duty Adjustments")
+    expect(page).to have_content("Contention: Active Duty Adjustments - Description for Active Duty Adjustments")
 
     # ratings end product
     expect(Fakes::VBMSService).to have_received(:establish_claim!).with(


### PR DESCRIPTION
Connects #7303 

### Description
- Fixes an issue where unidentified issues weren't showing up on the intake confirmation page, even though we create a Rating EP for them
- Widens the checklist so contention text is more legible 
- Displays contention_text instead of description for nonrated issues, which includes the category

Note - showing the warning alert for the unidentified issues per mock in #7303 will come in a later pr.

<img width="898" alt="screen shot 2018-10-30 at 5 32 15 pm" src="https://user-images.githubusercontent.com/279406/47807552-9fc11a00-dcf9-11e8-994b-5ea933fe8e22.png">

### Acceptance Criteria
- When an intake with an unidentified issue is completed, the confirmation page shows the unidentified issue under a rating EP
- When an intake is completed, the checklist in the confirmation page displays text in a legible way
- When an intake with a nonrated issue is completed, the confirmation page includes the category when displaying the nonrated issue

### Testing Plan
1. Complete any intake with an unidentified and nonrated issue
2. On the confirmation page, confirm the points in the description
