### PR TITLE
Case Details| show Judge when hearing is cancelled

### DIFF
--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -44,12 +44,11 @@ type Params = Props & {|
 
 class CaseHearingsDetail extends React.PureComponent<Params> {
   getHearingAttrs = (hearing: Hearing): Array<Object> => {
-    const listElements = [{
+    return [{
       label: 'Type',
       value: StringUtil.snakeCaseToCapitalized(hearing.type)
-    }];
-
-    listElements.push({
+    },
+    {
       label: 'Disposition',
       value: <React.Fragment>
         {hearing.disposition && StringUtil.snakeCaseToCapitalized(hearing.disposition)}&nbsp;&nbsp;
@@ -60,19 +59,15 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
           </Link>
         </Tooltip>}
       </React.Fragment>
-    });
-
-    if (hearing.disposition === 'cancelled') {
-      return listElements;
-    }
-
-    return listElements.concat([{
+    },
+    {
       label: 'Date',
       value: <DateString date={hearing.date} dateFormat="M/D/YY" style={marginRight} />
     }, {
       label: 'Judge',
       value: hearing.heldBy
-    }]);
+    }
+    ];
   }
 
   getHearingInfo = () => {

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -108,8 +108,8 @@ RSpec.feature "Case details" do
 
         expect(page).to have_content("Disposition: Cancelled")
 
-        expect(page).to_not have_content("Date: ")
-        expect(page).to_not have_content("Judge: ")
+        expect(page).to have_content("Date: ")
+        expect(page).to have_content("Judge: ")
       end
     end
 


### PR DESCRIPTION
Resolves #8348

### Description
This pr shows judge and date when hearing is cancelled

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to Daily-docket and cancel hearing.
2. Go to Case details and see if Judge and date exist.
<img width="1143" alt="screen shot 2019-01-03 at 2 33 21 pm" src="https://user-images.githubusercontent.com/23080951/50657671-2f3ab180-0f65-11e9-877c-1249a8e4cd2f.png">


