### PR TITLE
Bump loofah to 2.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem "jbuilder", "~> 2.0"
 gem "sdoc", "~> 0.4.0", group: :doc
 
 gem "active_model_serializers", "~> 0.10.0"
+# active_model_serializers has a default dependency on loofah 2.2.2 which has a security vuln (CVE-2018-16468)
+gem "loofah", ">= 2.2.3"
 
 # soft delete gem
 gem "paranoia", "~> 2.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     connection_pool (2.2.1)
     cork (0.3.0)
       colored2 (~> 3.1)
-    crass (1.0.3)
+    crass (1.0.4)
     d3-rails (4.13.0)
       railties (>= 3.1)
     danger (5.5.5)
@@ -259,7 +259,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -534,6 +534,7 @@ DEPENDENCIES
   jquery-rails
   jshint
   launchy
+  loofah (>= 2.2.3)
   moment_timezone-rails
   newrelic_rpm
   nokogiri (= 1.8.5)

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -21,9 +21,6 @@ task :security_caseflow do
     audit_cmd = "bundle-audit check"
   end
 
-  # ignore CVE-2018-1000201 (awaiting on https://github.com/rails/rails-html-sanitizer/pull/73)
-  audit_cmd += " --ignore CVE-2018-16468"
-
   audit_result = ShellCommand.run(audit_cmd)
 
   puts "\n"


### PR DESCRIPTION
Boo this got rejected: https://github.com/rails/rails-html-sanitizer/pull/73

so instead we should just manually update loofah to get around the ruby audit alert.