### PR TITLE
hide tasks that are on hold in the judge view of attorney caseloads

### DIFF
--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -57,6 +57,9 @@ export const incompleteTasksSelector = (tasks: Tasks | Array<Task>) =>
 export const completeTasksSelector = (tasks: Tasks) =>
   _.filter(tasks, (task) => task.status === TASK_STATUSES.completed);
 
+export const taskIsNotOnHoldSelector = (tasks: Tasks) =>
+  _.filter(tasks, (task) => !taskIsOnHold(task));
+
 export const getActiveModalType = createSelector(
   [getModals],
   (modals: { String: boolean }) => _.find(Object.keys(modals), (modalName) => modals[modalName])
@@ -293,7 +296,10 @@ const getAttorney = (state: State, attorneyId: string) => {
 };
 
 export const getAssignedTasks = (state: State, attorneyId: string) => {
-  const tasks = incompleteTasksSelector(tasksWithAppealSelector(state));
+  const tasks =
+    incompleteTasksSelector(
+      taskIsNotOnHoldSelector(
+        tasksWithAppealSelector(state)));
   const attorney = getAttorney(state, attorneyId);
   const cssId = attorney ? attorney.css_id : null;
 
@@ -301,7 +307,10 @@ export const getAssignedTasks = (state: State, attorneyId: string) => {
 };
 
 export const getTasksByUserId = (state: State) => {
-  const tasks = incompleteTasksSelector(tasksWithAppealSelector(state));
+  const tasks =
+    incompleteTasksSelector(
+      taskIsNotOnHoldSelector(
+        tasksWithAppealSelector(state)));
   const attorneys = state.queue.attorneysOfJudge;
   const attorneysByCssId = _.keyBy(attorneys, 'css_id');
 


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/caseflow/issues/8318
/cc @laurjpeterson 

### Description
This PR hides cases that are on hold from judge view of attorney caseloads. This PR follows @amprokop's proposed approach in https://github.com/department-of-veterans-affairs/caseflow/issues/8318.

When judges are assigning cases to their attorneys, they need to see an accurate number of cases that are on their attorney's plates.


