### PR TITLE
Changing count to length

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -212,7 +212,7 @@ class AppealRepository
       private_attorney_or_agent: case_record.bfso == "T",
       docket_number: folder_record.tinum || "Missing Docket Number",
       docket_date: case_record.bfd19,
-      number_of_issues: case_record.case_issues.count
+      number_of_issues: case_record.case_issues.length
     )
 
     appeal


### PR DESCRIPTION
### Description
We are trying to speed up the task endpoint by using `includes` to move everything into one query. However, if you use the count method, Rails still makes a DB query. Instead, we should use length since the active record relations are already loaded.

### Testing Plan
1. Tested locally by looking in the console and ensuring there are no: `SELECT COUNT(*) FROM "VACOLS"."ISSUES" WHERE "VACOLS"."ISSUES"."ISSKEY" = :a1` statements

