### PR TITLE
Add created/updated_at columns to OrganizationsUsers table

### DIFF
--- a/db/migrate/20181203174849_add_datetime_cols_to_organizations_users.rb
+++ b/db/migrate/20181203174849_add_datetime_cols_to_organizations_users.rb
@@ -1,0 +1,6 @@
+class AddDatetimeColsToOrganizationsUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations_users, :created_at, :datetime
+    add_column :organizations_users, :updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181129230649) do
+ActiveRecord::Schema.define(version: 20181203174849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -552,6 +552,8 @@ ActiveRecord::Schema.define(version: 20181129230649) do
     t.integer "organization_id"
     t.integer "user_id"
     t.boolean "admin", default: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index ["organization_id"], name: "index_organizations_users_on_organization_id"
     t.index ["user_id", "organization_id"], name: "index_organizations_users_on_user_id_and_organization_id", unique: true
   end
@@ -678,12 +680,12 @@ ActiveRecord::Schema.define(version: 20181129230649) do
     t.bigint "ineligible_due_to_id"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
-    t.string "ineligible_reason"
     t.string "ramp_claim_id"
     t.datetime "decision_sync_submitted_at"
     t.datetime "decision_sync_attempted_at"
     t.datetime "decision_sync_processed_at"
     t.string "decision_sync_error"
+    t.string "ineligible_reason"
     t.string "vacols_id"
     t.string "vacols_sequence_id"
     t.datetime "created_at"


### PR DESCRIPTION
Noticed while doing [a recent post-mortem](https://github.com/department-of-veterans-affairs/appeals-deployment/pull/1787) that the `organizations_users` table did not have `created_at` or `updated_at` columns. This PR adds those columns.