### PR TITLE
require receiptDate to be set

### DIFF
--- a/client/app/intake/pages/review.jsx
+++ b/client/app/intake/pages/review.jsx
@@ -79,8 +79,8 @@ class ReviewNextButton extends React.PureComponent {
         this.handleClick(selectedForm, intakeData);
       }}
       loading={intakeData ? intakeData.requestStatus.submitReview === REQUEST_STATE.IN_PROGRESS : true}
-      disabled={formType === 'ramp_refiling' ?
-        toggleIneligibleError(intakeData.hasInvalidOption, intakeData.optionSelected) : needsRelationships}
+      disabled={!intakeData.receiptDate || (formType === 'ramp_refiling' ?
+        toggleIneligibleError(intakeData.hasInvalidOption, intakeData.optionSelected) : needsRelationships)}
     >
       Continue to next step
     </Button>;

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -37,7 +37,7 @@ export const getReceiptDateError = (responseErrorCodes, state) => (
 );
 
 export const toggleIneligibleError = (hasInvalidOption, selectedOption) => (
-  hasInvalidOption && Boolean(selectedOption === REVIEW_OPTIONS.HIGHER_LEVEL_REVIEW.key ||
+  Boolean(hasInvalidOption) && Boolean(selectedOption === REVIEW_OPTIONS.HIGHER_LEVEL_REVIEW.key ||
     selectedOption === REVIEW_OPTIONS.HIGHER_LEVEL_REVIEW_WITH_HEARING.key)
 );
 


### PR DESCRIPTION
Connects #8739

This is a stopgap for the sentry error. Ideally we'd have validation on each type of form type to make sure all fields are filled out.