### PR TITLE
Fix search test

### DIFF
--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -255,7 +255,7 @@ RSpec.feature "Search" do
       end
 
       it "clicking on docket number sends us to the case details page" do
-        click_on appeal.docket_number
+        find("a", text: /\A#{appeal.docket_number}\z/).click
         expect(page.current_path).to eq("/queue/appeals/#{appeal.vacols_id}")
         expect(page).not_to have_content "Select an action"
       end


### PR DESCRIPTION
This PR ensures the link we click on contains only the `appeal.docket_number` and nothing else. This test was failing occasionally because we were trying to click on the text of the docket number but accidentally clicked on the dropdown menu when the CSS ID contained the `appeal.docket number`.

![image](https://user-images.githubusercontent.com/32683958/51037609-ad5b1180-157e-11e9-9bb5-e0874e83a5b7.png)