### PR TITLE
Prevent Scheduling Hearings if there is an Open Hearing

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -11,7 +11,7 @@ class RootTask < GenericTask
     return [Constants.TASK_ACTIONS.CREATE_MAIL_TASK.to_h] if MailTeam.singleton.user_has_access?(user)
 
     if HearingsManagement.singleton.user_has_access?(user) && legacy? &&
-       children.select { |t| t.is_a?(ScheduleHearingTask) && t.status == Constants.TASK_STATUSES.completed }.empty?
+       children.select { |t| t.is_a?(ScheduleHearingTask) && t.status != Constants.TASK_STATUSES.completed }.empty?
       return [Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h]
     end
 

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -30,7 +30,8 @@ import {
   appealWithDetailSelector,
   actionableTasksForAppeal
 } from '../selectors';
-import { onReceiveAmaTasks } from '../QueueActions';
+import { onReceiveAmaTasks, onReceiveAppealDetails } from '../QueueActions';
+import { prepareAppealForStore } from '../utils';
 import _ from 'lodash';
 import type { Appeal, Task } from '../types/models';
 import { CENTRAL_OFFICE_HEARING, VIDEO_HEARING } from '../../hearings/constants/constants';
@@ -48,6 +49,7 @@ type Props = Params & {|
   savePending: boolean,
   selectedRegionalOffice: Object,
   scheduleHearingTask: Object,
+  openHearing: Object,
   history: Object,
   hearingDay: Object,
   selectedHearingDay: Object,
@@ -63,6 +65,7 @@ type Props = Params & {|
   onReceiveAmaTasks: typeof onReceiveAmaTasks,
   onHearingDayChange: typeof onHearingDayChange,
   onHearingTimeChange: typeof onHearingTimeChange,
+  onReceiveAppealDetails: typeof onReceiveAppealDetails,
   // Inherited from EditModalBase
   setLoading: Function,
 |};
@@ -79,7 +82,17 @@ const centralOfficeStaticEntry = [{
 class AssignHearingModal extends React.PureComponent<Props, LocalState> {
 
   componentDidMount = () => {
-    const { hearingDay } = this.props;
+    const { hearingDay, openHearing } = this.props;
+
+    if (openHearing) {
+      this.props.showErrorMessage({
+        title: 'Open Hearing',
+        detail: `This appeal has an open hearing on ${formatDateStr(openHearing.date)}. ` +
+                'You cannot schedule another hearing.'
+      });
+
+      return;
+    }
 
     if (hearingDay.hearingTime) {
       this.props.onHearingTimeChange(hearingDay.hearingTime);
@@ -93,6 +106,11 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
   };
 
   validateForm = () => {
+
+    if (this.props.openHearing) {
+      return false;
+    }
+
     const hearingDate = this.formatHearingDate();
 
     if (hearingDate === null || this.props.selectedHearingTime === null) {
@@ -133,7 +151,7 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
         const resp = JSON.parse(response.text);
 
         this.props.onReceiveAmaTasks(resp.tasks.data);
-        console.log(resp.tasks.data);
+
         setLoading(false);
       });
     }
@@ -165,8 +183,9 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
 
     return this.props.requestPatch(`/tasks/${scheduleHearingTask.taskId}`, payload, this.getSuccessMsg()).
       then(() => {
-
         history.goBack();
+        this.resetAppealDetails();
+
       }, () => {
         this.props.showErrorMessage({
           title: 'No Available Slots',
@@ -174,6 +193,14 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
                   'Please select a different date.'
         });
       });
+  }
+
+  resetAppealDetails = () => {
+    const { appeal } = this.props;
+
+    ApiUtil.get(`/appeals/${appeal.externalId}`).then((response) => {
+      this.props.onReceiveAppealDetails(prepareAppealForStore([response.body.appeal]));
+    });
   }
 
   getTimeOptions = () => {
@@ -292,13 +319,15 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
   render = () => {
     const {
       selectedHearingDay, selectedRegionalOffice,
-      selectedHearingTime
+      selectedHearingTime, openHearing
     } = this.props;
-
-    console.log(this.props.scheduleHearingTask);
 
     const initVals = this.getInitialValues();
     const timeOptions = this.getTimeOptions();
+
+    if (openHearing) {
+      return null;
+    }
 
     return <React.Fragment>
       <div {...fullWidth} {...css({ marginBottom: '0' })} >
@@ -335,6 +364,10 @@ const mapStateToProps = (state: State, ownProps: Params) => ({
     actionableTasksForAppeal(state, { appealId: ownProps.appealId }),
     (task) => task.type === 'ScheduleHearingTask' && task.status !== 'completed'
   ),
+  openHearing: _.find(
+    appealWithDetailSelector(state, ownProps).hearings,
+    (hearing) => hearing.disposition === null
+  ),
   appeal: appealWithDetailSelector(state, ownProps),
   saveState: state.ui.saveState.savePending,
   selectedRegionalOffice: state.components.selectedRegionalOffice,
@@ -353,7 +386,8 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   onReceiveAmaTasks,
   onRegionalOfficeChange,
   onHearingDayChange,
-  onHearingTimeChange
+  onHearingTimeChange,
+  onReceiveAppealDetails
 }, dispatch);
 
 export default (withRouter(

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -133,6 +133,7 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
         const resp = JSON.parse(response.text);
 
         this.props.onReceiveAmaTasks(resp.tasks.data);
+        console.log(resp.tasks.data);
         setLoading(false);
       });
     }
@@ -294,6 +295,8 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
       selectedHearingTime
     } = this.props;
 
+    console.log(this.props.scheduleHearingTask);
+
     const initVals = this.getInitialValues();
     const timeOptions = this.getTimeOptions();
 
@@ -330,7 +333,7 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
 const mapStateToProps = (state: State, ownProps: Params) => ({
   scheduleHearingTask: _.find(
     actionableTasksForAppeal(state, { appealId: ownProps.appealId }),
-    (task) => task.type === 'ScheduleHearingTask'
+    (task) => task.type === 'ScheduleHearingTask' && task.status !== 'completed'
   ),
   appeal: appealWithDetailSelector(state, ownProps),
   saveState: state.ui.saveState.savePending,


### PR DESCRIPTION
Resolves #8144

- Adds error message after Schedule Veteran click if a hearing exist with null disposition
- After successfully creating a new hearing, re-fetches appeal details with up-to-date list of hearings
- Fixes root task available_actions logic

