### PR TITLE
Remove rails log statements used during debugging.

### DIFF
--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -46,7 +46,6 @@ class ScheduleHearingTask < GenericTask
     hearing_pkseq = task_business_payloads[0].values["hearing_pkseq"]
     hearing_type = task_business_payloads[0].values["hearing_type"]
     hearing = VACOLS::CaseHearing.find(hearing_pkseq)
-    Rails.logger.info("OARVT hearing_hash #{task_business_payloads[0]} .")
     if hearing_type == Hearing::CO_HEARING
       HearingRepository.update_vacols_hearing!(hearing, folder_nr: appeal.vacols_id)
     else

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -59,7 +59,6 @@ class HearingRepository
       parent_hearing_hash[:vdkey] = parent_hearing_hash[:hearing_pkseq]
       parent_hearing_hash.delete(:hearing_pkseq)
       parent_hearing_hash[:hearing_type] = "V"
-      Rails.logger.info("OARVT hearing_hash #{parent_hearing_hash} .")
       VACOLS::CaseHearing.create_child_hearing!(parent_hearing_hash)
     end
 


### PR DESCRIPTION
Resolves #7641 

### Description
Removed debugging log statements left during development.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Schedule a hearing. 
2. Check no logging statements with code OARVT in text show up.

