### PR TITLE
Use receipt_date to determine legacy eligibility

### DIFF
--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -140,7 +140,7 @@ class DecisionReview < ApplicationRecord
       {
         vacols_id: legacy_appeal.vacols_id,
         date: legacy_appeal.nod_date,
-        eligible_for_soc_opt_in: legacy_appeal.eligible_for_soc_opt_in?,
+        eligible_for_soc_opt_in: legacy_appeal.eligible_for_soc_opt_in?(receipt_date),
         issues: legacy_appeal.issues.map(&:intake_attributes)
       }
     end
@@ -200,7 +200,7 @@ class DecisionReview < ApplicationRecord
   def matchable_legacy_appeals
     @matchable_legacy_appeals ||= LegacyAppeal
       .fetch_appeals_by_file_number(veteran_file_number)
-      .select(&:matchable_to_request_issue?)
+      .select { |appeal| appeal.matchable_to_request_issue?(receipt_date) }
   end
 
   def active_matchable_legacy_appeals

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -212,16 +212,15 @@ class Issue
   end
 
   def eligible_for_opt_in?
-    return false unless legacy_appeal.eligible_for_soc_opt_in?
     return disposition_date_after_legacy_appeal_soc? if disposition_is_failure_to_respond?
     active?
   end
 
-  private
-
   def legacy_appeal
     @legacy_appeal ||= LegacyAppeal.find_by(vacols_id: id)
   end
+
+  private
 
   def disposition_is_failure_to_respond?
     [:remand_failure_to_respond, :advance_failure_to_respond].include?(disposition)

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -699,6 +699,7 @@ class LegacyAppeal < ApplicationRecord
     soc_eligible_date = receipt_date - 60.days
     nod_eligible_date = receipt_date - 372.days
 
+    # ssoc_dates are the VACOLS bfssoc* columns - see the AppealRepository class
     soc_date > soc_eligible_date || nod_date > nod_eligible_date || ssoc_dates.any? { |d| d > soc_eligible_date }
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -693,7 +693,8 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def eligible_for_soc_opt_in?(receipt_date)
-    return false unless nod_date || soc_date || ssoc_dates.any?
+    return false unless nod_date
+    return false unless soc_date
 
     soc_eligible_date = receipt_date - 60.days
     nod_eligible_date = receipt_date - 372.days

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -688,15 +688,17 @@ class LegacyAppeal < ApplicationRecord
     end
   end
 
-  def matchable_to_request_issue?
-    issues.any? && (active? || eligible_for_soc_opt_in?)
+  def matchable_to_request_issue?(receipt_date)
+    issues.any? && (active? || eligible_for_soc_opt_in?(receipt_date))
   end
 
-  def eligible_for_soc_opt_in?
-    return false unless nod_date
-    return false unless soc_date
+  def eligible_for_soc_opt_in?(receipt_date)
+    return false unless nod_date || soc_date || ssoc_dates.any?
 
-    soc_date > soc_eligible_date || nod_date > nod_eligible_date
+    soc_eligible_date = receipt_date - 60.days
+    nod_eligible_date = receipt_date - 372.days
+
+    soc_date > soc_eligible_date || nod_date > nod_eligible_date || ssoc_dates.any? { |d| d > soc_eligible_date }
   end
 
   def serializer_class
@@ -725,14 +727,6 @@ class LegacyAppeal < ApplicationRecord
   end
 
   private
-
-  def soc_eligible_date
-    Time.zone.today - 60.days
-  end
-
-  def nod_eligible_date
-    Time.zone.today - 372.days
-  end
 
   def use_representative_info_from_bgs?
     FeatureToggle.enabled?(:use_representative_info_from_bgs, user: RequestStore[:current_user]) &&

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -327,9 +327,13 @@ class RequestIssue < ApplicationRecord
     return unless vacols_id
     return unless review_request.serialized_legacy_appeals.any?
 
-    if !vacols_issue.eligible_for_opt_in?
+    unless vacols_issue.eligible_for_opt_in? && legacy_appeal_eligible_for_opt_in?
       self.ineligible_reason = :legacy_appeal_not_eligible
     end
+  end
+
+  def legacy_appeal_eligible_for_opt_in?
+    vacols_issue.legacy_appeal.eligible_for_soc_opt_in?(review_request.receipt_date)
   end
 
   def rating_issue_rationale_to_request_issue_reason(rationale)

--- a/client/app/intake/components/LegacyOptInModal.jsx
+++ b/client/app/intake/components/LegacyOptInModal.jsx
@@ -38,7 +38,7 @@ class LegacyOptInModal extends React.Component {
 
       this.setState({
         vacolsId: legacyValues[0],
-        eligibleForSocOptIn: vacolsIssue.eligible_for_soc_opt_in,
+        eligibleForSocOptIn: (legacyAppeal.eligible_for_soc_opt_in && vacolsIssue.eligible_for_soc_opt_in),
         vacolsSequenceId
       });
     }

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -636,6 +636,8 @@ RSpec.feature "Appeal Intake" do
     end
 
     context "with legacy_opt_in_approved" do
+      let(:receipt_date) { Time.zone.today }
+
       scenario "adding issues" do
         start_appeal(veteran, legacy_opt_in_approved: true)
         visit "/intake/add_issues"

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1131,13 +1131,15 @@ RSpec.feature "Higher-Level Review" do
       end
 
       context "with legacy_opt_in_approved" do
+        let(:receipt_date) { Time.zone.today }
+
         scenario "adding issues" do
           start_higher_level_review(veteran, legacy_opt_in_approved: true)
           visit "/intake/add_issues"
 
           click_intake_add_issue
           expect(page).to have_content("Next")
-          add_intake_rating_issue("Left knee granted")
+          add_intake_rating_issue(/Left knee granted$/)
 
           # expect legacy opt in modal
           expect(page).to have_content("Does issue 1 match any of these VACOLS issues?")

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -825,13 +825,15 @@ RSpec.feature "Supplemental Claim Intake" do
       end
 
       context "with legacy_opt_in_approved" do
+        let(:receipt_date) { Time.zone.today }
+
         scenario "adding issues" do
           start_supplemental_claim(veteran, legacy_opt_in_approved: true)
           visit "/intake/add_issues"
 
           click_intake_add_issue
           expect(page).to have_content("Next")
-          add_intake_rating_issue("Left knee granted")
+          add_intake_rating_issue(/Left knee granted$/)
 
           # expect legacy opt in modal
           expect(page).to have_content("Does issue 1 match any of these VACOLS issues?")

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -12,8 +12,9 @@ describe LegacyAppeal do
   end
 
   context "#eligible_for_soc_opt_in? and #matchable_to_request_issue?" do
-    let(:soc_eligible_date) { Time.zone.today - 60.days }
-    let(:nod_eligible_date) { Time.zone.today - 372.days }
+    let(:soc_eligible_date) { receipt_date - 60.days }
+    let(:nod_eligible_date) { receipt_date - 372.days }
+    let(:receipt_date) { Time.zone.today }
 
     let(:vacols_case) do
       create(:case, bfcorlid: "123456789S")
@@ -27,8 +28,8 @@ describe LegacyAppeal do
       allow(appeal).to receive(:soc_date).and_return(soc_eligible_date - 1.day)
       allow(appeal).to receive(:nod_date).and_return(nod_eligible_date - 1.day)
 
-      expect(appeal.eligible_for_soc_opt_in?).to eq(false)
-      expect(appeal.matchable_to_request_issue?).to eq(true)
+      expect(appeal.eligible_for_soc_opt_in?(receipt_date)).to eq(false)
+      expect(appeal.matchable_to_request_issue?(receipt_date)).to eq(true)
     end
 
     scenario "when is not active but is eligible" do
@@ -37,8 +38,8 @@ describe LegacyAppeal do
       allow(appeal).to receive(:soc_date).and_return(soc_eligible_date + 1.day)
       allow(appeal).to receive(:nod_date).and_return(nod_eligible_date - 1.day)
 
-      expect(appeal.eligible_for_soc_opt_in?).to eq(true)
-      expect(appeal.matchable_to_request_issue?).to eq(true)
+      expect(appeal.eligible_for_soc_opt_in?(receipt_date)).to eq(true)
+      expect(appeal.matchable_to_request_issue?(receipt_date)).to eq(true)
     end
 
     scenario "when is not active or eligible" do
@@ -47,8 +48,8 @@ describe LegacyAppeal do
       allow(appeal).to receive(:soc_date).and_return(soc_eligible_date - 1.day)
       allow(appeal).to receive(:nod_date).and_return(nod_eligible_date - 1.day)
 
-      expect(appeal.eligible_for_soc_opt_in?).to eq(false)
-      expect(appeal.matchable_to_request_issue?).to eq(false)
+      expect(appeal.eligible_for_soc_opt_in?(receipt_date)).to eq(false)
+      expect(appeal.matchable_to_request_issue?(receipt_date)).to eq(false)
     end
 
     scenario "when is active or eligible but has no issues" do
@@ -57,8 +58,8 @@ describe LegacyAppeal do
       allow(appeal).to receive(:soc_date).and_return(soc_eligible_date + 1.day)
       allow(appeal).to receive(:nod_date).and_return(nod_eligible_date + 1.day)
 
-      expect(appeal.eligible_for_soc_opt_in?).to eq(true)
-      expect(appeal.matchable_to_request_issue?).to eq(false)
+      expect(appeal.eligible_for_soc_opt_in?(receipt_date)).to eq(true)
+      expect(appeal.matchable_to_request_issue?(receipt_date)).to eq(false)
     end
   end
 


### PR DESCRIPTION
connects #8081 

### Description
Pass `receipt_date` to `LegacyAppeal.eligible_for_soc_opt_in?` and include `ssoc_dates` in check.

