### PR TITLE
Throw error if appeals search response text is empty

### DIFF
--- a/client/app/queue/CaseList/CaseListActions.js
+++ b/client/app/queue/CaseList/CaseListActions.js
@@ -90,9 +90,9 @@ export const fetchAppealsUsingVeteranId = (searchQuery) =>
       headers: { 'veteran-id': veteranId }
     }).
       then((response) => {
-        const returnedObject = JSON.parse(response.text);
+        const isResponseEmpty = !response.text || _.size(JSON.parse(response.text) === 0);
 
-        if (_.size(returnedObject.appeals) === 0) {
+        if (isResponseEmpty) {
           dispatch(fetchedNoAppealsUsingVeteranId(veteranId));
 
           return reject();

--- a/client/app/queue/CaseList/CaseListActions.js
+++ b/client/app/queue/CaseList/CaseListActions.js
@@ -97,6 +97,9 @@ export const fetchAppealsUsingVeteranId = (searchQuery) =>
 
           return reject();
         }
+
+        const returnedObject = JSON.parse(response.text);
+
         dispatch(onReceiveAppealsUsingVeteranId(returnedObject.appeals));
 
         // Expect all of the appeals will be for the same Caseflow Veteran ID so we pull off the first for the URL.

--- a/client/app/queue/CaseList/CaseListActions.js
+++ b/client/app/queue/CaseList/CaseListActions.js
@@ -90,7 +90,7 @@ export const fetchAppealsUsingVeteranId = (searchQuery) =>
       headers: { 'veteran-id': veteranId }
     }).
       then((response) => {
-        const isResponseEmpty = !response.text || _.size(JSON.parse(response.text) === 0);
+        const isResponseEmpty = !response.text || (_.size(JSON.parse(response.text)) === 0);
 
         if (isResponseEmpty) {
           dispatch(fetchedNoAppealsUsingVeteranId(veteranId));


### PR DESCRIPTION
### Description
If the request to `/appeals` returns a `response.text` that is empty (`""`), throw an error rather than fail silently.

(`JSON.parse(response.text)` fails silently if `response.text === ""`)

<img width="961" alt="screenshot 2018-11-21 10 55 24" src="https://user-images.githubusercontent.com/2928395/48856598-6faaeb00-ed7c-11e8-94d8-5e8dc899c414.png">
