### PR TITLE
Daily docket fixes

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -9,7 +9,9 @@ class HearingsController < ApplicationController
       HearingRepository.slot_new_hearing(params["hearing"]["master_record_updated"], hearing.appeal)
     end
 
-    hearing.update(update_params)
+    hearing.update_caseflow_and_vacols(update_params)
+    # Because of how we map the hearing time, we need to refresh the VACOLS data after saving
+    HearingRepository.load_vacols_data(hearing)
     render json: hearing.to_hash(current_user.id)
   end
 

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -66,10 +66,10 @@ class Hearing < ApplicationRecord
     appeals << self.class.repository.appeals_ready_for_hearing(appeal.vbms_id)
   end
 
-  def update(hearing_hash)
+  def update_caseflow_and_vacols(hearing_hash)
     ActiveRecord::Base.multi_transaction do
       self.class.repository.update_vacols_hearing!(vacols_record, hearing_hash)
-      super
+      update!(hearing_hash)
     end
   end
 

--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -107,12 +107,16 @@ export default class DailyDocket extends React.Component {
     this.props.onCancelHearingUpdate(hearing);
   };
 
+  previouslyScheduled = (hearing) => {
+    return hearing.disposition === 'postponed' || hearing.disposition === 'cancelled';
+  };
+
   previouslyScheduledHearings = () => {
-    return _.filter(this.props.hearings, (hearing) => hearing.disposition === 'postponed');
+    return _.filter(this.props.hearings, (hearing) => this.previouslyScheduled(hearing));
   };
 
   dailyDocketHearings = () => {
-    return _.filter(this.props.hearings, (hearing) => hearing.disposition !== 'postponed');
+    return _.filter(this.props.hearings, (hearing) => !this.previouslyScheduled(hearing));
   };
 
   getAppellantInformation = (hearing) => {
@@ -192,16 +196,18 @@ export default class DailyDocket extends React.Component {
     />;
   };
 
-  getHearingTimeOptions = (hearing) => {
+  getHearingTimeOptions = (hearing, readOnly) => {
     if (hearing.requestType === 'CO') {
       return [
         {
           displayText: '9:00',
-          value: '9:00'
+          value: '9:00',
+          disabled: readOnly
         },
         {
           displayText: '1:00',
-          value: '13:00'
+          value: '13:00',
+          disabled: readOnly
         }
       ];
     }
@@ -209,11 +215,13 @@ export default class DailyDocket extends React.Component {
     return [
       {
         displayText: '8:30',
-        value: '8:30'
+        value: '8:30',
+        disabled: readOnly
       },
       {
         displayText: '12:30',
-        value: '12:30'
+        value: '12:30',
+        disabled: readOnly
       }
     ];
   };
@@ -230,7 +238,7 @@ export default class DailyDocket extends React.Component {
     />
     <RadioField
       name={`hearingTime${hearing.id}`}
-      options={this.getHearingTimeOptions(hearing)}
+      options={this.getHearingTimeOptions(hearing, readOnly)}
       value={hearing.editedTime ? hearing.editedTime : getTimeWithoutTimeZone(hearing.date, timezone)}
       onChange={this.onHearingTimeUpdate(hearing.id)}
       hideLabel


### PR DESCRIPTION
Resolves #7667 

### Description
This PR filters the daily docket such that canceled and postponed hearings are placed in the 'Previously Scheduled' section. It also updates the method name for updating hearings to not override the Active Record functionality.