### PR TITLE
Add explicit defaultSortIdx prop to TaskTable

### DIFF
--- a/client/app/nonComp/components/NonCompTabs.jsx
+++ b/client/app/nonComp/components/NonCompTabs.jsx
@@ -18,7 +18,8 @@ class NonCompTabsUnconnected extends React.PureComponent {
       label: 'Completed tasks',
       page: <TaskTableTab
         key="completed"
-        predefinedColumns={{ includeCompletedDate: true }}
+        predefinedColumns={{ includeCompletedDate: true,
+          defaultSortIdx: 3 }}
         tasks={this.props.completedTasks} />
     }];
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -48,13 +48,15 @@ type Params = {|
   customColumns?: Array<Function>,
   getKeyForRow?: Function,
   userId?: string,
+  defaultSortIdx?: number,
 |};
 
 type Props = Params & {|
   setSelectionOfTaskOfUser: Function,
   isTaskAssignedToUserSelected?: Object,
   userIsVsoEmployee: boolean,
-  userRole: string
+  userRole: string,
+  defaultSortIdx: number
 |};
 
 export class TaskTableUnconnected extends React.PureComponent<Props> {
@@ -296,6 +298,10 @@ export class TaskTableUnconnected extends React.PureComponent<Props> {
       ])), ['order'], ['desc']);
 
   getDefaultSortableColumn = () => {
+    if (this.props.defaultSortIdx) {
+      return this.props.defaultSortIdx;
+    }
+
     const index = _.findIndex(this.getQueueColumns(),
       (column) => column.header === COPY.CASE_LIST_TABLE_APPEAL_TYPE_COLUMN_TITLE);
 


### PR DESCRIPTION
connects #7992 

### Description
Adds an explicit `defaultSortIdx` property to the `TaskTable` so that consumers can specify the default column index to sort by.
