### PR TITLE
Fixing routing of appeal status job errors

### DIFF
--- a/app/jobs/take_docket_snapshot_job.rb
+++ b/app/jobs/take_docket_snapshot_job.rb
@@ -1,5 +1,6 @@
 class TakeDocketSnapshotJob < ApplicationJob
   queue_as :low_priority
+  application_attr :api
 
   def perform
     DocketSnapshot.create


### PR DESCRIPTION
### Description
We are not routing these errors properly on Slack.

