### PR TITLE
SC status model

### DIFF
--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -23,13 +23,7 @@ class Api::V2::AppealsController < Api::ApplicationController
   def json_appeals
     Rails.cache.fetch("appeals/v2/#{ssn}", expires_in: 20.hours, force: reload?) do
       if appeal_status_v3_enabled?
-        # eventually will return back the json for all of them (legacy, hlr, sc, ama appeal)
-        # for now just HLRs
-        ActiveModelSerializers::SerializableResource.new(
-          hlrs,
-          each_serializer: ::V2::HLRStatusSerializer,
-          key_transform: :camel_lower
-        ).as_json
+        all_reviews_and_appeals
       else
         ActiveModelSerializers::SerializableResource.new(
           appeals,
@@ -49,6 +43,26 @@ class Api::V2::AppealsController < Api::ApplicationController
 
   def hlrs
     @hlrs ||= HigherLevelReview.where(veteran_file_number: vbms_id.sub("S", ""))
+  end
+
+  def supplemental_claims
+    @supplemental_claims ||= SupplementalClaim.where(veteran_file_number: vbms_id.sub("S", ""))
+  end
+
+  def all_reviews_and_appeals
+    hlr_json = ActiveModelSerializers::SerializableResource.new(
+      hlrs,
+      each_serializer: ::V2::HLRStatusSerializer,
+      key_transform: :camel_lower
+    ).as_json
+
+    sc_json = ActiveModelSerializers::SerializableResource.new(
+      supplemental_claims,
+      each_serializer: ::V2::SCStatusSerializer,
+      key_transform: :camel_lower
+    ).as_json
+
+    { data: hlr_json[:data] + sc_json[:data] }
   end
 
   def vbms_id

--- a/app/models/serializers/v2/hlr_status_serializer.rb
+++ b/app/models/serializers/v2/hlr_status_serializer.rb
@@ -16,7 +16,7 @@ class V2::HLRStatusSerializer < V2::AppealSerializer
     "aoj"
   end
 
-  attribute :incomplete do
+  attribute :incomplete_history do
     false
   end
 

--- a/app/models/serializers/v2/sc_status_serializer.rb
+++ b/app/models/serializers/v2/sc_status_serializer.rb
@@ -1,0 +1,33 @@
+class SCStatusSerializer < V2::AppealSerializer
+  type :supplemental_claim
+
+  def id
+    object.review_status_id
+  end
+
+  attribute :linked_review_ids, key: :appeal_ids
+
+  attribute :type do
+    # this does not apply to SC
+  end
+
+  attribute :location do
+    # for SC will always be aoj
+    "aoj"
+  end
+
+  attribute :incomplete_history do
+    false
+  end
+
+  attribute :aod do
+    # does not apply to SC
+  end
+
+  attribute :docket do
+    # doesn't apply to SC
+  end
+
+  attribute :events do
+  end
+end

--- a/app/models/serializers/v2/sc_status_serializer.rb
+++ b/app/models/serializers/v2/sc_status_serializer.rb
@@ -1,4 +1,4 @@
-class SCStatusSerializer < V2::AppealSerializer
+class V2::SCStatusSerializer < V2::AppealSerializer
   type :supplemental_claim
 
   def id

--- a/app/models/supplemental_claim.rb
+++ b/app/models/supplemental_claim.rb
@@ -26,6 +26,58 @@ class SupplementalClaim < ClaimReview
     !!decision_review_remanded
   end
 
+  # needed for appeal status api
+
+  def review_status_id
+    "SC#{id}"
+  end
+
+  def linked_review_ids
+    Array.wrap(review_status_id)
+  end
+
+  def active?
+    end_product_establishments.any? { |ep| ep.status_active?(sync: false) }
+  end
+
+  def description
+    # need to implement
+  end
+
+  def aoj
+    # need to implement. add logic to return proper enum: - vba, vha, nca, other
+  end
+
+  def program
+    case benefit_type
+    when "voc_rehab"
+      "vre"
+    when "vha"
+      "medical"
+    when "nca"
+      "burial"
+    else
+      benefit_type
+    end
+  end
+
+  def status_hash
+    # need to implement. returns the details object for the status
+  end
+
+  def alerts
+    # need to implement. add logic to return alert enum
+  end
+
+  def issues
+    # need to implement. get request and corresponding rating issue
+    []
+  end
+
+  def events
+    # need to implement
+  end
+
   private
 
   def end_product_created_by


### PR DESCRIPTION
Resolves #{8727}

### Description
This adds the skeleton methods to SupplementClaim to support Appeals status api. Also adding a SC status serializer. The attributes will be filled in by other issues.

The associated feature flag will be FeatureToggle.enabled?(api_appeal_status_v3).
Feature flagging is not needed yet as this code is not being used.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. ran build exec rake lint
2. tested on the command line:
scs = SupplementalClaim.where(veteran_file_number: 682007349)
ActiveModelSerializers::SerializableResource.new(
        scs,
        each_serializer: ::SCStatusSerializer,
        key_transform: :camel_lower
      ).as_json

Output:

 {:data=>
  [{:id=>"SC1",
    :type=>"supplementalClaim",
    :attributes=>
     {:appealIds=>["SC1"],
      :updated=>"2019-01-22T19:52:10-05:00",
      :incompleteHistory=>false,
      :type=>nil,
      :active=>false,
      :description=>nil,
      :aod=>nil,
      :location=>"aoj",
      :aoj=>nil,
      :programArea=>"compensation",
      :status=>nil,
      :alerts=>nil,
      :docket=>nil,
      :issues=>[],
      :events=>nil,
      :evidence=>[]}}]}

