### PR TITLE
Legacy issue optin

### DIFF
--- a/app/models/legacy_issue_optin.rb
+++ b/app/models/legacy_issue_optin.rb
@@ -1,0 +1,6 @@
+class LegacyIssueOptin < ApplicationRecord
+  include Asyncable
+
+  belongs_to :review_request, polymorphic: true
+  belongs_to :request_issue
+end

--- a/app/models/legacy_issue_optin.rb
+++ b/app/models/legacy_issue_optin.rb
@@ -1,6 +1,5 @@
 class LegacyIssueOptin < ApplicationRecord
   include Asyncable
 
-  belongs_to :review_request, polymorphic: true
   belongs_to :request_issue
 end

--- a/db/migrate/20181119233040_add_legacy_issue_id_to_request_issues.rb
+++ b/db/migrate/20181119233040_add_legacy_issue_id_to_request_issues.rb
@@ -1,6 +1,6 @@
 class AddLegacyIssueIdToRequestIssues < ActiveRecord::Migration[5.1]
   def change
-    add_column :request_issues, :legacy_issue_reference_id, :integer
-    add_column :request_issues, :legacy_sequence_reference_id, :integer
+    add_column :request_issues, :vacols_id, :string
+    add_column :request_issues, :vacols_sequence_id, :string
   end
 end

--- a/db/migrate/20181119233040_add_legacy_issue_id_to_request_issues.rb
+++ b/db/migrate/20181119233040_add_legacy_issue_id_to_request_issues.rb
@@ -1,0 +1,6 @@
+class AddLegacyIssueIdToRequestIssues < ActiveRecord::Migration[5.1]
+  def change
+    add_column :request_issues, :legacy_issue_reference_id, :integer
+    add_column :request_issues, :legacy_sequence_reference_id, :integer
+  end
+end

--- a/db/migrate/20181127201444_create_legacy_issue_optins.rb
+++ b/db/migrate/20181127201444_create_legacy_issue_optins.rb
@@ -1,7 +1,6 @@
 class CreateLegacyIssueOptins < ActiveRecord::Migration[5.1]
   def change
     create_table :legacy_issue_optins do |t|
-      t.belongs_to :review_request, polymorphic: true, null: false, index: { name: "idx_legacy_issue_optins_review_request" }
       t.belongs_to :request_issue, null: false
       t.timestamps null: false
       t.datetime :submitted_at

--- a/db/migrate/20181127201444_create_legacy_issue_optins.rb
+++ b/db/migrate/20181127201444_create_legacy_issue_optins.rb
@@ -1,0 +1,13 @@
+class CreateLegacyIssueOptins < ActiveRecord::Migration[5.1]
+  def change
+    create_table :legacy_issue_optins do |t|
+      t.belongs_to :review_request, polymorphic: true, null: false, index: { name: "idx_legacy_issue_optins_review_request" }
+      t.belongs_to :request_issue, null: false
+      t.timestamps null: false
+      t.datetime :submitted_at
+      t.datetime :attempted_at
+      t.datetime :processed_at
+      t.string :error
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181126190223) do
+ActiveRecord::Schema.define(version: 20181127201444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -516,6 +516,20 @@ ActiveRecord::Schema.define(version: 20181126190223) do
     t.index ["vacols_id"], name: "index_legacy_appeals_on_vacols_id", unique: true
   end
 
+  create_table "legacy_issue_optins", force: :cascade do |t|
+    t.string "review_request_type", null: false
+    t.bigint "review_request_id", null: false
+    t.bigint "request_issue_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "submitted_at"
+    t.datetime "attempted_at"
+    t.datetime "processed_at"
+    t.string "error"
+    t.index ["request_issue_id"], name: "index_legacy_issue_optins_on_request_issue_id"
+    t.index ["review_request_type", "review_request_id"], name: "idx_legacy_issue_optins_review_request"
+  end
+
   create_table "non_availabilities", force: :cascade do |t|
     t.bigint "schedule_period_id", null: false
     t.string "type", null: false
@@ -662,12 +676,14 @@ ActiveRecord::Schema.define(version: 20181126190223) do
     t.bigint "ineligible_due_to_id"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
-    t.string "ineligible_reason"
     t.string "ramp_claim_id"
     t.datetime "decision_sync_submitted_at"
     t.datetime "decision_sync_attempted_at"
     t.datetime "decision_sync_processed_at"
     t.string "decision_sync_error"
+    t.string "ineligible_reason"
+    t.integer "legacy_issue_reference_id"
+    t.integer "legacy_sequence_reference_id"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["ineligible_due_to_id"], name: "index_request_issues_on_ineligible_due_to_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -679,8 +679,8 @@ ActiveRecord::Schema.define(version: 20181127201444) do
     t.datetime "decision_sync_processed_at"
     t.string "decision_sync_error"
     t.string "ineligible_reason"
-    t.integer "legacy_issue_reference_id"
-    t.integer "legacy_sequence_reference_id"
+    t.string "vacols_id"
+    t.string "vacols_sequence_id"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["ineligible_due_to_id"], name: "index_request_issues_on_ineligible_due_to_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -517,8 +517,6 @@ ActiveRecord::Schema.define(version: 20181127201444) do
   end
 
   create_table "legacy_issue_optins", force: :cascade do |t|
-    t.string "review_request_type", null: false
-    t.bigint "review_request_id", null: false
     t.bigint "request_issue_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -527,7 +525,6 @@ ActiveRecord::Schema.define(version: 20181127201444) do
     t.datetime "processed_at"
     t.string "error"
     t.index ["request_issue_id"], name: "index_legacy_issue_optins_on_request_issue_id"
-    t.index ["review_request_type", "review_request_id"], name: "idx_legacy_issue_optins_review_request"
   end
 
   create_table "non_availabilities", force: :cascade do |t|

--- a/spec/factories/legacy_issue_optin.rb
+++ b/spec/factories/legacy_issue_optin.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :legacy_issue_optin do
+    review_request { create(:appeal) }
+    request_issue { create(:request_issue) }
+  end
+end

--- a/spec/factories/legacy_issue_optin.rb
+++ b/spec/factories/legacy_issue_optin.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :legacy_issue_optin do
-    review_request { create(:appeal) }
     request_issue { create(:request_issue) }
   end
 end

--- a/spec/models/legacy_issue_optin_spec.rb
+++ b/spec/models/legacy_issue_optin_spec.rb
@@ -1,0 +1,58 @@
+describe LegacyIssueOptin do
+  context "async logic scopes" do
+    let!(:legacy_issue_optin_requiring_processing) do
+      create(:legacy_issue_optin).tap(&:submit_for_processing!)
+    end
+
+    let!(:legacy_issue_optin_processed) do
+      create(:legacy_issue_optin).tap(&:processed!)
+    end
+
+    let!(:legacy_issue_optin_recently_attempted) do
+      create(
+        :legacy_issue_optin,
+        attempted_at: (LegacyIssueOptin::REQUIRES_PROCESSING_RETRY_WINDOW_HOURS - 1).hours.ago
+      )
+    end
+
+    let!(:legacy_issue_optin_attempts_ended) do
+      create(
+        :legacy_issue_optin,
+        submitted_at: (LegacyIssueOptin::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
+        attempted_at: (LegacyIssueOptin::REQUIRES_PROCESSING_WINDOW_DAYS + 1).days.ago
+      )
+    end
+
+    context ".unexpired" do
+      it "matches inside the processing window" do
+        expect(described_class.unexpired).to eq([legacy_issue_optin_requiring_processing])
+      end
+    end
+
+    context ".processable" do
+      it "matches eligible for processing" do
+        expect(described_class.processable).to match_array(
+          [legacy_issue_optin_requiring_processing, legacy_issue_optin_attempts_ended]
+        )
+      end
+    end
+
+    context ".attemptable" do
+      it "matches could be attempted" do
+        expect(described_class.attemptable).not_to include(legacy_issue_optin_recently_attempted)
+      end
+    end
+
+    context ".requires_processing" do
+      it "matches must still be processed" do
+        expect(described_class.requires_processing).to eq([legacy_issue_optin_requiring_processing])
+      end
+    end
+
+    context ".expired_without_processing" do
+      it "matches unfinished but outside the retry window" do
+        expect(described_class.expired_without_processing).to eq([legacy_issue_optin_attempts_ended])
+      end
+    end
+  end
+end


### PR DESCRIPTION
connects #7337 

### Description
Adds migrations for storing legacy issue (VACOLS) id and sequence and for new model `LegacyIssueOptin` (see https://github.com/department-of-veterans-affairs/appeals-design-research/pull/1071).

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Tests continue to pass
