### PR TITLE
Caseflow CO hearing days - test fixes

### DIFF
--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -253,7 +253,8 @@ describe HearingDay do
 
     context "get parent and children structure" do
       subject do
-        HearingDay.load_days_with_open_hearing_slots((hearing.hearing_date - 1).beginning_of_day, hearing.hearing_date.beginning_of_day + 10, "C")
+        HearingDay.load_days_with_open_hearing_slots((hearing.hearing_date - 1).beginning_of_day,
+                                                     hearing.hearing_date.beginning_of_day + 10, "C")
       end
 
       it "returns nested hash structure" do

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -46,7 +46,7 @@ describe HearingDay do
         expect(hearing[:room]).to eq "1"
       end
     end
-    
+
     context "add a video hearing - Caseflow" do
       let(:hearing_hash) do
         { hearing_type: "C",


### PR DESCRIPTION
Tests are breaking because we switched from VACOLS to Caseflow hearing days for CO hearings on 1/1. This PR removes unnecessary tests and fixes the remaining tests.