### PR TITLE
Update rubocop target ruby version (tomas/8148)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -112,6 +112,9 @@ Style/TernaryParentheses:
 Style/IfUnlessModifier:
   Enabled: false
 
+Style/RedundantBegin:
+  Enabled: false
+
 Naming/FileName:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.2
   TargetRailsVersion: 4.2
   Include:
     - '**/config.ru'

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -148,7 +148,7 @@ class ApplicationController < ApplicationBaseController
   # rubocop:enable Metrics/CyclomaticComplexity
 
   def deny_vso_access
-    redirect_to "/unauthorized" if current_user && current_user.vso_employee?
+    redirect_to "/unauthorized" if current_user&.vso_employee?
   end
 
   # :nocov:
@@ -214,7 +214,7 @@ class ApplicationController < ApplicationBaseController
   helper_method :test_user?
 
   def verify_authentication
-    return true if current_user && current_user.authenticated?
+    return true if current_user&.authenticated?
 
     session["return_to"] = request.original_url
     redirect_to login_path

--- a/app/controllers/hearings/dockets_controller.rb
+++ b/app/controllers/hearings/dockets_controller.rb
@@ -27,7 +27,7 @@ class Hearings::DocketsController < HearingsController
 
   def date_from_string(date_string)
     # date should be YYYY-MM-DD
-    return nil unless /^\d{4}-\d{1,2}-\d{1,2}$/ =~ date_string
+    return nil unless /^\d{4}-\d{1,2}-\d{1,2}$/.match?(date_string)
 
     begin
       date_string.to_date

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,7 @@ class HomeController < ApplicationController
   skip_before_action :verify_authentication
 
   def index
-    return redirect_to("/help") unless current_user && current_user.authenticated?
+    return redirect_to("/help") unless current_user&.authenticated?
     return render("queue/index") if feature_enabled?(:case_search_home_page)
     redirect_to("/help")
   end

--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -30,7 +30,7 @@ class LegacyTasksController < ApplicationController
 
   def create
     assigned_to = legacy_task_params[:assigned_to]
-    if assigned_to && assigned_to.vacols_roles.length == 1 && assigned_to.judge_in_vacols?
+    if assigned_to&.vacols_roles&.length == 1 && assigned_to.judge_in_vacols?
       return assign_to_judge
     end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -11,7 +11,7 @@ class OrganizationsController < ApplicationController
   private
 
   def verify_organization_access
-    redirect_to "/unauthorized" unless organization && organization.user_has_access?(current_user)
+    redirect_to "/unauthorized" unless organization&.user_has_access?(current_user)
   end
 
   def verify_role_access

--- a/app/controllers/test/users_controller.rb
+++ b/app/controllers/test/users_controller.rb
@@ -109,16 +109,12 @@ class Test::UsersController < ApplicationController
   end
 
   def toggle_feature
-    if params[:enable]
-      params[:enable].each do |f|
-        FeatureToggle.enable!(f[:value])
-      end
+    params[:enable]&.each do |f|
+      FeatureToggle.enable!(f[:value])
     end
 
-    if params[:disable]
-      params[:disable].each do |f|
-        FeatureToggle.disable!(f[:value])
-      end
+    params[:disable]&.each do |f|
+      FeatureToggle.disable!(f[:value])
     end
   end
 

--- a/app/jobs/fetch_documents_for_reader_user_job.rb
+++ b/app/jobs/fetch_documents_for_reader_user_job.rb
@@ -45,20 +45,18 @@ class FetchDocumentsForReaderUserJob < ApplicationJob
   def fetch_documents_for_appeals(appeals)
     @counts[:appeals_total] = appeals.count
     appeals.each do |appeal|
-      begin
-        Raven.extra_context(appeal_id: appeal.id)
-        Rails.logger.debug("Fetching docs for appeal #{appeal.id}")
+      Raven.extra_context(appeal_id: appeal.id)
+      Rails.logger.debug("Fetching docs for appeal #{appeal.id}")
 
-        # signal to efolder X to fetch and save all documents
-        appeal.document_fetcher.find_or_create_documents!
-        @counts[:appeals_successful] += 1
-      rescue Caseflow::Error::EfolderAccessForbidden
-        Rails.logger.error "Encountered access forbidden error when fetching documents for appeal #{appeal.id}"
-        next
-      rescue Caseflow::Error::ClientRequestError, Caseflow::Error::DocumentRetrievalError
-        Rails.logger.error "Encountered client request error when fetching documents for appeal #{appeal.id}"
-        next
-      end
+      # signal to efolder X to fetch and save all documents
+      appeal.document_fetcher.find_or_create_documents!
+      @counts[:appeals_successful] += 1
+    rescue Caseflow::Error::EfolderAccessForbidden
+      Rails.logger.error "Encountered access forbidden error when fetching documents for appeal #{appeal.id}"
+      next
+    rescue Caseflow::Error::ClientRequestError, Caseflow::Error::DocumentRetrievalError
+      Rails.logger.error "Encountered client request error when fetching documents for appeal #{appeal.id}"
+      next
     end
   end
 

--- a/app/jobs/sync_intake_job.rb
+++ b/app/jobs/sync_intake_job.rb
@@ -13,13 +13,11 @@ class SyncIntakeJob < CaseflowJob
     appeals_to_reclose = RampClosedAppeal.appeals_to_reclose
     reclosed_appeals = []
     appeals_to_reclose.each do |appeal|
-      begin
-        appeal.reclose!
-        reclosed_appeals << appeal
-      rescue StandardError => e
-        # Rescue and capture errors so they don't cause the job to stop
-        Raven.capture_exception(e, extra: { ramp_closed_appeal_id: appeal.id })
-      end
+      appeal.reclose!
+      reclosed_appeals << appeal
+    rescue StandardError => e
+      # Rescue and capture errors so they don't cause the job to stop
+      Raven.capture_exception(e, extra: { ramp_closed_appeal_id: appeal.id })
     end
     slack_service.send_notification(
       "Intake: Successfully reclosed #{reclosed_appeals.count} out of #{appeals_to_reclose.count} RAMP VACOLS appeals"

--- a/app/jobs/sync_reviews_job.rb
+++ b/app/jobs/sync_reviews_job.rb
@@ -29,12 +29,10 @@ class SyncReviewsJob < CaseflowJob
 
   def perform_ramp_refiling_reprocessing
     RampRefiling.need_to_reprocess.each do |ramp_refiling|
-      begin
-        ramp_refiling.create_end_product_and_contentions!
-      rescue StandardError => e
-        # Rescue and capture errors so they don't cause the job to stop
-        Raven.capture_exception(e)
-      end
+      ramp_refiling.create_end_product_and_contentions!
+    rescue StandardError => e
+      # Rescue and capture errors so they don't cause the job to stop
+      Raven.capture_exception(e)
     end
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -28,7 +28,7 @@ class Appeal < DecisionReview
            :new_documents_for_user, :manifest_vva_fetched_at, to: :document_fetcher
 
   def self.find_appeal_by_id_or_find_or_create_legacy_appeal_by_vacols_id(id)
-    if UUID_REGEX.match(id)
+    if UUID_REGEX.match?(id)
       find_by_uuid!(id)
     else
       LegacyAppeal.find_or_create_by_vacols_id(id)
@@ -120,15 +120,15 @@ class Appeal < DecisionReview
 
   def veteran_name
     # For consistency with LegacyAppeal.veteran_name
-    veteran && veteran.name.formatted(:form)
+    veteran&.name&.formatted(:form)
   end
 
   def veteran_full_name
-    veteran && veteran.name.formatted(:readable_full)
+    veteran&.name&.formatted(:readable_full)
   end
 
   def veteran_middle_initial
-    veteran && veteran.name.middle_initial
+    veteran&.name&.middle_initial
   end
 
   def veteran_is_deceased
@@ -136,7 +136,7 @@ class Appeal < DecisionReview
   end
 
   def veteran_death_date
-    veteran && veteran.date_of_death
+    veteran&.date_of_death
   end
 
   delegate :address_line_1,
@@ -201,7 +201,7 @@ class Appeal < DecisionReview
 
   # For now power_of_attorney returns the first claimant's power of attorney
   def power_of_attorney
-    claimants.first.power_of_attorney if claimants.first
+    claimants.first&.power_of_attorney
   end
   delegate :representative_name, :representative_type, :representative_address, to: :power_of_attorney, allow_nil: true
 

--- a/app/models/concerns/case_review_concern.rb
+++ b/app/models/concerns/case_review_concern.rb
@@ -108,10 +108,10 @@ module CaseReviewConcern
   end
 
   def vacols_id
-    task_id.split("-", 2).first if task_id
+    task_id&.split("-", 2)&.first
   end
 
   def created_in_vacols_date
-    task_id.split("-", 2).second.to_date if task_id
+    task_id&.split("-", 2)&.second&.to_date
   end
 end

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -8,7 +8,7 @@ class DecisionIssue < ApplicationRecord
 
   def title_of_active_review
     request_issue = RequestIssue.find_active_by_contested_decision_id(id)
-    request_issue.review_title if request_issue
+    request_issue&.review_title
   end
 
   def source_higher_level_review

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -45,11 +45,11 @@ class DecisionReview < ApplicationRecord
   def ui_hash
     {
       veteran: {
-        name: veteran && veteran.name.formatted(:readable_short),
+        name: veteran&.name&.formatted(:readable_short),
         fileNumber: veteran_file_number,
-        formName: veteran && veteran.name.formatted(:form)
+        formName: veteran&.name&.formatted(:form)
       },
-      relationships: veteran && veteran.relationships,
+      relationships: veteran&.relationships,
       claimant: claimant_participant_id,
       veteranIsNotClaimant: veteran_is_not_claimant,
       receiptDate: receipt_date.to_formatted_s(:json_date),

--- a/app/models/dispatch/task.rb
+++ b/app/models/dispatch/task.rb
@@ -95,7 +95,7 @@ class Dispatch::Task < ApplicationRecord
 
     def find_and_assign_next!(user)
       retry_when ActiveRecord::StaleObjectError, limit: 3 do
-        next_assignable.tap { |task| task && task.assign!(user) }
+        next_assignable.tap { |task| task&.assign!(user) }
       end
     end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -64,7 +64,7 @@ class Document < ApplicationRecord
   end
 
   def receipt_date
-    received_at && received_at.to_date
+    received_at&.to_date
   end
 
   def match_vbms_document_from(vbms_documents)

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -148,7 +148,7 @@ class EndProductEstablishment < ApplicationRecord
       issue = issues_without_contentions.find do |i|
         i.contention_text == contention.text && i.contention_reference_id.nil?
       end
-      issue && issue.update!(contention_reference_id: contention.id)
+      issue&.update!(contention_reference_id: contention.id)
     end
 
     fail ContentionCreationFailed if issues_without_contentions.any? { |issue| issue.contention_reference_id.nil? }

--- a/app/models/establish_claim.rb
+++ b/app/models/establish_claim.rb
@@ -240,7 +240,7 @@ class EstablishClaim < Dispatch::Task
   end
 
   def sent_email
-    claim_establishment && claim_establishment.sent_email
+    claim_establishment&.sent_email
   end
 
   def ep_created?

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -3,7 +3,7 @@
 class Form8 < ApplicationRecord
   include UploadableDocument
 
-  FORM8_S3_SUB_BUCKET = "form_8".freeze
+  FORM8_S3_SUB_BUCKET = "form_8"
 
   FORM_FIELDS = [
     :vacols_id,

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -118,11 +118,9 @@ class Hearing < ApplicationRecord
   end
 
   cache_attribute :cached_number_of_documents do
-    begin
-      number_of_documents
-    rescue Caseflow::Error::EfolderError, VBMS::HTTPError
-      nil
-    end
+    number_of_documents
+  rescue Caseflow::Error::EfolderError, VBMS::HTTPError
+    nil
   end
 
   delegate \

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -118,9 +118,11 @@ class Hearing < ApplicationRecord
   end
 
   cache_attribute :cached_number_of_documents do
-    number_of_documents
-  rescue Caseflow::Error::EfolderError, VBMS::HTTPError
-    nil
+    begin
+      number_of_documents
+    rescue Caseflow::Error::EfolderError, VBMS::HTTPError
+      nil
+    end
   end
 
   delegate \

--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -32,7 +32,7 @@ class HigherLevelReview < ClaimReview
   end
 
   def end_product_description
-    rating_end_product_establishment && rating_end_product_establishment.description
+    rating_end_product_establishment&.description
   end
 
   def end_product_base_modifier

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -207,9 +207,9 @@ class Intake < ApplicationRecord
       id: id,
       form_type: form_type,
       veteran_file_number: veteran_file_number,
-      veteran_name: veteran && veteran.name.formatted(:readable_short),
-      veteran_form_name: veteran && veteran.name.formatted(:form),
-      veteran_is_deceased: veteran && veteran.deceased?,
+      veteran_name: veteran&.name&.formatted(:readable_short),
+      veteran_form_name: veteran&.name&.formatted(:form),
+      veteran_is_deceased: veteran&.deceased?,
       completed_at: completed_at,
       relationships: ama_enabled && veteran && veteran.relationships
     }

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -34,9 +34,11 @@ class Judge
   def attorneys
     return [] unless user
     (Constants::AttorneyJudgeTeams::JUDGES[Rails.current_env][user.css_id].try(:[], :attorneys) || []).map do |css_id|
-      User.find_or_create_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
-    rescue ActiveRecord::RecordNotUnique
-      User.find_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
+      begin
+        User.find_or_create_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
+      rescue ActiveRecord::RecordNotUnique
+        User.find_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
+      end
     end
   end
 

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -34,11 +34,9 @@ class Judge
   def attorneys
     return [] unless user
     (Constants::AttorneyJudgeTeams::JUDGES[Rails.current_env][user.css_id].try(:[], :attorneys) || []).map do |css_id|
-      begin
-        User.find_or_create_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
-      rescue ActiveRecord::RecordNotUnique
-        User.find_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
-      end
+      User.find_or_create_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
+    rescue ActiveRecord::RecordNotUnique
+      User.find_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
     end
   end
 

--- a/app/models/judge_case_assignment_to_attorney.rb
+++ b/app/models/judge_case_assignment_to_attorney.rb
@@ -33,7 +33,7 @@ class JudgeCaseAssignmentToAttorney
   end
 
   def created_in_vacols_date
-    task_id.split("-", 2).second.to_date if task_id
+    task_id&.split("-", 2)&.second&.to_date
   end
 
   def vacols_id
@@ -47,7 +47,7 @@ class JudgeCaseAssignmentToAttorney
   private
 
   def vacols_id_from_task_id
-    task_id.split("-", 2).first if task_id
+    task_id&.split("-", 2)&.first
   end
 
   def assigned_by_role_is_valid

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -143,9 +143,11 @@ class LegacyAppeal < ApplicationRecord
   end
 
   cache_attribute :cached_number_of_documents_after_certification do
-    number_of_documents_after_certification
-  rescue Caseflow::Error::EfolderError, VBMS::HTTPError
-    nil
+    begin
+      number_of_documents_after_certification
+    rescue Caseflow::Error::EfolderError, VBMS::HTTPError
+      nil
+    end
   end
 
   # If we do not yet have the vbms_id saved in Caseflow's DB, then

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -143,11 +143,9 @@ class LegacyAppeal < ApplicationRecord
   end
 
   cache_attribute :cached_number_of_documents_after_certification do
-    begin
-      number_of_documents_after_certification
-    rescue Caseflow::Error::EfolderError, VBMS::HTTPError
-      nil
-    end
+    number_of_documents_after_certification
+  rescue Caseflow::Error::EfolderError, VBMS::HTTPError
+    nil
   end
 
   # If we do not yet have the vbms_id saved in Caseflow's DB, then
@@ -191,7 +189,7 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def veteran_ssn
-    vbms_id.ends_with?("C") ? (veteran && veteran.ssn) : sanitized_vbms_id
+    vbms_id.ends_with?("C") ? (veteran&.ssn) : sanitized_vbms_id
   end
 
   delegate :address_line_1,
@@ -269,7 +267,7 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def veteran_death_date
-    veteran && veteran.date_of_death
+    veteran&.date_of_death
   end
 
   attr_writer :cavc_decisions

--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -23,11 +23,11 @@ class LegacyTask
   delegate :first_name, :last_name, :pg_id, :css_id, to: :assigned_by, prefix: true
 
   def user_id
-    assigned_to && assigned_to.css_id
+    assigned_to&.css_id
   end
 
   def assigned_to_pg_id
-    assigned_to && assigned_to.id
+    assigned_to&.id
   end
 
   def appeal

--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -31,10 +31,8 @@ class RampElection < RampReview
     transaction do
       issues.destroy_all
 
-      if contentions
-        contentions.each do |contention|
-          issues.create!(contention: contention)
-        end
+      contentions&.each do |contention|
+        issues.create!(contention: contention)
       end
     end
   end

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -145,7 +145,7 @@ class RampElectionIntake < Intake
   end
 
   def existing_ramp_election_active?
-    existing_ramp_election && existing_ramp_election.end_product_active?
+    existing_ramp_election&.end_product_active?
   end
 
   def use_existing_ramp_election

--- a/app/models/ramp_election_rollback.rb
+++ b/app/models/ramp_election_rollback.rb
@@ -44,7 +44,7 @@ class RampElectionRollback < ApplicationRecord
   # require that it was canceled manually beforehand
   def validate_canceled_end_product
     establishment = EndProductEstablishment.find_by(source: ramp_election)
-    unless establishment && establishment.status_canceled?
+    unless establishment&.status_canceled?
       errors.add(:ramp_election, "end_product_not_canceled")
     end
   end

--- a/app/models/ramp_refiling.rb
+++ b/app/models/ramp_refiling.rb
@@ -73,7 +73,7 @@ class RampRefiling < RampReview
         matching_issue = issues.find do |issue|
           issue.description == contention.text && issue.contention_reference_id.nil?
         end
-        matching_issue && matching_issue.update!(contention_reference_id: contention.id)
+        matching_issue&.update!(contention_reference_id: contention.id)
       end
 
       fail ContentionCreationFailed if issues.any? { |issue| !issue.contention_reference_id }

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -74,7 +74,7 @@ class RatingIssue
   def title_of_active_review
     return unless reference_id
     request_issue = RequestIssue.find_active_by_reference_id(reference_id)
-    request_issue.review_title if request_issue
+    request_issue&.review_title
   end
 
   def source_higher_level_review
@@ -88,7 +88,7 @@ class RatingIssue
   end
 
   def ramp_claim_id
-    associated_ramp_ep && associated_ramp_ep.claim_id
+    associated_ramp_ep&.claim_id
   end
 
   def contention_reference_id

--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -553,7 +553,7 @@ class RegionalOffice
 
   def compute_station_key
     result = STATIONS.find { |_station, ros| [*ros].include? key }
-    result && result.first
+    result&.first
   end
 
   class << self

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -85,14 +85,14 @@ class RequestIssue < ApplicationRecord
 
     def find_active_by_reference_id(reference_id)
       request_issue = unscoped.find_by(rating_issue_reference_id: reference_id, removed_at: nil, ineligible_reason: nil)
-      return unless request_issue && request_issue.status_active?
+      return unless request_issue&.status_active?
       request_issue
     end
 
     def find_active_by_contested_decision_id(contested_decision_issue_id)
       request_issue = unscoped.find_by(contested_decision_issue_id: contested_decision_issue_id,
                                        removed_at: nil, ineligible_reason: nil)
-      return unless request_issue && request_issue.status_active?
+      return unless request_issue&.status_active?
       request_issue
     end
   end
@@ -166,7 +166,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def previous_request_issue
-    contested_decision_issue && contested_decision_issue.request_issues.first
+    contested_decision_issue&.request_issues&.first
   end
 
   def sync_decision_issues!

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -45,17 +45,17 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
   end
 
   attribute :appellant_full_name do
-    object.claimants[0].name if object.claimants && object.claimants.any?
+    object.claimants[0].name if object.claimants&.any?
   end
 
   attribute :appellant_address do
-    if object.claimants && object.claimants.any?
+    if object.claimants&.any?
       object.claimants[0].address
     end
   end
 
   attribute :appellant_relationship do
-    object.claimants[0].relationship if object.claimants && object.claimants.any?
+    object.claimants[0].relationship if object.claimants&.any?
   end
 
   attribute :veteran_file_number do

--- a/app/models/supplemental_claim.rb
+++ b/app/models/supplemental_claim.rb
@@ -20,7 +20,7 @@ class SupplementalClaim < ClaimReview
   end
 
   def end_product_description
-    rating_end_product_establishment && rating_end_product_establishment.description
+    rating_end_product_establishment&.description
   end
 
   def end_product_base_modifier

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -138,7 +138,7 @@ class Task < ApplicationRecord
 
   def mark_as_complete!
     update!(status: :completed)
-    parent.when_child_task_completed if parent
+    parent&.when_child_task_completed
   end
 
   def when_child_task_completed
@@ -200,7 +200,7 @@ class Task < ApplicationRecord
   def assign_to_user_data
     users = if assigned_to.is_a?(Organization)
               assigned_to.users
-            elsif parent && parent.assigned_to.is_a?(Organization)
+            elsif parent&.assigned_to.is_a?(Organization)
               parent.assigned_to.users.reject { |u| u == assigned_to }
             else
               []

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -34,7 +34,7 @@ class AttorneyTask < Task
   private
 
   def parent_attorney_child_count
-    errors.add(:parent, "has too many children") if parent&.children_attorney_tasks&.length >= 1
+    errors.add(:parent, "has too many children") if parent&.children_attorney_tasks&.length &.>= 1
   end
 
   def assigned_to_role_is_valid

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -34,7 +34,7 @@ class AttorneyTask < Task
   private
 
   def parent_attorney_child_count
-    errors.add(:parent, "has too many children") if parent && parent.children_attorney_tasks.length >= 1
+    errors.add(:parent, "has too many children") if parent&.children_attorney_tasks&.length >= 1
   end
 
   def assigned_to_role_is_valid

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -34,7 +34,7 @@ class BvaDispatchTask < GenericTask
 
       decision.upload!
     rescue ActiveRecord::RecordInvalid => e
-      raise(Caseflow::Error::OutcodeValidationFailure, message: e.message) if e.message =~ /^Validation failed:/
+      raise(Caseflow::Error::OutcodeValidationFailure, message: e.message) if e.message.match?(/^Validation failed:/)
       raise e
     rescue VBMS::HTTPError => e
       Raven.capture_exception(e)

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -74,8 +74,7 @@ class GenericTask < Task
   private
 
   def task_is_assigned_to_user_within_organiztaion?(user)
-    parent &&
-      parent.assigned_to.is_a?(Organization) &&
+    parent&.assigned_to.is_a?(Organization) &&
       assigned_to.is_a?(User) &&
       parent.assigned_to.user_has_access?(user)
   end

--- a/app/models/user_quota.rb
+++ b/app/models/user_quota.rb
@@ -32,7 +32,7 @@ class UserQuota < ApplicationRecord
   end
 
   def user_name
-    user && user.full_name
+    user&.full_name
   end
 
   def locked?

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -182,7 +182,7 @@ class VACOLS::CaseHearing < VACOLS::Record
   end
 
   def master_record_type
-    return :video if folder_nr =~ /VIDEO/
+    return :video if folder_nr.match?(/VIDEO/)
   end
 
   def update_hearing!(hearing_info)

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -45,7 +45,7 @@ class Veteran < ApplicationRecord
   end
 
   def country_requires_zip?
-    COUNTRIES_REQUIRING_ZIP.include?(country && country.upcase)
+    COUNTRIES_REQUIRING_ZIP.include?(country&.upcase)
   end
 
   def state_is_required?
@@ -101,7 +101,7 @@ class Veteran < ApplicationRecord
     Raven.capture_exception(error)
 
     # Set the veteran as inaccessible if a sensitivity error is thrown
-    raise error unless error.message =~ /Sensitive File/
+    raise error unless error.message.match?(/Sensitive File/)
 
     @accessible = false
   end
@@ -116,7 +116,7 @@ class Veteran < ApplicationRecord
 
   # Postal code might be stored in address line 3 for international addresses
   def zip_code
-    @zip_code || (@address_line3 if @address_line3 =~ /(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/)
+    @zip_code || (@address_line3 if @address_line3.match?(/(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/))
   end
   alias zip zip_code
   alias address_line_1 address_line1

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -55,16 +55,14 @@ class DocumentFetcher
     end
 
     documents.map do |document|
-      begin
-        if existing_documents[document.vbms_document_id]
-          document.merge_into(existing_documents[document.vbms_document_id]).save!
-          existing_documents[document.vbms_document_id]
-        else
-          create_new_document!(document, ids)
-        end
-      rescue ActiveRecord::RecordNotUnique
-        Document.find_by_vbms_document_id(document.vbms_document_id)
+      if existing_documents[document.vbms_document_id]
+        document.merge_into(existing_documents[document.vbms_document_id]).save!
+        existing_documents[document.vbms_document_id]
+      else
+        create_new_document!(document, ids)
       end
+    rescue ActiveRecord::RecordNotUnique
+      Document.find_by_vbms_document_id(document.vbms_document_id)
     end
   end
 

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -27,7 +27,7 @@ class ExternalApi::VBMSService
     request = VBMS::Requests::GetDocumentContent.new(vbms_id)
 
     result = send_and_log_request(vbms_id, request)
-    result && result.content
+    result&.content
   end
 
   def self.fetch_documents_for(appeal, _user = nil)

--- a/app/services/form8_pdf_service.rb
+++ b/app/services/form8_pdf_service.rb
@@ -3,8 +3,8 @@
 require "pdf_forms"
 
 class Form8PdfService
-  PDF_PAGE_1 = "form1[0].#subform[0].#area[0].".freeze
-  PDF_PAGE_2 = "form1[0].#subform[1].".freeze
+  PDF_PAGE_1 = "form1[0].#subform[0].#area[0]."
+  PDF_PAGE_2 = "form1[0].#subform[1]."
 
   # Currently, the only thing on Page 2 of the VA Form 8 is the continued
   # remarks. As a result, we'll just say anything except for that is actually
@@ -42,7 +42,7 @@ class Form8PdfService
     certification_date: "TextField1[10]"
   }.freeze
 
-  PDF_CHECKBOX_SYMBOL = "1".freeze
+  PDF_CHECKBOX_SYMBOL = "1"
 
   # Rubocop complains about the number of conditions here,
   # but IMO it's pretty clear and I don't want to break it up

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,9 @@
 #!/usr/bin/env ruby
 VENDOR_PATH = File.expand_path("..", __dir__)
 Dir.chdir(VENDOR_PATH) do
-  begin
-    exec "yarnpkg #{ARGV.join(' ')}"
-  rescue Errno::ENOENT
-    warn "Yarn executable was not detected in the system."
-    warn "Download Yarn at https://yarnpkg.com/en/docs/install"
-    exit 1
-  end
+  exec "yarnpkg #{ARGV.join(' ')}"
+rescue Errno::ENOENT
+  warn "Yarn executable was not detected in the system."
+  warn "Download Yarn at https://yarnpkg.com/en/docs/install"
+  exit 1
 end

--- a/ci-bin/concatenate-log.rb
+++ b/ci-bin/concatenate-log.rb
@@ -10,7 +10,7 @@ artifacts_url = "https://circleci.com/api/v1.1/project"\
 artifacts = JSON.parse(open(artifacts_url).read)
 
 log_file_urls = artifacts.map do |artifact|
-  if artifact["path"] =~ /\.log$/
+  if artifact["path"].match?(/\.log$/)
     artifact["url"]
   end
 end.compact

--- a/lib/helpers/sanitizers.rb
+++ b/lib/helpers/sanitizers.rb
@@ -57,10 +57,10 @@ class Helpers::Sanitizers
     record.attributes.each do |k, v|
       next if !v.is_a?(String) || ignore_pii_in_fields.include?("#{record.class.name}-#{k}")
 
-      errors.push("WARNING -- Probable vetid: #{record.class.name}-#{k}-#{v}") if VETID_REGEX.match(v)
-      errors.push("WARNING -- Probable email: #{record.class.name}-#{k}-#{v}") if EMAIL_REGEX.match(v)
-      errors.push("WARNING -- Probable phone number: #{record.class.name}-#{k}-#{v}") if PHONE_REGEX.match(v)
-      errors.push("WARNING -- Possible PII in freetext: #{record.class.name}-#{k}-#{v}") if SENTENCE_REGEX.match(v)
+      errors.push("WARNING -- Probable vetid: #{record.class.name}-#{k}-#{v}") if VETID_REGEX.match?(v)
+      errors.push("WARNING -- Probable email: #{record.class.name}-#{k}-#{v}") if EMAIL_REGEX.match?(v)
+      errors.push("WARNING -- Probable phone number: #{record.class.name}-#{k}-#{v}") if PHONE_REGEX.match?(v)
+      errors.push("WARNING -- Possible PII in freetext: #{record.class.name}-#{k}-#{v}") if SENTENCE_REGEX.match?(v)
     end
   end
 
@@ -330,7 +330,7 @@ class Helpers::Sanitizers
 
     # Note we only keep board_members when they have number IDs, not RO letter IDs
     hearing.assign_attributes(
-      board_member: ONLY_NUMBER_REGEX.match(hearing.board_member) ? hearing.board_member : nil,
+      board_member: ONLY_NUMBER_REGEX.match?(hearing.board_member) ? hearing.board_member : nil,
       repname: ::Faker::Name.name,
       rep_state: ::Faker::Address.state_abbr,
       notes1: random_or_nil(::Faker::Lorem.sentence),

--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
           defolder: vacols_case.bfkey,
           deadusr: slogid ? slogid : "TEST",
           demdusr: assigner_slogid ? assigner_slogid : "ASSIGNER",
-          dereceive: (evaluator.user && evaluator.user.vacols_roles.include?("judge")) ? Time.zone.today : nil,
+          dereceive: (evaluator.user&.vacols_roles&.include?("judge")) ? Time.zone.today : nil,
           dedocid: evaluator.document_id || nil,
           deatty: sattyid || "100"
         )
@@ -271,7 +271,7 @@ FactoryBot.define do
     trait :paper_case do
       after(:build) do |vacols_case, _evaluator|
         vacols_case.folder.tivbms = "N" if %w[Y 1 0].include?(vacols_case.folder.tivbms)
-        vacols_case.folder.tisubj2 = "N" if vacols_case.folder.tisubj2 && vacols_case.folder.tisubj2.eq?("Y")
+        vacols_case.folder.tisubj2 = "N" if vacols_case.folder.tisubj2&.eq?("Y")
       end
     end
 

--- a/spec/factories/vacols/staff.rb
+++ b/spec/factories/vacols/staff.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
     end
 
     after(:build) do |staff, evaluator|
-      if evaluator.user && evaluator.user.full_name
+      if evaluator.user&.full_name
         staff.snamef, staff.snamel = evaluator.user.full_name.split(" ")
       end
     end

--- a/spec/models/ramp_refiling_intake_spec.rb
+++ b/spec/models/ramp_refiling_intake_spec.rb
@@ -355,7 +355,7 @@ describe RampRefilingIntake do
 
     let(:params) do
       {
-        issue_ids: source_issues && source_issues.map(&:id),
+        issue_ids: source_issues&.map(&:id),
         has_ineligible_issue: true
       }
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -120,7 +120,7 @@ module StubbableUser
     end
 
     def authenticate!(css_id: nil, roles: nil, user: nil)
-      Functions.grant!("System Admin", users: ["DSUSER"]) if roles && roles.include?("System Admin")
+      Functions.grant!("System Admin", users: ["DSUSER"]) if roles&.include?("System Admin")
 
       if user.nil?
         user = User.from_session(
@@ -357,16 +357,14 @@ RSpec::Matchers.define :become_truthy do |wait: Capybara.default_max_wait_time|
   supports_block_expectations
 
   match do |block|
-    begin
-      Timeout.timeout(wait) do
-        # rubocop:disable AssignmentInCondition
-        sleep(0.1) until value = block.call
-        # rubocop:enable AssignmentInCondition
-        value
-      end
-    rescue TimeoutError
-      false
+    Timeout.timeout(wait) do
+      # rubocop:disable AssignmentInCondition
+      sleep(0.1) until value = block.call
+      # rubocop:enable AssignmentInCondition
+      value
     end
+  rescue TimeoutError
+    false
   end
 end
 

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -65,7 +65,7 @@ module IntakeHelpers
 
   def find_intake_issue_by_number(number)
     find_all(:xpath, './/div[@class="issues"]/*/div[@class="issue"]').each do |node|
-      if node.find(".issue-num").text =~ /^#{number}\./
+      if node.find(".issue-num").text.match?(/^#{number}\./)
         return node
       end
     end
@@ -73,7 +73,7 @@ module IntakeHelpers
 
   def find_intake_issue_by_text(text)
     find_all(:xpath, './/div[@class="issues"]/*/div[@class="issue"]').each do |node|
-      if node.text =~ /#{text}/
+      if node.text.match?(/#{text}/)
         return node
       end
     end


### PR DESCRIPTION
Resolves #8148

### Description
I removed `TargetRubyVersion` from the `.rubocop.yml` file, which causes rubocop to use the value in `.ruby-version`. Then I ran `bundle exec rubocop -Ra` to auto-fix all the new flags, and manually fixed the one flag it couldn't auto-fix.
