### PR TITLE
Differentiate between VACOLS calls for metrics

### DIFF
--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -163,7 +163,7 @@ class HearingRepository
     def load_vacols_data(hearing)
       vacols_record = MetricsService.record("VACOLS: HearingRepository.load_vacols_data: #{hearing.vacols_id}",
                                             service: :vacols,
-                                            name: "load_vacols_data") do
+                                            name: "load_vacols_hearing_data") do
         VACOLS::CaseHearing.load_hearing(hearing.vacols_id)
       end
 

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -47,7 +47,7 @@ class AppealRepository
   def self.load_vacols_data(appeal)
     case_record = MetricsService.record("VACOLS: load_vacols_data #{appeal.vacols_id}",
                                         service: :vacols,
-                                        name: "load_vacols_data") do
+                                        name: "load_vacols_appeal_data") do
       find_case_record(appeal.vacols_id)
     end
 


### PR DESCRIPTION
Requests to VACOLS for appeals and hearings data are currently clumped into one bucket in our metrics. This PR separates them so we can determine where these requests are truly coming from.

![image](https://user-images.githubusercontent.com/32683958/51694682-5a964680-1fcf-11e9-89ff-f29c129d392c.png)
