### PR TITLE
fix bgs call

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -44,7 +44,11 @@ class ExternalApi::BGSService
                             modifier = #{end_product_modifier}",
                             service: :bgs,
                             name: "claims.cancel_end_product") do
-        client.claims.cancel_end_product(veteran_file_number, end_product_code, end_product_modifier)
+        client.claims.cancel_end_product(
+          file_number: veteran_file_number,
+          end_product_code: end_product_code,
+          modifier: end_product_modifier
+        )
       end
   end
 


### PR DESCRIPTION
Connects #6214

Fixes this error https://sentry.uat.ds.va.gov/sentry/caseflow-uat/issues/1061/

```
wrong number of arguments (given 3, expected 0; required keywords: file_number, end_product_code, modifier)
```