### PR TITLE
Tries alternative claim number if ssn does not work in VBMS request

### DIFF
--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -5,6 +5,9 @@ class PrepareEstablishClaimTasksJob < ApplicationJob
   def perform
     count = { success: 0, fail: 0 }
 
+    # Set user to system_user to avoid sensitivity errors
+    RequestStore.store[:current_user] = User.system_user
+
     EstablishClaim.unprepared.each do |task|
       status = task.prepare_with_decision!
       count[:success] += ((status == :success) ? 1 : 0)

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -37,7 +37,19 @@ class ExternalApi::VBMSService
 
     veteran_file_number = appeal.veteran_file_number
     request = VBMS::Requests::FindDocumentVersionReference.new(veteran_file_number)
-    documents = send_and_log_request(veteran_file_number, request)
+
+    begin
+      documents = send_and_log_request(veteran_file_number, request)
+    rescue VBMS::HTTPError => e
+      raise unless e.body.include?("File Number does not exist within the system.")
+
+      alternative_file_number = ExternalApi::BGSService.new.fetch_veteran_info(veteran_file_number)[:claim_number]
+
+      raise if alternative_file_number == veteran_file_number
+
+      request = VBMS::Requests::FindDocumentVersionReference.new(alternative_file_number)
+      documents = send_and_log_request(alternative_file_number, request)
+    end
 
     Rails.logger.info("Document list length: #{documents.length}")
 


### PR DESCRIPTION
Resolves #4567

### Description
In some situations the file number in VACOLS (the `bfcorlid` column) is incorrect. It will be the SSN where it should be a claim number. When hitting the VBMS endpoint to get a list of files, we use the wrong number, and get an error with text: "File Number does not exist within the system." To solve this problem we can make a call to BGS to find the correct file number and then call VBMS with that instead.

