### PR TITLE
Do not assign ColocatedTasks to admins

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,14 @@ class Organization < ApplicationRecord
   has_many :organizations_users, dependent: :destroy
   has_many :users, through: :organizations_users
 
+  def admins
+    organizations_users.select(&:admin?).map(&:user)
+  end
+
+  def non_admin_users
+    organizations_users.reject(&:admin?).map(&:user)
+  end
+
   def self.assignable(task)
     select { |org| org.can_receive_task?(task) }
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -7,7 +7,7 @@ class Organization < ApplicationRecord
     organizations_users.select(&:admin?).map(&:user)
   end
 
-  def non_admin_users
+  def non_admins
     organizations_users.reject(&:admin?).map(&:user)
   end
 

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -36,7 +36,7 @@ class ColocatedTask < Task
     private
 
     def list_of_assignees
-      Colocated.singleton.users.order(:id).pluck(:css_id)
+      Colocated.singleton.non_admin_users.sort_by(&:id).pluck(:css_id)
     end
   end
 

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -36,7 +36,7 @@ class ColocatedTask < Task
     private
 
     def list_of_assignees
-      Colocated.singleton.non_admin_users.sort_by(&:id).pluck(:css_id)
+      Colocated.singleton.non_admins.sort_by(&:id).pluck(:css_id)
     end
   end
 


### PR DESCRIPTION
Connects #7973. Prevents `ColocatedTask`s from being assigned to admins on the VLJ support team (`Colocated`).
