### PR TITLE
Browser date math is outside our control, make regex more robust

### DIFF
--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -54,8 +54,11 @@ feature "NonComp Reviews Queue" do
       expect(page).to have_content(veteran.participant_id, count: 2)
 
       # ordered by assigned_at descending
+      # this funky regex is due to how the momentjs lib does date math and rounding.
+      # since we can't control the time/zone of the browser, only here in the specs with Timecop,
+      # we allow for a range of "days" like [01] or [678]
       expect(page).to have_content(
-        /#{veteran.name} 5\d+ 0 0 Higher-Level Review #{veteran.name} 5\d+ 0 7/
+        /#{veteran.name} 5\d+ 0 [01] Higher-Level Review #{veteran.name} 5\d+ 0 [678]/
       )
 
       click_on "Completed tasks"


### PR DESCRIPTION
fixes flakey test