### PR TITLE
Parse BGS address array considering that array first element might not be an address in some cases

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -147,7 +147,8 @@ class ExternalApi::BGSService
       end
       if bgs_address
         # Count on addresses being sorted with most recent first if we return a list of addresses.
-        bgs_address = bgs_address[0] if bgs_address.is_a?(Array)
+        # The very first element of the array might not necessarily be an address
+        bgs_address = bgs_address.select { |a| a.key?(:addrs_one_txt) }[0] if bgs_address.is_a?(Array)
         @poa_addresses[participant_id] = get_address_from_bgs_address(bgs_address)
       end
     end


### PR DESCRIPTION
In some cases BGS address service returns an array of hashes and sometimes an address is not the first element. This solves this problem.