### PR TITLE
assign `BvaDispatchTask`s with automatic child creation

### DIFF
--- a/app/controllers/case_reviews_controller.rb
+++ b/app/controllers/case_reviews_controller.rb
@@ -46,7 +46,7 @@ class CaseReviewsController < ApplicationController
     if QualityReviewCaseSelector.select_case_for_quality_review?
       QualityReviewTask.create_from_root_task(root_task)
     else
-      BvaDispatchTask.create_and_assign(root_task)
+      BvaDispatchTask.create_from_root_task(root_task)
     end
   end
 

--- a/app/models/bva_dispatch_task_distributor.rb
+++ b/app/models/bva_dispatch_task_distributor.rb
@@ -1,0 +1,6 @@
+class BvaDispatchTaskDistributor < RoundRobinTaskDistributor
+  def initialize(list_of_assignees: BvaDispatch.singleton.users.order(:id).pluck(:css_id),
+                 task_class: BvaDispatchTask)
+    super
+  end
+end

--- a/app/models/organizations/bva_dispatch.rb
+++ b/app/models/organizations/bva_dispatch.rb
@@ -2,4 +2,8 @@ class BvaDispatch < Organization
   def self.singleton
     BvaDispatch.first || BvaDispatch.create(name: "Board Dispatch")
   end
+
+  def next_assignee(options = {})
+    BvaDispatchTaskDistributor.new.next_assignee(options)
+  end
 end

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -1,19 +1,7 @@
 class BvaDispatchTask < GenericTask
-  include RoundRobinAssigner
-
   class << self
-    def create_and_assign(root_task)
-      parent = create!(
-        assigned_to: BvaDispatch.singleton,
-        parent_id: root_task.id,
-        appeal: root_task.appeal,
-        status: Constants.TASK_STATUSES.on_hold
-      )
-      create!(
-        appeal: parent.appeal,
-        parent_id: parent.id,
-        assigned_to: next_assignee
-      )
+    def create_from_root_task(root_task)
+      create!(assigned_to: BvaDispatch.singleton, parent_id: root_task.id, appeal: root_task.appeal)
     end
 
     def outcode(appeal, params, user)

--- a/app/models/tasks/quality_review_task.rb
+++ b/app/models/tasks/quality_review_task.rb
@@ -16,7 +16,7 @@ class QualityReviewTask < GenericTask
     # QualityReviewTasks may be assigned to organizations or individuals. However, for each appeal that goes through
     # quality review the a task assigned to the organization will exist (even if there is none assigned to an
     # individual). To prevent creating duplicate BvaDispatchTasks only create one for the organization task.
-    BvaDispatchTask.create_and_assign(root_task) if assigned_to == QualityReview.singleton
+    BvaDispatchTask.create_from_root_task(root_task) if assigned_to == QualityReview.singleton
     super
   end
 end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -484,7 +484,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
     end
 
     before do
-      allow(BvaDispatchTask).to receive(:list_of_assignees).and_return([user.css_id])
+      OrganizationsUser.add_user_to_organization(user, BvaDispatch.singleton)
 
       key, t = Idt::Token.generate_one_time_key_and_proposed_token
       Idt::Token.activate_proposed_token(key, user.css_id)
@@ -498,7 +498,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
     context "when some params are missing" do
       let(:params) { { appeal_id: root_task.appeal.external_id } }
-      before { BvaDispatchTask.create_and_assign(root_task) }
+      before { BvaDispatchTask.create_from_root_task(root_task) }
 
       it "should throw an error" do
         post :outcode, params: params
@@ -510,7 +510,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
     context "when citation_number parameter fails validation" do
       let(:citation_number) { "INVALID" }
-      before { BvaDispatchTask.create_and_assign(root_task) }
+      before { BvaDispatchTask.create_from_root_task(root_task) }
 
       it "should throw an error" do
         post :outcode, params: params
@@ -521,7 +521,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
     end
 
     context "when single BvaDispatchTask exists for user and appeal combination" do
-      before { BvaDispatchTask.create_and_assign(root_task) }
+      before { BvaDispatchTask.create_from_root_task(root_task) }
 
       it "should complete the BvaDispatchTask assigned to the User and the task assigned to the BvaDispatch org" do
         post :outcode, params: params
@@ -540,9 +540,9 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       let(:task_count) { 4 }
       before do
         task_count.times do
-          personal_task = BvaDispatchTask.create_and_assign(root_task)
+          org_task = BvaDispatchTask.create_from_root_task(root_task)
           # Set status of org-level task to completed to avoid getting caught by GenericTask.verify_org_task_unique.
-          personal_task.parent.update!(status: Constants.TASK_STATUSES.completed)
+          org_task.update!(status: Constants.TASK_STATUSES.completed)
         end
       end
 

--- a/spec/models/organizations/bva_dispatch_spec.rb
+++ b/spec/models/organizations/bva_dispatch_spec.rb
@@ -1,0 +1,53 @@
+describe BvaDispatch do
+  let(:bva_dispatch_org) { BvaDispatch.singleton }
+
+  before do
+    FactoryBot.create_list(:user, 6).each do |u|
+      OrganizationsUser.add_user_to_organization(u, bva_dispatch_org)
+    end
+  end
+
+  describe ".next_assignee" do
+    subject { bva_dispatch_org.next_assignee }
+
+    context "when there are no members of the BVA Dispatch team" do
+      before do
+        OrganizationsUser.where(organization: bva_dispatch_org).delete_all
+      end
+
+      it "should throw an error" do
+        expect { subject }.to raise_error do |error|
+          expect(error).to be_a(Caseflow::Error::RoundRobinTaskDistributorError)
+          expect(error.message).to eq("list_of_assignees cannot be empty")
+        end
+      end
+    end
+
+    context "when there are members on the BVA Dispatch team" do
+      it "should return the first member of the BVA Dispatch team" do
+        expect(subject).to eq(bva_dispatch_org.users.first)
+      end
+    end
+  end
+
+  describe ".automatically_assign_to_member?" do
+    subject { bva_dispatch_org.automatically_assign_to_member? }
+
+    it "should return true" do
+      expect(subject).to eq(true)
+    end
+
+    context "when there are no members of the BVA Dispatch team" do
+      before do
+        OrganizationsUser.where(organization: bva_dispatch_org).delete_all
+      end
+
+      it "should throw an error" do
+        expect { subject }.to raise_error do |error|
+          expect(error).to be_a(Caseflow::Error::RoundRobinTaskDistributorError)
+          expect(error.message).to eq("list_of_assignees cannot be empty")
+        end
+      end
+    end
+  end
+end

--- a/spec/models/tasks/bva_dispatch_task_spec.rb
+++ b/spec/models/tasks/bva_dispatch_task_spec.rb
@@ -3,38 +3,39 @@ describe BvaDispatchTask do
     Timecop.freeze(Time.utc(2020, 1, 1, 19, 0, 0))
   end
 
-  describe ".create_and_assign" do
+  describe ".create_from_root_task" do
     context "when no root_task passed as argument" do
       it "throws an error" do
-        expect { BvaDispatchTask.create_and_assign(nil) }.to raise_error(NoMethodError)
+        expect { BvaDispatchTask.create_from_root_task(nil) }.to raise_error(NoMethodError)
       end
     end
 
     context "when valid root_task passed as argument" do
       let(:root_task) { FactoryBot.create(:root_task) }
       before do
-        # Make sure the BvaDispatch team has members
         OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
       end
 
       it "should create a BvaDispatchTask assigned to a User with a parent task assigned to the BvaDispatch org" do
-        task = BvaDispatchTask.create_and_assign(root_task)
-        expect(task.assigned_to.class).to eq(User)
-        expect(task.parent.assigned_to.class).to eq(BvaDispatch)
-        expect(task.parent.status).to eq(Constants.TASK_STATUSES.on_hold)
+        parent_task = BvaDispatchTask.create_from_root_task(root_task)
+        expect(parent_task.assigned_to.class).to eq(BvaDispatch)
+        expect(parent_task.status).to eq(Constants.TASK_STATUSES.on_hold)
+        expect(parent_task.children.count).to eq 1
+        child_task = parent_task.children.first
+        expect(child_task.assigned_to.class).to eq User
+        expect(child_task.status).to eq(Constants.TASK_STATUSES.assigned)
       end
     end
 
     context "when organization-level BvaDispatchTask already exists" do
       let(:root_task) { FactoryBot.create(:root_task) }
       before do
-        # Make sure the BvaDispatch team has members
         OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
-        BvaDispatchTask.create_and_assign(root_task)
+        BvaDispatchTask.create_from_root_task(root_task)
       end
 
       it "should raise an error" do
-        expect { BvaDispatchTask.create_and_assign(root_task) }.to raise_error(Caseflow::Error::DuplicateOrgTask)
+        expect { BvaDispatchTask.create_from_root_task(root_task) }.to raise_error(Caseflow::Error::DuplicateOrgTask)
       end
     end
   end
@@ -53,14 +54,16 @@ describe BvaDispatchTask do
     end
 
     before do
-      allow(BvaDispatchTask).to receive(:list_of_assignees).and_return([user.css_id])
+      OrganizationsUser.add_user_to_organization(user, BvaDispatch.singleton)
       FeatureToggle.enable!(:decision_document_upload)
     end
 
-    after { FeatureToggle.disable!(:decision_document_upload) }
+    after do
+      FeatureToggle.disable!(:decision_document_upload)
+    end
 
     context "when single BvaDispatchTask exists for user and appeal combination" do
-      before { BvaDispatchTask.create_and_assign(root_task) }
+      before { BvaDispatchTask.create_from_root_task(root_task) }
 
       context "when :decision_document_upload feature is enabled" do
         it "should complete the BvaDispatchTask assigned to the User and the task assigned to the BvaDispatch org" do
@@ -98,9 +101,9 @@ describe BvaDispatchTask do
       let(:task_count) { 4 }
       before do
         task_count.times do
-          personal_task = BvaDispatchTask.create_and_assign(root_task)
+          org_task = BvaDispatchTask.create_from_root_task(root_task)
           # Set status of org-level task to completed to avoid getting caught by GenericTask.verify_org_task_unique.
-          personal_task.parent.update!(status: Constants.TASK_STATUSES.completed)
+          org_task.update!(status: Constants.TASK_STATUSES.completed)
         end
       end
 
@@ -127,7 +130,7 @@ describe BvaDispatchTask do
 
     context "when parameters do not pass vaidation" do
       let(:citation_number) { "ABADCITATIONUMBER" }
-      before { BvaDispatchTask.create_and_assign(root_task) }
+      before { BvaDispatchTask.create_from_root_task(root_task) }
 
       it "should throw an error" do
         expect { BvaDispatchTask.outcode(root_task.appeal, params, user) }.to(raise_error) do |e|
@@ -142,7 +145,7 @@ describe BvaDispatchTask do
         p.delete(:decision_date)
         p
       end
-      before { BvaDispatchTask.create_and_assign(root_task) }
+      before { BvaDispatchTask.create_from_root_task(root_task) }
 
       it "should complete the BvaDispatchTask assigned to the User and the task assigned to the BvaDispatch org" do
         expect { BvaDispatchTask.outcode(root_task.appeal, incomplete_params, user) }.to(raise_error) do |e|
@@ -159,7 +162,7 @@ describe BvaDispatchTask do
       end
       before do
         allow(Caseflow::Fakes::S3Service).to receive(:store_file)
-        BvaDispatchTask.create_and_assign(root_task)
+        BvaDispatchTask.create_from_root_task(root_task)
         BvaDispatchTask.outcode(root_task.appeal, params, user)
       end
 


### PR DESCRIPTION
Resolves #8533

### Description
Uses the method established in #8489 to distribute `BvaDispatchTask`s
