### PR TITLE
Restrict access to organization admin pages

### DIFF
--- a/app/controllers/organizations/users_controller.rb
+++ b/app/controllers/organizations/users_controller.rb
@@ -30,9 +30,7 @@ class Organizations::UsersController < OrganizationsController
   end
 
   def verify_organization_access
-    return if current_user.admin?
-
-    super
+    redirect_to "/unauthorized" unless current_user.admin? || current_user.administered_teams.include?(organization)
   end
 
   def verify_role_access

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -265,5 +265,7 @@
   "DECISION_ISSUE_MODAL_DESCRIPTION": "Description",
   "DECISION_ISSUE_MODAL_DESCRIPTION_EXAMPLE": "Ex: Increased rating for arthritis is granted with an evaluation of 90%",
   "DECISION_ISSUE_MODAL_DISPOSITION": "Disposition",
-  "DECISION_ISSUE_MODAL_BENEFIT_TYPE": "Benefit type"
+  "DECISION_ISSUE_MODAL_BENEFIT_TYPE": "Benefit type",
+
+  "UNAUTHORIZED_PAGE_ACCESS_MESSAGE": "You aren't authorized to use this part of Caseflow yet."
 }

--- a/client/app/containers/Unauthorized.jsx
+++ b/client/app/containers/Unauthorized.jsx
@@ -6,6 +6,8 @@ import Footer from '@department-of-veterans-affairs/caseflow-frontend-toolkit/co
 import { COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
 import { BrowserRouter } from 'react-router-dom';
 
+import COPY from '../../COPY.json';
+
 const options = [{ title: 'Help',
   link: '/help' },
 { title: 'Switch User',
@@ -24,7 +26,7 @@ const Unauthorized = (props) => <BrowserRouter>
       }} />
     <AppFrame>
       <StatusMessage title= "Drat!">
-             You aren't authorized to use this part of Caseflow yet.
+        { COPY.UNAUTHORIZED_PAGE_ACCESS_MESSAGE }
         { props.dependenciesFaked &&
             <p className="cf-msg-screen-text">
               <a href="/test/users">

--- a/spec/feature/queue/user_organization_spec.rb
+++ b/spec/feature/queue/user_organization_spec.rb
@@ -8,8 +8,23 @@ RSpec.feature "User organization" do
   let!(:user_with_role) { create(:user, full_name: "with role", roles: [role]) }
   let!(:user_without_role) { create(:user, full_name: "without role") }
 
-  context "When user is in the organization" do
-    let!(:organization_user) { OrganizationsUser.add_user_to_organization(user, organization) }
+  context "When user is in the organization but not an admin" do
+    before { OrganizationsUser.add_user_to_organization(user, organization) }
+
+    scenario "Adds and removes users from the organization" do
+      visit organization.user_admin_path
+
+      expect(page).to have_content(COPY::UNAUTHORIZED_PAGE_ACCESS_MESSAGE)
+    end
+
+    scenario "Organization task list view shows queue switcher dropdown" do
+      visit organization.path
+      expect(page).to have_content(COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_LABEL)
+    end
+  end
+
+  context "When user is admin of the organization" do
+    before { OrganizationsUser.make_user_admin(user, organization) }
 
     scenario "Adds and removes users from the organization" do
       visit organization.user_admin_path
@@ -41,7 +56,7 @@ RSpec.feature "User organization" do
     scenario "Adds and removes users from the organization" do
       visit organization.user_admin_path
 
-      expect(page).to have_content("You aren't authorized")
+      expect(page).to have_content(COPY::UNAUTHORIZED_PAGE_ACCESS_MESSAGE)
     end
 
     context "but user is a system admin" do


### PR DESCRIPTION
Resolves #8062. Restricts access to organization user admin pages to only admins of those organizations.

Slack thread where LP confirms that nobody is using these pages yet (except for us) so nobody should be impacted: https://dsva.slack.com/archives/C6E41RE92/p1543585632005800 (and if they are, then we can make them an admin of that organization).