### PR TITLE
Fix decision issue descriptions

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -348,6 +348,7 @@ class RequestIssue < ApplicationRecord
       decision_issues.create!(
         participant_id: review_request.veteran.participant_id,
         disposition: contention_disposition.disposition,
+        description: "#{contention_disposition.disposition}: #{description}",
         decision_review: review_request,
         benefit_type: benefit_type,
         end_product_last_action_date: end_product_establishment.result.last_action_date

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -810,12 +810,13 @@ describe RequestIssue do
               )
             end
 
-            it "creates decision issues based on contention disposition" do
+            it "creates decision issues based on contention disposition", focus: true do
               subject
               expect(rating_request_issue.decision_issues.count).to eq(1)
               expect(rating_request_issue.decision_issues.first).to have_attributes(
                 participant_id: veteran.participant_id,
                 disposition: "allowed",
+                description: "allowed: #{request_issue.description}"
                 decision_review_type: "HigherLevelReview",
                 decision_review_id: review.id,
                 benefit_type: "compensation",

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -816,7 +816,7 @@ describe RequestIssue do
               expect(rating_request_issue.decision_issues.first).to have_attributes(
                 participant_id: veteran.participant_id,
                 disposition: "allowed",
-                description: "allowed: #{request_issue.description}"
+                description: "allowed: #{request_issue.description}",
                 decision_review_type: "HigherLevelReview",
                 decision_review_id: review.id,
                 benefit_type: "compensation",

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -810,7 +810,7 @@ describe RequestIssue do
               )
             end
 
-            it "creates decision issues based on contention disposition", focus: true do
+            it "creates decision issues based on contention disposition" do
               subject
               expect(rating_request_issue.decision_issues.count).to eq(1)
               expect(rating_request_issue.decision_issues.first).to have_attributes(


### PR DESCRIPTION
connects #8518

If a decision issue doesn't have a description it breaks when we try and create a DTA error 😢 