### PR TITLE
Change display name of VLJ support team (colocated)

### DIFF
--- a/app/models/organizations/colocated.rb
+++ b/app/models/organizations/colocated.rb
@@ -1,5 +1,5 @@
 class Colocated < Organization
   def self.singleton
-    Colocated.first || Colocated.create(name: "VLJ Support Staff", url: "vlj-support-staff")
+    Colocated.first || Colocated.create(name: "VLJ Support Staff", url: "vlj-support")
   end
 end

--- a/app/models/organizations/colocated.rb
+++ b/app/models/organizations/colocated.rb
@@ -1,5 +1,5 @@
 class Colocated < Organization
   def self.singleton
-    Colocated.first || Colocated.create(name: "VLJ Support Management", url: "vlj-support-management")
+    Colocated.first || Colocated.create(name: "VLJ Support Staff", url: "vlj-support-staff")
   end
 end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -56,7 +56,7 @@
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL": "This Post Remand data has hearing data associated with a previous original appeal.",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL_LINK": "View all cases",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL_POST_LINK": " to see other cases associated with this Veteran.",
-  "CASE_DETAILS_INCORRECT_POA": "POA data comes from VBMS. To update POA, please send a request to the VLJ support management branch.",
+  "CASE_DETAILS_INCORRECT_POA": "POA data comes from VBMS. To update POA, please send a request to the VLJ support staff.",
   "CASE_DETAILS_UNABLE_TO_LOAD": "We're unable to load this information. If the problem persists, please submit feedback through Caseflow",
   "CASE_DETAILS_LOADING": "Loading...",
   "CASE_DETAILS_POA_VSO": "Veteran Service Organization",


### PR DESCRIPTION
During a meeting with several Board teams yesterday, a Board representative informed us that the VLJ support management is now referred to as the "VLJ Support Staff". This PR changes their display name throughout the application ("assign to team" task actions, co-located team queue, and one place in the copy of the case details page).