### PR TITLE
fix detection of non-body transient errors

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -41,8 +41,9 @@ class EndProductEstablishment < ApplicationRecord
       end
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def self.from_bgs_error(error, epe)
-      case error.try(:body)
+      case error.try(:body) || error.message
       when /WssVerification Exception - Security Verification Exception/
         # This occasionally happens when client/server timestamps get out of sync. Uncertain why this
         # happens or how to fix it - it only happens occasionally.
@@ -63,7 +64,7 @@ class EndProductEstablishment < ApplicationRecord
         #
         # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2910/
         TransientBGSSyncError.new(error, epe)
-      when /Connection timed out - connect(2) for "bepprod.vba.va.gov" port 443/
+      when /Connection timed out - connect\(2\) for "bepprod.vba.va.gov" port 443/
         # Transient timeouts to BGS because of connectivity issues
         #
         # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2888/
@@ -85,6 +86,7 @@ class EndProductEstablishment < ApplicationRecord
       end
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
   class TransientBGSSyncError < BGSSyncError; end
 
   class << self

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -530,18 +530,31 @@ describe EndProductEstablishment do
         end
       end
 
-      context "when VBMS/BGS causes a transient error" do
+      context "when VBMS/BGS has a transient internal error" do
         before do
-          # rubocop:disable Metrics/LineLength
           # from https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3116/
+          # rubocop:disable Metrics/LineLength
           sample_transient_error_body = '<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><env:Fault><faultcode xmlns:ns1="http://www.w3.org/2003/05/soap-envelope">ns1:Server</faultcode><faultstring>gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception - Security Verification Exception GUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</faultstring><detail><cdm:faultDetailBean xmlns:cdm="http://vbms.vba.va.gov/cdm" cdm:message="gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception - Security Verification Exception GUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" cdm:exceptionClassName="gov.va.vba.vbms.ws.VbmsWSException" cdm:uid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" cdm:serverException="true"/></detail></env:Fault></env:Body></env:Envelope>'
           # rubocop:enable Metrics/LineLength
-          allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(
-            VBMS::HTTPError.new(500, sample_transient_error_body)
-          )
+          error = VBMS::HTTPError.new(500, sample_transient_error_body)
+          allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(error)
         end
 
-        it "re-raises a transient error" do
+        it "re-raises a transient ignorable error" do
+          expect { subject }.to raise_error(EndProductEstablishment::TransientBGSSyncError)
+        end
+      end
+
+      context "when VBMS/BGS has a transient network error" do
+        before do
+          # from https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2888/
+          # rubocop:disable Metrics/LineLength
+          error = Errno::ETIMEDOUT.new('Connection timed out - Connection timed out - connect(2) for "bepprod.vba.va.gov" port 443 (bepprod.vba.va.gov:443)')
+          # rubocop:enable Metrics/LineLength
+          allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(error)
+        end
+
+        it "re-raises a transient ignorable error" do
           expect { subject }.to raise_error(EndProductEstablishment::TransientBGSSyncError)
         end
       end


### PR DESCRIPTION
### Description
1. check `error.message` (timeouts set the standard Error.message, not the body)
1. escape regex chars so we detect timeouts correctly