### PR TITLE
Add alert for unidentified issues on intake confirmation

### DIFF
--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -10,6 +10,7 @@ import Alert from '../../components/Alert';
 
 const leadMessageList = ({ veteran, formName, requestIssues }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
+
   if (unidentifiedIssues.length === 0) {
     return [
       `${veteran.name}'s (ID #${veteran.fileNumber}) ` +
@@ -19,22 +20,21 @@ const leadMessageList = ({ veteran, formName, requestIssues }) => {
     ];
   }
 
-  const unidentifiedIssuesAlert = (unidentifiedIssues) => {
-    return <Alert type='warning'>
-      <h2>Unidentified issue</h2>
-      <p>There is still an unidentified issue that needs to be resolved before sending the notice letter. To edit, go to VBMS claim details and click the “Edit in Caseflow” button.</p>
-      {unidentifiedIssues.map((ri, i) => <p class="cf-red-text" key={i}>
-        Unidentified issue: no issue matched for requested "{ri.description}"
-      </p>)}
-    </Alert>;
-  };
+  const unidentifiedIssuesAlert = <Alert type="warning">
+    <h2>Unidentified issue</h2>
+    <p>There is still an unidentified issue that needs to be resolved before sending the notice
+    letter. To edit, go to VBMS claim details and click the “Edit in Caseflow” button.</p>
+    {unidentifiedIssues.map((ri, i) => <p className="cf-red-text" key={i}>
+      Unidentified issue: no issue matched for requested "{ri.description}"
+    </p>)}
+  </Alert>;
 
   return [
     `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been processed.`,
-    unidentifiedIssuesAlert(unidentifiedIssues),
+    unidentifiedIssuesAlert,
     <strong>Edit the notice letter to reflect the status of requested issues.</strong>
   ];
-}
+};
 
 const getChecklistItems = (formType, requestIssues, isInformalConferenceRequested) => {
   const checklist = [];
@@ -132,7 +132,9 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
     return <div><StatusMessage
       title="Intake completed"
       type="success"
-      leadMessageList={leadMessageList({ veteran, formName: selectedForm.name, requestIssues })}
+      leadMessageList={leadMessageList({ veteran,
+        formName: selectedForm.name,
+        requestIssues })}
       checklist={getChecklistItems(formType, requestIssues, informalConference)}
       wrapInAppSegment={false}
     />

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -24,7 +24,7 @@ const leadMessageList = ({ veteran, formName, requestIssues }) => {
     <h2>Unidentified issue</h2>
     <p>There is still an unidentified issue that needs to be resolved before sending the notice
     letter. To edit, go to VBMS claim details and click the “Edit in Caseflow” button.</p>
-    {unidentifiedIssues.map((ri, i) => <p className="cf-red-text" key={i}>
+    {unidentifiedIssues.map((ri, i) => <p className="cf-red-text" key={`unidentified-alert-${i}`}>
       Unidentified issue: no issue matched for requested "{ri.description}"
     </p>)}
   </Alert>;
@@ -52,7 +52,7 @@ const getChecklistItems = (formType, requestIssues, isInformalConferenceRequeste
   if (formType === 'appeal') {
     checklist.push(<Fragment>
       <strong>Appeal created:</strong>
-      {eligibleRequestIssues.map((ri, i) => <p key={i}>Issue: {ri.contentionText}</p>)}
+      {eligibleRequestIssues.map((ri, i) => <p key={`appeal-issue-${i}`}>Issue: {ri.contentionText}</p>)}
     </Fragment>);
   }
 

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -6,6 +6,35 @@ import { PAGE_PATHS, INTAKE_STATES, FORM_TYPES } from '../constants';
 import INELIGIBLE_REQUEST_ISSUES from '../../../constants/INELIGIBLE_REQUEST_ISSUES.json';
 import { getIntakeStatus } from '../selectors';
 import _ from 'lodash';
+import Alert from '../../components/Alert';
+
+const leadMessageList = ({ veteran, formName, requestIssues }) => {
+  const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
+  if (unidentifiedIssues.length === 0) {
+    return [
+      `${veteran.name}'s (ID #${veteran.fileNumber}) ` +
+        `Request for ${formName} has been processed. ` +
+        'If you need to edit this, go to VBMS claim details and click the “Edit in Caseflow” button.',
+      <strong>Edit the notice letter to reflect the status of requested issues.</strong>
+    ];
+  }
+
+  const unidentifiedIssuesAlert = (unidentifiedIssues) => {
+    return <Alert type='warning'>
+      <h2>Unidentified issue</h2>
+      <p>There is still an unidentified issue that needs to be resolved before sending the notice letter. To edit, go to VBMS claim details and click the “Edit in Caseflow” button.</p>
+      {unidentifiedIssues.map((ri, i) => <p class="cf-red-text" key={i}>
+        Unidentified issue: no issue matched for requested "{ri.description}"
+      </p>)}
+    </Alert>;
+  };
+
+  return [
+    `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been processed.`,
+    unidentifiedIssuesAlert(unidentifiedIssues),
+    <strong>Edit the notice letter to reflect the status of requested issues.</strong>
+  ];
+}
 
 const getChecklistItems = (formType, requestIssues, isInformalConferenceRequested) => {
   const checklist = [];
@@ -100,17 +129,10 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
     default:
     }
 
-    const leadMessageList = [
-      `${veteran.name}'s (ID #${veteran.fileNumber}) ` +
-        `Request for ${selectedForm.name} has been processed. ` +
-        'If you need to edit this, go to VBMS claim details and click the “Edit in Caseflow” button.',
-      <strong>Edit the notice letter to reflect the status of requested issues.</strong>
-    ];
-
     return <div><StatusMessage
       title="Intake completed"
       type="success"
-      leadMessageList={leadMessageList}
+      leadMessageList={leadMessageList({ veteran, formName: selectedForm.name, requestIssues })}
       checklist={getChecklistItems(formType, requestIssues, informalConference)}
       wrapInAppSegment={false}
     />

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -458,6 +458,7 @@ RSpec.feature "Appeal Intake" do
 
     expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
     expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
+    expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
 
     success_checklist = find("ul.cf-success-checklist")
     expect(success_checklist).to_not have_content("Non-RAMP issue before AMA Activation")

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -827,6 +827,7 @@ RSpec.feature "Higher-Level Review" do
 
       expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
+      expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
       success_checklist = find("ul.cf-success-checklist")
       expect(success_checklist).to_not have_content("Already reviewed injury")
       expect(success_checklist).to_not have_content("Another Description for Active Duty Adjustments")

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -638,6 +638,7 @@ RSpec.feature "Supplemental Claim Intake" do
 
       expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
+      expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
       success_checklist = find("ul.cf-success-checklist")
       expect(success_checklist).to_not have_content("Non-RAMP issue before AMA Activation")
       expect(success_checklist).to_not have_content("A nonrating issue before AMA")


### PR DESCRIPTION
Connects #7304 

### Description
Displays an alert for unidentified issues on intake completion. The issue says to add this to both intake and edit, but the edit page is coming later in #7313, so this just adds to the intake confirmation page.

Two notes:
1. I think the confirmation page needs some refactoring soon, but that would come in a followup
1. The spacing is too big, that will also get tweaked in a followup

<img width="1419" alt="screen shot 2018-11-20 at 14 05 57" src="https://user-images.githubusercontent.com/279406/48799779-07a1c980-ecd6-11e8-932e-256984f50a10.png">

### Acceptance Criteria
- After an intake has been completed for any AMA lane, if the review contains any unidentified issues, the confirmation screen will show it as an alert box with instructions on how to come back and edit.
- If there are multiple unidentified issues, show them on separate lines in the same alert box

### Testing Plan
1. Complete any decision review with unidentified issues, then view the confirmation page.
