### PR TITLE
View Schedule | Dates include the day

### DIFF
--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -4,7 +4,6 @@ import _ from 'lodash';
 import { LOGO_COLORS } from '../../constants/AppConstants';
 import { css } from 'glamor';
 import Table from '../../components/Table';
-import { formatDateStr } from '../../util/DateUtil';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import Button from '../../components/Button';
 import FilterRibbon from '../../components/FilterRibbon';
@@ -19,6 +18,7 @@ import { bindActionCreators } from 'redux';
 import connect from 'react-redux/es/connect/connect';
 import LoadingDataDisplay from '../../components/LoadingDataDisplay';
 import ListScheduleDateSearch from './ListScheduleDateSearch';
+import moment from 'moment';
 
 const downloadButtonStyling = css({
   marginTop: '60px'
@@ -114,7 +114,8 @@ class ListSchedule extends React.Component {
 
     return _.orderBy(hearingSchedule, (hearingDay) => hearingDay.hearingDate, 'asc').
       map((hearingDay) => ({
-        hearingDate: <Link to={`/schedule/docket/${hearingDay.id}`}>{formatDateStr(hearingDay.hearingDate)}</Link>,
+        hearingDate: <Link to={`/schedule/docket/${hearingDay.id}`}>
+          {moment(hearingDay.hearingDate).format('ddd M/DD/YYYY')}</Link>,
         hearingType: hearingDay.hearingType,
         regionalOffice: hearingDay.regionalOffice,
         room: hearingDay.room,


### PR DESCRIPTION
Resolves #8371

### Description
This pr shows the days on the hearing view schedule page

### Acceptance Criteria
- [ ] Add the day of the way in front of the date on the View hearing schedule page. This will help place-make for the users and provide an alter if a Sat/Sun is accidentally scheduled

### Testing Plan
1. Go to View schedule page

<img width="1433" alt="screen shot 2018-12-19 at 7 52 36 pm" src="https://user-images.githubusercontent.com/23080951/50257232-68e9b500-03c8-11e9-9ae8-58a96d5c720c.png">


