### PR TITLE
No End Products on non-comp SC and HLR

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -202,11 +202,15 @@ class Appeal < DecisionReview
     "not implemented for AMA"
   end
 
+  def benefit_type
+    # temporary until ticket for appeals benefit type by issue is implemented
+    # https://github.com/department-of-veterans-affairs/caseflow/issues/5882
+    "compensation"
+  end
+
   def create_issues!(new_issues)
     new_issues.each do |issue|
-      # temporary until ticket for appeals benefit type by issue is implemented
-      # https://github.com/department-of-veterans-affairs/caseflow/issues/5882
-      issue.update!(benefit_type: "compensation")
+      issue.update!(benefit_type: benefit_type)
       create_legacy_issue_optin(issue) if issue.vacols_id && issue.eligible?
     end
   end

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -84,10 +84,6 @@ class ClaimReview < DecisionReview
     request_issues.find { |reqi| reqi.description == description }
   end
 
-  def non_comp?
-    !ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE.include?(benefit_type)
-  end
-
   private
 
   def contestable_decision_issues

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -84,6 +84,10 @@ class ClaimReview < DecisionReview
     request_issues.find { |reqi| reqi.description == description }
   end
 
+  def non_comp?
+    !ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE.include?(benefit_type)
+  end
+
   private
 
   def contestable_decision_issues

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -55,8 +55,13 @@ class DecisionReview < ApplicationRecord
     end
   end
 
+  def non_comp?
+    !ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE.include?(benefit_type)
+  end
+
   def serialized_ratings
     return unless receipt_date
+    return if non_comp?
 
     cached_serialized_ratings.each do |rating|
       rating[:issues].each do |rating_issue_hash|
@@ -165,6 +170,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def contestable_issues
+    return contestable_issues_from_decision_issues if non_comp?
     contestable_issues_from_ratings + contestable_issues_from_decision_issues
   end
 

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -5,6 +5,7 @@ class DecisionReviewIntake < Intake
       claimant: detail.claimant_participant_id,
       veteran_is_not_claimant: detail.veteran_is_not_claimant,
       payeeCode: detail.payee_code,
+      nonComp: detail.non_comp?,
       legacy_opt_in_approved: detail.legacy_opt_in_approved,
       legacyAppeals: detail.serialized_legacy_appeals,
       ratings: detail.serialized_ratings,

--- a/client/app/intake/pages/higherLevelReview/finish.jsx
+++ b/client/app/intake/pages/higherLevelReview/finish.jsx
@@ -5,7 +5,7 @@ import Button from '../../../components/Button';
 import CancelButton from '../../components/CancelButton';
 import IssueCounter from '../../components/IssueCounter';
 import { completeIntake } from '../../actions/decisionReview';
-import { REQUEST_STATE } from '../../constants';
+import { REQUEST_STATE, FORM_TYPES } from '../../constants';
 import { issueCountSelector } from '../../selectors';
 
 class FinishNextButton extends React.PureComponent {
@@ -19,6 +19,14 @@ class FinishNextButton extends React.PureComponent {
     );
   }
 
+  buttonText = () => {
+    if (this.props.higherLevelReview.nonComp) {
+      return `Establish ${FORM_TYPES.HIGHER_LEVEL_REVIEW.shortName}`;
+    }
+
+    return 'Establish EP';
+  }
+
   render = () =>
     <Button
       name="finish-intake"
@@ -26,7 +34,7 @@ class FinishNextButton extends React.PureComponent {
       loading={this.props.requestState === REQUEST_STATE.IN_PROGRESS}
       disabled={!this.props.issueCount && !this.props.addedIssues}
     >
-      Establish EP
+      {this.buttonText()}
     </Button>;
 }
 

--- a/client/app/intake/pages/supplementalClaim/finish.jsx
+++ b/client/app/intake/pages/supplementalClaim/finish.jsx
@@ -5,7 +5,7 @@ import Button from '../../../components/Button';
 import CancelButton from '../../components/CancelButton';
 import IssueCounter from '../../components/IssueCounter';
 import { completeIntake } from '../../actions/decisionReview';
-import { REQUEST_STATE } from '../../constants';
+import { REQUEST_STATE, FORM_TYPES } from '../../constants';
 import { issueCountSelector } from '../../selectors';
 
 class FinishNextButton extends React.PureComponent {
@@ -19,6 +19,14 @@ class FinishNextButton extends React.PureComponent {
     );
   }
 
+  buttonText = () => {
+    if (this.props.supplementalClaim.nonComp) {
+      return `Establish ${FORM_TYPES.SUPPLEMENTAL_CLAIM.shortName}`;
+    }
+
+    return 'Establish EP';
+  }
+
   render = () =>
     <Button
       name="finish-intake"
@@ -26,7 +34,7 @@ class FinishNextButton extends React.PureComponent {
       loading={this.props.requestState === REQUEST_STATE.IN_PROGRESS}
       disabled={!this.props.issueCount && !this.props.addedIssues}
     >
-      Establish EP
+      {this.buttonText()}
     </Button>;
 }
 

--- a/client/app/intake/reducers/appeal.js
+++ b/client/app/intake/reducers/appeal.js
@@ -31,6 +31,9 @@ const updateFromServerIntake = (state, serverIntake) => {
     veteranIsNotClaimant: {
       $set: serverIntake.veteran_is_not_claimant
     },
+    nonComp: {
+      $set: serverIntake.nonComp
+    },
     claimant: {
       $set: serverIntake.veteran_is_not_claimant ? serverIntake.claimant : null
     },

--- a/client/app/intake/reducers/higherLevelReview.js
+++ b/client/app/intake/reducers/higherLevelReview.js
@@ -43,6 +43,9 @@ const updateFromServerIntake = (state, serverIntake) => {
     payeeCode: {
       $set: serverIntake.payeeCode
     },
+    nonComp: {
+      $set: serverIntake.nonComp
+    },
     legacyOptInApproved: {
       $set: serverIntake.legacy_opt_in_approved
     },

--- a/client/app/intake/reducers/supplementalClaim.js
+++ b/client/app/intake/reducers/supplementalClaim.js
@@ -28,6 +28,9 @@ const updateFromServerIntake = (state, serverIntake) => {
     benefitType: {
       $set: serverIntake.benefit_type
     },
+    nonComp: {
+      $set: serverIntake.nonComp
+    },
     veteranIsNotClaimant: {
       $set: serverIntake.veteran_is_not_claimant
     },

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -2,11 +2,11 @@ FactoryBot.define do
   factory :higher_level_review do
     sequence(:veteran_file_number, &:to_s)
     receipt_date { 1.month.ago }
+    benefit_type "compensation"
 
     trait :with_end_product_establishment do
       after(:create) do |higher_level_review|
-        create(:end_product_establishment,
-               source: higher_level_review)
+        create(:end_product_establishment, source: higher_level_review)
       end
     end
   end

--- a/spec/factories/supplemental_claim.rb
+++ b/spec/factories/supplemental_claim.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :supplemental_claim do
     sequence(:veteran_file_number, &:to_s)
     receipt_date { 1.month.ago }
+    benefit_type "compensation"
   end
 end

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1075,33 +1075,54 @@ RSpec.feature "Higher-Level Review" do
       expect(page).to have_current_path("/intake/add_issues")
     end
 
-    scenario "Non-compensation" do
-      hlr, = start_higher_level_review(veteran, is_comp: false)
-      visit "/intake/add_issues"
+    context "Non-compensation" do
+      context "decision issues present" do
+        scenario "Add Issues button shows contestable issues" do
+          hlr, = start_higher_level_review(veteran, is_comp: false)
+          create(:decision_issue,
+                 decision_review: hlr,
+                 benefit_type: hlr.benefit_type,
+                 decision_text: "something was decided",
+                 participant_id: veteran.participant_id)
 
-      expect(page).to have_content("Add / Remove Issues")
-      check_row("Form", Constants.INTAKE_FORM_NAMES.higher_level_review)
-      check_row("Benefit type", "Education")
-      expect(page).to_not have_content("Claimant")
-      click_intake_add_issue
-      expect(page).to_not have_content("Left knee granted")
+          visit "/intake/add_issues"
+          click_intake_add_issue
 
-      add_intake_nonrating_issue(
-        category: "Active Duty Adjustments",
-        description: "Description for Active Duty Adjustments",
-        date: "10/25/2017"
-      )
-      expect(page).to_not have_content("Establish EP")
-      expect(page).to have_content("Establish Higher-Level Review")
+          expect(page).to have_content("something was decided")
+          expect(page).to_not have_content("Left knee granted")
+        end
+      end
 
-      click_intake_finish
-      expect(page).to have_content("Intake completed")
-      # request issue should have matching benefit type
-      expect(RequestIssue.find_by(
-               review_request: hlr,
-               description: "Description for Active Duty Adjustments",
-               benefit_type: hlr.benefit_type
-      )).to_not be_nil
+      context "no contestable issues present" do
+        scenario "no rating issues show on first Add Issues modal" do
+          hlr, = start_higher_level_review(veteran, is_comp: false)
+          visit "/intake/add_issues"
+
+          expect(page).to have_content("Add / Remove Issues")
+          check_row("Form", Constants.INTAKE_FORM_NAMES.higher_level_review)
+          check_row("Benefit type", "Education")
+          expect(page).to_not have_content("Claimant")
+          click_intake_add_issue
+          expect(page).to_not have_content("Left knee granted")
+
+          add_intake_nonrating_issue(
+            category: "Active Duty Adjustments",
+            description: "Description for Active Duty Adjustments",
+            date: "10/25/2017"
+          )
+          expect(page).to_not have_content("Establish EP")
+          expect(page).to have_content("Establish Higher-Level Review")
+
+          click_intake_finish
+          expect(page).to have_content("Intake completed")
+          # request issue should have matching benefit type
+          expect(RequestIssue.find_by(
+                   review_request: hlr,
+                   description: "Description for Active Duty Adjustments",
+                   benefit_type: hlr.benefit_type
+          )).to_not be_nil
+        end
+      end
     end
 
     scenario "canceling" do

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1084,14 +1084,23 @@ RSpec.feature "Higher-Level Review" do
       check_row("Benefit type", "Education")
       expect(page).to_not have_content("Claimant")
       click_intake_add_issue
-      add_intake_rating_issue(/^Left knee granted$/)
+      expect(page).to_not have_content("Left knee granted")
+
+      add_intake_nonrating_issue(
+        category: "Active Duty Adjustments",
+        description: "Description for Active Duty Adjustments",
+        date: "10/25/2017"
+      )
+      expect(page).to_not have_content("Establish EP")
+      expect(page).to have_content("Establish Higher-Level Review")
+
       click_intake_finish
       expect(page).to have_content("Intake completed")
       # request issue should have matching benefit type
       expect(RequestIssue.find_by(
                review_request: hlr,
-               description: "Left knee granted",
-               benefit_type: "education"
+               description: "Description for Active Duty Adjustments",
+               benefit_type: hlr.benefit_type
       )).to_not be_nil
     end
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -779,34 +779,58 @@ RSpec.feature "Supplemental Claim Intake" do
       expect(page).to have_current_path("/intake/add_issues")
     end
 
-    scenario "Non-compensation" do
-      sc, = start_supplemental_claim(veteran, is_comp: false)
-      visit "/intake/add_issues"
+    context "Non-compensation" do
+      context "decision issues are present" do
+        scenario "Add Issues button shows contestable issues" do
+          sc, = start_supplemental_claim(veteran, is_comp: false)
+          create(:decision_issue,
+                 decision_review: sc,
+                 benefit_type: sc.benefit_type,
+                 decision_text: "something was decided",
+                 participant_id: veteran.participant_id)
 
-      expect(page).to have_content("Add / Remove Issues")
-      check_row("Form", Constants.INTAKE_FORM_NAMES.supplemental_claim)
-      check_row("Benefit type", "Education")
+          visit "/intake/add_issues"
+          click_intake_add_issue
 
-      expect(page).to_not have_content("Left knee granted")
+          expect(page).to have_content("something was decided")
+          expect(page).to_not have_content("Left knee granted")
+        end
+      end
 
-      click_intake_add_issue
-      add_intake_nonrating_issue(
-        category: "Active Duty Adjustments",
-        description: "Description for Active Duty Adjustments",
-        date: "10/25/2017"
-      )
-      expect(page).to_not have_content("Establish EP")
-      expect(page).to have_content("Establish Supplemental Claim")
-      expect(page).to_not have_content("Claimant")
+      context "no contestable issues present" do
+        scenario "no rating issues show on first Add Issues modal" do
+          sc, = start_supplemental_claim(veteran, is_comp: false)
 
-      click_intake_finish
-      expect(page).to have_content("Intake completed")
-      # request issue should have matching benefit type
-      expect(RequestIssue.find_by(
-               review_request: sc,
-               description: "Description for Active Duty Adjustments",
-               benefit_type: sc.benefit_type
-      )).to_not be_nil
+          visit "/intake/add_issues"
+
+          expect(page).to have_content("Add / Remove Issues")
+          check_row("Form", Constants.INTAKE_FORM_NAMES.supplemental_claim)
+          check_row("Benefit type", "Education")
+
+          expect(page).to_not have_content("Left knee granted")
+
+          click_intake_add_issue
+          add_intake_nonrating_issue(
+            category: "Active Duty Adjustments",
+            description: "Description for Active Duty Adjustments",
+            date: "10/25/2017"
+          )
+          expect(page).to_not have_content("Establish EP")
+          expect(page).to have_content("Establish Supplemental Claim")
+          expect(page).to_not have_content("Claimant")
+
+          click_intake_finish
+
+          expect(page).to have_content("Intake completed")
+
+          # request issue should have matching benefit type
+          expect(RequestIssue.find_by(
+                   review_request: sc,
+                   description: "Description for Active Duty Adjustments",
+                   benefit_type: sc.benefit_type
+          )).to_not be_nil
+        end
+      end
     end
 
     scenario "canceling" do

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -185,6 +185,30 @@ describe ClaimReview do
     end
   end
 
+  context "#non_comp?" do
+    let(:claim_review) { create(:higher_level_review, benefit_type: benefit_type) }
+
+    subject { claim_review.non_comp? }
+
+    context "when benefit_type is compensation" do
+      let(:benefit_type) { "compensation" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when benefit_type is pension" do
+      let(:benefit_type) { "pension" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context "when benefit_type is something else" do
+      let(:benefit_type) { "foobar" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
   context "#create_issues!" do
     before { claim_review.save! }
     subject { claim_review.create_issues!(issues) }

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -26,7 +26,8 @@ describe ClaimReview do
   let(:same_office) { nil }
 
   let(:rating_request_issue) do
-    RequestIssue.new(
+    build(
+      :request_issue,
       review_request: claim_review,
       rating_issue_reference_id: "reference-id",
       rating_issue_profile_date: Date.new(2018, 4, 30),
@@ -35,7 +36,8 @@ describe ClaimReview do
   end
 
   let(:second_rating_request_issue) do
-    RequestIssue.new(
+    build(
+      :request_issue,
       review_request: claim_review,
       rating_issue_reference_id: "reference-id2",
       rating_issue_profile_date: Date.new(2018, 4, 30),
@@ -44,7 +46,8 @@ describe ClaimReview do
   end
 
   let(:non_rating_request_issue) do
-    RequestIssue.new(
+    build(
+      :request_issue,
       review_request: claim_review,
       description: "Issue text",
       issue_category: "surgery",
@@ -53,7 +56,8 @@ describe ClaimReview do
   end
 
   let(:second_non_rating_request_issue) do
-    RequestIssue.new(
+    build(
+      :request_issue,
       review_request: claim_review,
       description: "some other issue",
       issue_category: "something",
@@ -62,7 +66,8 @@ describe ClaimReview do
   end
 
   let(:claim_review) do
-    HigherLevelReview.new(
+    build(
+      :higher_level_review,
       veteran_file_number: veteran_file_number,
       receipt_date: receipt_date,
       informal_conference: informal_conference,
@@ -71,7 +76,8 @@ describe ClaimReview do
   end
 
   let!(:claimant) do
-    Claimant.create!(
+    create(
+      :claimant,
       review_request: claim_review,
       participant_id: veteran_participant_id,
       payee_code: "00"

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -198,7 +198,8 @@ describe HigherLevelReviewIntake do
     let(:legacy_opt_in_approved) { false }
 
     let(:detail) do
-      HigherLevelReview.create!(
+      create(
+        :higher_level_review,
         veteran_file_number: "64205555",
         receipt_date: 3.days.ago,
         legacy_opt_in_approved: legacy_opt_in_approved

--- a/spec/models/supplemental_claim_intake_spec.rb
+++ b/spec/models/supplemental_claim_intake_spec.rb
@@ -25,7 +25,8 @@ describe SupplementalClaimIntake do
     subject { intake.cancel!(reason: "system_error", other: nil) }
 
     let(:detail) do
-      SupplementalClaim.create!(
+      create(
+        :supplemental_claim,
         veteran_file_number: "64205555",
         receipt_date: 3.days.ago
       )
@@ -73,7 +74,9 @@ describe SupplementalClaimIntake do
     let(:veteran_is_not_claimant) { false }
 
     let(:detail) do
-      SupplementalClaim.create!(
+      create(
+        :supplemental_claim,
+        benefit_type: nil,
         veteran_file_number: "64205555",
         receipt_date: 3.days.ago
       )
@@ -194,7 +197,8 @@ describe SupplementalClaimIntake do
     let(:legacy_opt_in_approved) { false }
 
     let(:detail) do
-      SupplementalClaim.create!(
+      create(
+        :supplemental_claim,
         veteran_file_number: "64205555",
         receipt_date: 3.days.ago,
         legacy_opt_in_approved: legacy_opt_in_approved
@@ -202,8 +206,10 @@ describe SupplementalClaimIntake do
     end
 
     let!(:claimant) do
-      Claimant.create!(
+      create(
+        :claimant,
         review_request: detail,
+        payee_code: "00",
         participant_id: "1234"
       )
     end


### PR DESCRIPTION
connect #7985 

### Description
Adds new method `DecisionReview.non_comp?` and applies it to UI text and processing logic.

Note that `Appeal` now has a hardcoded `benefit_type` in order to satisfy the `non_comp?` method. That is intended, and will be resolved when #5882 is implemented.
