### PR TITLE
Include instructions to clone repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ cd /opt/oracle/instantclient_11_2
 sudo ln -s libclntsh.so.12.1 libclntsh.so
 ```
 
+### Clone this repo
+Navigate to the directory you'd like to clone this repo into and run:
+
+    git clone https://github.com/department-of-veterans-affairs/caseflow.git
+
 ### Install Ruby dependencies
 
     cd caseflow


### PR DESCRIPTION
### Description
Noticed the README didn't explicitly contain an instruction to clone the repo before installing dependencies inside the repo, so I added a line with instructions.
