### PR TITLE
Schedule  | Daily Docket | Add Docket number and ama lane tags

### DIFF
--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -113,12 +113,14 @@ export default class DailyDocket extends React.Component {
     const appellantName = hearing.appellantMiFormatted || hearing.veteranMiFormatted;
 
     return <div><b>{appellantName}</b><br />
-      <DocketTypeBadge name={hearing.docketName} number={hearing.docketNumber} />
       <b><Link
         href={`/queue/appeals/${hearing.appealVacolsId}`}
         name={hearing.vbmsId} >
         {hearing.vbmsId}
-      </Link></b> <br />
+      </Link></b><br />
+      <DocketTypeBadge name={hearing.docketName} number={hearing.docketNumber} />
+      {hearing.docketNumber}
+      <br />
       {hearing.appellantAddressLine1}<br />
       {hearing.appellantCity} {hearing.appellantState} {hearing.appellantZip}
     </div>;


### PR DESCRIPTION
Resolves #8048

### Description
This pr shows that the docket number and tool-tip have been added

### Acceptance Criteria
- [ ] Verify that the docket number shows underneath the Veteran ID
- [ ] Verify that it has the correct AMA/legacy lane tag
- [ ] Verify that the tool tip works


### Testing Plan
1. Go to DailyDocket and verify that Tooltip and Docket number exist

<img width="1392" alt="screen shot 2018-12-18 at 11 39 45 am" src="https://user-images.githubusercontent.com/23080951/50168832-53866500-02ba-11e9-965e-37ff1db6f812.png">

Case-detail page 
<img width="1377" alt="screen shot 2018-12-18 at 11 45 01 am" src="https://user-images.githubusercontent.com/23080951/50168930-83ce0380-02ba-11e9-8a10-5400139a029e.png">

The tooltip already exists on the case detail page so we might as well close this ticket 8046.
