### PR TITLE
Allow Intake users to access IDT

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -50,10 +50,7 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
             else
               []
             end
-
-    if feature_enabled?(:idt_ama_appeals)
-      tasks += Task.where(assigned_to: user).where.not(status: [:completed, :on_hold])
-    end
+    tasks += Task.where(assigned_to: user).where.not(status: [:completed, :on_hold])
     tasks.reject { |task| (task.is_a?(JudgeLegacyTask) && task.action == "assign") || task.is_a?(JudgeAssignTask) }
   end
 
@@ -63,9 +60,7 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
 
   def appeals_by_file_number
     appeals = LegacyAppeal.fetch_appeals_by_file_number(file_number).select(&:activated?)
-    if feature_enabled?(:idt_ama_appeals)
-      appeals += Appeal.where(veteran_file_number: file_number)
-    end
+    appeals += Appeal.where(veteran_file_number: file_number)
     appeals
   end
 

--- a/app/controllers/idt/api/v1/base_controller.rb
+++ b/app/controllers/idt/api/v1/base_controller.rb
@@ -8,8 +8,13 @@ class Idt::Api::V1::BaseController < ActionController::Base
   end
 
   def verify_access
-    has_access = user.attorney_in_vacols? || user.judge_in_vacols? || user.dispatch_user_in_vacols?
-    return render json: { message: "User must be attorney, judge, or dispatch" }, status: :forbidden unless has_access
+    has_access = user.attorney_in_vacols? ||
+                 user.judge_in_vacols? ||
+                 user.dispatch_user_in_vacols? ||
+                 user.intake_user?
+    unless has_access
+      return render json: { message: "User must be attorney, judge, dispatch, or intake" }, status: :forbidden
+    end
   end
 
   def user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,6 +57,10 @@ class User < ApplicationRecord
     vacols_roles.include?("dispatch")
   end
 
+  def intake_user?
+    roles && (roles.include?("Mail Intake") || roles.include?("Admin Intake"))
+  end
+
   def vacols_uniq_id
     @vacols_uniq_id ||= user_info[:uniq_id]
   end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -86,8 +86,9 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       end
 
       context "and user is a mail intake" do
+        let(:user) { User.find_by(css_id: "ID1234") }
         before do
-          User.authenticate!(roles: ["Mail Intake"], css_id: "TEST_ID")
+          User.authenticate!(roles: ["Mail Intake"], css_id: "ID1234")
           request.headers["TOKEN"] = token
         end
 

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -69,29 +69,34 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
           ]
         end
 
-        context "with AMA appeals" do
-          before do
-            FeatureToggle.enable!(:idt_ama_appeals)
-          end
+        it "returns a list of assigned appeals" do
+          get :list
+          expect(response.status).to eq 200
+          expect(RequestStore[:current_user]).to eq user
+          response_body = JSON.parse(response.body)["data"]
+          ama_appeals = response_body
+            .select { |appeal| appeal["type"] == "appeals" }
+            .sort_by { |appeal| appeal["attributes"]["file_number"] }
 
-          after do
-            FeatureToggle.disable!(:idt_ama_appeals)
-          end
+          expect(ama_appeals.size).to eq 1
+          expect(ama_appeals.first["id"]).to eq tasks.second.appeal.uuid
+          expect(ama_appeals.first["attributes"]["docket_number"]).to eq tasks.second.appeal.docket_number
+          expect(ama_appeals.first["attributes"]["veteran_first_name"]).to eq veteran2.reload.name.first_name
+        end
+      end
 
-          it "returns a list of assigned appeals" do
-            get :list
-            expect(response.status).to eq 200
-            expect(RequestStore[:current_user]).to eq user
-            response_body = JSON.parse(response.body)["data"]
-            ama_appeals = response_body
-              .select { |appeal| appeal["type"] == "appeals" }
-              .sort_by { |appeal| appeal["attributes"]["file_number"] }
+      context "and user is a mail intake" do
+        before do
+          User.authenticate!(roles: ["Mail Intake"], css_id: "TEST_ID")
+          request.headers["TOKEN"] = token
+        end
 
-            expect(ama_appeals.size).to eq 1
-            expect(ama_appeals.first["id"]).to eq tasks.second.appeal.uuid
-            expect(ama_appeals.first["attributes"]["docket_number"]).to eq tasks.second.appeal.docket_number
-            expect(ama_appeals.first["attributes"]["veteran_first_name"]).to eq veteran2.reload.name.first_name
-          end
+        it "returns an empty list" do
+          get :list
+          expect(response.status).to eq 200
+          response_body = JSON.parse(response.body)["data"]
+          # Intake users don't have any appeals assigned to them
+          expect(response_body).to eq []
         end
       end
 
@@ -160,62 +165,52 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
         let!(:case_review1) { create(:attorney_case_review, task_id: tasks.first.id) }
         let!(:case_review2) { create(:attorney_case_review, task_id: tasks.first.id) }
 
-        context "with AMA appeals" do
-          before do
-            FeatureToggle.enable!(:idt_ama_appeals)
-          end
+        it "returns a list of assigned appeals" do
+          tasks.first.update(assigned_at: 5.days.ago)
+          tasks.second.update(assigned_at: 15.days.ago)
+          get :list
+          expect(response.status).to eq 200
+          expect(RequestStore[:current_user]).to eq user
+          response_body = JSON.parse(response.body)["data"]
+          ama_appeals = response_body
+            .select { |appeal| appeal["type"] == "appeals" }
+            .sort_by { |appeal| appeal["attributes"]["file_number"] }
 
-          after do
-            FeatureToggle.disable!(:idt_ama_appeals)
-          end
+          expect(ama_appeals.size).to eq 2
+          expect(ama_appeals.first["id"]).to eq tasks.first.appeal.uuid
+          expect(ama_appeals.first["attributes"]["docket_number"]).to eq tasks.first.appeal.docket_number
+          expect(ama_appeals.first["attributes"]["veteran_first_name"]).to eq veteran1.reload.name.first_name
+          expect(ama_appeals.first["attributes"]["days_waiting"]).to eq 5
 
-          it "returns a list of assigned appeals" do
-            tasks.first.update(assigned_at: 5.days.ago)
-            tasks.second.update(assigned_at: 15.days.ago)
-            get :list
-            expect(response.status).to eq 200
-            expect(RequestStore[:current_user]).to eq user
-            response_body = JSON.parse(response.body)["data"]
-            ama_appeals = response_body
-              .select { |appeal| appeal["type"] == "appeals" }
-              .sort_by { |appeal| appeal["attributes"]["file_number"] }
+          expect(ama_appeals.second["id"]).to eq tasks.second.appeal.uuid
+          expect(ama_appeals.second["attributes"]["docket_number"]).to eq tasks.second.appeal.docket_number
+          expect(ama_appeals.second["attributes"]["veteran_first_name"]).to eq veteran2.reload.name.first_name
+          expect(ama_appeals.second["attributes"]["days_waiting"]).to eq 15
 
-            expect(ama_appeals.size).to eq 2
-            expect(ama_appeals.first["id"]).to eq tasks.first.appeal.uuid
-            expect(ama_appeals.first["attributes"]["docket_number"]).to eq tasks.first.appeal.docket_number
-            expect(ama_appeals.first["attributes"]["veteran_first_name"]).to eq veteran1.reload.name.first_name
-            expect(ama_appeals.first["attributes"]["days_waiting"]).to eq 5
+          expect(ama_appeals.first["attributes"]["assigned_by"]).to eq tasks.first.parent.assigned_to.full_name
+          expect(ama_appeals.first["attributes"]["documents"].size).to eq 2
+          expect(ama_appeals.first["attributes"]["documents"].first["written_by"])
+            .to eq case_review1.attorney.full_name
+          expect(ama_appeals.first["attributes"]["documents"].first["document_id"])
+            .to eq case_review1.document_id
+          expect(ama_appeals.first["attributes"]["documents"].second["written_by"])
+            .to eq case_review2.attorney.full_name
+          expect(ama_appeals.first["attributes"]["documents"].second["document_id"])
+            .to eq case_review2.document_id
+        end
 
-            expect(ama_appeals.second["id"]).to eq tasks.second.appeal.uuid
-            expect(ama_appeals.second["attributes"]["docket_number"]).to eq tasks.second.appeal.docket_number
-            expect(ama_appeals.second["attributes"]["veteran_first_name"]).to eq veteran2.reload.name.first_name
-            expect(ama_appeals.second["attributes"]["days_waiting"]).to eq 15
-
-            expect(ama_appeals.first["attributes"]["assigned_by"]).to eq tasks.first.parent.assigned_to.full_name
-            expect(ama_appeals.first["attributes"]["documents"].size).to eq 2
-            expect(ama_appeals.first["attributes"]["documents"].first["written_by"])
-              .to eq case_review1.attorney.full_name
-            expect(ama_appeals.first["attributes"]["documents"].first["document_id"])
-              .to eq case_review1.document_id
-            expect(ama_appeals.first["attributes"]["documents"].second["written_by"])
-              .to eq case_review2.attorney.full_name
-            expect(ama_appeals.first["attributes"]["documents"].second["document_id"])
-              .to eq case_review2.document_id
-          end
-
-          it "returns appeals associated with a file number" do
-            headers = { "FILENUMBER" => tasks.first.appeal.veteran_file_number }
-            request.headers.merge! headers
-            get :list
-            expect(response.status).to eq 200
-            response_body = JSON.parse(response.body)["data"]
-            ama_appeals = response_body.select { |appeal| appeal["type"] == "appeals" }
-            expect(ama_appeals.size).to eq 1
-            expect(ama_appeals.first["attributes"]["docket_number"]).to eq tasks.first.appeal.docket_number
-            expect(ama_appeals.first["attributes"]["veteran_first_name"]).to eq veteran1.reload.name.first_name
-            expect(ama_appeals.first["attributes"]["assigned_by"]).to eq tasks.first.parent.assigned_to.full_name
-            expect(ama_appeals.first["attributes"]["documents"].size).to eq 2
-          end
+        it "returns appeals associated with a file number" do
+          headers = { "FILENUMBER" => tasks.first.appeal.veteran_file_number }
+          request.headers.merge! headers
+          get :list
+          expect(response.status).to eq 200
+          response_body = JSON.parse(response.body)["data"]
+          ama_appeals = response_body.select { |appeal| appeal["type"] == "appeals" }
+          expect(ama_appeals.size).to eq 1
+          expect(ama_appeals.first["attributes"]["docket_number"]).to eq tasks.first.appeal.docket_number
+          expect(ama_appeals.first["attributes"]["veteran_first_name"]).to eq veteran1.reload.name.first_name
+          expect(ama_appeals.first["attributes"]["assigned_by"]).to eq tasks.first.parent.assigned_to.full_name
+          expect(ama_appeals.first["attributes"]["documents"].size).to eq 2
         end
 
         context "and appeal id URL parameter not is passed" do


### PR DESCRIPTION
Intake users should be able to search appeals by file number through IDT. I think it is okay to give access to Intake users to all endpoints so I didn't limit the endpoint. 