### PR TITLE
Remove rails_stdout_logging gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,11 +103,6 @@ group :production, :staging, :ssh_forwarding, :development, :test do
   gem "ruby-oci8", require: "oci8"
 end
 
-# Development was ommited due to double logging issue (https://github.com/heroku/rails_stdout_logging/issues/1)
-group :production, :staging do
-  gem "rails_stdout_logging"
-end
-
 group :test, :development, :demo do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails_stdout_logging (0.0.5)
     railties (5.1.6.1)
       actionpack (= 5.1.6.1)
       activesupport (= 5.1.6.1)
@@ -550,7 +549,6 @@ DEPENDENCIES
   puma (~> 3.12.0)
   rack (~> 2.0.6)
   rails (= 5.1.6.1)
-  rails_stdout_logging
   rainbow
   rb-readline
   react_on_rails (= 8.0.6)
@@ -580,4 +578,4 @@ DEPENDENCIES
   zero_downtime_migrations
 
 BUNDLED WITH
-   1.16.4
+   1.17.2


### PR DESCRIPTION
**Why**: It is no longer needed in Rails 5 as long as certain settings are
configured in `config/environments/production.rb`, which we already have.

Reference: https://github.com/heroku/rails_stdout_logging#rails-5

Also, I believe these settings only apply to Heroku. Do we need them for AWS
as well? As a point of comparison, login.gov, which is hosted on AWS, doesn't
have these logger settings.