### PR TITLE
Async jobs page resists bad data

### DIFF
--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -3,7 +3,7 @@ class AsyncableJobsController < ApplicationController
 
   def index
     if allowed_params[:asyncable_job_klass]
-      @jobs = asyncable_job_klass.expired_without_processing
+      @jobs = asyncable_job_klass.potentially_stuck
     end
   end
 

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -82,7 +82,7 @@ module Asyncable
 
     def potentially_stuck
       processable
-        .previously_attempted_ready_for_retry
+        .attemptable
         .or(expired_without_processing)
         .or(attempted_without_being_submitted)
         .order_by_oldest_submitted

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -74,6 +74,17 @@ module Asyncable
     def expired_without_processing
       where(processed_at_column => nil)
         .where(arel_table[submitted_at_column].lteq(REQUIRES_PROCESSING_WINDOW_DAYS.days.ago))
+    end
+
+    def attempted_without_being_submitted
+      where(arel_table[attempted_at_column].lteq(Time.zone.now)).where(submitted_at_column => nil)
+    end
+
+    def potentially_stuck
+      processable
+        .previously_attempted_ready_for_retry
+        .or(expired_without_processing)
+        .or(attempted_without_being_submitted)
         .order_by_oldest_submitted
     end
   end
@@ -142,7 +153,7 @@ module Asyncable
       attempted_at: self[self.class.attempted_at_column],
       processed_at: self[self.class.processed_at_column],
       error: self[self.class.error_column],
-      veteran_file_number: veteran.file_number
+      veteran_file_number: try(:veteran).try(:file_number)
     }
   end
 end

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -18,7 +18,7 @@ class AsyncableJobs
   def gather_jobs
     expired_jobs = []
     models.each do |klass|
-      expired_jobs << klass.previously_attempted_ready_for_retry
+      expired_jobs << klass.potentially_stuck
     end
     expired_jobs.flatten.sort_by(&:sort_by_submitted_at)
   end

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -123,7 +123,13 @@ class AsyncableJobsPage extends React.PureComponent {
       },
       {
         header: 'Veteran',
-        valueName: 'veteran_file_number'
+        valueFunction: (job) => {
+          if (!job.veteran_file_number) {
+            return 'unknown';
+          }
+
+          return job.veteran_file_number;
+        }
       },
       {
         header: 'Restart',
@@ -131,6 +137,7 @@ class AsyncableJobsPage extends React.PureComponent {
         valueFunction: (job) => {
           return <Button
             id={`job-${job.klass}-${job.id}`}
+            title={`${job.klass} ${job.id}`}
             loading={this.state.jobsRestarting[job.id]}
             loadingText="Restarting..."
             onClick={() => {

--- a/client/app/components/Button.jsx
+++ b/client/app/components/Button.jsx
@@ -28,7 +28,8 @@ export default class Button extends React.Component {
       dangerStyling,
       willNeverBeLoading,
       type,
-      styling
+      styling,
+      title
     } = this.props;
 
     let LoadingIndicator = () => {
@@ -75,6 +76,7 @@ export default class Button extends React.Component {
       type={type}
       disabled={disabled}
       onClick={onClick}
+      title={title}
       aria-label={ariaLabel}
       {...styling}>
       {children}

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -40,11 +40,11 @@ feature "Asyncable Jobs index" do
   end
 
   describe "index page" do
-    it "shows only jobs that have failed at least once or look potentially stuck" do
+    it "shows jobs that look potentially stuck" do
       visit "/jobs"
 
       expect(page).to have_content(veteran.file_number)
-      expect(page).to_not have_content(veteran2.file_number)
+      expect(page).to have_content(veteran2.file_number)
     end
 
     it "shows 'unknown' when no veteran is associated" do
@@ -71,11 +71,9 @@ feature "Asyncable Jobs index" do
       expect(hlr.reload.establishment_submitted_at).to eq(now)
     end
 
-    context "zero expired jobs" do
+    context "zero unprocesed jobs" do
       before do
-        hlr.restart!
-        sc.restart!
-        request_issues_update.restart!
+        AsyncableJobs.new.jobs.each(&:processed!)
       end
 
       it "shows nice message" do

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -18,17 +18,29 @@ describe AsyncableJobs do
              establishment_attempted_at: 7.days.ago,
              veteran_file_number: veteran.file_number)
     end
+    let!(:sc_not_attempted) do
+      create(:supplemental_claim,
+             establishment_submitted_at: 2.days.ago,
+             veteran_file_number: veteran.file_number)
+    end
+    let!(:sc_not_attempted_expired) do
+      create(:supplemental_claim,
+             establishment_submitted_at: 8.days.ago,
+             veteran_file_number: veteran.file_number)
+    end
 
     it "returns an Array of model instances that consume Asyncable concern" do
       expect(subject.jobs).to be_a(Array)
-      expect(subject.jobs.length).to eq(3)
+      expect(subject.jobs.length).to eq(4)
       expect(subject.jobs).to include(hlr)
       expect(subject.jobs).to include(sc)
       expect(subject.jobs).to include(sc_not_submitted)
+      expect(subject.jobs).to include(sc_not_attempted_expired)
+      expect(subject.jobs).to_not include(sc_not_attempted)
     end
 
     it "sorts by the submited_at column, descending order" do
-      expect(subject.jobs).to eq([hlr, sc, sc_not_submitted])
+      expect(subject.jobs).to eq([sc_not_attempted_expired, hlr, sc, sc_not_submitted])
     end
   end
 

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -31,16 +31,16 @@ describe AsyncableJobs do
 
     it "returns an Array of model instances that consume Asyncable concern" do
       expect(subject.jobs).to be_a(Array)
-      expect(subject.jobs.length).to eq(4)
+      expect(subject.jobs.length).to eq(5)
       expect(subject.jobs).to include(hlr)
       expect(subject.jobs).to include(sc)
       expect(subject.jobs).to include(sc_not_submitted)
       expect(subject.jobs).to include(sc_not_attempted_expired)
-      expect(subject.jobs).to_not include(sc_not_attempted)
+      expect(subject.jobs).to include(sc_not_attempted)
     end
 
     it "sorts by the submited_at column, descending order" do
-      expect(subject.jobs).to eq([sc_not_attempted_expired, hlr, sc, sc_not_submitted])
+      expect(subject.jobs).to eq([sc_not_attempted_expired, hlr, sc, sc_not_attempted, sc_not_submitted])
     end
   end
 


### PR DESCRIPTION
connects #6944 

When there is bad data or jobs appear stuck indefinitely, show them on the /jobs page so that the data can be fixed.