### PR TITLE
Do not delay document upload background job

### DIFF
--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -10,7 +10,6 @@ class DecisionDocument < ApplicationRecord
   attr_writer :file
 
   S3_SUB_BUCKET = "decisions".freeze
-  DECISION_OUTCODING_DELAY = 3.hours
 
   def document_type
     "BVA Decision"
@@ -31,7 +30,7 @@ class DecisionDocument < ApplicationRecord
     return no_processing_required! unless upload_enabled?
 
     cache_file!
-    super(delay: DECISION_OUTCODING_DELAY)
+    super
   end
 
   def process!

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -49,13 +49,9 @@ class BvaDispatchTask < GenericTask
 
         # TODO: remove this unless statement when all decision documents require async processing
         unless decision_document.processed?
-          delayed_process_decision_document_job.perform_later(decision_document)
+          ProcessDecisionDocumentJob.perform_later(decision_document)
         end
       end
-    end
-
-    def delayed_process_decision_document_job
-      ProcessDecisionDocumentJob.set(wait: DecisionDocument::DECISION_OUTCODING_DELAY)
     end
   end
 end

--- a/spec/models/decision_document_spec.rb
+++ b/spec/models/decision_document_spec.rb
@@ -28,7 +28,7 @@ describe DecisionDocument do
       it "caches the file" do
         expect(S3Service).to receive(:store_file).with(expected_path, /PDF/)
         subject
-        expect(decision_document.submitted_at).to eq(Time.zone.now + DecisionDocument::DECISION_OUTCODING_DELAY)
+        expect(decision_document.submitted_at).to eq(Time.zone.now)
       end
     end
 

--- a/spec/models/tasks/bva_dispatch_task_spec.rb
+++ b/spec/models/tasks/bva_dispatch_task_spec.rb
@@ -64,11 +64,9 @@ describe BvaDispatchTask do
 
       context "when :decision_document_upload feature is enabled" do
         it "should complete the BvaDispatchTask assigned to the User and the task assigned to the BvaDispatch org" do
-          delayed_decision_time = Time.zone.now + DecisionDocument::DECISION_OUTCODING_DELAY
-
           expect do
             BvaDispatchTask.outcode(root_task.appeal, params, user)
-          end.to have_enqueued_job(ProcessDecisionDocumentJob).at(delayed_decision_time)
+          end.to have_enqueued_job(ProcessDecisionDocumentJob).exactly(:once)
 
           tasks = BvaDispatchTask.where(appeal: root_task.appeal, assigned_to: user)
           expect(tasks.length).to eq(1)


### PR DESCRIPTION
Resolves #8438 

### Description
Based on our recent discussion we decided not to wait 3 hours and start the background job immediately. 



