### PR TITLE
Remove reference to shared Constants in BGS Setup

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -68,12 +68,23 @@ class Fakes::BGSService
         )
         Generators::Rating.build(
           participant_id: veteran.participant_id,
-          profile_date: DecisionReview.ama_activation_date - 10.days,
-          promulgation_date: DecisionReview.ama_activation_date - 5.days,
+          profile_date: Date.new(2019, 2, 14) - 10.days,
+          promulgation_date: Date.new(2019, 2, 14) - 5.days,
           issues: [
             { decision_text: "Issue before AMA not from a RAMP Review", reference_id: "before_ama_ref_id" },
             { decision_text: "Issue before AMA from a RAMP Review",
               associated_claims: { bnft_clm_tc: "683SCRRRAMP", clm_id: "ramp_claim_id" },
+              reference_id: "ramp_reference_id" }
+          ]
+        )
+        Generators::Rating.build(
+          participant_id: veteran.participant_id,
+          profile_date: Date.new(2017, 11, 1) - 10.days,
+          promulgation_date: Date.new(2017, 11, 1) - 5.days,
+          issues: [
+            { decision_text: "Issue before test AMA not from a RAMP Review", reference_id: "before_test_ama_ref_id" },
+            { decision_text: "Issue before test AMA from a RAMP Review",
+              associated_claims: { bnft_clm_tc: "683SCRRRAMP", clm_id: "ramp_test_claim_id" },
               reference_id: "ramp_reference_id" }
           ]
         )


### PR DESCRIPTION
Using Constants::Dates was causing an "uninitialized constant" bug in some folks' dev setup, so removing it from BGS Service where the fake ratings are set up.