### PR TITLE
populate fake ratings with unique issue ids

### DIFF
--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -103,7 +103,7 @@ class Generators::Rating
     def populate_issue_ids(attrs)
       return unless attrs[:issues]
       # gives a unique id to each issue that is tied to a specific participant_id
-      attrs[:issues].each_with_index.map do |issue, i|
+      attrs[:issues].map do |issue|
         issue[:reference_id] ||= "#{attrs[:participant_id]}#{generate_external_id}"
         issue
       end

--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -100,16 +100,11 @@ class Generators::Rating
       end
     end
 
-    def get_prev_issues_count(participant_id)
-      Fakes::BGSService.rating_profile_records[participant_id].values.flatten(1).count
-    end
-
     def populate_issue_ids(attrs)
       return unless attrs[:issues]
       # gives a unique id to each issue that is tied to a specific participant_id
-      prev_count = get_prev_issues_count(attrs[:participant_id])
       attrs[:issues].each_with_index.map do |issue, i|
-        issue[:reference_id] ||= "#{attrs[:participant_id]}#{prev_count + i}"
+        issue[:reference_id] ||= "#{attrs[:participant_id]}#{generate_external_id}"
         issue
       end
     end


### PR DESCRIPTION
### Description
Generator code was producing the same nonunique reference ids, which were showing up in a buggy Intake local env:

![demo](https://user-images.githubusercontent.com/279406/49617741-a4b56100-f96a-11e8-85a7-a4171a0aeca4.gif)