### PR TITLE
Updating selection styling

### DIFF
--- a/client/app/constants/AppConstants.js
+++ b/client/app/constants/AppConstants.js
@@ -15,6 +15,7 @@ export const COLORS = {
   GOLD_LIGHT: '#F9C642',
   GREEN_LIGHTER: '#94BFA2',
   GREY_BACKGROUND: '#f9f9f9',
+  COLOR_COOL_BLUE_LIGHTER: '#8ba6ca',
   PRIMARY: '#0071bc',
   BASE: '#212121',
   RED_DARK: '#cd2026'

--- a/client/app/reader/CommentLayer.jsx
+++ b/client/app/reader/CommentLayer.jsx
@@ -14,6 +14,8 @@ import { placeAnnotation, showPlaceAnnotationIcon,
 } from '../reader/AnnotationLayer/AnnotationActions';
 
 import { CATEGORIES } from '../reader/analytics';
+import { css } from 'glamor';
+import { COLORS } from '../constants/AppConstants';
 
 const DIV_STYLING = {
   width: '100%',
@@ -21,6 +23,17 @@ const DIV_STYLING = {
   zIndex: 10,
   position: 'relative'
 };
+
+const SELECTION_STYLING = css({
+  '> div': {
+    '::selection': {
+      background: COLORS.COLOR_COOL_BLUE_LIGHTER
+    },
+    '::-moz-selection': {
+      background: COLORS.COLOR_COOL_BLUE_LIGHTER
+    }
+  }
+});
 
 // The comment layer is a div on top of a page that draws the comment
 // icons on the page. It is the div that receives the onClick
@@ -170,6 +183,7 @@ class CommentLayer extends PureComponent {
       ref={this.getCommentLayerDivRef}>
       {this.props.isVisible && this.getCommentIcons()}
       <div
+        {...SELECTION_STYLING}
         style={TEXT_LAYER_STYLING}
         ref={this.props.getTextLayerRef}
         className="textLayer" />


### PR DESCRIPTION
### Description
Currently the text selection color is: 
![screen shot 2018-11-07 at 12 53 53 pm](https://user-images.githubusercontent.com/3885236/48150297-41adad00-e28c-11e8-9738-7868a065110c.png)

Which is not visible. This PR changes it to this:
![screen shot 2018-11-07 at 12 53 25 pm](https://user-images.githubusercontent.com/3885236/48150298-41adad00-e28c-11e8-8a5e-fa4ac03bb4ce.png)

### Testing Plan
1. Go into Reader and select text.

