### PR TITLE
Allow multiple contentions to map to 1 request issue

### DIFF
--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -65,8 +65,9 @@ class BoardGrantEffectuation < ApplicationRecord
   def matching_rating_issue
     return unless associated_rating
 
-    @matching_rating_issue ||
-      associated_rating.issues.find { |i| i.contention_reference_id == contention_reference_id }
+    @matching_rating_issue || associated_rating.issues.find do |rating_issue|
+      rating_issue.decides_contention?(contention_reference_id: contention_reference_id)
+    end
   end
 
   def update_from_matching_rating_issue!

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -3,7 +3,7 @@ class ContestableIssue
   include ActiveModel::Model
 
   attr_accessor :rating_issue_reference_id, :date, :description, :ramp_claim_id, :contesting_decision_review,
-                :decision_issue_id, :promulgation_date, :rating_issue_profile_date, :source_request_issue,
+                :decision_issue_id, :promulgation_date, :rating_issue_profile_date, :source_request_issues,
                 :rating_issue_disability_code
 
   class << self
@@ -14,7 +14,7 @@ class ContestableIssue
         date: rating_issue.profile_date.to_date,
         description: rating_issue.decision_text,
         ramp_claim_id: rating_issue.ramp_claim_id,
-        source_request_issue: rating_issue.source_request_issue,
+        source_request_issues: rating_issue.source_request_issues,
         contesting_decision_review: contesting_decision_review,
         rating_issue_disability_code: rating_issue.disability_code
       )
@@ -27,7 +27,7 @@ class ContestableIssue
         decision_issue_id: decision_issue.id,
         date: decision_issue.approx_decision_date,
         description: decision_issue.description,
-        source_request_issue: decision_issue,
+        source_request_issues: decision_issue.request_issues,
         contesting_decision_review: contesting_decision_review
       )
     end
@@ -49,9 +49,9 @@ class ContestableIssue
   end
 
   def source_review_type
-    return unless source_request_issue
+    return unless source_request_issues.first
 
-    decision_issue? ? source_request_issue.decision_review_type : source_request_issue.review_request_type
+    decision_issue? ? source_request_issues.first.decision_review_type : source_request_issues.first.review_request_type
   end
 
   private

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -42,6 +42,6 @@ class DecisionReviewIntake < Intake
   end
 
   def build_issues(request_issues_data)
-    request_issues_data.map { |data| detail.request_issues.from_intake_data(data) }
+    request_issues_data.map { |data| RequestIssue.from_intake_data(data, decision_review: detail) }
   end
 end

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -1,13 +1,11 @@
 # ephemeral class used for caching Rating Issues for client,
-# and for creating DecisionIssues when a Rating Issue has a contention_reference_id
+# and for creating DecisionIssues when a Rating Issue has contention_reference_ids
 
 class RatingIssue
   include ActiveModel::Model
 
   attr_accessor :reference_id, :decision_text, :profile_date, :associated_end_products,
                 :promulgation_date, :participant_id, :rba_contentions_data, :disability_code
-
-  attr_writer :contention_reference_id
 
   class << self
     def from_bgs_hash(rating, bgs_data)
@@ -64,7 +62,6 @@ class RatingIssue
       decision_text: decision_text,
       promulgation_date: promulgation_date,
       profile_date: profile_date,
-      contention_reference_id: contention_reference_id,
       ramp_claim_id: ramp_claim_id,
       title_of_active_review: title_of_active_review,
       rba_contentions_data: rba_contentions_data,
@@ -95,19 +92,40 @@ class RatingIssue
     associated_ramp_ep&.claim_id
   end
 
-  def contention_reference_id
-    return unless rba_contentions_data
+  def contention_reference_ids
+    return [] unless rba_contentions_data
 
-    @contention_reference_id ||= rba_contentions_data.first.dig(:cntntn_id)
+    @contention_reference_ids ||= calculate_contention_reference_ids
   end
 
-  def source_request_issue
-    return if contention_reference_id.nil?
+  def source_request_issues
+    return [] if contention_reference_ids.empty?
 
-    @source_request_issue ||= RequestIssue.unscoped.find_by(contention_reference_id: contention_reference_id)
+    @source_request_issues ||= calculate_source_request_issues
+  end
+
+  # tells whether a the rating issue was made as a decision in response to a contention
+  def decides_contention?(contention_reference_id:)
+    contention_reference_ids.any? { |reference_id| reference_id.to_i == contention_reference_id.to_i }
   end
 
   private
+
+  def calculate_source_request_issues
+    result = contention_reference_ids.map do |contention_reference_id|
+      RequestIssue.find_by(contention_reference_id: contention_reference_id)
+    end
+
+    result.reject(&:nil?)
+  end
+
+  def calculate_contention_reference_ids
+    result = rba_contentions_data.map do |contention_data|
+      contention_data.dig(:cntntn_id)
+    end
+
+    result.reject(&:nil?)
+  end
 
   def associated_ramp_ep
     @associated_ramp_ep ||= associated_end_products.find(&:ramp?)

--- a/spec/models/board_grant_effectuation_spec.rb
+++ b/spec/models/board_grant_effectuation_spec.rb
@@ -44,8 +44,8 @@ describe BoardGrantEffectuation do
         promulgation_date: 15.days.ago,
         profile_date: 20.days.ago,
         issues: [
-          { reference_id: "ref_id1", decision_text: "PTSD denied", contention_reference_id: "contention_ref_id" },
-          { reference_id: "ref_id2", decision_text: "Left leg", contention_reference_id: "contention_ref_id2" }
+          { reference_id: "ref_id1", decision_text: "PTSD denied", contention_reference_id: "1111" },
+          { reference_id: "ref_id2", decision_text: "Left leg", contention_reference_id: "2222" }
         ],
         associated_claims: associated_claims
       )
@@ -72,7 +72,7 @@ describe BoardGrantEffectuation do
       let(:associated_claims) { [{ clm_id:  "ep_ref_id", bnft_clm_tc: "ep_code" }] }
 
       context "when a matching rating issue is found" do
-        let(:contention_reference_id) { "contention_ref_id" }
+        let(:contention_reference_id) { "1111" }
 
         it "Updates the granted decision issue" do
           subject
@@ -87,7 +87,7 @@ describe BoardGrantEffectuation do
       end
 
       context "when a matching rating issue is not found" do
-        let(:contention_reference_id) { "not_found" }
+        let(:contention_reference_id) { "9999" }
 
         it "is processed but does not update granted decision issue" do
           subject

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -64,7 +64,7 @@ describe RatingIssue do
         reference_id: "NBA",
         decision_text: "This broadcast may not be reproduced",
         profile_date: profile_date,
-        contention_reference_id: nil
+        contention_reference_ids: []
       )
     end
 
@@ -82,7 +82,7 @@ describe RatingIssue do
           reference_id: "NBA",
           decision_text: "This broadcast may not be reproduced",
           profile_date: profile_date,
-          contention_reference_id: "foul"
+          contention_reference_ids: ["foul"]
         )
       end
     end
@@ -92,7 +92,10 @@ describe RatingIssue do
         {
           rba_issue_id: "NBA",
           decn_txt: "This broadcast may not be reproduced",
-          rba_issue_contentions: [{ prfil_dt: Time.zone.now, cntntn_id: "foul" }]
+          rba_issue_contentions: [
+            { prfil_dt: Time.zone.now, cntntn_id: "foul" },
+            { prfil_dt: Time.zone.now, cntntn_id: "dunk" }
+          ]
         }
       end
 
@@ -101,7 +104,7 @@ describe RatingIssue do
           reference_id: "NBA",
           decision_text: "This broadcast may not be reproduced",
           profile_date: profile_date,
-          contention_reference_id: "foul"
+          contention_reference_ids: %w[foul dunk]
         )
       end
     end


### PR DESCRIPTION
We learned today that multiple contentions can map to 1 rating issue. Updating the logic to account for that.

Also cleaned up an issue where we had to use `unscoped` do override scoping. 

connects #9001
