### PR TITLE
intake feature test helpers

### DIFF
--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -356,7 +356,7 @@ RSpec.feature "Appeal Intake" do
     expect(page).to_not have_content("Notes:")
 
     # removing the issue should hide the issue
-    safe_click ".remove-issue"
+    click_remove_intake_issue("1")
 
     expect(page).to_not have_content("Left knee granted")
 
@@ -409,8 +409,7 @@ RSpec.feature "Appeal Intake" do
     expect(page).to_not have_content("5. Really old injury #{Constants.INELIGIBLE_REQUEST_ISSUES.untimely}")
 
     # remove and re-add with different answer to exemption
-    page.all(".remove-issue").last.click
-
+    click_remove_intake_issue("5")
     click_intake_add_issue
     add_intake_rating_issue("Really old injury")
     add_untimely_exemption_response("No")

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -155,7 +155,7 @@ RSpec.feature "Appeal Intake" do
 
     find("label", text: "PTSD denied").click
 
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     safe_click ".Select"
     expect(page).to have_content("1 issue")
@@ -173,7 +173,7 @@ RSpec.feature "Appeal Intake" do
 
     expect(page).to have_content("2 issues")
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
     expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES_SHORT.appeal} created:")
@@ -265,7 +265,7 @@ RSpec.feature "Appeal Intake" do
 
     expect(page).to have_content("This Veteran has no rated, disability issues")
 
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     safe_click ".Select"
 
@@ -276,7 +276,7 @@ RSpec.feature "Appeal Intake" do
 
     expect(page).to have_content("1 issue")
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
   end

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -338,7 +338,7 @@ RSpec.feature "Appeal Intake" do
     check_row("Claimant", "Ed Merica")
 
     # clicking the add issues button should bring up the modal
-    safe_click "#button-add-issue"
+    click_intake_add_issue
     expect(page).to have_content("Add issue 1")
     expect(page).to have_content("Does issue 1 match any of these issues")
     expect(page).to have_content("Left knee granted")
@@ -349,9 +349,8 @@ RSpec.feature "Appeal Intake" do
     expect(page).to_not have_content("Left knee granted")
 
     # adding an issue should show the issue
-    safe_click "#button-add-issue"
-    find_all("label", text: "Left knee granted").first.click
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_rating_issue("Left knee granted")
 
     expect(page).to have_content("1. Left knee granted")
     expect(page).to_not have_content("Notes:")
@@ -362,16 +361,14 @@ RSpec.feature "Appeal Intake" do
     expect(page).to_not have_content("Left knee granted")
 
     # re-add to proceed
-    safe_click "#button-add-issue"
-    find_all("label", text: "Left knee granted").first.click
-    fill_in "Notes", with: "I am an issue note"
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_rating_issue("Left knee granted", "I am an issue note")
 
     expect(page).to have_content("1. Left knee granted")
     expect(page).to have_content("I am an issue note")
 
     # clicking add issue again should show a disabled radio button for that same rating
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     expect(page).to have_content("Add issue 2")
     expect(page).to have_content("Does issue 2 match any of these issues")
@@ -379,42 +376,33 @@ RSpec.feature "Appeal Intake" do
     expect(page).to have_css("input[disabled][id='rating-radio_xyz123']", visible: false)
 
     # Add nonrating issue
-    safe_click ".no-matching-issues"
-    expect(page).to have_content("Does issue 2 match any of these issue categories?")
-    expect(page).to have_button("Add this issue", disabled: true)
-    fill_in "Issue category", with: "Active Duty Adjustments"
-    find("#issue-category").send_keys :enter
-    fill_in "Issue description", with: "Description for Active Duty Adjustments"
-    fill_in "Decision date", with: "04/19/2018"
-    expect(page).to have_button("Add this issue", disabled: false)
-    safe_click ".add-issue"
+    add_intake_nonrating_issue(
+      category: "Active Duty Adjustments",
+      description: "Description for Active Duty Adjustments",
+      date: "04/19/2018"
+    )
     expect(page).to have_content("2 issues")
+
     # this nonrating request issue is timely
     expect(page).to_not have_content(
       "Description for Active Duty Adjustments #{Constants.INELIGIBLE_REQUEST_ISSUES.untimely}"
     )
 
     # add unidentified issue
-    safe_click "#button-add-issue"
-    safe_click ".no-matching-issues"
-    safe_click ".no-matching-issues"
-    expect(page).to have_content("Describe the issue to mark it as needing further review.")
-    fill_in "Transcribe the issue as it's written on the form", with: "This is an unidentified issue"
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_unidentified_issue("This is an unidentified issue")
     expect(page).to have_content("3 issues")
     expect(page).to have_content("This is an unidentified issue")
 
     # add ineligible issue
-    safe_click "#button-add-issue"
-    find_all("label", text: "Old injury in review").first.click
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_rating_issue("Old injury in review")
     expect(page).to have_content("4 issues")
     expect(page).to have_content("4. Old injury in review is ineligible because it's already under review as a Appeal")
 
     # add untimely rating request issue
-    safe_click "#button-add-issue"
-    find_all("label", text: "Really old injury").first.click
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_rating_issue("Really old injury")
     add_untimely_exemption_response("Yes")
     expect(page).to have_content("5 issues")
     expect(page).to have_content("I am an exemption note")
@@ -422,24 +410,21 @@ RSpec.feature "Appeal Intake" do
 
     # remove and re-add with different answer to exemption
     page.all(".remove-issue").last.click
-    safe_click "#button-add-issue"
-    find_all("label", text: "Really old injury").first.click
-    safe_click ".add-issue"
+
+    click_intake_add_issue
+    add_intake_rating_issue("Really old injury")
     add_untimely_exemption_response("No")
     expect(page).to have_content("5 issues")
     expect(page).to have_content("I am an exemption note")
     expect(page).to have_content("5. Really old injury #{Constants.INELIGIBLE_REQUEST_ISSUES.untimely}")
 
     # add untimely nonrating request issue
-    safe_click "#button-add-issue"
-    safe_click ".no-matching-issues"
-    expect(page).to have_button("Add this issue", disabled: true)
-    fill_in "Issue category", with: "Active Duty Adjustments"
-    find("#issue-category").send_keys :enter
-    fill_in "Issue description", with: "Another Description for Active Duty Adjustments"
-    fill_in "Decision date", with: "04/19/2016"
-    expect(page).to have_button("Add this issue", disabled: false)
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_nonrating_issue(
+      category: "Active Duty Adjustments",
+      description: "Another Description for Active Duty Adjustments",
+      date: "04/19/2016"
+    )
     add_untimely_exemption_response("No", "I am an untimely exemption")
     expect(page).to have_content("6 issues")
     expect(page).to have_content("I am an untimely exemption")
@@ -448,35 +433,29 @@ RSpec.feature "Appeal Intake" do
     )
 
     # add before_ama ratings
-    safe_click "#button-add-issue"
-    find_all("label", text: "Non-RAMP Issue before AMA Activation").first.click
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
     expect(page).to have_content(
       "7. Non-RAMP Issue before AMA Activation #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
     )
 
     # Eligible because it comes from a RAMP decision
-    safe_click "#button-add-issue"
-    find_all("label", text: "Issue before AMA Activation from RAMP").first.click
-    safe_click ".add-issue"
-    expect(page).to have_content(
-      "8. Issue before AMA Activation from RAMP Decision date:"
-    )
+    click_intake_add_issue
+    add_intake_rating_issue("Issue before AMA Activation from RAMP")
+    expect(page).to have_content("8. Issue before AMA Activation from RAMP Decision date:")
 
-    safe_click "#button-add-issue"
-    safe_click ".no-matching-issues"
-    expect(page).to have_button("Add this issue", disabled: true)
-    fill_in "Issue category", with: "Drill Pay Adjustments"
-    find("#issue-category").send_keys :enter
-    fill_in "Issue description", with: "A nonrating issue before AMA"
-    fill_in "Decision date", with: "10/19/2017"
-    expect(page).to have_button("Add this issue", disabled: false)
-    safe_click ".add-issue"
+    # nonrating before_ama
+    click_intake_add_issue
+    add_intake_nonrating_issue(
+      category: "Drill Pay Adjustments",
+      description: "A nonrating issue before AMA",
+      date: "10/19/2017"
+    )
     expect(page).to have_content(
       "A nonrating issue before AMA #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
     )
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
     expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
@@ -562,16 +541,14 @@ RSpec.feature "Appeal Intake" do
     start_appeal(veteran)
     visit "/intake/add_issues"
 
-    safe_click "#button-add-issue"
-    find_all("label", text: "Left knee granted").first.click
-    fill_in "Notes", with: "I am an issue note"
-    safe_click ".add-issue"
+    click_intake_add_issue
+    add_intake_rating_issue("Left knee granted", "I am an issue note")
     add_untimely_exemption_response("Yes")
 
     ## Validate error message when complete intake fails
     expect_any_instance_of(AppealIntake).to receive(:complete!).and_raise("A random error. Oh no!")
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("Something went wrong")
     expect(page).to have_current_path("/intake/add_issues")
@@ -617,7 +594,7 @@ RSpec.feature "Appeal Intake" do
       start_appeal(veteran)
       visit "/intake/add_issues"
 
-      safe_click "#button-add-issue"
+      click_intake_add_issue
       expect(page).to have_content("Next")
     end
   end

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -89,8 +89,8 @@ RSpec.feature "Edit issues" do
 
       expect(page).to have_content("nonrating description")
       # remove an issue
-      page.all(".remove-issue")[0].click
-      safe_click ".remove-issue"
+      click_remove_intake_issue("1")
+      click_remove_issue_confirmation
       expect(page).not_to have_content("nonrating description")
 
       # add an issue
@@ -389,8 +389,8 @@ RSpec.feature "Edit issues" do
         expect(page).to_not have_content("Notes:")
 
         # remove existing issue
-        page.all(".remove-issue")[0].click
-        safe_click ".remove-issue"
+        click_remove_intake_issue("1")
+        click_remove_issue_confirmation
         expect(page).not_to have_content("PTSD denied")
 
         # re-add to proceed
@@ -538,17 +538,16 @@ RSpec.feature "Edit issues" do
         add_intake_rating_issue("Left knee granted")
         expect(page).to have_button("Save", disabled: false)
 
-        page.all(".remove-issue")[1].click
-        safe_click ".remove-issue"
+        click_remove_intake_issue("2")
+        click_remove_issue_confirmation
         expect(page).to_not have_content("Left knee granted")
         expect(page).to have_button("Save", disabled: true)
       end
 
       it "Does not allow save if no issues are selected" do
         visit "higher_level_reviews/#{rating_ep_claim_id}/edit"
-        safe_click ".remove-issue"
-        # click again to get rid of pop up
-        safe_click ".remove-issue"
+        click_remove_intake_issue("1")
+        click_remove_issue_confirmation
 
         expect(page).to have_button("Save", disabled: true)
       end
@@ -583,9 +582,8 @@ RSpec.feature "Edit issues" do
         allow(Fakes::VBMSService).to receive(:remove_contention!).and_call_original
 
         visit "higher_level_reviews/#{rating_ep_claim_id}/edit"
-        safe_click ".remove-issue"
-        # click again to get rid of pop-up
-        safe_click ".remove-issue"
+        click_remove_intake_issue("1")
+        click_remove_issue_confirmation
         click_intake_add_issue
         add_intake_rating_issue("Left knee granted")
 
@@ -819,11 +817,11 @@ RSpec.feature "Edit issues" do
 
         expect(page).to have_content("2. Left knee granted")
         expect(page).to_not have_content("Notes:")
-        safe_click ".remove-issue"
+        click_remove_intake_issue("1")
 
         # expect a pop up
         expect(page).to have_content("Are you sure you want to remove this issue?")
-        safe_click ".remove-issue"
+        click_remove_issue_confirmation
 
         expect(page).not_to have_content("PTSD denied")
 
@@ -865,18 +863,17 @@ RSpec.feature "Edit issues" do
 
         expect(page).to have_button("Save", disabled: false)
 
-        page.all(".remove-issue")[1].click
-        # click remove issue again to get rid of popup
-        safe_click ".remove-issue"
+        click_remove_intake_issue("2")
+        click_remove_issue_confirmation
+
         expect(page).to_not have_content("Left knee granted")
         expect(page).to have_button("Save", disabled: true)
       end
 
       it "Does not allow save if no issues are selected" do
         visit "supplemental_claims/#{rating_ep_claim_id}/edit"
-        safe_click ".remove-issue"
-        # click remove issue again to get rid of popup
-        safe_click ".remove-issue"
+        click_remove_intake_issue("1")
+        click_remove_issue_confirmation
 
         expect(page).to have_button("Save", disabled: true)
       end
@@ -910,8 +907,8 @@ RSpec.feature "Edit issues" do
         allow(Fakes::VBMSService).to receive(:remove_contention!).and_call_original
 
         visit "supplemental_claims/#{rating_ep_claim_id}/edit"
-        safe_click ".remove-issue"
-        safe_click ".remove-issue"
+        click_remove_intake_issue("1")
+        click_remove_issue_confirmation
         click_intake_add_issue
         add_intake_rating_issue("Left knee granted")
 

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -94,9 +94,8 @@ RSpec.feature "Edit issues" do
       expect(page).not_to have_content("nonrating description")
 
       # add an issue
-      safe_click "#button-add-issue"
-      find("label", text: "Left knee granted").click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted")
 
       # save
       expect(page).to have_content("Left knee granted")
@@ -307,21 +306,19 @@ RSpec.feature "Edit issues" do
 
         expect(page).to have_content("Military Retired Pay")
 
-        safe_click "#button-add-issue"
-        safe_click ".no-matching-issues"
-        fill_in "Issue category", with: "Active Duty Adjustments"
-        find("#issue-category").send_keys :enter
-        fill_in "Issue description", with: "A description!"
-        fill_in "Decision date", with: "04/26/2018"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_nonrating_issue(
+          category: "Active Duty Adjustments",
+          description: "A description!",
+          date: "04/26/2018"
+        )
 
-        safe_click "#button-add-issue"
-        safe_click ".no-matching-issues"
-        fill_in "Issue category", with: "Drill Pay Adjustments"
-        find("#issue-category").send_keys :enter
-        fill_in "Issue description", with: "A nonrating issue before AMA"
-        fill_in "Decision date", with: "10/25/2017"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_nonrating_issue(
+          category: "Drill Pay Adjustments",
+          description: "A nonrating issue before AMA",
+          date: "10/25/2017"
+        )
 
         safe_click("#button-submit-update")
 
@@ -374,7 +371,7 @@ RSpec.feature "Edit issues" do
         expect(page).to_not have_content("Left knee granted")
         expect(page).to have_content("PTSD denied")
 
-        safe_click "#button-add-issue"
+        click_intake_add_issue
 
         expect(page).to have_content("Add issue 2")
         expect(page).to have_content("Does issue 2 match any of these issues")
@@ -386,10 +383,8 @@ RSpec.feature "Edit issues" do
         expect(page).to_not have_content("2. Left knee granted")
 
         # adding an issue should show the issue
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
-
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
         expect(page).to have_content("2. Left knee granted")
         expect(page).to_not have_content("Notes:")
 
@@ -399,10 +394,8 @@ RSpec.feature "Edit issues" do
         expect(page).not_to have_content("PTSD denied")
 
         # re-add to proceed
-        safe_click "#button-add-issue"
-        find("label", text: "PTSD denied").click
-        fill_in "Notes", with: "I am an issue note"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("PTSD denied", "I am an issue note")
         expect(page).to have_content("PTSD denied")
         # TODO: : Need to fix a bug, but these two expect statements should replace the above one
         # expect(page).to have_content("PTSD denied Decision Date:")
@@ -410,62 +403,48 @@ RSpec.feature "Edit issues" do
         expect(page).to have_content("I am an issue note")
 
         # clicking add issue again should show a disabled radio button for that same rating
-        safe_click "#button-add-issue"
+        click_intake_add_issue
         expect(page).to have_content("Add issue 3")
         expect(page).to have_content("Does issue 3 match any of these issues")
         expect(page).to have_content("Left knee granted (already selected for issue 1)")
         expect(page).to have_css("input[disabled][id='rating-radio_abc123']", visible: false)
 
         # Add nonrating issue
-        safe_click ".no-matching-issues"
-        expect(page).to have_content("Does issue 3 match any of these issue categories?")
-        expect(page).to have_button("Add this issue", disabled: true)
-        fill_in "Issue category", with: "Active Duty Adjustments"
-        find("#issue-category").send_keys :enter
-        fill_in "Issue description", with: "Description for Active Duty Adjustments"
-        fill_in "Decision date", with: "04/25/2018"
-        expect(page).to have_button("Add this issue", disabled: false)
-        safe_click ".add-issue"
+        add_intake_nonrating_issue(
+          category: "Active Duty Adjustments",
+          description: "Description for Active Duty Adjustments",
+          date: "04/25/2018"
+        )
         expect(page).to have_content("3 issues")
 
         # Add untimely nonrating issue
-        safe_click "#button-add-issue"
-        safe_click ".no-matching-issues"
-        expect(page).to have_content("Does issue 4 match any of these issue categories?")
-        expect(page).to have_button("Add this issue", disabled: true)
-        fill_in "Issue category", with: "Active Duty Adjustments"
-        find("#issue-category").send_keys :enter
-        fill_in "Issue description", with: "Another Description for Active Duty Adjustments"
-        fill_in "Decision date", with: "04/25/2016"
-        expect(page).to have_button("Add this issue", disabled: false)
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_nonrating_issue(
+          category: "Active Duty Adjustments",
+          description: "Another Description for Active Duty Adjustments",
+          date: "04/25/2016"
+        )
         add_untimely_exemption_response("No", "I am a nonrating exemption note")
         expect(page).to have_content("4 issues")
         expect(page).to have_content("I am a nonrating exemption note")
         expect(page).to have_content("Another Description for Active Duty Adjustments")
 
         # add unidentified issue
-        safe_click "#button-add-issue"
-        safe_click ".no-matching-issues"
-        safe_click ".no-matching-issues"
-        expect(page).to have_content("Describe the issue to mark it as needing further review.")
-        fill_in "Transcribe the issue as it's written on the form", with: "This is an unidentified issue"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_unidentified_issue("This is an unidentified issue")
         expect(page).to have_content("5 issues")
         expect(page).to have_content("This is an unidentified issue")
 
         # add issue before AMA
-        safe_click "#button-add-issue"
-        find("label", text: "Non-RAMP Issue before AMA Activation").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
         expect(page).to have_content(
           "Non-RAMP Issue before AMA Activation #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
         )
 
         # add RAMP issue before AMA
-        safe_click "#button-add-issue"
-        find("label", text: "Issue before AMA Activation from RAMP").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Issue before AMA Activation from RAMP")
         expect(page).to have_content("Issue before AMA Activation from RAMP Decision date:")
 
         safe_click("#button-submit-update")
@@ -555,10 +534,8 @@ RSpec.feature "Edit issues" do
 
         expect(page).to have_button("Save", disabled: true)
 
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
-
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
         expect(page).to have_button("Save", disabled: false)
 
         page.all(".remove-issue")[1].click
@@ -588,11 +565,12 @@ RSpec.feature "Edit issues" do
         )
 
         visit "higher_level_reviews/#{rating_ep_claim_id}/edit"
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
         safe_click("#button-submit-update")
+
         expect(page).to have_content("The review originally had 1 issue but now has 2.")
+
         safe_click ".confirm"
 
         expect(page).to have_content("Previous update not yet done processing")
@@ -608,9 +586,8 @@ RSpec.feature "Edit issues" do
         safe_click ".remove-issue"
         # click again to get rid of pop-up
         safe_click ".remove-issue"
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
 
         expect(page).to have_button("Save", disabled: false)
 
@@ -765,13 +742,12 @@ RSpec.feature "Edit issues" do
 
         expect(page).to have_content("Military Retired Pay")
 
-        safe_click "#button-add-issue"
-        safe_click ".no-matching-issues"
-        fill_in "Issue category", with: "Active Duty Adjustments"
-        find("#issue-category").send_keys :enter
-        fill_in "Issue description", with: "A description!"
-        fill_in "Decision date", with: "04/25/2018"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_nonrating_issue(
+          category: "Active Duty Adjustments",
+          description: "A description!",
+          date: "04/25/2018"
+        )
 
         safe_click("#button-submit-update")
 
@@ -826,7 +802,7 @@ RSpec.feature "Edit issues" do
         check_row("Benefit type", "Compensation")
         check_row("Claimant", "Bob Vance, Spouse (payee code 10)")
 
-        safe_click "#button-add-issue"
+        click_intake_add_issue
 
         expect(page).to have_content("Add issue 2")
         expect(page).to have_content("Does issue 2 match any of these issues")
@@ -838,9 +814,8 @@ RSpec.feature "Edit issues" do
         expect(page).to_not have_content("2. Left knee granted")
 
         # adding an issue should show the issue
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
 
         expect(page).to have_content("2. Left knee granted")
         expect(page).to_not have_content("Notes:")
@@ -853,39 +828,29 @@ RSpec.feature "Edit issues" do
         expect(page).not_to have_content("PTSD denied")
 
         # re-add to proceed
-        safe_click "#button-add-issue"
-        find("label", text: "PTSD denied").click
-        fill_in "Notes", with: "I am an issue note"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("PTSD denied", "I am an issue note")
         expect(page).to have_content("2. PTSD denied")
         expect(page).to have_content("I am an issue note")
 
         # clicking add issue again should show a disabled radio button for that same rating
-        safe_click "#button-add-issue"
+        click_intake_add_issue
         expect(page).to have_content("Add issue 3")
         expect(page).to have_content("Does issue 3 match any of these issues")
         expect(page).to have_content("Left knee granted (already selected for issue 1)")
         expect(page).to have_css("input[disabled][id='rating-radio_abc123']", visible: false)
 
         # Add nonrating issue
-        safe_click ".no-matching-issues"
-        expect(page).to have_content("Does issue 3 match any of these issue categories?")
-        expect(page).to have_button("Add this issue", disabled: true)
-        fill_in "Issue category", with: "Active Duty Adjustments"
-        find("#issue-category").send_keys :enter
-        fill_in "Issue description", with: "Description for Active Duty Adjustments"
-        fill_in "Decision date", with: "04/25/2018"
-        expect(page).to have_button("Add this issue", disabled: false)
-        safe_click ".add-issue"
+        add_intake_nonrating_issue(
+          category: "Active Duty Adjustments",
+          description: "Description for Active Duty Adjustments",
+          date: "04/25/2018"
+        )
         expect(page).to have_content("3 issues")
 
         # add unidentified issue
-        safe_click "#button-add-issue"
-        safe_click ".no-matching-issues"
-        safe_click ".no-matching-issues"
-        expect(page).to have_content("Describe the issue to mark it as needing further review.")
-        fill_in "Transcribe the issue as it's written on the form", with: "This is an unidentified issue"
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_unidentified_issue("This is an unidentified issue")
         expect(page).to have_content("4 issues")
         expect(page).to have_content("This is an unidentified issue")
       end
@@ -895,9 +860,8 @@ RSpec.feature "Edit issues" do
 
         expect(page).to have_button("Save", disabled: true)
 
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
 
         expect(page).to have_button("Save", disabled: false)
 
@@ -929,9 +893,8 @@ RSpec.feature "Edit issues" do
         )
 
         visit "supplemental_claims/#{rating_ep_claim_id}/edit"
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
         safe_click("#button-submit-update")
 
         expect(page).to have_content("The review originally had 1 issue but now has 2.")
@@ -949,9 +912,8 @@ RSpec.feature "Edit issues" do
         visit "supplemental_claims/#{rating_ep_claim_id}/edit"
         safe_click ".remove-issue"
         safe_click ".remove-issue"
-        safe_click "#button-add-issue"
-        find("label", text: "Left knee granted").click
-        safe_click ".add-issue"
+        click_intake_add_issue
+        add_intake_rating_issue("Left knee granted")
 
         expect(page).to have_button("Save", disabled: false)
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -664,7 +664,7 @@ RSpec.feature "Higher-Level Review" do
       expect(page).to_not have_content("Notes:")
 
       # removing an issue
-      safe_click ".remove-issue"
+      click_remove_intake_issue("1")
       expect(page).not_to have_content("Left knee granted")
 
       # re-add to proceed
@@ -713,7 +713,7 @@ RSpec.feature "Higher-Level Review" do
       expect(page).to_not have_content("5. Really old injury #{Constants.INELIGIBLE_REQUEST_ISSUES.untimely}")
 
       # remove and re-add with different answer to exemption
-      page.all(".remove-issue").last.click
+      click_remove_intake_issue("5")
       click_intake_add_issue
       add_intake_rating_issue("Really old injury")
       add_untimely_exemption_response("No")

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -215,7 +215,7 @@ RSpec.feature "Higher-Level Review" do
     find("label", text: "Left knee granted").click
     expect(page).to have_content("1 issue")
 
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     safe_click ".Select"
 
@@ -232,7 +232,7 @@ RSpec.feature "Higher-Level Review" do
 
     expect(page).to have_content("2 issues")
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
     expect(page).to have_content(
@@ -505,7 +505,7 @@ RSpec.feature "Higher-Level Review" do
 
     expect(page).to have_content("This Veteran has no rated, disability issues")
 
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     safe_click ".Select"
 
@@ -644,7 +644,7 @@ RSpec.feature "Higher-Level Review" do
       check_row("Claimant", "Bob Vance, Spouse (payee code 02)")
 
       # clicking the add issues button should bring up the modal
-      safe_click "#button-add-issue"
+      click_intake_add_issue
 
       expect(page).to have_content("Add issue 1")
       expect(page).to have_content("Does issue 1 match any of these issues")
@@ -657,41 +657,35 @@ RSpec.feature "Higher-Level Review" do
       expect(page).to_not have_content("Left knee granted")
 
       # adding an issue should show the issue
-      safe_click "#button-add-issue"
-      find_all("label", text: "Left knee granted").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted")
 
       expect(page).to have_content("1. Left knee granted")
       expect(page).to_not have_content("Notes:")
-      safe_click ".remove-issue"
 
+      # removing an issue
+      safe_click ".remove-issue"
       expect(page).not_to have_content("Left knee granted")
 
       # re-add to proceed
-      safe_click "#button-add-issue"
-      find_all("label", text: "Left knee granted").first.click
-      fill_in "Notes", with: "I am an issue note"
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted", "I am an issue note")
       expect(page).to have_content("1. Left knee granted")
       expect(page).to have_content("I am an issue note")
 
       # clicking add issue again should show a disabled radio button for that same rating
-      safe_click "#button-add-issue"
+      click_intake_add_issue
       expect(page).to have_content("Add issue 2")
       expect(page).to have_content("Does issue 2 match any of these issues")
       expect(page).to have_content("Left knee granted (already selected for issue 1)")
       expect(page).to have_css("input[disabled][id='rating-radio_xyz123']", visible: false)
 
       # Add nonrating issue
-      safe_click ".no-matching-issues"
-      expect(page).to have_content("Does issue 2 match any of these issue categories?")
-      expect(page).to have_button("Add this issue", disabled: true)
-      fill_in "Issue category", with: "Active Duty Adjustments"
-      find("#issue-category").send_keys :enter
-      fill_in "Issue description", with: "Description for Active Duty Adjustments"
-      fill_in "Decision date", with: "04/25/2018"
-      expect(page).to have_button("Add this issue", disabled: false)
-      safe_click ".add-issue"
+      add_intake_nonrating_issue(
+        category: "Active Duty Adjustments",
+        description: "Description for Active Duty Adjustments",
+        date: "04/25/2018"
+      )
       expect(page).to have_content("2 issues")
       # this nonrating request issue is timely
       expect(page).to_not have_content(
@@ -699,26 +693,20 @@ RSpec.feature "Higher-Level Review" do
       )
 
       # add unidentified issue
-      safe_click "#button-add-issue"
-      safe_click ".no-matching-issues"
-      safe_click ".no-matching-issues"
-      expect(page).to have_content("Describe the issue to mark it as needing further review.")
-      fill_in "Transcribe the issue as it's written on the form", with: "This is an unidentified issue"
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_unidentified_issue("This is an unidentified issue")
       expect(page).to have_content("3 issues")
       expect(page).to have_content("This is an unidentified issue")
 
       # add ineligible issue
-      safe_click "#button-add-issue"
-      find_all("label", text: "Old injury").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Old injury")
       expect(page).to have_content("4 issues")
       expect(page).to have_content("4. Old injury is ineligible because it's already under review as a Appeal")
 
       # add untimely rating request issue
-      safe_click "#button-add-issue"
-      find_all("label", text: "Really old injury").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Really old injury")
       add_untimely_exemption_response("Yes")
       expect(page).to have_content("5 issues")
       expect(page).to have_content("I am an exemption note")
@@ -726,24 +714,20 @@ RSpec.feature "Higher-Level Review" do
 
       # remove and re-add with different answer to exemption
       page.all(".remove-issue").last.click
-      safe_click "#button-add-issue"
-      find_all("label", text: "Really old injury").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Really old injury")
       add_untimely_exemption_response("No")
       expect(page).to have_content("5 issues")
       expect(page).to have_content("I am an exemption note")
       expect(page).to have_content("5. Really old injury #{Constants.INELIGIBLE_REQUEST_ISSUES.untimely}")
 
       # add untimely nonrating request issue
-      safe_click "#button-add-issue"
-      safe_click ".no-matching-issues"
-      expect(page).to have_button("Add this issue", disabled: true)
-      fill_in "Issue category", with: "Active Duty Adjustments"
-      find("#issue-category").send_keys :enter
-      fill_in "Issue description", with: "Another Description for Active Duty Adjustments"
-      fill_in "Decision date", with: "04/19/2016"
-      expect(page).to have_button("Add this issue", disabled: false)
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_nonrating_issue(
+        category: "Active Duty Adjustments",
+        description: "Another Description for Active Duty Adjustments",
+        date: "04/19/2016"
+      )
       add_untimely_exemption_response("No", "I am a nonrating exemption note")
       expect(page).to have_content("6 issues")
       expect(page).to have_content("I am a nonrating exemption note")
@@ -752,44 +736,38 @@ RSpec.feature "Higher-Level Review" do
       )
 
       # add prior reviewed issue
-      safe_click "#button-add-issue"
-      find_all("label", text: "Already reviewed injury").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Already reviewed injury")
       expect(page).to have_content("7 issues")
       expect(page).to have_content(
         "7. Already reviewed injury #{Constants.INELIGIBLE_REQUEST_ISSUES.previous_higher_level_review}"
       )
 
       # add before_ama ratings
-      safe_click "#button-add-issue"
-      find_all("label", text: "Non-RAMP Issue before AMA Activation").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
       expect(page).to have_content(
         "8. Non-RAMP Issue before AMA Activation #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
       )
 
       # Eligible because it comes from a RAMP decision
-      safe_click "#button-add-issue"
-      find_all("label", text: "Issue before AMA Activation from RAMP").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Issue before AMA Activation from RAMP")
       expect(page).to have_content(
         "9. Issue before AMA Activation from RAMP Decision date:"
       )
 
-      safe_click "#button-add-issue"
-      safe_click ".no-matching-issues"
-      expect(page).to have_button("Add this issue", disabled: true)
-      fill_in "Issue category", with: "Drill Pay Adjustments"
-      find("#issue-category").send_keys :enter
-      fill_in "Issue description", with: "A nonrating issue before AMA"
-      fill_in "Decision date", with: "10/19/2017"
-      expect(page).to have_button("Add this issue", disabled: false)
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_nonrating_issue(
+        category: "Drill Pay Adjustments",
+        description: "A nonrating issue before AMA",
+        date: "10/19/2017"
+      )
       expect(page).to have_content(
         "A nonrating issue before AMA #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
       )
 
-      safe_click "#button-finish-intake"
+      click_intake_finish
 
       expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
@@ -926,15 +904,13 @@ RSpec.feature "Higher-Level Review" do
       start_higher_level_review(veteran)
       visit "/intake/add_issues"
 
-      safe_click "#button-add-issue"
-      find_all("label", text: "Left knee granted").first.click
-      fill_in "Notes", with: "I am an issue note"
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted", "I am an issue note")
 
       ## Validate error message when complete intake fails
       expect_any_instance_of(HigherLevelReviewIntake).to receive(:complete!).and_raise("A random error. Oh no!")
 
-      safe_click "#button-finish-intake"
+      click_intake_finish
 
       expect(page).to have_content("Something went wrong")
       expect(page).to have_current_path("/intake/add_issues")
@@ -990,7 +966,7 @@ RSpec.feature "Higher-Level Review" do
         start_higher_level_review(veteran)
         visit "/intake/add_issues"
 
-        safe_click "#button-add-issue"
+        click_intake_add_issue
         expect(page).to have_content("Next")
       end
     end

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -1,6 +1,9 @@
 require "rails_helper"
+require "support/intake_helpers"
 
 RSpec.feature "Supplemental Claim Intake" do
+  include IntakeHelpers
+
   before do
     FeatureToggle.enable!(:intake)
     FeatureToggle.enable!(:intakeAma)
@@ -197,7 +200,7 @@ RSpec.feature "Supplemental Claim Intake" do
     find("label", text: "Left knee granted").click
     expect(page).to have_content("1 issue")
 
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     safe_click ".Select"
 
@@ -214,7 +217,7 @@ RSpec.feature "Supplemental Claim Intake" do
 
     expect(page).to have_content("2 issues")
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
     expect(page).to have_content(
@@ -392,7 +395,7 @@ RSpec.feature "Supplemental Claim Intake" do
 
     expect(page).to have_content("This Veteran has no rated, disability issues")
 
-    safe_click "#button-add-issue"
+    click_intake_add_issue
 
     safe_click ".Select"
 
@@ -403,7 +406,7 @@ RSpec.feature "Supplemental Claim Intake" do
 
     expect(page).to have_content("1 issue")
 
-    safe_click "#button-finish-intake"
+    click_intake_finish
 
     expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
   end
@@ -499,7 +502,7 @@ RSpec.feature "Supplemental Claim Intake" do
       check_row("Claimant", "Ed Merica")
 
       # clicking the add issues button should bring up the modal
-      safe_click "#button-add-issue"
+      click_intake_add_issue
       expect(page).to have_content("Add issue 1")
       expect(page).to have_content("Does issue 1 match any of these issues")
       expect(page).to have_content("Left knee granted")
@@ -511,101 +514,81 @@ RSpec.feature "Supplemental Claim Intake" do
       expect(page).to_not have_content("Left knee granted")
 
       # adding an issue should show the issue
-      safe_click "#button-add-issue"
-      find_all("label", text: "Left knee granted").first.click
-      safe_click ".add-issue"
-
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted")
       expect(page).to have_content("1. Left knee granted")
       expect(page).to_not have_content("Notes:")
-      safe_click ".remove-issue"
 
+      safe_click ".remove-issue"
       expect(page).not_to have_content("Left knee granted")
 
       # re-add to proceed
-      safe_click "#button-add-issue"
-      find_all("label", text: "Left knee granted").first.click
-      fill_in "Notes", with: "I am an issue note"
-      safe_click ".add-issue"
-
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted", "I am an issue note")
       expect(page).to have_content("1. Left knee granted")
       expect(page).to have_content("I am an issue note")
 
       # clicking add issue again should show a disabled radio button for that same rating
-      safe_click "#button-add-issue"
+      click_intake_add_issue
       expect(page).to have_content("Add issue 2")
       expect(page).to have_content("Does issue 2 match any of these issues")
       expect(page).to have_content("Left knee granted (already selected for issue 1)")
       expect(page).to have_css("input[disabled][id='rating-radio_xyz123']", visible: false)
 
       # Add nonrating issue
-      safe_click ".no-matching-issues"
-      expect(page).to have_content("Does issue 2 match any of these issue categories?")
-      expect(page).to have_button("Add this issue", disabled: true)
-      fill_in "Issue category", with: "Active Duty Adjustments"
-      find("#issue-category").send_keys :enter
-      fill_in "Issue description", with: "Description for Active Duty Adjustments"
-      fill_in "Decision date", with: "04/25/2018"
-      expect(page).to have_button("Add this issue", disabled: false)
-      safe_click ".add-issue"
+      add_intake_nonrating_issue(
+        category: "Active Duty Adjustments",
+        description: "Description for Active Duty Adjustments",
+        date: "04/25/2018"
+      )
       expect(page).to have_content("2 issues")
       # SC is always timely
       expect(page).to_not have_content("Description for Active Duty Adjustments is ineligible because it has a prior")
 
       # add unidentified issue
-      safe_click "#button-add-issue"
-      safe_click ".no-matching-issues"
-      safe_click ".no-matching-issues"
-      expect(page).to have_content("Describe the issue to mark it as needing further review.")
-      fill_in "Transcribe the issue as it's written on the form", with: "This is an unidentified issue"
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_unidentified_issue("This is an unidentified issue")
       expect(page).to have_content("3 issues")
       expect(page).to have_content("This is an unidentified issue")
 
       # add ineligible issue
-      safe_click "#button-add-issue"
-      find_all("label", text: "Old injury").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Old injury")
       expect(page).to have_content("4 issues")
       expect(page).to have_content("4. Old injury is ineligible because it's already under review as a Appeal")
 
       # add untimely issue (OK on Supplemental Claim)
-      safe_click "#button-add-issue"
-      find_all("label", text: "Really old injury").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Really old injury")
       expect(page).to have_content("5 issues")
       expect(page).to have_content("5. Really old injury")
       expect(page).to_not have_content("5. Really old injury #{Constants.INELIGIBLE_REQUEST_ISSUES.untimely}")
 
       # add before_ama ratings
-      safe_click "#button-add-issue"
-      find_all("label", text: "Non-RAMP Issue before AMA Activation").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
       expect(page).to have_content(
         "6. Non-RAMP Issue before AMA Activation #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
       )
 
       # Eligible because it comes from a RAMP decision
-      safe_click "#button-add-issue"
-      find_all("label", text: "Issue before AMA Activation from RAMP").first.click
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Issue before AMA Activation from RAMP")
       expect(page).to have_content(
         "7. Issue before AMA Activation from RAMP Decision date:"
       )
 
-      safe_click "#button-add-issue"
-      safe_click ".no-matching-issues"
-      expect(page).to have_button("Add this issue", disabled: true)
-      fill_in "Issue category", with: "Drill Pay Adjustments"
-      find("#issue-category").send_keys :enter
-      fill_in "Issue description", with: "A nonrating issue before AMA"
-      fill_in "Decision date", with: "10/19/2017"
-      expect(page).to have_button("Add this issue", disabled: false)
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_nonrating_issue(
+        category: "Drill Pay Adjustments",
+        description: "A nonrating issue before AMA",
+        date: "10/19/2017"
+      )
       expect(page).to have_content(
         "A nonrating issue before AMA #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
       )
 
-      safe_click "#button-finish-intake"
+      click_intake_finish
 
       expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
@@ -709,15 +692,13 @@ RSpec.feature "Supplemental Claim Intake" do
       start_supplemental_claim(veteran)
       visit "/intake/add_issues"
 
-      safe_click "#button-add-issue"
-      find_all("label", text: "Left knee granted").first.click
-      fill_in "Notes", with: "I am an issue note"
-      safe_click ".add-issue"
+      click_intake_add_issue
+      add_intake_rating_issue("Left knee granted", "I am an issue note")
 
       ## Validate error message when complete intake fails
       expect_any_instance_of(SupplementalClaimIntake).to receive(:complete!).and_raise("A random error. Oh no!")
 
-      safe_click "#button-finish-intake"
+      click_intake_finish
 
       expect(page).to have_content("Something went wrong")
       expect(page).to have_current_path("/intake/add_issues")
@@ -773,7 +754,7 @@ RSpec.feature "Supplemental Claim Intake" do
         start_supplemental_claim(veteran)
         visit "/intake/add_issues"
 
-        safe_click "#button-add-issue"
+        click_intake_add_issue
         expect(page).to have_content("Next")
       end
     end

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -519,7 +519,7 @@ RSpec.feature "Supplemental Claim Intake" do
       expect(page).to have_content("1. Left knee granted")
       expect(page).to_not have_content("Notes:")
 
-      safe_click ".remove-issue"
+      click_remove_intake_issue("1")
       expect(page).not_to have_content("Left knee granted")
 
       # re-add to proceed

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -365,7 +365,7 @@ describe Veteran do
       RequestStore[:current_user] = create(:user)
 
       allow_any_instance_of(BGS::OrgWebService).to receive(:find_poas_by_ptcpnt_ids)
-        .with(participant_ids).and_return(poas)
+        .with(array_including(participant_ids)).and_return(poas)
     end
 
     after do

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -22,7 +22,7 @@ module IntakeHelpers
 
   def add_intake_nonrating_issue(category:, description:, date:)
     safe_click ".no-matching-issues"
-    expect(page.text).to match(/Does issue \d match any of these issue categories?/)
+    expect(page.text).to match(/Does issue \d+ match any of these issue categories?/)
     expect(page).to have_button("Add this issue", disabled: true)
     fill_in "Issue category", with: category
     find("#issue-category").send_keys :enter

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -5,4 +5,38 @@ module IntakeHelpers
     fill_in "Notes", with: note
     safe_click ".add-issue"
   end
+
+  def click_intake_add_issue
+    safe_click "#button-add-issue"
+  end
+
+  def click_intake_finish
+    safe_click "#button-finish-intake"
+  end
+
+  def add_intake_rating_issue(description, note = nil)
+    find_all("label", text: description).first.click
+    fill_in("Notes", with: note) if note
+    safe_click ".add-issue"
+  end
+
+  def add_intake_nonrating_issue(category:, description:, date:)
+    safe_click ".no-matching-issues"
+    expect(page.text).to match(/Does issue \d match any of these issue categories?/)
+    expect(page).to have_button("Add this issue", disabled: true)
+    fill_in "Issue category", with: category
+    find("#issue-category").send_keys :enter
+    fill_in "Issue description", with: description
+    fill_in "Decision date", with: date
+    expect(page).to have_button("Add this issue", disabled: false)
+    safe_click ".add-issue"
+  end
+
+  def add_intake_unidentified_issue(description)
+    safe_click ".no-matching-issues"
+    safe_click ".no-matching-issues"
+    expect(page).to have_content("Describe the issue to mark it as needing further review.")
+    fill_in "Transcribe the issue as it's written on the form", with: description
+    safe_click ".add-issue"
+  end
 end

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -40,4 +40,21 @@ module IntakeHelpers
     fill_in "Transcribe the issue as it's written on the form", with: description
     safe_click ".add-issue"
   end
+
+  def click_remove_intake_issue(number)
+    issue_el = find_intake_issue_by_number(number)
+    issue_el.find(".remove-issue").click
+  end
+
+  def click_remove_issue_confirmation
+    safe_click ".remove-issue"
+  end
+
+  def find_intake_issue_by_number(number)
+    find_all(:xpath, './/div[@class="issues"]/*/div[@class="issue"]').each do |node|
+      if node.find(".issue-num").text =~ /^#{number}\./
+        return node
+      end
+    end
+  end
 end

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -15,7 +15,8 @@ module IntakeHelpers
   end
 
   def add_intake_rating_issue(description, note = nil)
-    find_all("label", text: description).first.click
+    # find_all with 'minimum' will wait like find() does.
+    find_all("label", text: description, minimum: 1).first.click
     fill_in("Notes", with: note) if note
     safe_click ".add-issue"
   end


### PR DESCRIPTION
### Description
Reduce spec boilerplate by refactoring common interactions into helper methods. Mostly this deals with adding rating/nonrating/unspecified issues via the new modal UI.

Hopefully this reduces some of the repetitive code that can become visual noise in tests.

### Acceptance Criteria
- [x] Tests continue to pass.
