### PR TITLE
Schedule| Adding room to Daily docket

### DIFF
--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -391,7 +391,7 @@ export default class DailyDocket extends React.Component {
       { this.props.dailyDocketServerError && <Alert
         type="error"
         styling={alertStyling}
-        title={` Unable to delete Hearing Day 
+        title={` Unable to delete Hearing Day
                 ${moment(this.props.dailyDocket.hearingDate).format('M/DD/YYYY')} in Caseflow.`}
         message="Please delete the hearing day through VACOLS" />}
       <div className="cf-push-left">
@@ -428,7 +428,8 @@ export default class DailyDocket extends React.Component {
       <span className="cf-push-right">
         VLJ: {this.props.dailyDocket.judgeFirstName} {this.props.dailyDocket.judgeLastName} <br />
         Coordinator: {this.props.dailyDocket.bvaPoc} <br />
-        Hearing type: {this.props.dailyDocket.hearingType}
+        Hearing type: {this.props.dailyDocket.hearingType} <br />
+        Room number: {this.props.dailyDocket.room}
       </span>
       <div {...noMarginStyling}>
         { !_.isEmpty(dailyDocketRows) && <Table


### PR DESCRIPTION
Resolves #8364

### Description
This adds room number to the Daily docket

### Acceptance Criteria
- [ ] We want to display the hearing day's room number in the top righthand corner of the daily docke

### Testing Plan
1. Go to Daily Docket in schedule

<img width="1423" alt="screen shot 2018-12-19 at 1 31 36 pm" src="https://user-images.githubusercontent.com/23080951/50240686-64ef7000-0393-11e9-83a5-40ef5e300683.png">


