### PR TITLE
Show HLRs / SCs if there aren't any appeals for a veteran

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -35,6 +35,7 @@
   "CASE_LIST_TABLE_QUEUE_DROPDOWN_LABEL": "Switch views",
   "CASE_LIST_TABLE_QUEUE_DROPDOWN_OWN_CASES_LABEL": "Your cases",
   "CASE_LIST_TABLE_QUEUE_DROPDOWN_TEAM_CASES_LABEL": "%s team cases",
+  "CASE_LIST_TABLE_EMPTY_TEXT": "This Veteran has no appeals at this time.",
 
   "OTHER_REVIEWS_TABLE_TITLE": "Higher Level Reviews & Supplemental Claims",
   "OTHER_REVIEWS_TABLE_EP_CODE_COLUMN_TITLE": "EP Code(s)",

--- a/client/app/queue/CaseList/CaseListActions.js
+++ b/client/app/queue/CaseList/CaseListActions.js
@@ -121,7 +121,9 @@ export const fetchAppealsUsingVeteranId = (searchQuery) =>
         dispatch(onReceiveClaimReviewsUsingVeteranId(returnedObject.claim_reviews));
 
         // Expect all of the appeals will be for the same Caseflow Veteran ID so we pull off the first for the URL.
-        const caseflowVeteranId = returnedObject.appeals[0].attributes.caseflow_veteran_id;
+        const caseflowVeteranId = returnedObject.appeals.length > 0 ?
+          returnedObject.appeals[0].attributes.caseflow_veteran_id :
+          returnedObject.claim_reviews[0].caseflow_veteran_id;
 
         return resolve(caseflowVeteranId);
 

--- a/client/app/queue/CaseListTable.jsx
+++ b/client/app/queue/CaseListTable.jsx
@@ -96,13 +96,19 @@ class CaseListTable extends React.PureComponent {
     return columns;
   }
 
-  render = () => <Table
-    className="cf-case-list-table"
-    columns={this.getColumns}
-    rowObjects={this.props.appeals}
-    getKeyForRow={this.getKeyForRow}
-    styling={this.props.styling}
-  />
+  render = () => {
+    if (this.props.appeals.length === 0) {
+      return <p>{COPY.CASE_LIST_TABLE_EMPTY_TEXT}</p>;
+    }
+
+    return <Table
+      className="cf-case-list-table"
+      columns={this.getColumns}
+      rowObjects={this.props.appeals}
+      getKeyForRow={this.getKeyForRow}
+      styling={this.props.styling}
+    />;
+  }
 }
 
 CaseListTable.propTypes = {

--- a/client/app/queue/CaseListView.jsx
+++ b/client/app/queue/CaseListView.jsx
@@ -41,7 +41,7 @@ class CaseListView extends React.PureComponent {
   createLoadPromise = () => {
     const caseflowVeteranId = this.props.caseflowVeteranId;
 
-    if (this.props.appeals.length || !caseflowVeteranId) {
+    if (this.props.appeals.length || this.props.claimReviews.length || !caseflowVeteranId) {
       return Promise.resolve();
     }
 
@@ -61,9 +61,12 @@ class CaseListView extends React.PureComponent {
   </React.Fragment>;
 
   caseListTable = () => {
+    let heading;
     const appealsCount = this.props.appeals.length;
+    const claimReviewsCount = this.props.claimReviews.length;
+    const doesSearchHaveAnyResults = (appealsCount + claimReviewsCount > 0);
 
-    if (!appealsCount) {
+    if (!doesSearchHaveAnyResults) {
       return <div>
         {this.searchPageHeading()}
         <hr {...horizontalRuleStyling} />
@@ -73,9 +76,16 @@ class CaseListView extends React.PureComponent {
 
     // Using the first appeal in the list to get the Veteran's name and ID. We expect that data to be
     // the same for all appeals in the list.
-    const firstAppeal = this.props.appeals[0];
-    const heading = `${appealsCount} ${pluralize('case', appealsCount)} found for
-        “${firstAppeal.veteranFullName} (${firstAppeal.veteranFileNumber})”`;
+    if (this.props.appeals.length > 0) {
+      const firstAppeal = this.props.appeals[0];
+
+      heading = `${appealsCount} ${pluralize('case', appealsCount)} found for
+          “${firstAppeal.veteranFullName} (${firstAppeal.veteranFileNumber})”`;
+    } else if (this.props.claimReviews.length > 0) {
+      const firstClaimReview = this.props.claimReviews[0];
+
+      heading = `No cases found for “${firstClaimReview.veteranFullName} (${firstClaimReview.veteranFileNumber})”`;
+    }
 
     return <div>
       {this.searchPageHeading()}

--- a/client/app/queue/OtherReviewsTable.jsx
+++ b/client/app/queue/OtherReviewsTable.jsx
@@ -31,7 +31,7 @@ class SubdividedTableRow extends React.PureComponent {
   }
 }
 
-class CaseListTable extends React.PureComponent {
+class OtherReviewsTable extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = { styling: {} };
@@ -148,7 +148,7 @@ class CaseListTable extends React.PureComponent {
   }
 }
 
-CaseListTable.propTypes = {
+OtherReviewsTable.propTypes = {
   reviews: PropTypes.arrayOf(PropTypes.object).isRequired,
   veteranName: PropTypes.string,
   styling: PropTypes.object
@@ -163,4 +163,4 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   clearCaseListSearch
 }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(CaseListTable);
+export default connect(mapStateToProps, mapDispatchToProps)(OtherReviewsTable);


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/8747

cc @shanear 

### Description
This PR fixes a bug caused by this condition:
- When a veteran has no appeals, but does have claim reviews, they do not show up on the case search page.

![screenshot 2019-01-15 18 30 08](https://user-images.githubusercontent.com/2928395/51222669-9b1d0280-18f3-11e9-9dcf-9b819b28578d.png)

