### PR TITLE
Show personalized task queue as home page for all VLJ staff

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -138,7 +138,6 @@ class ApplicationController < ApplicationBaseController
       return false if current_user.admin?
       return false if current_user.organization_queue_user? || current_user.vso_employee?
       return false if current_user.attorney_in_vacols? || current_user.judge_in_vacols?
-      return false if current_user.colocated_in_vacols? && feature_enabled?(:colocated_queue)
       return true
     end
     false


### PR DESCRIPTION
Connects #7892.

Currently if a member of the VLJ support staff does not have the [`colocated_queue` feature enabled](https://github.com/department-of-veterans-affairs/appeals-deployment/blob/d93ab9655a883d246b9bb960ddbd63a4148e2cb9/ansible/vars/features-config.yml#L154) then we will show them the search page (`/search`) when they navigate to `appeals.cf.ds.va.gov`. If the `colocated_queue` feature is enabled, then that member of the VLJ support staff would see their personalized task queue (`/queue`). This PR changes that redirect behaviour so that all VLJ support staff will see their personalized task queues if they navigate to `appeals.cf.ds.va.gov`.