### PR TITLE
Create TrackVeteranTask when creating RootTasks for appeals represented by VSOs

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -15,6 +15,7 @@ class WorkQueue::TaskSerializer < ActiveModel::Serializer
   attribute :instructions
   attribute :appeal_type
   attribute :timeline_title
+  attribute :hide_from_queue_table_view
   attribute :hide_from_case_timeline
   attribute :hide_from_task_snapshot
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -118,6 +118,10 @@ class Task < ApplicationRecord
     [self]
   end
 
+  def hide_from_queue_table_view
+    false
+  end
+
   def hide_from_case_timeline
     false
   end

--- a/app/models/tasks/evidence_submission_window_task.rb
+++ b/app/models/tasks/evidence_submission_window_task.rb
@@ -7,7 +7,7 @@ class EvidenceSubmissionWindowTask < GenericTask
   end
 
   def create_vso_subtask
-    RootTask.create_vso_subtask!(appeal, parent)
+    RootTask.create_ihp_tasks!(appeal, parent)
   end
 
   def self.timer_delay

--- a/app/models/tasks/evidence_submission_window_task.rb
+++ b/app/models/tasks/evidence_submission_window_task.rb
@@ -1,12 +1,12 @@
 class EvidenceSubmissionWindowTask < GenericTask
   include TimeableTask
-  after_update :create_vso_subtask, if: :status_changed_to_completed_and_has_parent?
+  after_update :create_ihp_task, if: :status_changed_to_completed_and_has_parent?
 
   def when_timer_ends
     update!(status: :completed)
   end
 
-  def create_vso_subtask
+  def create_ihp_task
     RootTask.create_ihp_tasks!(appeal, parent)
   end
 

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -31,7 +31,7 @@ class RootTask < GenericTask
   class << self
     def create_root_and_sub_tasks!(appeal)
       root_task = create!(appeal: appeal)
-      maybe_create_vso_tracking_tasks(appeal, root_task)
+      create_vso_tracking_tasks(appeal, root_task)
       if FeatureToggle.enabled?(:ama_auto_case_distribution)
         create_subtasks!(appeal, root_task)
       else
@@ -51,7 +51,7 @@ class RootTask < GenericTask
 
     private
 
-    def maybe_create_vso_tracking_tasks(appeal, parent)
+    def create_vso_tracking_tasks(appeal, parent)
       appeal.vsos.map do |vso_organization|
         TrackVeteranTask.create!(
           appeal: appeal,

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -3,6 +3,10 @@ class TrackVeteranTask < GenericTask
     []
   end
 
+  def hide_from_queue_table_view
+    true
+  end
+
   def hide_from_case_timeline
     true
   end

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -1,0 +1,13 @@
+class TrackVeteranTask < GenericTask
+  def available_actions(_user)
+    []
+  end
+
+  def hide_from_case_timeline
+    true
+  end
+
+  def hide_from_task_snapshot
+    true
+  end
+end

--- a/client/app/queue/CaseTimeline.jsx
+++ b/client/app/queue/CaseTimeline.jsx
@@ -18,7 +18,7 @@ class CaseTimeline extends React.PureComponent {
 
     return <React.Fragment>
       {COPY.CASE_TIMELINE_HEADER}
-      <table>
+      <table id="case-timeline-table">
         <tbody>
           { <TaskRows appeal={appeal} taskList={tasks} timeline /> }
         </tbody>

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -61,7 +61,7 @@ export const taskIsNotOnHoldSelector = (tasks: Tasks) =>
   _.filter(tasks, (task) => !taskIsOnHold(task));
 
 export const workTasksSelector = (tasks: Tasks | Array<Task> | Array<TaskWithAppeal>) =>
-  _.filter(tasks, (task) => task.type === 'TrackVeteranTask');
+  _.filter(tasks, (task) => task.type !== 'TrackVeteranTask');
 
 export const getActiveModalType = createSelector(
   [getModals],

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -60,6 +60,9 @@ export const completeTasksSelector = (tasks: Tasks) =>
 export const taskIsNotOnHoldSelector = (tasks: Tasks) =>
   _.filter(tasks, (task) => !taskIsOnHold(task));
 
+export const workTasksSelector = (tasks: Tasks | Array<Task> | Array<TaskWithAppeal>) =>
+  _.filter(tasks, (task) => task.type === 'TrackVeteranTask');
+
 export const getActiveModalType = createSelector(
   [getModals],
   (modals: { String: boolean }) => _.find(Object.keys(modals), (modalName) => modals[modalName])
@@ -85,6 +88,11 @@ export const tasksWithAppealSelector = createSelector(
       }))
     ];
   }
+);
+
+// To differentiate between tracking tasks which exist purely to provide visibility into appeals.
+export const workTasksWithAppealSelector = createSelector(
+  [tasksWithAppealSelector], (tasks: Array<TaskWithAppeal>) => workTasksSelector(tasks)
 );
 
 export const tasksByOrganization = createSelector(
@@ -133,19 +141,19 @@ export const getAllTasksForAppeal = createSelector(
 );
 
 export const getUnassignedOrganizationalTasks = createSelector(
-  [tasksWithAppealSelector],
+  [workTasksWithAppealSelector],
   (tasks: Tasks) => _.filter(tasks, (task) => {
     return (task.status === TASK_STATUSES.assigned || task.status === TASK_STATUSES.in_progress);
   })
 );
 
 export const getAssignedOrganizationalTasks = createSelector(
-  [tasksWithAppealSelector],
+  [workTasksWithAppealSelector],
   (tasks: Tasks) => _.filter(tasks, (task) => (task.status === TASK_STATUSES.on_hold))
 );
 
 export const getCompletedOrganizationalTasks = createSelector(
-  [tasksWithAppealSelector],
+  [workTasksWithAppealSelector],
   (tasks: Tasks) => _.filter(tasks, (task) => task.status === TASK_STATUSES.completed)
 );
 
@@ -176,6 +184,10 @@ export const tasksByAssigneeCssIdSelector = createSelector(
     _.filter(tasks, (task) => task.assignedTo.cssId === cssId)
 );
 
+export const workTasksByAssigneeCssIdSelector = createSelector(
+  [tasksByAssigneeCssIdSelector], (tasks: Tasks) => workTasksSelector(tasks)
+);
+
 export const tasksByAssignerCssIdSelector = createSelector(
   [tasksWithAppealSelector, getUserCssId],
   (tasks: Array<TaskWithAppeal>, cssId: string) =>
@@ -183,17 +195,17 @@ export const tasksByAssignerCssIdSelector = createSelector(
 );
 
 export const incompleteTasksByAssigneeCssIdSelector = createSelector(
-  [tasksByAssigneeCssIdSelector],
+  [workTasksByAssigneeCssIdSelector],
   (tasks: Tasks) => incompleteTasksSelector(tasks)
 );
 
-export const incompleteTasksByAssignerCssIdSelector = createSelector(
+export const incompleteWorkTasksByAssignerCssIdSelector = createSelector(
   [tasksByAssignerCssIdSelector],
-  (tasks: Tasks) => incompleteTasksSelector(tasks)
+  (tasks: Tasks) => incompleteTasksSelector(workTasksSelector(tasks))
 );
 
 export const completeTasksByAssigneeCssIdSelector = createSelector(
-  [tasksByAssigneeCssIdSelector],
+  [workTasksByAssigneeCssIdSelector],
   (tasks: Tasks) => completeTasksSelector(tasks)
 );
 
@@ -223,7 +235,7 @@ export const newTasksByAssigneeCssIdSelector = createSelector(
 );
 
 export const workableTasksByAssigneeCssIdSelector = createSelector(
-  [tasksByAssigneeCssIdSelector],
+  [workTasksByAssigneeCssIdSelector],
   (tasks: Array<TaskWithAppeal>) => tasks.filter(
     (task) => {
       return (task.appeal.isLegacyAppeal ||
@@ -253,7 +265,7 @@ export const onHoldTasksByAssigneeCssIdSelector: (State) => Array<Task> = create
 );
 
 export const onHoldTasksForAttorney: (State) => Array<Task> = createSelector(
-  [incompleteTasksWithHold, incompleteTasksByAssignerCssIdSelector],
+  [incompleteTasksWithHold, incompleteWorkTasksByAssignerCssIdSelector],
   (incompleteWithHold: Array<Task>, incompleteByAssigner: Array<Task>) => {
     const onHoldTasksWithDuplicates = incompleteWithHold.concat(incompleteByAssigner);
 
@@ -262,7 +274,7 @@ export const onHoldTasksForAttorney: (State) => Array<Task> = createSelector(
 );
 
 export const judgeDecisionReviewTasksSelector = createSelector(
-  [tasksByAssigneeCssIdSelector],
+  [workTasksByAssigneeCssIdSelector],
   (tasks) => _.filter(tasks, (task: TaskWithAppeal) => {
     if (task.appealType === 'Appeal') {
       return (['review', 'quality review'].includes(task.label)) &&
@@ -275,7 +287,7 @@ export const judgeDecisionReviewTasksSelector = createSelector(
 );
 
 export const judgeAssignTasksSelector = createSelector(
-  [tasksByAssigneeCssIdSelector],
+  [workTasksByAssigneeCssIdSelector],
   (tasks) => _.filter(tasks, (task: TaskWithAppeal) => {
     if (task.appealType === 'Appeal') {
       return task.label === 'assign' &&

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -61,7 +61,7 @@ export const taskIsNotOnHoldSelector = (tasks: Tasks) =>
   _.filter(tasks, (task) => !taskIsOnHold(task));
 
 export const workTasksSelector = (tasks: Tasks | Array<Task> | Array<TaskWithAppeal>) =>
-  _.filter(tasks, (task) => task.type !== 'TrackVeteranTask');
+  _.filter(tasks, (task) => !task.hideFromQueueTableView);
 
 export const getActiveModalType = createSelector(
   [getModals],

--- a/client/app/queue/types/models.js
+++ b/client/app/queue/types/models.js
@@ -90,6 +90,7 @@ export type Task = {
   },
   availableActions: Array<{ label?: string, value: string, data: ?Object }>,
   taskBusinessPayloads: Array<{description: string, values: Object}>,
+  hideFromQueueTableView: boolean,
   hideFromCaseTimeline: boolean,
   hideFromTaskSnapshot: boolean
 };

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -91,6 +91,7 @@ export const prepareTasksForStore = (tasks: Array<Object>): Tasks =>
       taskBusinessPayloads: task.attributes.task_business_payloads,
       caseReviewId: task.attributes.attorney_case_review_id,
       timelineTitle: task.attributes.timeline_title,
+      hideFromQueueTableView: task.attributes.hide_from_queue_table_view,
       hideFromTaskSnapshot: task.attributes.hide_from_task_snapshot,
       hideFromCaseTimeline: task.attributes.hide_from_case_timeline
     };
@@ -164,6 +165,7 @@ export const prepareLegacyTasksForStore = (tasks: Array<Object>): Tasks => {
       availableActions: task.attributes.available_actions,
       taskBusinessPayloads: task.attributes.task_business_payloads,
       timelineTitle: task.attributes.timeline_title,
+      hideFromQueueTableView: task.attributes.hide_from_queue_table_view,
       hideFromTaskSnapshot: task.attributes.hide_from_task_snapshot,
       hideFromCaseTimeline: task.attributes.hide_from_case_timeline
     };

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -80,6 +80,7 @@ describe('ColocatedTaskListView', () => {
     decisionPreparedBy: null,
     availableActions: [],
     taskBusinessPayloads: [],
+    hideFromQueueTableView: false,
     hideFromCaseTimeline: false,
     hideFromTaskSnapshot: false
   });

--- a/client/test/karma/queue/QueueLoadingScreen-test.js
+++ b/client/test/karma/queue/QueueLoadingScreen-test.js
@@ -45,6 +45,7 @@ const serverData = {
           veteran_name: 'Mills, Beulah, J',
           work_product: 'OTD',
           status: 'Assigned',
+          hide_from_queue_table_view: false,
           hide_from_case_timeline: false,
           hide_from_task_snapshot: false
         },
@@ -96,6 +97,7 @@ describe('QueueLoadingScreen', () => {
         status: 'Assigned',
         decisionPreparedBy: null,
         type: 'LegacyJudgeTask',
+        hideFromQueueTableView: false,
         hideFromCaseTimeline: false,
         hideFromTaskSnapshot: false
       }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -90,7 +90,6 @@ class SeedDB
     OrganizationsUser.add_user_to_organization(user, Colocated.singleton)
   end
 
-  # TODO: Add VSO tracking tasks here.
   def create_vso_users_and_tasks
     vso = Vso.create(
       name: "VSO",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -90,6 +90,7 @@ class SeedDB
     OrganizationsUser.add_user_to_organization(user, Colocated.singleton)
   end
 
+  # TODO: Add VSO tracking tasks here.
   def create_vso_users_and_tasks
     vso = Vso.create(
       name: "VSO",

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -89,6 +89,11 @@ FactoryBot.define do
       appeal { create(:appeal) }
     end
 
+    factory :track_veteran_task, class: TrackVeteranTask do
+      type TrackVeteranTask.name
+      appeal { create(:appeal) }
+    end
+
     factory :ama_attorney_task do
       type AttorneyTask.name
       appeal { create(:appeal) }

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -701,4 +701,39 @@ RSpec.feature "Case details" do
       end
     end
   end
+
+  describe "case timeline" do
+    context "when the only completed task is a TrackVeteranTask" do
+      let(:root_task) { FactoryBot.create(:root_task) }
+      let(:appeal) { root_task.appeal }
+      let!(:tracking_task) do
+        FactoryBot.create(
+          :track_veteran_task,
+          appeal: appeal,
+          parent: root_task,
+          status: Constants.TASK_STATUSES.completed
+        )
+      end
+
+      it "should not show the tracking task in case timeline" do
+        visit("/queue/appeals/#{tracking_task.appeal.uuid}")
+
+        # Expect to only find the "NOD received" row and the "dispatch pending" rows.
+        expect(page).to have_css("table#case-timeline-table tbody tr", count: 2)
+      end
+    end
+  end
+
+  describe "task snapshot" do
+    context "when the only task is a TrackVeteranTask" do
+      let(:root_task) { FactoryBot.create(:root_task) }
+      let(:appeal) { root_task.appeal }
+      let(:tracking_task) { FactoryBot.create(:track_veteran_task, appeal: appeal, parent: root_task) }
+
+      it "should not show the tracking task in task snapshot" do
+        visit("/queue/appeals/#{tracking_task.appeal.uuid}")
+        expect(page).to have_content(COPY::TASK_SNAPSHOT_NO_ACTIVE_LABEL)
+      end
+    end
+  end
 end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -136,6 +136,42 @@ RSpec.feature "Task queue" do
     end
   end
 
+  context "VSO team queue" do
+    let(:vso_employee) { FactoryBot.create(:user, roles: ["VSO"]) }
+    let(:vso) { FactoryBot.create(:vso) }
+
+    let(:unassigned_count) { 3 }
+    let(:assigned_count) { 7 }
+    let(:tracking_task_count) { 14 }
+
+    before do
+      FactoryBot.create_list(:informal_hearing_presentation_task, unassigned_count, :in_progress, assigned_to: vso)
+      FactoryBot.create_list(:informal_hearing_presentation_task, assigned_count, :on_hold, assigned_to: vso)
+      FactoryBot.create_list(:track_veteran_task, tracking_task_count, assigned_to: vso)
+
+      allow_any_instance_of(Vso).to receive(:user_has_access?).and_return(true)
+      User.authenticate!(user: vso_employee)
+      visit(vso.path)
+    end
+
+    it "shows the right number of cases in each tab" do
+      step("Unassigned tab") do
+        expect(page).to have_content(
+          format(COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, vso.name)
+        )
+        expect(find("tbody").find_all("tr").length).to eq(unassigned_count)
+      end
+
+      step("Assigned tab") do
+        find("button", text: format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, assigned_count)).click
+        expect(page).to have_content(
+          format(COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, vso.name)
+        )
+        expect(find("tbody").find_all("tr").length).to eq(assigned_count)
+      end
+    end
+  end
+
   describe "Creating a mail task" do
     let(:mail_user) { FactoryBot.create(:user) }
     let(:mail_team) { MailTeam.singleton }

--- a/spec/models/tasks/track_veteran_task_spec.rb
+++ b/spec/models/tasks/track_veteran_task_spec.rb
@@ -1,0 +1,30 @@
+describe TrackVeteranTask do
+  let(:vso) { FactoryBot.create(:vso) }
+  let(:root_task) { FactoryBot.create(:root_task) }
+  let(:tracking_task) do
+    FactoryBot.create(
+      :track_veteran_task,
+      parent: root_task,
+      appeal: root_task.appeal,
+      assigned_to: vso
+    )
+  end
+
+  describe ".available_actions" do
+    it "should never have available_actions" do
+      expect(tracking_task.available_actions(vso)).to eq([])
+    end
+  end
+
+  describe ".hide_from_case_timeline" do
+    it "should always be hidden from case timeline" do
+      expect(tracking_task.hide_from_case_timeline).to eq(true)
+    end
+  end
+
+  describe ".hide_from_task_snapshot" do
+    it "should always be hidden from task snapshot" do
+      expect(tracking_task.hide_from_case_timeline).to eq(true)
+    end
+  end
+end

--- a/spec/models/tasks/track_veteran_task_spec.rb
+++ b/spec/models/tasks/track_veteran_task_spec.rb
@@ -16,6 +16,12 @@ describe TrackVeteranTask do
     end
   end
 
+  describe ".hide_from_queue_table_view" do
+    it "should always be hidden from queue table view" do
+      expect(tracking_task.hide_from_queue_table_view).to eq(true)
+    end
+  end
+
   describe ".hide_from_case_timeline" do
     it "should always be hidden from case timeline" do
       expect(tracking_task.hide_from_case_timeline).to eq(true)


### PR DESCRIPTION
Connects #7905.

This PR creates a `TrackVeteranTask` for each VSO listed as a representative for an appeal but does not yet show that task anywhere on the front-end.