### PR TITLE
Default RO Value on Assign Hearings Page

### DIFF
--- a/client/app/hearingSchedule/containers/AssignHearingsContainer.jsx
+++ b/client/app/hearingSchedule/containers/AssignHearingsContainer.jsx
@@ -20,6 +20,7 @@ import { onReceiveTasks } from '../../queue/QueueActions';
 import { setUserCssId } from '../../queue/uiReducer/uiActions';
 import RoSelectorDropdown from '../../components/RoSelectorDropdown';
 import AssignHearings from '../components/AssignHearings';
+import { getQueryParams } from '../../util/QueryParamsUtil';
 
 const centralOfficeStaticEntry = [{
   label: 'Central',
@@ -53,7 +54,11 @@ class AssignHearingsContainer extends React.PureComponent {
 
   componentDidMount = () => {
     this.props.setUserCssId(this.props.userCssId);
-    this.props.onRegionalOfficeChange('');
+  }
+
+  onRegionalOfficeChange = (opt) => {
+    window.history.replaceState('', '', `?roValue=${opt.value}`);
+    this.props.onRegionalOfficeChange(opt);
   }
 
   loadUpcomingHearingDays = () => {
@@ -114,8 +119,8 @@ class AssignHearingsContainer extends React.PureComponent {
         </Link>
         <section className="usa-form-large" {...roSelectionStyling}>
           <RoSelectorDropdown
-            onChange={this.props.onRegionalOfficeChange}
-            value={this.props.selectedRegionalOffice ? this.props.selectedRegionalOffice : null}
+            onChange={this.onRegionalOfficeChange}
+            value={this.props.selectedRegionalOffice || getQueryParams(window.location.search).roValue}
             staticOptions={centralOfficeStaticEntry}
           />
         </section>

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -218,12 +218,13 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
     const hearingDateStr = formatDateStr(selectedHearingDay.value.hearingDate, 'YYYY-MM-DD', 'MM/DD/YYYY');
     const title = `You have successfully assigned ${appeal.veteranFullName} ` +
                   `to a ${this.getHearingType()} hearing on ${hearingDateStr}.`;
+    const href = `/hearings/schedule/assign?roValue=${selectedRegionalOffice.value}`;
 
     const detail = (
       <p>
         To assign another veteran please use the "Schedule Veterans" link below.
         You can also use the hearings section below to view the hearing in new tab.<br /><br />
-       <Link href={`/hearings/schedule/assign?roValue=${selectedRegionalOffice.value}`}>Back to Schedule Veterans</Link>
+        <Link href={href}>Back to Schedule Veterans</Link>
       </p>
     );
 

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -213,7 +213,7 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
   }
 
   getSuccessMsg = () => {
-    const { appeal, selectedHearingDay } = this.props;
+    const { appeal, selectedHearingDay, selectedRegionalOffice } = this.props;
 
     const hearingDateStr = formatDateStr(selectedHearingDay.value.hearingDate, 'YYYY-MM-DD', 'MM/DD/YYYY');
     const title = `You have successfully assigned ${appeal.veteranFullName} ` +
@@ -223,7 +223,7 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
       <p>
         To assign another veteran please use the "Schedule Veterans" link below.
         You can also use the hearings section below to view the hearing in new tab.<br /><br />
-        <Link href="/hearings/schedule/assign">Back to Schedule Veterans</Link>
+       <Link href={`/hearings/schedule/assign?roValue=${selectedRegionalOffice.value}`}>Back to Schedule Veterans</Link>
       </p>
     );
 


### PR DESCRIPTION
Resolves #7670 and merge conflicts with #8026

### Description
- changes window history with `roValue` in search string on RO dropdown change so any back button will return to selected RO
- adds `roValue` as default dropdown value
- adds `roValue` to query string on link back from `AssignHearingsModal`

