### PR TITLE
Daily Docket Fixes

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -1,7 +1,8 @@
 class HearingsController < ApplicationController
-  before_action :verify_access, except: [:show_print, :show]
+  before_action :verify_access, except: [:show_print, :show, :update]
   before_action :check_hearing_prep_out_of_service
   before_action :verify_access_to_reader_or_hearings, only: [:show_print, :show]
+  before_action :verify_access_to_hearing_prep_or_schedule, only: [:update]
 
   def update
     hearing.update(update_params)
@@ -36,6 +37,10 @@ class HearingsController < ApplicationController
 
   def verify_access_to_reader_or_hearings
     verify_authorized_roles("Reader", "Hearing Prep")
+  end
+
+  def verify_access_to_hearing_prep_or_schedule
+    verify_authorized_roles("Hearing Prep", "Edit HearSched", "Build HearSched")
   end
 
   def set_application

--- a/app/repositories/hearing_day_repository.rb
+++ b/app/repositories/hearing_day_repository.rb
@@ -28,7 +28,7 @@ class HearingDayRepository
         result << to_canonical_hash(hearing)
       end
       travel_board = VACOLS::TravelBoardSchedule.load_days_for_range(start_date, end_date)
-      [video_and_co, travel_board]
+      [video_and_co.uniq { |hearing_day| hearing_day[:hearing_date] && hearing_day[:room_info] }, travel_board]
     end
 
     def load_days_for_central_office(start_date, end_date)

--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -139,17 +139,16 @@ class ListSchedule extends React.Component {
     };
 
     const hearingScheduleRows = _.map(hearingSchedule, (hearingDay) => ({
-      hearingDate: formatDate(hearingDay.hearingDate),
+      hearingDate: <Link to={`/schedule/docket/${hearingDay.id}`}>{formatDate(hearingDay.hearingDate)}</Link>,
       hearingType: hearingDay.hearingType,
       regionalOffice: hearingDay.regionalOffice,
       room: hearingDay.roomInfo,
       vlj: formatVljName(hearingDay.judgeLastName, hearingDay.judgeFirstName)
     }));
 
-    const removeCoDuplicates = _.uniqWith(hearingScheduleRows, _.isEqual);
-    const uniqueHearingTypes = populateFilterDropDowns(removeCoDuplicates, 'hearingType');
-    const uniqueVljs = populateFilterDropDowns(removeCoDuplicates, 'vlj');
-    const uniqueLocations = populateFilterDropDowns(removeCoDuplicates, 'regionalOffice');
+    const uniqueHearingTypes = populateFilterDropDowns(hearingScheduleRows, 'hearingType');
+    const uniqueVljs = populateFilterDropDowns(hearingScheduleRows, 'vlj');
+    const uniqueLocations = populateFilterDropDowns(hearingScheduleRows, 'regionalOffice');
     const fileName = `HearingSchedule ${this.props.startDateValue}-${this.props.endDateValue}.csv`;
 
     const hearingScheduleColumns = [
@@ -244,7 +243,7 @@ class ListSchedule extends React.Component {
         <Button
           classNames={['usa-button-secondary']}>
           <CSVLink
-            data={removeCoDuplicates}
+            data={hearingScheduleRows}
             target="_blank"
             filename={fileName}>
             Download current view
@@ -254,7 +253,7 @@ class ListSchedule extends React.Component {
       <div {...hearingSchedStyling} className="section-hearings-list">
         <Table
           columns={hearingScheduleColumns}
-          rowObjects={removeCoDuplicates}
+          rowObjects={hearingScheduleRows}
           summary="hearing-schedule"
         />
       </div>


### PR DESCRIPTION
This PR:
- updates user permissions such that Build HearSched, Edit HearSched, and Hearing Prep can update hearings in VACOLS
- adds links to the Daily Docket from the View Schedule page
- updates the hearing day controller to only return unique CO records

