### PR TITLE
Formatting dates in oracle query

### DIFF
--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -96,7 +96,8 @@ class VACOLS::CaseHearing < VACOLS::Record
     end
 
     def load_days_for_range(start_date, end_date)
-      select_schedule_days.where("trunc(hearing_date) between ? and ?", start_date, end_date).order(:hearing_date)
+      select_schedule_days.where("trunc(hearing_date) between ? and ?", VacolsHelper.day_only_str(start_date),
+                                 VacolsHelper.day_only_str(end_date)).order(:hearing_date)
     end
 
     def load_days_for_central_office(start_date, end_date)


### PR DESCRIPTION
Resolves #7845 

### Description
Tuesday dates weren't showing up on the View Hearings page correctly. It looks like it's because the date wasn't in the correct format. I've confirmed the Tuesday hearings are returned when running this fix in production.
