### PR TITLE
Better Schedule Hearing Modal Validation

### DIFF
--- a/client/app/components/HearingDayDropdown.jsx
+++ b/client/app/components/HearingDayDropdown.jsx
@@ -26,7 +26,7 @@ class HearingDayDropdown extends React.Component {
     const { regionalOffice } = this.props;
 
     this.setState({ loading: true });
-    
+
     return ApiUtil.get(`/regional_offices/${regionalOffice}/open_hearing_dates.json`).then((response) => {
       const resp = ApiUtil.convertToCamelCase(JSON.parse(response.text));
 

--- a/client/app/components/HearingDayDropdown.jsx
+++ b/client/app/components/HearingDayDropdown.jsx
@@ -9,13 +9,15 @@ import { onReceiveHearingDays } from './common/actions';
 import { bindActionCreators } from 'redux';
 import connect from 'react-redux/es/connect/connect';
 import { formatDateStr } from '../util/DateUtil';
+import { loadingSymbolHtml } from './RenderFunctions';
 
 class HearingDayDropdown extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
-      editable: false
+      editable: false,
+      loading: true
     };
   }
 
@@ -27,6 +29,7 @@ class HearingDayDropdown extends React.Component {
       const resp = ApiUtil.convertToCamelCase(JSON.parse(response.text));
 
       this.props.onReceiveHearingDays(resp.hearingDays);
+      this.setState({ loading: false });
     });
 
   };
@@ -78,7 +81,7 @@ class HearingDayDropdown extends React.Component {
     const { readOnly, onChange, placeholder } = this.props;
     const hearingDayOptions = this.hearingDayOptions();
 
-    if (!this.props.changePrompt || this.state.editable) {
+    if ((!this.props.changePrompt || this.state.editable) && !this.state.loading) {
       return (
         <SearchableDropdown
           name="hearing_date"
@@ -102,13 +105,15 @@ class HearingDayDropdown extends React.Component {
             width: '150px' }}>
             {this.getValue().label}
           </p>
-          <Button
+          {!this.state.loading && <Button
             name="Change"
             linkStyling
             onClick={() => {
               this.setState({ editable: true });
-            }} />
+            }} />}
+          {this.state.loading && loadingSymbolHtml('', '20px')}
         </InlineForm>
+
       </React.Fragment>
     );
   }

--- a/client/app/components/HearingDayDropdown.jsx
+++ b/client/app/components/HearingDayDropdown.jsx
@@ -17,7 +17,7 @@ class HearingDayDropdown extends React.Component {
 
     this.state = {
       editable: false,
-      loading: true
+      loading: false
     };
   }
 
@@ -25,6 +25,8 @@ class HearingDayDropdown extends React.Component {
 
     const { regionalOffice } = this.props;
 
+    this.setState({ loading: true });
+    
     return ApiUtil.get(`/regional_offices/${regionalOffice}/open_hearing_dates.json`).then((response) => {
       const resp = ApiUtil.convertToCamelCase(JSON.parse(response.text));
 

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -113,10 +113,14 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
 
     const hearingDate = this.formatHearingDate();
 
-    let invalid = [];
+    const invalid = [];
 
-    if (!hearingDate){ invalid.push('Date of Hearing'); }
-    if (!this.props.selectedHearingTime){ invalid.push('Hearing Time'); }
+    if (!hearingDate) {
+      invalid.push('Date of Hearing');
+    }
+    if (!this.props.selectedHearingTime) {
+      invalid.push('Hearing Time');
+    }
 
     if (invalid.length > 0) {
 
@@ -279,7 +283,7 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
   formatHearingDate = () => {
     const { selectedHearingDay, selectedHearingTime } = this.props;
 
-    if (selectedHearingDay && !selectedHearingTime){
+    if (selectedHearingDay && !selectedHearingTime) {
       return new Date(selectedHearingDay.value.hearingDate);
     } else if (!selectedHearingTime || !selectedHearingDay) {
       return null;

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -113,11 +113,16 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
 
     const hearingDate = this.formatHearingDate();
 
-    if (hearingDate === null || this.props.selectedHearingTime === null) {
+    let invalid = [];
+
+    if (!hearingDate){ invalid.push('Date of Hearing'); }
+    if (!this.props.selectedHearingTime){ invalid.push('Hearing Time'); }
+
+    if (invalid.length > 0) {
 
       this.props.showErrorMessage({
         title: 'Required Fields',
-        detail: 'Please fill in Date of Hearing and Time fields'
+        detail: `Please fill in the following fields: ${invalid.join(', ')}.`
       });
 
       return false;
@@ -274,7 +279,9 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
   formatHearingDate = () => {
     const { selectedHearingDay, selectedHearingTime } = this.props;
 
-    if (!selectedHearingTime || !selectedHearingDay) {
+    if (selectedHearingDay && !selectedHearingTime){
+      return new Date(selectedHearingDay.value.hearingDate);
+    } else if (!selectedHearingTime || !selectedHearingDay) {
       return null;
     }
 
@@ -293,18 +300,6 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
 
     return hearingDate;
   };
-
-  getSelectedTimeOption = () => {
-    const { selectedHearingTime } = this.props;
-    const timeOptions = this.getTimeOptions();
-
-    if (!selectedHearingTime) {
-
-      return {};
-    }
-
-    return _.find(timeOptions, (option) => option.value === selectedHearingTime);
-  }
 
   getInitialValues = () => {
     const { hearingDay } = this.props;


### PR DESCRIPTION
resolves? #8313

Could not replicate the issue locally but added catches for likely culprits 

- *data is submitted before hearing day options are fetched*: adds loading icon and prevents changing before hearing day is fetched 
- adds more specific error message
