### PR TITLE
Do not set redux store with result of task update

### DIFF
--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -25,12 +25,7 @@ class CaseDetailsLink extends React.PureComponent {
         }
       };
 
-      ApiUtil.patch(`/tasks/${task.taskId}`, payload).
-        then((resp) => {
-          const response = JSON.parse(resp.text);
-
-          this.props.onReceiveAmaTasks(response.tasks.data);
-        });
+      ApiUtil.patch(`/tasks/${task.taskId}`, payload);
     }
 
     return this.props.onClick ? this.props.onClick(arguments) : true;


### PR DESCRIPTION
Currently, when we click into the case details page we make 2 requests. One loads [all tasks related to an appeal](https://github.com/department-of-veterans-affairs/caseflow/blob/f7efed2dd1bc62be29867eae45a9a467570a907a/app/controllers/tasks_controller.rb#L87) kicked off [by the `CaseDetailsLoadingScreen` component](https://github.com/department-of-veterans-affairs/caseflow/blob/f7efed2dd1bc62be29867eae45a9a467570a907a/client/app/queue/CaseDetailsLoadingScreen.jsx#L39). The other [updates the status of the task](https://github.com/department-of-veterans-affairs/caseflow/blob/f7efed2dd1bc62be29867eae45a9a467570a907a/app/controllers/tasks_controller.rb#L78) to `assigned` to `in_progress` to indicate that the current assignee has visited the case details page for this task which is [kicked off by `CaseDetailsLink` component](https://github.com/department-of-veterans-affairs/caseflow/blob/f7efed2dd1bc62be29867eae45a9a467570a907a/client/app/queue/CaseDetailsLink.jsx#L15).

This PR addresses an issue caused by the first request finishing first, updating the state to include [all tasks related to an appeal](https://github.com/department-of-veterans-affairs/caseflow/blob/f7efed2dd1bc62be29867eae45a9a467570a907a/app/controllers/tasks_controller.rb#L101) (including the ones that do not have available actions for the current user), then the second request finishes, and it updates the state to only have tasks related to this appeal (and all appeals) [which the current user can take action on](https://github.com/department-of-veterans-affairs/caseflow/blob/f7efed2dd1bc62be29867eae45a9a467570a907a/app/controllers/tasks_controller.rb#L82).

Spoofed the timing bug here by delaying the setting of the redux store by the `CaseDetailsLink`:
```jsx
setTimeout(() => { this.props.onReceiveAmaTasks(response.tasks.data) }, 2000);
```
![timing-bug](https://user-images.githubusercontent.com/32683958/52149893-493ae300-263c-11e9-96ed-95baade53484.gif)

This PR addresses the issue by not updating the store. The case details page (and rest of the application outside of the bolding of case details links on the queue table views) does not recognize the difference between tasks with status of `assigned` or `in_progress`.

This PR is somewhat related to #9136 in that it would solve the flicker of tasks appearing/disappearing from the task snapshot.