### PR TITLE
Set autocomplete to off for Document ID field

### DIFF
--- a/client/app/components/TextField.jsx
+++ b/client/app/components/TextField.jsx
@@ -24,7 +24,8 @@ export default class TextField extends React.Component {
       onKeyPress,
       strongLabel,
       maxLength,
-      max
+      max,
+      autoComplete
     } = this.props;
 
     let textInputClass = className.concat(
@@ -75,6 +76,7 @@ export default class TextField extends React.Component {
           title={title}
           maxLength={maxLength}
           max={max}
+          autoComplete={autoComplete}
         />
       }
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -194,6 +194,7 @@ class SubmitDecisionView extends React.PureComponent<Props> {
         onChange={(value) => this.props.setDecisionOptions({ document_id: value })}
         value={decisionOpts.document_id}
         maxLength={DOCUMENT_ID_MAX_LENGTH}
+        autoComplete="off"
       />
       <JudgeSelectComponent assignedByCssId={
         (this.props.task && this.props.task.addedByCssId) || '' /* not compatible with AMA tasks */


### PR DESCRIPTION
**Why**: Some users are being confused by the autocomplete dropdown
that shows them previous document IDs they've entered in that browser.

Resolves #8785

**Acceptance Criteria:**
The Document ID text field should have the property `autocomplete=off`.

**Test Plan:**
1. Go through the decision checkout flow once, then repeat.
2. On the last page of the decision checkout flow, start typing a number.
A dropdown with previously-entered document IDs should not appear.