### PR TITLE
Fix document count missing in case details spec

### DIFF
--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -254,10 +254,10 @@ RSpec.feature "Case details" do
 
   context "when an appeal has some number of documents" do
     let!(:appeal) do
-      FactoryBot.create(
+      create(
         :legacy_appeal,
         :with_veteran,
-        vacols_case: FactoryBot.create(:case_with_soc, :assigned, user: attorney_user)
+        vacols_case: create(:case_with_soc, :assigned, :docs_in_vbms, user: attorney_user)
       )
     end
 
@@ -267,9 +267,7 @@ RSpec.feature "Case details" do
     scenario "reader link appears on page and sends us to reader" do
       visit "/queue"
       click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
-      # TODO: Why isn't the document count coming through here?
-      # click_on "View #{appeal.documents.count} documents"
-      click_on "View"
+      click_on "View #{appeal.documents.count} docs"
 
       # ["Caseflow", "> Reader"] are two elements, space handled by margin-left on second
       expect(page).to have_content("Caseflow> Reader")


### PR DESCRIPTION
**Details**:
The `AppealDocumentCount` React component does not attempt to fetch
the document count if the appeal's `file_type` is "Paper". In this
particular spec, the file type was "Paper", and so the document count
wouldn't show up.

In order to make this a non-paper file type, we can use either the
`:docs_in_vbms` or `:docs_in_vva` trait for the `case` factory. This is
because the file type gets set based on VACOLS attributes when the
`AppealsController` is called.

The flow is as follows:
1. `AppealsController#index` calls `get_appeals_for_file_number`
2. `LegacyAppeal.fetch_appeals_by_file_number` is called
3. `AppealRepository.appeals_by_vbms_id` is called
4. `AppealRepository.build_appeal` is called
4. `AppealRepository.set_vacols_values` is called
5. `file_type` is set to `AppealRepository.folder_type_from`
Unless the properties `tivbms` or `tisubj2` are set to specific values,
the `file_type` will be set to "Paper".