### PR TITLE
Prevent saving video hearings to Caseflow with hearing dates prior to 4/1/2019

### DIFF
--- a/client/app/hearingSchedule/components/HearingDayAddModal.jsx
+++ b/client/app/hearingSchedule/components/HearingDayAddModal.jsx
@@ -115,6 +115,11 @@ class HearingDayAddModal extends React.Component {
       roErrorMessages.push('Please make sure you select a Regional Office');
     }
 
+    if (this.state.videoSelected && this.videoHearingDateNotValid(this.props.selectedHearingDay)) {
+      this.setState({ dateError: true });
+      errorMessages.push('Video hearing days cannot be scheduled for prior than April 1st through Caseflow.');
+    }
+
     if (errorMessages.length > 0) {
       this.setState({ errorMessages });
     }
@@ -128,6 +133,12 @@ class HearingDayAddModal extends React.Component {
     }
 
     this.persistHearingDay();
+  };
+
+  videoHearingDateNotValid = (hearingDate) => {
+    const integerDate = parseInt(hearingDate.split('-').join(''), 10);
+
+    return integerDate < 20190401;
   };
 
   persistHearingDay = () => {
@@ -260,7 +271,7 @@ class HearingDayAddModal extends React.Component {
 
   showAlert = () => {
     return this.state.serverError || this.state.noRoomsAvailable;
-  }
+  };
 
   modalMessage = () => {
     return <React.Fragment>

--- a/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
+++ b/client/app/hearingSchedule/containers/ListScheduleContainer.jsx
@@ -57,7 +57,7 @@ export class ListScheduleContainer extends React.Component {
   componentDidMount = () => {
     this.props.onSelectedHearingDayChange('');
     this.setState({ showModalAlert: false });
-  }
+  };
 
   componentWillUnmount = () => {
     this.props.onResetDeleteSuccessful();

--- a/spec/feature/hearing_schedule/add_hearing_day_spec.rb
+++ b/spec/feature/hearing_schedule/add_hearing_day_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature "Add a Hearing Day" do
       fill_in "coordinator", with: "Casimir R Funk"
       fill_in "Notes (Optional)", with: "Test notes."
       find("button", text: "Confirm").click
-      expect(page).to have_content("You have successfully added Hearing Day 01/15/2019")
+      expect(page).to have_content("You have successfully added Hearing Day 01/15/2019", wait: 30)
     end
   end
 
@@ -82,7 +82,7 @@ RSpec.feature "Add a Hearing Day" do
       expect(page).to have_content("Welcome to Hearing Schedule!")
       find("button", text: "Add Hearing Date").click
       expect(page).to have_content("Add Hearing Day")
-      fill_in "hearingDate", with: "01152019"
+      fill_in "hearingDate", with: "04152019"
       click_dropdown(index: "V", text: "Video")
       expect(page).to have_content("Select Regional Office (RO)", wait: 30)
       dropdowns = page.all(".Select-control")
@@ -92,7 +92,7 @@ RSpec.feature "Add a Hearing Day" do
       fill_in "coordinator", with: "Casimir R Funk"
       fill_in "Notes (Optional)", with: "Test notes."
       find("button", text: "Confirm").click
-      expect(page).to have_content("You have successfully added Hearing Day 01/15/2019")
+      expect(page).to have_content("You have successfully added Hearing Day 04/15/2019", wait: 30)
     end
 
     scenario "Leave Regional Office without a selection, expect error" do
@@ -100,7 +100,7 @@ RSpec.feature "Add a Hearing Day" do
       expect(page).to have_content("Welcome to Hearing Schedule!")
       find("button", text: "Add Hearing Date").click
       expect(page).to have_content("Add Hearing Day")
-      fill_in "hearingDate", with: "01152019"
+      fill_in "hearingDate", with: "04152019"
       click_dropdown(index: "V", text: "Video")
       expect(page).to have_content("Select Regional Office (RO)", wait: 30)
       fill_in "vlj", with: "Sallie L Anderson"


### PR DESCRIPTION

Resolves #8783 

### Description
Implemented check for video hearings where none may be added if the hearing date entered is prior to the 4/1/2019 date.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Add Hearing Day
2. Enter a Feb or March date
3. Confirm error is shown
4. Change hearing date to a date after April 1, 2019
5. Confirm hearing day is added successfully


