### PR TITLE
Fixing nil return

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -109,9 +109,11 @@ class HearingDay < ApplicationRecord
       regional_office_keys = total_video_and_co.map { |hearing_day| hearing_day[:regional_office] }
       regional_office_hash = HearingDayRepository.ro_staff_hash(regional_office_keys)
 
-      hearing_days_to_array_of_days_and_hearings(
+      hold = hearing_days_to_array_of_days_and_hearings(
         total_video_and_co, regional_office.nil? || regional_office == "C"
-      ).map do |value|
+      )
+
+      hold.map do |value|
         hearing_day = value[:hearing_day]
 
         scheduled_hearings = filter_non_scheduled_hearings(value[:hearings] || [])
@@ -119,11 +121,13 @@ class HearingDay < ApplicationRecord
           regional_office_hash[hearing_day[:regional_office]], hearing_day
         )
 
-        return nil if scheduled_hearings.length >= total_slots || hearing_day[:lock]
-
-        hearing_day.slice(:id, :scheduled_for, :request_type, :room).tap do |day|
-          day[:hearings] = scheduled_hearings
-          day[:total_slots] = total_slots
+        if scheduled_hearings.length >= total_slots || hearing_day[:lock]
+          nil
+        else
+          hearing_day.slice(:id, :scheduled_for, :request_type, :room).tap do |day|
+            day[:hearings] = scheduled_hearings
+            day[:total_slots] = total_slots
+          end
         end
       end.compact
     end

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -109,11 +109,9 @@ class HearingDay < ApplicationRecord
       regional_office_keys = total_video_and_co.map { |hearing_day| hearing_day[:regional_office] }
       regional_office_hash = HearingDayRepository.ro_staff_hash(regional_office_keys)
 
-      hold = hearing_days_to_array_of_days_and_hearings(
+      hearing_days_to_array_of_days_and_hearings(
         total_video_and_co, regional_office.nil? || regional_office == "C"
-      )
-
-      hold.map do |value|
+      ).map do |value|
         hearing_day = value[:hearing_day]
 
         scheduled_hearings = filter_non_scheduled_hearings(value[:hearings] || [])

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -73,7 +73,7 @@ class VACOLS::CaseHearing < VACOLS::Record
     end
 
     def co_hearings_for_master_records(parent_hearing_dates)
-      select_hearings.where("hearing_type = ? and folder_nr NOT LIKE ? and trunc(hearing_date) = ?",
+      select_hearings.where("hearing_type = ? and folder_nr NOT LIKE ? and trunc(hearing_date) IN (?)",
                             "C", "%VIDEO%", parent_hearing_dates.map(&:to_date))
     end
 

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -262,6 +262,32 @@ describe HearingDay do
         expect(subject[0][:hearings][0][:appeal_id]).to eq appeal_tomorrow.id
       end
     end
+
+    context "When there are hearing days that are filled up" do
+      before do
+        allow(HearingDayRepository).to receive(:fetch_hearing_day_slots).and_return(1, 5)
+      end
+
+      let(:appeal_today) do
+        create(
+          :legacy_appeal, :with_veteran, vacols_case: create(:case)
+        )
+      end
+      let(:appeal_tomorrow) do
+        create(
+          :legacy_appeal, :with_veteran, vacols_case: create(:case)
+        )
+      end
+      let!(:hearing_tomorrow) do
+        create(
+          :case_hearing, hearing_date: Time.zone.tomorrow, folder_nr: appeal_tomorrow.vacols_id
+        )
+      end
+
+      it "only returns hearing days that are not full" do
+        expect(subject.size).to eq 1
+      end
+    end
   end
 
   context "Central Office parent and child rows for a date range" do


### PR DESCRIPTION
We were returning nil: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3346/

### Description
We returned from a map thinking that would return from the map and not the function. So we were returning nil from the function instead of an array with fewer elements.

### Testing Plan
1. Created a new test for this scenario.

