### PR TITLE
Allow editing document ID for legacy cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,8 @@ Rails/Present:
 
 Metrics/MethodLength:
   Max: 20
+  Exclude:
+    - "spec/**/*"
 
 Metrics/ClassLength:
   Max: 400

--- a/app/controllers/case_reviews_controller.rb
+++ b/app/controllers/case_reviews_controller.rb
@@ -26,9 +26,10 @@ class CaseReviewsController < ApplicationController
   end
 
   def update
-    result = UpdateAttorneyCaseReview.new(
+    case_review_class = (params[:legacy] == true) ? UpdateLegacyAttorneyCaseReview : UpdateAttorneyCaseReview
+    result = case_review_class.new(
       id: params[:id],
-      user_id: current_user.id,
+      user: current_user,
       document_id: params[:document_id]
     ).call
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -4,7 +4,7 @@ class Organization < ApplicationRecord
   has_many :users, through: :organizations_users
 
   def admins
-    organizations_users.select(&:admin?).map(&:user)
+    organizations_users.includes(:user).select(&:admin?).map(&:user)
   end
 
   def non_admins

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -130,6 +130,13 @@ class WorkQueue::AppealSerializer < ActiveModel::Serializer
     latest_attorney_case_review&.id
   end
 
+  attribute :can_edit_document_id do
+    AmaDocumentIdPolicy.new(
+      user: @instance_options[:user],
+      case_review: latest_attorney_case_review
+    ).editable?
+  end
+
   def latest_attorney_case_review
     AttorneyCaseReview.where(task_id: Task.where(appeal: object).pluck(:id)).order(:created_at).last
   end

--- a/app/models/serializers/work_queue/legacy_appeal_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_serializer.rb
@@ -89,6 +89,17 @@ class WorkQueue::LegacyAppealSerializer < ActiveModel::Serializer
     latest_attorney_case_review&.document_id
   end
 
+  attribute :can_edit_document_id do
+    LegacyDocumentIdPolicy.new(
+      user: @instance_options[:user],
+      case_review: latest_attorney_case_review
+    ).editable?
+  end
+
+  attribute :attorney_case_review_id do
+    latest_attorney_case_review&.vacols_id
+  end
+
   def latest_attorney_case_review
     VACOLS::CaseAssignment.latest_task_for_appeal(object.vacols_id)
   end

--- a/app/policies/ama_document_id_policy.rb
+++ b/app/policies/ama_document_id_policy.rb
@@ -1,0 +1,16 @@
+class AmaDocumentIdPolicy
+  def initialize(user:, case_review:)
+    @user = user
+    @case_review = case_review
+  end
+
+  def editable?
+    return false unless case_review
+
+    [case_review.attorney_id, case_review.reviewing_judge_id].include?(user.id)
+  end
+
+  private
+
+  attr_reader :user, :case_review
+end

--- a/app/policies/legacy_document_id_policy.rb
+++ b/app/policies/legacy_document_id_policy.rb
@@ -1,0 +1,16 @@
+class LegacyDocumentIdPolicy
+  def initialize(user:, case_review:)
+    @user = user
+    @case_review = case_review
+  end
+
+  def editable?
+    return false unless case_review && user
+
+    [case_review.assigned_to_css_id, case_review.assigned_by_css_id].include?(user.css_id)
+  end
+
+  private
+
+  attr_reader :user, :case_review
+end

--- a/app/workflows/update_legacy_attorney_case_review.rb
+++ b/app/workflows/update_legacy_attorney_case_review.rb
@@ -1,0 +1,146 @@
+class UpdateLegacyAttorneyCaseReview
+  include ActiveModel::Model
+
+  validates :id, presence: true
+  validate :vacols_case_review_exists
+  validate :authorized_to_edit
+  validate :correct_format
+
+  def initialize(id:, document_id:, user:)
+    @id = id
+    @document_id = document_id
+    @user = user
+  end
+
+  def call
+    success = valid?
+
+    if success
+      update_attorney_case_review
+      update_vacols_decass_table
+    end
+
+    FormResponse.new(success: success, errors: errors.messages)
+  end
+
+  private
+
+  attr_reader :id, :document_id, :user
+
+  def update_attorney_case_review
+    attorney_case_review.update!(document_id: document_id)
+  end
+
+  def attorney_case_review
+    AttorneyCaseReview.find_by(task_id: "#{id}-#{vacols_case_review_creation_date_in_string_format}")
+  end
+
+  def update_vacols_decass_table
+    VACOLS::Decass.where(
+      defolder: id,
+      deadtim: vacols_case_review_creation_date_in_vacols_format
+    ).update_all(dedocid: document_id)
+  end
+
+  def vacols_case_review_creation_date_in_vacols_format
+    vacols_case_review_creation_date_in_string_format.to_date
+  end
+
+  def vacols_case_review_creation_date_in_string_format
+    VacolsHelper.day_only_str(vacols_case_review.created_at)
+  end
+
+  def vacols_case_review_exists
+    return if vacols_case_review
+
+    errors.add(:document_id, "Could not find a legacy Attorney Case Review with id #{id}")
+  end
+
+  def vacols_case_review
+    @vacols_case_review ||= VACOLS::CaseAssignment.latest_task_for_appeal(id)
+  end
+
+  def authorized_to_edit
+    return unless vacols_case_review
+    return if allowed_to_edit_legacy_case_review?
+
+    errors.add(:document_id, "You are not authorized to edit this document ID")
+  end
+
+  def allowed_to_edit_legacy_case_review?
+    LegacyDocumentIdPolicy.new(user: user, case_review: vacols_case_review).editable?
+  end
+
+  def correct_format
+    return unless vacols_case_review
+    return if correct_format?
+
+    errors.add(:document_id, work_product_error_hash[work_product])
+  end
+
+  def correct_format?
+    if decision_work_product?
+      return document_id.match?(new_decision_regex) || document_id.match?(old_decision_regex)
+    end
+
+    return document_id.match?(vha_regex) if vha_work_product?
+
+    document_id.match?(ime_regex) if ime_work_product?
+  end
+
+  def decision_work_product?
+    %w[DEC OTD].include?(work_product)
+  end
+
+  def vha_work_product?
+    %w[VHA OTV].include?(work_product)
+  end
+
+  def ime_work_product?
+    %w[IME OTI].include?(work_product)
+  end
+
+  def work_product
+    vacols_case_review.work_product
+  end
+
+  def new_decision_regex
+    /^\d{5}-\d{8}$/
+  end
+
+  def old_decision_regex
+    /^\d{8}\.\d{3,4}$/
+  end
+
+  def vha_regex
+    /^V\d{7}\.\d{3,4}$/
+  end
+
+  def ime_regex
+    /^M\d{7}\.\d{3,4}$/
+  end
+
+  def work_product_error_hash
+    {
+      "VHA" => invalid_vha_document_id_message,
+      "OTV" => invalid_vha_document_id_message,
+      "IME" => invalid_ime_document_id_message,
+      "OTI" => invalid_ime_document_id_message,
+      "DEC" => invalid_decision_document_id_message,
+      "OTD" => invalid_decision_document_id_message
+    }
+  end
+
+  def invalid_vha_document_id_message
+    "VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"
+  end
+
+  def invalid_ime_document_id_message
+    "IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"
+  end
+
+  def invalid_decision_document_id_message
+    "Draft Decision Document IDs must be in one of these formats: " \
+      "12345-12345678 or 12345678.123 or 12345678.1234"
+  end
+end

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -104,14 +104,16 @@ export class CaseTitleDetails extends React.PureComponent {
     });
   }
 
-  submitForm = (appealId) => () => {
+  submitForm = (reviewId, legacy) => () => {
     const payload = {
       data: {
-        document_id: this.state.value
+        document_id: this.state.value,
+        legacy,
+        review_id: reviewId
       }
     };
 
-    this.props.requestPatch(`/case_reviews/${appealId}`, payload, { title: 'Document Id Saved!' }).
+    this.props.requestPatch(`/case_reviews/${reviewId}`, payload, { title: 'Document Id Saved!' }).
       then(() => {
         this.handleModalClose();
       }).
@@ -186,8 +188,8 @@ export class CaseTitleDetails extends React.PureComponent {
       { !userIsVsoEmployee && appeal && appeal.documentID &&
         <React.Fragment>
           <h4>{COPY.TASK_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL}</h4>
-          <div><CopyTextButton text={this.state.value || appeal.documentID} />
-            { !appeal.isLegacyAppeal &&
+          <div id="document-id"><CopyTextButton text={this.state.value || appeal.documentID} />
+            { appeal.canEditDocumentId &&
               <Button
                 linkStyling
                 onClick={this.handleModalClose} >
@@ -206,7 +208,7 @@ export class CaseTitleDetails extends React.PureComponent {
               { classNames: ['usa-button'],
                 name: 'Save',
                 disabled: !this.state.value,
-                onClick: this.submitForm(appeal.caseReviewId)
+                onClick: this.submitForm(appeal.caseReviewId, appeal.isLegacyAppeal)
               }
             ]}
             closeHandler={this.handleModalClose}
@@ -217,6 +219,7 @@ export class CaseTitleDetails extends React.PureComponent {
               placeholder={appeal.documentID}
               value={this.state.value}
               onChange={this.changeButtonState}
+              autoComplete="off"
               required />
 
           </Modal>}

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -273,7 +273,8 @@ export const prepareAppealForStore =
         regionalOffice: appeal.attributes.regional_office,
         caseflowVeteranId: appeal.attributes.caseflow_veteran_id,
         documentID: appeal.attributes.document_id,
-        caseReviewId: appeal.attributes.attorney_case_review_id
+        caseReviewId: appeal.attributes.attorney_case_review_id,
+        canEditDocumentId: appeal.attributes.can_edit_document_id
       };
 
       return accumulator;

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -169,7 +169,6 @@ def check_deceased_veteran_cant_be_payee
   expect(page).to have_content("10 - Spouse")
 end
 
-# rubocop: disable Metrics/MethodLength
 # rubocop: disable Metrics/AbcSize
 def check_pension_and_compensation_payee_code
   visit "/intake"
@@ -211,5 +210,5 @@ def check_pension_and_compensation_payee_code
   click_intake_continue
   expect(page).to have_current_path("/intake/add_issues")
 end
-# rubocop: enable Metrics/MethodLength
+
 # rubocop: enable Metrics/AbcSize

--- a/spec/feature/queue/case_details/update_document_id_spec.rb
+++ b/spec/feature/queue/case_details/update_document_id_spec.rb
@@ -1,60 +1,179 @@
 require "rails_helper"
 
 feature "Updating Document ID" do
-  context "Valid Document ID" do
-    it "updates the Document ID and displays the new ID" do
-      appeal = create(:appeal)
-      user = create(:user)
-      root_task = create(:root_task, appeal: appeal, assigned_to: user)
-      attorney_task = create(
-        :ama_attorney_task,
-        appeal: appeal,
-        parent: root_task,
-        assigned_to: user,
-        completed_at: Time.zone.now - 4.days
-      )
-      attorney_task.update!(status: Constants.TASK_STATUSES.completed)
-      create(:attorney_case_review, task_id: attorney_task.id, attorney: user)
+  context "AMA case review" do
+    it "only allows assigner and assignee to edit document ID and validates ID format" do
+      attorney = create_ama_case_review
 
-      User.authenticate!(user: user)
-      visit("/queue/appeals/#{appeal.external_id}")
-      click_button "Edit"
-      fill_in "Decision Document ID", with: "11111-22334455"
-      click_button "Save"
+      User.authenticate!(user: attorney)
+      visit("/queue/appeals/#{Appeal.last.external_id}")
 
-      expect(page).to have_content "Document Id Saved!"
-      expect(page).to have_content "11111-22334455"
-    end
-  end
+      within "#document-id" do
+        click_button "Edit"
+      end
 
-  context "Invalid Document ID" do
-    it "does not update the Document ID and displays an error" do
-      appeal = create(:appeal)
-      user = create(:user)
-      root_task = create(:root_task, appeal: appeal, assigned_to: user)
-      attorney_task = create(
-        :ama_attorney_task,
-        appeal: appeal,
-        parent: root_task,
-        assigned_to: user,
-        completed_at: Time.zone.now - 4.days
-      )
-      attorney_task.update!(status: Constants.TASK_STATUSES.completed)
-      create(
-        :attorney_case_review,
-        task_id: attorney_task.id,
-        attorney: user,
-        document_id: "12345678.1234"
-      )
-
-      User.authenticate!(user: user)
-      visit("/queue/appeals/#{appeal.external_id}")
-      click_button "Edit"
-      fill_in "Decision Document ID", with: "123.123"
-      click_button "Save"
+      enter_invalid_decision_document_id
 
       expect(page).to have_content "Draft Decision Document IDs must be in one of these formats:"
       expect(page).to have_content "12345678.1234"
+
+      enter_valid_decision_document_id
+
+      expect(page).to have_content "Document Id Saved!"
+      expect(page).to have_content "11111-22334455"
+
+      switch_to_user_not_associated_with_case_and_visit_ama_appeals_page
+
+      within "#document-id" do
+        expect(page).to_not have_button "Edit"
+      end
+
+      judge = User.find_by(full_name: "Aaron Judge")
+      switch_to_judge_associated_with_case_and_visit_ama_appeals_page(judge)
+
+      within "#document-id" do
+        expect(page).to have_button "Edit"
+      end
     end
+  end
+
+  context "Legacy VHA case review" do
+    it "only allows assigner and assignee to edit document ID and validates ID format" do
+      judge = create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Judge")
+      create(:staff, :judge_role, sdomainid: judge.css_id)
+      attorney = create_legacy_case_review
+      appeal = LegacyAppeal.last
+
+      User.authenticate!(user: attorney)
+      create_legacy_attorney_case_review_in_browser(appeal)
+      visit("/queue/appeals/#{appeal.vacols_id}")
+
+      within "#document-id" do
+        click_button "Edit"
+      end
+
+      enter_invalid_vha_document_id
+
+      expect(page).to have_content "VHA Document IDs must be in one of these formats:"
+
+      enter_valid_vha_document_id
+
+      expect(page).to have_content "Document Id Saved!"
+      expect(page).to have_content "V1234567.321"
+
+      reload_page_to_verify_document_id_was_updated_in_vacols
+
+      expect(page).to have_content "V1234567.321"
+
+      switch_to_user_not_associated_with_case_and_visit_legacy_appeals_page
+
+      within "#document-id" do
+        expect(page).to_not have_button "Edit"
+      end
+
+      switch_to_judge_associated_with_case_and_visit_legacy_appeals_page(judge)
+
+      within "#document-id" do
+        expect(page).to have_button "Edit"
+      end
+    end
+  end
+
+  def create_ama_case_review
+    judge = create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Judge")
+    create(:staff, :judge_role, sdomainid: judge.css_id)
+    appeal = create(:appeal)
+    attorney = create(:user)
+    root_task = create(:root_task, appeal: appeal, assigned_to: attorney)
+    attorney_task = create(
+      :ama_attorney_task,
+      appeal: appeal,
+      parent: root_task,
+      assigned_to: attorney,
+      completed_at: Time.zone.now - 4.days
+    )
+    attorney_task.update!(status: Constants.TASK_STATUSES.completed)
+    create(
+      :attorney_case_review,
+      task_id: attorney_task.id,
+      attorney: attorney,
+      reviewing_judge_id: judge.id,
+      document_id: "12345678.1234"
+    )
+    attorney
+  end
+
+  def enter_invalid_decision_document_id
+    fill_in "Decision Document ID", with: "123.123"
+    click_button "Save"
+  end
+
+  def enter_valid_decision_document_id
+    fill_in "Decision Document ID", with: "11111-22334455"
+    click_button "Save"
+  end
+
+  def switch_to_user_not_associated_with_case_and_visit_ama_appeals_page
+    user = create(:user)
+    User.authenticate!(user: user)
+    visit("/queue/appeals/#{Appeal.last.external_id}")
+  end
+
+  def switch_to_judge_associated_with_case_and_visit_ama_appeals_page(judge)
+    User.authenticate!(user: judge)
+    visit("/queue/appeals/#{Appeal.last.external_id}")
+  end
+
+  def create_legacy_case_review
+    attorney = create(:user)
+    create(
+      :legacy_appeal,
+      :with_veteran,
+      vacols_case: create(
+        :case,
+        :assigned,
+        user: attorney,
+        case_issues: [create(:case_issue)]
+      )
+    )
+    attorney
+  end
+
+  def create_legacy_attorney_case_review_in_browser(appeal)
+    visit "/queue"
+    click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
+    click_dropdown(index: 1)
+    click_label("omo-type_OMO - VHA")
+    click_label("overtime")
+    fill_in "document_id", with: "V1234567.1234"
+    fill_in "notes", with: "test"
+    safe_click("#select-judge")
+    click_dropdown(index: 0)
+    click_on "Continue"
+  end
+
+  def enter_invalid_vha_document_id
+    fill_in "Decision Document ID", with: "123.123"
+    click_button "Save"
+  end
+
+  def enter_valid_vha_document_id
+    fill_in "Decision Document ID", with: "V1234567.321"
+    click_button "Save"
+  end
+
+  def reload_page_to_verify_document_id_was_updated_in_vacols
+    visit("/queue/appeals/#{LegacyAppeal.last.vacols_id}")
+  end
+
+  def switch_to_user_not_associated_with_case_and_visit_legacy_appeals_page
+    user = create(:user)
+    User.authenticate!(user: user)
+    visit("/queue/appeals/#{LegacyAppeal.last.vacols_id}")
+  end
+
+  def switch_to_judge_associated_with_case_and_visit_legacy_appeals_page(judge)
+    User.authenticate!(user: judge)
+    visit("/queue/appeals/#{LegacyAppeal.last.vacols_id}")
   end
 end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -356,7 +356,8 @@ RSpec.feature "Case details" do
 
       # Wait for page to load some known content before testing for expected content.
       expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL)
-      expect(page).to_not have_button "Edit"
+      edit_link_url = "/queue/appeals/#{appeal.external_id}/modal/advanced_on_docket_motion"
+      expect(page).to_not have_link("Edit", href: edit_link_url)
       expect(page.document.text).to match(/#{COPY::TASK_SNAPSHOT_TASK_ASSIGNOR_LABEL} #{preparer_name}/i)
       expect(page.document.text).to match(/#{COPY::TASK_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL} #{task.document_id}/i)
     end

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -211,8 +211,6 @@ describe FetchHearingLocationsForVeteransJob do
       end
     end
   end
-
-  # rubocop:disable Metrics/MethodLength
   def veteran_record(file_number:, state: "MA")
     {
       file_number: file_number,
@@ -304,5 +302,4 @@ describe FetchHearingLocationsForVeteransJob do
       "distance": distance
     }
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -1,6 +1,5 @@
 # rubocop:disable Metrics/ModuleLength
 module IntakeHelpers
-  # rubocop: disable Metrics/MethodLength
   # rubocop: disable Metrics/ParameterLists
   def start_higher_level_review(
     test_veteran,
@@ -107,7 +106,6 @@ module IntakeHelpers
 
     [appeal, intake]
   end
-  # rubocop: enable Metrics/MethodLength
   # rubocop: enable Metrics/ParameterLists
 
   def start_claim_review(claim_review_type, veteran: create(:veteran), veteran_is_not_claimant: false)
@@ -397,7 +395,6 @@ module IntakeHelpers
                   reject_reason: "Converted or Backfilled Rating - no promulgated ratings found")
   end
 
-  # rubocop:disable Metrics/MethodLength
   def generate_ratings_with_disabilities(
     veteran,
     promulgation_date,
@@ -442,7 +439,6 @@ module IntakeHelpers
       disabilities: disabilities
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
   def save_and_check_request_issues_with_disability_codes(form_name, decision_review)
     click_intake_add_issue
@@ -467,7 +463,6 @@ module IntakeHelpers
            )).to_not be_nil
   end
 
-  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def verify_decision_issues_can_be_added_and_removed(page_url,
                                                       original_request_issue,
@@ -538,10 +533,8 @@ module IntakeHelpers
       contested_issue_description: contested_decision_issues.second.description
     )
   end
-  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 
-  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
   def verify_request_issue_contending_decision_issue_not_readded(
       page_url,
@@ -585,7 +578,6 @@ module IntakeHelpers
     expect(request_issue_update.created_issues.map(&:id)).to_not include(non_modified_ids)
     expect(request_issue_update.removed_issues.map(&:id)).to_not include(non_modified_ids)
   end
-  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 end
 # rubocop:enable Metrics/ModuleLength

--- a/spec/workflows/update_attorney_case_review_spec.rb
+++ b/spec/workflows/update_attorney_case_review_spec.rb
@@ -8,7 +8,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: valid_decision_document_id,
-          user_id: 123_456_789
+          user: build(:user, id: 123_456_789)
         ).call
         errors = { document_id: ["You are not authorized to edit this document ID"] }
 
@@ -23,7 +23,7 @@ describe UpdateAttorneyCaseReview do
         UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: valid_decision_document_id,
-          user_id: review.reviewing_judge_id
+          user: build(:user, id: review.reviewing_judge_id)
         ).call
 
         expect(review.reload.document_id).to eq valid_decision_document_id
@@ -36,7 +36,7 @@ describe UpdateAttorneyCaseReview do
         UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: valid_decision_document_id,
-          user_id: review.attorney_id
+          user: build(:user, id: review.attorney_id)
         ).call
 
         expect(review.reload.document_id).to eq valid_decision_document_id
@@ -49,7 +49,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.12",
-          user_id: review.attorney_id
+          user: build(:user, id: review.attorney_id)
         ).call
 
         errors = {
@@ -66,7 +66,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.123",
-          user_id: review.attorney_id
+          user: build(:user, id: review.attorney_id)
         ).call
 
         expect(result.success?).to eq true
@@ -79,7 +79,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.123",
-          user_id: review.attorney_id
+          user: build(:user, id: review.attorney_id)
         ).call
 
         errors = {
@@ -96,7 +96,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "M1234567.1234",
-          user_id: review.attorney_id
+          user: build(:user, id: review.attorney_id)
         ).call
 
         expect(result.success?).to eq true
@@ -109,7 +109,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.123",
-          user_id: review.attorney_id
+          user: build(:user, id: review.attorney_id)
         ).call
 
         error_message = "Draft Decision Document IDs must be in one of these formats: " \
@@ -127,7 +127,7 @@ describe UpdateAttorneyCaseReview do
         result = UpdateAttorneyCaseReview.new(
           id: 123,
           document_id: "V1234567.123",
-          user_id: 1
+          user: build(:user)
         ).call
 
         errors = {

--- a/spec/workflows/update_legacy_attorney_case_review_spec.rb
+++ b/spec/workflows/update_legacy_attorney_case_review_spec.rb
@@ -1,0 +1,286 @@
+require "rails_helper"
+
+describe UpdateLegacyAttorneyCaseReview do
+  describe "#call" do
+    let(:judge) { build(:user, css_id: "JUDGE") }
+    let(:attorney) { build(:user, css_id: "ATTORNEY") }
+    let(:vacols_id) { "123456" }
+    let(:document_id) { "V1234567.222" }
+    let(:created_at) { "2019-02-14" }
+    let(:attorney_case_review) { create(:attorney_case_review, task_id: "#{vacols_id}-#{created_at}") }
+
+    def stub_case_assignment_with_work_product(work_product)
+      case_assignment = double(
+        vacols_id: vacols_id,
+        assigned_by_css_id: attorney.css_id,
+        assigned_to_css_id: judge.css_id,
+        document_id: document_id,
+        work_product: work_product,
+        created_at: created_at.to_date
+      )
+      allow(VACOLS::CaseAssignment).to receive(:latest_task_for_appeal).with(vacols_id).and_return(case_assignment)
+      attorney_case_review
+    end
+
+    def valid_decision_document_id
+      "12345678.123"
+    end
+
+    def valid_vha_document_id
+      "V1234567.123"
+    end
+
+    def valid_ime_document_id
+      "M1234567.123"
+    end
+
+    def invalid_document_id
+      "1234567.123"
+    end
+
+    context "when the current user is not associated with the case" do
+      it "does not update the case review" do
+        stub_case_assignment_with_work_product("VHA")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_vha_document_id,
+          user: build(:user, id: 123_456_789)
+        ).call
+        errors = { document_id: ["You are not authorized to edit this document ID"] }
+
+        expect(attorney_case_review.reload.document_id).to_not eq valid_vha_document_id
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the current user is a judge associated with the case" do
+      it "updates both the attorney case review and the VACOLS Decass table" do
+        stub_case_assignment_with_work_product("VHA")
+
+        decass = class_double(VACOLS::Decass)
+        expect(VACOLS::Decass)
+          .to receive(:where).with(defolder: vacols_id, deadtim: created_at.to_date).and_return(decass)
+        expect(decass).to receive(:update_all).with(dedocid: valid_vha_document_id)
+
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_vha_document_id,
+          user: judge
+        ).call
+
+        expect(result.success?).to eq true
+        expect(attorney_case_review.reload.document_id).to eq valid_vha_document_id
+      end
+    end
+
+    context "when the current user is an attorney associated with the case" do
+      it "updates the case review" do
+        stub_case_assignment_with_work_product("VHA")
+        UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_vha_document_id,
+          user: attorney
+        ).call
+
+        expect(attorney_case_review.reload.document_id).to eq valid_vha_document_id
+      end
+    end
+
+    context "when the work_product is 'VHA' but the document_id is in the wrong format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("VHA")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: invalid_document_id,
+          user: attorney
+        ).call
+
+        errors = {
+          document_id: ["VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the work_product is 'OTV' but the document_id is in the wrong format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("OTV")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: invalid_document_id,
+          user: attorney
+        ).call
+
+        errors = {
+          document_id: ["VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the work_product is 'IME' but the document_id is in the wrong format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("IME")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: invalid_document_id,
+          user: attorney
+        ).call
+
+        errors = {
+          document_id: ["IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the work_product is 'OTI' but the document_id is in the wrong format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("OTI")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: invalid_document_id,
+          user: attorney
+        ).call
+
+        errors = {
+          document_id: ["IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the work_product is 'DEC' but the document_id is in the wrong format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("DEC")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: invalid_document_id,
+          user: attorney
+        ).call
+
+        error_message = "Draft Decision Document IDs must be in one of these formats: " \
+                        "12345-12345678 or 12345678.123 or 12345678.1234"
+        errors = {
+          document_id: [error_message]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the work_product is 'OTD' but the document_id is in the wrong format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("OTD")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: invalid_document_id,
+          user: attorney
+        ).call
+
+        error_message = "Draft Decision Document IDs must be in one of these formats: " \
+                        "12345-12345678 or 12345678.123 or 12345678.1234"
+        errors = {
+          document_id: [error_message]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+
+    context "when the work_product is 'OTV' and the document_id is in the correct format" do
+      it "updates successfully" do
+        stub_case_assignment_with_work_product("OTV")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_vha_document_id,
+          user: judge
+        ).call
+
+        expect(result.success?).to eq true
+        expect(attorney_case_review.reload.document_id).to eq valid_vha_document_id
+      end
+    end
+
+    context "when the work_product is 'IME' and the document_id is in the correct format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("IME")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_ime_document_id,
+          user: attorney
+        ).call
+
+        expect(result.success?).to eq true
+        expect(attorney_case_review.reload.document_id).to eq valid_ime_document_id
+      end
+    end
+
+    context "when the work_product is 'OTI' and the document_id is in the correct format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("OTI")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_ime_document_id,
+          user: attorney
+        ).call
+
+        expect(result.success?).to eq true
+        expect(attorney_case_review.reload.document_id).to eq valid_ime_document_id
+      end
+    end
+
+    context "when the work_product is 'DEC' and the document_id is in the correct format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("DEC")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_decision_document_id,
+          user: attorney
+        ).call
+
+        expect(result.success?).to eq true
+        expect(attorney_case_review.reload.document_id).to eq valid_decision_document_id
+      end
+    end
+
+    context "when the work_product is 'OTD' and the document_id is in the correct format" do
+      it "returns an error" do
+        stub_case_assignment_with_work_product("OTD")
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: valid_decision_document_id,
+          user: attorney
+        ).call
+
+        expect(result.success?).to eq true
+        expect(attorney_case_review.reload.document_id).to eq valid_decision_document_id
+      end
+    end
+
+    context "when the Vacols case assignment cannot be found" do
+      it "returns an error" do
+        attorney = build(:user, css_id: "ATTORNEY")
+        vacols_id = "123"
+
+        allow(VACOLS::CaseAssignment).to receive(:latest_task_for_appeal).with(vacols_id).and_return(nil)
+
+        result = UpdateLegacyAttorneyCaseReview.new(
+          id: vacols_id,
+          document_id: "V1234567.123",
+          user: attorney
+        ).call
+
+        errors = {
+          document_id: ["Could not find a legacy Attorney Case Review with id #{vacols_id}"]
+        }
+
+        expect(result.errors).to eq errors
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: This is a follow-up to the feature where we added the ability
to edit document IDs for AMA cases. Now, we are supporting legacy cases
as well.

Resolves #8640

**Acceptance Criteria**:
- A judge or attorney assigned to a legacy case can edit the Document ID
- A user that is not associated with a case (whether AMA or legacy)
should not see the "Edit" link
- When the document ID for a legacy case is updated, both the
`AttorneyCaseReviews` and `VACOLS::Decass` tables should be updated.
- The format of Document IDs is validated based on the work product

**Test Plan**:
1. Sign in as an attorney and complete the checkout flow for a legacy
case
2. Visit the appeals details page
Expected Result: you should be able edit the document ID
3. Enter an invalid ID, such as "123", and click Save
Expected Result: an error message appears
4. Enter a valid ID and click Save
Expected Result: the new document ID appears on the page
5. Reload the page
Expected Result: the new document ID appears on the page
6. Switch to the judge user assigned to the case
7. Repeat steps 2-5
8. Switch to a user not associated with the case
Expected Result: you should not be able to edit the document ID