### PR TITLE
Backwards compatible migration

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -21,6 +21,10 @@ class HearingDay < ApplicationRecord
     hearing_type == HEARING_TYPES[:central]
   end
 
+  def hearing_date
+    try(:scheduled_for) || super
+  end
+
   def update_children_records
     hearings = if hearing_type == HEARING_TYPES[:central]
                  HearingRepository.fetch_co_hearings_for_parent(hearing_date)


### PR DESCRIPTION
In a different PR: https://github.com/department-of-veterans-affairs/caseflow/pull/8544, I'm renaming a column in the hearing_days table. This PR adds a method for hearing_date to make the migration backwards compatible.

