### PR TITLE
Fix 'undefined local variable user' error

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -36,7 +36,7 @@ class Task < ApplicationRecord
     end
   end
 
-  def no_actions_available?(_user)
+  def no_actions_available?(user)
     return true if [Constants.TASK_STATUSES.on_hold, Constants.TASK_STATUSES.completed].include?(status)
 
     # Users who are assigned a subtask of an organization don't have actions on the organizational task.


### PR DESCRIPTION
Resolves these `NameError`s [we've been seeing](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2957/events/181332/).

> NameError: app/models/task.rb in block in no_actions_available?
> undefined local variable or method `user'