### PR TITLE
Changing file number generator in case.rb

### DIFF
--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :case, class: VACOLS::Case do
     sequence(:bfkey)
     sequence(:bfcorkey)
-    sequence(:bfcorlid, 500_000_000) { |n| "#{n}S" }
+    sequence(:bfcorlid, 300_000_000) { |n| "#{n}S" }
 
     association :correspondent, factory: :correspondent
     association :folder, factory: :folder, ticknum: :bfkey


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/7803

### Description
I fixed some other flakey tests by changing how case.rb creates veteran ids. However this caused a new test failure because of collisions of veteran ids. Changing it again to avoid this problem.

### Testing Plan
1. Circle passes

