### PR TITLE
8956 update contested issue copy

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -9,6 +9,7 @@
   "CASE_SEARCH_ERROR_UNKNOWN_ERROR_MESSAGE": "Please retry your search and contact support if errors persist.",
   "CASE_SEARCH_DATA_LOAD_IN_PROGRESS_MESSAGE": "Loading cases...",
   "CASE_SEARCH_DATA_LOAD_FAILED_MESSAGE": "Unable to load cases",
+  "CONTESTED_ISSUE": "Contested Issue",
 
   "CASE_LIST_TABLE_TITLE": "Appeals",
   "CASE_LIST_TABLE_VETERAN_NAME_COLUMN_TITLE": "Case Details",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -9,7 +9,7 @@
   "CASE_SEARCH_ERROR_UNKNOWN_ERROR_MESSAGE": "Please retry your search and contact support if errors persist.",
   "CASE_SEARCH_DATA_LOAD_IN_PROGRESS_MESSAGE": "Loading cases...",
   "CASE_SEARCH_DATA_LOAD_FAILED_MESSAGE": "Unable to load cases",
-  "CONTESTED_ISSUE": "Contested Issue",
+  "CONTESTED_ISSUE": "Issue",
 
   "CASE_LIST_TABLE_TITLE": "Appeals",
   "CASE_LIST_TABLE_VETERAN_NAME_COLUMN_TITLE": "Case Details",

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -287,7 +287,7 @@ class SelectDispositionsView extends React.PureComponent {
       >
 
         <div {...contestedIssueStyling}>
-          Contested Issue
+          {COPY.CONTESTED_ISSUE}
           <ul>
             {
               connectedRequestIssues.map((issue) => <li key={issue.id}>{issue.description}</li>)


### PR DESCRIPTION
### Description
Resolves #8956 

### Acceptance Criteria
- [ ] Issue instead of Contested Issue in delete/edit modals for AMA decision issues

### Testing Plan
see this PR for steps to test:
https://github.com/department-of-veterans-affairs/caseflow/pull/8823

once the modal appears in add/edit decision you should see 'Issue' instead of 'Contested Issue' in the header like so:


<img width="804" alt="screen shot 2019-01-29 at 9 52 07 am" src="https://user-images.githubusercontent.com/46791771/51916596-a66c3580-23ab-11e9-8dc6-0351c65a5a86.png">

