### PR TITLE
Tomas/create feature helper module

### DIFF
--- a/spec/feature/hearing_schedule/schedule_veteran_spec.rb
+++ b/spec/feature/hearing_schedule/schedule_veteran_spec.rb
@@ -10,13 +10,6 @@ RSpec.feature "Schedule Veteran For A Hearing" do
     create(:hearings_management)
   end
 
-  def click_dropdown(opt_idx, container = page)
-    dropdown = container.find(".Select-control")
-    dropdown.click
-    yield if block_given?
-    dropdown.sibling(".Select-menu-outer").find("div[id$='--option-#{opt_idx}']").click
-  end
-
   context "When creating Caseflow Central hearings" do
     let!(:hearing_day) { create(:hearing_day) }
     let!(:vacols_case) do
@@ -29,12 +22,12 @@ RSpec.feature "Schedule Veteran For A Hearing" do
     scenario "Schedule Veteran for central hearing" do
       visit "hearings/schedule/assign"
       expect(page).to have_content("Regional Office")
-      click_dropdown 7
+      click_dropdown(index: 7)
       click_button("Schedule a Veteran")
       appeal_link = page.find(:xpath, "//tbody/tr/td[1]/a")
       appeal_link.click
       expect(page).to have_content("Actions")
-      click_dropdown 0
+      click_dropdown(index: 0)
       expect(page).to have_content("Time")
       radio_link = find(".cf-form-radio-option", match: :first)
       radio_link.click
@@ -72,12 +65,12 @@ RSpec.feature "Schedule Veteran For A Hearing" do
     scenario "Schedule Veteran for video" do
       visit "hearings/schedule/assign"
       expect(page).to have_content("Regional Office")
-      click_dropdown 12
+      click_dropdown(index: 12)
       click_button("Schedule a Veteran")
       appeal_link = page.find(:xpath, "//tbody/tr/td[1]/a")
       appeal_link.click
       expect(page).to have_content("Actions")
-      click_dropdown 0
+      click_dropdown(index: 0)
       expect(page).to have_content("Time")
       radio_link = find(".cf-form-radio-option", match: :first)
       radio_link.click

--- a/spec/feature/queue/case_assignment_spec.rb
+++ b/spec/feature/queue/case_assignment_spec.rb
@@ -1,17 +1,5 @@
 require "rails_helper"
 
-def generate_text(length)
-  charset = ("A".."Z").to_a.concat(("a".."z").to_a)
-  Array.new(length) { charset.sample }.join
-end
-
-def generate_words(n_words)
-  Array.new(n_words).map do
-    word_length = [rand(12), 3].max
-    generate_text(word_length)
-  end.join(" ")
-end
-
 RSpec.feature "Case Assignment flows" do
   let(:attorney_user) { FactoryBot.create(:user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
@@ -75,7 +63,7 @@ RSpec.feature "Case Assignment flows" do
         expect(visible_options.length).to eq Constants::CO_LOCATED_ADMIN_ACTIONS.length
       end
 
-      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: generate_words(20)
+      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: generate_words(5)
 
       click_on "Assign Action"
 

--- a/spec/feature/queue/case_assignment_spec.rb
+++ b/spec/feature/queue/case_assignment_spec.rb
@@ -1,12 +1,5 @@
 require "rails_helper"
 
-def click_dropdown(opt_idx, container = page)
-  dropdown = container.find(".Select-control")
-  dropdown.click
-  yield if block_given?
-  dropdown.sibling(".Select-menu-outer").find("div[id$='--option-#{opt_idx}']").click
-end
-
 def generate_text(length)
   charset = ("A".."Z").to_a.concat(("a".."z").to_a)
   Array.new(length) { charset.sample }.join
@@ -70,14 +63,14 @@ RSpec.feature "Case Assignment flows" do
     scenario "adds colocated task" do
       visit "/queue"
       click_on "#{appeals[0].veteran_full_name} (#{appeals[0].sanitized_vbms_id})"
-      click_dropdown 2
+      click_dropdown(index: 2)
 
       expect(page).to have_content("Submit admin action")
 
       opt_idx = rand(Constants::CO_LOCATED_ADMIN_ACTIONS.length)
       selected_opt = Constants::CO_LOCATED_ADMIN_ACTIONS.values[opt_idx]
 
-      click_dropdown opt_idx do
+      click_dropdown(index: opt_idx) do
         visible_options = page.find_all(".Select-option")
         expect(visible_options.length).to eq Constants::CO_LOCATED_ADMIN_ACTIONS.length
       end

--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -1,12 +1,5 @@
 require "rails_helper"
 
-def click_dropdown(opt_idx, container = page)
-  dropdown = container.find(".Select-control")
-  dropdown.click
-  yield if block_given?
-  dropdown.sibling(".Select-menu-outer").find("div[id$='--option-#{opt_idx}']").click
-end
-
 def generate_text(length)
   charset = ("A".."Z").to_a.concat(("a".."z").to_a)
   Array.new(length) { charset.sample }.join
@@ -59,7 +52,7 @@ RSpec.feature "Checkout flows" do
     scenario "submits draft decision" do
       visit "/queue"
       click_on "(#{appeal.veteran_file_number})"
-      click_dropdown 0
+      click_dropdown(index: 0)
       click_label "radiation"
 
       click_on "Continue"
@@ -68,7 +61,7 @@ RSpec.feature "Checkout flows" do
       click_on "Cancel"
       click_on "Yes, cancel"
 
-      click_dropdown 0
+      click_dropdown(index: 0)
 
       # Radiation should still be checked
       expect(page).to have_field("radiation", checked: true, visible: false)
@@ -99,7 +92,7 @@ RSpec.feature "Checkout flows" do
       fill_in "notes", with: "note"
 
       safe_click "#select-judge"
-      click_dropdown 0
+      click_dropdown(index: 0)
 
       click_on "Continue"
       expect(page).to have_content(COPY::NO_CASES_IN_QUEUE_MESSAGE)
@@ -133,7 +126,7 @@ RSpec.feature "Checkout flows" do
         expect(page).to have_content(issue_description)
         expect(page).to have_content(issue_note)
 
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         click_on "Continue"
 
@@ -208,7 +201,7 @@ RSpec.feature "Checkout flows" do
         fill_in "notes", with: "note"
 
         safe_click "#select-judge"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         click_on "Continue"
         expect(page).to have_content(COPY::NO_CASES_IN_QUEUE_MESSAGE)
@@ -225,7 +218,7 @@ RSpec.feature "Checkout flows" do
         User.authenticate!(user: judge_user)
         visit "/queue"
         click_on "(#{appeal.veteran_file_number})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         # Skip the special issues page
         click_on "Continue"
@@ -289,7 +282,7 @@ RSpec.feature "Checkout flows" do
       scenario "attorney checkout flow from case detail view loads" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         expect(page).to have_content "Select Dispositions"
 
@@ -301,7 +294,7 @@ RSpec.feature "Checkout flows" do
         expect(cancel_modal.matches_css?(".active")).to eq true
         cancel_modal.find(".usa-button-warning").click
 
-        click_dropdown 1
+        click_dropdown(index: 1)
 
         expect(page).to have_content "Submit OMO for Review"
 
@@ -316,7 +309,7 @@ RSpec.feature "Checkout flows" do
         visit "/queue"
 
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 1
+        click_dropdown(index: 1)
 
         expect(page).to have_content "Back"
 
@@ -333,7 +326,7 @@ RSpec.feature "Checkout flows" do
       scenario "selects issue dispositions" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         expect(page).to have_content("Select Dispositions")
 
@@ -341,7 +334,7 @@ RSpec.feature "Checkout flows" do
         expect(table_rows.length).to eq(appeal.issues.length)
 
         # do not select all dispositions
-        table_rows[0..0].each { |row| click_dropdown 1, row }
+        table_rows[0..0].each { |row| click_dropdown({ index: 1 }, row) }
 
         click_on "Continue"
 
@@ -351,7 +344,7 @@ RSpec.feature "Checkout flows" do
         end
 
         # select all dispositions
-        table_rows.each { |row| click_dropdown 2, row }
+        table_rows.each { |row| click_dropdown({ index: 2 }, row) }
 
         click_on "Continue"
 
@@ -361,7 +354,7 @@ RSpec.feature "Checkout flows" do
       scenario "submits draft decision" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         issue_dispositions = page.find_all(".Select-control", text: "Select Disposition", count: appeal.issues.length)
 
@@ -400,7 +393,7 @@ RSpec.feature "Checkout flows" do
         # Expect this to be populated with all judge_staff we've created
         # by way of FactoryBot.create(:staff, :judge_role...
         safe_click "#select-judge"
-        click_dropdown 0
+        click_dropdown(index: 0)
         expect(page).to have_content(judge_user.full_name)
 
         click_on "Continue"
@@ -415,7 +408,7 @@ RSpec.feature "Checkout flows" do
       scenario "submits omo request" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 1
+        click_dropdown(index: 1)
 
         expect(page).to have_content("Submit OMO for Review")
 
@@ -434,7 +427,7 @@ RSpec.feature "Checkout flows" do
         expect(page).to have_content(dummy_note[0..349])
 
         safe_click("#select-judge")
-        click_dropdown 0
+        click_dropdown(index: 0)
         expect(page).to have_content(judge_user.full_name)
 
         click_on "Continue"
@@ -448,7 +441,7 @@ RSpec.feature "Checkout flows" do
       scenario "deletes issue" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         expect(page).to have_content("Select Dispositions")
 
@@ -504,7 +497,7 @@ RSpec.feature "Checkout flows" do
       scenario "edits issue information" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         expect(page).to have_content("Select Dispositions")
 
@@ -517,7 +510,7 @@ RSpec.feature "Checkout flows" do
           # changing options at the top of the form affects what options are enabled further down
           next if row.matches_css? ".is-disabled"
 
-          click_dropdown 1, row
+          click_dropdown({ index: 1 }, row)
           row.find(".Select-value-label").text
         end
         fill_in "Notes:", with: "this is the note"
@@ -534,7 +527,7 @@ RSpec.feature "Checkout flows" do
       scenario "shows/hides diagnostic code option" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         expect(page).to have_content "Select Dispositions"
 
@@ -555,7 +548,7 @@ RSpec.feature "Checkout flows" do
       scenario "adds issue" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
-        click_dropdown 0
+        click_dropdown(index: 0)
 
         expect(page).to have_content "Select Dispositions"
 
@@ -645,7 +638,7 @@ RSpec.feature "Checkout flows" do
       visit "/queue"
       click_on "(#{appeal.veteran_file_number})"
 
-      click_dropdown 0 do
+      click_dropdown(index: 0) do
         visible_options = page.find_all(".Select-option")
         expect(visible_options.length).to eq 1
         expect(visible_options.first.text).to eq COPY::JUDGE_CHECKOUT_DISPATCH_LABEL
@@ -715,7 +708,7 @@ RSpec.feature "Checkout flows" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
 
-        click_dropdown 0 do
+        click_dropdown(index: 0) do
           visible_options = page.find_all(".Select-option")
           expect(visible_options.length).to eq 1
           expect(visible_options.first.text).to eq COPY::JUDGE_CHECKOUT_DISPATCH_LABEL
@@ -755,7 +748,7 @@ RSpec.feature "Checkout flows" do
       scenario "completes assign to omo checkout flow" do
         visit "/queue/appeals/#{appeal.vacols_id}"
 
-        click_dropdown 0 do
+        click_dropdown(index: 0) do
           visible_options = page.find_all(".Select-option")
           expect(visible_options.length).to eq 1
           expect(visible_options.first.text).to eq COPY::JUDGE_CHECKOUT_OMO_LABEL
@@ -857,7 +850,7 @@ RSpec.feature "Checkout flows" do
       vet_name = appeal.veteran_full_name
 
       click_on "#{vet_name.split(' ').first} #{vet_name.split(' ').last} (#{appeal.sanitized_vbms_id})"
-      click_dropdown 0
+      click_dropdown(index: 0)
 
       expect(page).to have_content(COPY::MARK_TASK_COMPLETE_BUTTON)
       click_on COPY::MARK_TASK_COMPLETE_BUTTON
@@ -880,13 +873,13 @@ RSpec.feature "Checkout flows" do
 
       expect(page).to have_content("Actions")
 
-      click_dropdown 1
+      click_dropdown(index: 1)
 
       expect(page).to have_content(
         format(COPY::COLOCATED_ACTION_PLACE_HOLD_HEAD, vet_name, appeal.sanitized_vbms_id)
       )
 
-      click_dropdown 6
+      click_dropdown(index: 6)
       expect(page).to have_content(COPY::COLOCATED_ACTION_PLACE_CUSTOM_HOLD_COPY)
 
       hold_duration = [rand(100), 1].max
@@ -914,7 +907,7 @@ RSpec.feature "Checkout flows" do
       vet_name = appeal.veteran_full_name
       click_on "#{vet_name.split(' ').first} #{vet_name.split(' ').last} (#{appeal.sanitized_vbms_id})"
 
-      click_dropdown 0
+      click_dropdown(index: 0)
 
       expect(page).to have_content(
         format(COPY::COLOCATED_ACTION_SEND_TO_ANOTHER_TEAM_HEAD, team_name)

--- a/spec/feature/queue/checkout_flows_spec.rb
+++ b/spec/feature/queue/checkout_flows_spec.rb
@@ -1,17 +1,5 @@
 require "rails_helper"
 
-def generate_text(length)
-  charset = ("A".."Z").to_a.concat(("a".."z").to_a)
-  Array.new(length) { charset.sample }.join
-end
-
-def generate_words(n_words)
-  Array.new(n_words).map do
-    word_length = [rand(12), 3].max
-    generate_text(word_length)
-  end.join(" ")
-end
-
 RSpec.feature "Checkout flows" do
   let(:attorney_user) { FactoryBot.create(:default_user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -1,12 +1,5 @@
 require "rails_helper"
 
-def click_dropdown_text(opt_text, container = page)
-  dropdown = container.find(".Select-control")
-  dropdown.click
-  yield if block_given?
-  dropdown.sibling(".Select-menu-outer").find("div .Select-option", text: opt_text).click
-end
-
 RSpec.feature "Judge assignment to attorney" do
   let(:judge) { Judge.new(FactoryBot.create(:user, full_name: "Billie Daniel")) }
   let!(:judge_team) { JudgeTeam.create_for_judge(judge.user) }
@@ -48,7 +41,7 @@ RSpec.feature "Judge assignment to attorney" do
       check "2", allow_label_click: true
 
       safe_click ".Select"
-      click_dropdown_text attorney_one.full_name
+      click_dropdown(text: attorney_one.full_name)
 
       click_on "Assign 2 cases"
       expect(page).to have_content("Assigned 2 cases")
@@ -65,7 +58,7 @@ RSpec.feature "Judge assignment to attorney" do
       check "3", allow_label_click: true
 
       safe_click ".Select"
-      click_dropdown_text attorney_two.full_name
+      click_dropdown(text: attorney_two.full_name)
 
       click_on "Assign 1 case"
       expect(page).to have_content("Assigned 1 case")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,6 +16,7 @@ require_relative "support/sauce_driver"
 require_relative "support/database_cleaner"
 require_relative "support/download_helper"
 require_relative "support/clear_cache"
+require_relative "support/feature_helper"
 require "timeout"
 
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -375,4 +376,5 @@ end
 RSpec.configure do |config|
   config.include ActionView::Helpers::NumberHelper
   config.include FakeDateHelper
+  config.include FeatureHelper, type: :feature
 end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -1,0 +1,13 @@
+module FeatureHelper
+  def click_dropdown(options = {}, container = page)
+    options = { index: nil, text: nil }.merge(options)
+    dropdown = container.find(".Select-control")
+    dropdown.click
+    yield if block_given?
+    if options[:text].present?
+      dropdown.sibling(".Select-menu-outer").find("div .Select-option", text: options[:text]).click
+    elsif options[:index].present?
+      dropdown.sibling(".Select-menu-outer").find("div[id$='--option-#{options[:index]}']").click
+    end
+  end
+end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -10,4 +10,18 @@ module FeatureHelper
       dropdown.sibling(".Select-menu-outer").find("div[id$='--option-#{options[:index]}']").click
     end
   end
+
+  def generate_words(n_words)
+    Array.new(n_words).map do
+      word_length = [rand(12), 3].max
+      generate_text(word_length)
+    end.join(" ")
+  end
+
+  private
+
+  def generate_text(length)
+    charset = ("A".."Z").to_a.concat(("a".."z").to_a)
+    Array.new(length) { charset.sample }.join
+  end
 end


### PR DESCRIPTION
### Description
This PR moves the `click_dropdown` and `generate_words` methods into a feature helper module, so they're accessible to all our feature tests. It also modifies the `click_dropdown` method so you can pass it either an index or a text value.
