### PR TITLE
Fix symbol value to :central to coincide with value in the declared constant HEARING_TYPES.

### DIFF
--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -47,7 +47,7 @@ module HearingMapper
     # asctime - returns a canonical string representation of time
     def datetime_based_on_type(datetime:, regional_office_key:, type:)
       datetime = VacolsHelper.normalize_vacols_datetime(datetime)
-      return datetime if type == :central_office
+      return datetime if type == :central
 
       datetime.asctime.in_time_zone(timezone(regional_office_key)).in_time_zone("Eastern Time (US & Canada)")
     end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -32,7 +32,7 @@ class Hearing < ApplicationRecord
   end
 
   def location
-    (type == :central_office) ? "Board of Veterans' Appeals in Washington, DC" : venue[:label]
+    (type == :central) ? "Board of Veterans' Appeals in Washington, DC" : venue[:label]
   end
 
   def closed?

--- a/spec/mappers/hearing_mapper_spec.rb
+++ b/spec/mappers/hearing_mapper_spec.rb
@@ -84,7 +84,7 @@ describe HearingMapper do
     end
 
     context "when central_office" do
-      let(:type) { :central_office }
+      let(:type) { :central }
 
       it "does not use a regional office timezone" do
         expect(subject.day).to eq 6

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -35,7 +35,7 @@ describe Hearing do
     it { is_expected.to eq("Baltimore regional office") }
 
     context "when it's a central office hearing" do
-      let(:type) { :central_office }
+      let(:type) { :central }
 
       it { is_expected.to eq("Board of Veterans' Appeals in Washington, DC") }
     end

--- a/spec/requests/hearing_day_spec.rb
+++ b/spec/requests/hearing_day_spec.rb
@@ -307,6 +307,46 @@ RSpec.describe "Hearing Schedule", type: :request do
     end
   end
 
+  describe "Get scheduled hearing" do
+    let!(:staff) { create(:staff, stafkey: "RO18", stc2: 2, stc3: 3, stc4: 4) }
+    let(:vacols_case) do
+      create(
+        :case,
+        folder: create(:folder, tinum: "docket-number"),
+        bfregoff: "RO18",
+        bfcurloc: "57"
+      )
+    end
+    let(:appeal) do
+      create(:legacy_appeal, :with_veteran, vacols_case: vacols_case)
+    end
+    let!(:hearing_day) do
+      create(:hearing_day, hearing_date: Date.new(2019, 1, 7))
+    end
+    let!(:hearings) do
+      RequestStore[:current_user] = user
+      Generators::Vacols::Staff.create(sattyid: "111")
+      create(:case_hearing,
+             hearing_type: "C",
+             hearing_date: VacolsHelper.format_datetime_with_utc_timezone(Time.zone.local(2019, 0o1, 0o7, 9, 0, 0)),
+             folder_nr: appeal.vacols_id,
+             vdkey: hearing_day.id)
+    end
+
+    it "Get scheduled hearing for veteran. Check hearing time is in EST" do
+      hearings
+      headers = {
+        "ACCEPT" => "application/json"
+      }
+      get "/hearings/schedule/assign/hearing_days", params: {}, headers: headers
+      expect(response).to have_http_status(:success)
+      hearing_days = JSON.parse(response.body)["hearing_days"]
+      expect(hearing_days.size).to be(1)
+      expected_hearing_date = VacolsHelper.normalize_vacols_datetime(hearing_days[0]["hearings"][0]["date"])
+      expect(expected_hearing_date).to eq(Time.zone.local(2019, 0o1, 0o7, 9, 0, 0))
+    end
+  end
+
   describe "Get veterans for hearings" do
     let!(:vacols_case) do
       create(

--- a/spec/requests/hearing_day_spec.rb
+++ b/spec/requests/hearing_day_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe "Hearing Schedule", type: :request do
     end
   end
 
-  describe "Get scheduled hearing" do
+  describe "Get CO scheduled hearing with correct time." do
     let!(:staff) { create(:staff, stafkey: "RO18", stc2: 2, stc3: 3, stc4: 4) }
     let(:vacols_case) do
       create(
@@ -321,7 +321,7 @@ RSpec.describe "Hearing Schedule", type: :request do
       create(:legacy_appeal, :with_veteran, vacols_case: vacols_case)
     end
     let!(:hearing_day) do
-      create(:hearing_day, hearing_date: Date.new(2019, 1, 7))
+      create(:hearing_day, hearing_type: "C", hearing_date: Date.new(2019, 1, 7))
     end
     let!(:hearings) do
       RequestStore[:current_user] = user


### PR DESCRIPTION
…in VACOLS::CaseHearing

Resolves #8323 

### Description
Correct variable name to match declared constants.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Schedule a veteran for a CO hearing. Confirm veteran is from a non EST timezone.
2. Verify the time in Schedule Veteran page, Schedule tab is the correct time and matches what is on the database.

