### PR TITLE
Fix feature test flake by expecting header text

### DIFF
--- a/spec/feature/hearing_schedule/schedule_veteran_spec.rb
+++ b/spec/feature/hearing_schedule/schedule_veteran_spec.rb
@@ -125,6 +125,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         click_dropdown(text: "Denver")
         click_button("AMA Veterans Waiting")
         click_on "Bob Smith"
+        expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL)
 
         # Case details screen
         click_dropdown(text: Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h[:label])


### PR DESCRIPTION
If we expect to see header text, rspec will wait for the page to load before looking for the `.Select-control` element.

A fix for [this flake](https://circleci.com/gh/department-of-veterans-affairs/caseflow/36440).
