### PR TITLE
Fixed VLJ filtering.

### DIFF
--- a/client/app/hearingSchedule/components/ListSchedule.jsx
+++ b/client/app/hearingSchedule/components/ListSchedule.jsx
@@ -51,6 +51,15 @@ const populateFilterDropDowns = (resultSet, filterName) => {
   return _.sortBy(uniqueOptions, 'displayText');
 };
 
+const judgeNameToIdMap = (hearings) => {
+  let nameToIdMap = {};
+
+  _.forEach(hearings, (hearingDay) => nameToIdMap[formatVljName(hearingDay.judgeLastName,
+    hearingDay.judgeFirstName)] = hearingDay.judgeId);
+
+  return nameToIdMap;
+};
+
 const filterSchedule = (scheduleToFilter, filterName, value) => {
   let filteredSchedule = {};
 
@@ -203,8 +212,18 @@ class ListSchedule extends React.Component {
     this.props.toggleLocationFilterVisibility();
   };
 
+  /*
+    As props.hearingSchedule does not have judge full name we need to create a full name to judgeId mapping
+    to use when receiving the full name through the value parameter.
+   */
   setVljSelectedValue = (value) => {
-    this.props.onReceiveHearingSchedule(filterSchedule(this.props.hearingSchedule, 'judgeName', value));
+    const judges = judgeNameToIdMap(this.props.hearingSchedule);
+
+    if (value === 'null') {
+      this.props.onReceiveHearingSchedule(filterSchedule(this.props.hearingSchedule, 'judgeLastName', null));
+    } else {
+      this.props.onReceiveHearingSchedule(filterSchedule(this.props.hearingSchedule, 'judgeId', judges[value]));
+    }
     this.setState({
       filteredByList: this.state.filteredByList.concat(['VLJ'])
     });


### PR DESCRIPTION
Resolves #8928 

### Description
Fixed VLJ filtering method to account for fact that props.hearingSchedule does not contain judge full name.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to View Hearing Schedule
2. Select a VLJ to filter
3. Confirm result set is properly filtered with value selected

