### PR TITLE
[WIP] adding hlr skeleton for appeal status

### DIFF
--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -37,6 +37,10 @@ class Api::V2::AppealsController < Api::ApplicationController
     end
   end
 
+  def hlrs
+    @hlrs ||= HigherLevelReview.where(veteran_file_number: vbms_id)
+  end
+
   def vbms_id
     @vbms_id ||= fetch_vbms_id
   end

--- a/app/models/higher_level_review.rb
+++ b/app/models/higher_level_review.rb
@@ -29,6 +29,69 @@ class HigherLevelReview < ClaimReview
     create_dta_supplemental_claim
   end
 
+## needed for appeal status api
+  def review_status_id
+    return "HLR#{id}"
+  end
+
+  def vacols_ids
+    #doesn't apply to HLRs
+    []
+  end
+
+  def incomplete
+    return false
+  end
+
+  def type_code
+    # TODO: add logic to return - original, post_remand, post_cavc_remand, reconsideration, cue
+  end
+
+  def active?
+    end_product_establishments.any? { |ep| ep.status_active?(sync: false) }
+  end
+
+  def description
+    #need to impelement
+  end
+
+  def aod
+    #doesn't apply to HLRs
+  end
+
+  def location
+    #will this always be aoj?
+  end
+
+  def aoj
+    #add logic to return proper enum: - vba, vha, nca, other 
+  end
+
+  def program
+    #maps to benefit_type?
+  end
+
+  def status_hash
+    #add logic to return: hlr_received, hlr_dta_error, hlr_decision, hlr_closed
+  end
+
+  def alerts
+    #add logic to return alert enum
+  end
+
+  def docket_hash
+    #doesn't apply to HLRs
+  end
+
+  def issues
+    #get request and corresponding rating issue
+    []
+  end
+
+  def events
+    # hlr_request, hlr_decision, hlr_dta_error, or hlr_other_close
+  end
+
   private
 
   def create_dta_supplemental_claim

--- a/app/models/serializers/v2/appeal_serializer.rb
+++ b/app/models/serializers/v2/appeal_serializer.rb
@@ -1,8 +1,19 @@
 class V2::AppealSerializer < ActiveModel::Serializer
-  type :legacy_appeal
+
+  def type
+    if appeal_status_v3_enabled?
+      object.class.to_s.camelize(:lower)
+    else
+      :legacy_appeal
+    end
+  end
 
   def id
-    object.vacols_id
+    if appeal_status_v3_enabled?
+      object.review_status_id
+    else
+      object.vacols_id
+    end
   end
 
   attribute :vacols_ids, key: :appeal_ids
@@ -31,5 +42,9 @@ class V2::AppealSerializer < ActiveModel::Serializer
   # Stubbed attributes
   attribute :evidence do
     []
+  end
+
+  def appeal_status_v3_enabled?
+    FeatureToggle.enabled?(:api_appeal_status_v3)
   end
 end


### PR DESCRIPTION
Resolves #{8726}

### Description
Added in skeleton model for HLR. Updated the serializer to get the id and type from the object passed in. It is not hooked up to the path to serialize it.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
tested on command line to see it is would serialize:

=> {:data=>
  [{:id=>"HLR9",
    :type=>"higherLevelReviews",
    :attributes=>
     {:appealIds=>[],
      :updated=>"2019-01-21T21:30:16-05:00",
      :incompleteHistory=>false,
      :type=>nil,
      :active=>true,
      :description=>nil,
      :aod=>nil,
      :location=>nil,
      :aoj=>nil,
      :programArea=>nil,
      :status=>nil,
      :alerts=>nil,
      :docket=>nil,
      :issues=>[],
      :evidence=>[]}},
   {:id=>"HLR10",
    :type=>"higherLevelReviews",
    :attributes=>
     {:appealIds=>[],
      :updated=>"2019-01-21T21:30:16-05:00",
      :incompleteHistory=>false,
      :type=>nil,
      :active=>false,
      :description=>nil,
      :aod=>nil,
      :location=>nil,
      :aoj=>nil,
      :programArea=>nil,
      :status=>nil,
      :alerts=>nil,
      :docket=>nil,
      :issues=>[],
      :evidence=>[]}}]}

