### PR TITLE
Do not wrap the upstream sync and the db update in a transaction

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -160,14 +160,8 @@ class EndProductEstablishment < ApplicationRecord
 
     fail EstablishedEndProductNotFound unless result
 
-    transaction do
-      update!(
-        synced_status: result.status_type_code,
-        last_synced_at: Time.zone.now
-      )
-
-      sync_source!
-    end
+    sync_source!
+    update!(synced_status: result.status_type_code, last_synced_at: Time.zone.now)
   rescue EstablishedEndProductNotFound => e
     raise e
   rescue StandardError => e


### PR DESCRIPTION
connects #7753 

### Description
If upstream syncs take longer than the psql transaction timeout length, the whole transaction will fail.

This may be the desired behavior, because it ensures that the sync will be attempted again later.

Alternative would be to increase the psql transaction timeout length, which is currently 30 seconds.

in `config/database.yml`
```
statement_timeout: 30_000 # 30 seconds
```

### Acceptance Criteria
- [ ] Code compiles correctly


