### PR TITLE
Fix bug with creating decision issues from dispositions

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -254,7 +254,7 @@ class RequestIssue < ApplicationRecord
 
   def contention_disposition
     @contention_disposition ||= end_product_establishment.fetch_dispositions_from_vbms.find do |disposition|
-      disposition[:contention_id].to_i == contention_reference_id
+      disposition.contention_id.to_i == contention_reference_id
     end
   end
 


### PR DESCRIPTION
`Contention` is an object not a hash. Because we use `OpenStruct` in our tests, they did not catch this 😢