### PR TITLE
Skip soft-deleted RequestIssues for match on decision review edit

### DIFF
--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -188,6 +188,7 @@ class DecisionReview < ApplicationRecord
   def active_nonrating_request_issues
     @active_nonrating_request_issues ||= RequestIssue.nonrating
       .where(veteran_participant_id: veteran.participant_id)
+      .where.not(review_request_id: nil)
       .where.not(id: request_issues.map(&:id))
       .select(&:status_active?)
   end

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -186,9 +186,8 @@ class DecisionReview < ApplicationRecord
   end
 
   def active_nonrating_request_issues
-    @active_nonrating_request_issues ||= RequestIssue.nonrating
+    @active_nonrating_request_issues ||= RequestIssue.nonrating.not_deleted
       .where(veteran_participant_id: veteran.participant_id)
-      .where.not(review_request_id: nil)
       .where.not(id: request_issues.map(&:id))
       .select(&:status_active?)
   end

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -131,6 +131,10 @@ class RequestIssue < ApplicationRecord
       ).where.not(issue_category: nil)
     end
 
+    def not_deleted
+      where.not(review_request_id: nil)
+    end
+
     def unidentified
       where(
         contested_rating_issue_reference_id: nil,

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -546,8 +546,7 @@ feature "Higher Level Review Edit issues" do
         click_intake_add_issue
         click_intake_no_matching_issues
 
-        fill_in "Issue category", with: active_nonrating_request_issue.issue_category
-        find("#issue-category").send_keys :enter
+        click_dropdown(text: active_nonrating_request_issue.issue_category)
         expect(page).to have_content("Does issue 2 match any of the issues actively being reviewed?")
         expect(page).to have_content("#{active_nonrating_request_issue.issue_category}: " \
                                      "#{active_nonrating_request_issue.description}")
@@ -572,6 +571,33 @@ feature "Higher Level Review Edit issues" do
             decision_date: active_nonrating_request_issue.decision_date
           )
         ).to_not be_nil
+      end
+    end
+
+    context "nonrating request issue was added and then removed" do
+      let!(:active_nonrating_request_issue) do
+        create(
+          :request_issue,
+          :nonrating,
+          review_request: higher_level_review
+        )
+      end
+
+      before do
+        higher_level_review.create_issues!([active_nonrating_request_issue])
+        active_nonrating_request_issue.remove_from_review
+        higher_level_review.reload
+      end
+
+      it "does not appear as a potential match on edit" do
+        visit "higher_level_reviews/#{nonrating_ep_claim_id}/edit"
+        click_intake_add_issue
+        click_intake_no_matching_issues
+        click_dropdown(text: active_nonrating_request_issue.issue_category)
+
+        expect(page).to have_content("Does issue 2 match any of these issue categories?")
+        expect(page).to_not have_content("Does issue match any of the issues actively being reviewed?")
+        expect(page).to_not have_content("nonrating issue description")
       end
     end
   end

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -125,6 +125,16 @@ describe RequestIssue do
     end
   end
 
+  context ".not_deleted" do
+    subject { RequestIssue.not_deleted }
+
+    let!(:deleted_request_issue) { create(:request_issue, review_request: nil) }
+
+    it "filters by whether it is associated with a review_request" do
+      expect(subject.find_by(id: deleted_request_issue.id)).to be_nil
+    end
+  end
+
   context ".find_active_by_contested_rating_issue_reference_id" do
     let(:active_rating_request_issue) do
       rating_request_issue.tap do |ri|


### PR DESCRIPTION
connects #8799 

### Description
Exclude RequestIssues that are not associated with any review_request, as they are "soft deleted."