### PR TITLE
Rename administrated_teams to administered_teams

### DIFF
--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -1,6 +1,6 @@
 class JudgeTeam < Organization
   def self.for_judge(user)
-    user.administrated_teams.select { |team| team.is_a?(JudgeTeam) }.first
+    user.administered_teams.select { |team| team.is_a?(JudgeTeam) }.first
   end
 
   def self.create_for_judge(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -209,7 +209,7 @@ class User < ApplicationRecord
     self.class.appeal_repository.load_user_case_assignments_from_vacols(css_id)
   end
 
-  def administrated_teams
+  def administered_teams
     organizations_users.select(&:admin?).map(&:organization)
   end
 

--- a/spec/models/judge_team_spec.rb
+++ b/spec/models/judge_team_spec.rb
@@ -10,8 +10,8 @@ describe JudgeTeam do
         judge.reload
 
         expect(judge.organizations.length).to eq(1)
-        expect(judge.administrated_teams.length).to eq(1)
-        expect(judge.administrated_teams.first.class).to eq(JudgeTeam)
+        expect(judge.administered_teams.length).to eq(1)
+        expect(judge.administered_teams.first.class).to eq(JudgeTeam)
       end
     end
   end
@@ -51,7 +51,7 @@ describe JudgeTeam do
 
       it "should return first judge team even when they admin two judge teams" do
         expect(JudgeTeam.for_judge(user)).to eq(first_judge_team)
-        expect(user.administrated_teams.length).to eq(2)
+        expect(user.administered_teams.length).to eq(2)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -381,24 +381,24 @@ describe User do
     end
   end
 
-  describe ".administrated_teams" do
+  describe ".administered_teams" do
   end
 
-  describe ".administrated_teams" do
+  describe ".administered_teams" do
     let(:org) { create(:organization) }
     let(:user) { create(:user) }
 
     context "when user belongs to one organization but is not an admin" do
       before { OrganizationsUser.add_user_to_organization(user, org) }
       it "should return an empty list" do
-        expect(user.administrated_teams).to eq([])
+        expect(user.administered_teams).to eq([])
       end
     end
 
     context "when user is an admin of one organization" do
       before { OrganizationsUser.make_user_admin(user, org) }
       it "should return a list that contains the single organization" do
-        expect(user.administrated_teams).to eq([org])
+        expect(user.administered_teams).to eq([org])
       end
     end
 
@@ -411,7 +411,7 @@ describe User do
         admin_orgs.each { |o| OrganizationsUser.make_user_admin(user, o) }
       end
       it "should return a list of all teams user is an admin for" do
-        expect(user.administrated_teams).to eq(admin_orgs)
+        expect(user.administered_teams).to eq(admin_orgs)
       end
     end
   end


### PR DESCRIPTION
Missed one suggestion to rename this method in #7964. This PR renames the method.