### PR TITLE
ineligible decision issues

### DIFF
--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -58,12 +58,12 @@ class ContestableIssue
 
   def conflicting_request_issue_by_rating
     return unless rating_issue_reference_id
-    RequestIssue.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
+   potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
   end
 
   def conflicting_request_issue_by_decision_issue
     return unless decision_issue_id
-    RequestIssue.find_active_by_contested_decision_id(decision_issue_id)
+   potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
   end
 
   def conflicting_request_issue

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -66,6 +66,10 @@ class ContestableIssue
    potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
   end
 
+  def potentially_conflicting_request_issues
+    RequestIssue.where.not(review_request: contesting_decision_review)
+  end
+
   def conflicting_request_issue
     return unless contesting_decision_review
     found_request_issue = conflicting_request_issue_by_decision_issue || conflicting_request_issue_by_rating

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -58,12 +58,12 @@ class ContestableIssue
 
   def conflicting_request_issue_by_rating
     return unless rating_issue_reference_id
-   potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
+    potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
   end
 
   def conflicting_request_issue_by_decision_issue
     return unless decision_issue_id
-   potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
+    potentially_conflicting_request_issues.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
   end
 
   def potentially_conflicting_request_issues

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -8,11 +8,6 @@ class DecisionIssue < ApplicationRecord
   has_many :remand_reasons, dependent: :destroy
   belongs_to :decision_review, polymorphic: true
 
-  def title_of_active_review
-    request_issue = RequestIssue.find_active_by_contested_decision_id(id)
-    request_issue&.review_title
-  end
-
   def source_higher_level_review
     return unless decision_review
     decision_review.is_a?(HigherLevelReview) ? decision_review.id : nil

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -336,14 +336,29 @@ class RequestIssue < ApplicationRecord
     rationale.to_s.sub(/^source_/, "previous_").to_sym
   end
 
-  def check_for_active_request_issue!
+  def check_for_active_request_issue_by_rating!
     return unless rating?
-    return unless eligible?
-    existing_request_issue = self.class.find_active_by_rating_issue_reference_id(rating_issue_reference_id)
+
+    add_duplicate_issue_error(self.class.find_active_by_rating_issue_reference_id(rating_issue_reference_id))
+  end
+
+  def check_for_active_request_issue_by_decision_issue!
+    return unless contested_decision_issue_id
+
+    add_duplicate_issue_error(self.class.find_active_by_contested_decision_id(contested_decision_issue_id))
+  end
+
+  def add_duplicate_issue_error(existing_request_issue)
     if existing_request_issue && existing_request_issue.review_request != review_request
       self.ineligible_reason = :duplicate_of_issue_in_active_review
       self.ineligible_due_to = existing_request_issue
     end
+  end
+
+  def check_for_active_request_issue!
+    return unless eligible?
+    check_for_active_request_issue_by_rating!
+    check_for_active_request_issue_by_decision_issue!
   end
 
   def check_for_untimely!

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -2,5 +2,12 @@ FactoryBot.define do
   factory :higher_level_review do
     sequence(:veteran_file_number, &:to_s)
     receipt_date { 1.month.ago }
+
+    trait :with_end_product_establishment do
+      after(:create) do |higher_level_review|
+        create(:end_product_establishment,
+               source: higher_level_review)
+      end
+    end
   end
 end

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -796,7 +796,7 @@ RSpec.feature "Edit issues" do
           )
         end
 
-        let!(:already_active_request_issue) do
+        let!(:request_issue_that_causes_ineligiblity) do
           already_active_hlr = create(:higher_level_review, :with_end_product_establishment)
           create(
             :request_issue,
@@ -1338,7 +1338,7 @@ RSpec.feature "Edit issues" do
 
         let(:request_issues) { [request_issue, decision_request_issue] }
 
-        let!(:already_active_request_issue) do
+        let!(:request_issue_that_causes_ineligiblity) do
           already_active_hlr = create(:higher_level_review, :with_end_product_establishment)
           create(
             :request_issue,


### PR DESCRIPTION
Connects #7978

Adds an ineligibility message if there is another request issue contesting the same decision issue

![decision_issue_ineligible](https://user-images.githubusercontent.com/577629/49976043-4867b980-fef5-11e8-9d42-abddaa1d0b76.gif)
