### PR TITLE
Validation: blank regional office for CO hearings

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -5,6 +5,7 @@
 class HearingDay < ApplicationRecord
   acts_as_paranoid
   belongs_to :judge, class_name: "User"
+  validates :regional_office, absence: true, if: :central_office?
 
   HEARING_TYPES = {
     video: "V",
@@ -15,6 +16,10 @@ class HearingDay < ApplicationRecord
   # rubocop:disable Style/SymbolProc
   after_update { |hearing_day| hearing_day.update_children_records }
   # rubocop:enable Style/SymbolProc
+
+  def central_office?
+    hearing_type == HEARING_TYPES[:central]
+  end
 
   def update_children_records
     hearings = if hearing_type == HEARING_TYPES[:central]

--- a/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
+++ b/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
@@ -163,7 +163,7 @@ export class ListScheduleContainer extends React.Component {
 
     if (this.props.selectedRegionalOffice &&
         this.props.selectedRegionalOffice.value !== '' &&
-        this.props.hearingType.value !== "C") {
+        this.props.hearingType.value !== 'C') {
       data.regional_office = this.props.selectedRegionalOffice.value;
     }
 

--- a/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
+++ b/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
@@ -161,7 +161,9 @@ export class ListScheduleContainer extends React.Component {
       assign_room: this.props.roomRequired
     };
 
-    if (this.props.selectedRegionalOffice && this.props.selectedRegionalOffice.value !== '') {
+    if (this.props.selectedRegionalOffice &&
+        this.props.selectedRegionalOffice.value !== '' &&
+        this.props.hearingType.value !== "C") {
       data.regional_office = this.props.selectedRegionalOffice.value;
     }
 

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe HearingsController, type: :controller do
           hearing_type: "C",
           hearing_date: hearing_date,
           room: "123",
-          judge_id: "456",
-          regional_office: "RO18"
+          judge_id: "456"
         )
       end
 

--- a/spec/requests/hearing_day_spec.rb
+++ b/spec/requests/hearing_day_spec.rb
@@ -272,9 +272,9 @@ RSpec.describe "Hearing Schedule", type: :request do
     let!(:hearings) do
       RequestStore[:current_user] = user
       HearingDay.create(
-        [{ hearing_type: HearingDay::HEARING_TYPES[:central], hearing_date: "7-Jun-2019 09:00:00.000-4:00",
+        [{ hearing_type: HearingDay::HEARING_TYPES[:video], hearing_date: "7-Jun-2019 09:00:00.000-4:00",
            room: "1", regional_office: "RO17", created_by: "ramiro", updated_by: "ramiro" },
-         { hearing_type: HearingDay::HEARING_TYPES[:central], hearing_date: "9-Jun-2019 09:00:00.000-4:00",
+         { hearing_type: HearingDay::HEARING_TYPES[:video], hearing_date: "9-Jun-2019 09:00:00.000-4:00",
            room: "3", regional_office: "RO27", created_by: "ramiro", updated_by: "ramiro" }]
       )
       Generators::Vacols::TravelBoardSchedule.create(tbyear: 2019, tbstdate: "2019-01-30 00:00:00",
@@ -301,9 +301,9 @@ RSpec.describe "Hearing Schedule", type: :request do
       RequestStore[:current_user] = user
       Generators::Vacols::Staff.create(sattyid: "111")
       HearingDay.create(
-        [{ hearing_type: HearingDay::HEARING_TYPES[:central], hearing_date: "7-Mar-2019 09:00:00.000-4:00",
+        [{ hearing_type: HearingDay::HEARING_TYPES[:video], hearing_date: "7-Mar-2019 09:00:00.000-4:00",
            room: "1", regional_office: "RO04", created_by: "ramiro", updated_by: "ramiro" },
-         { hearing_type: HearingDay::HEARING_TYPES[:central], hearing_date: "9-Mar-2019 09:00:00.000-4:00",
+         { hearing_type: HearingDay::HEARING_TYPES[:video], hearing_date: "9-Mar-2019 09:00:00.000-4:00",
            room: "3", regional_office: "RO04", created_by: "ramiro", updated_by: "ramiro" }]
       )
     end


### PR DESCRIPTION
Resolves #8367 

### Description
This PR adds backend validation such that the regional office must be blank for CO hearings. It also updates the frontend code to only pass a regional office to the backend if the hearing type is not CO.

### Testing Plan
1. Go to the view schedule page
1. Click 'Add hearing day'
1. Choose video, choose an RO, then go back and choose CO
1. Confirm that the hearing day is created with no associated regional office
1. Create a video hearing day and confirm the regional office is properly set

