### PR TITLE
Validate document ID when submitting decision

### DIFF
--- a/app/models/attorney_case_review.rb
+++ b/app/models/attorney_case_review.rb
@@ -1,6 +1,7 @@
 class AttorneyCaseReview < ApplicationRecord
   include CaseReviewConcern
   include IssueUpdater
+  include ::AmaAttorneyCaseReviewDocumentIdValidator
 
   belongs_to :reviewing_judge, class_name: "User"
   belongs_to :attorney, class_name: "User"
@@ -15,8 +16,6 @@ class AttorneyCaseReview < ApplicationRecord
     omo_request: Constants::APPEAL_DECISION_TYPES["OMO_REQUEST"],
     draft_decision: Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"]
   }
-
-  before_create :strip_document_id
 
   def update_in_vacols!
     MetricsService.record("VACOLS: reassign_case_to_judge #{task_id}",
@@ -62,10 +61,6 @@ class AttorneyCaseReview < ApplicationRecord
 
   def modifying_user
     attorney.vacols_uniq_id
-  end
-
-  def strip_document_id
-    self.document_id = document_id&.strip
   end
 
   class << self

--- a/app/services/form_response.rb
+++ b/app/services/form_response.rb
@@ -1,7 +1,7 @@
 class FormResponse
   def initialize(success:, errors:, extra: {})
     @success = success
-    @errors = errors.to_hash
+    @errors = errors.to_ary
     @extra = extra
   end
 

--- a/app/validators/ama_attorney_case_review_document_id_validator.rb
+++ b/app/validators/ama_attorney_case_review_document_id_validator.rb
@@ -1,0 +1,66 @@
+module AmaAttorneyCaseReviewDocumentIdValidator
+  extend ActiveSupport::Concern
+
+  included do
+    validate :correct_ama_document_id, if: :document_id
+  end
+
+  private
+
+  def correct_ama_document_id
+    return if correct_format?
+
+    errors.add(:document_id, work_product_error_hash[work_product])
+  end
+
+  def correct_format?
+    self.document_id = document_id.strip
+
+    if decision_work_product?
+      return document_id.match?(new_decision_regex) || document_id.match?(old_decision_regex)
+    end
+
+    return document_id.match?(vha_regex) if vha_work_product?
+
+    document_id.match?(ime_regex) if ime_work_product?
+  end
+
+  def decision_work_product?
+    work_product == "Decision"
+  end
+
+  def vha_work_product?
+    work_product == "OMO - VHA"
+  end
+
+  def ime_work_product?
+    work_product == "OMO - IME"
+  end
+
+  def new_decision_regex
+    /^\d{5}-\d{8}$/
+  end
+
+  def old_decision_regex
+    /^\d{8}\.\d{3,4}$/
+  end
+
+  def vha_regex
+    /^V\d{7}\.\d{3,4}$/
+  end
+
+  def ime_regex
+    /^M\d{7}\.\d{3,4}$/
+  end
+
+  def work_product_error_hash
+    {
+      "OMO - VHA" => "of type VHA must be in one of these formats: " \
+                     "V1234567.123 or V1234567.1234",
+      "OMO - IME" => "of type IME must be in one of these formats: " \
+                     "M1234567.123 or M1234567.1234",
+      "Decision" => "of type Draft Decision must be in one of these formats: " \
+                    "12345-12345678 or 12345678.123 or 12345678.1234"
+    }
+  end
+end

--- a/app/workflows/complete_case_review.rb
+++ b/app/workflows/complete_case_review.rb
@@ -1,0 +1,56 @@
+class CompleteCaseReview
+  include ActiveModel::Model
+
+  def initialize(case_review_class:, params:)
+    @case_review_class = case_review_class
+    @params = params
+  end
+
+  def call
+    @success = case_review.valid?
+
+    create_quality_review_task if success
+
+    FormResponse.new(success: success, errors: [response_errors], extra: completed_case_review)
+  end
+
+  private
+
+  attr_reader :case_review_class, :params, :success
+
+  def case_review
+    @case_review ||= review_class.complete(params)
+  end
+
+  def review_class
+    case_review_class.constantize
+  end
+
+  def create_quality_review_task
+    return if case_review.appeal.is_a?(LegacyAppeal) ||
+              !case_review.is_a?(JudgeCaseReview) ||
+              case_review.task.parent.is_a?(QualityReviewTask)
+
+    root_task = case_review.task.root_task
+    if QualityReviewCaseSelector.select_case_for_quality_review?
+      QualityReviewTask.create_from_root_task(root_task)
+    else
+      BvaDispatchTask.create_from_root_task(root_task)
+    end
+  end
+
+  def response_errors
+    return if success
+
+    {
+      title: "Record is invalid",
+      detail: case_review.errors.full_messages.join(", ")
+    }
+  end
+
+  def completed_case_review
+    return {} unless success
+
+    { case_review: case_review }
+  end
+end

--- a/app/workflows/update_attorney_case_review.rb
+++ b/app/workflows/update_attorney_case_review.rb
@@ -1,10 +1,10 @@
 class UpdateAttorneyCaseReview
   include ActiveModel::Model
+  include ::AmaAttorneyCaseReviewDocumentIdValidator
 
   validates :id, presence: true
   validate :attorney_case_review_exists
   validate :authorized_to_edit
-  validate :correct_format
 
   def initialize(id:, document_id:, user:)
     @id = id
@@ -13,16 +13,17 @@ class UpdateAttorneyCaseReview
   end
 
   def call
-    success = valid?
+    @success = valid?
 
     case_review.update!(document_id: document_id) if success
 
-    FormResponse.new(success: success, errors: errors.messages)
+    FormResponse.new(success: success, errors: [response_errors])
   end
 
   private
 
-  attr_reader :id, :document_id, :user
+  attr_reader :id, :document_id, :user, :success
+  attr_writer :document_id
 
   def case_review
     @case_review ||= AttorneyCaseReview.find_by(id: id)
@@ -31,77 +32,37 @@ class UpdateAttorneyCaseReview
   def attorney_case_review_exists
     return if case_review
 
-    errors.add(:document_id, "Could not find an Attorney Case Review with id #{id}")
+    errors.add(:attorney_case_review, "id #{id} could not be found")
   end
 
   def authorized_to_edit
     return unless case_review
     return if allowed_to_edit_ama_case_review?
 
-    errors.add(:document_id, "You are not authorized to edit this document ID")
+    errors.add(:user, "not authorized to edit this document ID")
   end
 
   def allowed_to_edit_ama_case_review?
     AmaDocumentIdPolicy.new(user: user, case_review: case_review).editable?
   end
 
-  def correct_format
+  def correct_ama_document_id
     return unless case_review
     return if correct_format?
 
     errors.add(:document_id, work_product_error_hash[work_product])
   end
 
-  def correct_format?
-    if decision_work_product?
-      return document_id.match?(new_decision_regex) || document_id.match?(old_decision_regex)
-    end
-
-    return document_id.match?(vha_regex) if vha_work_product?
-
-    document_id.match?(ime_regex) if ime_work_product?
-  end
-
-  def decision_work_product?
-    work_product == "Decision"
-  end
-
-  def vha_work_product?
-    work_product == "OMO - VHA"
-  end
-
-  def ime_work_product?
-    work_product == "OMO - IME"
-  end
-
   def work_product
     case_review.work_product
   end
 
-  def new_decision_regex
-    /^\d{5}-\d{8}$/
-  end
+  def response_errors
+    return if success
 
-  def old_decision_regex
-    /^\d{8}\.\d{3,4}$/
-  end
-
-  def vha_regex
-    /^V\d{7}\.\d{3,4}$/
-  end
-
-  def ime_regex
-    /^M\d{7}\.\d{3,4}$/
-  end
-
-  def work_product_error_hash
     {
-      "OMO - VHA" => "VHA Document IDs must be in one of these formats: " \
-                     "V1234567.123 or V1234567.1234",
-      "OMO - IME" => "IME Document IDs must be in one of these formats: " \
-                     "M1234567.123 or M1234567.1234",
-      "Decision" => "Draft Decision Document IDs must be in one of these formats: " \
-                    "12345-12345678 or 12345678.123 or 12345678.1234"
+      title: "Record is invalid",
+      detail: errors.full_messages.join(", ")
     }
   end
 end

--- a/app/workflows/update_legacy_attorney_case_review.rb
+++ b/app/workflows/update_legacy_attorney_case_review.rb
@@ -13,19 +13,19 @@ class UpdateLegacyAttorneyCaseReview
   end
 
   def call
-    success = valid?
+    @success = valid?
 
     if success
       update_attorney_case_review
       update_vacols_decass_table
     end
 
-    FormResponse.new(success: success, errors: errors.messages)
+    FormResponse.new(success: success, errors: [response_errors])
   end
 
   private
 
-  attr_reader :id, :document_id, :user
+  attr_reader :id, :document_id, :user, :success
 
   def update_attorney_case_review
     return unless attorney_case_review
@@ -144,5 +144,14 @@ class UpdateLegacyAttorneyCaseReview
   def invalid_decision_document_id_message
     "Draft Decision Document IDs must be in one of these formats: " \
       "12345-12345678 or 12345678.123 or 12345678.1234"
+  end
+
+  def response_errors
+    return if success
+
+    {
+      title: "Record is invalid",
+      detail: errors.to_hash[:document_id][0]
+    }
   end
 end

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -118,9 +118,9 @@ export class CaseTitleDetails extends React.PureComponent {
         this.handleModalClose();
       }).
       catch((error) => {
-        const documentIdErrors = JSON.parse(error.message).errors.document_id;
+        const documentIdErrors = JSON.parse(error.message).errors;
 
-        const documentIdErrorText = documentIdErrors && documentIdErrors[0];
+        const documentIdErrorText = documentIdErrors && documentIdErrors[0].detail;
 
         this.setState({
           highlightModal: true,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,11 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  activerecord:
+    attributes:
+      attorney_case_review:
+        document_id: "Document ID"
+  activemodel:
+    attributes:
+      update_attorney_case_review:
+        document_id: "Document ID"

--- a/spec/controllers/case_reviews_controller_spec.rb
+++ b/spec/controllers/case_reviews_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe CaseReviewsController, type: :controller do
               "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
               "reviewing_judge_id": judge.id,
               "work_product": "Decision",
-              "document_id": "123456789.1234",
+              "document_id": "12345678.1234",
               "overtime": true,
               "note": "something",
               "issues": [{ "disposition": "allowed", "id": request_issue1.id },
@@ -46,7 +46,7 @@ RSpec.describe CaseReviewsController, type: :controller do
             post :complete, params: { task_id: task.id, tasks: params }
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)
-            expect(response_body["task"]["document_id"]).to eq "123456789.1234"
+            expect(response_body["task"]["document_id"]).to eq "12345678.1234"
             expect(response_body["task"]["overtime"]).to eq true
             expect(response_body["task"]["note"]).to eq "something"
             expect(response_body.keys).to include "issues"
@@ -72,7 +72,7 @@ RSpec.describe CaseReviewsController, type: :controller do
                 "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
                 "reviewing_judge_id": judge.id,
                 "work_product": "Decision",
-                "document_id": "123456789.1234",
+                "document_id": "12345678.1234",
                 "overtime": true,
                 "note": "something",
                 "issues": [{ "description": "wonderful life",
@@ -105,7 +105,7 @@ RSpec.describe CaseReviewsController, type: :controller do
                 "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
                 "reviewing_judge_id": judge.id,
                 "work_product": "Decision",
-                "document_id": "123456789.1234",
+                "document_id": "12345678.1234",
                 "overtime": true,
                 "note": "something",
                 "issues": [{ "disposition": "allowed", "description": "wonderful life",
@@ -137,7 +137,7 @@ RSpec.describe CaseReviewsController, type: :controller do
                 "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
                 "reviewing_judge_id": judge.id,
                 "work_product": "Decision",
-                "document_id": "123456789.1234",
+                "document_id": "12345678.1234",
                 "overtime": true,
                 "note": "something",
                 "issues": [{ "disposition": "allowed", "description": "wonderful life",
@@ -158,7 +158,7 @@ RSpec.describe CaseReviewsController, type: :controller do
               post :complete, params: { task_id: task.id, tasks: params }
               expect(response.status).to eq 200
               response_body = JSON.parse(response.body)
-              expect(response_body["task"]["document_id"]).to eq "123456789.1234"
+              expect(response_body["task"]["document_id"]).to eq "12345678.1234"
               expect(response_body["task"]["overtime"]).to eq true
               expect(response_body["task"]["note"]).to eq "something"
               expect(response_body.keys).to include "issues"
@@ -308,7 +308,7 @@ RSpec.describe CaseReviewsController, type: :controller do
               "document_type": Constants::APPEAL_DECISION_TYPES["OMO_REQUEST"],
               "reviewing_judge_id": judge.id,
               "work_product": "OMO - IME",
-              "document_id": "123456789.1234",
+              "document_id": "M1234567.1234",
               "overtime": true,
               "note": "something"
             }
@@ -319,7 +319,7 @@ RSpec.describe CaseReviewsController, type: :controller do
             post :complete, params: { task_id: task_id, tasks: params }
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)
-            expect(response_body["task"]["document_id"]).to eq "123456789.1234"
+            expect(response_body["task"]["document_id"]).to eq "M1234567.1234"
             expect(response_body["task"]["overtime"]).to eq true
             expect(response_body["task"]["note"]).to eq "something"
             expect(bva_dispatch_task_count_before).to eq(BvaDispatchTask.count)
@@ -333,7 +333,7 @@ RSpec.describe CaseReviewsController, type: :controller do
               "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
               "reviewing_judge_id": judge.id,
               "work_product": "Decision",
-              "document_id": "123456789.1234",
+              "document_id": "12345678.1234",
               "overtime": true,
               "note": "something",
               "issues": [{ "disposition": "3", "id": vacols_issue_remanded.issseq,
@@ -347,7 +347,7 @@ RSpec.describe CaseReviewsController, type: :controller do
             post :complete, params: { task_id: task_id, tasks: params }
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)
-            expect(response_body["task"]["document_id"]).to eq "123456789.1234"
+            expect(response_body["task"]["document_id"]).to eq "12345678.1234"
             expect(response_body["task"]["overtime"]).to eq true
             expect(response_body["task"]["note"]).to eq "something"
             expect(response_body.keys).to include "issues"
@@ -355,13 +355,12 @@ RSpec.describe CaseReviewsController, type: :controller do
           end
         end
 
-        context "when not all parameters are present" do
+        context "when some required parameters are not present" do
           let(:params) do
             {
               "type": "AttorneyCaseReview",
               "document_type": Constants::APPEAL_DECISION_TYPES["OMO_REQUEST"],
               "work_product": "OMO - IME",
-              "document_id": "123456789.1234",
               "overtime": true,
               "note": "something"
             }
@@ -372,7 +371,33 @@ RSpec.describe CaseReviewsController, type: :controller do
             expect(response.status).to eq 400
             response_body = JSON.parse(response.body)
             expect(response_body["errors"].first["title"]).to eq "Record is invalid"
-            expect(response_body["errors"].first["detail"]).to eq "Reviewing judge can't be blank"
+            expect(response_body["errors"].first["detail"])
+              .to eq "Reviewing judge can't be blank, Document ID can't be blank"
+          end
+        end
+
+        context "when document_id is in the wrong format" do
+          let(:params) do
+            {
+              "type": "AttorneyCaseReview",
+              "document_id": "123456789.1234",
+              "document_type": Constants::APPEAL_DECISION_TYPES["OMO_REQUEST"],
+              "work_product": "OMO - IME",
+              "overtime": true,
+              "note": "something"
+            }
+          end
+
+          it "should not be successful" do
+            post :complete, params: { task_id: task_id, tasks: params }
+            response_body = JSON.parse(response.body)
+
+            expect(response.status).to eq 400
+            expect(response_body["errors"].first["title"]).to eq "Record is invalid"
+            expect(response_body["errors"].first["detail"])
+              .to eq "Document ID of type IME must be in one of these formats: M1234567.123 or M1234567.1234, " \
+                      "Reviewing judge can't be blank"
+            expect(AttorneyCaseReview.count).to eq 0
           end
         end
       end

--- a/spec/factories/attorney_case_review.rb
+++ b/spec/factories/attorney_case_review.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :attorney_case_review do
     task_id { "123456-2017-08-07" }
-    document_id "173250939.1116"
+    document_id "17325093.1116"
     overtime false
     work_product "Decision"
     document_type "draft_decision"

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "AmaQueue" do
+  def valid_document_id
+    "12345-12345678"
+  end
+
   context "loads appellant detail view" do
     let(:attorney_first_name) { "Robby" }
     let(:attorney_last_name) { "McDobby" }
@@ -478,7 +482,7 @@ RSpec.feature "AmaQueue" do
 
       expect(page).to have_content("Submit Draft Decision for Review")
 
-      fill_in "Document ID:", with: "1234"
+      fill_in "Document ID:", with: valid_document_id
       click_on "Select a judge"
       find(".Select-control", text: "Select a judge…").click
       first("div", class: "Select-option", text: judge_user.full_name).click
@@ -557,8 +561,6 @@ RSpec.feature "AmaQueue" do
       FactoryBot.create(:ama_judge_task, appeal: appeal, parent: root_task, assigned_to: judge_user, status: :assigned)
     end
 
-    let(:document_id) { "5551212" }
-
     before do
       ["Elaine Abitong", "Byron Acero", "Jan Antonioni"].each do |attorney_name|
         another_attorney_on_the_team = FactoryBot.create(
@@ -614,7 +616,7 @@ RSpec.feature "AmaQueue" do
 
         expect(page).to have_content("Submit Draft Decision for Review")
 
-        fill_in "Document ID:", with: "12345"
+        fill_in "Document ID:", with: valid_document_id
         click_on "Select a judge"
         click_dropdown(prompt: "Select a judge", text: judge_user.full_name)
         fill_in "notes", with: "all done"
@@ -662,7 +664,7 @@ RSpec.feature "AmaQueue" do
 
         expect(page).to have_content("Submit Draft Decision for Review")
 
-        fill_in "Document ID:", with: document_id
+        fill_in "Document ID:", with: valid_document_id
         click_on "Select a judge"
         click_dropdown(prompt: "Select a judge", text: judge_user.full_name)
         fill_in "notes", with: "corrections made"
@@ -679,7 +681,7 @@ RSpec.feature "AmaQueue" do
         visit "/queue"
 
         expect(page).to have_content veteran_full_name
-        expect(page).to have_content document_id
+        expect(page).to have_content valid_document_id
       end
     end
   end

--- a/spec/feature/queue/case_details/update_document_id_spec.rb
+++ b/spec/feature/queue/case_details/update_document_id_spec.rb
@@ -14,7 +14,7 @@ feature "Updating Document ID" do
 
       enter_invalid_decision_document_id
 
-      expect(page).to have_content "Draft Decision Document IDs must be in one of these formats:"
+      expect(page).to have_content "Document ID of type Draft Decision must be in one of these formats:"
       expect(page).to have_content "12345678.1234"
 
       enter_valid_decision_document_id

--- a/spec/models/attorney_case_review_spec.rb
+++ b/spec/models/attorney_case_review_spec.rb
@@ -161,7 +161,7 @@ describe AttorneyCaseReview do
   context ".complete" do
     let(:document_type) { Constants::APPEAL_DECISION_TYPES["OMO_REQUEST"] }
     let(:work_product) { "OMO - IME" }
-    let(:document_id) { "123456789.1234" }
+    let(:document_id) { "M1234567.1234" }
     let(:padded_document_id) { "     #{document_id}    " }
     let(:note) { "something" }
     let(:task_id) { create(:ama_attorney_task, assigned_by: judge, assigned_to: attorney).id }
@@ -268,6 +268,7 @@ describe AttorneyCaseReview do
       context "when ama" do
         let(:document_type) { Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"] }
         let(:work_product) { "Decision" }
+        let(:document_id) { "12345-12345678" }
         let(:task) { create(:ama_attorney_task, assigned_by: judge, assigned_to: attorney) }
         let(:task_id) { task.id }
         let!(:request_issue1) do
@@ -400,6 +401,7 @@ describe AttorneyCaseReview do
         let(:vacols_case) { FactoryBot.create(:case, :assigned, staff: vacols_atty, case_issues: case_issues) }
         let(:document_type) { Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"] }
         let(:work_product) { "Decision" }
+        let(:document_id) { "12345-12345678" }
         let(:vacated_issue) { FactoryBot.create(:case_issue, :disposition_vacated) }
         let(:remand_reason) { FactoryBot.create(:remand_reason, rmdval: "AB", rmddev: "R2") }
         let(:remanded_issue) do

--- a/spec/workflows/update_attorney_case_review_spec.rb
+++ b/spec/workflows/update_attorney_case_review_spec.rb
@@ -10,10 +10,13 @@ describe UpdateAttorneyCaseReview do
           document_id: valid_decision_document_id,
           user: build(:user, id: 123_456_789)
         ).call
-        errors = { document_id: ["You are not authorized to edit this document ID"] }
+        errors = {
+          title: "Record is invalid",
+          detail: "User not authorized to edit this document ID"
+        }
 
         expect(review.reload.document_id).to_not eq "123"
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
@@ -45,7 +48,7 @@ describe UpdateAttorneyCaseReview do
 
     context "when the work_product is 'OMO - VHA' but the document_id is in the wrong format" do
       it "returns an error" do
-        review = create(:attorney_case_review, work_product: "OMO - VHA")
+        review = create_vha_attorney_case_review
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.12",
@@ -53,16 +56,17 @@ describe UpdateAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"]
+          title: "Record is invalid",
+          detail: "Document ID of type VHA must be in one of these formats: V1234567.123 or V1234567.1234"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is 'OMO - VHA' and the document_id is in the correct format" do
       it "updates successfully" do
-        review = create(:attorney_case_review, work_product: "OMO - VHA")
+        review = create_vha_attorney_case_review
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.123",
@@ -75,7 +79,7 @@ describe UpdateAttorneyCaseReview do
 
     context "when the work_product is 'OMO - IME' but the document_id is in the wrong format" do
       it "returns an error" do
-        review = create(:attorney_case_review, work_product: "OMO - IME")
+        review = create_ime_attorney_case_review
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "V1234567.123",
@@ -83,16 +87,17 @@ describe UpdateAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"]
+          title: "Record is invalid",
+          detail: "Document ID of type IME must be in one of these formats: M1234567.123 or M1234567.1234"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is 'OMO - IME' and the document_id is in the correct format" do
       it "updates successfully" do
-        review = create(:attorney_case_review, work_product: "OMO - IME")
+        review = create_ime_attorney_case_review
         result = UpdateAttorneyCaseReview.new(
           id: review.id,
           document_id: "M1234567.1234",
@@ -112,13 +117,14 @@ describe UpdateAttorneyCaseReview do
           user: build(:user, id: review.attorney_id)
         ).call
 
-        error_message = "Draft Decision Document IDs must be in one of these formats: " \
+        error_message = "Document ID of type Draft Decision must be in one of these formats: " \
                         "12345-12345678 or 12345678.123 or 12345678.1234"
         errors = {
-          document_id: [error_message]
+          title: "Record is invalid",
+          detail: error_message
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
@@ -131,11 +137,41 @@ describe UpdateAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["Could not find an Attorney Case Review with id 123"]
+          title: "Record is invalid",
+          detail: "Attorney case review id 123 could not be found"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
+    end
+
+    context "when the document ID contains extra whitespace" do
+      it "strips the whitespace" do
+        review = create_vha_attorney_case_review
+        UpdateAttorneyCaseReview.new(
+          id: review.id,
+          document_id: "  V1234567.123  ",
+          user: build(:user, id: review.attorney_id)
+        ).call
+
+        expect(AttorneyCaseReview.last.document_id).to eq "V1234567.123"
+      end
+    end
+
+    def create_vha_attorney_case_review
+      create(
+        :attorney_case_review,
+        work_product: "OMO - VHA",
+        document_id: "V1234567.1234"
+      )
+    end
+
+    def create_ime_attorney_case_review
+      create(
+        :attorney_case_review,
+        work_product: "OMO - IME",
+        document_id: "M1234567.1234"
+      )
     end
 
     def valid_decision_document_id

--- a/spec/workflows/update_legacy_attorney_case_review_spec.rb
+++ b/spec/workflows/update_legacy_attorney_case_review_spec.rb
@@ -7,7 +7,6 @@ describe UpdateLegacyAttorneyCaseReview do
     let(:vacols_id) { "123456" }
     let(:document_id) { "V1234567.222" }
     let(:created_at) { "2019-02-14" }
-    let(:attorney_case_review) { create(:attorney_case_review, task_id: "#{vacols_id}-#{created_at}") }
 
     def stub_case_assignment_with_work_product(work_product)
       case_assignment = double(
@@ -19,7 +18,33 @@ describe UpdateLegacyAttorneyCaseReview do
         created_at: created_at.to_date
       )
       allow(VACOLS::CaseAssignment).to receive(:latest_task_for_appeal).with(vacols_id).and_return(case_assignment)
-      attorney_case_review
+    end
+
+    def create_vha_attorney_case_review
+      create(
+        :attorney_case_review,
+        work_product: "OMO - VHA",
+        document_id: "V1234567.1234",
+        task_id: "#{vacols_id}-#{created_at}"
+      )
+    end
+
+    def create_ime_attorney_case_review
+      create(
+        :attorney_case_review,
+        work_product: "OMO - IME",
+        document_id: "M1234567.1234",
+        task_id: "#{vacols_id}-#{created_at}"
+      )
+    end
+
+    def create_decision_attorney_case_review
+      create(
+        :attorney_case_review,
+        work_product: "Decision",
+        document_id: "12345-12341234",
+        task_id: "#{vacols_id}-#{created_at}"
+      )
     end
 
     def valid_decision_document_id
@@ -41,21 +66,26 @@ describe UpdateLegacyAttorneyCaseReview do
     context "when the current user is not associated with the case" do
       it "does not update the case review" do
         stub_case_assignment_with_work_product("VHA")
+        attorney_case_review = create_vha_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: valid_vha_document_id,
           user: build(:user, id: 123_456_789)
         ).call
-        errors = { document_id: ["You are not authorized to edit this document ID"] }
+        errors = {
+          title: "Record is invalid",
+          detail: "You are not authorized to edit this document ID"
+        }
 
         expect(attorney_case_review.reload.document_id).to_not eq valid_vha_document_id
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the current user is a judge associated with the case" do
       it "updates both the attorney case review and the VACOLS Decass table" do
         stub_case_assignment_with_work_product("VHA")
+        attorney_case_review = create_vha_attorney_case_review
 
         decass = class_double(VACOLS::Decass)
         expect(VACOLS::Decass)
@@ -76,6 +106,7 @@ describe UpdateLegacyAttorneyCaseReview do
     context "when the current user is an attorney associated with the case" do
       it "updates the case review" do
         stub_case_assignment_with_work_product("VHA")
+        attorney_case_review = create_vha_attorney_case_review
         UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: valid_vha_document_id,
@@ -89,6 +120,7 @@ describe UpdateLegacyAttorneyCaseReview do
     context "when the work_product is 'VHA' but the document_id is in the wrong format" do
       it "returns an error" do
         stub_case_assignment_with_work_product("VHA")
+        create_vha_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: invalid_document_id,
@@ -96,16 +128,18 @@ describe UpdateLegacyAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"]
+          title: "Record is invalid",
+          detail: "VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is 'OTV' but the document_id is in the wrong format" do
       it "returns an error" do
         stub_case_assignment_with_work_product("OTV")
+        create_vha_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: invalid_document_id,
@@ -113,16 +147,18 @@ describe UpdateLegacyAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"]
+          title: "Record is invalid",
+          detail: "VHA Document IDs must be in one of these formats: V1234567.123 or V1234567.1234"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is 'IME' but the document_id is in the wrong format" do
       it "returns an error" do
         stub_case_assignment_with_work_product("IME")
+        create_ime_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: invalid_document_id,
@@ -130,16 +166,18 @@ describe UpdateLegacyAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"]
+          title: "Record is invalid",
+          detail: "IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is 'OTI' but the document_id is in the wrong format" do
       it "returns an error" do
         stub_case_assignment_with_work_product("OTI")
+        create_ime_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: invalid_document_id,
@@ -147,16 +185,18 @@ describe UpdateLegacyAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"]
+          title: "Record is invalid",
+          detail: "IME Document IDs must be in one of these formats: M1234567.123 or M1234567.1234"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is a draft decision but the document_id is in the wrong format" do
       it "returns an error" do
         stub_case_assignment_with_work_product("DEC")
+        create_decision_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: invalid_document_id,
@@ -166,16 +206,18 @@ describe UpdateLegacyAttorneyCaseReview do
         error_message = "Draft Decision Document IDs must be in one of these formats: " \
                         "12345-12345678 or 12345678.123 or 12345678.1234"
         errors = {
-          document_id: [error_message]
+          title: "Record is invalid",
+          detail: error_message
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 
     context "when the work_product is 'OTV' and the document_id is in the correct format" do
       it "updates successfully" do
         stub_case_assignment_with_work_product("OTV")
+        attorney_case_review = create_vha_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: valid_vha_document_id,
@@ -188,8 +230,9 @@ describe UpdateLegacyAttorneyCaseReview do
     end
 
     context "when the work_product is 'IME' and the document_id is in the correct format" do
-      it "returns an error" do
+      it "updates successfully" do
         stub_case_assignment_with_work_product("IME")
+        attorney_case_review = create_ime_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: valid_ime_document_id,
@@ -202,8 +245,9 @@ describe UpdateLegacyAttorneyCaseReview do
     end
 
     context "when the work_product is 'OTI' and the document_id is in the correct format" do
-      it "returns an error" do
+      it "updates successfully" do
         stub_case_assignment_with_work_product("OTI")
+        attorney_case_review = create_ime_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: valid_ime_document_id,
@@ -216,8 +260,9 @@ describe UpdateLegacyAttorneyCaseReview do
     end
 
     context "when the work_product is draft decision and the document_id is in the correct format" do
-      it "returns an error" do
-        stub_case_assignment_with_work_product("REM")
+      it "updates successfully" do
+        stub_case_assignment_with_work_product("DEC")
+        attorney_case_review = create_decision_attorney_case_review
         result = UpdateLegacyAttorneyCaseReview.new(
           id: vacols_id,
           document_id: valid_decision_document_id,
@@ -243,10 +288,11 @@ describe UpdateLegacyAttorneyCaseReview do
         ).call
 
         errors = {
-          document_id: ["Could not find a legacy Attorney Case Review with id #{vacols_id}"]
+          title: "Record is invalid",
+          detail: "Could not find a legacy Attorney Case Review with id #{vacols_id}"
         }
 
-        expect(result.errors).to eq errors
+        expect(result.errors).to eq [errors]
       end
     end
 


### PR DESCRIPTION
**Why**: Document IDs follow different formats depending on the work
product. We first introduced Document ID validation in #8575, but that
only applied to editing an existing Document ID. In this PR, we are
making sure Document IDs are validated during the attorney checkout
flow, when they are first created.

Resolves #8659

Testing Plan:
1. As an attorney, select an AMA case in your queue
2. From the Actions dropdown, select Decision ready for review
3. Complete the rest of the checkout flow until you reach the last page
where you can enter the Document ID
4. Enter an invalid ID, such as "123" and click Continue
Expected Result: You get a helpful error message stating what the
expected format is
5. Enter a valid ID, such as "12345-12345678" and click Continue
Expected Result: the case is successfully saved
5. Go back to your queue and select a Legacy case
6. From the Actions dropdown, select "Medical Request Ready for Review"
7. Select "OMO - VHA" or "OMO - IME"
4. Enter an invalid ID, such as "123" and click Continue
Expected Result: You get a helpful error message stating what the
expected format is
5. Enter a valid ID, such as "V1234567.123" (for VHA) and click Continue
Expected Result: the case is successfully saved