### PR TITLE
Adding padding-left to new document icon

### DIFF
--- a/client/app/components/Tooltip.jsx
+++ b/client/app/components/Tooltip.jsx
@@ -24,8 +24,12 @@ const Tooltip = (props) => {
     [`& #${id}:after`]: { [`border${borderToColor}Color`]: COLORS.GREY_DARK }
   });
 
+  const iconStyling = css({
+    paddingLeft: '0.5rem'
+  });
+
   return <React.Fragment>
-    <span data-tip data-for={id}>{props.children}</span>
+    <span {...iconStyling} data-tip data-for={id}>{props.children}</span>
     <span {...tooltipStyling} >
       <ReactTooltip effect="solid" id={id} offset={offset} place={position} multiline>{text}</ReactTooltip>
     </span>


### PR DESCRIPTION
Resolves 8271 - Add left padding to new documents icon


| Before | After |
| --- | --- |
| ![screen shot 2018-12-13 at 4 29 52 pm](https://user-images.githubusercontent.com/44415076/49968640-65e85380-fef4-11e8-9c29-54ee255322ac.png) | ![screen shot 2018-12-13 at 4 30 07 pm](https://user-images.githubusercontent.com/44415076/49968654-6bde3480-fef4-11e8-87e4-79da51285fc4.png) |

