### PR TITLE
Use named and relative dates rather than hardcoded strings

### DIFF
--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -193,7 +193,7 @@ feature "Appeal Intake" do
 
     expect(appeal.request_issues.count).to eq 2
 
-    rating_request_issue = appeal.request_issues.find(&:ri.rating_issue_reference_id)
+    rating_request_issue = appeal.request_issues.find(&:rating_issue_reference_id)
     nonrating_request_issue = appeal.request_issues.find { |ri| ri.rating_issue_reference_id.nil? }
 
     expect(rating_request_issue).to have_attributes(

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -1,7 +1,6 @@
-require "rails_helper"
 require "support/intake_helpers"
 
-RSpec.feature "Appeal Intake" do
+feature "Appeal Intake" do
   include IntakeHelpers
 
   before do
@@ -11,7 +10,7 @@ RSpec.feature "Appeal Intake" do
     FeatureToggle.enable!(:intake_legacy_opt_in, users: [current_user.css_id])
 
     Time.zone = "America/New_York"
-    Timecop.freeze(Time.utc(2018, 11, 28))
+    Timecop.freeze(post_ramp_start_date)
   end
 
   after do
@@ -41,11 +40,15 @@ RSpec.feature "Appeal Intake" do
                               participant_id: "44444444")
   end
 
-  let(:receipt_date) { Date.new(2018, 9, 20) }
+  let(:future_date) { Time.zone.now + 30.days }
+
+  let(:receipt_date) { post_ramp_start_date - 30.days }
 
   let(:untimely_days) { 372.days }
 
-  let(:profile_date) { Time.zone.local(2018, 9, 15) }
+  let(:profile_date) { post_ramp_start_date - 35.days }
+
+  let(:untimely_date) { receipt_date - 373.days }
 
   let!(:rating) do
     Generators::Rating.build(
@@ -106,13 +109,13 @@ RSpec.feature "Appeal Intake" do
     click_on "Search"
     expect(page).to have_current_path("/intake/review_request")
 
-    fill_in "What is the Receipt Date of this form?", with: "12/15/2018"
+    fill_in "What is the Receipt Date of this form?", with: future_date.strftime("%D")
     click_intake_continue
 
     expect(page).to have_content("Receipt date cannot be in the future.")
     expect(page).to have_content("Please select an option.")
 
-    fill_in "What is the Receipt Date of this form?", with: "09/20/2018"
+    fill_in "What is the Receipt Date of this form?", with: receipt_date.strftime("%D")
 
     within_fieldset("Which review option did the Veteran request?") do
       find("label", text: "Evidence Submission", match: :prefer_exact).click
@@ -170,7 +173,7 @@ RSpec.feature "Appeal Intake" do
     add_intake_nonrating_issue(
       category: "Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
-      date: "10/27/2018"
+      date: profile_date.strftime("%D")
     )
 
     expect(page).to have_content("2 issues")
@@ -190,7 +193,7 @@ RSpec.feature "Appeal Intake" do
     expect(appeal.request_issues.count).to eq 2
     expect(appeal.request_issues.first).to have_attributes(
       rating_issue_reference_id: "def456",
-      rating_issue_profile_date: profile_date,
+      rating_issue_profile_date: profile_date.asctime.in_time_zone(Time.zone),
       description: "PTSD denied",
       decision_date: nil,
       benefit_type: "compensation"
@@ -201,7 +204,7 @@ RSpec.feature "Appeal Intake" do
       rating_issue_profile_date: nil,
       issue_category: "Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
-      decision_date: 1.month.ago.to_date,
+      decision_date: profile_date,
       benefit_type: "compensation"
     )
   end
@@ -212,7 +215,7 @@ RSpec.feature "Appeal Intake" do
 
     visit "/intake"
 
-    fill_in "What is the Receipt Date of this form?", with: "04/20/2018"
+    fill_in "What is the Receipt Date of this form?", with: receipt_date.strftime("%D")
 
     within_fieldset("Which review option did the Veteran request?") do
       find("label", text: "Evidence Submission", match: :prefer_exact).click
@@ -407,7 +410,7 @@ RSpec.feature "Appeal Intake" do
     add_intake_nonrating_issue(
       category: "Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
-      date: "10/27/2018"
+      date: profile_date.strftime("%D")
     )
     expect(page).to have_content("2 issues")
 
@@ -457,7 +460,7 @@ RSpec.feature "Appeal Intake" do
     add_intake_nonrating_issue(
       category: "Active Duty Adjustments",
       description: "Another Description for Active Duty Adjustments",
-      date: "04/19/2016"
+      date: untimely_date.strftime("%D")
     )
     add_untimely_exemption_response("No", "I am an untimely exemption")
     expect(page).to have_content("6 issues")
@@ -486,7 +489,7 @@ RSpec.feature "Appeal Intake" do
     add_intake_nonrating_issue(
       category: "Drill Pay Adjustments",
       description: "A nonrating issue before AMA",
-      date: "10/19/2017"
+      date: pre_ramp_start_date.strftime("%D")
     )
     expect(page).to have_content(
       "A nonrating issue before AMA #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
@@ -528,11 +531,10 @@ RSpec.feature "Appeal Intake" do
     )).to_not be_nil
 
     active_duty_adjustments_request_issue = RequestIssue.find_by!(
-      review_request_type: "Appeal",
-      review_request_id: appeal.id,
+      review_request: appeal,
       issue_category: "Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
-      decision_date: 1.month.ago
+      decision_date: profile_date
     )
 
     expect(active_duty_adjustments_request_issue.untimely?).to eq(false)
@@ -572,6 +574,12 @@ RSpec.feature "Appeal Intake" do
              review_request: appeal,
              description: "A nonrating issue before AMA",
              ineligible_reason: :before_ama
+    )).to_not be_nil
+
+    expect(RequestIssue.find_by(
+             review_request: appeal,
+             description: "A nonrating issue before AMA",
+             decision_date: pre_ramp_start_date
     )).to_not be_nil
 
     duplicate_request_issues = RequestIssue.where(rating_issue_reference_id: duplicate_reference_id)
@@ -670,7 +678,7 @@ RSpec.feature "Appeal Intake" do
         add_intake_nonrating_issue(
           category: "Active Duty Adjustments",
           description: "Description for Active Duty Adjustments",
-          date: "10/25/2017",
+          date: profile_date.strftime("%D"),
           legacy_issues: true
         )
 

--- a/spec/feature/intake/ramp_election_spec.rb
+++ b/spec/feature/intake/ramp_election_spec.rb
@@ -1,14 +1,12 @@
-require "rails_helper"
 require "support/intake_helpers"
 
-RSpec.feature "RAMP Election Intake" do
+feature "RAMP Election Intake" do
   include IntakeHelpers
 
   before do
     FeatureToggle.enable!(:intake)
 
-    Time.zone = "America/New_York"
-    Timecop.freeze(Time.utc(2017, 12, 8))
+    Timecop.freeze(post_ramp_start_date)
 
     allow(Fakes::VBMSService).to receive(:establish_claim!).and_call_original
     allow(Fakes::VBMSService).to receive(:create_contentions!).and_call_original

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -58,7 +58,7 @@ describe HearingDay do
       it "creates a video hearing" do
         expect(hearing[:hearing_type]).to eq "C"
         expect(hearing[:hearing_date].strftime("%Y-%m-%d %H:%M:%S"))
-          .to eq test_hearing_date_vacols.strftime("%Y-%m-%d %H:%M:%S")
+          .to eq test_hearing_date_vacols.to_date.strftime("%Y-%m-%d %H:%M:%S")
         expect(hearing[:regional_office]).to eq "RO89"
         expect(hearing[:room]).to eq "5"
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,6 +17,7 @@ require_relative "support/database_cleaner"
 require_relative "support/download_helper"
 require_relative "support/clear_cache"
 require_relative "support/feature_helper"
+require_relative "support/date_time_helper"
 require "timeout"
 
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -380,4 +381,5 @@ RSpec.configure do |config|
   config.include ActionView::Helpers::NumberHelper
   config.include FakeDateHelper
   config.include FeatureHelper, type: :feature
+  config.include DateTimeHelper
 end

--- a/spec/support/date_time_helper.rb
+++ b/spec/support/date_time_helper.rb
@@ -1,0 +1,21 @@
+module DateTimeHelper
+  def post_ama_start_date
+    ama_start_date + 30.days
+  end
+
+  def ama_start_date
+    Time.new(2019, 2, 14).in_time_zone
+  end
+
+  def pre_ramp_start_date
+    Time.new(2016, 12, 8).in_time_zone
+  end
+
+  def ramp_start_date
+    Time.new(2017, 11, 1).in_time_zone
+  end
+
+  def post_ramp_start_date
+    Time.new(2017, 12, 8).in_time_zone
+  end
+end


### PR DESCRIPTION
Refactor tests to use named and relative dates rather than hardcoded strings. This should make them easier to read and maintain since it should provide more meaningful names and make it easier to shift specs as dates move.