### PR TITLE
Read from new rating issue description columns

### DIFF
--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -18,7 +18,7 @@ class BoardGrantEffectuation < ApplicationRecord
   }.freeze
 
   def contention_text
-    granted_decision_issue.formatted_description
+    granted_decision_issue.description
   end
 
   private

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -139,10 +139,6 @@ class ClaimReview < DecisionReview
     end_product_establishments.any? { |ep| ep.status_cleared?(sync: true) }
   end
 
-  def find_request_issue_by_description(description)
-    request_issues.find { |reqi| reqi.description == description }
-  end
-
   private
 
   def informal_conference?

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -24,7 +24,7 @@ class ContestableIssue
         rating_issue_profile_date: decision_issue.profile_date.try(:to_date),
         decision_issue_id: decision_issue.id,
         date: decision_issue.approx_decision_date,
-        description: decision_issue.formatted_description,
+        description: decision_issue.description,
         source_request_issue: decision_issue,
         contesting_decision_review: contesting_decision_review
       )

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -10,6 +10,9 @@ class DecisionIssue < ApplicationRecord
   belongs_to :decision_review, polymorphic: true
   has_one :effectuation, class_name: "BoardGrantEffectuation", foreign_key: :granted_decision_issue_id
 
+  # Attorneys will be entering in a description of the decision manually for appeals
+  before_save :calculate_and_set_description, unless: :appeal?
+
   def self.granted
     # TODO: "allowed" is the disposition for BVA grants, not necessarily the disposition for granted HLRs and SCs
     #       we need to add that
@@ -18,12 +21,6 @@ class DecisionIssue < ApplicationRecord
 
   def approx_decision_date
     profile_date ? profile_date.to_date : end_product_last_action_date
-  end
-
-  def formatted_description
-    return description if description
-
-    (associated_request_issue&.nonrating?) ? nonrating_description : rating_description
   end
 
   def issue_category
@@ -43,20 +40,21 @@ class DecisionIssue < ApplicationRecord
 
   private
 
+  def calculate_and_set_description
+    self.description ||= calculate_description
+  end
+
+  def calculate_description
+    return decision_text if decision_text
+    return nil unless associated_request_issue
+
+    "#{disposition}: #{associated_request_issue.description}"
+  end
+
   def associated_request_issue
     return unless request_issues.any?
 
     request_issues.first
-  end
-
-  def nonrating_description
-    "#{disposition}: #{issue_category} - #{associated_request_issue.description}"
-  end
-
-  def rating_description
-    return decision_text unless associated_request_issue&.notes
-
-    "#{decision_text}. Notes: #{associated_request_issue.notes}"
   end
 
   def appeal?

--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -92,7 +92,6 @@ class HigherLevelReview < ClaimReview
         # parent_request_issue_id: dta_issue.id, delete this from table
         rating_issue_reference_id: dta_decision_issue.rating_issue_reference_id,
         rating_issue_profile_date: dta_decision_issue.profile_date.to_s,
-        description: dta_decision_issue.description,
         contested_rating_issue_reference_id: dta_decision_issue.rating_issue_reference_id,
         contested_rating_issue_profile_date: dta_decision_issue.profile_date,
         contested_issue_description: dta_decision_issue.description,

--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -95,7 +95,7 @@ class HigherLevelReview < ClaimReview
         description: dta_decision_issue.description,
         contested_rating_issue_reference_id: dta_decision_issue.rating_issue_reference_id,
         contested_rating_issue_profile_date: dta_decision_issue.profile_date,
-        contested_rating_issue_description: dta_decision_issue.description,
+        contested_issue_description: dta_decision_issue.description,
         issue_category: dta_decision_issue.issue_category,
         benefit_type: dta_decision_issue.benefit_type,
         decision_date: dta_decision_issue.approx_decision_date

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -112,15 +112,22 @@ class RequestIssue < ApplicationRecord
 
     private
 
+    # rubocop:disable Metrics/MethodLength
     def attributes_from_intake_data(data)
+      contested_issue_present = data[:rating_issue_reference_id] || data[:contested_decision_issue_id]
+
       {
         # TODO: these are going away in favor of `contested_rating_issue_*`
         rating_issue_reference_id: data[:rating_issue_reference_id],
         rating_issue_profile_date: data[:rating_issue_profile_date],
+
         description: data[:decision_text],
 
         contested_rating_issue_reference_id: data[:rating_issue_reference_id],
-        contested_rating_issue_description: data[:decision_text],
+
+        contested_issue_description: contested_issue_present ? data[:decision_text] : nil,
+        nonrating_issue_description: data[:issue_category] ? data[:decision_text] : nil,
+        unidentified_issue_text: data[:is_unidentified] ? data[:decision_text] : nil,
 
         decision_date: data[:decision_date],
         issue_category: data[:issue_category],
@@ -137,6 +144,7 @@ class RequestIssue < ApplicationRecord
       }
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def status_active?
     return appeal_active? if review_request.is_a?(Appeal)

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -111,6 +111,7 @@ class RequestIssue < ApplicationRecord
 
     private
 
+    # rubocop:disable Metrics/MethodLength
     def attributes_from_intake_data(data)
       contested_issue_present = data[:rating_issue_reference_id] || data[:contested_decision_issue_id]
 
@@ -136,6 +137,7 @@ class RequestIssue < ApplicationRecord
         ineligible_due_to_id: data[:ineligible_due_to_id]
       }
     end
+    # rubocop:enable Metrics/MethodLength
   end
 
   def status_active?

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -85,8 +85,7 @@ class RequestIssue < ApplicationRecord
     end
 
     def find_or_build_from_intake_data(data)
-      # request issues on edit have ids
-      # but newly added issues do not
+      # request issues on edit have ids but newly added issues do not
       data[:request_issue_id] ? find(data[:request_issue_id]) : from_intake_data(data)
     end
 
@@ -154,7 +153,7 @@ class RequestIssue < ApplicationRecord
   #       nonrating. Currently it won't be because we don't copy over these fields from the contested
   #       decision issue if they are present.
   def nonrating?
-    issue_category && decision_date
+    !!issue_category
   end
 
   def description

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -201,7 +201,7 @@ const formatRatingRequestIssues = (state) => {
         ramp_claim_id: issue.rampClaimId,
         vacols_id: issue.vacolsId,
         vacols_sequence_id: issue.vacolsSequenceId,
-        contested_decision_isssue_id: issue.decisionIssueId,
+        contested_decision_issue_id: issue.decisionIssueId,
         ineligible_reason: issue.ineligibleReason,
         ineligible_due_to_id: issue.ineligibleDueToId
       };
@@ -212,7 +212,7 @@ const formatNonratingRequestIssues = (state) => {
   return (state.addedIssues || []).filter((issue) => !issue.isRating && !issue.isUnidentified).map((issue) => {
     return {
       request_issue_id: issue.id,
-      contested_decision_isssue_id: issue.decisionIssueId,
+      contested_decision_issue_id: issue.decisionIssueId,
       issue_category: issue.category,
       decision_text: issue.description,
       decision_date: formatDateStringForApi(issue.decisionDate),
@@ -336,7 +336,7 @@ export const formatAddedIssues = (intakeData, useAmaActivationDate = false) => {
     // returns nonrating request issue format
     return {
       referenceId: issue.id,
-      text: `${issue.category} - ${issue.description}`,
+      text: issue.decisionIssueId ? issue.description : `${issue.category} - ${issue.description}`,
       date: formatDate(issue.decisionDate),
       timely: issue.timely,
       beforeAma: decisionDate < amaActivationDate,

--- a/db/migrate/20190107210543_add_request_issue_description_columns.rb
+++ b/db/migrate/20190107210543_add_request_issue_description_columns.rb
@@ -1,0 +1,8 @@
+class AddRequestIssueDescriptionColumns < ActiveRecord::Migration[5.1]
+  def change
+  	remove_column :request_issues, :contested_rating_issue_description, :string
+  	add_column :request_issues, :contested_issue_description, :string
+  	add_column :request_issues, :nonrating_issue_description, :string
+  	add_column :request_issues, :unidentified_issue_text, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190107161740) do
+ActiveRecord::Schema.define(version: 20190107210543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -740,12 +740,14 @@ ActiveRecord::Schema.define(version: 20190107161740) do
     t.string "benefit_type", null: false
     t.integer "contested_decision_issue_id"
     t.string "veteran_participant_id"
-    t.string "contested_rating_issue_diagnostic_code"
     t.string "decision_review_type"
     t.bigint "decision_review_id"
     t.string "contested_rating_issue_reference_id"
     t.string "contested_rating_issue_profile_date"
-    t.string "contested_rating_issue_description"
+    t.string "contested_rating_issue_diagnostic_code"
+    t.string "contested_issue_description"
+    t.string "nonrating_issue_description"
+    t.string "unidentified_issue_text"
     t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
     t.index ["contested_decision_issue_id"], name: "index_request_issues_on_contested_decision_issue_id"
     t.index ["contested_rating_issue_reference_id"], name: "index_request_issues_on_contested_rating_issue_reference_id"

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -34,7 +34,10 @@ FactoryBot.define do
                                 benefit_type: request_issue.review_request.benefit_type,
                                 decision_text: "a rating decision issue",
                                 request_issues: [request_issue])
-        request_issue.update!(contested_decision_issue_id: decision_issue.id)
+        request_issue.update!(
+          contested_decision_issue_id: decision_issue.id,
+          contested_issue_description: decision_issue.description
+        )
       end
     end
 
@@ -52,7 +55,10 @@ FactoryBot.define do
                                 end_product_last_action_date: request_issue.decision_date,
                                 disposition: "nonrating decision issue dispositon",
                                 request_issues: [request_issue])
-        request_issue.update!(contested_decision_issue_id: decision_issue.id)
+        request_issue.update!(
+          contested_decision_issue_id: decision_issue.id,
+          contested_issue_description: decision_issue.description
+        )
       end
     end
 

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -190,7 +190,6 @@ feature "Appeal Intake" do
       contested_rating_issue_reference_id: "def456",
       contested_rating_issue_profile_date: profile_date.to_s,
       contested_issue_description: "PTSD denied",
-      description: "PTSD denied",
       decision_date: nil,
       benefit_type: "compensation"
     )
@@ -199,7 +198,6 @@ feature "Appeal Intake" do
       contested_rating_issue_reference_id: nil,
       contested_rating_issue_profile_date: nil,
       issue_category: "Active Duty Adjustments",
-      description: "Description for Active Duty Adjustments",
       nonrating_issue_description: "Description for Active Duty Adjustments",
       benefit_type: "compensation"
     )
@@ -353,8 +351,7 @@ feature "Appeal Intake" do
       :request_issue,
       end_product_establishment: epe,
       contested_rating_issue_reference_id: duplicate_reference_id,
-      contested_issue_description: "Old injury",
-      description: "Old injury"
+      contested_issue_description: "Old injury"
     )
 
     appeal, = start_appeal(veteran)
@@ -517,14 +514,12 @@ feature "Appeal Intake" do
              review_request: appeal,
              contested_rating_issue_reference_id: "xyz123",
              contested_issue_description: "Left knee granted 2",
-             description: "Left knee granted 2",
              notes: "I am an issue note"
            )).to_not be_nil
 
     expect(RequestIssue.find_by(
              review_request: appeal,
              contested_issue_description: "Really old injury",
-             description: "Really old injury",
              untimely_exemption: false,
              untimely_exemption_notes: "I am an exemption note"
            )).to_not be_nil
@@ -533,7 +528,6 @@ feature "Appeal Intake" do
       review_request: appeal,
       issue_category: "Active Duty Adjustments",
       nonrating_issue_description: "Description for Active Duty Adjustments",
-      description: "Description for Active Duty Adjustments",
       decision_date: profile_date
     )
 
@@ -543,8 +537,7 @@ feature "Appeal Intake" do
       review_request_type: "Appeal",
       review_request_id: appeal.id,
       issue_category: "Active Duty Adjustments",
-      nonrating_issue_description: "Another Description for Active Duty Adjustments",
-      description: "Another Description for Active Duty Adjustments"
+      nonrating_issue_description: "Another Description for Active Duty Adjustments"
     )
 
     expect(another_active_duty_adjustments_request_issue.untimely?).to eq(true)
@@ -561,14 +554,12 @@ feature "Appeal Intake" do
     expect(RequestIssue.find_by(
              review_request: appeal,
              contested_issue_description: "Non-RAMP Issue before AMA Activation",
-             description: "Non-RAMP Issue before AMA Activation",
              ineligible_reason: :before_ama
            )).to_not be_nil
 
     expect(RequestIssue.find_by(
              review_request: appeal,
              contested_issue_description: "Issue before AMA Activation from RAMP",
-             description: "Issue before AMA Activation from RAMP",
              ineligible_reason: nil,
              ramp_claim_id: "ramp_claim_id"
            )).to_not be_nil
@@ -576,14 +567,12 @@ feature "Appeal Intake" do
     expect(RequestIssue.find_by(
              review_request: appeal,
              nonrating_issue_description: "A nonrating issue before AMA",
-             description: "A nonrating issue before AMA",
              ineligible_reason: :before_ama
            )).to_not be_nil
 
     expect(RequestIssue.find_by(
              review_request: appeal,
              nonrating_issue_description: "A nonrating issue before AMA",
-             description: "A nonrating issue before AMA",
              decision_date: pre_ramp_start_date
            )).to_not be_nil
 
@@ -639,10 +628,7 @@ feature "Appeal Intake" do
 
       expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
       expect(
-        RequestIssue.find_by(
-          contested_issue_description: "appeal decision issue",
-          description: "appeal decision issue"
-        ).ineligible_reason
+        RequestIssue.find_by(contested_issue_description: "appeal decision issue").ineligible_reason
       ).to eq("appeal_to_appeal")
       ineligible_checklist = find("ul.cf-ineligible-checklist")
       expect(ineligible_checklist).to have_content(
@@ -765,7 +751,6 @@ feature "Appeal Intake" do
         )
 
         expect(RequestIssue.find_by(
-                 description: "Left knee granted",
                  contested_issue_description: "Left knee granted",
                  ineligible_reason: :legacy_appeal_not_eligible,
                  vacols_id: "vacols2",
@@ -802,7 +787,6 @@ feature "Appeal Intake" do
         )
 
         expect(RequestIssue.find_by(
-                 description: "Left knee granted",
                  contested_issue_description: "Left knee granted",
                  ineligible_reason: :legacy_issue_not_withdrawn,
                  vacols_id: "vacols1",

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -189,6 +189,7 @@ feature "Appeal Intake" do
     expect(rating_request_issue).to have_attributes(
       contested_rating_issue_reference_id: "def456",
       contested_rating_issue_profile_date: profile_date.to_s,
+      contested_issue_description: "PTSD denied",
       description: "PTSD denied",
       decision_date: nil,
       benefit_type: "compensation"
@@ -199,6 +200,7 @@ feature "Appeal Intake" do
       contested_rating_issue_profile_date: nil,
       issue_category: "Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
+      nonrating_issue_description: "Description for Active Duty Adjustments",
       benefit_type: "compensation"
     )
     expect(nonrating_request_issue.decision_date.to_date).to eq(profile_date.to_date)
@@ -351,6 +353,7 @@ feature "Appeal Intake" do
       :request_issue,
       end_product_establishment: epe,
       contested_rating_issue_reference_id: duplicate_reference_id,
+      contested_issue_description: "Old injury",
       description: "Old injury"
     )
 
@@ -513,12 +516,14 @@ feature "Appeal Intake" do
     expect(RequestIssue.find_by(
              review_request: appeal,
              contested_rating_issue_reference_id: "xyz123",
+             contested_issue_description: "Left knee granted 2",
              description: "Left knee granted 2",
              notes: "I am an issue note"
            )).to_not be_nil
 
     expect(RequestIssue.find_by(
              review_request: appeal,
+             contested_issue_description: "Really old injury",
              description: "Really old injury",
              untimely_exemption: false,
              untimely_exemption_notes: "I am an exemption note"
@@ -527,6 +532,7 @@ feature "Appeal Intake" do
     active_duty_adjustments_request_issue = RequestIssue.find_by!(
       review_request: appeal,
       issue_category: "Active Duty Adjustments",
+      nonrating_issue_description: "Description for Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
       decision_date: profile_date
     )
@@ -537,6 +543,7 @@ feature "Appeal Intake" do
       review_request_type: "Appeal",
       review_request_id: appeal.id,
       issue_category: "Active Duty Adjustments",
+      nonrating_issue_description: "Another Description for Active Duty Adjustments",
       description: "Another Description for Active Duty Adjustments"
     )
 
@@ -546,19 +553,21 @@ feature "Appeal Intake" do
 
     expect(RequestIssue.find_by(
              review_request: appeal,
-             description: "This is an unidentified issue",
+             unidentified_issue_text: "This is an unidentified issue",
              is_unidentified: true
            )).to_not be_nil
 
     # Issues before AMA
     expect(RequestIssue.find_by(
              review_request: appeal,
+             contested_issue_description: "Non-RAMP Issue before AMA Activation",
              description: "Non-RAMP Issue before AMA Activation",
              ineligible_reason: :before_ama
            )).to_not be_nil
 
     expect(RequestIssue.find_by(
              review_request: appeal,
+             contested_issue_description: "Issue before AMA Activation from RAMP",
              description: "Issue before AMA Activation from RAMP",
              ineligible_reason: nil,
              ramp_claim_id: "ramp_claim_id"
@@ -566,12 +575,14 @@ feature "Appeal Intake" do
 
     expect(RequestIssue.find_by(
              review_request: appeal,
+             nonrating_issue_description: "A nonrating issue before AMA",
              description: "A nonrating issue before AMA",
              ineligible_reason: :before_ama
            )).to_not be_nil
 
     expect(RequestIssue.find_by(
              review_request: appeal,
+             nonrating_issue_description: "A nonrating issue before AMA",
              description: "A nonrating issue before AMA",
              decision_date: pre_ramp_start_date
            )).to_not be_nil
@@ -627,7 +638,12 @@ feature "Appeal Intake" do
       click_intake_finish
 
       expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
-      expect(RequestIssue.find_by(description: "appeal decision issue").ineligible_reason).to eq("appeal_to_appeal")
+      expect(
+        RequestIssue.find_by(
+          contested_issue_description: "appeal decision issue",
+          description: "appeal decision issue"
+        ).ineligible_reason
+      ).to eq("appeal_to_appeal")
       ineligible_checklist = find("ul.cf-ineligible-checklist")
       expect(ineligible_checklist).to have_content(
         "appeal decision issue #{Constants.INELIGIBLE_REQUEST_ISSUES.appeal_to_appeal}"
@@ -750,6 +766,7 @@ feature "Appeal Intake" do
 
         expect(RequestIssue.find_by(
                  description: "Left knee granted",
+                 contested_issue_description: "Left knee granted",
                  ineligible_reason: :legacy_appeal_not_eligible,
                  vacols_id: "vacols2",
                  vacols_sequence_id: "1"
@@ -786,6 +803,7 @@ feature "Appeal Intake" do
 
         expect(RequestIssue.find_by(
                  description: "Left knee granted",
+                 contested_issue_description: "Left knee granted",
                  ineligible_reason: :legacy_issue_not_withdrawn,
                  vacols_id: "vacols1",
                  vacols_sequence_id: "1"

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -386,12 +386,12 @@ feature "Edit issues" do
     # check that new request issue is created contesting the decision issue
     expect(RequestIssue.find_by(review_request: review_request,
                                 contested_decision_issue_id: contested_decision_issues.first.id,
-                                description: contested_decision_issues.first.formatted_description)).to_not be_nil
+                                description: contested_decision_issues.first.description)).to_not be_nil
 
     expect(RequestIssue.find_by(review_request: review_request,
                                 contested_decision_issue_id: contested_decision_issues.second.id,
                                 ineligible_reason: :duplicate_of_rating_issue_in_active_review,
-                                description: contested_decision_issues.second.formatted_description)).to_not be_nil
+                                description: contested_decision_issues.second.description)).to_not be_nil
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -391,7 +391,7 @@ feature "Edit issues" do
     )
 
     expect(second_request_issue).to have_attributes(
-      ineligible_reason: :duplicate_of_rating_issue_in_active_review,
+      ineligible_reason: "duplicate_of_rating_issue_in_active_review",
       contested_issue_description: contested_decision_issues.second.description
     )
   end

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -382,23 +382,20 @@ feature "Edit issues" do
     expect(updated_request_issue.review_request).to be_nil
 
     # check that new request issue is created contesting the decision issue
-    expect(
-      RequestIssue.find_by(
-        review_request: review_request,
-        contested_decision_issue_id: contested_decision_issues.first.id,
-        contested_issue_description: contested_decision_issues.first.description
-      )
-    ).to_not be_nil
+    request_issues = review_request.reload.request_issues
+    first_request_issue = request_issues.find_by(contested_decision_issue_id: contested_decision_issues.first.id)
+    second_request_issue = request_issues.find_by(contested_decision_issue_id: contested_decision_issues.second.id)
 
-    expect(
-      RequestIssue.find_by(
-        review_request: review_request,
-        contested_decision_issue_id: contested_decision_issues.second.id,
-        ineligible_reason: :duplicate_of_rating_issue_in_active_review,
-        contested_issue_description: contested_decision_issues.second.description
-      )
-    ).to_not be_nil
+    expect(first_request_issue).to have_attributes(
+      contested_issue_description: contested_decision_issues.first.description
+    )
+
+    expect(second_request_issue).to have_attributes(
+      ineligible_reason: :duplicate_of_rating_issue_in_active_review,
+      contested_issue_description: contested_decision_issues.second.description
+    )
   end
+
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 

--- a/spec/feature/intake/edit_spec.rb
+++ b/spec/feature/intake/edit_spec.rb
@@ -103,7 +103,7 @@ feature "Edit issues" do
       {
         review_request: appeal,
         issue_category: "Military Retired Pay",
-        description: "nonrating description",
+        nonrating_issue_description: "nonrating description",
         contention_reference_id: "1234",
         decision_date: 1.month.ago
       }
@@ -116,7 +116,7 @@ feature "Edit issues" do
         review_request: appeal,
         contested_rating_issue_reference_id: "def456",
         contested_rating_issue_profile_date: profile_date,
-        description: "PTSD denied",
+        contested_issue_description: "PTSD denied",
         contention_reference_id: "4567"
       }
     end
@@ -246,14 +246,14 @@ feature "Edit issues" do
           expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
 
           expect(RequestIssue.find_by(
-                   description: "Left knee granted",
+                   contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_appeal_not_eligible,
                    vacols_id: "vacols2",
                    vacols_sequence_id: "1"
                  )).to_not be_nil
 
           ri_with_optin = RequestIssue.find_by(
-            description: "Back pain",
+            contested_issue_description: "Back pain",
             ineligible_reason: nil,
             vacols_id: "vacols1",
             vacols_sequence_id: "1"
@@ -305,7 +305,7 @@ feature "Edit issues" do
           expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
 
           expect(RequestIssue.find_by(
-                   description: "Left knee granted",
+                   contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_issue_not_withdrawn,
                    vacols_id: "vacols1",
                    vacols_sequence_id: "1"
@@ -342,8 +342,7 @@ feature "Edit issues" do
     expect(page).to have_css("input[disabled]", visible: false)
     expect(page).to have_content("PTSD denied (already selected for")
 
-    nonrating_decision_issue_description = "nonrating decision issue dispositon: " \
-                                           "Active Duty Adjustments - Test nonrating decision issue"
+    nonrating_decision_issue_description = "nonrating decision issue"
     rating_decision_issue_description = "a rating decision issue"
     # check that nonrating and rating decision issues show up
 
@@ -356,7 +355,6 @@ feature "Edit issues" do
     click_remove_issue_confirmation
 
     # add new decision issue
-
     click_intake_add_issue
     add_intake_rating_issue(rating_decision_issue_description)
     expect(page).to have_content(rating_decision_issue_description)
@@ -384,14 +382,22 @@ feature "Edit issues" do
     expect(updated_request_issue.review_request).to be_nil
 
     # check that new request issue is created contesting the decision issue
-    expect(RequestIssue.find_by(review_request: review_request,
-                                contested_decision_issue_id: contested_decision_issues.first.id,
-                                description: contested_decision_issues.first.description)).to_not be_nil
+    expect(
+      RequestIssue.find_by(
+        review_request: review_request,
+        contested_decision_issue_id: contested_decision_issues.first.id,
+        contested_issue_description: contested_decision_issues.first.description
+      )
+    ).to_not be_nil
 
-    expect(RequestIssue.find_by(review_request: review_request,
-                                contested_decision_issue_id: contested_decision_issues.second.id,
-                                ineligible_reason: :duplicate_of_rating_issue_in_active_review,
-                                description: contested_decision_issues.second.description)).to_not be_nil
+    expect(
+      RequestIssue.find_by(
+        review_request: review_request,
+        contested_decision_issue_id: contested_decision_issues.second.id,
+        ineligible_reason: :duplicate_of_rating_issue_in_active_review,
+        contested_issue_description: contested_decision_issues.second.description
+      )
+    ).to_not be_nil
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
@@ -499,7 +505,7 @@ feature "Edit issues" do
         RequestIssue.create!(
           review_request: higher_level_review,
           issue_category: "Military Retired Pay",
-          description: "eligible nonrating description",
+          nonrating_issue_description: "eligible nonrating description",
           contention_reference_id: "1234",
           ineligible_reason: nil,
           benefit_type: "compensation",
@@ -511,7 +517,7 @@ feature "Edit issues" do
         RequestIssue.create!(
           review_request: higher_level_review,
           issue_category: "Active Duty Adjustments",
-          description: "untimely nonrating description",
+          nonrating_issue_description: "untimely nonrating description",
           contention_reference_id: "12345",
           benefit_type: "compensation",
           ineligible_reason: :untimely
@@ -523,7 +529,7 @@ feature "Edit issues" do
           contested_rating_issue_reference_id: "def456",
           contested_rating_issue_profile_date: rating.profile_date,
           review_request: another_higher_level_review,
-          description: "PTSD denied",
+          contested_issue_description: "PTSD denied",
           contention_reference_id: "123",
           benefit_type: "compensation",
           ineligible_reason: nil,
@@ -536,7 +542,7 @@ feature "Edit issues" do
           contested_rating_issue_reference_id: "def456",
           contested_rating_issue_profile_date: rating.profile_date,
           review_request: higher_level_review,
-          description: "PTSD denied",
+          contested_issue_description: "PTSD denied",
           contention_reference_id: "111",
           ineligible_reason: :duplicate_of_rating_issue_in_active_review,
           benefit_type: "compensation",
@@ -550,7 +556,7 @@ feature "Edit issues" do
           contested_rating_issue_profile_date: rating.profile_date,
           review_request: another_higher_level_review,
           benefit_type: "compensation",
-          description: "Left knee granted",
+          contested_issue_description: "Left knee granted",
           contention_reference_id: 55
         )
       end
@@ -560,7 +566,7 @@ feature "Edit issues" do
           contested_rating_issue_reference_id: "abc123",
           contested_rating_issue_profile_date: rating.profile_date,
           review_request: higher_level_review,
-          description: "Left knee granted",
+          contested_issue_description: "Left knee granted",
           benefit_type: "compensation",
           ineligible_reason: :higher_level_review_to_higher_level_review,
           ineligible_due_to: ri_previous_hlr
@@ -573,7 +579,7 @@ feature "Edit issues" do
           contested_rating_issue_profile_date: rating_before_ama.profile_date,
           review_request: higher_level_review,
           benefit_type: "compensation",
-          description: "Non-RAMP Issue before AMA Activation",
+          contested_issue_description: "Non-RAMP Issue before AMA Activation",
           contention_reference_id: "12345",
           ineligible_reason: :before_ama
         )
@@ -585,7 +591,7 @@ feature "Edit issues" do
           contested_rating_issue_profile_date: rating_before_ama_from_ramp.profile_date,
           review_request: higher_level_review,
           benefit_type: "compensation",
-          description: "Issue before AMA Activation from RAMP",
+          contested_issue_description: "Issue before AMA Activation from RAMP",
           contention_reference_id: "123456",
           ramp_claim_id: "ramp_claim_id"
         )
@@ -596,7 +602,7 @@ feature "Edit issues" do
           contested_rating_issue_reference_id: "has_legacy_issue",
           contested_rating_issue_profile_date: rating_before_ama.profile_date,
           review_request: higher_level_review,
-          description: "Issue with legacy issue not withdrawn",
+          contested_issue_description: "Issue with legacy issue not withdrawn",
           vacols_id: "vacols1",
           benefit_type: "compensation",
           vacols_sequence_id: "1",
@@ -610,7 +616,7 @@ feature "Edit issues" do
           contested_rating_issue_reference_id: "has_ineligible_legacy_appeal",
           contested_rating_issue_profile_date: rating_before_ama.profile_date,
           review_request: higher_level_review,
-          description: "Issue connected to ineligible legacy appeal",
+          contested_issue_description: "Issue connected to ineligible legacy appeal",
           contention_reference_id: "12345678",
           vacols_id: "vacols2",
           benefit_type: "compensation",
@@ -788,7 +794,7 @@ feature "Edit issues" do
         RequestIssue.create!(
           review_request: higher_level_review,
           issue_category: "Military Retired Pay",
-          description: "nonrating description",
+          nonrating_issue_description: "nonrating description",
           contention_reference_id: "1234",
           benefit_type: "compensation",
           decision_date: 1.month.ago
@@ -873,12 +879,16 @@ feature "Edit issues" do
             "/higher_level_reviews/#{nonrating_ep_claim_id}/edit/confirmation"
           )
 
-          expect(RequestIssue.find_by(review_request: higher_level_review,
-                                      issue_category: active_nonrating_request_issue.issue_category,
-                                      ineligible_due_to: active_nonrating_request_issue.id,
-                                      ineligible_reason: "duplicate_of_nonrating_issue_in_active_review",
-                                      description: active_nonrating_request_issue.description,
-                                      decision_date: active_nonrating_request_issue.decision_date)).to_not be_nil
+          expect(
+            RequestIssue.find_by(
+              review_request: higher_level_review,
+              issue_category: active_nonrating_request_issue.issue_category,
+              ineligible_due_to: active_nonrating_request_issue.id,
+              ineligible_reason: "duplicate_of_nonrating_issue_in_active_review",
+              nonrating_issue_description: active_nonrating_request_issue.description,
+              decision_date: active_nonrating_request_issue.decision_date
+            )
+          ).to_not be_nil
         end
       end
     end
@@ -902,7 +912,12 @@ feature "Edit issues" do
         )
       end
       let(:request_issue) do
-        create(:request_issue, description: "nonrating issue desc", review_request: higher_level_review)
+        create(
+          :request_issue,
+          :nonrating,
+          nonrating_issue_description: "nonrating issue desc",
+          review_request: higher_level_review
+        )
       end
       let(:rating_ep_claim_id) do
         higher_level_review.end_product_establishments.first.reference_id
@@ -932,11 +947,13 @@ feature "Edit issues" do
     context "when there is a rating end product" do
       let(:contention_ref_id) { "123" }
       let!(:request_issue) do
-        create(:request_issue,
-               contested_rating_issue_reference_id: "def456",
-               contested_rating_issue_profile_date: rating.profile_date,
-               review_request: higher_level_review,
-               description: "PTSD denied")
+        create(
+          :request_issue,
+          review_request: higher_level_review,
+          contested_rating_issue_reference_id: "def456",
+          contested_rating_issue_profile_date: rating.profile_date,
+          contested_issue_description: "PTSD denied"
+        )
       end
 
       let(:request_issues) { [request_issue] }
@@ -960,7 +977,7 @@ feature "Edit issues" do
           create(
             :request_issue,
             review_request: higher_level_review,
-            description: "currently contesting decision issue",
+            contested_issue_description: "currently contesting decision issue",
             decision_date: Time.zone.now - 2.days,
             contested_decision_issue_id: contested_decision_issues.first.id
           )
@@ -971,7 +988,7 @@ feature "Edit issues" do
           create(
             :request_issue,
             review_request: already_active_hlr,
-            description: "currently active request issue",
+            contested_issue_description: "currently active request issue",
             decision_date: Time.zone.now - 2.days,
             end_product_establishment_id: already_active_hlr.end_product_establishments.first.id,
             contested_decision_issue_id: contested_decision_issues.second.id
@@ -1121,7 +1138,7 @@ feature "Edit issues" do
           review_request: higher_level_review,
           issue_category: "Active Duty Adjustments",
           decision_date: 1.month.ago,
-          description: "Description for Active Duty Adjustments"
+          nonrating_issue_description: "Description for Active Duty Adjustments"
         )
 
         expect(active_duty_adjustments_request_issue.untimely?).to eq(false)
@@ -1129,22 +1146,26 @@ feature "Edit issues" do
         another_active_duty_adjustments_request_issue = RequestIssue.find_by!(
           review_request: higher_level_review,
           issue_category: "Active Duty Adjustments",
-          description: "Another Description for Active Duty Adjustments"
+          nonrating_issue_description: "Another Description for Active Duty Adjustments"
         )
 
         expect(another_active_duty_adjustments_request_issue.untimely?).to eq(true)
         expect(another_active_duty_adjustments_request_issue.untimely_exemption?).to eq(false)
         expect(another_active_duty_adjustments_request_issue.untimely_exemption_notes).to_not be_nil
 
-        expect(RequestIssue.find_by(
-                 review_request: higher_level_review,
-                 description: "This is an unidentified issue"
-               )).to_not be_nil
+        expect(
+          RequestIssue.find_by(
+            review_request: higher_level_review,
+            unidentified_issue_text: "This is an unidentified issue"
+          )
+        ).to_not be_nil
 
-        expect(RequestIssue.find_by(
-                 review_request: higher_level_review,
-                 ramp_claim_id: "ramp_claim_id"
-               )).to_not be_nil
+        expect(
+          RequestIssue.find_by(
+            review_request: higher_level_review,
+            ramp_claim_id: "ramp_claim_id"
+          )
+        ).to_not be_nil
 
         rating_epe = EndProductEstablishment.find_by!(
           source: higher_level_review,
@@ -1158,7 +1179,11 @@ feature "Edit issues" do
 
         # expect the remove/re-add to create a new RequestIssue for same RatingIssue
         expect(higher_level_review.reload.request_issues).to_not include(request_issue)
-        new_version_of_request_issue = higher_level_review.find_request_issue_by_description(request_issue.description)
+
+        new_version_of_request_issue = higher_level_review.request_issues.find do |ri|
+          ri.description == request_issue.description
+        end
+
         expect(new_version_of_request_issue.contested_rating_issue_reference_id).to eq(
           request_issue.contested_rating_issue_reference_id
         )
@@ -1371,7 +1396,7 @@ feature "Edit issues" do
         RequestIssue.create!(
           review_request: supplemental_claim,
           issue_category: "Military Retired Pay",
-          description: "nonrating description",
+          nonrating_issue_description: "nonrating description",
           contention_reference_id: "1234",
           benefit_type: "compensation",
           decision_date: 1.month.ago
@@ -1445,7 +1470,7 @@ feature "Edit issues" do
           contested_rating_issue_profile_date: rating.profile_date,
           review_request: supplemental_claim,
           benefit_type: "compensation",
-          description: "PTSD denied"
+          contested_issue_description: "PTSD denied"
         )
       end
 
@@ -1587,12 +1612,16 @@ feature "Edit issues" do
             "/supplemental_claims/#{rating_ep_claim_id}/edit/confirmation"
           )
 
-          expect(RequestIssue.find_by(review_request: supplemental_claim,
-                                      issue_category: active_nonrating_request_issue.issue_category,
-                                      ineligible_due_to: active_nonrating_request_issue.id,
-                                      ineligible_reason: "duplicate_of_nonrating_issue_in_active_review",
-                                      description: active_nonrating_request_issue.description,
-                                      decision_date: active_nonrating_request_issue.decision_date)).to_not be_nil
+          expect(
+            RequestIssue.find_by(
+              review_request: supplemental_claim,
+              issue_category: active_nonrating_request_issue.issue_category,
+              ineligible_due_to: active_nonrating_request_issue.id,
+              ineligible_reason: "duplicate_of_nonrating_issue_in_active_review",
+              nonrating_issue_description: active_nonrating_request_issue.description,
+              decision_date: active_nonrating_request_issue.decision_date
+            )
+          ).to_not be_nil
         end
       end
 
@@ -1602,7 +1631,7 @@ feature "Edit issues" do
           create(
             :request_issue,
             review_request: supplemental_claim,
-            description: "currently contesting decision issue",
+            contested_issue_description: "currently contesting decision issue",
             decision_date: Time.zone.now - 2.days,
             contested_decision_issue_id: contested_decision_issues.first.id
           )
@@ -1615,7 +1644,7 @@ feature "Edit issues" do
           create(
             :request_issue,
             review_request: already_active_hlr,
-            description: "currently active request issue",
+            contested_issue_description: "currently active request issue",
             decision_date: Time.zone.now - 2.days,
             end_product_establishment_id: already_active_hlr.end_product_establishments.first.id,
             contested_decision_issue_id: contested_decision_issues.second.id

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -349,7 +349,6 @@ feature "Higher-Level Review" do
     )
 
     rating_request_issue = higher_level_review.request_issues.find_by(
-      description: "PTSD denied",
       contested_issue_description: "PTSD denied"
     )
 
@@ -393,7 +392,6 @@ feature "Higher-Level Review" do
       contested_rating_issue_reference_id: "def456",
       contested_rating_issue_profile_date: profile_date.to_s,
       contested_issue_description: "PTSD denied",
-      description: "PTSD denied",
       decision_date: nil,
       rating_issue_associated_at: Time.zone.now
     )
@@ -403,7 +401,6 @@ feature "Higher-Level Review" do
       contested_rating_issue_profile_date: nil,
       issue_category: "Active Duty Adjustments",
       nonrating_issue_description: "Description for Active Duty Adjustments",
-      description: "Description for Active Duty Adjustments",
       decision_date: 1.month.ago.to_date
     )
 
@@ -630,8 +627,7 @@ feature "Higher-Level Review" do
         :request_issue,
         end_product_establishment: active_epe,
         contested_rating_issue_reference_id: duplicate_reference_id,
-        contested_issue_description: "Old injury",
-        description: "Old injury"
+        contested_issue_description: "Old injury"
       )
     end
 
@@ -892,7 +888,6 @@ feature "Higher-Level Review" do
                review_request: higher_level_review,
                contested_decision_issue_id: decision_issue.id,
                contested_issue_description: "supplemental claim decision issue",
-               description: "supplemental claim decision issue",
                end_product_establishment_id: end_product_establishment.id,
                notes: "decision issue with note",
                benefit_type: "compensation"
@@ -902,7 +897,6 @@ feature "Higher-Level Review" do
                review_request: higher_level_review,
                contested_rating_issue_reference_id: "xyz123",
                contested_issue_description: "Left knee granted 2",
-               description: "Left knee granted 2",
                end_product_establishment_id: end_product_establishment.id,
                notes: "I am an issue note",
                benefit_type: "compensation"
@@ -910,7 +904,6 @@ feature "Higher-Level Review" do
 
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
-               description: "Really old injury",
                contested_issue_description: "Really old injury",
                end_product_establishment_id: end_product_establishment.id,
                untimely_exemption: false,
@@ -922,7 +915,6 @@ feature "Higher-Level Review" do
         review_request: higher_level_review,
         issue_category: "Active Duty Adjustments",
         nonrating_issue_description: "Description for Active Duty Adjustments",
-        description: "Description for Active Duty Adjustments",
         decision_date: 1.month.ago,
         end_product_establishment_id: non_rating_end_product_establishment.id,
         benefit_type: "compensation"
@@ -934,7 +926,6 @@ feature "Higher-Level Review" do
         review_request: higher_level_review,
         issue_category: "Active Duty Adjustments",
         nonrating_issue_description: "Another Description for Active Duty Adjustments",
-        description: "Another Description for Active Duty Adjustments",
         benefit_type: "compensation"
       )
 
@@ -945,7 +936,6 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                unidentified_issue_text: "This is an unidentified issue",
-               description: "This is an unidentified issue",
                is_unidentified: true,
                end_product_establishment_id: end_product_establishment.id,
                benefit_type: "compensation"
@@ -955,7 +945,6 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                contested_issue_description: "Non-RAMP Issue before AMA Activation",
-               description: "Non-RAMP Issue before AMA Activation",
                end_product_establishment_id: end_product_establishment.id,
                ineligible_reason: :before_ama,
                benefit_type: "compensation"
@@ -964,7 +953,6 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                contested_issue_description: "Issue before AMA Activation from RAMP",
-               description: "Issue before AMA Activation from RAMP",
                ineligible_reason: nil,
                ramp_claim_id: "ramp_claim_id",
                end_product_establishment_id: end_product_establishment.id,
@@ -974,7 +962,6 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                nonrating_issue_description: "A nonrating issue before AMA",
-               description: "A nonrating issue before AMA",
                ineligible_reason: :before_ama,
                end_product_establishment_id: non_rating_end_product_establishment.id,
                benefit_type: "compensation"
@@ -1097,7 +1084,6 @@ feature "Higher-Level Review" do
                                     ineligible_due_to: active_nonrating_request_issue.id,
                                     ineligible_reason: "duplicate_of_nonrating_issue_in_active_review",
                                     nonrating_issue_description: active_nonrating_request_issue.description,
-                                    description: active_nonrating_request_issue.description,
                                     decision_date: active_nonrating_request_issue.decision_date)).to_not be_nil
       end
     end
@@ -1283,7 +1269,6 @@ feature "Higher-Level Review" do
           )
 
           expect(RequestIssue.find_by(
-                   description: "Left knee granted",
                    contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_appeal_not_eligible,
                    vacols_id: "vacols2",
@@ -1333,7 +1318,6 @@ feature "Higher-Level Review" do
           )
 
           expect(RequestIssue.find_by(
-                   description: "Left knee granted",
                    contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_issue_not_withdrawn,
                    vacols_id: "vacols1",

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -348,7 +348,10 @@ feature "Higher-Level Review" do
       )
     )
 
-    rating_request_issue = higher_level_review.request_issues.find_by(description: "PTSD denied")
+    rating_request_issue = higher_level_review.request_issues.find_by(
+      description: "PTSD denied",
+      contested_issue_description: "PTSD denied"
+    )
 
     expect(Fakes::VBMSService).to have_received(:associate_rating_request_issues!).with(
       claim_id: ratings_end_product_establishment.reference_id,
@@ -389,6 +392,7 @@ feature "Higher-Level Review" do
     expect(higher_level_review.request_issues.first).to have_attributes(
       contested_rating_issue_reference_id: "def456",
       contested_rating_issue_profile_date: profile_date.to_s,
+      contested_issue_description: "PTSD denied",
       description: "PTSD denied",
       decision_date: nil,
       rating_issue_associated_at: Time.zone.now
@@ -398,6 +402,7 @@ feature "Higher-Level Review" do
       contested_rating_issue_reference_id: nil,
       contested_rating_issue_profile_date: nil,
       issue_category: "Active Duty Adjustments",
+      nonrating_issue_description: "Description for Active Duty Adjustments",
       description: "Description for Active Duty Adjustments",
       decision_date: 1.month.ago.to_date
     )
@@ -625,6 +630,7 @@ feature "Higher-Level Review" do
         :request_issue,
         end_product_establishment: active_epe,
         contested_rating_issue_reference_id: duplicate_reference_id,
+        contested_issue_description: "Old injury",
         description: "Old injury"
       )
     end
@@ -885,6 +891,7 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                contested_decision_issue_id: decision_issue.id,
+               contested_issue_description: "supplemental claim decision issue",
                description: "supplemental claim decision issue",
                end_product_establishment_id: end_product_establishment.id,
                notes: "decision issue with note",
@@ -894,6 +901,7 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                contested_rating_issue_reference_id: "xyz123",
+               contested_issue_description: "Left knee granted 2",
                description: "Left knee granted 2",
                end_product_establishment_id: end_product_establishment.id,
                notes: "I am an issue note",
@@ -903,6 +911,7 @@ feature "Higher-Level Review" do
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
                description: "Really old injury",
+               contested_issue_description: "Really old injury",
                end_product_establishment_id: end_product_establishment.id,
                untimely_exemption: false,
                untimely_exemption_notes: "I am an exemption note",
@@ -912,6 +921,7 @@ feature "Higher-Level Review" do
       active_duty_adjustments_request_issue = RequestIssue.find_by!(
         review_request: higher_level_review,
         issue_category: "Active Duty Adjustments",
+        nonrating_issue_description: "Description for Active Duty Adjustments",
         description: "Description for Active Duty Adjustments",
         decision_date: 1.month.ago,
         end_product_establishment_id: non_rating_end_product_establishment.id,
@@ -923,6 +933,7 @@ feature "Higher-Level Review" do
       another_active_duty_adjustments_request_issue = RequestIssue.find_by!(
         review_request: higher_level_review,
         issue_category: "Active Duty Adjustments",
+        nonrating_issue_description: "Another Description for Active Duty Adjustments",
         description: "Another Description for Active Duty Adjustments",
         benefit_type: "compensation"
       )
@@ -933,6 +944,7 @@ feature "Higher-Level Review" do
 
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
+               unidentified_issue_text: "This is an unidentified issue",
                description: "This is an unidentified issue",
                is_unidentified: true,
                end_product_establishment_id: end_product_establishment.id,
@@ -942,6 +954,7 @@ feature "Higher-Level Review" do
       # Issues before AMA
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
+               contested_issue_description: "Non-RAMP Issue before AMA Activation",
                description: "Non-RAMP Issue before AMA Activation",
                end_product_establishment_id: end_product_establishment.id,
                ineligible_reason: :before_ama,
@@ -950,6 +963,7 @@ feature "Higher-Level Review" do
 
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
+               contested_issue_description: "Issue before AMA Activation from RAMP",
                description: "Issue before AMA Activation from RAMP",
                ineligible_reason: nil,
                ramp_claim_id: "ramp_claim_id",
@@ -959,6 +973,7 @@ feature "Higher-Level Review" do
 
       expect(RequestIssue.find_by(
                review_request: higher_level_review,
+               nonrating_issue_description: "A nonrating issue before AMA",
                description: "A nonrating issue before AMA",
                ineligible_reason: :before_ama,
                end_product_establishment_id: non_rating_end_product_establishment.id,
@@ -1038,9 +1053,11 @@ feature "Higher-Level Review" do
         click_intake_finish
 
         expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
-        expect(RequestIssue.find_by(description: "appeal decision issue").ineligible_reason).to eq(
-          "appeal_to_higher_level_review"
-        )
+
+        expect(
+          RequestIssue.find_by(contested_issue_description: "appeal decision issue").ineligible_reason
+        ).to eq("appeal_to_higher_level_review")
+
         ineligible_checklist = find("ul.cf-ineligible-checklist")
         expect(ineligible_checklist).to have_content(
           "appeal decision issue #{ineligible_constants.appeal_to_higher_level_review}"
@@ -1079,6 +1096,7 @@ feature "Higher-Level Review" do
                                     issue_category: active_nonrating_request_issue.issue_category,
                                     ineligible_due_to: active_nonrating_request_issue.id,
                                     ineligible_reason: "duplicate_of_nonrating_issue_in_active_review",
+                                    nonrating_issue_description: active_nonrating_request_issue.description,
                                     description: active_nonrating_request_issue.description,
                                     decision_date: active_nonrating_request_issue.decision_date)).to_not be_nil
       end
@@ -1266,6 +1284,7 @@ feature "Higher-Level Review" do
 
           expect(RequestIssue.find_by(
                    description: "Left knee granted",
+                   contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_appeal_not_eligible,
                    vacols_id: "vacols2",
                    vacols_sequence_id: "1"
@@ -1315,6 +1334,7 @@ feature "Higher-Level Review" do
 
           expect(RequestIssue.find_by(
                    description: "Left knee granted",
+                   contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_issue_not_withdrawn,
                    vacols_id: "vacols1",
                    vacols_sequence_id: "1"

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -324,7 +324,6 @@ feature "Supplemental Claim Intake" do
       contested_rating_issue_reference_id: "def456",
       contested_rating_issue_profile_date: profile_date.to_s,
       contested_issue_description: "PTSD denied",
-      description: "PTSD denied",
       decision_date: nil,
       rating_issue_associated_at: Time.zone.now
     )
@@ -481,8 +480,7 @@ feature "Supplemental Claim Intake" do
         :request_issue,
         end_product_establishment: active_epe,
         contested_rating_issue_reference_id: duplicate_reference_id,
-        contested_issue_description: "Old injury",
-        description: "Old injury"
+        contested_issue_description: "Old injury"
       )
     end
 
@@ -644,7 +642,6 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
                contested_rating_issue_reference_id: "xyz123",
-               description: "Left knee granted 2",
                contested_issue_description: "Left knee granted 2",
                end_product_establishment_id: end_product_establishment.id,
                notes: "I am an issue note"
@@ -653,7 +650,6 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
                issue_category: "Active Duty Adjustments",
-               description: "Description for Active Duty Adjustments",
                nonrating_issue_description: "Description for Active Duty Adjustments",
                decision_date: 1.month.ago.to_date,
                end_product_establishment_id: non_rating_end_product_establishment.id
@@ -661,7 +657,6 @@ feature "Supplemental Claim Intake" do
 
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
-               description: "This is an unidentified issue",
                unidentified_issue_text: "This is an unidentified issue",
                is_unidentified: true,
                end_product_establishment_id: end_product_establishment.id
@@ -670,7 +665,6 @@ feature "Supplemental Claim Intake" do
       # Issues before AMA
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
-               description: "Non-RAMP Issue before AMA Activation",
                contested_issue_description: "Non-RAMP Issue before AMA Activation",
                end_product_establishment_id: end_product_establishment.id,
                ineligible_reason: :before_ama
@@ -678,7 +672,6 @@ feature "Supplemental Claim Intake" do
 
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
-               description: "Issue before AMA Activation from RAMP",
                contested_issue_description: "Issue before AMA Activation from RAMP",
                ineligible_reason: nil,
                ramp_claim_id: "ramp_claim_id",
@@ -687,7 +680,6 @@ feature "Supplemental Claim Intake" do
 
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
-               description: "A nonrating issue before AMA",
                nonrating_issue_description: "A nonrating issue before AMA",
                ineligible_reason: :before_ama,
                end_product_establishment_id: non_rating_end_product_establishment.id

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -305,7 +305,7 @@ feature "Supplemental Claim Intake" do
       user: current_user
     )
 
-    rating_request_issue = supplemental_claim.request_issues.find_by(description: "PTSD denied")
+    rating_request_issue = supplemental_claim.request_issues.find_by(contested_issue_description: "PTSD denied")
 
     expect(Fakes::VBMSService).to have_received(:associate_rating_request_issues!).with(
       claim_id: ratings_end_product_establishment.reference_id,
@@ -323,6 +323,7 @@ feature "Supplemental Claim Intake" do
     expect(supplemental_claim.request_issues.first).to have_attributes(
       contested_rating_issue_reference_id: "def456",
       contested_rating_issue_profile_date: profile_date.to_s,
+      contested_issue_description: "PTSD denied",
       description: "PTSD denied",
       decision_date: nil,
       rating_issue_associated_at: Time.zone.now
@@ -331,7 +332,7 @@ feature "Supplemental Claim Intake" do
       contested_rating_issue_reference_id: nil,
       contested_rating_issue_profile_date: nil,
       issue_category: "Active Duty Adjustments",
-      description: "Description for Active Duty Adjustments",
+      nonrating_issue_description: "Description for Active Duty Adjustments",
       decision_date: 1.month.ago.to_date
     )
 
@@ -480,6 +481,7 @@ feature "Supplemental Claim Intake" do
         :request_issue,
         end_product_establishment: active_epe,
         contested_rating_issue_reference_id: duplicate_reference_id,
+        contested_issue_description: "Old injury",
         description: "Old injury"
       )
     end
@@ -643,6 +645,7 @@ feature "Supplemental Claim Intake" do
                review_request: supplemental_claim,
                contested_rating_issue_reference_id: "xyz123",
                description: "Left knee granted 2",
+               contested_issue_description: "Left knee granted 2",
                end_product_establishment_id: end_product_establishment.id,
                notes: "I am an issue note"
              )).to_not be_nil
@@ -651,6 +654,7 @@ feature "Supplemental Claim Intake" do
                review_request: supplemental_claim,
                issue_category: "Active Duty Adjustments",
                description: "Description for Active Duty Adjustments",
+               nonrating_issue_description: "Description for Active Duty Adjustments",
                decision_date: 1.month.ago.to_date,
                end_product_establishment_id: non_rating_end_product_establishment.id
              )).to_not be_nil
@@ -658,6 +662,7 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
                description: "This is an unidentified issue",
+               unidentified_issue_text: "This is an unidentified issue",
                is_unidentified: true,
                end_product_establishment_id: end_product_establishment.id
              )).to_not be_nil
@@ -666,6 +671,7 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
                description: "Non-RAMP Issue before AMA Activation",
+               contested_issue_description: "Non-RAMP Issue before AMA Activation",
                end_product_establishment_id: end_product_establishment.id,
                ineligible_reason: :before_ama
              )).to_not be_nil
@@ -673,6 +679,7 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
                description: "Issue before AMA Activation from RAMP",
+               contested_issue_description: "Issue before AMA Activation from RAMP",
                ineligible_reason: nil,
                ramp_claim_id: "ramp_claim_id",
                end_product_establishment_id: end_product_establishment.id
@@ -681,6 +688,7 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                review_request: supplemental_claim,
                description: "A nonrating issue before AMA",
+               nonrating_issue_description: "A nonrating issue before AMA",
                ineligible_reason: :before_ama,
                end_product_establishment_id: non_rating_end_product_establishment.id
              )).to_not be_nil
@@ -876,6 +884,7 @@ feature "Supplemental Claim Intake" do
 
           expect(RequestIssue.find_by(
                    description: "Left knee granted",
+                   contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_appeal_not_eligible,
                    vacols_id: "vacols2",
                    vacols_sequence_id: "1"
@@ -912,6 +921,7 @@ feature "Supplemental Claim Intake" do
 
           expect(RequestIssue.find_by(
                    description: "Left knee granted",
+                   contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_issue_not_withdrawn,
                    vacols_id: "vacols1",
                    vacols_sequence_id: "1"

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -875,7 +875,6 @@ feature "Supplemental Claim Intake" do
           )
 
           expect(RequestIssue.find_by(
-                   description: "Left knee granted",
                    contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_appeal_not_eligible,
                    vacols_id: "vacols2",
@@ -912,7 +911,6 @@ feature "Supplemental Claim Intake" do
           )
 
           expect(RequestIssue.find_by(
-                   description: "Left knee granted",
                    contested_issue_description: "Left knee granted",
                    ineligible_reason: :legacy_issue_not_withdrawn,
                    vacols_id: "vacols1",

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -62,20 +62,32 @@ RSpec.feature "AmaQueue" do
             bgs_veteran_record: { first_name: "Pal" }
           ),
           documents: create_list(:document, 5),
-          request_issues: build_list(:request_issue, 3, description: "Knee pain")
+          request_issues: build_list(
+            :request_issue, 3,
+            contested_issue_description: "Knee pain",
+            description: "Knee pain"
+          )
         ),
         create(
           :appeal,
           veteran: create(:veteran),
           documents: create_list(:document, 4),
-          request_issues: build_list(:request_issue, 2, description: "PTSD")
+          request_issues: build_list(
+            :request_issue, 2,
+            contested_issue_description: "PTSD",
+            description: "PTSD"
+          )
         ),
         create(
           :appeal,
           number_of_claimants: 1,
           veteran: create(:veteran),
           documents: create_list(:document, 3),
-          request_issues: build_list(:request_issue, 1, description: "Tinnitus")
+          request_issues: build_list(
+            :request_issue, 1,
+            contested_issue_description: "Tinnitus",
+            description: "Tinnitus"
+          )
         )
       ]
     end

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -62,32 +62,20 @@ RSpec.feature "AmaQueue" do
             bgs_veteran_record: { first_name: "Pal" }
           ),
           documents: create_list(:document, 5),
-          request_issues: build_list(
-            :request_issue, 3,
-            contested_issue_description: "Knee pain",
-            description: "Knee pain"
-          )
+          request_issues: build_list(:request_issue, 3, contested_issue_description: "Knee pain")
         ),
         create(
           :appeal,
           veteran: create(:veteran),
           documents: create_list(:document, 4),
-          request_issues: build_list(
-            :request_issue, 2,
-            contested_issue_description: "PTSD",
-            description: "PTSD"
-          )
+          request_issues: build_list(:request_issue, 2, contested_issue_description: "PTSD")
         ),
         create(
           :appeal,
           number_of_claimants: 1,
           veteran: create(:veteran),
           documents: create_list(:document, 3),
-          request_issues: build_list(
-            :request_issue, 1,
-            contested_issue_description: "Tinnitus",
-            description: "Tinnitus"
-          )
+          request_issues: build_list(:request_issue, 1, contested_issue_description: "Tinnitus")
         )
       ]
     end

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature "Attorney checkout flow" do
           number_of_claimants: 1,
           request_issues: FactoryBot.build_list(
             :request_issue, 2,
-            description: issue_description,
+            contested_issue_description: issue_description,
             notes: issue_note,
             contested_rating_issue_diagnostic_code: diagnostic_code
           )

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -308,8 +308,18 @@ RSpec.feature "Case details" do
     let(:ineligible_issue_cnt) { 3 }
     let(:issues) do
       [
-        build_list(:request_issue, eligible_issue_cnt, description: "Knee pain"),
-        build_list(:request_issue, ineligible_issue_cnt, description: "Sunburn", ineligible_reason: :untimely)
+        build_list(
+          :request_issue,
+          eligible_issue_cnt,
+          contested_issue_description: "Knee pain",
+          description: "Knee pain"
+        ),
+        build_list(
+          :request_issue,
+          ineligible_issue_cnt,
+          contested_issue_description: "Sunburn",
+          ineligible_reason: :untimely
+        )
       ].flatten
     end
     let!(:appeal) { FactoryBot.create(:appeal, request_issues: issues) }
@@ -496,12 +506,22 @@ RSpec.feature "Case details" do
         issue_description = "Head trauma 1"
         issue_description2 = "Head trauma 2"
         let!(:request_issue) do
-          FactoryBot.create(:request_issue, review_request_id: appeal.id, description: issue_description,
-                                            review_request_type: "Appeal")
+          FactoryBot.create(
+            :request_issue,
+            review_request_id: appeal.id,
+            contested_issue_description: issue_description,
+            description: issue_description,
+            review_request_type: "Appeal"
+          )
         end
         let!(:request_issue2) do
-          FactoryBot.create(:request_issue, review_request_id: appeal.id, description: issue_description2,
-                                            review_request_type: "Appeal")
+          FactoryBot.create(
+            :request_issue,
+            review_request_id: appeal.id,
+            contested_issue_description: issue_description2,
+            description: issue_description2,
+            review_request_type: "Appeal"
+          )
         end
 
         it "should display sorted issues" do

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -311,8 +311,7 @@ RSpec.feature "Case details" do
         build_list(
           :request_issue,
           eligible_issue_cnt,
-          contested_issue_description: "Knee pain",
-          description: "Knee pain"
+          contested_issue_description: "Knee pain"
         ),
         build_list(
           :request_issue,
@@ -510,7 +509,6 @@ RSpec.feature "Case details" do
             :request_issue,
             review_request_id: appeal.id,
             contested_issue_description: issue_description,
-            description: issue_description,
             review_request_type: "Appeal"
           )
         end
@@ -519,7 +517,6 @@ RSpec.feature "Case details" do
             :request_issue,
             review_request_id: appeal.id,
             contested_issue_description: issue_description2,
-            description: issue_description2,
             review_request_type: "Appeal"
           )
         end

--- a/spec/models/appeal_intake_spec.rb
+++ b/spec/models/appeal_intake_spec.rb
@@ -42,8 +42,7 @@ describe AppealIntake do
         contested_rating_issue_profile_date: Time.zone.local(2018, 4, 30),
         contested_rating_issue_reference_id: "issue1",
         contested_issue_description: "description",
-        contention_reference_id: "1234",
-        description: "description"
+        contention_reference_id: "1234"
       )
     end
 
@@ -180,14 +179,12 @@ describe AppealIntake do
       expect(intake.detail.request_issues.count).to eq 2
       expect(intake.detail.request_issues.first).to have_attributes(
         contested_rating_issue_reference_id: "reference-id",
-        contested_issue_description: "decision text",
-        description: "decision text"
+        contested_issue_description: "decision text"
       )
       expect(intake.detail.request_issues.second).to have_attributes(
         issue_category: "test issue category",
         decision_date: Date.new(2018, 12, 25),
-        nonrating_issue_description: "nonrating request issue decision text",
-        description: "nonrating request issue decision text"
+        nonrating_issue_description: "nonrating request issue decision text"
       )
       expect(intake.detail.tasks.count).to eq 1
       expect(intake.detail.submitted?).to eq true

--- a/spec/models/appeal_intake_spec.rb
+++ b/spec/models/appeal_intake_spec.rb
@@ -41,6 +41,7 @@ describe AppealIntake do
         review_request: detail,
         contested_rating_issue_profile_date: Time.zone.local(2018, 4, 30),
         contested_rating_issue_reference_id: "issue1",
+        contested_issue_description: "description",
         contention_reference_id: "1234",
         description: "description"
       )
@@ -179,11 +180,13 @@ describe AppealIntake do
       expect(intake.detail.request_issues.count).to eq 2
       expect(intake.detail.request_issues.first).to have_attributes(
         contested_rating_issue_reference_id: "reference-id",
+        contested_issue_description: "decision text",
         description: "decision text"
       )
       expect(intake.detail.request_issues.second).to have_attributes(
         issue_category: "test issue category",
         decision_date: Date.new(2018, 12, 25),
+        nonrating_issue_description: "nonrating request issue decision text",
         description: "nonrating request issue decision text"
       )
       expect(intake.detail.tasks.count).to eq 1

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -32,8 +32,7 @@ describe ClaimReview do
       review_request: claim_review,
       contested_rating_issue_reference_id: "reference-id",
       contested_rating_issue_profile_date: Date.new(2018, 4, 30),
-      contested_issue_description: "decision text",
-      description: "decision text"
+      contested_issue_description: "decision text"
     )
   end
 
@@ -43,8 +42,7 @@ describe ClaimReview do
       review_request: claim_review,
       contested_rating_issue_reference_id: "reference-id2",
       contested_rating_issue_profile_date: Date.new(2018, 4, 30),
-      contested_issue_description: "another decision text",
-      description: "another decision text"
+      contested_issue_description: "another decision text"
     )
   end
 
@@ -52,7 +50,6 @@ describe ClaimReview do
     build(
       :request_issue,
       review_request: claim_review,
-      description: "Issue text",
       nonrating_issue_description: "Issue text",
       issue_category: "surgery",
       decision_date: 4.days.ago.to_date
@@ -64,7 +61,6 @@ describe ClaimReview do
       :request_issue,
       review_request: claim_review,
       nonrating_issue_description: "some other issue",
-      description: "some other issue",
       issue_category: "something",
       decision_date: 3.days.ago.to_date
     )

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -32,6 +32,7 @@ describe ClaimReview do
       review_request: claim_review,
       contested_rating_issue_reference_id: "reference-id",
       contested_rating_issue_profile_date: Date.new(2018, 4, 30),
+      contested_issue_description: "decision text",
       description: "decision text"
     )
   end
@@ -42,6 +43,7 @@ describe ClaimReview do
       review_request: claim_review,
       contested_rating_issue_reference_id: "reference-id2",
       contested_rating_issue_profile_date: Date.new(2018, 4, 30),
+      contested_issue_description: "another decision text",
       description: "another decision text"
     )
   end
@@ -51,6 +53,7 @@ describe ClaimReview do
       :request_issue,
       review_request: claim_review,
       description: "Issue text",
+      nonrating_issue_description: "Issue text",
       issue_category: "surgery",
       decision_date: 4.days.ago.to_date
     )
@@ -60,6 +63,7 @@ describe ClaimReview do
     build(
       :request_issue,
       review_request: claim_review,
+      nonrating_issue_description: "some other issue",
       description: "some other issue",
       issue_category: "something",
       decision_date: 3.days.ago.to_date

--- a/spec/models/contestable_issue_spec.rb
+++ b/spec/models/contestable_issue_spec.rb
@@ -23,7 +23,7 @@ describe ContestableIssue do
       id: "1",
       rating_issue_reference_id: "rating1",
       profile_date: profile_date,
-      decision_text: "this is a disposition"
+      description: "this is a good decision"
     )
   end
 
@@ -84,7 +84,7 @@ describe ContestableIssue do
         rating_issue_profile_date: profile_date,
         decision_issue_id: decision_issue.id,
         date: profile_date,
-        description: decision_issue.decision_text,
+        description: decision_issue.description,
         source_request_issue: decision_issue,
         contesting_decision_review: decision_review
       )
@@ -94,7 +94,7 @@ describe ContestableIssue do
         ratingIssueProfileDate: profile_date,
         decisionIssueId: decision_issue.id,
         date: profile_date,
-        description: decision_issue.decision_text,
+        description: decision_issue.description,
         rampClaimId: nil,
         titleOfActiveReview: nil,
         sourceReviewType: nil,
@@ -111,7 +111,7 @@ describe ContestableIssue do
           ratingIssueProfileDate: profile_date,
           decisionIssueId: decision_issue.id,
           date: profile_date,
-          description: decision_issue.decision_text,
+          description: decision_issue.description,
           rampClaimId: nil,
           titleOfActiveReview: nil,
           sourceReviewType: nil,

--- a/spec/models/decision_document_spec.rb
+++ b/spec/models/decision_document_spec.rb
@@ -180,8 +180,8 @@ describe DecisionDocument do
             veteran_file_number: decision_document.appeal.veteran_file_number,
             claim_id: decision_document.end_product_establishments.last.reference_id,
             contention_descriptions: array_including(
-              granted_issue.formatted_description,
-              another_granted_issue.formatted_description
+              granted_issue.description,
+              another_granted_issue.description
             ),
             special_issues: [],
             user: User.system_user

--- a/spec/models/decision_issue_spec.rb
+++ b/spec/models/decision_issue_spec.rb
@@ -78,7 +78,12 @@ describe DecisionIssue do
     subject { decision_issue.issue_category }
 
     let(:request_issues) do
-      [create(:request_issue, issue_category: "test category", description: "request issue description")]
+      [create(
+        :request_issue,
+        issue_category: "test category",
+        nonrating_issue_description: "request issue description",
+        description: "request issue description"
+      )]
     end
 
     it "finds the issue category" do
@@ -92,7 +97,13 @@ describe DecisionIssue do
     context "when description not set" do
       context "when nonrating" do
         let(:request_issues) do
-          [create(:request_issue, :nonrating, issue_category: "test category", description: "req issue description")]
+          [create(
+            :request_issue,
+            :nonrating,
+            issue_category: "test category",
+            nonrating_issue_description: "req issue description",
+            description: "req issue description"
+          )]
         end
 
         it { is_expected.to eq("test disposition: test category - req issue description") }

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -233,6 +233,7 @@ describe EndProductEstablishment do
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30),
+          contested_issue_description: "this is a big decision",
           description: "this is a big decision"
         ),
         create(
@@ -241,6 +242,7 @@ describe EndProductEstablishment do
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30),
+          contested_issue_description: "more decisionz",
           description: "more decisionz"
         ),
         create(
@@ -249,12 +251,14 @@ describe EndProductEstablishment do
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30),
-          description: "this is a big decision", # intentional duplicate
+          contested_issue_description: "this is a big decision",
+          description: "this is a big decision" # intentional duplicate
         ),
         create(
           :request_issue,
           end_product_establishment: end_product_establishment,
           is_unidentified: true,
+          unidentified_issue_text: "identity unknown",
           description: "identity unknown",
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
@@ -383,6 +387,7 @@ describe EndProductEstablishment do
         review_request: source,
         contested_rating_issue_reference_id: "reference-id",
         contested_rating_issue_profile_date: Date.new(2018, 4, 30),
+        contested_issue_description: "this is a big decision",
         description: "this is a big decision",
         benefit_type: "compensation",
         contention_reference_id: contention_ref_id
@@ -528,6 +533,7 @@ describe EndProductEstablishment do
           # rubocop:disable Metrics/LineLength
           sample_transient_error_body = '<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><env:Fault><faultcode xmlns:ns1="http://www.w3.org/2003/05/soap-envelope">ns1:Server</faultcode><faultstring>gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception - Security Verification Exception GUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</faultstring><detail><cdm:faultDetailBean xmlns:cdm="http://vbms.vba.va.gov/cdm" cdm:message="gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception - Security Verification Exception GUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" cdm:exceptionClassName="gov.va.vba.vbms.ws.VbmsWSException" cdm:uid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" cdm:serverException="true"/></detail></env:Fault></env:Body></env:Envelope>'
           # rubocop:enable Metrics/LineLength
+
           error = VBMS::HTTPError.new(500, sample_transient_error_body)
           allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(error)
         end
@@ -543,6 +549,7 @@ describe EndProductEstablishment do
           # rubocop:disable Metrics/LineLength
           error = Errno::ETIMEDOUT.new('Connection timed out - Connection timed out - connect(2) for "bepprod.vba.va.gov" port 443 (bepprod.vba.va.gov:443)')
           # rubocop:enable Metrics/LineLength
+
           allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(error)
         end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -233,8 +233,7 @@ describe EndProductEstablishment do
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30),
-          contested_issue_description: "this is a big decision",
-          description: "this is a big decision"
+          contested_issue_description: "this is a big decision"
         ),
         create(
           :request_issue,
@@ -242,8 +241,7 @@ describe EndProductEstablishment do
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30),
-          contested_issue_description: "more decisionz",
-          description: "more decisionz"
+          contested_issue_description: "more decisionz"
         ),
         create(
           :request_issue,
@@ -251,15 +249,13 @@ describe EndProductEstablishment do
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30),
-          contested_issue_description: "this is a big decision",
-          description: "this is a big decision" # intentional duplicate
+          contested_issue_description: "this is a big decision"
         ),
         create(
           :request_issue,
           end_product_establishment: end_product_establishment,
           is_unidentified: true,
           unidentified_issue_text: "identity unknown",
-          description: "identity unknown",
           review_request: source,
           contested_rating_issue_reference_id: "reference-id",
           contested_rating_issue_profile_date: Date.new(2018, 4, 30)
@@ -388,7 +384,6 @@ describe EndProductEstablishment do
         contested_rating_issue_reference_id: "reference-id",
         contested_rating_issue_profile_date: Date.new(2018, 4, 30),
         contested_issue_description: "this is a big decision",
-        description: "this is a big decision",
         benefit_type: "compensation",
         contention_reference_id: contention_ref_id
       )

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -45,8 +45,7 @@ describe HigherLevelReviewIntake do
         contested_rating_issue_profile_date: Time.zone.local(2018, 4, 5),
         contested_rating_issue_reference_id: "issue1",
         contested_issue_description: "description",
-        contention_reference_id: "1234",
-        description: "description"
+        contention_reference_id: "1234"
       )
     end
 

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -44,6 +44,7 @@ describe HigherLevelReviewIntake do
         review_request: detail,
         contested_rating_issue_profile_date: Time.zone.local(2018, 4, 5),
         contested_rating_issue_reference_id: "issue1",
+        contested_issue_description: "description",
         contention_reference_id: "1234",
         description: "description"
       )
@@ -256,7 +257,7 @@ describe HigherLevelReviewIntake do
       expect(intake.detail.request_issues.count).to eq 1
       expect(intake.detail.request_issues.first).to have_attributes(
         contested_rating_issue_reference_id: "reference-id",
-        description: "decision text",
+        contested_issue_description: "decision text",
         rating_issue_associated_at: Time.zone.now
       )
     end

--- a/spec/models/higher_level_review_spec.rb
+++ b/spec/models/higher_level_review_spec.rb
@@ -294,6 +294,7 @@ describe HigherLevelReview do
           contested_decision_issue_id: decision_issues.first.id,
           contested_rating_issue_reference_id: "rating1",
           contested_rating_issue_profile_date: decision_issues.first.profile_date.to_s,
+          contested_issue_description: decision_issues.first.description,
           issue_category: decision_issues.first.issue_category,
           benefit_type: higher_level_review.benefit_type,
           decision_date: decision_issues.first.approx_decision_date
@@ -307,6 +308,7 @@ describe HigherLevelReview do
           contested_decision_issue_id: decision_issues.second.id,
           contested_rating_issue_reference_id: "rating2",
           contested_rating_issue_profile_date: decision_issues.second.profile_date.to_s,
+          contested_issue_description: decision_issues.first.description,
           issue_category: decision_issues.second.issue_category,
           benefit_type: higher_level_review.benefit_type,
           decision_date: decision_issues.second.approx_decision_date

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -51,6 +51,7 @@ describe RequestIssue do
       review_request: review,
       contested_rating_issue_reference_id: contested_rating_issue_reference_id,
       contested_rating_issue_profile_date: profile_date,
+      contested_issue_description: "a rating request issue",
       description: "a rating request issue",
       ramp_claim_id: ramp_claim_id,
       decision_sync_processed_at: decision_sync_processed_at,
@@ -64,6 +65,7 @@ describe RequestIssue do
     create(
       :request_issue,
       review_request: review,
+      nonrating_issue_description: "a nonrating request issue description",
       description: "a nonrating request issue description",
       issue_category: "a category",
       decision_date: 1.day.ago,
@@ -77,6 +79,7 @@ describe RequestIssue do
     create(
       :request_issue,
       review_request: review,
+      unidentified_issue_text: "an unidentified issue",
       description: "an unidentified issue",
       is_unidentified: true
     )
@@ -248,6 +251,7 @@ describe RequestIssue do
         review_request: previous_higher_level_review,
         contested_rating_issue_reference_id: higher_level_review_reference_id,
         contested_rating_issue_profile_date: profile_date,
+        contested_issue_description: "a rating request issue",
         contention_reference_id: contention_reference_id,
         end_product_establishment: previous_end_product_establishment,
         description: "a rating request issue"
@@ -317,6 +321,7 @@ describe RequestIssue do
         :request_issue,
         review_request: appeal_in_progress,
         contested_rating_issue_reference_id: duplicate_appeal_reference_id,
+        contested_issue_description: "Appealed injury",
         description: "Appealed injury"
       )
     end
@@ -364,6 +369,7 @@ describe RequestIssue do
         :request_issue,
         end_product_establishment: active_epe,
         contested_rating_issue_reference_id: duplicate_reference_id,
+        contested_issue_description: "Old injury",
         description: "Old injury"
       )
     end

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -50,7 +50,6 @@ describe RequestIssuesUpdate do
         contested_rating_issue_reference_id: "issue1",
         contention_reference_id: request_issue_contentions[0].id,
         contested_issue_description: request_issue_contentions[0].text,
-        description: request_issue_contentions[0].text,
         rating_issue_associated_at: 5.days.ago
       ),
       RequestIssue.new(
@@ -59,7 +58,6 @@ describe RequestIssuesUpdate do
         contested_rating_issue_reference_id: "issue2",
         contention_reference_id: request_issue_contentions[1].id,
         contested_issue_description: request_issue_contentions[1].text,
-        description: request_issue_contentions[1].text,
         rating_issue_associated_at: 5.days.ago,
         vacols_id: vacols_id,
         vacols_sequence_id: vacols_sequence_id
@@ -218,7 +216,6 @@ describe RequestIssuesUpdate do
 
           created_issue = review.request_issues.find_by(contested_rating_issue_reference_id: "issue3")
           expect(created_issue).to have_attributes(
-            description: "Service connection for cancer was denied",
             contested_issue_description: "Service connection for cancer was denied"
           )
           expect(created_issue.contention_reference_id).to_not be_nil
@@ -318,7 +315,6 @@ describe RequestIssuesUpdate do
             review_request: review,
             end_product_establishment: nonrating_end_product_establishment,
             contention_reference_id: nonrating_request_issue_contention.id,
-            description: nonrating_request_issue_contention.text,
             nonrating_issue_description: nonrating_request_issue_contention.text,
             issue_category: "Apportionment"
           )

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -49,6 +49,7 @@ describe RequestIssuesUpdate do
         contested_rating_issue_profile_date: Time.zone.local(2017, 4, 5),
         contested_rating_issue_reference_id: "issue1",
         contention_reference_id: request_issue_contentions[0].id,
+        contested_issue_description: request_issue_contentions[0].text,
         description: request_issue_contentions[0].text,
         rating_issue_associated_at: 5.days.ago
       ),
@@ -57,6 +58,7 @@ describe RequestIssuesUpdate do
         contested_rating_issue_profile_date: Time.zone.local(2017, 4, 6),
         contested_rating_issue_reference_id: "issue2",
         contention_reference_id: request_issue_contentions[1].id,
+        contested_issue_description: request_issue_contentions[1].text,
         description: request_issue_contentions[1].text,
         rating_issue_associated_at: 5.days.ago,
         vacols_id: vacols_id,
@@ -109,7 +111,13 @@ describe RequestIssuesUpdate do
 
       context "when new issues were added as part of the update" do
         let(:request_issues_data) { request_issues_data_with_new_issue }
-        let(:new_request_issue) { RequestIssue.find_by(contested_rating_issue_reference_id: "issue3") }
+
+        let(:new_request_issue) do
+          RequestIssue.find_by(
+            contested_rating_issue_reference_id: "issue3",
+            contested_issue_description: "Service connection for cancer was denied"
+          )
+        end
 
         it { is_expected.to contain_exactly(new_request_issue) }
       end
@@ -210,7 +218,8 @@ describe RequestIssuesUpdate do
 
           created_issue = review.request_issues.find_by(contested_rating_issue_reference_id: "issue3")
           expect(created_issue).to have_attributes(
-            description: "Service connection for cancer was denied"
+            description: "Service connection for cancer was denied",
+            contested_issue_description: "Service connection for cancer was denied"
           )
           expect(created_issue.contention_reference_id).to_not be_nil
         end
@@ -218,7 +227,6 @@ describe RequestIssuesUpdate do
         context "with nonrating request issue" do
           let(:request_issues_data) do
             review.request_issues.map { |issue| { request_issue_id: issue.id } } + [{
-              rating_reference_id: "issue3",
               decision_text: "Nonrating issue",
               issue_category: "Apportionment",
               decision_date: 1.month.ago
@@ -311,6 +319,7 @@ describe RequestIssuesUpdate do
             end_product_establishment: nonrating_end_product_establishment,
             contention_reference_id: nonrating_request_issue_contention.id,
             description: nonrating_request_issue_contention.text,
+            nonrating_issue_description: nonrating_request_issue_contention.text,
             issue_category: "Apportionment"
           )
 

--- a/spec/models/supplemental_claim_intake_spec.rb
+++ b/spec/models/supplemental_claim_intake_spec.rb
@@ -46,7 +46,6 @@ describe SupplementalClaimIntake do
         contested_rating_issue_reference_id: "issue1",
         contested_rating_issue_profile_date: Time.zone.local(2018, 4, 5),
         contested_issue_description: "description",
-        description: "description",
         contention_reference_id: "1234"
       )
     end
@@ -266,7 +265,6 @@ describe SupplementalClaimIntake do
       expect(intake.detail.request_issues.count).to eq 1
       expect(intake.detail.request_issues.first).to have_attributes(
         contested_rating_issue_reference_id: "reference-id",
-        description: "decision text",
         contested_issue_description: "decision text",
         rating_issue_associated_at: Time.zone.now
       )

--- a/spec/models/supplemental_claim_intake_spec.rb
+++ b/spec/models/supplemental_claim_intake_spec.rb
@@ -45,8 +45,9 @@ describe SupplementalClaimIntake do
         review_request: detail,
         contested_rating_issue_reference_id: "issue1",
         contested_rating_issue_profile_date: Time.zone.local(2018, 4, 5),
-        contention_reference_id: "1234",
-        description: "description"
+        contested_issue_description: "description",
+        description: "description",
+        contention_reference_id: "1234"
       )
     end
 
@@ -266,6 +267,7 @@ describe SupplementalClaimIntake do
       expect(intake.detail.request_issues.first).to have_attributes(
         contested_rating_issue_reference_id: "reference-id",
         description: "decision text",
+        contested_issue_description: "decision text",
         rating_issue_associated_at: Time.zone.now
       )
     end

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -326,7 +326,6 @@ module IntakeHelpers
   def setup_request_issue_with_nonrating_decision_issue(decision_review, issue_category: "Active Duty Adjustments")
     create(:request_issue,
            :with_nonrating_decision_issue,
-           description: "Test nonrating decision issue",
            nonrating_issue_description: "Test nonrating decision issue",
            review_request: decision_review,
            decision_date: decision_review.receipt_date - 1.day,
@@ -339,7 +338,6 @@ module IntakeHelpers
            :with_rating_decision_issue,
            contested_rating_issue_reference_id: contested_rating_issue_reference_id,
            contested_rating_issue_profile_date: decision_review.receipt_date - 1.day,
-           description: "Test rating decision issue",
            contested_issue_description: "Test rating decision issue",
            review_request: decision_review,
            veteran_participant_id: veteran.participant_id)

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -327,6 +327,7 @@ module IntakeHelpers
     create(:request_issue,
            :with_nonrating_decision_issue,
            description: "Test nonrating decision issue",
+           nonrating_issue_description: "Test nonrating decision issue",
            review_request: decision_review,
            decision_date: decision_review.receipt_date - 1.day,
            issue_category: issue_category,
@@ -339,6 +340,7 @@ module IntakeHelpers
            contested_rating_issue_reference_id: contested_rating_issue_reference_id,
            contested_rating_issue_profile_date: decision_review.receipt_date - 1.day,
            description: "Test rating decision issue",
+           contested_issue_description: "Test rating decision issue",
            review_request: decision_review,
            veteran_participant_id: veteran.participant_id)
   end


### PR DESCRIPTION
yay for renaming things. 😭

This PR will be merged after #8549 is deployed to prod and the following migration script is run:

```
RequestIssue.all.each do |r|
  if r.contested_rating_issue_reference_id
    r.update!(contested_issue_description: r.description)
  elsif r.issue_category
    r.update!(nonrating_issue_description: r.description)
  elsif r.is_unidentified
    r.update!(unidentified_issue_text: r.description)
  else
    raise "bad issue found #{r.id}"
  end
end
```

This also fixes #8518 and an unrecorded issue where non rating request issues weren't displaying properly on queue (re: @aroltsch)