### PR TITLE
Remove extra RootTask method

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -42,10 +42,4 @@ class RootTask < GenericTask
       end
     end
   end
-
-  def can_be_updated_by_user?(user)
-    return true if HearingsManagement.singleton.user_has_access?(user)
-
-    super(user)
-  end
 end

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -8,12 +8,16 @@ class RootTask < GenericTask
   def when_child_task_completed; end
 
   def available_actions(user)
-    return [Constants.TASK_ACTIONS.CREATE_MAIL_TASK.to_h] if MailTeam.singleton.user_has_access?(user)
+    return [Constants.TASK_ACTIONS.CREATE_MAIL_TASK.to_h] if
+      MailTeam.singleton.user_has_access?(user)
 
-    if HearingsManagement.singleton.user_has_access?(user) && legacy? &&
-       children.select { |t| t.is_a?(ScheduleHearingTask) && t.status != Constants.TASK_STATUSES.completed }.empty?
-      return [Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h]
-    end
+    return [Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h] if
+      HearingsManagement.singleton.user_has_access?(user) &&
+      legacy? &&
+      children.select do |t|
+        t.is_a?(ScheduleHearingTask) &&
+        t.status != Constants.TASK_STATUSES.completed
+      end.empty?
 
     []
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -94,6 +94,13 @@ FactoryBot.define do
       assigned_by nil
     end
 
+    factory :schedule_hearing_task do
+      type ScheduleHearingTask.name
+      appeal_type Appeal.name
+      appeal { create(:appeal) }
+      assigned_by nil
+    end
+
     factory :quality_review_task do
       type QualityReviewTask.name
       appeal_type Appeal.name

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -10,21 +10,11 @@ describe ScheduleHearingTask do
     FeatureToggle.disable!(:test_facols)
   end
 
-  let(:vacols_case) do
-    FactoryBot.create(:case)
-  end
-  let(:appeal) do
-    create(:legacy_appeal, vacols_case: vacols_case)
-  end
-  let!(:hearings_user) do
-    create(:hearings_coordinator)
-  end
-  let(:staff) do
-    create(:staff, sdomainid: "BVATWARNER", slogid: "TWARNER")
-  end
-  let!(:hearings_org) do
-    create(:hearings_management)
-  end
+  let(:vacols_case) { FactoryBot.create(:case) }
+  let(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+  let!(:hearings_user) { create(:hearings_coordinator) }
+  let(:staff) { create(:staff, sdomainid: "BVATWARNER", slogid: "TWARNER") }
+  let!(:hearings_org) { create(:hearings_management) }
 
   let(:test_hearing_date_vacols) do
     Time.use_zone("Eastern Time (US & Canada)") do
@@ -33,7 +23,8 @@ describe ScheduleHearingTask do
   end
 
   describe "Add a schedule hearing task" do
-    let(:root_task) { FactoryBot.create(:root_task, appeal_type: LegacyAppeal.name, appeal: appeal) }
+    let(:root_task) { FactoryBot.create(:root_task, appeal_type: root_task_appeal_type, appeal: appeal) }
+    let(:root_task_appeal_type) { LegacyAppeal.name }
     let(:params) do
       {
         type: ScheduleHearingTask.name,
@@ -45,12 +36,29 @@ describe ScheduleHearingTask do
       }
     end
 
-    it "should create a taks of type ScheduleHearingTask" do
-      hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
+    subject { ScheduleHearingTask.create_from_params(params, hearings_user) }
 
-      expect(hearing_task.type).to eq(ScheduleHearingTask.name)
-      expect(hearing_task.appeal_type).to eq(LegacyAppeal.name)
-      expect(hearing_task.status).to eq("assigned")
+    it "should create a task of type ScheduleHearingTask" do
+      expect(subject.type).to eq(ScheduleHearingTask.name)
+      expect(subject.appeal_type).to eq(LegacyAppeal.name)
+      expect(subject.status).to eq("assigned")
+    end
+
+    context "the root task is not a legacy task" do
+      let(:appeal) { create :appeal }
+      let(:root_task_appeal_type) { Appeal.name }
+
+      it "raises an ActionForbiddenError" do
+        expect { subject }.to raise_error(Caseflow::Error::ActionForbiddenError)
+      end
+    end
+
+    context "the root task has an on hold ScheduleHearingTask child" do
+      let!(:on_hold_task) { create(:schedule_hearing_task, parent: root_task, status: Constants.TASK_STATUSES.on_hold) }
+
+      it "raises an ActionForbiddenError" do
+        expect { subject }.to raise_error(Caseflow::Error::ActionForbiddenError)
+      end
     end
   end
 
@@ -98,7 +106,7 @@ describe ScheduleHearingTask do
       }
     end
 
-    it "should create a taks of type ScheduleHearingTask" do
+    it "should create a task of type ScheduleHearingTask" do
       hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
 
       expect(hearing_task.type).to eq(ScheduleHearingTask.name)
@@ -148,7 +156,7 @@ describe ScheduleHearingTask do
       }
     end
 
-    it "should create a taks of type ScheduleHearingTask" do
+    it "should create a task of type ScheduleHearingTask" do
       hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
       updated_task = hearing_task.update_from_params(update_params, hearings_user)
 
@@ -197,7 +205,7 @@ describe ScheduleHearingTask do
       }
     end
 
-    it "should create a taks of type ScheduleHearingTask" do
+    it "should create a task of type ScheduleHearingTask" do
       hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
       hearing_task.update_from_params(update_params, hearings_user)
       updated_hearing = VACOLS::CaseHearing.find(hearing.hearing_pkseq)
@@ -244,7 +252,7 @@ describe ScheduleHearingTask do
       }
     end
 
-    it "should create a taks of type ScheduleHearingTask" do
+    it "should create a task of type ScheduleHearingTask" do
       hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
       hearing_task.update_from_params(update_params, hearings_user)
       created_hearing = VACOLS::CaseHearing.find_by(hearing_type: "V",


### PR DESCRIPTION
As currently written, we expect `RootTask.can_be_updated_by_user?` to always return the same result as `GenericTask.can_be_updated_by_user?` except in the case where [the condition in `RootTask.available_actions` evaluates to false](https://github.com/department-of-veterans-affairs/caseflow/blob/bd3d4a6c493932fb9f47029fb7a58018a557d148/app/models/tasks/root_task.rb#L13). This change is desirable because we should not be creating child tasks in those circumstances. This PR makes that change.