### PR TITLE
Ignore nil submitted at when sorting asyncable jobs

### DIFF
--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -111,8 +111,8 @@ module Asyncable
     !!self[self.class.submitted_at_column]
   end
 
-  def asyncable_submitted_at
-    self[self.class.submitted_at_column]
+  def sort_by_submitted_at
+    self[self.class.submitted_at_column] || Time.zone.now
   end
 
   def clear_error!

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -20,6 +20,6 @@ class AsyncableJobs
     models.each do |klass|
       expired_jobs << klass.previously_attempted_ready_for_retry
     end
-    expired_jobs.flatten.sort_by(&:asyncable_submitted_at)
+    expired_jobs.flatten.sort_by(&:sort_by_submitted_at)
   end
 end

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -13,16 +13,22 @@ describe AsyncableJobs do
              establishment_attempted_at: 7.days.ago,
              veteran_file_number: veteran.file_number)
     end
+    let!(:sc_not_submitted) do
+      create(:supplemental_claim,
+             establishment_attempted_at: 7.days.ago,
+             veteran_file_number: veteran.file_number)
+    end
 
     it "returns an Array of model instances that consume Asyncable concern" do
       expect(subject.jobs).to be_a(Array)
-      expect(subject.jobs.length).to eq(2)
+      expect(subject.jobs.length).to eq(3)
       expect(subject.jobs).to include(hlr)
       expect(subject.jobs).to include(sc)
+      expect(subject.jobs).to include(sc_not_submitted)
     end
 
     it "sorts by the submited_at column, descending order" do
-      expect(subject.jobs).to eq([hlr, sc])
+      expect(subject.jobs).to eq([hlr, sc, sc_not_submitted])
     end
   end
 


### PR DESCRIPTION
connects #6944 

### Description
When the submitted_at column is nil, Ruby was throwing a bad comparison error on sort. This is due to bad data (see #8802) but work around it any way.