### PR TITLE
Show POA and Veteran information in Case Details page for VSO employees

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -4,7 +4,7 @@ class AppealsController < ApplicationController
   before_action :react_routed
   before_action :set_application, only: [:document_count, :new_documents]
   # Only whitelist endpoints VSOs should have access to.
-  skip_before_action :deny_vso_access, only: [:index, :show_case_list, :show]
+  skip_before_action :deny_vso_access, only: [:index, :power_of_attorney, :show_case_list, :show, :veteran]
 
   def index
     get_appeals_for_file_number(request.headers["HTTP_VETERAN_ID"]) && return


### PR DESCRIPTION
Connects #7678. Currently, we prevent VSO users from seeing POA and Veteran information on the Case Details page. This PR changes that.

I'm pretty stumped about how to test this. I think we aught to have some automated tests, but I'm struggling to think of a way to test this short of just logging onto a prod box and confirming this change did what we expect (since we are relying on the BGS response to deny access to POA/Veteran information to which particular VSO employees should not have access).