### PR TITLE
adding prior payee code for appeal remand

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -34,7 +34,7 @@ class Relationship
   end
 
   def previous_claim_payee_code
-    @previous_claim_payee_code ||= end_products.max_by(&:claim_date).try(:payee_code)
+    @previous_claim_payee_code ||= latest_end_product.try(:payee_code)
   end
 
   def payee_code_by_relationship_type
@@ -53,8 +53,8 @@ class Relationship
     end
   end
 
-  def end_products
-    veteran.end_products.select { |ep| ep.claimant_first_name == first_name && ep.claimant_last_name == last_name }
+  def latest_end_product
+    veteran.find_latest_end_product_by_claimant(self)
   end
 
   def veteran

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -67,6 +67,12 @@ class Veteran < ApplicationRecord
     military_address? ? military_address_vbms_hash : base_vbms_hash
   end
 
+  def find_latest_end_product_by_claimant(claimant)
+    end_products.select do |ep|
+      ep.claimant_first_name == claimant.first_name && ep.claimant_last_name == claimant.last_name
+    end.max_by(&:claim_date)
+  end
+
   def end_products
     @end_products ||= fetch_end_products
   end


### PR DESCRIPTION
Connects #8676

When there is an appeal dta, attempt to:
- use the latest prior ep's payee code that had the same claimant on the same veteran
- if ☝️ is not found, put both the appeal and the sc in an error state