### PR TITLE
Always use the contention disposition for decision issue sync

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190128185846) do
+ActiveRecord::Schema.define(version: 20190129002938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -251,7 +251,7 @@ ActiveRecord::Schema.define(version: 20190128185846) do
     t.datetime "profile_date"
     t.datetime "promulgation_date"
     t.string "rating_issue_reference_id"
-    t.index ["rating_issue_reference_id", "participant_id"], name: "decision_issues_uniq_idx", unique: true
+    t.index ["rating_issue_reference_id", "disposition", "participant_id"], name: "decision_issues_uniq_by_disposition_and_ref_id", unique: true
   end
 
   create_table "dispatch_tasks", id: :serial, force: :cascade do |t|

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -927,16 +927,35 @@ describe RequestIssue do
                code: ep_code)
       end
 
+      let!(:contention) do
+        Generators::Contention.build(
+          id: contention_reference_id,
+          claim_id: end_product_establishment.reference_id,
+          disposition: "allowed"
+        )
+      end
+
       context "with rating ep" do
         context "when associated rating exists" do
           let(:associated_claims) { [{ clm_id: end_product_establishment.reference_id, bnft_clm_tc: ep_code }] }
 
           context "when matching rating issues exist" do
+            let!(:decision_issue_not_matching_disposition) do
+              create(
+                :decision_issue,
+                decision_review: review,
+                participant_id: veteran.participant_id,
+                disposition: "denied",
+                rating_issue_reference_id: contested_rating_issue_reference_id
+              )
+            end
+
             it "creates decision issues based on rating issues" do
               subject
               expect(rating_request_issue.decision_issues.count).to eq(1)
               expect(rating_request_issue.decision_issues.first).to have_attributes(
                 rating_issue_reference_id: contested_rating_issue_reference_id,
+                disposition: "allowed",
                 participant_id: veteran.participant_id,
                 promulgation_date: ratings.promulgation_date,
                 decision_text: "Left knee granted",
@@ -958,19 +977,30 @@ describe RequestIssue do
                 expect { subject }.to raise_error(RequestIssue::NilEndProductLastActionDate)
               end
             end
+
+            context "when decision issue with disposition and rating issue already exists" do
+              let!(:preexisting_decision_issue) do
+                create(
+                  :decision_issue,
+                  decision_review: review,
+                  participant_id: veteran.participant_id,
+                  disposition: "allowed",
+                  rating_issue_reference_id: contested_rating_issue_reference_id
+                )
+              end
+
+              it "links preexisting decision issue to request issue" do
+                subject
+                expect(rating_request_issue.decision_issues.count).to eq(1)
+                expect(rating_request_issue.decision_issues.first).to eq(preexisting_decision_issue)
+                expect(rating_request_issue.processed?).to eq(true)
+              end
+            end
           end
 
           context "when no matching rating issues exist" do
             let(:issues) do
               [{ reference_id: "xyz456", decision_text: "PTSD denied", contention_reference_id: "bad_id" }]
-            end
-
-            let!(:contention) do
-              Generators::Contention.build(
-                id: contention_reference_id,
-                claim_id: end_product_establishment.reference_id,
-                disposition: "allowed"
-              )
             end
 
             it "creates decision issues based on contention disposition" do

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -548,7 +548,16 @@ describe RequestIssue do
     end
 
     context "when contesting the same decision review" do
+      let(:previous_contention) do
+        Generators::Contention.build(
+          id: contention_reference_id,
+          claim_id: previous_end_product_establishment.reference_id,
+          disposition: "allowed"
+        )
+      end
+
       let(:contested_decision_issue_id) do
+        previous_contention
         previous_request_issue.sync_decision_issues!
         previous_request_issue.decision_issues.first.id
       end


### PR DESCRIPTION
After a discussion with Nate, we decided we should ALWAYS use the contention disposition as the disposition of the decision issue. We also need to support many contentions being connected to one rating issue. This PR does that, and explains why in a comment.

connects #9001