### PR TITLE
Bugfix: Restrict membership of Hearings Management team

### DIFF
--- a/app/models/organizations/hearings_management.rb
+++ b/app/models/organizations/hearings_management.rb
@@ -2,8 +2,4 @@ class HearingsManagement < Organization
   def self.singleton
     HearingsManagement.first || HearingsManagement.create(name: "Hearings Management")
   end
-
-  def user_has_access?(_user)
-    true
-  end
 end

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -2,6 +2,7 @@ describe ScheduleHearingTask do
   before do
     FeatureToggle.enable!(:test_facols)
     Time.zone = "Eastern Time (US & Canada)"
+    OrganizationsUser.add_user_to_organization(hearings_user, HearingsManagement.singleton)
     RequestStore[:current_user] = hearings_user
   end
 


### PR DESCRIPTION
Since #8101 [was released Friday morning](https://dsva.slack.com/archives/C7VNGMYUQ/p1544197518034200), members of the VLJ support staff have likely been unable to take any action on `ColocatedTask`s associated with Legacy appeals.

#8101 creates a `RootTask` for an appeal if one does not already exist when anybody visit's that appeal's case details page. The combination of the following three factors results in the application showing the "Schedule hearing" task action to members of the VLJ support staff instead of the task actions that would normally be associated with a `ColocatedTask`:
1. Everybody is effectively a member of the `HearingsManagement` organization.
1. [We only show one task for each appeal](https://github.com/department-of-veterans-affairs/caseflow/blob/ea7373248eac68e41b951c6ddc46a645e6050730/client/app/queue/CaseSnapshot.jsx#L315) on the case details page.
1. The `RootTask` for the appeal was likely created (and thus more likely--but not guaranteed--to be sorted after) the `ColocatedTask`s associated with that appeal.

This PR fixes this bug by restricting membership in the `HearingsManagement` organization to only those users who are associated with that organization in the `organizations_users` table (the standard way for defining membership).

[A test that demonstrates this bug](https://github.com/department-of-veterans-affairs/caseflow/pull/8105/files#diff-efa486e7a6efccf82a4c273d357d0ab3R30) was written as part of a recent PR.