### PR TITLE
example of backup error messages for users

### DIFF
--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -1,5 +1,13 @@
 class ClaimReviewController < ApplicationController
   before_action :verify_access, :react_routed, :verify_feature_enabled, :set_application
+  helper_method :props
+
+  def edit
+    props
+  rescue StandardError => e
+    Raven.capture_exception(e)
+    flash[:error] = e.message
+  end
 
   def update
     if request_issues_update.perform!
@@ -12,6 +20,20 @@ class ClaimReviewController < ApplicationController
   end
 
   private
+
+  def props
+    @props ||= {
+      userDisplayName: current_user.display_name,
+      dropdownUrls: dropdown_urls,
+      feedbackUrl: feedback_url,
+      buildDate: build_date,
+      serverIntake: higher_level_review.ui_hash,
+      claimId: url_claim_id,
+      featureToggles: {
+        useAmaActivationDate: FeatureToggle.enabled?(:use_ama_activation_date, user: current_user)
+      }
+    }
+  end
 
   def source_type
     fail "Must override source_type"
@@ -26,6 +48,7 @@ class ClaimReviewController < ApplicationController
   end
 
   def claim_review
+    raise StandardError.new("oh no")
     @claim_review ||=
       EndProductEstablishment.find_by!(reference_id: url_claim_id, source_type: source_type).source
   end

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -3,6 +3,7 @@
     userDisplayName: current_user ? current_user.display_name : "",
     dropdownUrls: dropdown_urls,
     feedbackUrl: feedback_url,
-    buildDate: build_date
+    buildDate: build_date,
+    flashError: flash[:error]
   }) %>
 <% end %>

--- a/app/views/higher_level_reviews/edit.html.erb
+++ b/app/views/higher_level_reviews/edit.html.erb
@@ -1,13 +1,3 @@
 <% content_for :full_page_content do %>
-  <%= react_component("IntakeEdit", props: {
-    userDisplayName: current_user.display_name,
-    dropdownUrls: dropdown_urls,
-    feedbackUrl: feedback_url,
-    buildDate: build_date,
-    serverIntake: higher_level_review.ui_hash,
-    claimId: url_claim_id,
-    featureToggles: {
-      useAmaActivationDate: FeatureToggle.enabled?(:use_ama_activation_date, user: current_user)
-    }
-  }) %>
+  <%= react_component("IntakeEdit", props: props) %>
 <% end %>

--- a/client/app/errors/Error500.jsx
+++ b/client/app/errors/Error500.jsx
@@ -28,6 +28,9 @@ class Error500 extends React.PureComponent {
         <AppFrame>
           <StatusMessage title="Something went wrong." type="alert">
              If you continue to see this page, please contact the help desk.
+
+             <p>Error:</p>
+             <p>{this.props.flashError}</p>
           </StatusMessage>
         </AppFrame>
         <Footer

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       = false
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp/caching-dev.txt').exist?


### PR DESCRIPTION
### Description
We've had a couple instances where obscured errors make it impossible for Intake users to know what went wrong (transient? bad data?), leading them to being blocked for up to a day until the intake expires. Additionally, if the specific veteran has an issue where any intake will fail, the Intake user might simply run into the same problem again.

While a better outcome would be to avoid these errors altogether or fix/workaround them automatically, a good first step is to give users useful information if we can. This PR illustrates how we can use Rails flash messages to do this:

* Capture specific errors and set `flash[:error]` in the controller
* Pass the flash error to the Error redux app
* Show the error when we render the 500 page

Again, this pattern is not intended to replace proper error messages integrated into the UI, but as a cheap fallback. The screenshot below shows what renders if an unhandled error is raised with a message:
<img width="952" alt="screen shot 2018-12-24 at 17 28 36" src="https://user-images.githubusercontent.com/279406/50408881-1717a500-07a3-11e9-8365-104d87f0d37f.png">