### PR TITLE
Skip ineligible rating request issues when associating contentions

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -402,11 +402,15 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def unassociated_rating_request_issues
-    rating_request_issues.select { |ri| ri.rating_issue_associated_at.nil? }
+    eligible_rating_request_issues.select { |ri| ri.rating_issue_associated_at.nil? }
   end
 
   def eligible_request_issues
     request_issues.select(&:eligible?)
+  end
+
+  def eligible_rating_request_issues
+    eligible_request_issues.select(&:rating?)
   end
 
   def select_ready_for_contentions(records)

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -335,6 +335,61 @@ describe EndProductEstablishment do
     end
   end
 
+  context "#associate_rating_request_issues!" do
+    before do
+      allow(Fakes::VBMSService).to receive(:associate_rating_request_issues!).and_call_original
+    end
+
+    let(:reference_id) { "stevenasmith" }
+    let(:contention_ref_id) { 1234 }
+    let!(:contention) do
+      Generators::Contention.build(id: contention_ref_id, claim_id: reference_id, text: "Left knee")
+    end
+
+    subject { end_product_establishment.associate_rating_request_issues! }
+
+    context "request issue is ineligible" do
+      let!(:request_issues) do
+        [
+          create(
+            :request_issue,
+            :rating,
+            end_product_establishment: end_product_establishment,
+            review_request: source,
+            ineligible_reason: :duplicate_of_rating_issue_in_active_review
+          )
+        ]
+      end
+
+      it "skips ineligible rating request issues" do
+        subject
+        expect(Fakes::VBMSService).to_not have_received(:associate_rating_request_issues!)
+      end
+    end
+
+    context "request issue is eligible" do
+      let!(:request_issues) do
+        [
+          create(
+            :request_issue,
+            :rating,
+            end_product_establishment: end_product_establishment,
+            review_request: source,
+            contention_reference_id: contention_ref_id
+          )
+        ]
+      end
+
+      it "sends mapping of rating request issues to contentions" do
+        subject
+        expect(Fakes::VBMSService).to have_received(:associate_rating_request_issues!).once.with(
+          claim_id: reference_id,
+          rating_issue_contention_map: { request_issues[0].contested_rating_issue_reference_id => contention_ref_id }
+        )
+      end
+    end
+  end
+
   context "#generate_claimant_letter!" do
     subject { end_product_establishment.generate_claimant_letter! }
 


### PR DESCRIPTION
connects #8901 

### Description
The logic that creates contentions skips ineligible request issues (e.g. duplicates).

The logic that associates rating request issues should apply the same rule.