### PR TITLE
Create hearing task at case details load

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -85,6 +85,17 @@ class TasksController < ApplicationController
   def for_appeal
     no_cache
     RootTask.find_or_create_by!(appeal: appeal)
+
+    # This is a temporary solution for legacy hearings. We need them to exist on the case details
+    # page, but have no good way to create them before a page load. So we need to check here if we
+    # need to create a hearing task and if so, create it.
+    # binding.pry
+    if appeal.is_a?(LegacyAppeal) && appeal.case_record.bfcurloc == "57"
+      ScheduleHearingTask.find_or_create_by!(appeal: appeal) do |task|
+        task.update(assigned_to: HearingsManagement.singleton)
+      end
+    end
+
     # VSO users should only get tasks assigned to them or their organization.
     if current_user.vso_employee?
       return json_vso_tasks

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -89,12 +89,7 @@ class TasksController < ApplicationController
     # This is a temporary solution for legacy hearings. We need them to exist on the case details
     # page, but have no good way to create them before a page load. So we need to check here if we
     # need to create a hearing task and if so, create it.
-    # binding.pry
-    if appeal.is_a?(LegacyAppeal) && appeal.case_record.bfcurloc == "57"
-      ScheduleHearingTask.find_or_create_by!(appeal: appeal) do |task|
-        task.update(assigned_to: HearingsManagement.singleton)
-      end
-    end
+    ScheduleHearingTask.create_if_eligible(appeal)
 
     # VSO users should only get tasks assigned to them or their organization.
     if current_user.vso_employee?

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -1,14 +1,14 @@
 class ScheduleHearingTask < GenericTask
   class << self
-    def create_from_params(params, current_user)
-      root_task = RootTask.find_or_create_by!(appeal: params[:appeal])
-      params[:parent_id] = root_task.id
-
-      task_payloads = params.delete(:business_payloads)
-      child_task = super(params, current_user)
-      child_task.task_business_payloads.create(task_payloads) if task_payloads
-
-      child_task
+    def create_if_eligible(appeal)
+      if appeal.is_a?(LegacyAppeal) && appeal.case_record.bfcurloc == "57"
+        ScheduleHearingTask.find_or_create_by!(appeal: appeal) do |task|
+          task.update(
+            assigned_to: HearingsManagement.singleton,
+            parent: RootTask.find_or_create_by!(appeal: appeal)
+          )
+        end
+      end
     end
   end
 
@@ -28,25 +28,9 @@ class ScheduleHearingTask < GenericTask
       task_business_payloads.create(task_payloads)
     end
 
+    update_hearing if params[:status] == Constants.TASK_STATUSES.completed
+
     super(params, current_user)
-  end
-
-  def update_parent_status
-    hearing_pkseq = task_business_payloads[0].values["hearing_pkseq"]
-    hearing_type = task_business_payloads[0].values["hearing_type"]
-    hearing_date = Time.zone.parse(task_business_payloads[0].values["hearing_date"])
-    hearing_date_str = "#{hearing_date.year}-#{hearing_date.month}-#{hearing_date.day} " \
-                       "#{format('%##d', hearing_date.hour)}:#{format('%##d', hearing_date.min)}:00"
-
-    if hearing_type == LegacyHearing::CO_HEARING
-      HearingRepository.update_co_hearing(hearing_date_str, appeal)
-    else
-      HearingRepository.create_child_video_hearing(hearing_pkseq, hearing_date, appeal)
-    end
-
-    AppealRepository.update_location!(appeal, location_based_on_hearing_type(hearing_type))
-
-    super
   end
 
   def location_based_on_hearing_type(hearing_type)
@@ -65,5 +49,23 @@ class ScheduleHearingTask < GenericTask
     end
 
     []
+  end
+
+  private
+
+  def update_hearing
+    hearing_pkseq = task_business_payloads[0].values["hearing_pkseq"]
+    hearing_type = task_business_payloads[0].values["hearing_type"]
+    hearing_date = Time.zone.parse(task_business_payloads[0].values["hearing_date"])
+    hearing_date_str = "#{hearing_date.year}-#{hearing_date.month}-#{hearing_date.day} " \
+                       "#{format('%##d', hearing_date.hour)}:#{format('%##d', hearing_date.min)}:00"
+
+    if hearing_type == LegacyHearing::CO_HEARING
+      HearingRepository.update_co_hearing(hearing_date_str, appeal)
+    else
+      HearingRepository.create_child_video_hearing(hearing_pkseq, hearing_date, appeal)
+    end
+
+    AppealRepository.update_location!(appeal, location_based_on_hearing_type(hearing_type))
   end
 end

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -97,8 +97,6 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
     if (hearingDay.hearingTime) {
       this.props.onHearingTimeChange(hearingDay.hearingTime);
     }
-
-    this.addScheduleHearingTask();
   }
 
   submit = () => {
@@ -133,37 +131,6 @@ class AssignHearingModal extends React.PureComponent<Props, LocalState> {
     }
 
     return true;
-  }
-
-  addScheduleHearingTask = () => {
-    const {
-      scheduleHearingTask, appeal, userId, setLoading
-    } = this.props;
-
-    if (!scheduleHearingTask) {
-      const payload = {
-        data: {
-          tasks: [
-            {
-              type: 'ScheduleHearingTask',
-              external_id: appeal.externalId,
-              assigned_to_type: 'User',
-              assigned_to_id: userId
-            }
-          ]
-        }
-      };
-
-      setLoading(true);
-
-      return ApiUtil.post('/tasks', payload).then((response) => {
-        const resp = JSON.parse(response.text);
-
-        this.props.onReceiveAmaTasks(resp.tasks.data);
-
-        setLoading(false);
-      });
-    }
   }
 
   completeScheduleHearingTask = () => {

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -468,52 +468,6 @@ RSpec.describe TasksController, type: :controller do
             expect(response.status).to eq 404
           end
         end
-
-        context "when creating a Hearings Management task" do
-          let!(:hearings_user) do
-            create(:hearings_coordinator)
-          end
-          let(:params) do
-            [{
-              "type": ScheduleHearingTask.name,
-              "action": "Assign Hearing",
-              "external_id": appeal.vacols_id,
-              "assigned_to_type": "User",
-              "assigned_to_id": hearings_user.id,
-              "business_payloads": {
-                description: "test",
-                values: {
-                  "regional_office_value": "RO17",
-                  "hearing_date": "2018-10-25",
-                  "hearing_time": "8:00"
-                }
-              }
-            }]
-          end
-
-          before do
-            OrganizationsUser.add_user_to_organization(hearings_user, HearingsManagement.singleton)
-            User.authenticate!(user: hearings_user)
-          end
-
-          it "should be successful" do
-            post :create, params: { tasks: params }
-            expect(response.status).to eq 200
-            response_body = JSON.parse(response.body)["tasks"]["data"]
-            expect(response_body.size).to eq 1
-            expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
-            expect(response_body.first["attributes"]["appeal_id"]).to eq appeal.id
-            expect(response_body.first["attributes"]["assigned_to"]["id"]).to eq hearings_user.id
-
-            payloads = response_body.first["attributes"]["task_business_payloads"]
-            expect(payloads.size).to eq 1
-            expect(payloads[0]["description"]).to eq("test")
-            expect(payloads[0]["values"].size).to eq 3
-            expect(payloads[0]["values"]["regional_office_value"]).to eq("RO17")
-            expect(payloads[0]["values"]["hearing_date"]).to eq("2018-10-25")
-            expect(payloads[0]["values"]["hearing_time"]).to eq("8:00")
-          end
-        end
       end
     end
   end

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -62,64 +62,6 @@ describe ScheduleHearingTask do
     end
   end
 
-  describe "Add a schedule hearing task without a pre-existing Root Task" do
-    let(:params) do
-      {
-        type: ScheduleHearingTask.name,
-        action: "Assign Hearing",
-        appeal: appeal,
-        assigned_to_type: "User",
-        assigned_to_id: hearings_user.id
-      }
-    end
-
-    it "should create a root task and a task of type ScheduleHearingTask" do
-      hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
-      parent_task = RootTask.find_by(appeal_id: appeal.id)
-
-      expect(hearing_task.type).to eq(ScheduleHearingTask.name)
-      expect(hearing_task.appeal_type).to eq(LegacyAppeal.name)
-      expect(hearing_task.status).to eq("assigned")
-      expect(hearing_task.parent_id).to eq(parent_task.id)
-      expect(parent_task.appeal_type).to eq(LegacyAppeal.name)
-    end
-  end
-
-  describe "Add a schedule hearing task with a business payload" do
-    let(:root_task) { FactoryBot.create(:root_task, appeal_type: "LegacyAppeal", appeal: appeal) }
-    let(:params) do
-      {
-        type: ScheduleHearingTask.name,
-        action: "Assign Hearing",
-        appeal: appeal,
-        assigned_to_type: "User",
-        assigned_to_id: hearings_user.id,
-        parent_id: root_task.id,
-        business_payloads: {
-          description: "test",
-          values: {
-            "regional_office": "RO17",
-            "hearing_date": "2018-10-25",
-            "hearing_time": "8:00"
-          }
-        }
-      }
-    end
-
-    it "should create a task of type ScheduleHearingTask" do
-      hearing_task = ScheduleHearingTask.create_from_params(params, hearings_user)
-
-      expect(hearing_task.type).to eq(ScheduleHearingTask.name)
-      expect(hearing_task.appeal_type).to eq(LegacyAppeal.name)
-      expect(hearing_task.status).to eq("assigned")
-      expect(hearing_task.task_business_payloads.size).to eq 1
-      expect(hearing_task.task_business_payloads[0].description).to eq("test")
-      expect(hearing_task.task_business_payloads[0].values["regional_office"]).to eq("RO17")
-      expect(hearing_task.task_business_payloads[0].values["hearing_date"]).to eq("2018-10-25")
-      expect(hearing_task.task_business_payloads[0].values["hearing_time"]).to eq("8:00")
-    end
-  end
-
   describe "Add and update a schedule hearing task with a new business payload" do
     let(:hearing) { FactoryBot.create(:case_hearing) }
     let(:root_task) { FactoryBot.create(:root_task, appeal_type: "LegacyAppeal", appeal: appeal) }

--- a/spec/requests/hearing_day_spec.rb
+++ b/spec/requests/hearing_day_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Hearing Schedule", type: :request do
+  before do
+    Timecop.freeze(Time.utc(2019, 1, 1, 0, 0, 0))
+  end
+
   let!(:user) do
     User.authenticate!(roles: ["Build HearSched"])
   end


### PR DESCRIPTION
Resolves #8573

### Description
This moves the task creation of ScheduleHearingTasks from clicking on a task action to loading the case details page. This will allow us to add admin actions to the schedule hearing task.

### Testing Plan
1. Manually ensure that the task action box appears when an appeal that needs a hearing schedule is navigated to.

