### PR TITLE
stop disappearing tasks attached to appeals w/documents

### DIFF
--- a/app/models/queues/attorney_queue.rb
+++ b/app/models/queues/attorney_queue.rb
@@ -8,7 +8,7 @@ class AttorneyQueue
   # using assigned by user. We set status to being on_hold and placed_on_hold_at to assigned_at timestamp
   def tasks
     colocated_tasks_grouped = ColocatedTask.where(assigned_by: user).group_by(&:appeal_id)
-    on_hold_legacy_tasks = colocated_tasks_grouped.each_with_object([]) do |(_k, value), result|
+    colocated_tasks_for_attorney_tasks = colocated_tasks_grouped.each_with_object([]) do |(_k, value), result|
       # Attorneys can assign multiple admin actions per appeal, we assume a case is still on hold
       # if not all admin actions are completed
       next if value.map(&:status).uniq == [Constants.TASK_STATUSES.completed]
@@ -18,9 +18,9 @@ class AttorneyQueue
       end
       result
     end
-    ama_tasks = Task.incomplete_or_recently_completed
+    caseflow_tasks = Task.incomplete_or_recently_completed
       .where(assigned_to: user, type: [AttorneyTask.name, QualityReviewTask.name])
-    (on_hold_legacy_tasks + ama_tasks).flatten
+    (colocated_tasks_for_attorney_tasks + caseflow_tasks).flatten
   end
 
   def tasks_by_appeal_id(appeal_id, appeal_type)

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -191,7 +191,7 @@ export const workableTasksByAssigneeCssIdSelector = createSelector(
 
 const incompleteTasksWithHold: (State) => Array<Task> = createSelector(
   [incompleteTasksByAssigneeCssIdSelector],
-  (tasks: Array<Task>) => tasks.filter((task) => task.placedOnHoldAt)
+  (tasks: Array<Task>) => tasks.filter((task) => taskIsOnHold(task))
 );
 
 export const pendingTasksByAssigneeCssIdSelector: (State) => Array<Task> = createSelector(
@@ -209,9 +209,9 @@ export const onHoldTasksByAssigneeCssIdSelector: (State) => Array<Task> = create
 );
 
 export const onHoldTasksForAttorney: (State) => Array<Task> = createSelector(
-  [onHoldTasksByAssigneeCssIdSelector, incompleteTasksByAssignerCssIdSelector],
-  (onHoldByAssignee: Array<Task>, incompleteByAssigner: Array<Task>) => {
-    const onHoldTasksWithDuplicates = onHoldByAssignee.concat(incompleteByAssigner);
+  [incompleteTasksWithHold, incompleteTasksByAssignerCssIdSelector],
+  (incompleteWithHold: Array<Task>, incompleteByAssigner: Array<Task>) => {
+    const onHoldTasksWithDuplicates = incompleteWithHold.concat(incompleteByAssigner);
 
     return _.filter(onHoldTasksWithDuplicates, (task) => task.assignedTo.type === 'User');
   }

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -35,6 +35,18 @@ RSpec.feature "Task queue" do
       visit "/queue"
     end
 
+    context "the on-hold task is attached to an appeal with documents" do
+      let!(:documents) { ["NOD", "BVA Decision", "SSOC"].map { |t| FactoryBot.build(:document, type: t) } }
+
+      before do
+        allow_any_instance_of(Appeal).to receive(:new_documents_for_user) { documents }
+      end
+
+      it "shows the correct number of tasks on hold" do
+        expect(page).to have_content(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 1))
+      end
+    end
+
     it "displays a table with a row for each case assigned to the attorney" do
       expect(page).to have_content(COPY::ATTORNEY_QUEUE_TABLE_TITLE)
       expect(find("tbody").find_all("tr").length).to eq(vacols_tasks.length)


### PR DESCRIPTION
Connects #8095

Resolves the issue noted in [this comment](https://github.com/department-of-veterans-affairs/caseflow/issues/8095#issuecomment-448296003)
