### PR TITLE
explain how to fix security audit failures

### DIFF
--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -14,11 +14,11 @@ task :security_caseflow do
 
   snoozed_cves = [
     # Example:
-    # { cve_name: 'CVE-2018-1000201', until: Time.zone.local(2018, 9, 10) }
+    # { cve_name: "CVE-2018-1000201", until: Time.zone.local(2018, 9, 10) }
   ]
 
   alerting_cves = snoozed_cves
-    .filter { |cve| cve[:until] <= Time.zone.today }
+    .select { |cve| cve[:until] <= Time.zone.today }
     .map { |cve| cve[:cve_name] }
 
   audit_result = ShellCommand.run("bundle-audit check --ignore=#{alerting_cves.join(' ')}")

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -30,7 +30,10 @@ task :security_caseflow do
     puts Rainbow(
       "Failed. Security vulnerabilities were found. Find the dependency in Gemfile.lock, "\
       "then specify a safe version of the dependency in the Gemfile (preferred) or "\
-      "snooze the CVE in security.rake for a week"
+      "snooze the CVE in security.rake for a week."
+    ).red
+    puts Rainbow(
+      "See https://github.com/department-of-veterans-affairs/caseflow/pull/7639 for an example."
     ).red
     exit!(1)
   end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -12,13 +12,26 @@ task :security_caseflow do
   puts "running bundle-audit to check for insecure dependencies..."
   exit!(1) unless ShellCommand.run("bundle-audit update")
 
-  audit_result = ShellCommand.run("bundle-audit check")
+  snoozed_cves = [
+    # Example:
+    # { cve_name: 'CVE-2018-1000201', until: Time.zone.local(2018, 9, 10) }
+  ]
+
+  alerting_cves = snoozed_cves
+    .filter { |cve| cve[:until] <= Time.zone.today }
+    .map { |cve| cve[:cve_name] }
+
+  audit_result = ShellCommand.run("bundle-audit check --ignore=#{alerting_cves.join(' ')}")
 
   puts "\n"
   if brakeman_result && audit_result
     puts Rainbow("Passed. No obvious security vulnerabilities.").green
   else
-    puts Rainbow("Failed. Security vulnerabilities were found.").red
+    puts Rainbow(
+      "Failed. Security vulnerabilities were found. Find the dependency in Gemfile.lock, "\
+      "then specify a safe version of the dependency in the Gemfile (preferred) or "\
+      "snooze the CVE in security.rake for a week"
+    ).red
     exit!(1)
   end
 end


### PR DESCRIPTION
### Description
We've seen a couple times where Brakeman fails CI on a security audit of the installed gems. Adding an explanation of how to address when this comes up so people don't get stuck.

In addition to the audit findings (which list a CVE and the gem in violation), the rake task will also print the following:
```
Failed. Security vulnerabilities were found. Find the dependency in Gemfile.lock, then specify a safe version of the dependency in the Gemfile (preferred) or snooze the CVE in security.rake for a week.
See https://github.com/department-of-veterans-affairs/caseflow/pull/7639 for an example.
```

### Acceptance Criteria
N/A

### Testing Plan
N/A
