### PR TITLE
Allow attorneys and judges to edit remand reasons

### DIFF
--- a/app/models/concerns/case_review_concern.rb
+++ b/app/models/concerns/case_review_concern.rb
@@ -47,9 +47,20 @@ module CaseReviewConcern
       request_issues.each do |request_issue|
         RequestDecisionIssue.create!(decision_issue: decision_issue, request_issue: request_issue)
       end
+      create_remand_reasons(decision_issue, issue_attrs[:remand_reasons] || [])
     end
   end
 
+  def create_remand_reasons(decision_issue, remand_reasons_attrs)
+    remand_reasons_attrs.each do |attrs|
+      decision_issue.remand_reasons.find_or_initialize_by(code: attrs[:code]).tap do |record|
+        record.post_aoj = attrs[:post_aoj]
+        record.save!
+      end
+    end
+  end
+
+  # Delete this method when feature flag 'ama_decision_issues' is enabled for all
   def update_issue_dispositions
     (issues || []).each do |issue_attrs|
       request_issue = appeal.request_issues.find_by(id: issue_attrs["id"]) if appeal
@@ -62,6 +73,7 @@ module CaseReviewConcern
     end
   end
 
+  # Delete this method when feature flag 'ama_decision_issues' is enabled for all
   def update_remand_reasons(request_issue, remand_reasons_attrs)
     remand_reasons_attrs.each do |remand_reason_attrs|
       request_issue.remand_reasons.find_or_initialize_by(code: remand_reason_attrs["code"]).tap do |record|

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -2,4 +2,5 @@ class DecisionIssue < ApplicationRecord
   validates :disposition, inclusion: { in: Constants::ISSUE_DISPOSITIONS_BY_ID.keys.map(&:to_s) }, allow_nil: true
   has_many :request_decision_issues, dependent: :destroy
   has_many :request_issues, through: :request_decision_issues
+  has_many :remand_reasons, dependent: :destroy
 end

--- a/app/models/remand_reason.rb
+++ b/app/models/remand_reason.rb
@@ -1,6 +1,7 @@
 class RemandReason < ApplicationRecord
   validates :code, inclusion: { in: Constants::AMA_REMAND_REASONS_BY_ID.values.map(&:keys).flatten }
-  validates :request_issue, presence: true
   validates :post_aoj, inclusion: { in: [true, false] }
+  # This will be removed
   belongs_to :request_issue
+  belongs_to :decision_issue
 end

--- a/db/migrate/20181123182557_add_decision_issue_id_to_remand_reasons.rb
+++ b/db/migrate/20181123182557_add_decision_issue_id_to_remand_reasons.rb
@@ -1,0 +1,6 @@
+class AddDecisionIssueIdToRemandReasons < ActiveRecord::Migration[5.1]
+
+  def change
+  	add_column :remand_reasons, :decision_issue_id, :integer
+  end
+end

--- a/db/migrate/20181123211515_add_index_remand_reasons.rb
+++ b/db/migrate/20181123211515_add_index_remand_reasons.rb
@@ -1,0 +1,7 @@
+class AddIndexRemandReasons < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  
+  def change
+    add_index :remand_reasons, :decision_issue_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -645,6 +645,8 @@ ActiveRecord::Schema.define(version: 20181127201444) do
     t.string "code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "decision_issue_id"
+    t.index ["decision_issue_id"], name: "index_remand_reasons_on_decision_issue_id"
     t.index ["request_issue_id"], name: "index_remand_reasons_on_request_issue_id"
   end
 

--- a/spec/controllers/case_reviews_controller_spec.rb
+++ b/spec/controllers/case_reviews_controller_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe CaseReviewsController, type: :controller do
               "issues": [{ "disposition": "allowed", "description": "wonderful life",
                            "request_issue_ids": [request_issue1.id, request_issue3.id] },
                          { "disposition": "remanded", "description": "great moments",
-                           "request_issue_ids": [request_issue2.id] }]
+                           "request_issue_ids": [request_issue2.id],
+                           "remand_reasons": [{ "code": "va_records", "post_aoj": true }] }]
             }
           end
           let!(:bva_dispatch_task_count_before) { BvaDispatchTask.count }
@@ -102,6 +103,9 @@ RSpec.describe CaseReviewsController, type: :controller do
 
             expect(request_issue2.decision_issues.first.disposition).to eq "remanded"
             expect(request_issue2.decision_issues.first.description).to eq "great moments"
+            expect(request_issue2.decision_issues.first.remand_reasons.size).to eq 1
+            expect(request_issue2.decision_issues.first.remand_reasons.first.code).to eq "va_records"
+            expect(request_issue2.decision_issues.first.remand_reasons.first.post_aoj).to eq true
 
             expect(task.reload.status).to eq "completed"
             expect(task.completed_at).to_not eq nil

--- a/spec/factories/decision_issue.rb
+++ b/spec/factories/decision_issue.rb
@@ -7,9 +7,19 @@ FactoryBot.define do
     transient do
       request_issues []
     end
+    transient do
+      remand_reasons []
+    end
+
     after(:create) do |decision_issue, evaluator|
       if evaluator.request_issues
         decision_issue.request_issues << evaluator.request_issues
+        decision_issue.save
+      end
+
+      if evaluator.remand_reasons
+        decision_issue.remand_reasons << evaluator.remand_reasons
+        decision_issue.disposition = "remanded"
         decision_issue.save
       end
     end


### PR DESCRIPTION
Resolves #7967 

### Description
Add remand reasons for decision issues.

Note: currently remand_reasons table has request_issue_id and decision_issue_id in order to not break the existing functionality by adding remand reasons to request issues. `request_issue_id` will be removed

