### PR TITLE
add app tagging for debugging

### DIFF
--- a/app/controllers/dispatch/tasks_controller.rb
+++ b/app/controllers/dispatch/tasks_controller.rb
@@ -2,7 +2,7 @@ class Dispatch::TasksController < ApplicationController
   class InvalidTaskClassError < StandardError; end
   class InvalidTaskStateError < StandardError; end
 
-  before_action :check_dispatch_out_of_service
+  before_action :check_dispatch_out_of_service, :set_application
   before_action :verify_admin_access, only: [:index]
 
   TASK_CLASSES = {
@@ -20,6 +20,10 @@ class Dispatch::TasksController < ApplicationController
   end
 
   private
+
+  def set_application
+    RequestStore.store[:application] = "dispatch"
+  end
 
   def check_dispatch_out_of_service
     render "out_of_service", layout: "application" if Rails.cache.read("dispatch_out_of_service")

--- a/app/controllers/dispatch/user_quotas_controller.rb
+++ b/app/controllers/dispatch/user_quotas_controller.rb
@@ -1,5 +1,6 @@
 class Dispatch::UserQuotasController < ApplicationController
   before_action :verify_manager_access
+  before_action :set_application
 
   def update
     user_quota.update!(user_quota_params)
@@ -10,6 +11,10 @@ class Dispatch::UserQuotasController < ApplicationController
   end
 
   private
+
+  def set_application
+    RequestStore.store[:application] = "dispatch"
+  end
 
   def user_quota_params
     { locked_task_count: params[:locked_task_count] }

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -11,5 +11,8 @@ class ApplicationJob < ActiveJob::Base
     # setup debug context
     Raven.tags_context(job: job.class.name, queue: job.queue_name)
     Raven.extra_context(application: self.class.app_name.to_s)
+    if self.class.app_name.present?
+      RequestStore.store[:application] = "#{self.class.app_name}_job"
+    end
   end
 end

--- a/app/jobs/decision_issue_sync_job.rb
+++ b/app/jobs/decision_issue_sync_job.rb
@@ -5,7 +5,6 @@ class DecisionIssueSyncJob < CaseflowJob
   application_attr :intake
 
   def perform(request_issue_or_effectuation)
-    RequestStore.store[:application] = "intake"
     RequestStore.store[:current_user] = User.system_user
 
     begin

--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -7,7 +7,6 @@ class DecisionReviewProcessJob < CaseflowJob
   def perform(decision_review)
     # restore whatever the user was when we finish, in case we are not running async (as during tests)
     current_user = RequestStore.store[:current_user]
-    RequestStore.store[:application] = "intake"
     RequestStore.store[:current_user] = User.system_user
 
     return_value = nil

--- a/app/jobs/fetch_documents_for_reader_user_job.rb
+++ b/app/jobs/fetch_documents_for_reader_user_job.rb
@@ -31,7 +31,6 @@ class FetchDocumentsForReaderUserJob < ApplicationJob
 
   def setup_debug_context(reader_user)
     current_user = reader_user.user
-    RequestStore.store[:application] = "reader"
     RequestStore.store[:current_user] = current_user
     Raven.extra_context(application: "reader")
     Raven.user_context(

--- a/app/jobs/retrieve_documents_for_reader_job.rb
+++ b/app/jobs/retrieve_documents_for_reader_job.rb
@@ -6,8 +6,6 @@ class RetrieveDocumentsForReaderJob < ApplicationJob
 
   DEFAULT_USERS_LIMIT = 3
   def perform(args = {})
-    RequestStore.store[:application] = "reader"
-
     # specified limit of users we fetch for
     limit = args["limit"] || DEFAULT_USERS_LIMIT
     find_all_reader_users_by_documents_fetched_at(limit).each do |user|

--- a/app/jobs/sync_reviews_job.rb
+++ b/app/jobs/sync_reviews_job.rb
@@ -6,7 +6,6 @@ class SyncReviewsJob < CaseflowJob
   DEFAULT_EP_LIMIT = 100
 
   def perform(args = {})
-    RequestStore.store[:application] = "intake"
     RequestStore.store[:current_user] = User.system_user
 
     # specified limit of end products that will be synced

--- a/app/jobs/task_timer_job.rb
+++ b/app/jobs/task_timer_job.rb
@@ -3,7 +3,6 @@ class TaskTimerJob < CaseflowJob
   application_attr :queue
 
   def perform
-    RequestStore.store[:application] = "queue"
     RequestStore.store[:current_user] = User.system_user
 
     TaskTimer.requires_processing.includes(:task).each do |task_timer|


### PR DESCRIPTION
It's hard to to map latency issues spotted in Datadog to specific parts of the application. It's also hard to differentiate which data points originate from user interaction vs jobs (where latency is less critical). In order to make debugging these a bit easier, I'm doing two things:

1. tagging the application name in Dispatch controllers
1. reading `application_attr` inside the base `ApplicationJob#before_perform` method to set the application name
1. for jobs, appending `_job` so we can differentiate between user interaction and jobs

Jobs that want to explicitly use a different app name still can by setting it in `perform` (see https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/jobs/process_decision_document_job.rb)

I'm wary of breaking any alerting/reporting that is observing application names - I can just use the application name directly if that is the case.