### PR TITLE
Remove unused line from ui_hash

### DIFF
--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -64,7 +64,6 @@ class RatingIssue
       decision_text: decision_text,
       promulgation_date: promulgation_date,
       profile_date: profile_date,
-      contention_reference_id: contention_reference_id,
       ramp_claim_id: ramp_claim_id,
       title_of_active_review: title_of_active_review,
       rba_contentions_data: rba_contentions_data,

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -7,8 +7,6 @@ class RatingIssue
   attr_accessor :reference_id, :decision_text, :profile_date, :associated_end_products,
                 :promulgation_date, :participant_id, :rba_contentions_data, :disability_code
 
-  attr_writer :contention_reference_id
-
   class << self
     def from_bgs_hash(rating, bgs_data)
       new(


### PR DESCRIPTION
This line appears to be unused anywhere in the code. If tests pass
I'm going to merge it.

connects #9001 