### PR TITLE
Create non-comp LOB on demand

### DIFF
--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -26,9 +26,7 @@ class ClaimReviewController < ApplicationController
   end
 
   def claim_review
-    @claim_review ||=
-      source_type.constantize.find(url_claim_id) ||
-      EndProductEstablishment.find_by!(reference_id: url_claim_id, source_type: source_type).source
+    @claim_review ||= source_type.constantize.find_by_uuid_or_reference_id!(url_claim_id)
   end
 
   def url_claim_id

--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -27,6 +27,7 @@ class ClaimReviewController < ApplicationController
 
   def claim_review
     @claim_review ||=
+      source_type.constantize.find(url_claim_id) ||
       EndProductEstablishment.find_by!(reference_id: url_claim_id, source_type: source_type).source
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -64,7 +64,7 @@ class Appeal < DecisionReview
     )
   end
 
-  def edit_issues_url
+  def caseflow_only_edit_issues_url
     "/appeals/#{uuid}/edit"
   end
 

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -36,7 +36,7 @@ class ClaimReview < DecisionReview
     )
   end
 
-  def edit_issues_url
+  def caseflow_only_edit_issues_url
     "/#{self.class.to_s.underscore.pluralize}/#{uuid}/edit"
   end
 

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -19,6 +19,15 @@ class ClaimReview < DecisionReview
 
   class NoEndProductsRequired < StandardError; end
 
+  class << self
+    def find_by_uuid_or_reference_id!(claim_id)
+      claim_review = find_by(uuid: claim_id) ||
+                     EndProductEstablishment.find_by(reference_id: claim_id, source_type: to_s).source
+      fail ActiveRecord::RecordNotFound unless claim_review
+      claim_review
+    end
+  end
+
   def ui_hash
     super.merge(
       benefitType: benefit_type,

--- a/app/models/claim_review_intake.rb
+++ b/app/models/claim_review_intake.rb
@@ -41,7 +41,7 @@ class ClaimReviewIntake < DecisionReviewIntake
   def complete!(request_params)
     super(request_params) do
       detail.submit_for_processing!
-      detail.create_non_comp_task! if detail.non_comp?
+      detail.create_decision_review_task! if detail.caseflow_only?
       if run_async?
         DecisionReviewProcessJob.perform_later(detail)
       else

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -56,13 +56,13 @@ class DecisionReview < ApplicationRecord
     end
   end
 
-  def non_comp?
+  def caseflow_only?
     !ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE.include?(benefit_type)
   end
 
   def serialized_ratings
     return unless receipt_date
-    return if non_comp?
+    return if caseflow_only?
 
     cached_serialized_ratings.each do |rating|
       rating[:issues].each do |rating_issue_hash|
@@ -190,7 +190,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def contestable_issues
-    return contestable_issues_from_decision_issues if non_comp?
+    return contestable_issues_from_decision_issues if caseflow_only?
     contestable_issues_from_ratings + contestable_issues_from_decision_issues
   end
 

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -103,7 +103,7 @@ class DecisionReview < ApplicationRecord
       requestIssues: request_issues.map(&:ui_hash),
       activeNonratingRequestIssues: active_nonrating_request_issues.map(&:ui_hash),
       contestableIssuesByDate: contestable_issues.map(&:serialize),
-      editIssuesUrl: edit_issues_url
+      editIssuesUrl: caseflow_only_edit_issues_url
     }
   end
 

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -5,7 +5,7 @@ class DecisionReviewIntake < Intake
       claimant: detail.claimant_participant_id,
       veteran_is_not_claimant: detail.veteran_is_not_claimant,
       payeeCode: detail.payee_code,
-      nonComp: detail.non_comp?,
+      nonComp: detail.caseflow_only?,
       legacy_opt_in_approved: detail.legacy_opt_in_approved,
       legacyAppeals: detail.serialized_legacy_appeals,
       ratings: detail.serialized_ratings,

--- a/db/migrate/20190104163907_add_hlrscuuid.rb
+++ b/db/migrate/20190104163907_add_hlrscuuid.rb
@@ -1,0 +1,9 @@
+class AddHlrscuuid < ActiveRecord::Migration[5.1]
+  def change
+    # safe because our tables are currently small enough to risk the LOCK wait time.
+    safety_assured do
+      add_column :higher_level_reviews, :uuid, :uuid, null: false, default: 'uuid_generate_v4()'
+      add_column :supplemental_claims, :uuid, :uuid, null: false, default: 'uuid_generate_v4()'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190103200519) do
+ActiveRecord::Schema.define(version: 20190104163907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -462,6 +462,7 @@ ActiveRecord::Schema.define(version: 20190103200519) do
     t.string "establishment_error"
     t.boolean "legacy_opt_in_approved"
     t.boolean "veteran_is_not_claimant"
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["veteran_file_number"], name: "index_higher_level_reviews_on_veteran_file_number"
   end
 
@@ -786,6 +787,7 @@ ActiveRecord::Schema.define(version: 20190103200519) do
     t.string "establishment_error"
     t.boolean "legacy_opt_in_approved"
     t.boolean "veteran_is_not_claimant"
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["veteran_file_number"], name: "index_supplemental_claims_on_veteran_file_number"
   end
 

--- a/spec/controllers/higher_level_reviews_controller_spec.rb
+++ b/spec/controllers/higher_level_reviews_controller_spec.rb
@@ -1,0 +1,32 @@
+describe HigherLevelReviewsController, type: :controller do
+  before do
+    FeatureToggle.enable!(:intake)
+
+    User.stub = user
+    user.update(roles: user.roles << "Mail Intake")
+    Functions.grant!("Mail Intake", users: [user.css_id])
+  end
+
+  after do
+    FeatureToggle.disable!(:intake)
+  end
+
+  let(:hlr) { create(:higher_level_review, :with_end_product_establishment).reload }
+  let(:user) { create(:default_user) }
+
+  describe "#edit" do
+    it "finds by UUID" do
+      get :edit, params: { claim_id: hlr.uuid }
+
+      expect(response.status).to eq 200
+    end
+
+    it "finds by EPE reference_id" do
+      hlr.end_product_establishments.first.update!(reference_id: "abc123")
+
+      get :edit, params: { claim_id: hlr.end_product_establishments.first.reference_id }
+
+      expect(response.status).to eq 200
+    end
+  end
+end

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -76,7 +76,7 @@ feature "NonComp Dispositions Page" do
         visit dispositions_url
         click_on "Edit Issues"
 
-        expect(page).to have_current_path(hlr.reload.edit_issues_url)
+        expect(page).to have_current_path(hlr.reload.caseflow_only_edit_issues_url)
       end
     end
   end

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+feature "NonComp Dispositions Page" do
+  before do
+    FeatureToggle.enable!(:decision_reviews)
+  end
+
+  after do
+    FeatureToggle.disable!(:decision_reviews)
+  end
+
+  context "with an existing organization" do
+    let!(:non_comp_org) { create(:business_line, name: "Non-Comp Org", url: "nco") }
+
+    let(:user) { create(:default_user) }
+
+    let(:veteran) { create(:veteran) }
+
+    let(:epe) { create(:end_product_establishment, veteran_file_number: veteran.file_number) }
+
+    let(:hlr) do
+      create(
+        :higher_level_review,
+        end_product_establishments: [epe],
+        veteran_file_number: veteran.file_number
+      )
+    end
+
+    let(:request_issues) do
+      3.times do
+        create(:request_issue,
+               :nonrating,
+               end_product_establishment: epe,
+               veteran_participant_id: veteran.participant_id,
+               review_request: hlr)
+      end
+    end
+
+    let!(:in_progress_task) do
+      create(:higher_level_review_task, :in_progress, appeal: hlr, assigned_to: non_comp_org)
+    end
+
+    let!(:completed_task) do
+      create(:higher_level_review_task, :completed, appeal: hlr, assigned_to: non_comp_org)
+    end
+
+    let(:dispositions_url) { "decision_reviews/nco/tasks/#{in_progress_task.id}" }
+
+    before do
+      User.stub = user
+      OrganizationsUser.add_user_to_organization(user, non_comp_org)
+    end
+
+    scenario "displays dispositions page" do
+      visit dispositions_url
+
+      expect(page).to have_content("Non-Comp Org")
+      expect(page).to have_content("Decision")
+      expect(page).to have_content(veteran.name)
+    end
+
+    context "with user enabled for intake" do
+      before do
+        FeatureToggle.enable!(:intake)
+
+        # allow user to have access to intake
+        user.update(roles: user.roles << "Mail Intake")
+        Functions.grant!("Mail Intake", users: [user.css_id])
+      end
+
+      after do
+        FeatureToggle.disable!(:intake)
+      end
+
+      scenario "goes back to intake" do
+        visit dispositions_url
+        click_on "Edit Issues"
+
+        expect(page).to have_current_path(hlr.edit_issues_url)
+      end
+    end
+  end
+end

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -76,7 +76,7 @@ feature "NonComp Dispositions Page" do
         visit dispositions_url
         click_on "Edit Issues"
 
-        expect(page).to have_current_path(hlr.edit_issues_url)
+        expect(page).to have_current_path(hlr.reload.edit_issues_url)
       end
     end
   end

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -226,10 +226,10 @@ describe ClaimReview do
     end
   end
 
-  context "#non_comp?" do
+  context "#caseflow_only?" do
     let(:claim_review) { create(:higher_level_review, benefit_type: benefit_type) }
 
-    subject { claim_review.non_comp? }
+    subject { claim_review.caseflow_only? }
 
     context "when benefit_type is compensation" do
       let(:benefit_type) { "compensation" }

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -660,4 +660,18 @@ describe ClaimReview do
       end
     end
   end
+
+  describe ".find_by_uuid_or_reference_id!" do
+    let(:hlr) { create(:higher_level_review, :with_end_product_establishment).reload }
+
+    it "finds by UUID" do
+      expect(HigherLevelReview.find_by_uuid_or_reference_id!(hlr.uuid)).to eq(hlr)
+    end
+
+    it "finds by EPE reference_id" do
+      hlr.end_product_establishments.first.update!(reference_id: "abc123")
+
+      expect(HigherLevelReview.find_by_uuid_or_reference_id!("abc123")).to eq(hlr)
+    end
+  end
 end


### PR DESCRIPTION
connects #7990 

### Description
Uses a `BusinessLine` for each non-comp task assignment, creating it if necessary.

Also adds a UUID to HLR and SC tables so we can use that for URLs rather than an EPE (which will not exist for non-comp intakes).

