### PR TITLE
Immutable decision issues

### DIFF
--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -44,21 +44,17 @@ class RatingIssue
   def save_decision_issue
     return unless source_request_issue
 
-    # if a DecisionIssue already exists, update rather than attempt to insert a duplicate.
-    # don't bother updating if already set.
-    if decision_issue
-      return if decision_issue.source_request_issue == source_request_issue
-      decision_issue.update!(source_request_issue: source_request_issue)
-    else
-      DecisionIssue.create!(
-        source_request_issue: source_request_issue,
-        rating_issue_reference_id: reference_id,
-        participant_id: participant_id,
-        promulgation_date: promulgation_date,
-        decision_text: decision_text,
-        profile_date: profile_date
-      )
-    end
+    # if a DecisionIssue already exists then do not touch it. These should be immutable.
+    return if decision_issue
+
+    DecisionIssue.create!(
+      source_request_issue: source_request_issue,
+      rating_issue_reference_id: reference_id,
+      participant_id: participant_id,
+      promulgation_date: promulgation_date,
+      decision_text: decision_text,
+      profile_date: profile_date
+    )
   end
 
   # If you change this method, you will need to clear cache in prod for your changes to

--- a/db/migrate/20181109131525_remove_null_constraint_decision_issue_rating_ref_id.rb
+++ b/db/migrate/20181109131525_remove_null_constraint_decision_issue_rating_ref_id.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintDecisionIssueRatingRefId < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :decision_issues, :rating_issue_reference_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181107225536) do
+ActiveRecord::Schema.define(version: 20181109131525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -190,7 +190,7 @@ ActiveRecord::Schema.define(version: 20181107225536) do
     t.datetime "promulgation_date"
     t.datetime "profile_date"
     t.integer "participant_id", null: false
-    t.string "rating_issue_reference_id", null: false
+    t.string "rating_issue_reference_id"
     t.string "decision_text"
     t.index ["rating_issue_reference_id", "participant_id"], name: "decision_issues_uniq_idx", unique: true
     t.index ["source_request_issue_id"], name: "index_decision_issues_on_source_request_issue_id"
@@ -630,10 +630,10 @@ ActiveRecord::Schema.define(version: 20181107225536) do
     t.integer "parent_request_issue_id"
     t.text "notes"
     t.boolean "is_unidentified"
-    t.bigint "ineligible_due_to_id"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
     t.string "ramp_claim_id"
+    t.bigint "ineligible_due_to_id"
     t.string "ineligible_reason"
     t.datetime "decision_sync_submitted_at"
     t.datetime "decision_sync_attempted_at"

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -218,11 +218,10 @@ describe RatingIssue do
 
     it "does not save duplicates" do
       decision_issue = create(:decision_issue, rating_issue_reference_id: reference_id, participant_id: participant_id)
-      subject.save_decision_issue
 
-      expect(subject.source_request_issue).to eq(request_issue)
+      expect(subject.save_decision_issue).to eq(nil)
       expect(subject.decision_issue).to eq(decision_issue)
-      expect(subject.decision_issue.source_request_issue).to eq(request_issue)
+      expect(decision_issue.source_request_issue).to_not eq(request_issue)
     end
 
     it "returns nil if no source_request_issue is found" do


### PR DESCRIPTION
connects #7761

### Description

* Do not try and update DecisionIssues during RatingIssue sync.
* Allow for null `rating_issue_reference_id` to support nonrating decisions

