### PR TITLE
Only return tasks from LegacyWorkQueue methods

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -46,7 +46,7 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
 
   def tasks_assigned_to_user
     tasks = if user.attorney_in_vacols? || user.judge_in_vacols?
-              LegacyWorkQueue.tasks_with_appeals(user, role)[0].select { |task| task.appeal.activated? }
+              LegacyWorkQueue.tasks_with_appeals(user, role).select { |task| task.appeal.activated? }
             else
               []
             end

--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -19,7 +19,7 @@ class LegacyTasksController < ApplicationController
       format.json do
         MetricsService.record("VACOLS: Get all tasks with appeals for #{params[:user_id]}",
                               name: "LegacyTasksController.index") do
-          tasks, _appeals = LegacyWorkQueue.tasks_with_appeals(user, current_role)
+          tasks = LegacyWorkQueue.tasks_with_appeals(user, current_role)
           render json: {
             tasks: json_tasks(tasks, current_role)
           }

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -98,7 +98,7 @@ class TasksController < ApplicationController
 
     tasks = appeal.tasks
     if %w[attorney judge].include?(user_role) && appeal.is_a?(LegacyAppeal)
-      legacy_appeal_tasks, = LegacyWorkQueue.tasks_with_appeals_by_appeal_id(params[:appeal_id], user_role)
+      legacy_appeal_tasks = LegacyWorkQueue.tasks_with_appeals_by_appeal_id(params[:appeal_id], user_role)
       tasks = (legacy_appeal_tasks + tasks).uniq
     end
 

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -34,10 +34,9 @@ class LegacyWorkQueue
     def tasks_with_appeals_of_vacols_tasks(user, role, vacols_tasks)
       vacols_appeals = repository.appeals_by_vacols_ids(vacols_tasks.map(&:vacols_id))
 
-      tasks = vacols_tasks.zip(vacols_appeals).map do |task, appeal|
+      vacols_tasks.zip(vacols_appeals).map do |task, appeal|
         MODEL_CLASS_OF_ROLE[role.capitalize].from_vacols(task, appeal, user)
       end
-      [tasks, vacols_appeals]
     end
   end
 end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -10,10 +10,8 @@ class LegacyWorkQueue
 
     def tasks_with_appeals_by_appeal_id(appeal_id, role)
       vacols_tasks = repository.tasks_for_appeal(appeal_id)
-      if vacols_tasks.empty?
-        appeal = repository.appeals_by_vacols_ids([appeal_id])
-        return [[], [appeal]]
-      end
+      return [] if vacols_tasks.empty?
+
       assigned_to_css_id = vacols_tasks[0].assigned_to_css_id
       user = assigned_to_css_id &&
              User.find_or_create_by(css_id: assigned_to_css_id, station_id: User::BOARD_STATION_ID)

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -335,14 +335,17 @@ RSpec.feature "Case details" do
     end
 
     scenario "displays who prepared task" do
-      tasks, appeals = LegacyWorkQueue.tasks_with_appeals(judge_user, "judge")
+      tasks = LegacyWorkQueue.tasks_with_appeals(judge_user, "judge")
       task = tasks.first
-      appeal = appeals.first
+      appeal = task.appeal
 
       visit "/queue"
       click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
 
       preparer_name = "#{task.assigned_by.first_name[0]}. #{task.assigned_by.last_name}"
+
+      # Wait for page to load some known content before testing for expected content.
+      expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL)
 
       expect(page.document.text).to match(/#{COPY::TASK_SNAPSHOT_DECISION_PREPARER_LABEL} #{preparer_name}/i)
       expect(page.document.text).to match(/#{COPY::TASK_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL} #{task.document_id}/i)

--- a/spec/models/queues/legacy_work_queue_spec.rb
+++ b/spec/models/queues/legacy_work_queue_spec.rb
@@ -15,13 +15,8 @@ describe LegacyWorkQueue do
       let(:role) { "Attorney" }
 
       it "returns tasks" do
-        expect(subject[0].length).to eq(2)
-        expect(subject[0][0].class).to eq(AttorneyLegacyTask)
-      end
-
-      it "returns appeals" do
-        expect(subject[1].length).to eq(2)
-        expect(subject[1][0].class).to eq(LegacyAppeal)
+        expect(subject.length).to eq(2)
+        expect(subject[0].class).to eq(AttorneyLegacyTask)
       end
     end
 
@@ -29,13 +24,8 @@ describe LegacyWorkQueue do
       let(:role) { "Judge" }
 
       it "returns tasks" do
-        expect(subject[0].length).to eq(2)
-        expect(subject[0][0].class).to eq(JudgeLegacyTask)
-      end
-
-      it "returns appeals" do
-        expect(subject[1].length).to eq(2)
-        expect(subject[1][0].class).to eq(LegacyAppeal)
+        expect(subject.length).to eq(2)
+        expect(subject[0].class).to eq(JudgeLegacyTask)
       end
     end
   end
@@ -57,13 +47,8 @@ describe LegacyWorkQueue do
       let(:role) { "attorney" }
 
       it "returns a task" do
-        expect(subject[0].length).to eq(1)
-        expect(subject[0][0].class).to eq(AttorneyLegacyTask)
-      end
-
-      it "returns an appeal" do
-        expect(subject[1].length).to eq(1)
-        expect(subject[1][0].class).to eq(LegacyAppeal)
+        expect(subject.length).to eq(1)
+        expect(subject[0].class).to eq(AttorneyLegacyTask)
       end
     end
   end
@@ -85,14 +70,12 @@ describe LegacyWorkQueue do
       let(:role) { "attorney" }
 
       it "returns a task and an appeal" do
-        tasks, appeals = subject
+        tasks = subject
         expect(tasks.length).to eq(1)
         task = tasks[0]
         expect(task.class).to eq(AttorneyLegacyTask)
         expect(task.user_id).to be_nil
         expect(task.assigned_to_pg_id).to be_nil
-        expect(appeals.length).to eq(1)
-        expect(appeals[0].class).to eq(LegacyAppeal)
       end
     end
   end


### PR DESCRIPTION
In the process of writing a tech spec to unify all of the various `app/models/queue/` models we have I noticed that the `LegacyWorkQueue` methods return a list of two elements but we only ever use the first (tasks). This PR refactors the `LegacyWorkQueue` methods to only return the first element in that last.