### PR TITLE
Remove unused feature toggles

### DIFF
--- a/scripts/enable_features_dev.rb
+++ b/scripts/enable_features_dev.rb
@@ -23,19 +23,11 @@ json_config = <<EOS.strip_heredoc
           enable_all: true
         },
         {
-          feature: "intake_enable_add_issues_page",
-          enable_all: true
-        },
-        {
           feature: "reader",
           enable_all: true
         },
         {
           feature: "search",
-          enable_all: true
-        },
-        {
-          feature: "colocated_queue",
           enable_all: true
         },
         {

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1,12 +1,7 @@
 RSpec.describe TasksController, type: :controller do
   before do
     Fakes::Initializer.load!
-    FeatureToggle.enable!(:colocated_queue)
     User.authenticate!(roles: ["System Admin"])
-  end
-
-  after do
-    FeatureToggle.disable!(:colocated_queue)
   end
 
   describe "GET tasks/xxx" do

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -8,7 +8,6 @@ RSpec.feature "Supplemental Claim Intake" do
     FeatureToggle.enable!(:intake)
     FeatureToggle.enable!(:intakeAma)
     FeatureToggle.enable!(:intake_legacy_opt_in)
-    FeatureToggle.disable!(:intake_enable_add_issues_page)
 
     Time.zone = "America/New_York"
     Timecop.freeze(Time.utc(2018, 11, 28))

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -398,12 +398,7 @@ RSpec.feature "Case details" do
     end
 
     before do
-      FeatureToggle.enable!(:colocated_queue)
       User.authenticate!(user: colocated_user)
-    end
-
-    after do
-      FeatureToggle.disable!(:colocated_queue)
     end
 
     scenario "displays task information" do

--- a/spec/feature/queue/colocated_checkout_flow_spec.rb
+++ b/spec/feature/queue/colocated_checkout_flow_spec.rb
@@ -49,12 +49,7 @@ RSpec.feature "Colocated checkout flows" do
     end
 
     before do
-      FeatureToggle.enable!(:colocated_queue)
       User.authenticate!(user: colocated_user)
-    end
-
-    after do
-      FeatureToggle.disable!(:colocated_queue)
     end
 
     scenario "reassigns task to assigning attorney" do


### PR DESCRIPTION
Removes unused feature toggles from our tests. Related to the [similar PR for the appeals-deployment repo](https://github.com/department-of-veterans-affairs/appeals-deployment/pull/1839) earlier today.