### PR TITLE
Case Details -> Hearing Worksheet Link

### DIFF
--- a/app/models/serializers/work_queue/legacy_appeal_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_serializer.rb
@@ -23,7 +23,7 @@ class WorkQueue::LegacyAppealSerializer < ActiveModel::Serializer
         viewed_by_judge: !hearing.hearing_views.empty?,
         date: hearing.date,
         type: hearing.type,
-        id: hearing.id,
+        external_id: hearing.external_id,
         disposition: hearing.disposition
       }
     end

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -86,7 +86,9 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
       _.extend(hearingElementsStyle, marginLeft);
     }
 
-    const hearingElements = _.map(uniqueOrderedHearings, (hearing) => <div key={hearing.id} {...hearingElementsStyle}>
+    const hearingElements = _.map(uniqueOrderedHearings, (hearing) => <div
+      key={hearing.externalId} {...hearingElementsStyle}
+    >
       <span {...boldText}>Hearing{uniqueOrderedHearings.length > 1 ?
         ` ${uniqueOrderedHearings.indexOf(hearing) + 1}` : ''}:</span>
       <BareList compact

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -54,7 +54,7 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
         {hearing.disposition && StringUtil.snakeCaseToCapitalized(hearing.disposition)}&nbsp;&nbsp;
         {hearing.viewedByJudge &&
         <Tooltip id="hearing-worksheet-tip" text={COPY.CASE_DETAILS_HEARING_WORKSHEET_LINK_TOOLTIP}>
-          <Link rel="noopener" target="_blank" href={`/hearings/${hearing.id}/worksheet/print?keep_open=true`}>
+          <Link rel="noopener" target="_blank" href={`/hearings/${hearing.external_id}/worksheet/print?keep_open=true`}>
             {COPY.CASE_DETAILS_HEARING_WORKSHEET_LINK_COPY}
           </Link>
         </Tooltip>}

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -54,7 +54,7 @@ class CaseHearingsDetail extends React.PureComponent<Params> {
         {hearing.disposition && StringUtil.snakeCaseToCapitalized(hearing.disposition)}&nbsp;&nbsp;
         {hearing.viewedByJudge &&
         <Tooltip id="hearing-worksheet-tip" text={COPY.CASE_DETAILS_HEARING_WORKSHEET_LINK_TOOLTIP}>
-          <Link rel="noopener" target="_blank" href={`/hearings/${hearing.external_id}/worksheet/print?keep_open=true`}>
+          <Link rel="noopener" target="_blank" href={`/hearings/${hearing.externalId}/worksheet/print?keep_open=true`}>
             {COPY.CASE_DETAILS_HEARING_WORKSHEET_LINK_COPY}
           </Link>
         </Tooltip>}

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -105,7 +105,7 @@ export type Hearing = {
   viewedByJudge: boolean,
   date: string,
   type: string,
-  id: string,
+  externalId: string,
   disposition: string
 };
 

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -214,7 +214,7 @@ export const prepareAppealHearingsForStore = (appeal: { attributes: Object }) =>
     viewedByJudge: hearing.viewed_by_judge,
     date: hearing.date,
     type: hearing.type,
-    id: hearing.id,
+    externalId: hearing.external_id,
     disposition: hearing.disposition
   }));
 

--- a/client/app/reader/utils.js
+++ b/client/app/reader/utils.js
@@ -132,7 +132,7 @@ export const getHearingWorksheetLink = (hearings) => {
       {hearings.map((hearing, key) => {
         return <div>
           <a target="_blank"
-            href={`/hearings/${hearing.id}/worksheet/print?keep_open=true`}
+            href={`/hearings/${hearing.external_id}/worksheet/print?keep_open=true`}
             key={key}>Hearing Worksheet</a>
         </div>;
       })}

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature "Case details" do
         visit "/queue"
         page.find(:xpath, "//tr[@id='table-row-#{appeal.vacols_id}']/td[1]/a").click
 
-        worksheet_link = page.find("a[href='/hearings/#{hearing.id}/worksheet/print?keep_open=true']")
+        worksheet_link = page.find("a[href='/hearings/#{hearing.external_id}/worksheet/print?keep_open=true']")
         expect(worksheet_link.text).to eq("View Hearing Worksheet")
       end
     end


### PR DESCRIPTION
We updated the hearing worksheet link to use vacols_ids for legacy appeals and uuids for ama appeals, but we forgot to update the link from the case details page. This PR updates the case details page link.

