### PR TITLE
Moving all tasks assigned to VSOs to IHP tasks

### DIFF
--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -1,10 +1,6 @@
 class GenericTask < Task
   # rubocop:disable Metrics/AbcSize
   def available_actions(user)
-    if assigned_to.is_a?(Vso) && assigned_to.user_has_access?(user)
-      return [Constants.TASK_ACTIONS.MARK_COMPLETE.to_h]
-    end
-
     if assigned_to == user
       return [
         Constants.TASK_ACTIONS.ASSIGN_TO_TEAM.to_h,

--- a/db/migrate/20181107185230_change_generic_tasks_assigned_to_vsos_to_ihps.rb
+++ b/db/migrate/20181107185230_change_generic_tasks_assigned_to_vsos_to_ihps.rb
@@ -1,0 +1,8 @@
+class ChangeGenericTasksAssignedToVsosToIhps < ActiveRecord::Migration[5.1]
+  def up
+    GenericTask.joins("JOIN organizations ON assigned_to_id=organizations.id").
+      where("assigned_to_type=?", "Organization").
+      where("organizations.type=?", "Vso").
+      update_all(type: "InformalHearingPresentationTask")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181107182512) do
+ActiveRecord::Schema.define(version: 20181107185230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -629,9 +629,9 @@ ActiveRecord::Schema.define(version: 20181107182512) do
     t.integer "parent_request_issue_id"
     t.text "notes"
     t.boolean "is_unidentified"
+    t.bigint "ineligible_due_to_id"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
-    t.bigint "ineligible_due_to_id"
     t.string "ineligible_reason"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"


### PR DESCRIPTION
Connects #7480

### Description
Moving tasks assigned to VSOs to IHP tasks, and removing the check for VSOs in GenericTasks

### Testing Plan
1. Run the migration locally and ensure the GenericTasks assigned to VSO users are changed to IHP tasks.

