### PR TITLE
Allow tags to contain commas

### DIFF
--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -87,6 +87,18 @@ class SearchableDropdown extends React.Component<Props, ComponentState> {
     }
   }
 
+  // Override the default keys to create a new tag (allows creating options that contain a comma)
+  shouldKeyDownEventCreateNewOption = ({ keyCode }) => {
+    switch (keyCode) {
+    // Tab and Enter only
+    case 9:
+    case 13:
+      return true;
+    default:
+      return false;
+    }
+  };
+
   render() {
     const {
       options,
@@ -184,6 +196,7 @@ class SearchableDropdown extends React.Component<Props, ComponentState> {
           disabled={readOnly}
           multi={multi}
           onBlurResetsInput={false}
+          shouldKeyDownEventCreateNewOption={this.shouldKeyDownEventCreateNewOption}
           {...addCreatableOptions}
         />
       </div>

--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -88,7 +88,7 @@ class SearchableDropdown extends React.Component<Props, ComponentState> {
   }
 
   // Override the default keys to create a new tag (allows creating options that contain a comma)
-  shouldKeyDownEventCreateNewOption = ({ keyCode }) => {
+  shouldKeyDownEventCreateNewOption = ({ keyCode }: { keyCode: number }) => {
     switch (keyCode) {
     // Tab and Enter only
     case 9:


### PR DESCRIPTION
Resolves #7873

### Description
Modified the keys that can be pressed to complete a tag and start a new one.

### Acceptance Criteria
- [X] Tags in reader can contain commas

### Testing Plan
1. Go to a document in Reader
2. Begin entering a tag that contains a comma (must be typed, not copied/pasted to test correctly)
3. Notice entering a comma does not create a new tag

