### PR TITLE
Add last_submitted_at to asyncable models

### DIFF
--- a/app/models/concerns/timeable_task.rb
+++ b/app/models/concerns/timeable_task.rb
@@ -7,7 +7,7 @@ module TimeableTask
       fail Caseflow::Error::MissingTimerMethod unless respond_to?(:timer_delay)
 
       super(args).tap do |task|
-        TaskTimer.create!(task: task, submitted_at: Time.zone.now + timer_delay)
+        TaskTimer.create!(task: task, last_submitted_at: Time.zone.now + timer_delay)
       end
     end
   end

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -20,6 +20,6 @@ class AsyncableJobs
     models.each do |klass|
       expired_jobs << klass.potentially_stuck
     end
-    expired_jobs.flatten.sort_by(&:sort_by_submitted_at)
+    expired_jobs.flatten.sort_by(&:sort_by_last_submitted_at)
   end
 end

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -81,6 +81,21 @@ class AsyncableJobsPage extends React.PureComponent {
     return txt;
   }
 
+  disableRestart = (job) => {
+    if (!job.attempted_at) {
+      return false;
+    }
+
+    const fiveMinutes = 300000;
+
+    let lastAttempted = new Date(job.attempted_at);
+    let now = new Date();
+    console.log(lastAttempted);
+    console.log(now);
+
+    return (now - lastAttempted) < fiveMinutes;
+  }
+
   render = () => {
     const rowObjects = this.props.jobs;
 
@@ -96,13 +111,23 @@ class AsyncableJobsPage extends React.PureComponent {
         }
       },
       {
-        header: 'Submitted',
+        header: 'Originally Submitted',
         valueFunction: (job) => {
           if (job.submitted_at === 'restarted') {
             return job.submitted_at;
           }
 
           return moment(job.submitted_at).format(DATE_TIME_FORMAT);
+        }
+      },
+      {
+        header: 'Last Submitted',
+        valueFunction: (job) => {
+          if (job.last_submitted_at === 'restarted') {
+            return job.last_submitted_at;
+          }
+
+          return moment(job.last_submitted_at).format(DATE_TIME_FORMAT);
         }
       },
       {
@@ -140,6 +165,7 @@ class AsyncableJobsPage extends React.PureComponent {
             title={`${job.klass} ${job.id}`}
             loading={this.state.jobsRestarting[job.id]}
             loadingText="Restarting..."
+            disable={this.disableRestart(job)}
             onClick={() => {
               this.restartJob(job);
             }}

--- a/db/migrate/20190125223733_add_asyncable_last_submitted_at.rb
+++ b/db/migrate/20190125223733_add_asyncable_last_submitted_at.rb
@@ -1,5 +1,5 @@
 class AddAsyncableLastSubmittedAt < ActiveRecord::Migration[5.1]
-  def change
+  def asyncable_tables
     [
       :request_issues,
       :board_grant_effectuations,
@@ -9,8 +9,22 @@ class AddAsyncableLastSubmittedAt < ActiveRecord::Migration[5.1]
       :appeals,
       :supplemental_claims,
       :higher_level_reviews
-    ].each do |tbl|
-      add_column tbl, :last_submitted_at, :datetime
+    ]
+  end
+
+  def up
+    asyncable_tables.each do |tbl|
+      safety_assured do
+        submitted_at_column = tbl.to_s.classify.constantize.submitted_at_column
+        add_column tbl, :last_submitted_at, :datetime
+        execute "UPDATE #{tbl} SET last_submitted_at=#{submitted_at_column}"
+      end
+    end
+  end
+
+  def down
+    asyncable_tables.each do |tbl|
+      remove_column tbl, :last_submitted_at
     end
   end
 end

--- a/db/migrate/20190125223733_add_asyncable_last_submitted_at.rb
+++ b/db/migrate/20190125223733_add_asyncable_last_submitted_at.rb
@@ -1,0 +1,16 @@
+class AddAsyncableLastSubmittedAt < ActiveRecord::Migration[5.1]
+  def change
+    [
+      :request_issues,
+      :board_grant_effectuations,
+      :decision_documents,
+      :request_issues_updates,
+      :task_timers,
+      :appeals,
+      :supplemental_claims,
+      :higher_level_reviews
+    ].each do |tbl|
+      add_column tbl, :last_submitted_at, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190125151257) do
+ActiveRecord::Schema.define(version: 20190125223733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,6 +86,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.string "establishment_error"
     t.datetime "establishment_processed_at"
     t.datetime "establishment_submitted_at"
+    t.datetime "last_submitted_at"
     t.boolean "legacy_opt_in_approved"
     t.date "receipt_date"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
@@ -133,6 +134,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.datetime "decision_sync_submitted_at"
     t.bigint "end_product_establishment_id"
     t.bigint "granted_decision_issue_id", null: false
+    t.datetime "last_submitted_at"
     t.index ["appeal_id"], name: "index_board_grant_effectuations_on_appeal_id"
     t.index ["decision_document_id"], name: "index_board_grant_effectuations_on_decision_document_id"
     t.index ["end_product_establishment_id"], name: "index_board_grant_effectuations_on_end_product_establishment_id"
@@ -226,6 +228,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.datetime "created_at", null: false
     t.date "decision_date", null: false
     t.string "error"
+    t.datetime "last_submitted_at"
     t.datetime "processed_at"
     t.string "redacted_document_location", null: false
     t.datetime "submitted_at"
@@ -513,6 +516,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.datetime "establishment_processed_at"
     t.datetime "establishment_submitted_at"
     t.boolean "informal_conference"
+    t.datetime "last_submitted_at"
     t.boolean "legacy_opt_in_approved"
     t.date "receipt_date"
     t.boolean "same_office"
@@ -759,6 +763,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.string "ineligible_reason"
     t.boolean "is_unidentified"
     t.string "issue_category"
+    t.datetime "last_submitted_at"
     t.string "nonrating_issue_description"
     t.text "notes"
     t.integer "parent_request_issue_id"
@@ -791,6 +796,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.datetime "attempted_at"
     t.integer "before_request_issue_ids", null: false, array: true
     t.string "error"
+    t.datetime "last_submitted_at"
     t.datetime "processed_at"
     t.bigint "review_id", null: false
     t.string "review_type", null: false
@@ -851,6 +857,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.string "establishment_error"
     t.datetime "establishment_processed_at"
     t.datetime "establishment_submitted_at"
+    t.datetime "last_submitted_at"
     t.boolean "legacy_opt_in_approved"
     t.date "receipt_date"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
@@ -878,6 +885,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.datetime "attempted_at"
     t.datetime "created_at", null: false
     t.string "error"
+    t.datetime "last_submitted_at"
     t.datetime "processed_at"
     t.datetime "submitted_at"
     t.bigint "task_id", null: false

--- a/spec/factories/decision_document.rb
+++ b/spec/factories/decision_document.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     redacted_document_location { "C://Windows/User/BOBLAW/Documents/Decision.docx" }
 
     trait :requires_processing do
-      submitted_at { Time.zone.now - 1.minute }
+      last_submitted_at { Time.zone.now - 1.minute }
     end
 
     trait :processed do

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -55,7 +55,7 @@ feature "Asyncable Jobs index" do
       visit "/jobs"
 
       expect(page).to have_content(
-        /RequestIssuesUpdate #{six_days_ago} #{six_days_ago} unavailable unknown Restart/
+        /RequestIssuesUpdate #{six_days_ago} #{six_days_ago} queued unknown Queued/
       )
     end
 

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -8,6 +8,7 @@ feature "Asyncable Jobs index" do
   end
 
   let(:now) { post_ramp_start_date }
+  let(:six_days_ago) { 6.days.ago.strftime(date_format) }
 
   let!(:current_user) do
     User.authenticate!(roles: ["Admin Intake"])
@@ -18,25 +19,25 @@ feature "Asyncable Jobs index" do
   let(:veteran2) { create(:veteran) }
   let!(:hlr) do
     create(:higher_level_review,
-           establishment_submitted_at: 7.days.ago,
+           last_submitted_at: 7.days.ago,
            establishment_attempted_at: 6.days.ago,
            establishment_error: "oops!",
            veteran_file_number: veteran.file_number)
   end
   let!(:sc) do
     create(:supplemental_claim,
-           establishment_submitted_at: 6.days.ago,
+           last_submitted_at: 6.days.ago,
            establishment_attempted_at: 6.days.ago,
            establishment_error: "wrong!",
            veteran_file_number: veteran.file_number)
   end
   let!(:pending_hlr) do
     create(:higher_level_review,
-           establishment_submitted_at: 2.days.ago,
+           last_submitted_at: 2.days.ago,
            veteran_file_number: veteran2.file_number)
   end
   let!(:request_issues_update) do
-    create(:request_issues_update, submitted_at: 6.days.ago)
+    create(:request_issues_update, last_submitted_at: 6.days.ago, submitted_at: 6.days.ago)
   end
 
   describe "index page" do
@@ -52,7 +53,9 @@ feature "Asyncable Jobs index" do
 
       visit "/jobs"
 
-      expect(page).to have_content(/RequestIssuesUpdate Sat Dec 02 00:00:00 2017 never unknown Restart/)
+      expect(page).to have_content(
+        /RequestIssuesUpdate #{six_days_ago} #{six_days_ago} unavailable unknown Restart/
+      )
     end
 
     it "allows user to restart job" do
@@ -60,15 +63,15 @@ feature "Asyncable Jobs index" do
 
       expect(page).to have_content("oops!")
       expect(page).to have_content("wrong!")
-      expect(page).to have_content(hlr.establishment_submitted_at.strftime(date_format))
+      expect(page).to have_content(hlr.last_submitted_at.strftime(date_format))
 
       safe_click "#job-HigherLevelReview-#{hlr.id}"
 
       expect(page).to have_content("Restarted")
-      expect(page).to_not have_content(hlr.establishment_submitted_at.strftime(date_format))
+      expect(page).to_not have_content(hlr.last_submitted_at.strftime(date_format))
       expect(page).to_not have_content("oops!")
 
-      expect(hlr.reload.establishment_submitted_at).to eq(now)
+      expect(hlr.reload.last_submitted_at).to eq(now)
     end
 
     context "zero unprocesed jobs" do

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -20,6 +20,7 @@ feature "Asyncable Jobs index" do
   let!(:hlr) do
     create(:higher_level_review,
            last_submitted_at: 7.days.ago,
+           establishment_submitted_at: 8.days.ago,
            establishment_attempted_at: 6.days.ago,
            establishment_error: "oops!",
            veteran_file_number: veteran.file_number)
@@ -72,9 +73,10 @@ feature "Asyncable Jobs index" do
       expect(page).to_not have_content("oops!")
 
       expect(hlr.reload.last_submitted_at).to eq(now)
+      expect(hlr.establishment_submitted_at).to eq(8.days.ago)
     end
 
-    context "zero unprocesed jobs" do
+    context "zero unprocessed jobs" do
       before do
         AsyncableJobs.new.jobs.each(&:processed!)
       end

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -928,7 +928,7 @@ feature "Higher Level Review Edit issues" do
         before_request_issue_ids: [request_issue.id],
         after_request_issue_ids: [request_issue.id],
         attempted_at: Time.zone.now,
-        submitted_at: Time.zone.now,
+        last_submitted_at: Time.zone.now,
         processed_at: nil
       )
 

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -454,7 +454,7 @@ feature "Supplemental Claim Edit issues" do
         before_request_issue_ids: [request_issue.id],
         after_request_issue_ids: [request_issue.id],
         attempted_at: Time.zone.now,
-        submitted_at: Time.zone.now,
+        last_submitted_at: Time.zone.now,
         processed_at: nil
       )
 

--- a/spec/jobs/sync_reviews_job_spec.rb
+++ b/spec/jobs/sync_reviews_job_spec.rb
@@ -38,7 +38,7 @@ describe SyncReviewsJob do
     let!(:riu_attempts_ended) do
       create(
         :request_issues_update,
-        submitted_at: (RequestIssuesUpdate::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
+        last_submitted_at: (RequestIssuesUpdate::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
         attempted_at: (RequestIssuesUpdate::REQUIRES_PROCESSING_WINDOW_DAYS + 1).days.ago
       )
     end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -233,7 +233,7 @@ describe Appeal do
     let!(:appeal_attempts_ended) do
       create(
         :appeal,
-        establishment_submitted_at: (Appeal::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
+        last_submitted_at: (Appeal::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
         establishment_attempted_at: (Appeal::REQUIRES_PROCESSING_WINDOW_DAYS + 1).days.ago
       )
     end

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -122,7 +122,7 @@ describe ClaimReview do
       create(
         :higher_level_review,
         receipt_date: receipt_date,
-        establishment_submitted_at: (ClaimReview::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
+        last_submitted_at: (ClaimReview::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
         establishment_attempted_at: (ClaimReview::REQUIRES_PROCESSING_WINDOW_DAYS + 1).days.ago
       )
     end

--- a/spec/models/concerns/timeable_task_spec.rb
+++ b/spec/models/concerns/timeable_task_spec.rb
@@ -28,7 +28,7 @@ describe TimeableTask do
     task = SomeTimedTask.create!(appeal: appeal, assigned_to: Bva.singleton)
     timers = TaskTimer.where(task: task)
     expect(timers.length).to eq(1)
-    expect(timers.first.submitted_at).to eq(Time.zone.today + 5.days)
+    expect(timers.first.last_submitted_at).to eq(Time.zone.today + 5.days)
   end
 
   context "when not correctly configured" do

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -476,7 +476,7 @@ describe RequestIssuesUpdate do
     let!(:riu_attempts_ended) do
       create(
         :request_issues_update,
-        submitted_at: (RequestIssuesUpdate::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
+        last_submitted_at: (RequestIssuesUpdate::REQUIRES_PROCESSING_WINDOW_DAYS + 5).days.ago,
         attempted_at: (RequestIssuesUpdate::REQUIRES_PROCESSING_WINDOW_DAYS + 1).days.ago
       )
     end

--- a/spec/models/task_timer_spec.rb
+++ b/spec/models/task_timer_spec.rb
@@ -4,7 +4,7 @@ describe TaskTimer do
       expect(TaskTimer.requires_processing.count).to eq 0
 
       task = create(:generic_task, :on_hold)
-      TaskTimer.create!(task: task, submitted_at: Time.zone.now + 24.hours)
+      TaskTimer.create!(task: task, last_submitted_at: Time.zone.now + 24.hours)
 
       expect(TaskTimer.requires_processing.count).to eq 0
 

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -3,13 +3,13 @@ describe AsyncableJobs do
     let(:veteran) { create(:veteran) }
     let!(:hlr) do
       create(:higher_level_review,
-             establishment_submitted_at: 7.days.ago,
+             last_submitted_at: 7.days.ago,
              establishment_attempted_at: 7.days.ago,
              veteran_file_number: veteran.file_number)
     end
     let!(:sc) do
       create(:supplemental_claim,
-             establishment_submitted_at: 6.days.ago,
+             last_submitted_at: 6.days.ago,
              establishment_attempted_at: 7.days.ago,
              veteran_file_number: veteran.file_number)
     end
@@ -20,12 +20,12 @@ describe AsyncableJobs do
     end
     let!(:sc_not_attempted) do
       create(:supplemental_claim,
-             establishment_submitted_at: 2.days.ago,
+             last_submitted_at: 2.days.ago,
              veteran_file_number: veteran.file_number)
     end
     let!(:sc_not_attempted_expired) do
       create(:supplemental_claim,
-             establishment_submitted_at: 8.days.ago,
+             last_submitted_at: 8.days.ago,
              veteran_file_number: veteran.file_number)
     end
 


### PR DESCRIPTION
connects #6944 

### Description
The `submitted_at` column is used for reporting metrics on the time it takes to complete EPs, so we cannot reset it.

This adds a new column `last_submitted_at` that is used exclusively by the Asyncable concern for managing jobs, including restarting them.
