### PR TITLE
Remove brew install postgres from instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ Install the base dependencies via Homebrew:
     brew install rbenv nodenv yarn
     brew tap ouchxp/nodenv
     brew install nodenv-nvmrc
-    brew install postgresql
     brew tap caskroom/cask
     brew cask install chromedriver
 


### PR DESCRIPTION
This is redundant with our docker setup.