### PR TITLE
Don't update AttorneyCaseReview if not found

### DIFF
--- a/app/workflows/update_legacy_attorney_case_review.rb
+++ b/app/workflows/update_legacy_attorney_case_review.rb
@@ -28,6 +28,8 @@ class UpdateLegacyAttorneyCaseReview
   attr_reader :id, :document_id, :user
 
   def update_attorney_case_review
+    return unless attorney_case_review
+
     attorney_case_review.update!(document_id: document_id)
   end
 
@@ -79,7 +81,7 @@ class UpdateLegacyAttorneyCaseReview
   end
 
   def correct_format?
-    if decision_work_product?
+    if draft_decision_work_product?
       return document_id.match?(new_decision_regex) || document_id.match?(old_decision_regex)
     end
 
@@ -88,8 +90,8 @@ class UpdateLegacyAttorneyCaseReview
     document_id.match?(ime_regex) if ime_work_product?
   end
 
-  def decision_work_product?
-    %w[DEC OTD].include?(work_product)
+  def draft_decision_work_product?
+    Constants::DECASS_WORK_PRODUCT_TYPES["DRAFT_DECISION"].include?(work_product)
   end
 
   def vha_work_product?


### PR DESCRIPTION
**Why**: We came across a bug where someone attempted to update the
document ID for a case that only existed in VACOLS and had not gone
through the Caseflow checkout yet. This meant that a corresponding entry
in the AttorneyCaseReview table didn't exist. Previously, we assumed
there would always be a corresponding entry. When one did not exist,
the code tried to call `update!` on `nil`.

**How**
- If a corresponding entry in AttorneyCaseReview is not found, don't
attempt to update or create a new entry.
- Update the list of work product codes that correspond to draft
decisions by using the DECASS_WORK_PRODUCT_TYPES constant.

Fixes this Sentry issue:
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3521/