### PR TITLE
Serializer updates

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearings.jsx
+++ b/client/app/hearingSchedule/components/AssignHearings.jsx
@@ -154,13 +154,13 @@ export default class AssignHearings extends React.Component {
     return _.map(appeals, (appeal) => ({
       caseDetails: this.getCaseDetailsInformation(appeal),
       type: renderAppealType({
-        caseType: appeal.attributes.type,
+        caseType: appeal.attributes.caseType,
         isAdvancedOnDocket: appeal.attributes.aod
       }),
       docketNumber: this.getAppealDocketTag(appeal),
       location: this.getAppealLocation(appeal),
       time: null,
-      externalId: appeal.attributes.externalId
+      externalId: appeal.attributes.externalAppealId
     }));
   };
 


### PR DESCRIPTION
This PR updates the assign hearings page such that the appealExternalId and the caseType are correctly mapped in the table.

