### PR TITLE
Removed restrictions for displaying additional hearing attributes when no disposition set.

### DIFF
--- a/app/jobs/sync_reviews_job.rb
+++ b/app/jobs/sync_reviews_job.rb
@@ -31,7 +31,7 @@ class SyncReviewsJob < CaseflowJob
       ramp_refiling.create_end_product_and_contentions!
     rescue StandardError => e
       # Rescue and capture errors so they don't cause the job to stop
-      Raven.capture_exception(e)
+      Raven.capture_exception(e, extra: { ramp_refiling_id: ramp_refiling.id })
     end
   end
 

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -62,6 +62,10 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
       </React.Fragment>
     });
 
+    if (hearing.disposition === 'cancelled') {
+      return listElements;
+    }
+
     return listElements.concat([{
       label: 'Date',
       value: <DateString date={hearing.date} dateFormat="M/D/YY" style={marginRight} />

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -49,14 +49,10 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
       value: StringUtil.snakeCaseToCapitalized(hearing.type)
     }];
 
-    if (_.isNull(hearing.disposition)) {
-      return listElements;
-    }
-
     listElements.push({
       label: 'Disposition',
       value: <React.Fragment>
-        {StringUtil.snakeCaseToCapitalized(hearing.disposition)}&nbsp;&nbsp;
+        {hearing.disposition && StringUtil.snakeCaseToCapitalized(hearing.disposition)}&nbsp;&nbsp;
         {hearing.viewedByJudge &&
         <Tooltip id="hearing-worksheet-tip" text={COPY.CASE_DETAILS_HEARING_WORKSHEET_LINK_TOOLTIP}>
           <Link rel="noopener" target="_blank" href={`/hearings/${hearing.id}/worksheet/print?keep_open=true`}>
@@ -65,10 +61,6 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
         </Tooltip>}
       </React.Fragment>
     });
-
-    if (hearing.disposition === 'cancelled') {
-      return listElements;
-    }
 
     return listElements.concat([{
       label: 'Date',


### PR DESCRIPTION
Resolves #8172 

### Description
Removed logic that limited the display of all hearing attributes to when a disposition was present.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to CaseDetails for a veteran with a scheduled hearing.
2. Verify all hearing attributes display in the Hearing tab.

