### PR TITLE
Allow setting of user roles in seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,7 +55,7 @@ class SeedDB
   end
 
   def create_colocated_user
-    user = User.create(css_id: "BVALSPORER", station_id: 101, full_name: "Co-located with cases")
+    user = User.create(css_id: "BVALSPORER", station_id: 101, full_name: "Co-located with cases", roles: %w[Reader])
     FactoryBot.create(:staff, :colocated_role, user: user, sdept: "DSP")
     OrganizationsUser.add_user_to_organization(user, Colocated.singleton)
   end

--- a/lib/fakes/authentication_service.rb
+++ b/lib/fakes/authentication_service.rb
@@ -8,11 +8,13 @@ class Fakes::AuthenticationService
 
   def self.get_user_session(user_id)
     user = User.find(user_id)
+
     # Take the roles from the User's css_id
-    roles = user.css_id.split(",").map(&:strip)
+    roles = [user.roles, user.css_id.split(",").map(&:strip)].flatten.compact
     if roles.include?("System Admin")
       Functions.grant!("System Admin", users: [user.css_id])
     end
+
     {
       "id" => user.css_id,
       "css_id" => user.css_id,


### PR DESCRIPTION
In order to support a demo for the VLJ support team we would like to have tasks that are on hold show up in the on hold tab. However, the fact that there are "new documents" for the case causes on hold cases to show up in the "pending action" tab. One way we could resolve this problem is by going into Reader to reset the "new document" clock but the VLJ support staff demo user (`BVALSPORER`) does not have Reader access. 

The problem described below was due to an old session sticking around (even after switching users). Tested this approach in an private browser window and it worked as expected.
> I attempted to give BVALSPORER Reader access by setting that user's role in the seed data but this approach is failing even after the fix in this PR (this user ends up with a roles value of `["BVALSPORER", "BVALSPORER"]`).