### PR TITLE
Bump connect_vbms version to get XML escaping fix for RAMP contentions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem "therubyracer", platforms: :ruby
 
 gem "pg", platforms: :ruby
 
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "c9568319e5982f239b918bb4c3b07527d2c35cec"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "70a297053cfba50731a41e8bd31ab079bc1ac460"
 
 gem "redis-rails", "~> 5.0.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: c9568319e5982f239b918bb4c3b07527d2c35cec
-  ref: c9568319e5982f239b918bb4c3b07527d2c35cec
+  revision: 70a297053cfba50731a41e8bd31ab079bc1ac460
+  ref: 70a297053cfba50731a41e8bd31ab079bc1ac460
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
See https://github.com/department-of-veterans-affairs/connect_vbms/pull/207

Addresses https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3141/ et al
