### PR TITLE
Fix decision issues being sent to server

### DIFF
--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -58,7 +58,10 @@ class SelectRemandReasonsView extends React.Component {
     }
 
     const updatedIssues = _.map(renderedChildren, (child) => child.updateStoreIssue());
-    const mergedIssueUpdates = _.map(appeal.issues, (issue) => {
+
+    const appealIssues = useDecisionIssues ? appeal.decisionIssues : appeal.issues;
+
+    const mergedIssueUpdates = _.map(appealIssues, (issue) => {
       const updatedIssue = _.find(updatedIssues, { id: issue.id });
 
       if (updatedIssue) {
@@ -67,7 +70,8 @@ class SelectRemandReasonsView extends React.Component {
 
       return issue;
     });
-    const attributes = useDecisionIssues ? { decisionIssues: updatedIssues } : { issues: mergedIssueUpdates };
+
+    const attributes = useDecisionIssues ? { decisionIssues: mergedIssueUpdates } : { issues: mergedIssueUpdates };
 
     this.props.editStagedAppeal(appealId, attributes);
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/8269

### Description
Previously, for decision issues, if some issues were remanded we only sent dispositions for the remanded issues to the server. Now, we send all issues.


### Testing Plan
1. `FeatureToggle.enable!(:ama_decision_issues)`
1. Complete an appeal's case review as an attorney, filling in some remanded dispositions and some non-remanded dispositions
1. View the appeal as a judge, note that dispositions are present for all issues
1. From rails console, run `Appeal.find_by(uuid: "aacbbedf-b28a-4a37-9c6c-042461ab47e3").issues[:decision_issues].length` then `Appeal.find_by(uuid: "aacbbedf-b28a-4a37-9c6c-042461ab47e3").issues[:decision_issues].map(&:disposition)` - verify that all decision issues have dispositions

