### PR TITLE
Writing to legacy_hearings and hearings

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -4,6 +4,9 @@ class Hearing < ApplicationRecord
   include HearingConcern
   include AppealConcern
 
+  after_save :save_legacy_hearing
+  before_destroy :destroy_legacy_hearing
+
   vacols_attr_accessor :veteran_first_name, :veteran_middle_initial, :veteran_last_name
   vacols_attr_accessor :appellant_first_name, :appellant_middle_initial, :appellant_last_name
   vacols_attr_accessor :date, :type, :venue_key, :vacols_record, :disposition
@@ -235,6 +238,17 @@ class Hearing < ApplicationRecord
       update_attributes(military_service: veteran.periods_of_service.join("\n")) if persisted? && veteran
       super
     end
+  end
+
+  def save_legacy_hearing
+    legacy_hearing = LegacyHearing.find(attributes["id"])
+    legacy_hearing.update!(attributes)
+  rescue ActiveRecord::RecordNotFound
+    LegacyHearing.create!(attributes)
+  end
+
+  def destroy_legacy_hearing
+    LegacyHearing.find(attributes["id"]).destroy!
   end
 
   class << self

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -1,2 +1,4 @@
 class LegacyHearing < ApplicationRecord
+  belongs_to :appeal, class_name: "LegacyAppeal"
+  belongs_to :user # the judge
 end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -235,6 +235,15 @@ describe Hearing do
         expect(hearing.user).to eq user
         expect(hearing.prepped).to be_falsey
       end
+
+      it "should create a legacy hearing record" do
+        subject
+        legacy_hearing = LegacyHearing.find_by(vacols_id: case_hearing.hearing_pkseq)
+        expect(legacy_hearing.present?).to be true
+        expect(legacy_hearing.appeal.vacols_id).to eq "5678"
+        expect(legacy_hearing.user).to eq user
+        expect(legacy_hearing.prepped).to be_falsey
+      end
     end
 
     context "assign vacols record" do


### PR DESCRIPTION
Connects #8321 

### Description
This PR updates the hearings model to write to both hearings and legacy_hearings. It's step 2 of the full migration.

