### PR TITLE
Add request issues columns with updated names

### DIFF
--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -93,6 +93,9 @@ class HigherLevelReview < ClaimReview
         rating_issue_reference_id: dta_decision_issue.rating_issue_reference_id,
         rating_issue_profile_date: dta_decision_issue.profile_date,
         description: dta_decision_issue.description,
+        contested_rating_issue_reference_id: dta_decision_issue.rating_issue_reference_id,
+        contested_rating_issue_profile_date: dta_decision_issue.profile_date,
+        contested_rating_issue_description: dta_decision_issue.description,
         issue_category: dta_decision_issue.issue_category,
         benefit_type: dta_decision_issue.benefit_type,
         decision_date: dta_decision_issue.approx_decision_date

--- a/db/migrate/20190104182112_add_contested_rating_issue_columns_to_request_issue.rb
+++ b/db/migrate/20190104182112_add_contested_rating_issue_columns_to_request_issue.rb
@@ -1,0 +1,8 @@
+class AddContestedRatingIssueColumnsToRequestIssue < ActiveRecord::Migration[5.1]
+  def change
+  	add_reference :request_issues, :decision_review, index: { name: "index_request_issues_on_decision_review_columns"}, polymorphic: true
+  	add_column :request_issues, :contested_rating_issue_reference_id, :string
+  	add_column :request_issues, :contested_rating_issue_profile_date, :string
+  	add_column :request_issues, :contested_rating_issue_description, :string
+  end
+end

--- a/db/migrate/20190104190600_add_contested_rating_issue_reference_id_index.rb
+++ b/db/migrate/20190104190600_add_contested_rating_issue_reference_id_index.rb
@@ -1,0 +1,5 @@
+class AddContestedRatingIssueReferenceIdIndex < ActiveRecord::Migration[5.1]
+  def change
+  	safety_assured { add_index(:request_issues, :contested_rating_issue_reference_id) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190103200519) do
+ActiveRecord::Schema.define(version: 20190104190600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -709,8 +709,15 @@ ActiveRecord::Schema.define(version: 20190103200519) do
     t.string "benefit_type"
     t.integer "contested_decision_issue_id"
     t.string "veteran_participant_id"
+    t.string "decision_review_type"
+    t.bigint "decision_review_id"
+    t.string "contested_rating_issue_reference_id"
+    t.string "contested_rating_issue_profile_date"
+    t.string "contested_rating_issue_description"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["contested_decision_issue_id"], name: "index_request_issues_on_contested_decision_issue_id"
+    t.index ["contested_rating_issue_reference_id"], name: "index_request_issues_on_contested_rating_issue_reference_id"
+    t.index ["decision_review_type", "decision_review_id"], name: "index_request_issues_on_decision_review_columns"
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["ineligible_due_to_id"], name: "index_request_issues_on_ineligible_due_to_id"
     t.index ["parent_request_issue_id"], name: "index_request_issues_on_parent_request_issue_id"


### PR DESCRIPTION
Part 1 of implementing proposals 1-4 of #8239

This just adds the columns and makes sure any new writes are split between the new and old columns.

Next up, I will migrate any old data, and we will change the reads from the old columns to the new columns.

connects #8239
connects #8518