### PR TITLE
Naming conflicts from hearing prep fields

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -5,8 +5,8 @@ class HearingsController < ApplicationController
   before_action :verify_access_to_hearing_prep_or_schedule, only: [:update]
 
   def update
-    if params["hearing"]["date"]
-      HearingRepository.slot_new_hearing(params["hearing"]["date"], hearing.appeal)
+    if params["hearing"]["master_record_updated"]
+      HearingRepository.slot_new_hearing(params["hearing"]["master_record_updated"], hearing.appeal)
     end
 
     hearing.update(update_params)

--- a/client/app/hearingSchedule/containers/DailyDocketContainer.jsx
+++ b/client/app/hearingSchedule/containers/DailyDocketContainer.jsx
@@ -37,8 +37,7 @@ export class DailyDocketContainer extends React.Component {
     return {
       disposition: hearing.editedDisposition ? hearing.editedDisposition : hearing.disposition,
       notes: hearing.editedNotes ? hearing.editedNotes : hearing.notes,
-      date: hearing.editedDate ? hearing.editedDate : null,
-      time: hearing.editedTime ? hearing.editedTime : null
+      master_record_updated: hearing.editedDate ? hearing.editedDate : null
     };
   };
 


### PR DESCRIPTION
### Description
In hearing scheduling, we only send a date param when we want to update a child record's parent record. In the controller, we had added logic to create a new child record on a new parent record when the date param is set. 

However, in hearing prep, we send a date param regardless of whether or not the date was edited, so we were accidentally going into the new master record logic.

I updated the param in hearing scheduling to `master_record_updated` to avoid these param naming conflicts.

### Testing Plan
1. Go to the hearing prep daily docket and confirm you can update a hearing field
1. Go to the hearing schedule daily docket and confirm you can update a hearing date for both video and co records

