### PR TITLE
Postponing hearings with caseflow parent records

### DIFF
--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -64,7 +64,7 @@ class HearingRepository
     end
 
     def slot_new_hearing(parent_record_id, appeal)
-      hearing_day = HearingDayRepository.find_hearing_day(nil, parent_record_id)
+      hearing_day = HearingDay.find_hearing_day(nil, parent_record_id)
 
       if hearing_day[:hearing_type] == "C"
         update_co_hearing(hearing_day[:hearing_date], appeal)


### PR DESCRIPTION
This PR fixes this Sentry error: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3074/

Currently, if a user tries to postpone a hearing and reschedule it on a Caseflow parent record, the slot_new_hearings method can't find the Caseflow parent record. The find_hearing_day method on the HearingDay model checks both Casesflow and VACOLS for the parent records.

