### PR TITLE
Remove unused response status

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -65,7 +65,7 @@ class TasksController < ApplicationController
 
     tasks_to_return = (queue_class.new(user: current_user).tasks + tasks).uniq
 
-    render json: { tasks: json_tasks(tasks_to_return) }, status: :created
+    render json: { tasks: json_tasks(tasks_to_return) }
   end
 
   # To update attorney task

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe TasksController, type: :controller do
 
         it "should be successful" do
           post :create, params: { tasks: params }
-          expect(response.status).to eq 201
+          expect(response.status).to eq 200
 
           response_body = JSON.parse(response.body)["tasks"]["data"]
           expect(response_body.second["attributes"]["type"]).to eq AttorneyTask.name
@@ -301,7 +301,7 @@ RSpec.describe TasksController, type: :controller do
 
         it "should be successful" do
           post :create, params: { tasks: params }
-          expect(response.status).to eq 201
+          expect(response.status).to eq 200
         end
       end
     end
@@ -361,7 +361,7 @@ RSpec.describe TasksController, type: :controller do
           it "should be successful" do
             expect(AppealRepository).to receive(:update_location!).exactly(1).times
             post :create, params: { tasks: params }
-            expect(response.status).to eq 201
+            expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(4)
             expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.on_hold
@@ -408,7 +408,7 @@ RSpec.describe TasksController, type: :controller do
           it "should be successful" do
             expect(AppealRepository).to receive(:update_location!).exactly(1).times
             post :create, params: { tasks: params }
-            expect(response.status).to eq 201
+            expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(4)
             expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.on_hold
@@ -443,7 +443,7 @@ RSpec.describe TasksController, type: :controller do
 
           it "should be successful" do
             post :create, params: { tasks: params }
-            expect(response.status).to eq 201
+            expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(2)
             expect(response_body.last["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
@@ -465,7 +465,7 @@ RSpec.describe TasksController, type: :controller do
 
           it "should be successful" do
             post :create, params: { tasks: params }
-            expect(response.status).to eq 201
+            expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(2)
             expect(response_body.last["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
@@ -519,7 +519,7 @@ RSpec.describe TasksController, type: :controller do
 
           it "should be successful" do
             post :create, params: { tasks: params }
-            expect(response.status).to eq 201
+            expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq 1
             expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned


### PR DESCRIPTION
In the process of writing a tech spec to unify all of the various `app/models/queue/` models we have I noticed that we return a status code that is never used by the front-end. This PR removes the unused response status in order to prepare for a refactor of the `TasksController` that will probably result from the aforementioned tech spec.