### PR TITLE
Seperate document counts for efolder and and caseflow

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -2,7 +2,7 @@ class AppealsController < ApplicationController
   include Errors
 
   before_action :react_routed
-  before_action :set_application, only: [:document_count, :new_documents]
+  before_action :set_application, only: [:document_count_from_efolder, :document_count_from_caseflow, :new_documents]
   # Only whitelist endpoints VSOs should have access to.
   skip_before_action :deny_vso_access, only: [:index, :power_of_attorney, :show_case_list, :show, :veteran]
 
@@ -35,8 +35,14 @@ class AppealsController < ApplicationController
     end
   end
 
-  def document_count
+  def document_count_from_caseflow
     render json: { document_count: appeal.number_of_documents_from_caseflow }
+  rescue StandardError => e
+    handle_non_critical_error("document_count", e)
+  end
+
+  def document_count_from_efolder
+    render json: { document_count: appeal.number_of_documents }
   rescue StandardError => e
     handle_non_critical_error("document_count", e)
   end

--- a/client/app/queue/AppealDocumentCount.jsx
+++ b/client/app/queue/AppealDocumentCount.jsx
@@ -29,7 +29,7 @@ class AppealDocumentCount extends React.PureComponent {
         timeout: { response: 5 * 60 * 1000 }
       };
 
-      ApiUtil.get(`/appeals/${this.props.externalId}/document_count`, requestOptions).then((response) => {
+      ApiUtil.get(`/appeals/${this.props.externalId}/document_count_${this.props.endpoint}`, requestOptions).then((response) => {
         const resp = JSON.parse(response.text);
 
         this.props.setAppealDocCount(this.props.externalId, resp.document_count);
@@ -54,7 +54,8 @@ class AppealDocumentCount extends React.PureComponent {
 
 AppealDocumentCount.propTypes = {
   appeal: PropTypes.object.isRequired,
-  loadingText: PropTypes.bool
+  loadingText: PropTypes.bool,
+  endpoint: PropTypes.oneOf(['from_efolder', 'from_caseflow']).isRequired
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -160,6 +160,7 @@ export class CaseTitleDetails extends React.PureComponent {
               redirectUrl={redirectUrl}
               appeal={appeal}
               taskType={taskType}
+              endpoint="from_efolder"
               docCountWithinLink />
           </div>
         </React.Fragment> }

--- a/client/app/queue/ReaderLink.jsx
+++ b/client/app/queue/ReaderLink.jsx
@@ -30,7 +30,8 @@ export default class ReaderLink extends React.PureComponent {
       appealId,
       appeal,
       docCountWithinLink,
-      docCountBelowLink
+      docCountBelowLink,
+      endpoint
     } = this.props;
     const linkProps = {};
 
@@ -51,11 +52,11 @@ export default class ReaderLink extends React.PureComponent {
 
     return <React.Fragment>
       <Link {...linkProps} onClick={this.readerLinkAnalytics}>
-          View { docCountWithinLink && <AppealDocumentCount appeal={appeal} /> } docs
+          View { docCountWithinLink && <AppealDocumentCount appeal={appeal} endpoint={this.props.endpoint} /> } docs
         <span {...newFileIconStyling}><NewFile externalAppealId={appeal.externalId} /></span></Link>
       { docCountBelowLink &&
             <div {...documentCountSizeStyling}>
-              <AppealDocumentCount loadingText appeal={appeal} />
+              <AppealDocumentCount loadingText appeal={appeal} endpoint={this.props.endpoint} />
             </div>
       }
     </React.Fragment>;
@@ -69,7 +70,8 @@ ReaderLink.propTypes = {
   docCountBelowLink: PropTypes.bool,
   redirectUrl: PropTypes.string,
   taskType: PropTypes.string,
-  appealId: PropTypes.string.isRequired
+  appealId: PropTypes.string.isRequired,
+  endpoint: PropTypes.oneOf(['from_efolder', 'from_caseflow']).isRequired
 };
 
 ReaderLink.defaultProps = {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -274,6 +274,7 @@ export class TaskTableUnconnected extends React.PureComponent<Props> {
           analyticsSource={CATEGORIES.QUEUE_TABLE}
           redirectUrl={window.location.pathname}
           appeal={task.appeal}
+          endpoint="from_caseflow"
           docCountBelowLink />;
       }
     } : null;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,8 @@ Rails.application.routes.draw do
 
   resources :appeals, param: :appeal_id, only: [:index, :show, :edit] do
     member do
-      get :document_count
+      get :document_count_from_efolder
+      get :document_count_from_caseflow
       get :new_documents
       get :veteran
       get :power_of_attorney


### PR DESCRIPTION
Resolves #8820

### Description
* Show efolder count in case details
* Show caseflow count in queue

### Acceptance Criteria
- [ ] When a user navigates to their queue page, we should use a document count from Caseflow because all appeals on this page are assigned to a current user
- [ ] When a user navigates to the case details page, we should use a document count from VBMS

