### PR TITLE
Modal does not close when clicking the X. Due to missing…

### DIFF
--- a/client/app/hearingSchedule/components/HearingDayEditModal.jsx
+++ b/client/app/hearingSchedule/components/HearingDayEditModal.jsx
@@ -194,7 +194,7 @@ class HearingDayEditModal extends React.Component {
       <div className="cf-modal-scroll">
         <Modal
           title="Edit Hearing Day"
-          closeHandler={this.onCancelModal}
+          closeHandler={this.props.cancelModal}
           confirmButton={this.modalConfirmButton()}
           cancelButton={this.modalCancelButton()}
         >


### PR DESCRIPTION
Due to missing refactor when removing a method requested during review feedback on prior PR.

Resolves #8247 

### Description
Refactor method being called when X is clicked to close the modal.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to Edit a Hearing Day
2. Click on the X at the top right corner and ensure modal closes without saving any state.

