### PR TITLE
make stdout sync so we can see security rake task output

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -3,6 +3,7 @@ require "rainbow"
 
 desc "shortcut to run all linting tools, at the same time."
 task :security_caseflow do
+  $stdout.sync = true
   puts "running Brakeman security scan..."
   brakeman_result = ShellCommand.run(
     "brakeman --exit-on-warn --run-all-checks --confidence-level=2"


### PR DESCRIPTION
### Description
Like https://github.com/department-of-veterans-affairs/caseflow/pull/7324, but for the security rake task

### Acceptance Criteria
- [ ] Security rake task failures show up in CI

### Testing Plan
N/A
