### PR TITLE
Add migration to create Colocated organization tasks

### DIFF
--- a/db/migrate/20181113164150_insert_parent_colocated_task.rb
+++ b/db/migrate/20181113164150_insert_parent_colocated_task.rb
@@ -1,0 +1,26 @@
+class InsertParentColocatedTask < ActiveRecord::Migration[5.1]
+  safety_assured
+
+  def up
+    ColocatedTask.all.find_each do |t|
+      next if (t.parent && t.parent.assigned_to.is_a?(Colocated)) || t.assigned_to.is_a?(Colocated)
+
+      org_task = ColocatedTask.create!(
+        appeal: t.appeal,
+        action: t.action,
+        assigned_by: t.assigned_by,
+        parent_id: t.parent_id,
+        status: t.completed? ? Constants.TASK_STATUSES.completed : Constants.TASK_STATUSES.on_hold,
+        assigned_to: Colocated.singleton
+      )
+      t.update!(parent_id: org_task.id)
+    end
+  end
+
+  def down
+    ColocatedTask.where(assigned_to: Colocated.singleton).find_each do |org_task|
+      org_task.children.first.update!(parent_id: org_task.parent_id)
+      org_task.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181109131525) do
+ActiveRecord::Schema.define(version: 20181113164150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -630,15 +630,15 @@ ActiveRecord::Schema.define(version: 20181109131525) do
     t.integer "parent_request_issue_id"
     t.text "notes"
     t.boolean "is_unidentified"
+    t.bigint "ineligible_due_to_id"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
-    t.bigint "ineligible_due_to_id"
-    t.string "ineligible_reason"
+    t.string "ramp_claim_id"
     t.datetime "decision_sync_submitted_at"
     t.datetime "decision_sync_attempted_at"
     t.datetime "decision_sync_processed_at"
     t.string "decision_sync_error"
-    t.string "ramp_claim_id"
+    t.string "ineligible_reason"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["ineligible_due_to_id"], name: "index_request_issues_on_ineligible_due_to_id"


### PR DESCRIPTION
Connects #7528. Does exactly what #7801 did but is fully up to date with master so we don't have to deal with conflicting migrations.