### PR TITLE
#3972 show error message for diagnostic code

### DIFF
--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -337,6 +337,7 @@ class SelectDispositionsView extends React.PureComponent {
         />
         <h3>{COPY.DECISION_ISSUE_MODAL_DIAGNOSTIC_CODE}</h3>
         <SearchableDropdown
+          errorMessage={highlightModal && !decisionIssue.diagnostic_code ? 'This field is required' : null}
           name="Diagnostic code"
           placeholder={COPY.DECISION_ISSUE_MODAL_DIAGNOSTIC_CODE}
           hideLabel
@@ -346,7 +347,7 @@ class SelectDispositionsView extends React.PureComponent {
           onChange={(diagnosticCode) => this.setState({
             decisionIssue: {
               ...decisionIssue,
-              diagnostic_code: diagnosticCode.value
+              diagnostic_code: diagnosticCode ? diagnosticCode.value : ''
             }
           })}
         />


### PR DESCRIPTION
Resolves #3972 
Closes #9042

### Description
see this production bug: https://github.com/department-of-veterans-affairs/appeals-support/issues/3972

diagnostic code should show error message when blank on add/edit decisions page

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

