### PR TITLE
remove bootsnap to debug deployments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,8 +174,4 @@ gem "roo", "~> 2.7"
 gem "rubyzip", "~> 1.2.2"
 
 gem "business_time", "~> 0.9.3"
-
-# Bootsnap speeds up app boot (and started to be a default gem in 5.2).
-gem "bootsnap", require: false
-
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
     aws-sdk-resources (2.10.112)
       aws-sdk-core (= 2.10.112)
     aws-sigv4 (1.0.2)
-    bootsnap (1.3.2)
-      msgpack (~> 1.0)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -272,7 +270,6 @@ GEM
     moment_timezone-rails (0.5.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
-    msgpack (1.2.4)
     multi_json (1.12.2)
     multipart-post (2.0.0)
     nap (1.1.0)
@@ -512,7 +509,6 @@ DEPENDENCIES
   activerecord-oracle_enhanced-adapter
   acts_as_tree
   bgs!
-  bootsnap
   brakeman
   bundler-audit
   business_time (~> 0.9.3)

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,3 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup'


### PR DESCRIPTION
Running into some mysterious deploy failures related to file permissions errors, implicating bootsnap in the stack trace.

c.f.
https://github.com/Shopify/bootsnap/issues/77
https://github.com/Shopify/bootsnap/issues/169

Not certain this is the cause of deployments failing but testing if this changes anything.