### PR TITLE
fix judge assignment script

### DIFF
--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -77,6 +77,7 @@ class JudgeTask < Task
 
   def self.eligible_for_assigment?(task)
     # Hearing cases will not be processed until February 2019
+    return false if task.appeal.class == LegacyAppeal
     return false if task.appeal.hearing_docket?
 
     # If it's an evidence submission case, we need to wait until the


### PR DESCRIPTION
We now need to exclude RootTasks associated with LegacyAppeals, since hearings is creating RootTasks for LegacyAppeals.