### PR TITLE
bump connect_vbms (no logic change, just test updates)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "8dde00d67b7c629e4b871f8dcb3617bfe989b3db"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "4c32edb3b6a1e56a1d52fcc1610827e1c13dbe88"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "3b9edeeaebe3e6a49bb27e8d08486ed8b3959db4"
 gem "dogstatsd-ruby"
 gem "holidays", "~> 6.4"
 # Use jquery as the JavaScript library

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 4c32edb3b6a1e56a1d52fcc1610827e1c13dbe88
-  ref: 4c32edb3b6a1e56a1d52fcc1610827e1c13dbe88
+  revision: 3b9edeeaebe3e6a49bb27e8d08486ed8b3959db4
+  ref: 3b9edeeaebe3e6a49bb27e8d08486ed8b3959db4
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
Bumping connect_vbms gem only to make sure we're using the latest version (there are no logic changes in connect_vbms, just updates to tests).

connect_vbms changes here: https://github.com/department-of-veterans-affairs/connect_vbms/pull/210