### PR TITLE
Add missing function for judge legacy tasks

### DIFF
--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -31,6 +31,14 @@ class LegacyTask
     }
   end
 
+  def assign_to_attorney_data(_user)
+    {
+      selected: nil,
+      options: nil,
+      type: AttorneyLegacyTask.name
+    }
+  end
+
   ### Serializer Methods Start
   def assigned_on
     assigned_at


### PR DESCRIPTION
A recent PR changed the way we build [task actions for legacy tasks](https://github.com/department-of-veterans-affairs/caseflow/pull/8898/files#diff-ec8f72bc8c01c893cb1aa591a0551e6c). That PR missed one function that needs to be defined for legacy tasks that was not. This PR fixes that.

## Steps to reproduce:
* Run `master` branch locally
* Log in as a judge with legacy cases to be assigned
* Attempt to load `/queue`
* Notice that it fails
* Pull down this branch
* Log in as a judge with legacy cases to be assigned
* Attempt to load `/queue`
* Notice that it succeeds