### PR TITLE
Stop autocomplete suggestions for searchable dropdowns

### DIFF
--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -170,7 +170,10 @@ class SearchableDropdown extends React.Component<Props, ComponentState> {
       <div className={errorMessage ? 'usa-input-error' : ''}>
         {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
         <SelectComponent
-          inputProps={{ id: name }}
+          inputProps={{
+            id: name,
+            autoComplete: 'off'
+          }}
           options={options}
           onChange={this.onChange}
           value={this.state.value}


### PR DESCRIPTION
### Description
Stops autocomplete suggestions that block the searchable tags in any caseflow searchable dropdowns. See https://github.com/department-of-veterans-affairs/appeals-support/issues/3835

### Acceptance Criteria
- [x] No dropdown elements have autocomplete
