### PR TITLE
provide default payee codes in bgs fakes

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -110,7 +110,8 @@ class Fakes::BGSService
         epe = EndProductEstablishment.find_or_create_by!(
           reference_id: in_active_review_reference_id,
           veteran_file_number: veteran.file_number,
-          source: hlr
+          source: hlr,
+          payee_code: EndProduct::DEFAULT_PAYEE_CODE
         )
         RequestIssue.find_or_create_by!(
           review_request: hlr,
@@ -132,7 +133,8 @@ class Fakes::BGSService
           reference_id: completed_review_reference_id,
           veteran_file_number: veteran.file_number,
           source: previous_hlr,
-          synced_status: "CLR"
+          synced_status: "CLR",
+          payee_code: EndProduct::DEFAULT_PAYEE_CODE
         )
         RequestIssue.find_or_create_by!(
           review_request: previous_hlr,
@@ -178,7 +180,8 @@ class Fakes::BGSService
         EndProductEstablishment.find_or_create_by!(
           reference_id: claim_id,
           veteran_file_number: veteran.file_number,
-          source: sc
+          source: sc,
+          payee_code: EndProduct::DEFAULT_PAYEE_CODE
         )
         Generators::EndProduct.build(
           veteran_file_number: veteran.file_number,
@@ -194,7 +197,8 @@ class Fakes::BGSService
         epe = EndProductEstablishment.find_or_create_by!(
           reference_id: claim_id,
           veteran_file_number: veteran.file_number,
-          source: hlr
+          source: hlr,
+          payee_code: EndProduct::DEFAULT_PAYEE_CODE
         )
         RequestIssue.find_or_create_by!(
           review_request: hlr,


### PR DESCRIPTION
We [added a not-null constraint to the payee code column on end product establishments](https://github.com/department-of-veterans-affairs/caseflow/pull/8935), but the fake bgs setup code still was trying to create rows without a default value. 