### PR TITLE
Hide ineligible issues on case details page

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -11,7 +11,8 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
         disposition: issue.disposition,
         program: "Compensation",
         description: issue.description,
-        remand_reasons: issue.remand_reasons
+        remand_reasons: issue.remand_reasons,
+        is_eligible: issue.eligible?
       }
     end
   end

--- a/client/app/queue/components/CaseDetailsIssueList.jsx
+++ b/client/app/queue/components/CaseDetailsIssueList.jsx
@@ -25,7 +25,7 @@ const headingStyling = css({
 
 export default function CaseDetailsIssueList(props) {
   return <React.Fragment>
-    {props.issues.map((issue, i) =>
+    {props.issues.filter((iss) => iss.is_eligible).map((issue, i) =>
       <div key={i} {...singleIssueContainerStyling}>
         <h3 {...headingStyling}>Issue {1 + i}</h3>
         { props.isLegacyAppeal ?

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -44,6 +44,7 @@ export type Issue = {
   labels: Array<string>,
   readjudication: Boolean,
   remand_reasons: Array<Object>,
+  is_eligible: Boolean,
   description?: string
 };
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -273,6 +273,26 @@ RSpec.feature "Case details" do
     end
   end
 
+  context "when an appeal has an issue that is ineligble" do
+    let(:eligble_issue_cnt) { 5 }
+    let(:ineligble_issue_cnt) { 3 }
+    let(:issues) do
+      [
+        build_list(:request_issue, eligble_issue_cnt, description: "Knee pain"),
+        build_list(:request_issue, ineligble_issue_cnt, description: "Sunburn", ineligible_reason: "untimely")
+      ].flatten
+    end
+    let!(:appeal) { FactoryBot.create(:appeal, request_issues: issues) }
+
+    scenario "only eligble issues should appear in case details page" do
+      visit "/queue/appeals/#{appeal.uuid}"
+
+      # byebug
+      expect(page).to have_content("Issue #{eligble_issue_cnt}")
+      expect(page).to_not have_content("Issue #{eligble_issue_cnt + 1}")
+    end
+  end
+
   context "loads judge task detail views" do
     let!(:vacols_case) do
       FactoryBot.create(


### PR DESCRIPTION
Resolves #7625. Hides ineligible issues on the case details page.