### PR TITLE
Adding Appeal skeleton model for appeal status api

### DIFF
--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -26,7 +26,7 @@ class Api::V2::AppealsController < Api::ApplicationController
         all_reviews_and_appeals
       else
         ActiveModelSerializers::SerializableResource.new(
-          appeals,
+          legacy_appeals,
           each_serializer: ::V2::AppealSerializer,
           key_transform: :camel_lower
         ).as_json
@@ -34,9 +34,9 @@ class Api::V2::AppealsController < Api::ApplicationController
     end
   end
 
-  def appeals
+  def legacy_appeals
     # Appeals API is currently limited to VBA appeals
-    @appeals ||= AppealHistory.for_api(vbms_id: vbms_id).select do |series|
+    @legacy_appeals ||= AppealHistory.for_api(vbms_id: vbms_id).select do |series|
       series.aoj == :vba
     end
   end
@@ -47,6 +47,10 @@ class Api::V2::AppealsController < Api::ApplicationController
 
   def supplemental_claims
     @supplemental_claims ||= SupplementalClaim.where(veteran_file_number: vbms_id.sub("S", ""))
+  end
+
+  def appeals
+    @appeals ||= Appeal.where(veteran_file_number: vbms_id.sub("S", ""))
   end
 
   def all_reviews_and_appeals
@@ -62,7 +66,13 @@ class Api::V2::AppealsController < Api::ApplicationController
       key_transform: :camel_lower
     ).as_json
 
-    { data: hlr_json[:data] + sc_json[:data] }
+    appeal_json = ActiveModelSerializers::SerializableResource.new(
+      appeals,
+      each_serializer: ::V2::AppealStatusSerializer,
+      key_transform: :camel_lower
+    ).as_json
+
+    { data: hlr_json[:data] + sc_json[:data] + appeal_json[:data] }
   end
 
   def vbms_id

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -290,7 +290,7 @@ class Appeal < DecisionReview
     remand_supplemental_claims.each(&:start_processing_job!)
   end
 
-# needed for appeal status api
+  # needed for appeal status api
   def appeal_status_id
     "A#{id}"
   end
@@ -300,7 +300,27 @@ class Appeal < DecisionReview
   end
 
   def aod
-    #to be implemented
+    # to be implemented
+  end
+
+  def location
+    # to be implemented
+  end
+
+  def status_hash
+    # to be implemented
+  end
+
+  def alerts
+    # to be implemented
+  end
+
+  def description
+    # to be implemented
+  end
+
+  def program
+    # to be implemented
   end
 
   private

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -290,6 +290,19 @@ class Appeal < DecisionReview
     remand_supplemental_claims.each(&:start_processing_job!)
   end
 
+# needed for appeal status api
+  def appeal_status_id
+    "A#{id}"
+  end
+
+  def linked_review_ids
+    Array.wrap(appeal_status_id)
+  end
+
+  def aod
+    #to be implemented
+  end
+
   private
 
   def bgs

--- a/app/models/serializers/v2/appeal_status_serializer.rb
+++ b/app/models/serializers/v2/appeal_status_serializer.rb
@@ -39,5 +39,6 @@ class V2::AppealStatusSerializer < V2::AppealSerializer
     # to be implemented
     # will need to override method used
     # issues already exists in appeal
+    []
   end
 end

--- a/app/models/serializers/v2/appeal_status_serializer.rb
+++ b/app/models/serializers/v2/appeal_status_serializer.rb
@@ -1,0 +1,40 @@
+class V2::AppealStatusSerializer < V2::AppealSerializer
+  type :appeal
+
+  def id
+    object.appeal_status_id
+  end
+
+  attribute :linked_review_ids, key: :appeal_ids
+
+  attribute :type do
+    # this does not apply to HLR
+  end
+
+  attribute :location do
+    # to be implement
+  end
+
+  attribute :incomplete do
+    false
+  end
+
+  attribute :type do
+    "original"
+  end
+
+  attribute :aoj do
+    "other"
+  end
+
+  attribute :aod do
+    # to be implemented
+  end
+
+  attribute :docket do
+    # to be implemented
+  end
+
+  attribute :events do
+  end
+end

--- a/app/models/serializers/v2/appeal_status_serializer.rb
+++ b/app/models/serializers/v2/appeal_status_serializer.rb
@@ -8,19 +8,15 @@ class V2::AppealStatusSerializer < V2::AppealSerializer
   attribute :linked_review_ids, key: :appeal_ids
 
   attribute :type do
-    # this does not apply to HLR
+    "original"
   end
 
   attribute :location do
     # to be implement
   end
 
-  attribute :incomplete do
+  attribute :incomplete_history do
     false
-  end
-
-  attribute :type do
-    "original"
   end
 
   attribute :aoj do
@@ -36,5 +32,12 @@ class V2::AppealStatusSerializer < V2::AppealSerializer
   end
 
   attribute :events do
+    # to be implemented
+  end
+
+  attribute :issues do
+    # to be implemented
+    # will need to override method used
+    # issues already exists in appeal
   end
 end

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -131,6 +131,12 @@ describe "Appeals API v2", type: :request do
              veteran_is_not_claimant: veteran_is_not_claimant)
     end
 
+    let!(:appeal) do
+      create(:appeal,
+             veteran_file_number: veteran_file_number,
+             receipt_date: nil)
+    end
+
     before do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_file_number_by_ssn) do |_bgs, ssn|
         ssn
@@ -377,7 +383,7 @@ describe "Appeals API v2", type: :request do
       expect(ApiView.count).to eq(1)
     end
 
-    it "returns list of hlrs for veteran with SSN" do
+    it "returns list of hlr, sc, appeal for veteran with SSN" do
       allow_any_instance_of(Fakes::BGSService).to receive(:fetch_file_number_by_ssn) do |_bgs|
         veteran_file_number
       end
@@ -396,7 +402,7 @@ describe "Appeals API v2", type: :request do
       # test for the 200 status-code
       expect(response).to be_success
       # check to make sure the right amount of appeals are returned
-      expect(json["data"].length).to eq(2)
+      expect(json["data"].length).to eq(3)
 
       # check the attribtues on the hlr
       expect(json["data"].first["type"]).to eq("higherLevelReview")
@@ -435,6 +441,25 @@ describe "Appeals API v2", type: :request do
       expect(json["data"][1]["attributes"]["docket"]).to be_nil
       expect(json["data"][1]["attributes"]["status"]).to be_nil
       expect(json["data"][1]["attributes"]["issues"].length).to eq(0)
+
+      # checkout the attributes on the appeal
+      expect(json["data"][2]["type"]).to eq("appeal")
+      expect(json["data"][2]["id"]).to include("A")
+      expect(json["data"][2]["attributes"]["appealIds"].length).to eq(1)
+      expect(json["data"][2]["attributes"]["appealIds"].first).to include("A")
+      expect(json["data"][2]["attributes"]["updated"]).to eq("2015-01-01T07:00:00-05:00")
+      expect(json["data"][2]["attributes"]["type"]).to eq("original")
+      expect(json["data"][2]["attributes"]["active"]).to eq(false)
+      expect(json["data"][2]["attributes"]["incompleteHistory"]).to eq(false)
+      expect(json["data"][2]["attributes"]["description"]).to be_nil
+      expect(json["data"][2]["attributes"]["aod"]).to be_nil
+      expect(json["data"][2]["attributes"]["location"]).to be_nil
+      expect(json["data"][2]["attributes"]["alerts"]).to be_nil
+      expect(json["data"][2]["attributes"]["aoj"]).to eq("other")
+      expect(json["data"][2]["attributes"]["programArea"]).to be_nil
+      expect(json["data"][2]["attributes"]["docket"]).to be_nil
+      expect(json["data"][2]["attributes"]["status"]).to be_nil
+      expect(json["data"][2]["attributes"]["issues"].length).to eq(0)
 
       FeatureToggle.disable!(:api_appeal_status_v3)
     end


### PR DESCRIPTION
Resolves #{8728}

### Description
These are updates for Appeals to be supported in Appeal Status API.
Added a new serializer for appeal and skeleton methods to Appeal to support it.
Also updated the controller -- renamed appeals to legacy_appeals and "appeals" will refer to ama appeals and added the Appeal json to be returned along with hlr and sc.

Added a simple test. I will fill it in with as the attributes are implemented.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. ran lint
2. tested on the command line

appeals = Appeal.where(veteran_file_number: 701305078)

ActiveModelSerializers::SerializableResource.new(
        appeals,
        each_serializer: ::V2::AppealStatusSerializer,
        key_transform: :camel_lower
      ).as_json

Output: 
 {:data=>
  [{:id=>"A1",
    :type=>"appeal",
    :attributes=>
     {:appealIds=>["A1"],
      :updated=>"2019-01-24T15:52:12-05:00",
      :incompleteHistory=>false,
      :type=>"original",
      :active=>false,
      :description=>nil,
      :aod=>nil,
      :location=>nil,
      :aoj=>"other",
      :programArea=>nil,
      :status=>nil,
      :alerts=>nil,
      :docket=>nil,
      :issues=>[],
      :events=>nil,
      :evidence=>[]}}]}

