### PR TITLE
detect more transient bgs errors, encode as utf-8

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -45,6 +45,7 @@ class EndProductEstablishment < ApplicationRecord
     # rubocop:disable Metrics/MethodLength
     def self.from_bgs_error(error, epe)
       error_message = if error.try(:body)
+                        # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3124/
                         error.body.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")
                       else
                         error.message

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -87,6 +87,11 @@ class EndProductEstablishment < ApplicationRecord
         #
         # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3129/
         TransientBGSSyncError.new(error, epe)
+      when /execution expired/
+        # Connection timeout
+        #
+        # Example: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2935/
+        TransientBGSSyncError.new(error, epe)
       when /Unable to find SOAP operation: :find_benefit_claim/
         # Transient failure because a VBMS service is unavailable
         #


### PR DESCRIPTION
Detects a couple additional kinds of transient errors that have been occurring lately, and also encodes the error body before checking for known messages to avoid masking encoding errors.

Starting to feel like it'll be good to extract this error handling out of the EPE class.