### PR TITLE
Use VACOLS task eager loading functionality for organizations

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -19,8 +19,7 @@ class Organizations::TasksController < OrganizationsController
 
   def json_tasks(tasks)
     ActiveModelSerializers::SerializableResource.new(
-      tasks,
-      each_serializer: ::WorkQueue::TaskSerializer,
+      AppealRepository.eager_load_legacy_appeals_for_tasks(tasks),
       user: current_user
     ).as_json
   end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -190,33 +190,9 @@ class TasksController < ApplicationController
     }
   end
 
-  def json_legacy_tasks(tasks, role)
-    ActiveModelSerializers::SerializableResource.new(
-      tasks,
-      each_serializer: ::WorkQueue::LegacyTaskSerializer,
-      role: role
-    ).as_json
-  end
-
-  def eager_load_legacy_appeals_for_tasks(tasks)
-    # Make a single request to VACOLS to grab all of the rows we want here?
-    legacy_appeal_ids = tasks.select { |t| t.appeal.is_a?(LegacyAppeal) }.map(&:appeal).pluck(:vacols_id)
-
-    # Load the VACOLS case records associated with legacy tasks into memory in a single batch.
-    cases = AppealRepository.vacols_records_for_appeals(legacy_appeal_ids) || []
-
-    # Associate the cases we pulled from VACOLS to the appeals of the tasks.
-    tasks.each do |t|
-      if t.appeal.is_a?(LegacyAppeal)
-        case_record = cases.select { |cr| cr.id == t.appeal.vacols_id }.first
-        AppealRepository.set_vacols_values(appeal: t.appeal, case_record: case_record) if case_record
-      end
-    end
-  end
-
   def json_tasks(tasks)
     ActiveModelSerializers::SerializableResource.new(
-      eager_load_legacy_appeals_for_tasks(tasks),
+      AppealRepository.eager_load_legacy_appeals_for_tasks(tasks),
       user: current_user,
       role: user_role
     ).as_json


### PR DESCRIPTION
Currently we cannot load the VLJ support staff team queue because it takes too long to load. This PR fixes that by using the VACOLS eager loading stuff we added in #8427 for normal `TasksController` in `Organizations::TasksController` as well.