### PR TITLE
Rename Task.action to Task.label on frontend

### DIFF
--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -15,6 +15,10 @@ class LegacyTask
     assigned_at
   end
 
+  def label
+    action
+  end
+
   delegate :css_id, :name, to: :added_by, prefix: true
   delegate :first_name, :last_name, :pg_id, :css_id, to: :assigned_by, prefix: true
 

--- a/app/models/serializers/work_queue/legacy_task_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_task_serializer.rb
@@ -14,7 +14,7 @@ class WorkQueue::LegacyTaskSerializer < ActiveModel::Serializer
   attribute :added_by_name
   attribute :added_by_css_id
   attribute :task_id
-  attribute :action
+  attribute :label
   attribute :document_id
   attribute :work_product
   attribute :appeal_type

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -3,7 +3,7 @@ class WorkQueue::TaskSerializer < ActiveModel::Serializer
     false
   end
   attribute :type
-  attribute :action
+  attribute :label
   attribute :appeal_id
   attribute :status
   attribute :assigned_at

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,6 +23,10 @@ class Task < ApplicationRecord
     []
   end
 
+  def label
+    action
+  end
+
   # available_actions() returns an array of options from selected by the subclass
   # from TASK_ACTIONS that looks something like:
   # [ { "label": "Assign to person", "value": "modal/assign_to_person", "func": "assignable_users" }, ... ]

--- a/client/app/queue/AddColocatedTaskView.jsx
+++ b/client/app/queue/AddColocatedTaskView.jsx
@@ -31,7 +31,7 @@ import type { Appeal, Task } from './types/models';
 import type { UiStateMessage } from './types/state';
 
 type ComponentState = {|
-  action: ?string,
+  label: ?string,
   instructions: string
 |};
 
@@ -57,7 +57,7 @@ class AddColocatedTaskView extends React.PureComponent<Props, ComponentState> {
     super(props);
 
     this.state = {
-      action: null,
+      label: null,
       instructions: ''
     };
   }
@@ -83,7 +83,7 @@ class AddColocatedTaskView extends React.PureComponent<Props, ComponentState> {
       }
     };
     const successMsg = {
-      title: sprintf(COPY.ADD_COLOCATED_TASK_CONFIRMATION_TITLE, CO_LOCATED_ADMIN_ACTIONS[this.state.action]),
+      title: sprintf(COPY.ADD_COLOCATED_TASK_CONFIRMATION_TITLE, CO_LOCATED_ADMIN_ACTIONS[this.state.label]),
       detail: <DispatchSuccessDetail task={task} />
     };
 
@@ -101,7 +101,7 @@ class AddColocatedTaskView extends React.PureComponent<Props, ComponentState> {
 
   render = () => {
     const { highlightFormItems, error } = this.props;
-    const { action, instructions } = this.state;
+    const { label, instructions } = this.state;
 
     return <React.Fragment>
       <h1 className="cf-push-left" {...css(fullWidth, marginBottom(1))}>
@@ -113,15 +113,15 @@ class AddColocatedTaskView extends React.PureComponent<Props, ComponentState> {
       </Alert>}
       <div {...marginTop(4)}>
         <SearchableDropdown
-          errorMessage={highlightFormItems && !action ? COPY.FORM_ERROR_FIELD_REQUIRED : null}
+          errorMessage={highlightFormItems && !label ? COPY.FORM_ERROR_FIELD_REQUIRED : null}
           name={COPY.ADD_COLOCATED_TASK_ACTION_TYPE_LABEL}
           placeholder="Select an action type"
-          options={_.map(CO_LOCATED_ADMIN_ACTIONS, (label: string, value: string) => ({
-            label,
+          options={_.map(CO_LOCATED_ADMIN_ACTIONS, (key: string, value: string) => ({
+            key,
             value
           }))}
-          onChange={(option) => option && this.setState({ action: option.value })}
-          value={this.state.action} />
+          onChange={(option) => option && this.setState({ label: option.value })}
+          value={this.state.label} />
       </div>
       <div {...marginTop(4)}>
         <TextareaField

--- a/client/app/queue/AssignToAttorneyModalView.jsx
+++ b/client/app/queue/AssignToAttorneyModalView.jsx
@@ -38,7 +38,7 @@ class AssignToAttorneyModalView extends React.PureComponent<Props> {
   ) => {
     const previousAssigneeId = tasks[0].assignedTo.id.toString();
 
-    if (tasks[0].action === 'assign') {
+    if (tasks[0].label === 'assign') {
       return this.props.initialAssignTasksToUser({
         tasks,
         assigneeId,

--- a/client/app/queue/CaseSnapshot.jsx
+++ b/client/app/queue/CaseSnapshot.jsx
@@ -99,15 +99,15 @@ export class CaseSnapshot extends React.PureComponent<Props> {
 
   getActionName = () => {
     const {
-      action
+      label
     } = this.props.primaryTask;
 
-    // First see if there is a constant to convert the action, otherwise sentence-ify it
-    if (CO_LOCATED_ADMIN_ACTIONS[action]) {
-      return CO_LOCATED_ADMIN_ACTIONS[action];
+    // First see if there is a constant to convert the label, otherwise sentence-ify it
+    if (CO_LOCATED_ADMIN_ACTIONS[label]) {
+      return CO_LOCATED_ADMIN_ACTIONS[label];
     }
 
-    return StringUtil.snakeCaseToSentence(action);
+    return StringUtil.snakeCaseToSentence(label);
   }
 
   taskInstructionsWithLineBreaks = (instructions?: Array<string>) => <React.Fragment>
@@ -130,7 +130,7 @@ export class CaseSnapshot extends React.PureComponent<Props> {
       this.getAbbrevName(primaryTask.decisionPreparedBy) : null;
 
     return <React.Fragment>
-      { primaryTask.action &&
+      { primaryTask.label &&
         <React.Fragment>
           <dt>{COPY.CASE_SNAPSHOT_TASK_TYPE_LABEL}</dt><dd>{this.getActionName()}</dd>
         </React.Fragment> }
@@ -200,7 +200,7 @@ export class CaseSnapshot extends React.PureComponent<Props> {
         </React.Fragment>;
       } else if (userRole === USER_ROLE_TYPES.colocated) {
         return <React.Fragment>
-          <dt>{COPY.CASE_SNAPSHOT_TASK_TYPE_LABEL}</dt><dd>{CO_LOCATED_ADMIN_ACTIONS[primaryTask.action]}</dd>
+          <dt>{COPY.CASE_SNAPSHOT_TASK_TYPE_LABEL}</dt><dd>{CO_LOCATED_ADMIN_ACTIONS[primaryTask.label]}</dd>
           <dt>{COPY.CASE_SNAPSHOT_TASK_FROM_LABEL}</dt><dd>{assignedByAbbrev}</dd>
           { taskIsOnHold(primaryTask) &&
             <React.Fragment>

--- a/client/app/queue/ColocatedPlaceHoldView.jsx
+++ b/client/app/queue/ColocatedPlaceHoldView.jsx
@@ -131,7 +131,7 @@ class ColocatedPlaceHoldView extends React.Component<Props, ViewState> {
           <strong>Veteran ID:</strong> {appeal.veteranFileNumber}
         </span>
         <span {...columnStyling}>
-          <strong>Task:</strong> {CO_LOCATED_ADMIN_ACTIONS[task.action]}
+          <strong>Task:</strong> {CO_LOCATED_ADMIN_ACTIONS[task.label]}
         </span>
       </div>
       <hr />

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -112,8 +112,8 @@ class QueueApp extends React.PureComponent<Props> {
     <BeaamAppealListView {...this.props} />
   </QueueLoadingScreen>;
 
-  routedJudgeQueueList = (action) => ({ match }) => <QueueLoadingScreen {...this.propsForQueueLoadingScreen()}>
-    {action === 'assign' ?
+  routedJudgeQueueList = (label) => ({ match }) => <QueueLoadingScreen {...this.propsForQueueLoadingScreen()}>
+    {label === 'assign' ?
       <JudgeAssignTaskListView {...this.props} match={match} /> :
       <JudgeReviewTaskListView {...this.props} />}
   </QueueLoadingScreen>;
@@ -330,8 +330,8 @@ class QueueApp extends React.PureComponent<Props> {
           <PageRoute
             exact
             path={'/queue/appeals/:appealId/tasks/:taskId/:checkoutFlow(draft_decision|dispatch_decision)/' +
-              'dispositions/:action(add|edit)/:issueId?'}
-            title={(props) => `Draft Decision | ${StringUtil.titleCase(props.match.params.action)} Issue`}
+              'dispositions/:label(add|edit)/:issueId?'}
+            title={(props) => `Draft Decision | ${StringUtil.titleCase(props.match.params.label)} Issue`}
             render={this.routedAddEditIssue} />
           <PageRoute
             exact

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -330,8 +330,8 @@ class QueueApp extends React.PureComponent<Props> {
           <PageRoute
             exact
             path={'/queue/appeals/:appealId/tasks/:taskId/:checkoutFlow(draft_decision|dispatch_decision)/' +
-              'dispositions/:label(add|edit)/:issueId?'}
-            title={(props) => `Draft Decision | ${StringUtil.titleCase(props.match.params.label)} Issue`}
+              'dispositions/:action(add|edit)/:issueId?'}
+            title={(props) => `Draft Decision | ${StringUtil.titleCase(props.match.params.action)} Issue`}
             render={this.routedAddEditIssue} />
           <PageRoute
             exact

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -80,7 +80,7 @@ class CompleteTaskModal extends React.Component<Props> {
 
   getContentArgs = () => ({
     assignerName: this.getTaskAssignerName(),
-    teamName: CO_LOCATED_ADMIN_ACTIONS[this.props.task.action],
+    teamName: CO_LOCATED_ADMIN_ACTIONS[this.props.task.label],
     appeal: this.props.appeal
   });
 
@@ -127,7 +127,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 const propsToText = (props) => {
   return {
     title: SEND_TO_LOCATION_MODAL_TYPE_ATTRS[props.modalType].title({
-      teamName: (props.task && props.task.action) ? CO_LOCATED_ADMIN_ACTIONS[props.task.action] : ''
+      teamName: (props.task && props.task.label) ? CO_LOCATED_ADMIN_ACTIONS[props.task.label] : ''
     }),
     button: SEND_TO_LOCATION_MODAL_TYPE_ATTRS[props.modalType].buttonText
   };

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -117,7 +117,7 @@ class TaskTable extends React.PureComponent<Props> {
     } : null;
   }
 
-  actionNameOfTask = (task: TaskWithAppeal) => CO_LOCATED_ADMIN_ACTIONS[task.action]
+  actionNameOfTask = (task: TaskWithAppeal) => CO_LOCATED_ADMIN_ACTIONS[task.label]
 
   caseTaskColumn = () => {
     return this.props.includeTask ? {

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -201,12 +201,12 @@ export const judgeReviewTasksSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
   (tasks) => _.filter(tasks, (task: TaskWithAppeal) => {
     if (task.appealType === 'Appeal') {
-      return task.action === 'review' &&
+      return task.label === 'review' &&
         (task.status === TASK_STATUSES.in_progress || task.status === TASK_STATUSES.assigned);
     }
 
     // eslint-disable-next-line no-undefined
-    return [null, undefined, 'review'].includes(task.action);
+    return [null, undefined, 'review'].includes(task.label);
   })
 );
 
@@ -214,11 +214,11 @@ export const judgeAssignTasksSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
   (tasks) => _.filter(tasks, (task: TaskWithAppeal) => {
     if (task.appealType === 'Appeal') {
-      return task.action === 'assign' &&
+      return task.label === 'assign' &&
         (task.status === TASK_STATUSES.in_progress || task.status === TASK_STATUSES.assigned);
     }
 
-    return task.action === 'assign';
+    return task.label === 'assign';
   })
 );
 

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -54,7 +54,7 @@ export type Task = {
   uniqueId: string,
   isLegacy: boolean,
   type: ?string,
-  action: string,
+  label: string,
   appealId: number,
   appealType: string,
   externalAppealId: string,

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -79,7 +79,7 @@ export const prepareTasksForStore = (tasks: Array<Object>): Tasks =>
         pgId: task.attributes.assigned_by.pg_id
       },
       taskId: task.id,
-      action: task.attributes.action,
+      label: task.attributes.label,
       documentId: task.attributes.document_id,
       workProduct: null,
       previousTaskAssignedOn: task.attributes.previous_task.assigned_at,
@@ -152,7 +152,7 @@ export const prepareLegacyTasksForStore = (tasks: Array<Object>): Tasks => {
       addedByName: task.attributes.added_by_name,
       addedByCssId: task.attributes.added_by_css_id,
       taskId: task.attributes.task_id,
-      action: task.attributes.action,
+      label: task.attributes.label,
       documentId: task.attributes.document_id,
       workProduct: task.attributes.work_product,
       previousTaskAssignedOn: task.attributes.previous_task.assigned_on,

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -71,7 +71,7 @@ describe('ColocatedTaskListView', () => {
       pgId: 1
     },
     taskId: '8',
-    action: 'new_rep_arguments',
+    label: 'new_rep_arguments',
     documentId: null,
     workProduct: null,
     previousTaskAssignedOn: null,
@@ -153,7 +153,7 @@ describe('ColocatedTaskListView', () => {
 
       expect(caseDetails.text()).to.include(appeal.veteranFullName);
       expect(caseDetails.text()).to.include(appeal.veteranFileNumber);
-      expect(columnTasks.text()).to.include(CO_LOCATED_ADMIN_ACTIONS[task.action]);
+      expect(columnTasks.text()).to.include(CO_LOCATED_ADMIN_ACTIONS[task.label]);
       expect(types.text()).to.include(appeal.caseType);
       expect(docketNumber.text()).to.include(appeal.docketNumber);
       expect(daysWaiting.text()).to.equal('1');
@@ -302,7 +302,7 @@ describe('ColocatedTaskListView', () => {
 
       expect(caseDetails.text()).to.include(appeal.veteranFullName);
       expect(caseDetails.text()).to.include(appeal.veteranFileNumber);
-      expect(columnTasks.text()).to.include(CO_LOCATED_ADMIN_ACTIONS[task.action]);
+      expect(columnTasks.text()).to.include(CO_LOCATED_ADMIN_ACTIONS[task.label]);
       expect(types.text()).to.include(appeal.caseType);
       expect(docketNumber.text()).to.include(appeal.docketNumber);
       expect(daysOnHold.text()).to.equal('1 of 30');

--- a/client/test/karma/queue/QueueLoadingScreen-test.js
+++ b/client/test/karma/queue/QueueLoadingScreen-test.js
@@ -39,7 +39,7 @@ const serverData = {
             assigned_on: '2018-08-02T17:37:03.000Z'
           },
           task_id: '3625593-2018-07-11',
-          action: 'review',
+          label: 'review',
           user_id: 'BVANKUVALIS',
           veteran_file_number: '767574947',
           veteran_name: 'Mills, Beulah, J',
@@ -79,7 +79,7 @@ describe('QueueLoadingScreen', () => {
         addedByName: 'Nash X Kuvalis',
         addedByCssId: 'BVANKUVALIS',
         taskId: '3625593-2018-07-11',
-        action: 'review',
+        label: 'review',
         documentId: '12345-12345678',
         assignedBy: {
           firstName: 'Stephen',

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -322,7 +322,7 @@ RSpec.describe TasksController, type: :controller do
       context "when current user is an attorney" do
         let(:role) { :attorney_role }
 
-        context "when multiple admin actions" do
+        context "when multiple admin actions with task action field" do
           let(:params) do
             [{
               "external_id": appeal.vacols_id,
@@ -352,12 +352,12 @@ RSpec.describe TasksController, type: :controller do
             expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.on_hold
             expect(response_body.first["attributes"]["appeal_id"]).to eq appeal.id
             expect(response_body.first["attributes"]["instructions"][0]).to eq "do this"
-            expect(response_body.first["attributes"]["action"]).to eq "address_verification"
+            expect(response_body.first["attributes"]["label"]).to eq "address_verification"
 
             expect(response_body.second["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
             expect(response_body.second["attributes"]["appeal_id"]).to eq appeal.id
             expect(response_body.second["attributes"]["instructions"][0]).to eq "do this"
-            expect(response_body.second["attributes"]["action"]).to eq "address_verification"
+            expect(response_body.second["attributes"]["label"]).to eq "address_verification"
             # assignee should be the same person
             id = response_body.second["attributes"]["assigned_to"]["id"]
             expect(response_body.last["attributes"]["assigned_to"]["id"]).to eq id
@@ -365,11 +365,58 @@ RSpec.describe TasksController, type: :controller do
             expect(response_body.last["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
             expect(response_body.last["attributes"]["appeal_id"]).to eq appeal.id
             expect(response_body.last["attributes"]["instructions"][0]).to eq "another one"
-            expect(response_body.last["attributes"]["action"]).to eq "missing_records"
+            expect(response_body.last["attributes"]["label"]).to eq "missing_records"
           end
         end
 
-        context "when one admin action" do
+        context "when multiple admin actions with task label field" do
+          let(:params) do
+            [{
+              "external_id": appeal.vacols_id,
+              "type": ColocatedTask.name,
+              "label": "address_verification",
+              "instructions": "do this"
+            },
+             {
+               "external_id": appeal.vacols_id,
+               "type": ColocatedTask.name,
+               "label": "missing_records",
+               "instructions": "another one"
+             }]
+          end
+
+          before do
+            u = FactoryBot.create(:user)
+            OrganizationsUser.add_user_to_organization(u, Colocated.singleton)
+          end
+
+          it "should be successful" do
+            expect(AppealRepository).to receive(:update_location!).exactly(1).times
+            post :create, params: { tasks: params }
+            expect(response.status).to eq 201
+            response_body = JSON.parse(response.body)["tasks"]["data"]
+            expect(response_body.size).to eq(4)
+            expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.on_hold
+            expect(response_body.first["attributes"]["appeal_id"]).to eq appeal.id
+            expect(response_body.first["attributes"]["instructions"][0]).to eq "do this"
+            expect(response_body.first["attributes"]["label"]).to eq "address_verification"
+
+            expect(response_body.second["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
+            expect(response_body.second["attributes"]["appeal_id"]).to eq appeal.id
+            expect(response_body.second["attributes"]["instructions"][0]).to eq "do this"
+            expect(response_body.second["attributes"]["label"]).to eq "address_verification"
+            # assignee should be the same person
+            id = response_body.second["attributes"]["assigned_to"]["id"]
+            expect(response_body.last["attributes"]["assigned_to"]["id"]).to eq id
+
+            expect(response_body.last["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
+            expect(response_body.last["attributes"]["appeal_id"]).to eq appeal.id
+            expect(response_body.last["attributes"]["instructions"][0]).to eq "another one"
+            expect(response_body.last["attributes"]["label"]).to eq "missing_records"
+          end
+        end
+
+        context "when one admin action with task action field" do
           let(:params) do
             {
               "external_id": appeal.vacols_id,
@@ -387,7 +434,29 @@ RSpec.describe TasksController, type: :controller do
             expect(response_body.last["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
             expect(response_body.last["attributes"]["appeal_id"]).to eq appeal.id
             expect(response_body.last["attributes"]["instructions"][0]).to eq "do this"
-            expect(response_body.last["attributes"]["action"]).to eq "address_verification"
+            expect(response_body.last["attributes"]["label"]).to eq "address_verification"
+          end
+        end
+
+        context "when one admin action with task label field" do
+          let(:params) do
+            {
+              "external_id": appeal.vacols_id,
+              "type": ColocatedTask.name,
+              "label": "address_verification",
+              "instructions": "do this"
+            }
+          end
+
+          it "should be successful" do
+            post :create, params: { tasks: params }
+            expect(response.status).to eq 201
+            response_body = JSON.parse(response.body)["tasks"]["data"]
+            expect(response_body.size).to eq(2)
+            expect(response_body.last["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
+            expect(response_body.last["attributes"]["appeal_id"]).to eq appeal.id
+            expect(response_body.last["attributes"]["instructions"][0]).to eq "do this"
+            expect(response_body.last["attributes"]["label"]).to eq "address_verification"
           end
         end
 


### PR DESCRIPTION
Connects #7686. This is the first step in the removal of the `action` column from the `tasks` table. This PR changes all references to the `task.action` attribute to the `task.label` attribute on the frontend.