### PR TITLE
Move slow VBMS call outside the psql transaction to avoid timeout

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -157,6 +157,11 @@ class EndProductEstablishment < ApplicationRecord
     return true unless status_active?
     fail EstablishedEndProductNotFound unless result
 
+    # load contentions now, in case "source" needs them.
+    # this VBMS call is slow and will cause the transaction below
+    # to timeout in some cases.
+    contentions
+
     transaction do
       update!(
         synced_status: result.status_type_code,


### PR DESCRIPTION
connects #7753 

### Description
Run slow VBMS read call outside the psql transaction to avoid psql timeout.
