### PR TITLE
Frontend | Console errors

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -219,6 +219,7 @@ export default class AssignHearings extends React.Component {
         columns={tabWindowColumns}
         rowObjects={this.tableAssignHearingsRows(this.props.veteransReadyForHearing)}
         summary="scheduled-hearings-table"
+        slowReRendersAreOk
       />;
 
     };
@@ -243,6 +244,7 @@ export default class AssignHearings extends React.Component {
               columns={tabWindowColumns}
               rowObjects={this.tableScheduledHearingsRows(scheduledOrder)}
               summary="scheduled-hearings-table"
+              slowReRendersAreOk
             />
           },
           {

--- a/client/app/hearingSchedule/components/BuildSchedule.jsx
+++ b/client/app/hearingSchedule/components/BuildSchedule.jsx
@@ -147,6 +147,7 @@ export default class BuildSchedule extends React.Component {
         columns={pastUploadsColumns}
         rowObjects={pastUploadsRows}
         summary="past-uploads"
+        slowReRendersAreOk
       />
     </AppSegment>;
   }
@@ -165,4 +166,3 @@ BuildSchedule.propTypes = {
   schedulePeriod: PropTypes.object,
   displaySuccessMessage: PropTypes.bool
 };
-

--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -251,7 +251,7 @@ export default class DailyDocket extends React.Component {
       name="Notes"
       onChange={this.onHearingNotesUpdate(hearing.id)}
       textAreaStyling={notesFieldStyling}
-      value={_.isUndefined(hearing.editedNotes) ? hearing.notes : hearing.editedNotes || ''}
+      value={_.isUndefined(hearing.editedNotes) ? hearing.notes || '' : hearing.editedNotes}
     />;
   };
 
@@ -358,6 +358,7 @@ export default class DailyDocket extends React.Component {
           rowObjects={this.getDailyDocketRows(this.dailyDocketHearings(this.props.hearings), false)}
           summary="dailyDocket"
           bodyStyling={tableRowStyling}
+          slowReRendersAreOk
         />
       </div>
       { !_.isEmpty(this.previouslyScheduledHearings(this.props.hearings)) && <div>
@@ -368,7 +369,7 @@ export default class DailyDocket extends React.Component {
             rowObjects={this.getDailyDocketRows(this.previouslyScheduledHearings(), true)}
             summary="dailyDocket"
             bodyStyling={tableRowStyling}
-          />
+            slowReRendersAreOk />
         </div>
       </div> }
     </AppSegment>;

--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -258,7 +258,8 @@ class ListSchedule extends React.Component {
             <Table
               columns={hearingScheduleColumns}
               rowObjects={hearingScheduleRows}
-              summary="hearing-schedule" />
+              summary="hearing-schedule"
+              slowReRendersAreOk />
 
           </LoadingDataDisplay>
         </div>

--- a/client/app/hearingSchedule/components/ReviewAssignments.jsx
+++ b/client/app/hearingSchedule/components/ReviewAssignments.jsx
@@ -197,6 +197,7 @@ export default class ReviewAssignments extends React.Component {
         columns={hearingAssignmentColumns}
         rowObjects={hearingAssignmentRows}
         summary="hearing-assignments"
+        slowReRendersAreOk
       />
     </AppSegment>;
   }

--- a/client/app/hearingSchedule/containers/AssignHearingsContainer.jsx
+++ b/client/app/hearingSchedule/containers/AssignHearingsContainer.jsx
@@ -115,7 +115,7 @@ class AssignHearingsContainer extends React.PureComponent {
         <section className="usa-form-large" {...roSelectionStyling}>
           <RoSelectorDropdown
             onChange={this.props.onRegionalOfficeChange}
-            value={this.props.selectedRegionalOffice}
+            value={this.props.selectedRegionalOffice ? this.props.selectedRegionalOffice : null}
             staticOptions={centralOfficeStaticEntry}
           />
         </section>

--- a/client/app/hearings/DailyDocket.jsx
+++ b/client/app/hearings/DailyDocket.jsx
@@ -355,6 +355,7 @@ getAodDropdown = (hearing) => {
             rowObjects={this.getDailyDocketRows(docket)}
             summary="dailyDocket"
             bodyStyling={tableRowStyling}
+            slowReRendersAreOk
           />
         </div>
       </AppSegment>


### PR DESCRIPTION
Resolves #7948

### Description
This PR resolves console errors in Schedule and Hearing-prep
### Acceptance Criteria
- [ ] On the Assign Hearings page resolved Failed prop type
- [ ] On the Schedule Veteran tab passed `slowReRendersAreOK`
- [ ] On the Daily Docket in Hearing-prep and Schedule  passed `slowReRendersAreOK` and resolved `prop on textarea should not be null`
- [ ] On the  View Schedule page passed `slowReRendersAreOK`
### Testing Plan
1. Go to Hearing-prep and Schedule

