### PR TITLE
Limit org task unique check to same appeal

### DIFF
--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -4,7 +4,8 @@ class GenericTask < Task
   # Use the existence of an organization-level task to prevent duplicates since there should only ever be one org-level
   # task active at a time for a single appeal.
   def verify_org_task_unique
-    if Task.where(type: type, assigned_to: assigned_to).where.not(status: Constants.TASK_STATUSES.completed).any? &&
+    if Task.where(type: type, assigned_to: assigned_to, appeal: appeal)
+        .where.not(status: Constants.TASK_STATUSES.completed).any? &&
        assigned_to.is_a?(Organization)
       fail(
         Caseflow::Error::DuplicateOrgTask,

--- a/spec/models/tasks/generic_task_spec.rb
+++ b/spec/models/tasks/generic_task_spec.rb
@@ -341,4 +341,23 @@ describe GenericTask do
       end
     end
   end
+
+  describe ".verify_org_task_unique" do
+    context "when attempting to create two tasks for different appeals assigned to the same organization" do
+      let(:organization) { FactoryBot.create(:organization) }
+      let(:appeals) { FactoryBot.create_list(:appeal, 2) }
+      it "should succeed" do
+        expect do
+          appeals.each do |a|
+            root_task = RootTask.create(appeal: a)
+            GenericTask.create!(
+              assigned_to: organization,
+              parent_id: root_task.id,
+              appeal: a
+            )
+          end
+        end.to_not raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
#7833 introduced logic to prevent the creation of duplicate generic tasks at the organization level, however it did not scope that check to only the current appeal. This PR changes that oversight.

[Example error caused by this bug](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2964/).
> Caseflow::Error::DuplicateOrgTask: Appeal 555 already has an active task of type BvaDispatchTask assigned to BvaDispatch. No action necessary