### PR TITLE
Add common padding and margin CSS styles and adjust queue description spacing

### DIFF
--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -156,7 +156,7 @@ const mapDispatchToProps = (dispatch) => ({
 export default (connect(mapStateToProps, mapDispatchToProps)(AttorneyTaskListView): React.ComponentType<Params>);
 
 const TaskTableTab = ({ description, tasks }) => <React.Fragment>
-  <p>{description}</p>
+  <p className="cf-margin-top-0" >{description}</p>
   <TaskTable
     includeDetailsLink
     includeType

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -114,7 +114,7 @@ const NewTasksTab = connect(
   (state: State) => ({ tasks: newTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
     return <React.Fragment>
-      <p>{COPY.COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION}</p>
+      <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
         includeTask
@@ -131,7 +131,7 @@ const PendingTasksTab = connect(
   (state: State) => ({ tasks: pendingTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
     return <React.Fragment>
-      <p>{COPY.COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION}</p>
+      <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
         includeTask
@@ -148,7 +148,7 @@ const OnHoldTasksTab = connect(
   (state: State) => ({ tasks: onHoldTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
     return <React.Fragment>
-      <p>{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
+      <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
         includeTask
@@ -165,7 +165,7 @@ const CompleteTasksTab = connect(
   (state: State) => ({ tasks: completeTasksByAssigneeCssIdSelector(state) }))(
   (props: { tasks: Array<TaskWithAppeal> }) => {
     return <React.Fragment>
-      <p>{COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}</p>
+      <p className="cf-margin-top-0">{COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}</p>
       <TaskTable
         includeDetailsLink
         includeTask

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -98,7 +98,7 @@ const mapDispatchToProps = (dispatch) => ({
 export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 
 const TaskTableTab = ({ description, tasks }) => <React.Fragment>
-  <p>{description}</p>
+  <p className="cf-margin-top-0">{description}</p>
   <TaskTable
     includeDetailsLink
     includeTask

--- a/client/app/styles/_commons.scss
+++ b/client/app/styles/_commons.scss
@@ -181,6 +181,32 @@ dd {
 }
 
 //------------------------------------
+// Spacers
+//-----------------------------------*/
+
+/**
+ * This generates a set of margin and padding options that can be added to any element.
+ *
+ * ex.  <p className="cf-padding-top-3rem">
+ *  or  <h4 className="cf-margin-bottom-0">
+ *  or  <img className="cf-padding-right-6rem cf-padding-left-0rem">
+ */
+
+$styles: ("margin"), ("padding");
+$directions: ("top"), ("bottom"), ("left"), ("right");
+$rems: ("0", "0rem", "1rem", "2rem", "3rem", "4rem", "5rem", "6rem", "7rem", "8rem", "9rem", "10rem");
+
+@each $style in $styles {
+  @each $direction in $directions {
+    @each $rem in $rems {
+      .cf-#{$style}-#{$direction}-#{$rem} {
+        #{$style}-#{$direction}: #{$rem};
+      }
+    }
+  }
+}
+
+//------------------------------------
 // Icons
 //-----------------------------------*/
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/7791

@lowellrex: please review the CSS styles & let me know if you'd rather break this into two PRs
@sneha-pai: please give a visual design review

### Description
This PR does two things:
- adds common padding and margin CSS styles at `1rem` intervals
- removes the `margin-top` for queue descriptions
    - (the original issue #7791 calls for replacing the `p` tag with an `h*` tag, but after discussion with @sneha-pai we have decided to just remove the top margin)

(Let me know if you'd prefer I split this into two separate PRs.)

With changes:
![screenshot 2018-12-03 11 15 34](https://user-images.githubusercontent.com/2928395/49396083-1b452b00-f6ed-11e8-8420-5b34a398d252.png)

Before:
![screenshot 2018-12-03 11 15 50](https://user-images.githubusercontent.com/2928395/49396097-24ce9300-f6ed-11e8-89a3-ab300b005d8d.png)
