### PR TITLE
Remove role parameter from request to tasks endpoint

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,13 +15,6 @@ class TasksController < ApplicationController
     InformalHearingPresentationTask: InformalHearingPresentationTask
   }.freeze
 
-  QUEUES = {
-    attorney: AttorneyQueue,
-    colocated: GenericQueue,
-    judge: GenericQueue,
-    generic: GenericQueue
-  }.freeze
-
   def set_application
     RequestStore.store[:application] = "queue"
   end
@@ -123,7 +116,7 @@ class TasksController < ApplicationController
   end
 
   def queue_class
-    QUEUES[user_role.try(:to_sym)] || QUEUES[:generic]
+    (user_role == "attorney") ? AttorneyQueue : GenericQueue
   end
 
   def user_role

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -331,7 +331,7 @@ export const initialAssignTasksToUser = ({
   let params, url;
 
   if (oldTask.appealType === 'Appeal') {
-    url = '/tasks?role=Judge';
+    url = '/tasks';
     params = {
       data: {
         tasks: [{
@@ -390,7 +390,7 @@ export const reassignTasksToUser = ({
   let params, url;
 
   if (oldTask.appealType === 'Appeal') {
-    url = `/tasks/${oldTask.taskId}?role=Judge`;
+    url = `/tasks/${oldTask.taskId}`;
     params = {
       data: {
         task: {


### PR DESCRIPTION
#8445 combined `JudgeQueue` into `GenericQueue`. We can remove the hard-coded role parameter we were passing to the tasks endpoint because we [fall back to the `GenericQueue`](https://github.com/department-of-veterans-affairs/caseflow/blob/1752a4dd0b943bdb81b73245549dbc9750cd95ef/app/controllers/tasks_controller.rb#L125) if we do not pass a role parameter. And if we did pass the "Judge" role parameter we would [map to `GenericQueue`](https://github.com/department-of-veterans-affairs/caseflow/blob/1752a4dd0b943bdb81b73245549dbc9750cd95ef/app/controllers/tasks_controller.rb#L21) so that parameter is now redundant.

