### PR TITLE
Only show available_actions for active tasks

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -31,9 +31,15 @@ class Task < ApplicationRecord
   # from TASK_ACTIONS that looks something like:
   # [ { "label": "Assign to person", "value": "modal/assign_to_person", "func": "assignable_users" }, ... ]
   def available_actions_unwrapper(user)
+    return [] if no_actions_available(user)
+
     available_actions(user).map do |a|
       { label: a[:label], value: a[:value], data: a[:func] ? send(a[:func]) : nil }
     end
+  end
+
+  def no_actions_available(_user)
+    [Constants.TASK_STATUSES.on_hold, Constants.TASK_STATUSES.completed].include?(status)
   end
 
   def assigned_by_display_name

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -31,14 +31,14 @@ class Task < ApplicationRecord
   # from TASK_ACTIONS that looks something like:
   # [ { "label": "Assign to person", "value": "modal/assign_to_person", "func": "assignable_users" }, ... ]
   def available_actions_unwrapper(user)
-    return [] if no_actions_available(user)
+    return [] if no_actions_available?(user)
 
     available_actions(user).map do |a|
       { label: a[:label], value: a[:value], data: a[:func] ? send(a[:func]) : nil }
     end
   end
 
-  def no_actions_available(_user)
+  def no_actions_available?(_user)
     [Constants.TASK_STATUSES.on_hold, Constants.TASK_STATUSES.completed].include?(status)
   end
 

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -37,6 +37,7 @@ class ColocatedTask < Task
 
   def available_actions(user)
     return [] unless user.colocated_in_vacols?
+    return [] if completed?
 
     actions = [
       {

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -37,7 +37,6 @@ class ColocatedTask < Task
 
   def available_actions(user)
     return [] unless user.colocated_in_vacols?
-    return [] if completed?
 
     actions = [
       {
@@ -59,6 +58,10 @@ class ColocatedTask < Task
     end
 
     actions
+  end
+
+  def no_actions_available(_user)
+    completed?
   end
 
   def update_if_hold_expired!

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -60,7 +60,7 @@ class ColocatedTask < Task
     actions
   end
 
-  def no_actions_available(_user)
+  def no_actions_available?(_user)
     completed?
   end
 

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -1,9 +1,6 @@
 class GenericTask < Task
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
   def available_actions(user)
-    return [] if [Constants.TASK_STATUSES.on_hold, Constants.TASK_STATUSES.completed].include?(status)
-
     if assigned_to.is_a?(Vso) && assigned_to.user_has_access?(user)
       return [Constants.TASK_ACTIONS.MARK_COMPLETE.to_h]
     end
@@ -26,7 +23,6 @@ class GenericTask < Task
 
     []
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/AbcSize
 
   def update_from_params(params, current_user)

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -1,6 +1,9 @@
 class GenericTask < Task
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
   def available_actions(user)
+    return [] if [Constants.TASK_STATUSES.on_hold, Constants.TASK_STATUSES.completed].include?(status)
+
     if assigned_to.is_a?(Vso) && assigned_to.user_has_access?(user)
       return [Constants.TASK_ACTIONS.MARK_COMPLETE.to_h]
     end
@@ -23,6 +26,7 @@ class GenericTask < Task
 
     []
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/AbcSize
 
   def update_from_params(params, current_user)

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -263,16 +263,16 @@ describe ColocatedTask do
     end
   end
 
-  describe ".available_actions" do
+  describe ".available_actions_unwrapper" do
     let(:colocated_task) { ColocatedTask.find(FactoryBot.create(:colocated_task, assigned_by: attorney).id) }
     let(:colocated_user) { FactoryBot.create(:user) }
     before { FactoryBot.create(:staff, :colocated_role, user: colocated_user) }
 
     it "should vary depending on status of task" do
-      expect(colocated_task.available_actions(colocated_user).count).to_not eq(0)
+      expect(colocated_task.available_actions_unwrapper(colocated_user).count).to_not eq(0)
 
       colocated_task.update!(status: Constants.TASK_STATUSES.completed)
-      expect(colocated_task.available_actions(colocated_user).count).to eq(0)
+      expect(colocated_task.available_actions_unwrapper(colocated_user).count).to eq(0)
     end
   end
 end

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -262,4 +262,17 @@ describe ColocatedTask do
       end
     end
   end
+
+  describe ".available_actions" do
+    let(:colocated_task) { ColocatedTask.find(FactoryBot.create(:colocated_task, assigned_by: attorney).id) }
+    let(:colocated_user) { FactoryBot.create(:user) }
+    before { FactoryBot.create(:staff, :colocated_role, user: colocated_user) }
+
+    it "should vary depending on status of task" do
+      expect(colocated_task.available_actions(colocated_user).count).to_not eq(0)
+
+      colocated_task.update!(status: Constants.TASK_STATUSES.completed)
+      expect(colocated_task.available_actions(colocated_user).count).to eq(0)
+    end
+  end
 end

--- a/spec/models/tasks/generic_task_spec.rb
+++ b/spec/models/tasks/generic_task_spec.rb
@@ -55,6 +55,42 @@ describe GenericTask do
         expect(subject).to eq(expected_actions)
       end
     end
+
+    context "when task assigned to the user is has been completed" do
+      let(:user) { FactoryBot.create(:user) }
+      let(:task) do
+        GenericTask.find(
+          FactoryBot.create(
+            :generic_task,
+            assigned_to: user,
+            status: Constants.TASK_STATUSES.completed
+          ).id
+        )
+      end
+      let(:expected_actions) { [] }
+      it "should return an empty list" do
+        expect(subject).to eq(expected_actions)
+      end
+    end
+
+    context "when task assigned to an organization the user is a member of is on hold" do
+      let(:org) { Organization.find(FactoryBot.create(:organization).id) }
+      let(:task) do
+        GenericTask.find(
+          FactoryBot.create(
+            :generic_task,
+            assigned_to: org,
+            status: Constants.TASK_STATUSES.on_hold
+          ).id
+        )
+      end
+      let(:user) { FactoryBot.create(:user) }
+      let(:expected_actions) { [] }
+      before { allow_any_instance_of(Organization).to receive(:user_has_access?).and_return(true) }
+      it "should return an empty list" do
+        expect(subject).to eq(expected_actions)
+      end
+    end
   end
 
   describe ".verify_user_access!" do

--- a/spec/models/tasks/generic_task_spec.rb
+++ b/spec/models/tasks/generic_task_spec.rb
@@ -55,18 +55,16 @@ describe GenericTask do
         expect(subject).to eq(expected_actions)
       end
     end
+  end
+
+  describe ".available_actions_unwrapper" do
+    let(:user) { FactoryBot.create(:user) }
+    let(:task) { GenericTask.find(FactoryBot.create(:generic_task, assigned_to: assignee, status: status).id) }
+    subject { task.available_actions_unwrapper(user) }
 
     context "when task assigned to the user is has been completed" do
-      let(:user) { FactoryBot.create(:user) }
-      let(:task) do
-        GenericTask.find(
-          FactoryBot.create(
-            :generic_task,
-            assigned_to: user,
-            status: Constants.TASK_STATUSES.completed
-          ).id
-        )
-      end
+      let(:assignee) { user }
+      let(:status) { Constants.TASK_STATUSES.completed }
       let(:expected_actions) { [] }
       it "should return an empty list" do
         expect(subject).to eq(expected_actions)
@@ -74,17 +72,8 @@ describe GenericTask do
     end
 
     context "when task assigned to an organization the user is a member of is on hold" do
-      let(:org) { Organization.find(FactoryBot.create(:organization).id) }
-      let(:task) do
-        GenericTask.find(
-          FactoryBot.create(
-            :generic_task,
-            assigned_to: org,
-            status: Constants.TASK_STATUSES.on_hold
-          ).id
-        )
-      end
-      let(:user) { FactoryBot.create(:user) }
+      let(:assignee) { Organization.find(FactoryBot.create(:organization).id) }
+      let(:status) { Constants.TASK_STATUSES.on_hold }
       let(:expected_actions) { [] }
       before { allow_any_instance_of(Organization).to receive(:user_has_access?).and_return(true) }
       it "should return an empty list" do


### PR DESCRIPTION
Limited in scope to only GenericTasks and ColocatedTasks for now since we expect those to be the most frequent occurrences. GenericTasks will be assigned through organizations which should not have available actions when there are active child tasks (this PR fixes this situation), and ColocatedTasks should not be actionable once they have been returned to the assigning attorney even though colocated staffers will still be able to view the appeals to which they are connected.