### PR TITLE
Hearing prep checkbox wasn't working

### DIFF
--- a/client/app/hearings/actions/Dockets.js
+++ b/client/app/hearings/actions/Dockets.js
@@ -281,7 +281,7 @@ export const getDailyDocket = (dailyDocket, date) => (dispatch) => {
   }
 };
 
-export const setPrepped = (hearingId, prepped, date) => (dispatch) => {
+export const setPrepped = (hearingId, hearingExternalId, prepped, date) => (dispatch) => {
   const payload = {
     hearingId,
     prepped,
@@ -292,7 +292,7 @@ export const setPrepped = (hearingId, prepped, date) => (dispatch) => {
   dispatch(setHearingPrepped(payload,
     CATEGORIES.HEARING_WORKSHEET_PAGE));
 
-  ApiUtil.patch(`/hearings/${hearingId}`, { data: { prepped } }).
+  ApiUtil.patch(`/hearings/${hearingExternalId}`, { data: { prepped } }).
     then(() => {
       // request was successful
     },

--- a/client/app/hearings/components/WorksheetHeaderVeteranSelection.jsx
+++ b/client/app/hearings/components/WorksheetHeaderVeteranSelection.jsx
@@ -75,9 +75,11 @@ class WorksheetHeaderVeteranSelection extends React.PureComponent {
       }))
   );
 
-  savePrepped = (hearingId, value) => this.props.setPrepped(hearingId, value, this.date);
+  savePrepped = (hearingId, hearingExternalId, value) => {
+    this.props.setPrepped(hearingId, hearingExternalId, value, this.date);
+  };
 
-  preppedOnChange = (value) => this.savePrepped(this.props.worksheet.id, value);
+  preppedOnChange = (value) => this.savePrepped(this.props.worksheet.id, this.props.worksheet.external_id, value);
 
   onClickReviewClaimsFolder = () =>
     window.analyticsEvent(CATEGORIES.HEARING_WORKSHEET_PAGE, ACTIONS.CLICK_ON_REVIEW_CLAIMS_FOLDER);


### PR DESCRIPTION
### Description
This fixes the 'prepped' checkbox on the hearing worksheet. Previously we were sending the request to the wrong hearing id's endpoint. 
