### PR TITLE
kick users out of Completed before trying to read data

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -8,7 +8,7 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "WIP"
 warn("This is a Big PR. Try to break this down if possible.") if git.lines_of_code > 500
 
 # Don't let testing shortcuts get into master by accident
-fail("focus: true is left in test") if `git diff #{github.base_commit} spec/ | grep ':focus => true'`.length > 1
+fail("focus: true is left in test") if `git diff #{github.base_commit} spec/ | grep -E '(:focus => true)|(focus: true)'`.length > 1
 
 # We must take care of our VACOLS models.  Remind developers to test this thoroughly
 if !git.modified_files.grep(/app\/models\/vacols/).empty?

--- a/Dangerfile
+++ b/Dangerfile
@@ -8,7 +8,9 @@ warn("PR is classed as Work in Progress") if github.pr_title.include? "WIP"
 warn("This is a Big PR. Try to break this down if possible.") if git.lines_of_code > 500
 
 # Don't let testing shortcuts get into master by accident
-fail("focus: true is left in test") if `git diff #{github.base_commit} spec/ | grep -E '(:focus => true)|(focus: true)'`.length > 1
+if `git diff #{github.base_commit} spec/ | grep -E '(:focus => true)|(focus: true)'`.length > 1
+  fail("focus: true is left in test")
+end
 
 # We must take care of our VACOLS models.  Remind developers to test this thoroughly
 if !git.modified_files.grep(/app\/models\/vacols/).empty?

--- a/README.md
+++ b/README.md
@@ -430,8 +430,6 @@ adding [`focus: true`](https://relishapp.com/rspec/rspec-core/v/2-6/docs/filteri
 +context "test my new feature", focus: true do
 ```
 
-Make sure to remove the `focus: true` before marking your pr ready to merge! Otherwise CI may only run the tests you've focused.
-
 ### Guard
 
 In addition, if you are iterating on a subset of tests, [`guard`](https://github.com/guard/guard-rspec) is a useful tool that will

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -124,14 +124,18 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
     case INTAKE_STATES.STARTED:
       return <Redirect to={PAGE_PATHS.REVIEW} />;
     case INTAKE_STATES.REVIEWED:
-      return <Redirect to={PAGE_PATHS.FINISH} />;
+      if (formType === FORM_TYPES.RAMP_ELECTION.key || formType === FORM_TYPES.RAMP_REFILING.key) {
+        return <Redirect to={PAGE_PATHS.FINISH} />;
+      } else {
+        return <Redirect to={PAGE_PATHS.ADD_ISSUES} />;
+      }
     default:
     }
 
     const ineligibleRequestIssues = requestIssues.filter((ri) => ri.ineligibleReason);
     const vacolsOptInIssues = requestIssues.filter((ri) => ri.vacolsId && !ri.ineligibleReason);
 
-    if (completedReview.processedInCaseflow && formType !== 'appeal') {
+    if (completedReview.processedInCaseflow && formType !== FORM_TYPES.APPEAL.key) {
       // we do not use Redirect because state no longer matters,
       // and because we are likely not in a relative URL path any more.
       window.location = completedReview.redirectTo;

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -117,8 +117,6 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       informalConference,
       legacyAppeals
     } = completedReview;
-    const ineligibleRequestIssues = requestIssues.filter((ri) => ri.ineligibleReason);
-    const vacolsOptInIssues = requestIssues.filter((ri) => ri.vacolsId && !ri.ineligibleReason);
 
     switch (intakeStatus) {
     case INTAKE_STATES.NONE:
@@ -129,6 +127,9 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       return <Redirect to={PAGE_PATHS.FINISH} />;
     default:
     }
+
+    const ineligibleRequestIssues = requestIssues.filter((ri) => ri.ineligibleReason);
+    const vacolsOptInIssues = requestIssues.filter((ri) => ri.vacolsId && !ri.ineligibleReason);
 
     if (completedReview.processedInCaseflow && formType !== 'appeal') {
       // we do not use Redirect because state no longer matters,

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -126,9 +126,9 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
     case INTAKE_STATES.REVIEWED:
       if (formType === FORM_TYPES.RAMP_ELECTION.key || formType === FORM_TYPES.RAMP_REFILING.key) {
         return <Redirect to={PAGE_PATHS.FINISH} />;
-      } else {
-        return <Redirect to={PAGE_PATHS.ADD_ISSUES} />;
       }
+
+      return <Redirect to={PAGE_PATHS.ADD_ISSUES} />;
     default:
     }
 

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -44,6 +44,14 @@ feature "Intake Confirmation Page" do
             expect(page).to have_content("Tracked Item") if claim_review_type == :higher_level_review
             expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
           end
+
+          it "redirects you back if you manually visit /completed", focus: true do
+            start_claim_review(claim_review_type)
+
+            visit "/intake/completed"
+
+            expect(page).to have_current_path("/intake/add_issues")
+          end
         end
       end
     end

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -45,7 +45,7 @@ feature "Intake Confirmation Page" do
             expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
           end
 
-          it "redirects you back if you manually visit /completed", focus: true do
+          it "redirects you back if you manually visit /completed" do
             start_claim_review(claim_review_type)
 
             visit "/intake/completed"


### PR DESCRIPTION
Users can navigate directly to /completed - in this case we should redirect before trying to read some data that might not be there.

avoids https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3407/
and fixes https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3439/