### PR TITLE
Users with Admin Intake role may admin org users

### DIFF
--- a/app/controllers/organizations/users_controller.rb
+++ b/app/controllers/organizations/users_controller.rb
@@ -34,7 +34,7 @@ class Organizations::UsersController < OrganizationsController
   end
 
   def verify_role_access
-    return if current_user.admin?
+    return if current_user.administer_org_users?
 
     super
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,10 @@ class User < ApplicationRecord
     roles && (roles.include?("Mail Intake") || roles.include?("Admin Intake"))
   end
 
+  def administer_org_users?
+    admin? || granted?("Admin Intake")
+  end
+
   def vacols_uniq_id
     @vacols_uniq_id ||= user_info[:uniq_id]
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -281,6 +281,31 @@ describe User do
     end
   end
 
+  context "#administer_org_users?" do
+    subject { user.administer_org_users? }
+    before { session["user"]["roles"] = nil }
+    before { Functions.client.del("System Admin") }
+
+    context "when user with roles that are nil" do
+      it { is_expected.to be_falsey }
+    end
+
+    context "when user with roles that don't contain admin" do
+      before { session["user"]["roles"] = ["Do the other thing!"] }
+      it { is_expected.to be_falsey }
+    end
+
+    context "when user with roles that contain admin" do
+      before { Functions.grant!("System Admin", users: ["123"]) }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when user with roles that contain Admin Intake" do
+      before { Functions.grant!("Admin Intake", users: ["123"]) }
+      it { is_expected.to be_truthy }
+    end
+  end
+
   context "#can_edit_request_issues?" do
     let(:appeal) { create(:appeal) }
 


### PR DESCRIPTION
To ease the burden of adding users to a LOB organization, expand the definition of who is authorized to include `Admin Intake`.
