### PR TITLE
Upgrade rack to avoid XSS and DoS vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,10 @@ gem "zero_downtime_migrations"
 # https://github.com/sparklemotion/nokogiri/pull/1746
 gem "nokogiri", "1.8.5"
 
+# rack versions before 2.0.6 are affected by CVE-2018-16470 and CVE-2018-16471.
+# Explicitly define rack version here to avoid that.
+gem "rack", "~> 2.0.6"
+
 group :production, :staging, :ssh_forwarding, :development, :test do
   # Oracle DB
   gem "activerecord-oracle_enhanced-adapter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,7 +316,7 @@ GEM
     public_suffix (3.0.1)
     puma (3.12.0)
     quantile (0.2.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -548,6 +548,7 @@ DEPENDENCIES
   pry
   pry-byebug
   puma (~> 3.12.0)
+  rack (~> 2.0.6)
   rails (= 5.1.6)
   rails_stdout_logging
   rainbow


### PR DESCRIPTION
This PR addresses the following bundle-audit complaints:
```
Name: rack
Version: 2.0.5
Advisory: CVE-2018-16471
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/NAalCee8n6o
Title: Possible XSS vulnerability in Rack
Solution: upgrade to ~> 1.6.11, >= 2.0.6

Name: rack
Version: 2.0.5
Advisory: CVE-2018-16470
Criticality: Unknown
URL: https://groups.google.com/forum/#!topic/ruby-security-ann/Dz4sRl-ktKk
Title: Possible DoS vulnerability in Rack
Solution: upgrade to >= 2.0.6
```