### PR TITLE
ineligible enum should be string not integer

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -10,9 +10,9 @@ class RequestIssue < ApplicationRecord
   validates :ineligible_reason, exclusion: { in: ["untimely"] }, if: proc { |reqi| reqi.untimely_exemption }
 
   enum ineligible_reason: {
-    duplicate_of_issue_in_active_review: 0,
-    untimely: 1,
-    previous_higher_level_review: 2
+    duplicate_of_issue_in_active_review: "duplicate_of_issue_in_active_review",
+    untimely: "untimely",
+    previous_higher_level_review: "previous_higher_level_review"
   }
 
   UNIDENTIFIED_ISSUE_MSG = "UNIDENTIFIED ISSUE - Please click \"Edit in Caseflow\" button to fix".freeze

--- a/db/migrate/20181107182512_request_issue_enum_as_string.rb
+++ b/db/migrate/20181107182512_request_issue_enum_as_string.rb
@@ -1,0 +1,20 @@
+class RequestIssueEnumAsString < ActiveRecord::Migration[5.1]
+  def up
+    # add a new string column, convert the data, then drop the old column and rename the new
+    add_column :request_issues, :ineligible_reason_str, :string
+    execute "UPDATE request_issues SET ineligible_reason_str='duplicate_of_issue_in_active_review' WHERE ineligible_reason=0"
+    execute "UPDATE request_issues SET ineligible_reason_str='untimely' WHERE ineligible_reason=1"
+    execute "UPDATE request_issues SET ineligible_reason_str='previous_higher_level_review' WHERE ineligible_reason=2"
+    remove_column :request_issues, :ineligible_reason
+    rename_column :request_issues, :ineligible_reason_str, :ineligible_reason
+  end
+
+  def down
+    add_column :request_issues, :ineligible_reason_int, :integer
+    execute "UPDATE request_issues SET ineligible_reason_int=0 WHERE ineligible_reason='duplicate_of_issue_in_active_review'" 
+    execute "UPDATE request_issues SET ineligible_reason_int=1 WHERE ineligible_reason='untimely'"
+    execute "UPDATE request_issues SET ineligible_reason_int=2 WHERE ineligible_reason='previous_higher_level_review'"
+    remove_column :request_issues, :ineligible_reason
+    rename_column :request_issues, :ineligible_reason_int, :ineligible_reason
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181101193212) do
+ActiveRecord::Schema.define(version: 20181107182512) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -629,14 +629,13 @@ ActiveRecord::Schema.define(version: 20181101193212) do
     t.integer "parent_request_issue_id"
     t.text "notes"
     t.boolean "is_unidentified"
-    t.integer "ineligible_reason"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
     t.bigint "ineligible_due_to_id"
+    t.string "ineligible_reason"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["ineligible_due_to_id"], name: "index_request_issues_on_ineligible_due_to_id"
-    t.index ["ineligible_reason"], name: "index_request_issues_on_ineligible_reason"
     t.index ["parent_request_issue_id"], name: "index_request_issues_on_parent_request_issue_id"
     t.index ["rating_issue_reference_id"], name: "index_request_issues_on_rating_issue_reference_id"
     t.index ["review_request_type", "review_request_id"], name: "index_request_issues_on_review_request"


### PR DESCRIPTION
### Description
Our convention is to use `enum` columns as string values for easier use outside the Rails app.


