### PR TITLE
Fix bug that prevented VLJ support staff from taking any actions on tasks

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -40,9 +40,7 @@ class ColocatedTask < Task
     end
   end
 
-  def available_actions(user)
-    return [] unless user.colocated_in_vacols?
-
+  def available_actions(_user)
     actions = [
       {
         label: COPY::COLOCATED_ACTION_PLACE_HOLD,
@@ -65,8 +63,8 @@ class ColocatedTask < Task
     actions
   end
 
-  def no_actions_available?(_user)
-    completed?
+  def no_actions_available?(user)
+    completed? || assigned_to != user
   end
 
   def update_if_hold_expired!

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -221,4 +221,36 @@ RSpec.feature "Task queue" do
       expect(page).to have_content(COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_LABEL)
     end
   end
+
+  describe "VLJ support staff task action" do
+    let!(:attorney) { FactoryBot.create(:user) }
+    let!(:staff) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney.css_id) }
+    let!(:appeal) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+    let!(:vlj_support_staffer) { FactoryBot.create(:user) }
+
+    before do
+      OrganizationsUser.add_user_to_organization(vlj_support_staffer, Colocated.singleton)
+      User.authenticate!(user: vlj_support_staffer)
+    end
+
+    context "when a ColocatedTask has been assigned through the Colocated organization to an individual" do
+      before do
+        ColocatedTask.create_many_from_params([{
+                                                assigned_by: attorney,
+                                                action: :aoj,
+                                                appeal: appeal
+                                              }], attorney)
+      end
+
+      it "should be actionable" do
+        visit("/queue/appeals/#{appeal.external_id}")
+
+        find(".Select-control", text: "Select an action…").click
+        find("div", class: "Select-option", text: COPY::COLOCATED_ACTION_SEND_BACK_TO_ATTORNEY).click
+        find("button", text: COPY::MARK_TASK_COMPLETE_BUTTON).click
+
+        expect(page).to have_content(format(COPY::MARK_TASK_COMPLETE_CONFIRMATION, appeal.veteran_full_name))
+      end
+    end
+  end
 end

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -288,9 +288,10 @@ describe ColocatedTask do
   end
 
   describe ".available_actions_unwrapper" do
-    let(:colocated_task) { ColocatedTask.find(FactoryBot.create(:colocated_task, assigned_by: attorney).id) }
     let(:colocated_user) { FactoryBot.create(:user) }
-    before { FactoryBot.create(:staff, :colocated_role, user: colocated_user) }
+    let(:colocated_task) do
+      ColocatedTask.find(FactoryBot.create(:colocated_task, assigned_by: attorney, assigned_to: colocated_user).id)
+    end
 
     it "should vary depending on status of task" do
       expect(colocated_task.available_actions_unwrapper(colocated_user).count).to_not eq(0)


### PR DESCRIPTION
This PR fixes a bug that has prevented members of the VLJ support team from taking any action tasks assigned to them since we added the `Colocated` organization and started assigning individual tasks as [children of the organization's task](https://github.com/department-of-veterans-affairs/caseflow/pull/7785) (roughly 3 weeks). This was also reported by one of the folks who piloted VLJ support staff queue and really puzzled me at the time.

Relevant slack thread: https://dsva.slack.com/archives/CCPHFTQTH/p1543521756002300
> This is caused by a recent change to how we organize members of the VLJ support staff and assign tasks to them. They are all now part of the VLJ support staff team, and when we create a `ColocatedTask` we assign that task to the individual as a child of another task assigned to the VLJ support staff (so their can be team-wide visibility into all of the tasks that are being worked on at the moment). This bug is caused because we are trying to act on the **organization's** task instead of the **individual's** task. Working on a fix now