### PR TITLE
Reverse default room selector logic from negative to positive. All changes in front-end.

### DIFF
--- a/client/app/hearingSchedule/actions.js
+++ b/client/app/hearingSchedule/actions.js
@@ -311,10 +311,10 @@ export const onResetDeleteSuccessful = () => ({
   type: ACTIONS.RESET_DELETE_SUCCESSFUL
 });
 
-export const onAssignHearingRoom = (roomNotRequired) => ({
+export const onAssignHearingRoom = (roomRequired) => ({
   type: ACTIONS.ASSIGN_HEARING_ROOM,
   payload: {
-    roomNotRequired
+    roomRequired
   }
 });
 

--- a/client/app/hearingSchedule/components/HearingDayAddModal.jsx
+++ b/client/app/hearingSchedule/components/HearingDayAddModal.jsx
@@ -31,7 +31,7 @@ const spanStyling = css({
   marginBotton: '5px'
 });
 
-const roomNotRequiredStyling = css({
+const roomRequiredStyling = css({
   marginTop: '15px'
 });
 
@@ -195,7 +195,7 @@ class HearingDayAddModal extends React.Component {
     this.props.setNotes(value);
   };
 
-  onRoomNotRequired = (value) => {
+  onRoomRequired = (value) => {
     this.props.onAssignHearingRoom(value);
   };
 
@@ -255,12 +255,12 @@ class HearingDayAddModal extends React.Component {
           textAreaStyling={notesFieldStyling}
           value={this.props.notes} />
         <Checkbox
-          name="roomNotRequired"
-          label="Board Hearing Room Not Required"
+          name="roomRequired"
+          label="Assign Board Hearing Room"
           strongLabel
-          value={this.props.roomNotRequired}
-          onChange={this.onRoomNotRequired}
-          {...roomNotRequiredStyling} />
+          value={this.props.roomRequired}
+          onChange={this.onRoomRequired}
+          {...roomRequiredStyling} />
       </div>
     </React.Fragment>;
   };
@@ -297,7 +297,7 @@ const mapStateToProps = (state) => ({
   vlj: state.hearingSchedule.vlj,
   coordinator: state.hearingSchedule.coordinator,
   notes: state.hearingSchedule.notes,
-  roomNotRequired: state.hearingSchedule.roomNotRequired,
+  roomRequired: state.hearingSchedule.roomRequired,
   activeJudges: state.hearingSchedule.activeJudges,
   activeCoordinators: state.hearingSchedule.activeCoordinators
 });

--- a/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
+++ b/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
@@ -144,7 +144,7 @@ export class ListScheduleContainer extends React.Component {
     this.props.selectHearingCoordinator({ label: '',
       value: '' });
     this.props.setNotes('');
-    this.props.onAssignHearingRoom(false);
+    this.props.onAssignHearingRoom(true);
   }
 
   closeModal = () => {
@@ -157,7 +157,7 @@ export class ListScheduleContainer extends React.Component {
       judge_id: this.props.vlj.value,
       bva_poc: this.props.coordinator.label,
       notes: this.props.notes,
-      assign_room: !this.props.roomNotRequired
+      assign_room: this.props.roomRequired
     };
 
     if (this.props.selectedRegionalOffice && this.props.selectedRegionalOffice.value !== '') {
@@ -283,7 +283,7 @@ const mapStateToProps = (state) => ({
   vlj: state.hearingSchedule.vlj,
   coordinator: state.hearingSchedule.coordinator,
   notes: state.hearingSchedule.notes,
-  roomNotRequired: state.hearingSchedule.roomNotRequired,
+  roomRequired: state.hearingSchedule.roomRequired,
   successfulHearingDayDelete: state.hearingSchedule.successfulHearingDayDelete
 });
 

--- a/client/app/hearingSchedule/reducers.js
+++ b/client/app/hearingSchedule/reducers.js
@@ -299,8 +299,8 @@ const hearingScheduleReducer = (state = initialState, action = {}) => {
     });
   case ACTIONS.ASSIGN_HEARING_ROOM:
     return update(state, {
-      roomNotRequired: {
-        $set: action.payload.roomNotRequired
+      roomRequired: {
+        $set: action.payload.roomRequired
       }
     });
   case ACTIONS.HEARING_DAY_MODIFIED:


### PR DESCRIPTION
Resolves #8365 

### Description
Hearing room selector logic changed to positive logic. Copy was modified to reflect the positive approach.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to Add Hearing Day
2. Verify the checkbox is checked and it has the new copy
3. Save a new hearing day with box checked and unchecked.
4. Confirm hearing day has a room or not depending on checkbox state.

