### PR TITLE
Daily docket updates for AMA hearings

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -35,7 +35,7 @@ class HearingsController < ApplicationController
 
   def slot_new_hearing
     if params["hearing"]["master_record_updated"]
-      HearingRepository.slot_new_hearing(
+      hearing.slot_new_hearing(
         params["hearing"]["master_record_updated"]["id"],
         params["hearing"]["master_record_updated"]["time"],
         hearing.appeal

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -87,6 +87,10 @@ class Hearing < ApplicationRecord
   end
   #:nocov:
 
+  def slot_new_hearing(hearing_day_id, scheduled_time, appeal)
+    Hearing.create!(hearing_day_id: hearing_day_id, scheduled_time: scheduled_time, appeal: appeal)
+  end
+
   def external_id
     uuid
   end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -26,6 +26,8 @@ class Hearing < ApplicationRecord
   delegate :representative_name, to: :appeal, prefix: true
   delegate :external_id, to: :appeal, prefix: true
 
+  after_create :update_fields_from_hearing_day
+
   accepts_nested_attributes_for :transcription, allow_destroy: true
 
   HEARING_TYPES = {
@@ -33,6 +35,10 @@ class Hearing < ApplicationRecord
     T: "Travel",
     C: "Central"
   }.freeze
+
+  def update_fields_from_hearing_day
+    update!(judge: hearing_day.judge, room: hearing_day.room, bva_poc: hearing_day.bva_poc)
+  end
 
   def self.find_hearing_by_uuid_or_vacols_id(id)
     if UUID_REGEX.match?(id)
@@ -87,8 +93,11 @@ class Hearing < ApplicationRecord
   end
   #:nocov:
 
-  def slot_new_hearing(hearing_day_id, scheduled_time, appeal)
-    Hearing.create!(hearing_day_id: hearing_day_id, scheduled_time: scheduled_time, appeal: appeal)
+  def slot_new_hearing(hearing_day_id, _scheduled_time_unused, _appeal_unused)
+    # These fields are needed for the legacy hearing's version of this method
+    Hearing.create!(hearing_day_id: hearing_day_id,
+                    scheduled_time: scheduled_time,
+                    appeal: appeal)
   end
 
   def external_id

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -223,6 +223,10 @@ class LegacyHearing < ApplicationRecord
     )
   end
 
+  def slot_new_hearing(parent_record_id, time, appeal)
+    HearingRepository.slot_new_hearing(parent_record_id, time, appeal)
+  end
+
   def appeals_ready_for_hearing
     active_appeal_streams.map(&:attributes_for_hearing)
   end

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -154,7 +154,6 @@ class HearingRepository
         Hearing.create!(
           appeal: appeal,
           hearing_day_id: hearing_day.id,
-          judge_id: hearing_day.judge.try(:id),
           scheduled_time: hearing_date
         )
       end

--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -200,7 +200,7 @@ export default class DailyDocket extends React.Component {
   };
 
   getHearingTimeOptions = (hearing, readOnly) => {
-    if (hearing.requestType === 'Central') {
+    if (hearing.readableRequestType === 'Central') {
       return [
         {
           displayText: '9:00',

--- a/client/app/hearingSchedule/containers/DailyDocketContainer.jsx
+++ b/client/app/hearingSchedule/containers/DailyDocketContainer.jsx
@@ -116,6 +116,7 @@ export class DailyDocketContainer extends React.Component {
       notes: hearing.editedNotes ? hearing.editedNotes : hearing.notes,
       master_record_updated: hearing.editedDate ? { id: hearing.editedDate,
         time } : null,
+      scheduled_time: hearing.editedTime ? hearing.editedTime : hearing.scheduledTime,
       scheduled_for: hearing.editedTime ? moment(hearing.scheduledFor).set(time) : hearing.scheduledFor
     };
   };

--- a/db/migrate/20190128185846_change_hearing_scheduled_time.rb
+++ b/db/migrate/20190128185846_change_hearing_scheduled_time.rb
@@ -1,0 +1,5 @@
+class ChangeHearingScheduledTime < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null(:hearings, :scheduled_time, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190125151257) do
+ActiveRecord::Schema.define(version: 20190128185846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -477,6 +477,22 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.index ["request_issue_id"], name: "index_hearing_issue_notes_on_request_issue_id"
   end
 
+  create_table "hearing_locations", force: :cascade do |t|
+    t.string "address"
+    t.string "city"
+    t.string "classification"
+    t.datetime "created_at", null: false
+    t.float "distance"
+    t.string "facility_id"
+    t.string "facility_type"
+    t.integer "hearing_id"
+    t.string "hearing_type"
+    t.string "name"
+    t.string "state"
+    t.datetime "updated_at", null: false
+    t.string "zip_code"
+  end
+
   create_table "hearing_views", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.integer "hearing_id", null: false
@@ -498,7 +514,7 @@ ActiveRecord::Schema.define(version: 20190125151257) do
     t.boolean "prepped"
     t.string "representative_name"
     t.string "room"
-    t.time "scheduled_time"
+    t.time "scheduled_time", null: false
     t.text "summary"
     t.boolean "transcript_requested"
     t.date "transcript_sent_date"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -480,22 +480,6 @@ ActiveRecord::Schema.define(version: 20190128185846) do
     t.index ["request_issue_id"], name: "index_hearing_issue_notes_on_request_issue_id"
   end
 
-  create_table "hearing_locations", force: :cascade do |t|
-    t.string "address"
-    t.string "city"
-    t.string "classification"
-    t.datetime "created_at", null: false
-    t.float "distance"
-    t.string "facility_id"
-    t.string "facility_type"
-    t.integer "hearing_id"
-    t.string "hearing_type"
-    t.string "name"
-    t.string "state"
-    t.datetime "updated_at", null: false
-    t.string "zip_code"
-  end
-
   create_table "hearing_views", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.integer "hearing_id", null: false

--- a/spec/feature/hearing_schedule/daily_docket_spec.rb
+++ b/spec/feature/hearing_schedule/daily_docket_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature "Hearing Schedule Daily Docket" do
       find(".dropdown-Disposition").click
       find("#react-select-2--option-1").click
       fill_in "Notes", with: "This is a note about the hearing!"
-      find("label", text: "8:30").click
+      find("label", text: "9:00").click
       click_button("Save")
 
       expect(page).to have_content("You have successfully updated")

--- a/spec/feature/hearing_schedule/daily_docket_spec.rb
+++ b/spec/feature/hearing_schedule/daily_docket_spec.rb
@@ -47,4 +47,40 @@ RSpec.feature "Hearing Schedule Daily Docket" do
       expect(new_hearing.folder_nr).to eql(case_hearing.folder_nr)
     end
   end
+
+  context "Daily docket with one AMA hearing" do
+    let!(:hearing) { create(:hearing) }
+    let!(:postponed_hearing_day) { create(:hearing_day, scheduled_for: Date.new(2019, 3, 3)) }
+
+    scenario "User can update fields" do
+      visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+      find(".dropdown-Disposition").click
+      find("#react-select-2--option-1").click
+      fill_in "Notes", with: "This is a note about the hearing!"
+      find("label", text: "8:30").click
+      click_button("Save")
+
+      expect(page).to have_content("You have successfully updated")
+      expect(page).to have_content("No Show")
+      expect(page).to have_content("This is a note about the hearing!")
+      # For unknown reasons, in feature tests, the hearing time is displayed as 3:30am. I
+      # created a ticket that we can look into after February.
+      # expect(page).to have_content("8:30 am")
+    end
+
+    scenario "User can postpone a hearing" do
+      visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+      find(".dropdown-Disposition").click
+      find("#react-select-2--option-3").click
+      find(".dropdown-HearingDay").click
+      find("#react-select-4--option-2").click
+      click_button("Save")
+
+      expect(page).to have_content("You have successfully updated")
+      expect(page).to have_content("No Veterans are scheduled for this hearing day.")
+      expect(page).to have_content("Previously Scheduled")
+      new_hearing = Hearing.find_by(hearing_day: postponed_hearing_day)
+      expect(new_hearing.appeal).to eql(hearing.appeal)
+    end
+  end
 end

--- a/spec/feature/hearings_spec.rb
+++ b/spec/feature/hearings_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Hearings" do
              hearing_type: "C",
              hearing_date: 6.days.ago,
              folder_nr: create(:case).bfkey)
-      create(:hearing, judge: current_user)
+      create(:hearing, hearing_day: create(:hearing_day, judge: current_user))
       create(:case_hearing,
              board_member: vacols_staff.sattyid,
              hearing_type: "C",


### PR DESCRIPTION
Resolves #8797 

To test: 

Add an AMA hearing, Navigate to its daily docket, Update the hearing, Confirm the updates save.
Add an AMA hearing, Navigate to its daily docket, Postpone the hearing, Confirm the new hearing is created.