### PR TITLE
Create JudgeTeam class

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -26,7 +26,7 @@ class Organization < ApplicationRecord
   end
 
   def user_is_admin?(user)
-    organizations_users.where(admin: true).pluck(:user_id).include?(user.id)
+    admins.include?(user)
   end
 
   def path

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,6 +17,10 @@ class Organization < ApplicationRecord
     users.pluck(:id).include?(user.id)
   end
 
+  def user_is_admin?(user)
+    organizations_users.where(admin: true).pluck(:user_id).include?(user.id)
+  end
+
   def path
     "/organizations/#{url ? url : id}"
   end

--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -4,9 +4,9 @@ class JudgeTeam < Organization
   end
 
   def self.create_for_judge(user)
-    org = create!(name: user.css_id)
-    OrganizationsUser.make_user_admin(user, org)
-    org
+    create!(name: user.css_id).tap do |org|
+      OrganizationsUser.make_user_admin(user, org)
+    end
   end
 
   def can_receive_task?(_task)

--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -8,4 +8,8 @@ class JudgeTeam < Organization
     OrganizationsUser.make_user_admin(user, org)
     org
   end
+
+  def can_receive_task?(_task)
+    false
+  end
 end

--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -1,0 +1,11 @@
+class JudgeTeam < Organization
+  def self.for_judge(user)
+    user.administrated_teams.select { |team| team.is_a?(JudgeTeam) }.first
+  end
+
+  def self.create_for_judge(user)
+    org = create!(name: user.css_id)
+    OrganizationsUser.make_user_admin(user, org)
+    org
+  end
+end

--- a/app/models/organizations_user.rb
+++ b/app/models/organizations_user.rb
@@ -6,6 +6,10 @@ class OrganizationsUser < ApplicationRecord
     existing_record(user, organization) || create(organization_id: organization.id, user_id: user.id)
   end
 
+  def self.make_user_admin(user, organization)
+    add_user_to_organization(user, organization).update!(admin: true)
+  end
+
   def self.remove_user_from_organization(user, organization)
     existing_record(user, organization).destroy
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -210,7 +210,7 @@ class User < ApplicationRecord
   end
 
   def administrated_teams
-    organizations_users.where(admin: true).map(&:organization)
+    organizations_users.select(&:admin?).map(&:organization)
   end
 
   def judge_css_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,6 +209,10 @@ class User < ApplicationRecord
     self.class.appeal_repository.load_user_case_assignments_from_vacols(css_id)
   end
 
+  def administrated_teams
+    organizations_users.where(admin: true).map(&:organization)
+  end
+
   def judge_css_id
     Constants::AttorneyJudgeTeams::JUDGES[Rails.current_env].each_pair do |id, value|
       return id if value[:attorneys].include?(css_id)

--- a/spec/models/judge_team_spec.rb
+++ b/spec/models/judge_team_spec.rb
@@ -55,4 +55,10 @@ describe JudgeTeam do
       end
     end
   end
+
+  describe ".can_receive_task?" do
+    it "should return false because judge teams should not have tasks assigned to them in the web UI" do
+      expect(JudgeTeam.create_for_judge(judge).can_receive_task?(nil)).to eq(false)
+    end
+  end
 end

--- a/spec/models/judge_team_spec.rb
+++ b/spec/models/judge_team_spec.rb
@@ -1,0 +1,58 @@
+describe JudgeTeam do
+  let(:judge) { FactoryBot.create(:user) }
+
+  describe ".create_for_judge" do
+    context "when user is not already an admin of an existing JudgeTeam" do
+      it "should create a new organization and make the user an admin of that group" do
+        expect(judge.organizations.length).to eq(0)
+
+        expect { JudgeTeam.create_for_judge(judge) }.to_not raise_error
+        judge.reload
+
+        expect(judge.organizations.length).to eq(1)
+        expect(judge.administrated_teams.length).to eq(1)
+        expect(judge.administrated_teams.first.class).to eq(JudgeTeam)
+      end
+    end
+  end
+
+  describe ".for_judge" do
+    let(:user) { FactoryBot.create(:user) }
+
+    context "when user is admin of a non-JudgeTeam organization" do
+      before { OrganizationsUser.make_user_admin(user, FactoryBot.create(:organization)) }
+
+      it "should return nil" do
+        expect(JudgeTeam.for_judge(user)).to eq(nil)
+      end
+    end
+
+    context "when user is member of JudgeTeam" do
+      let!(:judge_team) { JudgeTeam.create_for_judge(judge) }
+      before { OrganizationsUser.add_user_to_organization(user, judge_team) }
+
+      it "should return nil" do
+        expect(JudgeTeam.for_judge(user)).to eq(nil)
+      end
+    end
+
+    context "when user is admin of JudgeTeam" do
+      let!(:judge_team) { JudgeTeam.create_for_judge(user) }
+
+      it "should return judge team" do
+        expect(JudgeTeam.for_judge(user)).to eq(judge_team)
+      end
+    end
+
+    # Limitation of the current approach is that users are effectively limited to being the admin of a single JudgeTeam.
+    context "when user is admin of multiple JudgeTeams" do
+      let!(:first_judge_team) { JudgeTeam.create_for_judge(user) }
+      let!(:second_judge_team) { JudgeTeam.create_for_judge(user) }
+
+      it "should return first judge team even when they admin two judge teams" do
+        expect(JudgeTeam.for_judge(user)).to eq(first_judge_team)
+        expect(user.administrated_teams.length).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -85,4 +85,23 @@ describe Organization do
       end
     end
   end
+
+  describe ".user_is_admin?" do
+    let(:org) { create(:organization) }
+    let(:user) { create(:user) }
+
+    context "when user is not an admin for the organization" do
+      before { OrganizationsUser.add_user_to_organization(user, org) }
+      it "should return false" do
+        expect(org.user_is_admin?(user)).to eq(false)
+      end
+    end
+
+    context "when user is an admin for the organization" do
+      before { OrganizationsUser.make_user_admin(user, org) }
+      it "should return true" do
+        expect(org.user_is_admin?(user)).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -380,4 +380,39 @@ describe User do
       it { is_expected.to eq(current_task) }
     end
   end
+
+  describe ".administrated_teams" do
+  end
+
+  describe ".administrated_teams" do
+    let(:org) { create(:organization) }
+    let(:user) { create(:user) }
+
+    context "when user belongs to one organization but is not an admin" do
+      before { OrganizationsUser.add_user_to_organization(user, org) }
+      it "should return an empty list" do
+        expect(user.administrated_teams).to eq([])
+      end
+    end
+
+    context "when user is an admin of one organization" do
+      before { OrganizationsUser.make_user_admin(user, org) }
+      it "should return a list that contains the single organization" do
+        expect(user.administrated_teams).to eq([org])
+      end
+    end
+
+    context "when user belongs to several organizations and is an admin of several different organizations" do
+      let(:member_orgs) { create_list(:organization, 5) }
+      let(:admin_orgs) { create_list(:organization, 3) }
+
+      before do
+        member_orgs.each { |o| OrganizationsUser.add_user_to_organization(user, o) }
+        admin_orgs.each { |o| OrganizationsUser.make_user_admin(user, o) }
+      end
+      it "should return a list of all teams user is an admin for" do
+        expect(user.administrated_teams).to eq(admin_orgs)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #7506.

In preparation for [moving attorney membership in judge teams](https://github.com/department-of-veterans-affairs/caseflow/pull/7847) over to the organization model this PR creates a new `JudgeTeam` class.
