### PR TITLE
Set default sort order for collections of ActiveRecord objects

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,4 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
+  default_scope { order(id: :asc) }
+
   self.abstract_class = true
 end
 


### PR DESCRIPTION
Neither [Rails](https://guides.rubyonrails.org/active_record_querying.html#ordering) nor [Postgres](https://www.postgresql.org/docs/current/queries-order.html) guarantees the order of results returned from the database unless an order clause is specified. We have been bitten by active record objects returning from the database in an indeterminate order (most recently [when selecting which task to display](https://github.com/department-of-veterans-affairs/caseflow/issues/9026#issuecomment-458611638) on the case details page). This PR solves that ordering problem by setting a default sort order for active record objects returned from the database.

_Note: We may need to change the 30 existing order methods into reorder calls_
`git grep -E "\.order\b" app | wc -l`