### PR TITLE
[bugfix] Show correct actions if judge assigns a QR task to an attorney

### DIFF
--- a/app/models/tasks/judge_assign_task.rb
+++ b/app/models/tasks/judge_assign_task.rb
@@ -1,9 +1,6 @@
 class JudgeAssignTask < JudgeTask
-  def available_actions(_user)
-    actions = [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]
-    actions << Constants.TASK_ACTIONS.MARK_COMPLETE.to_h if parent && parent.is_a?(QualityReviewTask)
-
-    actions
+  def baseline_actions
+    [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]
   end
 
   def label

--- a/app/models/tasks/judge_review_task.rb
+++ b/app/models/tasks/judge_review_task.rb
@@ -1,5 +1,5 @@
 class JudgeReviewTask < JudgeTask
-  def available_actions(_user)
+  def baseline_actions
     [
       {
         label: COPY::JUDGE_CHECKOUT_DISPATCH_LABEL,

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -1,6 +1,13 @@
 class JudgeTask < Task
   include RoundRobinAssigner
 
+  def available_actions(_user)
+    actions = baseline_actions
+    actions << Constants.TASK_ACTIONS.MARK_COMPLETE.to_h if parent && parent.is_a?(QualityReviewTask)
+
+    actions
+  end
+
   def actions_available?(user)
     assigned_to == user
   end

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -29,6 +29,49 @@ describe JudgeTask do
           expect(subject).to eq([review_task.build_action_hash(Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h)])
         end
       end
+
+      context "and the task was created by quality review and the judge has sent it back to an attorney" do
+        let!(:root_task) { FactoryBot.create(:root_task) }
+        let!(:appeal) { root_task.appeal }
+
+        let!(:qr_user) { FactoryBot.create(:user) }
+        let!(:qr_relationship) { OrganizationsUser.add_user_to_organization(qr_user, QualityReview.singleton) }
+        let!(:qr_org_task) { QualityReviewTask.create_from_root_task(root_task) }
+        let!(:qr_task_params) do
+          [{
+            appeal: appeal,
+            parent_id: qr_org_task.id,
+            assigned_to_id: qr_user.id,
+            assigned_to_type: qr_user.class.name,
+            assigned_by: qr_user
+          }]
+        end
+        let!(:qr_person_task) { QualityReviewTask.create_many_from_params(qr_task_params, qr_user).first }
+
+        # Quality reviewer returns the case to the judge for corrections.
+        let!(:judge_task) { JudgeAssignTask.create!(appeal: appeal, parent: qr_person_task, assigned_to: judge) }
+
+        # Judge sends the case to an attorney for corrections.
+        let!(:atty_task_params) do
+          [{ appeal: appeal, parent_id: judge_task.id, assigned_to: attorney, assigned_by: judge }]
+        end
+        let!(:atty_task) { AttorneyTask.create_many_from_params(atty_task_params, judge).first }
+
+        # Attorney is done with corrections and sends case back to judge.
+        let!(:complete_atty_task) { atty_task.mark_as_complete! }
+
+        # The judge task changed type so we have to grab it from the database again
+        let!(:assign_task) { Task.find(judge_task.id) }
+
+        it "should return the dispatch and mark complete options" do
+          options = [
+            review_task.build_action_hash(Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h),
+            review_task.build_action_hash(Constants.TASK_ACTIONS.MARK_COMPLETE.to_h)
+          ]
+
+          expect(subject).to eq(options)
+        end
+      end
     end
 
     context "when the task is not assigned to the current user" do


### PR DESCRIPTION
When the Quality Review team returns a case to a judge we create a `JudgeAssignTask`. If a `JudgeAssignTask` has a parent task of the type `QualityReviewTask` then we display an option to "Mark task complete" in order to return the case to the Quality Review team after the judge has addressed the concerns of the Quality Review team. However, if the judge assigns one of these cases to an attorney on their team (in the parlance of the application, creates a child `AttorneyTask`) then we change the type of the judge task from `JudgeAssignTask` to `JudgeReviewTask` [after the attorney returns the case to the judge](https://github.com/department-of-veterans-affairs/caseflow/blob/53dc4c07c63e195130d6ad9973a9515871bf1941/app/models/tasks/judge_task.rb#L23) (completes the `AttorneyTask`). Because we change the type of task, we no longer display the "Mark task complete" option. This PR changes that to correctly display the "Mark task complete" option in those cases.

This is just a temporary bugfix that should be addressed in a more thorough way by #8107.