### PR TITLE
Fix test data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -372,7 +372,7 @@ class SeedDB
     @ama_appeals << FactoryBot.create(
       :appeal,
       number_of_claimants: 1,
-      veteran_file_number: "231439628S",
+      veteran_file_number: "231439628",
       docket_type: "direct_review",
       request_issues: FactoryBot.create_list(:request_issue, 1, description: description, notes: notes)
     )


### PR DESCRIPTION
Resolves the bug noticed in [this slack thread](https://dsva.slack.com/archives/C6E41RE92/p1546960682007000).

This bug was caused by us creating two Veterans with effectively the same file number. The appeal factory [failed to peel off the trailing S](https://github.com/department-of-veterans-affairs/caseflow/blob/1ea47c1b65e1726c14adc9314c7a3117c9396fad/spec/factories/appeal.rb#L11) so they were not in fact connect to the same Veteran file. And since the search functionality [strips letters from file numbers](https://github.com/department-of-veterans-affairs/caseflow/blob/1ea47c1b65e1726c14adc9314c7a3117c9396fad/client/app/queue/CaseList/CaseListActions.js#L79) we did not return the full set of appeals for the ID we searched for.