### PR TITLE
Allow judges to create admin actions

### DIFF
--- a/app/models/legacy_tasks/judge_legacy_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_task.rb
@@ -10,13 +10,10 @@ class JudgeLegacyTask < LegacyTask
   def available_actions(role)
     return [] if role != "judge"
 
-    if action.eql? "review"
-      [review_action]
-    else
-      [
-        Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h
-      ]
-    end
+    [
+      Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+      action.eql?("review") ? review_action : Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h
+    ]
   end
 
   def self.from_vacols(record, appeal, user_id)

--- a/app/models/tasks/judge_assign_task.rb
+++ b/app/models/tasks/judge_assign_task.rb
@@ -1,5 +1,5 @@
 class JudgeAssignTask < JudgeTask
-  def available_actions(_user)
+  def additional_actions(_user)
     [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]
   end
 

--- a/app/models/tasks/judge_assign_task.rb
+++ b/app/models/tasks/judge_assign_task.rb
@@ -1,5 +1,5 @@
 class JudgeAssignTask < JudgeTask
-  def additional_actions(_user)
+  def additional_available_actions(_user)
     [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]
   end
 

--- a/app/models/tasks/judge_decision_review_task.rb
+++ b/app/models/tasks/judge_decision_review_task.rb
@@ -1,5 +1,5 @@
 class JudgeDecisionReviewTask < JudgeTask
-  def additional_actions(_user)
+  def additional_available_actions(_user)
     [Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h]
   end
 

--- a/app/models/tasks/judge_decision_review_task.rb
+++ b/app/models/tasks/judge_decision_review_task.rb
@@ -1,5 +1,5 @@
 class JudgeDecisionReviewTask < JudgeTask
-  def available_actions(_user)
+  def additional_actions(_user)
     [Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h]
   end
 

--- a/app/models/tasks/judge_quality_review_task.rb
+++ b/app/models/tasks/judge_quality_review_task.rb
@@ -1,5 +1,5 @@
 class JudgeQualityReviewTask < JudgeTask
-  def additional_actions(_user)
+  def additional_available_actions(_user)
     [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h, Constants.TASK_ACTIONS.MARK_COMPLETE.to_h]
   end
 

--- a/app/models/tasks/judge_quality_review_task.rb
+++ b/app/models/tasks/judge_quality_review_task.rb
@@ -1,5 +1,5 @@
 class JudgeQualityReviewTask < JudgeTask
-  def available_actions(_user)
+  def additional_actions(_user)
     [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h, Constants.TASK_ACTIONS.MARK_COMPLETE.to_h]
   end
 

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -2,14 +2,14 @@ class JudgeTask < Task
   include RoundRobinAssigner
 
   def available_actions(user)
-    additional_actions(user).unshift(Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h)
+    additional_available_actions(user).unshift(Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h)
   end
 
   def actions_available?(user)
     assigned_to == user
   end
 
-  def additional_actions(_user)
+  def additional_available_actions(_user)
     fail Caseflow::Error::MustImplementInSubclass
   end
 

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -1,12 +1,16 @@
 class JudgeTask < Task
   include RoundRobinAssigner
 
-  def available_actions(_user)
-    []
+  def available_actions(user)
+    additional_actions(user).unshift(Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h)
   end
 
   def actions_available?(user)
     assigned_to == user
+  end
+
+  def additional_actions(_user)
+    fail Caseflow::Error::MustImplementInSubclass
   end
 
   def timeline_title

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -309,8 +309,7 @@ RSpec.feature "Attorney checkout flow" do
 
         expect(page).to have_content "Correct issues"
         expect(page).to have_content("Added to 2 issues", count: 2)
-        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
-        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label)
 
         # Skip the special issues page
         click_on "Continue"

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -309,7 +309,8 @@ RSpec.feature "Attorney checkout flow" do
 
         expect(page).to have_content "Correct issues"
         expect(page).to have_content("Added to 2 issues", count: 2)
-        click_dropdown(index: 0)
+        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
 
         # Skip the special issues page
         click_on "Continue"

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -51,8 +51,7 @@ RSpec.feature "Judge checkout flow" do
       visit "/queue"
       click_on "(#{appeal.veteran_file_number})"
 
-      find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
+      click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label)
 
       # Special Issues screen
       click_on "Continue"
@@ -118,8 +117,7 @@ RSpec.feature "Judge checkout flow" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
 
-        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
-        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label)
 
         click_label "vamc"
 
@@ -129,8 +127,7 @@ RSpec.feature "Judge checkout flow" do
         click_on "Cancel"
         click_on "Yes, cancel"
 
-        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
-        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label)
 
         # Vamc should still be checked
         expect(page).to have_field("vamc", checked: true, visible: false)
@@ -175,8 +172,7 @@ RSpec.feature "Judge checkout flow" do
       scenario "completes assign to omo checkout flow" do
         visit "/queue/appeals/#{appeal.vacols_id}"
 
-        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
-        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_OMO.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_OMO.label)
 
         expect(page).to have_content("Evaluate Decision")
 

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -129,7 +129,8 @@ RSpec.feature "Judge checkout flow" do
         click_on "Cancel"
         click_on "Yes, cancel"
 
-        click_dropdown(index: 0)
+        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
 
         # Vamc should still be checked
         expect(page).to have_field("vamc", checked: true, visible: false)

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -51,11 +51,8 @@ RSpec.feature "Judge checkout flow" do
       visit "/queue"
       click_on "(#{appeal.veteran_file_number})"
 
-      click_dropdown(index: 0) do
-        visible_options = page.find_all(".Select-option")
-        expect(visible_options.length).to eq 1
-        expect(visible_options.first.text).to eq Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h[:label]
-      end
+      find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
 
       # Special Issues screen
       click_on "Continue"
@@ -121,11 +118,8 @@ RSpec.feature "Judge checkout flow" do
         visit "/queue"
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
 
-        click_dropdown(index: 0) do
-          visible_options = page.find_all(".Select-option")
-          expect(visible_options.length).to eq 1
-          expect(visible_options.first.text).to eq Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h[:label]
-        end
+        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.JUDGE_CHECKOUT.label).click
 
         click_label "vamc"
 
@@ -180,11 +174,8 @@ RSpec.feature "Judge checkout flow" do
       scenario "completes assign to omo checkout flow" do
         visit "/queue/appeals/#{appeal.vacols_id}"
 
-        click_dropdown(index: 0) do
-          visible_options = page.find_all(".Select-option")
-          expect(visible_options.length).to eq 1
-          expect(visible_options.first.text).to eq Constants.TASK_ACTIONS.ASSIGN_OMO.to_h[:label]
-        end
+        find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+        find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_OMO.label).click
 
         expect(page).to have_content("Evaluate Decision")
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -323,6 +323,9 @@ RSpec.feature "Task queue" do
 
       before do
         visit("/queue/appeals/#{appeal.external_id}")
+
+        # Add a user to the Colocated team so the task assignment will suceed.
+        OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), Colocated.singleton)
       end
 
       it "should display an option to mark task complete" do
@@ -335,6 +338,22 @@ RSpec.feature "Task queue" do
         expect(page).to have_content(format(COPY::MARK_TASK_COMPLETE_CONFIRMATION, appeal.veteran_full_name))
         expect(judge_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
         expect(qr_person_task.reload.status).to eq(Constants.TASK_STATUSES.assigned)
+      end
+
+      it "should be able to be sent to VLJ support staff" do
+        # On case details page select the "Add admin action" option
+        click_dropdown(text: Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.label)
+
+        # On case details page fill in the admin action
+        action = Constants::CO_LOCATED_ADMIN_ACTIONS["ihp"]
+        click_dropdown(text: action)
+        fill_in(COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Please complete this task")
+        find("button", text: COPY::ADD_COLOCATED_TASK_SUBMIT_BUTTON_LABEL).click
+
+        # Expect to see a success message and have the task in the database
+        expect(page).to have_content(format(COPY::ADD_COLOCATED_TASK_CONFIRMATION_TITLE, "an", "action", action))
+        expect(judge_task.children.length).to eq(1)
+        expect(judge_task.children.first).to be_a(ColocatedTask)
       end
     end
 

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -25,7 +25,12 @@ describe JudgeTask do
     context "the task is assigned to the current user" do
       context "in the assign phase" do
         it "should return the assignment action" do
-          expect(subject).to eq([subject_task.build_action_hash(Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h)])
+          expect(subject).to eq(
+            [
+              Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+              Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h
+            ].map { |action| subject_task.build_action_hash(action) }
+          )
         end
 
         context "the task was assigned from Quality Review" do
@@ -34,9 +39,10 @@ describe JudgeTask do
           it "should return the assignment and mark complete actions" do
             expect(subject).to eq(
               [
-                subject_task.build_action_hash(Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h),
-                subject_task.build_action_hash(Constants.TASK_ACTIONS.MARK_COMPLETE.to_h)
-              ]
+                Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+                Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,
+                Constants.TASK_ACTIONS.MARK_COMPLETE.to_h
+              ].map { |action| subject_task.build_action_hash(action) }
             )
           end
         end
@@ -46,7 +52,12 @@ describe JudgeTask do
         let(:subject_task) { FactoryBot.create(:ama_judge_decision_review_task, assigned_to: judge) }
 
         it "should return the dispatch action" do
-          expect(subject).to eq([subject_task.build_action_hash(Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h)])
+          expect(subject).to eq(
+            [
+              Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+              Constants.TASK_ACTIONS.JUDGE_CHECKOUT.to_h
+            ].map { |action| subject_task.build_action_hash(action) }
+          )
         end
       end
     end


### PR DESCRIPTION
Resolves #8608. This PR allows judges to send tasks directly to the VLJ support staff.

## Test path
* Log in as `BVAAABSHIRE`
* Notice that you can add an admin action for any case in the assign or review view