### PR TITLE
Treat EP status CLR and CAN as available for open modifiers

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -451,7 +451,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def taken_modifiers
-    @taken_modifiers ||= veteran.end_products.map(&:modifier)
+    @taken_modifiers ||= veteran.end_products.select(&:active?).map(&:modifier)
   end
 
   def find_open_modifier

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -171,6 +171,24 @@ describe EndProductEstablishment do
       end
     end
 
+    context "when existing EP has status CLR or CAN" do
+      before do
+        %w[030 031 032].each do |modifier|
+          Generators::EndProduct.build(
+            veteran_file_number: "12341234",
+            bgs_attrs: { end_product_type_code: modifier, status_type_code: %w[CLR CAN].sample }
+          )
+        end
+      end
+
+      it "considers those EP modifiers as open" do
+        subject
+        expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
+          hash_including(claim_hash: hash_including(benefit_type_code: Veteran::BENEFIT_TYPE_CODE_DEATH))
+        )
+      end
+    end
+
     context "when all goes well" do
       it "creates end product and sets reference_id" do
         subject

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -96,7 +96,7 @@ describe EndProductEstablishment do
     context "when eps with a valid modifiers already exist" do
       let!(:past_created_ep) do
         Generators::EndProduct.build(
-          veteran_file_number: "12341234",
+          veteran_file_number: veteran_file_number,
           bgs_attrs: { end_product_type_code: "030" }
         )
       end
@@ -160,7 +160,7 @@ describe EndProductEstablishment do
       before do
         %w[030 031 032].each do |modifier|
           Generators::EndProduct.build(
-            veteran_file_number: "12341234",
+            veteran_file_number: veteran_file_number,
             bgs_attrs: { end_product_type_code: modifier }
           )
         end
@@ -175,7 +175,7 @@ describe EndProductEstablishment do
       before do
         %w[030 031 032].each do |modifier|
           Generators::EndProduct.build(
-            veteran_file_number: "12341234",
+            veteran_file_number: veteran_file_number,
             bgs_attrs: { end_product_type_code: modifier, status_type_code: %w[CLR CAN].sample }
           )
         end
@@ -184,7 +184,7 @@ describe EndProductEstablishment do
       it "considers those EP modifiers as open" do
         subject
         expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
-          hash_including(claim_hash: hash_including(benefit_type_code: Veteran::BENEFIT_TYPE_CODE_DEATH))
+          hash_including(veteran_hash: veteran.reload.to_vbms_hash)
         )
       end
     end


### PR DESCRIPTION
connects #8762 

### Description
Only consider `active?` End Products in list of taken modifiers.
