### PR TITLE
Fix payee code

### DIFF
--- a/client/app/intake/reducers/intake.js
+++ b/client/app/intake/reducers/intake.js
@@ -21,7 +21,7 @@ const updateFromServerIntake = (state, serverIntake) => {
       fileNumber: {
         $set: serverIntake.veteran_file_number
       },
-      deceased: {
+      isDeceased: {
         $set: serverIntake.veteran_is_deceased
       }
     }
@@ -45,7 +45,7 @@ export const mapDataToInitialIntake = (data = { serverIntake: {} }) => (
       name: '',
       formName: '',
       fileNumber: '',
-      deceased: null
+      isDeceased: null
     },
     requestStatus: {
       fileNumberSearch: REQUEST_STATE.NOT_STARTED,

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -536,8 +536,7 @@ RSpec.feature "Higher-Level Review" do
     end
 
     scenario "do not show veteran as a valid payee code" do
-      _, intake = start_higher_level_review(veteran)
-
+      start_higher_level_review(veteran)
       visit "/intake"
 
       # click on payee code dropdown

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -530,6 +530,28 @@ RSpec.feature "Higher-Level Review" do
     FeatureToggle.disable!(:intake_enable_add_issues_page)
   end
 
+  context "when veteran is deceased" do
+    let(:veteran) do
+      Generators::Veteran.build(file_number: "123121234", date_of_death: Date.new(2017, 11, 20))
+    end
+
+    scenario "do not show veteran as a valid payee code" do
+      _, intake = start_higher_level_review(veteran)
+
+      visit "/intake"
+
+      # click on payee code dropdown
+      within_fieldset("Is the claimant someone other than the Veteran?") do
+        find("label", text: "Yes", match: :prefer_exact).click
+      end
+      find(".Select-control").click
+
+      # verify that veteran cannot be selected
+      expect(page).not_to have_content("00 - Veteran")
+      expect(page).to have_content("10 - Spouse")
+    end
+  end
+
   context "For new Add / Remove Issues page" do
     def check_row(label, text)
       row = find("tr", text: label)

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -406,6 +406,28 @@ RSpec.feature "Supplemental Claim Intake" do
     expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
   end
 
+  context "when veteran is deceased" do
+    let(:veteran) do
+      Generators::Veteran.build(file_number: "123121234", date_of_death: Date.new(2017, 11, 20))
+    end
+
+    scenario "do not show veteran as a valid payee code" do
+      _, intake = start_supplemental_claim(veteran)
+
+      visit "/intake"
+
+      # click on payee code dropdown
+      within_fieldset("Is the claimant someone other than the Veteran?") do
+        find("label", text: "Yes", match: :prefer_exact).click
+      end
+      find(".Select-control").click
+
+      # verify that veteran cannot be selected
+      expect(page).not_to have_content("00 - Veteran")
+      expect(page).to have_content("10 - Spouse")
+    end
+  end
+
   context "For new Add / Remove Issues page" do
     def check_row(label, text)
       row = find("tr", text: label)

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -412,7 +412,7 @@ RSpec.feature "Supplemental Claim Intake" do
     end
 
     scenario "do not show veteran as a valid payee code" do
-      _, intake = start_supplemental_claim(veteran)
+      start_supplemental_claim(veteran)
 
       visit "/intake"
 


### PR DESCRIPTION
Connects #6842

Fix a misname of a variable. Adds tests on checking payee code filter.

![image](https://user-images.githubusercontent.com/577629/48294432-0b616080-e439-11e8-9fd7-0075e61d6090.png)
