### PR TITLE
delete decision issue when request issue is deleted

### DIFF
--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -27,6 +27,11 @@ class DecisionIssue < ApplicationRecord
     associated_request_issue&.issue_category
   end
 
+  def delete_on_removed_request_issue(request_issue_id)
+    # delete if the request issue is deleted and there are no other request issues associated
+    delete if request_issues.length == 1 && request_issues.first.id == request_issue_id
+  end
+
   private
 
   def associated_request_issue

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -27,9 +27,9 @@ class DecisionIssue < ApplicationRecord
     associated_request_issue&.issue_category
   end
 
-  def delete_on_removed_request_issue(request_issue_id)
-    # delete if the request issue is deleted and there are no other request issues associated
-    delete if request_issues.length == 1 && request_issues.first.id == request_issue_id
+  def destroy_on_removed_request_issue(request_issue_id)
+    # destroy if the request issue is deleted and there are no other request issues associated
+    destroy if request_issues.length == 1 && request_issues.first.id == request_issue_id
   end
 
   private

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -230,7 +230,7 @@ class RequestIssue < ApplicationRecord
 
     # removing a request issue also deletes the associated request_decision_issue
     # if the decision issue is not associated with any other request issue, also delete
-    decision_issues.each{ |decision_issue| decision_issue.destroy_on_removed_request_issue(id) }
+    decision_issues.each { |decision_issue| decision_issue.destroy_on_removed_request_issue(id) }
     decision_issues.delete_all
   end
 

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -222,6 +222,18 @@ class RequestIssue < ApplicationRecord
     eligible? && vacols_id && vacols_sequence_id
   end
 
+  # Instead of fully deleting removed issues, we instead strip them from the review so we can
+  # maintain a record of the other data that was on them incase we need to revert the update.
+  def remove_from_review
+    update!(review_request: nil)
+    legacy_issue_optin&.flag_for_rollback!
+
+    # removing a request issue also deletes the associated request_decision_issue
+    # if the decision issue is not associated with any other request issue, also delete
+    decision_issues.each { |decision_issue| decision_issue.delete_on_removed_request_issue(id) }
+    decision_issues.delete_all
+  end
+
   private
 
   def build_contested_issue

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -230,7 +230,7 @@ class RequestIssue < ApplicationRecord
 
     # removing a request issue also deletes the associated request_decision_issue
     # if the decision issue is not associated with any other request issue, also delete
-    decision_issues.each { |decision_issue| decision_issue.delete_on_removed_request_issue(id) }
+    decision_issues.each{ |decision_issue| decision_issue.destroy_on_removed_request_issue(id) }
     decision_issues.delete_all
   end
 

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -119,12 +119,7 @@ class RequestIssuesUpdate < ApplicationRecord
     LegacyOptinManager.new(decision_review: review).process!
   end
 
-  # Instead of fully deleting removed issues, we instead strip them from the review so we can
-  # maintain a record of the other data that was on them incase we need to revert the update.
   def strip_removed_issues!
-    removed_issues.each do |issue|
-      issue.update!(review_request: nil)
-      issue.legacy_issue_optin&.flag_for_rollback!
-    end
+    removed_issues.each(&:remove_from_review)
   end
 end


### PR DESCRIPTION
See https://dsva.slack.com/archives/C754H751T/p1546552804074900?thread_ts=1546545287.060900&cid=C754H751T

When a request issue is deleted, does the following:
1. deletes all of the request issue's associations from request_decision_issues table
2. deletes a decision issue if the decision issue has no other associated request issue
