### PR TITLE
Remove organizationIds from codebase

### DIFF
--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -4,7 +4,6 @@
     userId: current_user.id,
     userRole: (current_user.vacols_roles.first || "").capitalize,
     userCssId: current_user.css_id,
-    organizationIds: current_user.organizations.pluck(:id),
     organizations: current_user.organizations.map {|o| o.slice(:id, :name, :url)},
     userIsVsoEmployee: current_user.vso_employee?,
     caseSearchHomePage: case_search_home_page,

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -4,7 +4,6 @@
     userId: current_user.id,
     userRole: (current_user.vacols_roles.first || "").capitalize,
     userCssId: current_user.css_id,
-    organizationIds: current_user.organizations.pluck(:id),
     organizations: current_user.organizations.map {|o| o.slice(:id, :name, :url)},
     userIsVsoEmployee: current_user.vso_employee?,
     caseSearchHomePage: case_search_home_page,

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -12,7 +12,6 @@ import {
   setUserCssId,
   setUserIsVsoEmployee,
   setFeedbackUrl,
-  setOrganizationIds,
   setOrganizations
 } from './uiReducer/uiActions';
 
@@ -70,7 +69,6 @@ type Props = {|
   userIsVsoEmployee?: boolean,
   caseSearchHomePage?: boolean,
   featureToggles: Object,
-  organizationIds: Array<number>,
   organizations: Array<Object>,
   // Action creators
   setFeatureToggles: typeof setFeatureToggles,
@@ -78,7 +76,6 @@ type Props = {|
   setUserCssId: typeof setUserCssId,
   setUserIsVsoEmployee: typeof setUserIsVsoEmployee,
   setFeedbackUrl: typeof setFeedbackUrl,
-  setOrganizationIds: typeof setOrganizationIds,
   setOrganizations: typeof setOrganizations
 |};
 
@@ -87,7 +84,6 @@ class QueueApp extends React.PureComponent<Props> {
     this.props.setFeatureToggles(this.props.featureToggles);
     this.props.setUserRole(this.props.userRole);
     this.props.setUserCssId(this.props.userCssId);
-    this.props.setOrganizationIds(this.props.organizationIds);
     this.props.setOrganizations(this.props.organizations);
     this.props.setUserIsVsoEmployee(this.props.userIsVsoEmployee);
     this.props.setFeedbackUrl(this.props.feedbackUrl);
@@ -422,7 +418,6 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   setUserCssId,
   setUserIsVsoEmployee,
   setFeedbackUrl,
-  setOrganizationIds,
   setOrganizations
 }, dispatch);
 

--- a/client/app/queue/reducers.js
+++ b/client/app/queue/reducers.js
@@ -45,7 +45,7 @@ export const initialState = {
   pendingDistribution: null,
   attorneys: {},
   organizationId: null,
-  organizations: null,
+  organizations: [],
   loadingAppealDetail: {}
 };
 

--- a/client/app/queue/reducers.js
+++ b/client/app/queue/reducers.js
@@ -45,6 +45,7 @@ export const initialState = {
   pendingDistribution: null,
   attorneys: {},
   organizationId: null,
+  organizations: null,
   loadingAppealDetail: {}
 };
 

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -89,6 +89,7 @@ export type QueueState = {|
   attorneys: Attorneys,
   newDocsForAppeal: NewDocsForAppeal,
   organizationId: ?number,
+  organizations: Array<Object>,
   specialIssues: Object,
   loadingAppealDetail: Object
 |};

--- a/client/app/queue/types/state.js
+++ b/client/app/queue/types/state.js
@@ -57,7 +57,6 @@ export type UiState = {
   userIsVsoEmployee: boolean,
   feedbackUrl: string,
   veteranCaseListIsVisible: boolean,
-  organizationIds: Array<number>,
   organizations: Array<Object>,
   canEditAod: boolean
 };

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -138,11 +138,6 @@ export const setUserCssId = (cssId: ?string) => ({
   payload: { cssId }
 });
 
-export const setOrganizationIds = (organizationIds: Array<number>) => ({
-  type: ACTIONS.SET_ORGANIZATION_IDS,
-  payload: { organizationIds }
-});
-
 export const setOrganizations = (organizations: Array<Object>) => ({
   type: ACTIONS.SET_ORGANIZATIONS,
   payload: { organizations }

--- a/client/app/queue/uiReducer/uiReducer.js
+++ b/client/app/queue/uiReducer/uiReducer.js
@@ -20,7 +20,6 @@ export const initialState = {
   featureToggles: {},
   userRole: '',
   userCssId: '',
-  organizationIds: [],
   organizations: [],
   activeOrganizationId: null,
   userIsVsoEmployee: false,
@@ -172,12 +171,6 @@ const workQueueUiReducer = (state: UiState = initialState, action: Object = {}) 
     return update(state, {
       selectedAssigneeSecondary: {
         $set: action.payload.assigneeId
-      }
-    });
-  case ACTIONS.SET_ORGANIZATION_IDS:
-    return update(state, {
-      organizationIds: {
-        $set: action.payload.organizationIds
       }
     });
   case ACTIONS.SET_ORGANIZATIONS:


### PR DESCRIPTION
Follow-on PR to https://github.com/department-of-veterans-affairs/caseflow/pull/8012 — removes references to `organizationIds` from codebase.
