### PR TITLE
Fix flakey Legacy automatic case distribution test

### DIFF
--- a/spec/models/vacols/case_docket_spec.rb
+++ b/spec/models/vacols/case_docket_spec.rb
@@ -97,12 +97,12 @@ describe VACOLS::CaseDocket do
   context ".counts_by_priority_and_readiness" do
     subject { VACOLS::CaseDocket.counts_by_priority_and_readiness }
     it "creates counts grouped by priority and readiness" do
-      expect(subject).to eq([
-                              { "n" => 1, "priority" => 1, "ready" => 0 },
-                              { "n" => 2, "priority" => 1, "ready" => 1 },
-                              { "n" => 1, "priority" => 0, "ready" => 0 },
-                              { "n" => 2, "priority" => 0, "ready" => 1 }
-                            ])
+      expect(subject).to match_array([
+                                       { "n" => 1, "priority" => 1, "ready" => 0 },
+                                       { "n" => 2, "priority" => 1, "ready" => 1 },
+                                       { "n" => 1, "priority" => 0, "ready" => 0 },
+                                       { "n" => 2, "priority" => 0, "ready" => 1 }
+                                     ])
     end
   end
 


### PR DESCRIPTION
I don't think we care about the order of this array (based only on the fact that we don't do any explicit ordering in [the sql query we are testing](https://github.com/department-of-veterans-affairs/caseflow/blob/90f439ed16a8e1fe812714d5285fa9c215437363/app/models/vacols/case_docket.rb#L52)), but if we do then we should update the underlying function to order in a deterministic fashion. Otherwise, this PR addresses the flakiness by not caring about the order of the returned array.