### PR TITLE
Move condition to decide if we show/hide task action dropdown to backend

### DIFF
--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -1,6 +1,6 @@
 class AttorneyLegacyTask < LegacyTask
   def available_actions(role)
-    return [] if role != "attorney"
+    return [] if role != "attorney" || !task_id
 
     actions = [
       {

--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -1,6 +1,11 @@
 class AttorneyLegacyTask < LegacyTask
   def available_actions(role)
-    return [] if role != "attorney" || !task_id
+    return [] if role != "attorney"
+
+    # AttorneyLegacyTasks are drawn from the VACOLS.BRIEFF table but should not be actionable unless there is a case
+    # assignment in the VACOLS.DECASS table. task_id is created using the created_at field from the VACOLS.DECASS table
+    # so we use the absence of this value to indicate that there is no case assignment and return no actions.
+    return [] unless task_id
 
     actions = [
       {

--- a/client/app/queue/TaskSnapshot.jsx
+++ b/client/app/queue/TaskSnapshot.jsx
@@ -218,24 +218,7 @@ export class TaskSnapshot extends React.PureComponent<Props> {
     </React.Fragment>;
   };
 
-  showActionsSection = (): boolean => {
-    if (this.props.hideDropdown) {
-      return false;
-    }
-
-    const {
-      userRole,
-      primaryTask
-    } = this.props;
-
-    if (!primaryTask) {
-      return false;
-    }
-
-    // users can end up at case details for appeals with no DAS
-    // record (!task.taskId). prevent starting attorney checkout flows
-    return userRole === USER_ROLE_TYPES.judge ? Boolean(primaryTask) : Boolean(primaryTask.taskId);
-  }
+  showActionsSection = (): boolean => (this.props.primaryTask && !this.props.hideDropdown);
 
   render = () => {
     const {

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -226,6 +226,28 @@ RSpec.feature "Case details" do
         expect(page).to have_content(appeal.appellant_address_line_1)
       end
     end
+
+    context "when attorney has a case assigned in VACOLS without a DECASS record" do
+      let!(:appeal) do
+        FactoryBot.create(
+          :legacy_appeal,
+          vacols_case: FactoryBot.create(
+            :case,
+            :assigned,
+            decass_count: 0,
+            user: attorney_user
+          )
+        )
+      end
+
+      it "should not display a tasks action dropdown" do
+        visit("/queue/appeals/#{appeal.external_id}")
+
+        # Expect to find content we know to be on the page so that we wait for the page to load.
+        expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL)
+        expect(page).not_to have_content("Select an action")
+      end
+    end
   end
 
   context "when an appeal has some number of documents" do


### PR DESCRIPTION
This PR moves logic onto the backend now that we have a robust model for determining available actions for each task. When this PR was created we were still using the [combination of individual, attorney, and organization tasks](https://github.com/department-of-veterans-affairs/caseflow/pull/7275/files#diff-5b5c7473c1568400a8104eccd0693108R241) in order to determine whether to show the task actions dropdown. Now that we are using the `Task. available_actions()` and the `actionableTasksForAppeal()` selector, we can move a bunch of this code to the backend.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/50454549-308d2e00-0916-11e9-9648-d2dd19946389.png) | ![image](https://user-images.githubusercontent.com/32683958/50454533-22d7a880-0916-11e9-9e9e-302f0b52a0d5.png)
