### PR TITLE
Fix another bug with dispositions

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -244,7 +244,7 @@ class RequestIssue < ApplicationRecord
     if contention_disposition
       decision_issues.create!(
         participant_id: review_request.veteran.participant_id,
-        disposition: contention_disposition[:disposition],
+        disposition: contention_disposition.disposition,
         decision_review: review_request,
         benefit_type: benefit_type,
         end_product_last_action_date: end_product_establishment.result.last_action_date


### PR DESCRIPTION
`Contention` is an object not a hash. Because we use `OpenStruct` in our tests, they did not catch this 😢

connects #7889