### PR TITLE
Fixing remand reasons

### DIFF
--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -103,7 +103,7 @@ class IssueRemandReasonsOptions extends React.PureComponent<Params, State> {
     const updatedIssues = issues.map((issue) => {
       if (issue.id === issueId) {
         return { ...issue,
-          remandReasons };
+          remand_reasons: remandReasons };
       }
 
       return issue;


### PR DESCRIPTION
### Description
My last PR broke remand reasons because we started sending `remandReasons` instead of `remand_reasons`

### Testing Plan
1. Locally checkout an appeal with a remand
1. Select a remand reason
1. Ensure the remand reasons is created on the backend

