### PR TITLE
Fix job error routing

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,23 +7,9 @@ class ApplicationJob < ActiveJob::Base
     attr_reader :app_name
   end
 
-  around_perform do |job, block|
-    begin
-      block.call
-    rescue StandardError => ex
-      tags = { job: job.class.name, queue: job.queue_name }
-      context = {
-        job_id: job.job_id,
-        queue_name: job.queue_name,
-        job_class: job.class.name
-      }
-      Raven.capture_exception(ex, tags: tags, extra: context)
-      raise
-    end
-  end
-
-  before_perform do
+  before_perform do |job|
     # setup debug context
-    Raven.extra_context(application: self.class.app_name.to_s)
+    Raven.tags_context({ job: job.class.name, queue: job.queue_name })
+    Raven.extra_context({ application: self.class.app_name.to_s })
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -9,7 +9,7 @@ class ApplicationJob < ActiveJob::Base
 
   before_perform do |job|
     # setup debug context
-    Raven.tags_context({ job: job.class.name, queue: job.queue_name })
-    Raven.extra_context({ application: self.class.app_name.to_s })
+    Raven.tags_context(job: job.class.name, queue: job.queue_name)
+    Raven.extra_context(application: self.class.app_name.to_s)
   end
 end

--- a/app/jobs/calculate_dispatch_stats_job.rb
+++ b/app/jobs/calculate_dispatch_stats_job.rb
@@ -1,5 +1,6 @@
 class CalculateDispatchStatsJob < ApplicationJob
   queue_as :low_priority
+  application_attr :dispatch
 
   # :nocov:
   def perform

--- a/app/jobs/calculate_intake_stats_job.rb
+++ b/app/jobs/calculate_intake_stats_job.rb
@@ -1,5 +1,6 @@
 class CalculateIntakeStatsJob < ApplicationJob
   queue_as :low_priority
+  application_attr :intake
 
   # :nocov:
   def perform

--- a/app/jobs/fetch_documents_for_reader_user_job.rb
+++ b/app/jobs/fetch_documents_for_reader_user_job.rb
@@ -12,14 +12,14 @@ class FetchDocumentsForReaderUserJob < ApplicationJob
       appeals_total: 0,
       appeals_successful: 0
     }
-    AddSeriesIdToDocumentsService.add_series_ids(LegacyAppeal.first)
+
     setup_debug_context(reader_user)
     update_fetched_at(reader_user)
     appeals = reader_user.user.current_case_assignments
     fetch_documents_for_appeals(appeals)
     log_info
   rescue StandardError => e
-    # log_error
+    log_error
     # raising an exception here triggers a retry through shoryuken
     raise e
   end

--- a/app/jobs/fetch_documents_for_reader_user_job.rb
+++ b/app/jobs/fetch_documents_for_reader_user_job.rb
@@ -12,14 +12,14 @@ class FetchDocumentsForReaderUserJob < ApplicationJob
       appeals_total: 0,
       appeals_successful: 0
     }
-
+    AddSeriesIdToDocumentsService.add_series_ids(LegacyAppeal.first)
     setup_debug_context(reader_user)
     update_fetched_at(reader_user)
     appeals = reader_user.user.current_case_assignments
     fetch_documents_for_appeals(appeals)
     log_info
   rescue StandardError => e
-    log_error
+    # log_error
     # raising an exception here triggers a retry through shoryuken
     raise e
   end

--- a/app/jobs/reassign_old_tasks_job.rb
+++ b/app/jobs/reassign_old_tasks_job.rb
@@ -1,5 +1,6 @@
 class ReassignOldTasksJob < ApplicationJob
   queue_as :low_priority
+  application_attr :dispatch
 
   def perform
     Dispatch::Task.assigned_not_completed.where(type: Dispatch::Task::REASSIGN_OLD_TASKS).each(&:expire!)

--- a/app/jobs/start_certification_job.rb
+++ b/app/jobs/start_certification_job.rb
@@ -1,6 +1,7 @@
 class StartCertificationJob < ApplicationJob
   queue_as :high_priority
   attr_accessor :certification
+  application_attr :certification
 
   def perform(certification, user = nil)
     @certification = certification

--- a/app/services/add_series_id_to_documents_service.rb
+++ b/app/services/add_series_id_to_documents_service.rb
@@ -1,7 +1,7 @@
-class AddSeriesIdToDocumentsJob < ApplicationJob
+class AddSeriesIdToDocumentsService < ApplicationJob
   queue_as :low_priority
 
-  def perform(appeal)
+  def self.add_series_ids(appeal)
     documents_to_check = Document.where(file_number: appeal.veteran_file_number).where(series_id: nil)
 
     if documents_to_check.count > 0

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -46,7 +46,7 @@ class DocumentFetcher
   end
 
   def save!
-    AddSeriesIdToDocumentsJob.perform_now(appeal)
+    AddSeriesIdToDocumentsService.add_series_ids(appeal)
 
     ids = documents.map(&:vbms_document_id)
     existing_documents = Document.where(vbms_document_id: ids)

--- a/spec/services/add_series_id_to_documents_service_spec.rb
+++ b/spec/services/add_series_id_to_documents_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe AddSeriesIdToDocumentsJob do
+describe AddSeriesIdToDocumentsService do
   context ".perform" do
     let(:appeal) do
       Generators::LegacyAppeal.build
@@ -61,7 +61,7 @@ describe AddSeriesIdToDocumentsJob do
       end
 
       it "assigns series_ids to documents without them" do
-        AddSeriesIdToDocumentsJob.perform_now(appeal)
+        AddSeriesIdToDocumentsService.add_series_ids(appeal)
 
         documents_without_series.zip(series_ids).each do |document, series_id|
           expect(document.reload.series_id).to eq(series_id)
@@ -84,7 +84,7 @@ describe AddSeriesIdToDocumentsJob do
       end
 
       it "documents with series ids are not touched" do
-        AddSeriesIdToDocumentsJob.perform_now(appeal)
+        AddSeriesIdToDocumentsService.add_series_ids(appeal)
 
         documents_with_series.zip(series_ids).each do |document, series_id|
           expect(document.reload.series_id).to eq(series_id)


### PR DESCRIPTION
### Description
The Raven gem we use already has an active job integration to report errors. So our error reporting is duplicated 😮 . This change gets rid of our reporting and relies on the gem's reporting: https://github.com/getsentry/raven-ruby/blob/master/lib/raven/integrations/rails/active_job.rb

We add also set the tags correctly for this method of reporting errors.

A number of jobs did not have their application names set. This PR updates them.

Finally, the fetch documents for reader job currently calls another job in a `perform_now`. However, since this is a job in a job, it messes up the error reporting. Errors get reported twice, and the outer job reporting doesn't get tagged with the application because Raven unsets the context after reporting an error. A workaround is to turn this into a service, instead of a job (which is probably more correct anyway). That change allows the error to only be reported once by the outer job!

### Acceptance Criteria
- [ ] Errors are only reported once, and have the right application set

### Testing Plan
1. Add:
```
module Raven
  class Rails
    module ActiveJobExtensions
      def capture_and_reraise_with_sentry(job, block)
        block.call
      rescue Exception => exception # rubocop:disable Lint/RescueException
        puts "#{job.class.name} CONTEXT-extra: #{Raven.context.extra}"

        return if rescue_with_handler(exception)
        unless already_supported_by_specific_integration?(job)
          Raven.capture_exception(exception, :extra => raven_context(job))
        end
        raise exception
      ensure
        Context.clear!
        BreadcrumbBuffer.clear!
      end
    end
  end
end
```
To `shoryuken.rb`.
2. Run shoryuken: `bundle exec shoryuken start -q caseflow_development_high_priority caseflow_development_low_priority -R`
3. Open up a Rails console and run `FetchDocumentsForReaderUserJob.perform_later(ReaderUser.first)`
4. Ensure the context printed has the application name.

