### PR TITLE
Specify class in the root task factory

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -352,67 +352,33 @@ class SeedDB
       docket_type: "direct_review",
       request_issues: FactoryBot.create_list(:request_issue, 3, contested_issue_description: description, notes: notes)
     )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      veteran_file_number: "783740847",
-      docket_type: "evidence_submission",
-      request_issues: FactoryBot.create_list(:request_issue, 3, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      veteran_file_number: "963360019",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 2, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "604969679",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 1, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "228081153",
-      docket_type: "evidence_submission",
-      request_issues: FactoryBot.create_list(:request_issue, 1, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "152003980",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 3, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "375273128",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 1, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "682007349",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 5, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "231439628",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 1, contested_issue_description: description, notes: notes)
-    )
-    @ama_appeals << FactoryBot.create(
-      :appeal,
-      number_of_claimants: 1,
-      veteran_file_number: "975191063",
-      docket_type: "direct_review",
-      request_issues: FactoryBot.create_list(:request_issue, 8, contested_issue_description: description, notes: notes)
-    )
+
+    es = "evidence_submission"
+    dr = "direct_review"
+    [
+      { number_of_claimants: nil, veteran_file_number: "783740847", docket_type: es, request_issue_count: 3 },
+      { number_of_claimants: nil, veteran_file_number: "963360019", docket_type: dr, request_issue_count: 2 },
+      { number_of_claimants: 1, veteran_file_number: "604969679", docket_type: dr, request_issue_count: 1 },
+      { number_of_claimants: 1, veteran_file_number: "228081153", docket_type: es, request_issue_count: 1 },
+      { number_of_claimants: 1, veteran_file_number: "152003980", docket_type: dr, request_issue_count: 3 },
+      { number_of_claimants: 1, veteran_file_number: "375273128", docket_type: dr, request_issue_count: 1 },
+      { number_of_claimants: 1, veteran_file_number: "682007349", docket_type: dr, request_issue_count: 5 },
+      { number_of_claimants: 1, veteran_file_number: "231439628", docket_type: dr, request_issue_count: 1 },
+      { number_of_claimants: 1, veteran_file_number: "975191063", docket_type: dr, request_issue_count: 8 },
+      { number_of_claimants: 1, veteran_file_number: "662643660", docket_type: dr, request_issue_count: 8 },
+      { number_of_claimants: 1, veteran_file_number: "162726229", docket_type: dr, request_issue_count: 8 },
+      { number_of_claimants: 1, veteran_file_number: "760362568", docket_type: dr, request_issue_count: 8 }
+    ].each do |params|
+      @ama_appeals << FactoryBot.create(
+        :appeal,
+        number_of_claimants: params[:number_of_claimants],
+        veteran_file_number: params[:veteran_file_number],
+        docket_type: params[:docket_type],
+        request_issues: FactoryBot.create_list(
+          :request_issue, params[:request_issue_count], contested_issue_description: description, notes: notes
+        )
+      )
+    end
 
     LegacyAppeal.create(vacols_id: "2096907", vbms_id: "228081153S")
     LegacyAppeal.create(vacols_id: "2226048", vbms_id: "213912991S")
@@ -701,13 +667,12 @@ class SeedDB
     create_task_at_colocated(FactoryBot.create(:appeal), judge, attorney, colocated, action: "translation")
     create_task_at_attorney_review(@ama_appeals[7], judge, attorney)
     create_task_at_attorney_review(@ama_appeals[8], judge, attorney)
-    create_task_at_judge_assignment(@ama_appeals[8], judge)
-    create_task_at_judge_review(@ama_appeals[8], judge, attorney)
-    create_task_at_colocated(@ama_appeals[8], judge, attorney, colocated)
+    create_task_at_judge_assignment(@ama_appeals[9], judge)
+    create_task_at_judge_review(@ama_appeals[10], judge, attorney)
+    create_task_at_colocated(@ama_appeals[11], judge, attorney, colocated)
 
     9.times do
       appeal = FactoryBot.create(:appeal)
-      FactoryBot.create(:root_task, appeal: appeal)
       create_task_at_judge_assignment(appeal, judge, Time.zone.today)
     end
 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
       completed_at Time.zone.now
     end
 
-    factory :root_task do
+    factory :root_task, class: RootTask do
       type RootTask.name
       appeal { create(:appeal) }
       assigned_by { nil }

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -183,7 +183,7 @@ RSpec.feature "Task queue" do
     end
 
     context "when we are a member of the mail team and a root task exists for the appeal" do
-      let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal).becomes(RootTask) }
+      let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
       let(:instructions) { "Some instructions for how to complete the task" }
 
       it "should allow us to assign a mail task to a user" do

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -207,9 +207,9 @@ describe JudgeTask do
     end
 
     context "with multiple root tasks" do
-      let(:root_task1) { FactoryBot.create(:root_task).becomes(RootTask) }
-      let(:root_task2) { FactoryBot.create(:root_task).becomes(RootTask) }
-      let(:root_task3) { FactoryBot.create(:root_task).becomes(RootTask) }
+      let(:root_task1) { FactoryBot.create(:root_task) }
+      let(:root_task2) { FactoryBot.create(:root_task) }
+      let(:root_task3) { FactoryBot.create(:root_task) }
       let(:root_tasks) { [root_task1, root_task2, root_task3] }
 
       it "evenly distributes the JudgeAssignTasks" do


### PR DESCRIPTION
Explicitly sets the class of RootTasks created by the FactoryBot factory, and fixes tests and seeds that break as a result.
