### PR TITLE
handle nil address3 when looking for zip code

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -116,7 +116,7 @@ class Veteran < ApplicationRecord
 
   # Postal code might be stored in address line 3 for international addresses
   def zip_code
-    @zip_code || (@address_line3 if @address_line3.match?(/(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/))
+    @zip_code || (@address_line3 if (@address_line3 || "").match?(/(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/))
   end
   alias zip zip_code
   alias address_line_1 address_line1

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -210,6 +210,12 @@ describe Veteran do
     context "when a zip code is nil" do
       let(:zip_code) { nil }
 
+      context "when address line 3 is nil" do
+        let(:address_line3) { nil }
+
+        it { is_expected.to include(zip_code: nil) }
+      end
+
       context "when address line 3 contains a zip code" do
         let(:address_line3) { "055411-177" }
 


### PR DESCRIPTION
Fixes https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3191/

when `@address_line3` is nil, the zip code helper method fails because `nil.match` is undefined.