### PR TITLE
Fix date parsing on non comp dispositions page

### DIFF
--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import update from 'immutability-helper';
 
-import { formatDate } from '../../util/DateUtil';
+import { formatDateStr } from '../../util/DateUtil';
 import InlineForm from '../../components/InlineForm';
 import DateSelector from '../../components/DateSelector';
 import Button from '../../components/Button';
@@ -47,7 +47,7 @@ class NonCompDecisionIssue extends React.PureComponent {
       index,
       disabled
     } = this.props;
-    let issueDate = formatDate(issue.rating_issue_profile_date || issue.decision_date);
+    let issueDate = formatDateStr(issue.rating_issue_profile_date || issue.decision_date);
 
     return <div className="cf-decision">
       <hr />
@@ -86,7 +86,7 @@ class NonCompDispositions extends React.PureComponent {
   constructor(props) {
     super(props);
 
-    let today = formatDate(new Date());
+    let today = formatDateStr(new Date());
 
     this.state = {
       requestIssues: formatRequestIssuesWithDecisionIssues(

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -71,6 +71,9 @@ feature "NonComp Dispositions Task Page" do
       expect(page).to have_content("Non-Comp Org")
       expect(page).to have_content("Decision")
       expect(page).to have_content(veteran.name)
+      expect(page).to have_content(
+        "Prior decision date: #{hlr.request_issues[0].decision_date.strftime("%m/%d/%Y")}"
+      )
       expect(page).to have_content(Constants.INTAKE_FORM_NAMES.higher_level_review)
     end
 


### PR DESCRIPTION
The JS util method `formatDate` expects a full ISO8601 string. When you pass it a m/d/Y string it will parse it into the local browser time zone, which is typically the "day before" since the negative UTC offset will count backwards from the implicit midnight time.