### PR TITLE
VACOLS issues should also ignore the AMA timeliness reqs

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -499,9 +499,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def should_check_for_before_ama?
-    return false if is_unidentified || ramp_claim_id || vacols_id
-
-    true
+    !is_unidentified && !ramp_claim_id && !vacols_id
   end
 
   def check_for_legacy_issue_not_withdrawn!

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -491,13 +491,17 @@ class RequestIssue < ApplicationRecord
   # rubocop:enable Metrics/PerceivedComplexity
 
   def check_for_before_ama!
-    return unless eligible?
-    return if is_unidentified
-    return if ramp_claim_id
+    return unless eligible? && should_check_for_before_ama?
 
     if decision_or_promulgation_date && decision_or_promulgation_date < DecisionReview.ama_activation_date
       self.ineligible_reason = :before_ama
     end
+  end
+
+  def should_check_for_before_ama?
+    return false if is_unidentified || ramp_claim_id || vacols_id
+
+    true
   end
 
   def check_for_legacy_issue_not_withdrawn!

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -61,14 +61,14 @@ class AddedIssue extends React.PureComponent {
       errorMsg = INELIGIBLE_REQUEST_ISSUES.appeal_to_higher_level_review;
     } else if (formType === 'appeal' && issue.sourceReviewType === 'Appeal') {
       errorMsg = INELIGIBLE_REQUEST_ISSUES.appeal_to_appeal;
-    } else if (issue.beforeAma && !issue.vacolsId) {
-      errorMsg = INELIGIBLE_REQUEST_ISSUES.before_ama;
     } else if (issue.vacolsId) {
       if (!legacyOptInApproved) {
         errorMsg = INELIGIBLE_REQUEST_ISSUES.legacy_issue_not_withdrawn;
       } else if (!issue.eligibleForSocOptIn) {
         errorMsg = INELIGIBLE_REQUEST_ISSUES.legacy_appeal_not_eligible;
       }
+    } else if (issue.beforeAma) {
+      errorMsg = INELIGIBLE_REQUEST_ISSUES.before_ama;
     }
 
     if (errorMsg !== '') {

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -61,7 +61,7 @@ class AddedIssue extends React.PureComponent {
       errorMsg = INELIGIBLE_REQUEST_ISSUES.appeal_to_higher_level_review;
     } else if (formType === 'appeal' && issue.sourceReviewType === 'Appeal') {
       errorMsg = INELIGIBLE_REQUEST_ISSUES.appeal_to_appeal;
-    } else if (issue.beforeAma) {
+    } else if (issue.beforeAma && !issue.vacolsId) {
       errorMsg = INELIGIBLE_REQUEST_ISSUES.before_ama;
     } else if (issue.vacolsId) {
       if (!legacyOptInApproved) {

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -74,6 +74,17 @@ feature "Appeal Intake" do
     )
   end
 
+  let!(:before_ama_rating) do
+    Generators::Rating.build(
+      participant_id: veteran.participant_id,
+      promulgation_date: DecisionReview.ama_activation_date - 5.days,
+      profile_date: DecisionReview.ama_activation_date - 11.days,
+      issues: [
+        { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
+      ]
+    )
+  end
+
   let(:no_ratings_err) { Rating::NilRatingProfileListError.new("none!") }
 
   it "cancels an intake in progress when there is a NilRatingProfileListError" do
@@ -330,15 +341,6 @@ feature "Appeal Intake" do
           reference_id: "ramp_ref_id" }
       ],
       associated_claims: { bnft_clm_tc: "683SCRRRAMP", clm_id: "ramp_claim_id" }
-    )
-
-    Generators::Rating.build(
-      participant_id: veteran.participant_id,
-      promulgation_date: DecisionReview.ama_activation_date - 5.days,
-      profile_date: DecisionReview.ama_activation_date - 11.days,
-      issues: [
-        { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
-      ]
     )
 
     epe = create(:end_product_establishment, :active)
@@ -768,6 +770,16 @@ feature "Appeal Intake" do
         add_intake_rating_issue("None of these match")
 
         expect(page).to have_content("Description for Active Duty Adjustments")
+
+        # add before_ama ratings
+        click_intake_add_issue
+        add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
+        add_intake_rating_issue("limitation of thigh motion (extension)")
+
+        expect(page).to have_content("Non-RAMP Issue before AMA Activation")
+        expect(page).to_not have_content(
+          "Non-RAMP Issue before AMA Activation #{Constants.INELIGIBLE_REQUEST_ISSUES.before_ama}"
+        )
 
         # add eligible legacy issue
         click_intake_add_issue

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -88,6 +88,17 @@ feature "Higher-Level Review" do
     )
   end
 
+  let!(:before_ama_rating) do
+    Generators::Rating.build(
+      participant_id: veteran.participant_id,
+      promulgation_date: DecisionReview.ama_activation_date - 5.days,
+      profile_date: DecisionReview.ama_activation_date - 10.days,
+      issues: [
+        { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
+      ]
+    )
+  end
+
   it "Creates an end product and contentions for it" do
     # Testing one relationship, tests 2 relationships in HRL and nil in Appeal
     allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(
@@ -589,17 +600,6 @@ feature "Higher-Level Review" do
         profile_date: receipt_date - 450.days,
         issues: [
           { reference_id: old_reference_id, decision_text: "Really old injury" }
-        ]
-      )
-    end
-
-    let!(:before_ama_rating) do
-      Generators::Rating.build(
-        participant_id: veteran.participant_id,
-        promulgation_date: DecisionReview.ama_activation_date - 5.days,
-        profile_date: DecisionReview.ama_activation_date - 10.days,
-        issues: [
-          { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
         ]
       )
     end
@@ -1266,6 +1266,17 @@ feature "Higher-Level Review" do
             "#{intake_constants.adding_this_issue_vacols_optin}: Service connection, ankylosis of hip"
           )
 
+          # add before_ama ratings
+          click_intake_add_issue
+          add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
+          add_intake_rating_issue("limitation of thigh motion (extension)")
+          add_untimely_exemption_response("Yes")
+
+          expect(page).to have_content("Non-RAMP Issue before AMA Activation")
+          expect(page).to_not have_content(
+            "Non-RAMP Issue before AMA Activation #{ineligible_constants.before_ama}"
+          )
+
           # add ineligible legacy issue (already opted-in)
           click_intake_add_issue
           add_intake_rating_issue("Looks like a VACOLS issue")
@@ -1291,7 +1302,7 @@ feature "Higher-Level Review" do
 
           expect(page).to have_content(intake_constants.vacols_optin_issue_closed)
 
-          expect(LegacyIssueOptin.all.count).to eq(1)
+          expect(LegacyIssueOptin.all.count).to eq(2)
 
           li_optin = LegacyIssueOptin.first
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -93,6 +93,17 @@ feature "Supplemental Claim Intake" do
     )
   end
 
+  let!(:before_ama_rating) do
+    Generators::Rating.build(
+      participant_id: veteran.participant_id,
+      promulgation_date: DecisionReview.ama_activation_date - 5.days,
+      profile_date: DecisionReview.ama_activation_date - 10.days,
+      issues: [
+        { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
+      ]
+    )
+  end
+
   it "Creates an end product" do
     # Testing two relationships, tests 1 relationship in HRL and nil in Appeal
     allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(
@@ -444,17 +455,6 @@ feature "Supplemental Claim Intake" do
             decision_text: "Really old injury" }
         ],
         associated_claims: { bnft_clm_tc: "683SCRRRAMP", clm_id: "ramp_claim_id" }
-      )
-    end
-
-    let!(:before_ama_rating) do
-      Generators::Rating.build(
-        participant_id: veteran.participant_id,
-        promulgation_date: DecisionReview.ama_activation_date - 5.days,
-        profile_date: DecisionReview.ama_activation_date - 10.days,
-        issues: [
-          { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
-        ]
       )
     end
 
@@ -866,6 +866,17 @@ feature "Supplemental Claim Intake" do
           add_intake_rating_issue("None of these match")
 
           expect(page).to have_content("Description for Active Duty Adjustments")
+
+          # add before_ama ratings
+          click_intake_add_issue
+          add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
+          add_intake_rating_issue("limitation of thigh motion (extension)")
+          add_untimely_exemption_response("Yes")
+
+          expect(page).to have_content("Non-RAMP Issue before AMA Activation")
+          expect(page).to_not have_content(
+            "Non-RAMP Issue before AMA Activation #{ineligible_constants.before_ama}"
+          )
 
           # add eligible legacy issue
           click_intake_add_issue

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -865,9 +865,22 @@ describe RequestIssue do
       context "rating issue is from a RAMP decision" do
         let(:ramp_claim_id) { "ramp_claim_id" }
 
-        it "does not flag rating issues before AMA from a RAMP decision" do
+        it "does not flag rating issues before AMA" do
           rating_request_issue.contested_rating_issue_reference_id = "ramp_ref_id"
+
           rating_request_issue.validate_eligibility!
+
+          expect(rating_request_issue.ineligible_reason).to be_nil
+        end
+      end
+
+      context "rating issue is from a VACOLS legacy opt-in" do
+        it "does not flag rating issues before AMA" do
+          rating_request_issue.review_request.legacy_opt_in_approved = true
+          rating_request_issue.vacols_id = "something"
+
+          rating_request_issue.validate_eligibility!
+
           expect(rating_request_issue.ineligible_reason).to be_nil
         end
       end


### PR DESCRIPTION
connects #7337 

### Description
VACOLS (legacy) issues do not get AMA timeliness check.

