### PR TITLE
Add method to Task to hide from task snapshot and case timeline

### DIFF
--- a/app/models/legacy_tasks/legacy_task.rb
+++ b/app/models/legacy_tasks/legacy_task.rb
@@ -48,6 +48,14 @@ class LegacyTask
     action
   end
 
+  def hide_from_case_timeline
+    false
+  end
+
+  def hide_from_task_snapshot
+    false
+  end
+
   def serializer_class
     ::WorkQueue::LegacyTaskSerializer
   end

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -15,6 +15,8 @@ class WorkQueue::TaskSerializer < ActiveModel::Serializer
   attribute :instructions
   attribute :appeal_type
   attribute :timeline_title
+  attribute :hide_from_case_timeline
+  attribute :hide_from_task_snapshot
 
   attribute :assigned_by do
     {

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -111,6 +111,14 @@ class Task < ApplicationRecord
     [self]
   end
 
+  def hide_from_case_timeline
+    false
+  end
+
+  def hide_from_task_snapshot
+    false
+  end
+
   def reassign; end
 
   def legacy?

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -7,6 +7,10 @@ class RootTask < GenericTask
 
   def when_child_task_completed; end
 
+  def hide_from_task_snapshot
+    true
+  end
+
   def available_actions(user)
     return [Constants.TASK_ACTIONS.CREATE_MAIL_TASK.to_h] if MailTeam.singleton.user_has_access?(user) && ama?
     return [Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h] if can_create_schedule_hearings_task?(user)

--- a/client/app/queue/CaseTimeline.jsx
+++ b/client/app/queue/CaseTimeline.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import type { State } from './types/state';
-import { allCompleteTasksForAppeal } from './selectors';
+import { caseTimelineTasksForAppeal } from './selectors';
 import COPY from '../../COPY.json';
 import TaskRows from './components/TaskRows';
-import _ from 'lodash';
 
 type Params = {|
   appealId: string
@@ -13,14 +12,15 @@ type Params = {|
 class CaseTimeline extends React.PureComponent {
   render = () => {
     const {
-      appeal
+      appeal,
+      tasks
     } = this.props;
 
     return <React.Fragment>
       {COPY.CASE_TIMELINE_HEADER}
       <table>
         <tbody>
-          { <TaskRows appeal={appeal} taskList={this.props.completedTasks} timeline /> }
+          { <TaskRows appeal={appeal} taskList={tasks} timeline /> }
         </tbody>
       </table>
     </React.Fragment>;
@@ -28,13 +28,8 @@ class CaseTimeline extends React.PureComponent {
 }
 
 const mapStateToProps = (state: State, ownProps: Params) => {
-
-  let completedTasks = allCompleteTasksForAppeal(state, { appealId: ownProps.appeal.externalId });
-
-  completedTasks = _.orderBy(completedTasks, ['completedOn'], ['desc']);
-
   return {
-    completedTasks
+    tasks: caseTimelineTasksForAppeal(state, { appealId: ownProps.appeal.externalId })
   };
 };
 

--- a/client/app/queue/TaskSnapshot.jsx
+++ b/client/app/queue/TaskSnapshot.jsx
@@ -3,8 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import {
   appealWithDetailSelector,
-  nonRootActionableTasksForAppeal,
-  incompleteNonActionableTasks
+  taskSnapshotTasksForAppeal
 } from './selectors';
 import AddNewTaskButton from './components/AddNewTaskButton';
 import TaskRows from './components/TaskRows';
@@ -28,7 +27,6 @@ type Params = {|
 |};
 
 type Props = Params & {|
-  userRole: string,
   appeal: Appeal
 |};
 
@@ -36,14 +34,13 @@ export class TaskSnapshot extends React.PureComponent<Props> {
 
   render = () => {
     const {
-      appeal
+      appeal,
+      tasks
     } = this.props;
 
     let sectionBody = COPY.TASK_SNAPSHOT_NO_ACTIVE_LABEL;
-    const tasks = this.props.tasks.concat(this.props.nonActionableTasks);
-    const taskLength = tasks.length;
 
-    if (taskLength) {
+    if (tasks.length) {
       sectionBody = <table {...tableStyling}>
         <tbody>
           { <TaskRows appeal={appeal} taskList={tasks} timeline={false} /> }
@@ -64,13 +61,9 @@ export class TaskSnapshot extends React.PureComponent<Props> {
 }
 
 const mapStateToProps = (state: State, ownProps: Params) => {
-  const { userRole } = state.ui;
-
   return {
     appeal: appealWithDetailSelector(state, { appealId: ownProps.appealId }),
-    userRole,
-    tasks: nonRootActionableTasksForAppeal(state, { appealId: ownProps.appealId }),
-    nonActionableTasks: incompleteNonActionableTasks(state, { appealId: ownProps.appealId })
+    tasks: taskSnapshotTasksForAppeal(state, { appealId: ownProps.appealId })
   };
 };
 

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -214,7 +214,7 @@ export const caseTimelineTasksForAppeal = createSelector(
 export const taskSnapshotTasksForAppeal = createSelector(
   [getAllTasksForAppeal],
   (tasks: Tasks) => _.orderBy(_.filter(incompleteTasksSelector(tasks), (task) =>
-    !task.hideFromTaskSnapshot), ['createdAt'], ['asc'])
+    !task.hideFromTaskSnapshot), ['createdAt'], ['desc'])
 );
 
 export const newTasksByAssigneeCssIdSelector = createSelector(

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -205,23 +205,16 @@ export const rootTasksForAppeal = createSelector(
   [actionableTasksForAppeal], (tasks: Tasks) => _.filter(tasks, (task) => task.type === 'RootTask')
 );
 
-export const nonRootActionableTasksForAppeal = createSelector(
-  [actionableTasksForAppeal], (tasks: Tasks) => _.filter(tasks, (task) => task.type !== 'RootTask')
+export const caseTimelineTasksForAppeal = createSelector(
+  [getAllTasksForAppeal],
+  (tasks: Tasks) => _.orderBy(_.filter(completeTasksSelector(tasks), (task) =>
+    !task.hideFromCaseTimeline), ['createdAt'], ['desc'])
 );
 
-export const allCompleteTasksForAppeal = createSelector(
-  [getAllTasksForAppeal, getAppealId],
-  (tasks: Tasks, appealId: string) => {
-    return _.filter(tasks, (task) => task.externalAppealId === appealId && task.status === TASK_STATUSES.completed);
-  }
-);
-
-export const incompleteNonActionableTasks = createSelector(
-  [getAllTasksForAppeal, getAppealId],
-  (tasks: Tasks, appealId: string) => {
-    return _.orderBy(_.filter(tasks, (task) => task.externalAppealId === appealId &&
-    (task.status !== TASK_STATUSES.completed && !task.availableActions.length)), ['createdAt'], ['desc']);
-  }
+export const taskSnapshotTasksForAppeal = createSelector(
+  [getAllTasksForAppeal],
+  (tasks: Tasks) => _.orderBy(_.filter(incompleteTasksSelector(tasks), (task) =>
+    !task.hideFromTaskSnapshot), ['createdAt'], ['asc'])
 );
 
 export const newTasksByAssigneeCssIdSelector = createSelector(

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -90,6 +90,8 @@ export type Task = {
   },
   availableActions: Array<{ label?: string, value: string, data: ?Object }>,
   taskBusinessPayloads: Array<{description: string, values: Object}>,
+  hideFromCaseTimeline: boolean,
+  hideFromTaskSnapshot: boolean
 };
 
 export type Tasks = { [string]: Task };

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -90,7 +90,9 @@ export const prepareTasksForStore = (tasks: Array<Object>): Tasks =>
       availableActions: task.attributes.available_actions,
       taskBusinessPayloads: task.attributes.task_business_payloads,
       caseReviewId: task.attributes.attorney_case_review_id,
-      timelineTitle: task.attributes.timeline_title
+      timelineTitle: task.attributes.timeline_title,
+      hideFromTaskSnapshot: task.attributes.hide_from_task_snapshot,
+      hideFromCaseTimeline: task.attributes.hide_from_case_timeline
     };
 
     return acc;
@@ -161,7 +163,9 @@ export const prepareLegacyTasksForStore = (tasks: Array<Object>): Tasks => {
       decisionPreparedBy: null,
       availableActions: task.attributes.available_actions,
       taskBusinessPayloads: task.attributes.task_business_payloads,
-      timelineTitle: task.attributes.timeline_title
+      timelineTitle: task.attributes.timeline_title,
+      hideFromTaskSnapshot: task.attributes.hide_from_task_snapshot,
+      hideFromCaseTimeline: task.attributes.hide_from_case_timeline
     };
   });
 

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -79,7 +79,9 @@ describe('ColocatedTaskListView', () => {
     onHoldDuration: null,
     decisionPreparedBy: null,
     availableActions: [],
-    taskBusinessPayloads: []
+    taskBusinessPayloads: [],
+    hideFromCaseTimeline: false,
+    hideFromTaskSnapshot: false
   });
 
   const appealTemplate: BasicAppeal = {

--- a/client/test/karma/queue/QueueLoadingScreen-test.js
+++ b/client/test/karma/queue/QueueLoadingScreen-test.js
@@ -44,7 +44,9 @@ const serverData = {
           veteran_file_number: '767574947',
           veteran_name: 'Mills, Beulah, J',
           work_product: 'OTD',
-          status: 'Assigned'
+          status: 'Assigned',
+          hide_from_case_timeline: false,
+          hide_from_task_snapshot: false
         },
         id: '3625593',
         type: 'judge_legacy_tasks'
@@ -93,7 +95,9 @@ describe('QueueLoadingScreen', () => {
         previousTaskAssignedOn: '2018-08-02T17:37:03.000Z',
         status: 'Assigned',
         decisionPreparedBy: null,
-        type: 'LegacyJudgeTask'
+        type: 'LegacyJudgeTask',
+        hideFromCaseTimeline: false,
+        hideFromTaskSnapshot: false
       }
     });
   });

--- a/spec/models/legacy_tasks/attorney_legacy_task_spec.rb
+++ b/spec/models/legacy_tasks/attorney_legacy_task_spec.rb
@@ -33,4 +33,54 @@ describe AttorneyLegacyTask do
       end
     end
   end
+
+  context "#hide_from_case_timeline" do
+    subject do
+      AttorneyLegacyTask.from_vacols(
+        case_assignment,
+        LegacyAppeal.create(vacols_id: "1111"),
+        User.new(css_id: "USER_ID")
+      )
+    end
+
+    let(:case_assignment) do
+      vacols_id = "1111"
+      OpenStruct.new(
+        vacols_id: vacols_id,
+        date_due: 1.day.ago,
+        assigned_to_location_date: 5.days.ago,
+        created_at: 6.days.ago,
+        docket_date: nil
+      )
+    end
+
+    it "should alwayse be false" do
+      expect(subject.hide_from_case_timeline).to eq(false)
+    end
+  end
+
+  context "#hide_from_task_snapshot" do
+    subject do
+      AttorneyLegacyTask.from_vacols(
+        case_assignment,
+        LegacyAppeal.create(vacols_id: "1111"),
+        User.new(css_id: "USER_ID")
+      )
+    end
+
+    let(:case_assignment) do
+      vacols_id = "1111"
+      OpenStruct.new(
+        vacols_id: vacols_id,
+        date_due: 1.day.ago,
+        assigned_to_location_date: 5.days.ago,
+        created_at: 6.days.ago,
+        docket_date: nil
+      )
+    end
+
+    it "should alwayse be false" do
+      expect(subject.hide_from_task_snapshot).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Refactor preparing for #7905 by adding two functions that will be set to `true` for soon-to-be-added `TrackVeteranTask`.

Instead of relying on the string value of type of the task (like we were with `RootTask`s previously), we will instead set this value to be true or false (default to false). This will allow us to control when a task is shown on the backend when we have full access to the database and the relationships between tasks (will re-enable [hiding of duplicate tasks](https://github.com/department-of-veterans-affairs/caseflow/issues/8937), for instance).