### PR TITLE
Add 'All cases' tab for VSOs

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -127,7 +127,7 @@
   "ORGANIZATIONAL_QUEUE_EMPTY_STATE_MESSAGE": "This queue is empty. You can ",
 
   "ALL_CASES_QUEUE_TABLE_TAB_TITLE": "All cases",
-  "ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION": "All AMA cases where the appellant is represented by %s",
+  "ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION": "All AMA cases where the appellant is represented by %s that have been active at the Board of Veterans' Appeals any time in the past 2 weeks",
 
   "JUDGE_CASE_REVIEW_TABLE_TITLE": "Review %s Cases",
   "JUDGE_ASSIGN_DROPDOWN_LINK_LABEL": "Assign Cases",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -126,6 +126,9 @@
   "ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to a member of the %s team.",
   "ORGANIZATIONAL_QUEUE_EMPTY_STATE_MESSAGE": "This queue is empty. You can ",
 
+  "ALL_CASES_QUEUE_TABLE_TAB_TITLE": "All cases",
+  "ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION": "All AMA cases where the appellant is represented by %s",
+
   "JUDGE_CASE_REVIEW_TABLE_TITLE": "Review %s Cases",
   "JUDGE_ASSIGN_DROPDOWN_LINK_LABEL": "Assign Cases",
   "JUDGE_REVIEW_DROPDOWN_LINK_LABEL": "Review Cases",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -127,7 +127,7 @@
   "ORGANIZATIONAL_QUEUE_EMPTY_STATE_MESSAGE": "This queue is empty. You can ",
 
   "ALL_CASES_QUEUE_TABLE_TAB_TITLE": "All cases",
-  "ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION": "All AMA cases where the appellant is represented by %s that have been active at the Board of Veterans' Appeals any time in the past 2 weeks",
+  "ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION": "All AMA cases represented by %s that have been active at the Board of Veterans' Appeals in the past 2 weeks.",
 
   "JUDGE_CASE_REVIEW_TABLE_TITLE": "Review %s Cases",
   "JUDGE_ASSIGN_DROPDOWN_LINK_LABEL": "Assign Cases",

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -14,6 +14,7 @@ import {
   getUnassignedOrganizationalTasks,
   getAssignedOrganizationalTasks,
   getCompletedOrganizationalTasks,
+  trackingTasksForOrganization,
   tasksByOrganization
 } from './selectors';
 
@@ -69,6 +70,27 @@ class OrganizationQueue extends React.PureComponent {
       }
     ];
 
+    let focusedTab = 0;
+
+    if (this.props.organizationIsVso) {
+      focusedTab = 1;
+      tabs.unshift({
+        label: 'All cases',
+        page: <React.Fragment>
+          <p className="cf-margin-top-0">
+            {sprintf('All AMA cases where the appellant is represented by %s', this.props.organizationName)}
+          </p>
+          <TaskTable
+            includeDetailsLink
+            includeIssueCount
+            includeType
+            includeDocketNumber
+            tasks={this.props.trackingTasks}
+          />
+        </React.Fragment>
+      });
+    }
+
     return <AppSegment filledBackground styling={containerStyles}>
       {success && <Alert type="success" title={success.title} message={success.detail} />}
       <div>
@@ -77,6 +99,7 @@ class OrganizationQueue extends React.PureComponent {
         <TabWindow
           name="tasks-organization-queue"
           tabs={tabs}
+          defaultPage={focusedTab}
         />
       </div>
     </AppSegment>;
@@ -93,10 +116,12 @@ const mapStateToProps = (state) => {
   return {
     success,
     organizationName: state.ui.activeOrganization.name,
+    organizationIsVso: state.ui.activeOrganization.isVso,
     organizations: state.ui.organizations,
     unassignedTasks: getUnassignedOrganizationalTasks(state),
     assignedTasks: getAssignedOrganizationalTasks(state),
     completedTasks: getCompletedOrganizationalTasks(state),
+    trackingTasks: trackingTasksForOrganization(state),
     tasks: tasksByOrganization(state)
   };
 };

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -68,6 +68,8 @@ class OrganizationQueue extends React.PureComponent {
       }
     ];
 
+    // Focus on the first tab in the list of tabs unless we have an "all cases" view, in which case the first tab will
+    // be the "all cases" tab. In that case focus on the second tab which will be the first tab with workable tasks.
     let focusedTab = 0;
 
     if (this.props.organizationIsVso) {

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -75,10 +75,10 @@ class OrganizationQueue extends React.PureComponent {
     if (this.props.organizationIsVso) {
       focusedTab = 1;
       tabs.unshift({
-        label: 'All cases',
+        label: COPY.ALL_CASES_QUEUE_TABLE_TAB_TITLE,
         page: <React.Fragment>
           <p className="cf-margin-top-0">
-            {sprintf('All AMA cases where the appellant is represented by %s', this.props.organizationName)}
+            {sprintf(COPY.ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, this.props.organizationName)}
           </p>
           <TaskTable
             includeDetailsLink

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
@@ -14,8 +13,7 @@ import {
   getUnassignedOrganizationalTasks,
   getAssignedOrganizationalTasks,
   getCompletedOrganizationalTasks,
-  trackingTasksForOrganization,
-  tasksByOrganization
+  trackingTasksForOrganization
 } from './selectors';
 
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
@@ -106,10 +104,6 @@ class OrganizationQueue extends React.PureComponent {
   };
 }
 
-OrganizationQueue.propTypes = {
-  tasks: PropTypes.array.isRequired
-};
-
 const mapStateToProps = (state) => {
   const { success } = state.ui.messages;
 
@@ -121,8 +115,7 @@ const mapStateToProps = (state) => {
     unassignedTasks: getUnassignedOrganizationalTasks(state),
     assignedTasks: getAssignedOrganizationalTasks(state),
     completedTasks: getCompletedOrganizationalTasks(state),
-    trackingTasks: trackingTasksForOrganization(state),
-    tasks: tasksByOrganization(state)
+    trackingTasks: trackingTasksForOrganization(state)
   };
 };
 

--- a/client/app/queue/OrganizationQueueLoadingScreen.jsx
+++ b/client/app/queue/OrganizationQueueLoadingScreen.jsx
@@ -35,7 +35,7 @@ class OrganizationQueueLoadingScreen extends React.PureComponent<Props> {
         tasks: { data: tasks },
         id,
         organization_name: organizationName,
-        isVso
+        is_vso: isVso
       } = JSON.parse(response.text);
 
       this.props.setActiveOrganization(id, organizationName, isVso);

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -99,12 +99,16 @@ export const workTasksWithAppealSelector = createSelector(
 );
 
 export const tasksByOrganization = createSelector(
-  [workTasksWithAppealSelector, getActiveOrganizationId],
+  [tasksWithAppealSelector, getActiveOrganizationId],
   (tasks: Array<TaskWithAppeal>, organizationId: string) =>
     _.filter(tasks, (task) => (
       task.assignedTo.id === organizationId &&
       task.assignedTo.isOrganization
     ))
+);
+
+export const workTasksByOrganization = createSelector(
+  [tasksByOrganization], (tasks: Array<TaskWithAppeal>) => workTasksSelector(tasks)
 );
 
 export const trackingTasksForOrganization = createSelector(
@@ -151,19 +155,19 @@ export const getAllTasksForAppeal = createSelector(
 );
 
 export const getUnassignedOrganizationalTasks = createSelector(
-  [tasksByOrganization],
+  [workTasksByOrganization],
   (tasks: Tasks) => _.filter(tasks, (task) => {
     return (task.status === TASK_STATUSES.assigned || task.status === TASK_STATUSES.in_progress);
   })
 );
 
 export const getAssignedOrganizationalTasks = createSelector(
-  [tasksByOrganization],
+  [workTasksByOrganization],
   (tasks: Tasks) => _.filter(tasks, (task) => (task.status === TASK_STATUSES.on_hold))
 );
 
 export const getCompletedOrganizationalTasks = createSelector(
-  [tasksByOrganization],
+  [workTasksByOrganization],
   (tasks: Tasks) => _.filter(tasks, (task) => task.status === TASK_STATUSES.completed)
 );
 

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -63,6 +63,9 @@ export const taskIsNotOnHoldSelector = (tasks: Tasks) =>
 export const workTasksSelector = (tasks: Tasks | Array<Task> | Array<TaskWithAppeal>) =>
   _.filter(tasks, (task) => !task.hideFromQueueTableView);
 
+export const trackingTasksSelector = (tasks: Tasks | Array<Task> | Array<TaskWithAppeal>) =>
+  _.filter(tasks, (task) => task.type === 'TrackVeteranTask');
+
 export const getActiveModalType = createSelector(
   [getModals],
   (modals: { String: boolean }) => _.find(Object.keys(modals), (modalName) => modals[modalName])
@@ -99,6 +102,10 @@ export const tasksByOrganization = createSelector(
   [tasksWithAppealSelector, getActiveOrganizationId],
   (tasks: Array<TaskWithAppeal>, organizationId: string) =>
     _.filter(tasks, (task) => (task.assignedTo.id === organizationId))
+);
+
+export const trackingTasksForOrganization = createSelector(
+  [tasksByOrganization], (tasks: Array<TaskWithAppeal>) => trackingTasksSelector(tasks)
 );
 
 export const taskById = createSelector(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -117,6 +117,12 @@ class SeedDB
           appeal: a,
           assigned_to: vso
         )
+        FactoryBot.create(
+          :track_veteran_task,
+          parent: root_task,
+          appeal: a,
+          assigned_to: vso
+        )
 
         next unless assign_to_user
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -156,18 +156,20 @@ RSpec.feature "Task queue" do
 
     it "shows the right number of cases in each tab" do
       step("Unassigned tab") do
-        expect(page).to have_content(
-          format(COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, vso.name)
-        )
+        expect(page).to have_content(format(COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, vso.name))
         expect(find("tbody").find_all("tr").length).to eq(unassigned_count)
       end
 
       step("Assigned tab") do
         find("button", text: format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, assigned_count)).click
-        expect(page).to have_content(
-          format(COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, vso.name)
-        )
+        expect(page).to have_content(format(COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, vso.name))
         expect(find("tbody").find_all("tr").length).to eq(assigned_count)
+      end
+
+      step("All cases tab") do
+        find("button", text: format(COPY::ALL_CASES_QUEUE_TABLE_TAB_TITLE, assigned_count)).click
+        expect(page).to have_content(format(COPY::ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, vso.name))
+        expect(find("tbody").find_all("tr").length).to eq(tracking_task_count)
       end
     end
   end
@@ -251,6 +253,10 @@ RSpec.feature "Task queue" do
         format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, assigned_count)
       )
       expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
+    end
+
+    it "does not show all cases tab for non-VSO organization" do
+      expect(page).to_not have_content(COPY::ALL_CASES_QUEUE_TABLE_TAB_TITLE)
     end
 
     it "shows the right number of cases in each tab" do


### PR DESCRIPTION
Connects #7905.

Adds an all cases tab to VSO organization queues which displays all appeals that have been active at the Board in the past 2 weeks which the VSO represents.

Organizational queue landing page | All cases view
--- | ---
![image](https://user-images.githubusercontent.com/32683958/52135142-21835500-2613-11e9-860e-e6cb7c1fddad.png) | ![image](https://user-images.githubusercontent.com/32683958/52135161-2942f980-2613-11e9-81db-086e408f5dbe.png)

