### PR TITLE
Appeal Status: Made serializers for each claim and appeal type

### DIFF
--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -27,7 +27,7 @@ class Api::V2::AppealsController < Api::ApplicationController
       else
         ActiveModelSerializers::SerializableResource.new(
           legacy_appeals,
-          each_serializer: ::V2::AppealSerializer,
+          each_serializer: ::V2::LegacyAppealStatusSerializer,
           key_transform: :camel_lower
         ).as_json
       end

--- a/app/models/serializers/v2/appeal_status_serializer.rb
+++ b/app/models/serializers/v2/appeal_status_serializer.rb
@@ -1,4 +1,4 @@
-class V2::AppealStatusSerializer < V2::AppealSerializer
+class V2::AppealStatusSerializer < ActiveModel::Serializer
   type :appeal
 
   def id
@@ -6,33 +6,52 @@ class V2::AppealStatusSerializer < V2::AppealSerializer
   end
 
   attribute :linked_review_ids, key: :appeal_ids
-  attribute :advanced_on_docket, key: :aod
-  attribute :active_status?, key: :active
 
-  attribute :type do
-    "original"
+  attribute :updated do
+    Time.zone.now.in_time_zone("Eastern Time (US & Canada)").round.iso8601
   end
 
   attribute :incomplete_history do
     false
   end
 
+  attribute :type do
+    "original"
+  end
+
+  attribute :active_status?, key: :active
+  attribute :description
+  attribute :advanced_on_docket, key: :aod
+  attribute :location
+
   attribute :aoj do
     "other"
   end
 
+  attribute :program, key: :program_area
+  attribute :status_hash, key: :status
+  attribute :alerts
+
   attribute :docket do
     # to be implemented
+    # as docket_hash in appeal object
   end
 
+  attribute :issues
+
   attribute :events do
-    # to be implemented
+    # to be implemented in appeal object
   end
 
   attribute :issues do
     # to be implemented
     # will need to override method used
     # issues already exists in appeal
+    []
+  end
+
+  # Stubbed attributes
+  attribute :evidence do
     []
   end
 end

--- a/app/models/serializers/v2/hlr_status_serializer.rb
+++ b/app/models/serializers/v2/hlr_status_serializer.rb
@@ -1,4 +1,4 @@
-class V2::HLRStatusSerializer < V2::AppealSerializer
+class V2::HLRStatusSerializer < ActiveModel::Serializer
   type :higher_level_review
 
   def id
@@ -7,27 +7,30 @@ class V2::HLRStatusSerializer < V2::AppealSerializer
 
   attribute :linked_review_ids, key: :appeal_ids
 
-  attribute :type do
-    # this does not apply to HLR
-  end
-
-  attribute :location do
-    # for HLR will always be aoj
-    "aoj"
+  attribute :updated do
+    Time.zone.now.in_time_zone("Eastern Time (US & Canada)").round.iso8601
   end
 
   attribute :incomplete_history do
     false
   end
 
-  attribute :aod do
-    # does not apply to HLR
+  attribute :active?, key: :active
+  attribute :description
+
+  attribute :location do
+    "aoj"
   end
 
-  attribute :docket do
-    # doesn't apply to HLRs
-  end
+  attribute :aoj
+  attribute :program, key: :program_area
+  attribute :status_hash, key: :status
+  attribute :alerts
+  attribute :issues
+  attribute :events
 
-  attribute :events do
+  # Stubbed attributes
+  attribute :evidence do
+    []
   end
 end

--- a/app/models/serializers/v2/legacy_appeal_status_serializer.rb
+++ b/app/models/serializers/v2/legacy_appeal_status_serializer.rb
@@ -1,4 +1,4 @@
-class V2::AppealSerializer < ActiveModel::Serializer
+class V2::LegacyAppealStatusSerializer < ActiveModel::Serializer
   type :legacy_appeal
 
   def id

--- a/app/models/serializers/v2/sc_status_serializer.rb
+++ b/app/models/serializers/v2/sc_status_serializer.rb
@@ -1,4 +1,4 @@
-class V2::SCStatusSerializer < V2::AppealSerializer
+class V2::SCStatusSerializer < ActiveModel::Serializer
   type :supplemental_claim
 
   def id
@@ -7,27 +7,30 @@ class V2::SCStatusSerializer < V2::AppealSerializer
 
   attribute :linked_review_ids, key: :appeal_ids
 
-  attribute :type do
-    # this does not apply to SC
-  end
-
-  attribute :location do
-    # for SC will always be aoj
-    "aoj"
+  attribute :updated do
+    Time.zone.now.in_time_zone("Eastern Time (US & Canada)").round.iso8601
   end
 
   attribute :incomplete_history do
     false
   end
 
-  attribute :aod do
-    # does not apply to SC
+  attribute :active?, key: :active
+  attribute :description
+
+  attribute :location do
+    "aoj"
   end
 
-  attribute :docket do
-    # doesn't apply to SC
-  end
+  attribute :aoj
+  attribute :program, key: :program_area
+  attribute :status_hash, key: :status
+  attribute :alerts
+  attribute :issues
+  attribute :events
 
-  attribute :events do
+  # Stubbed attributes
+  attribute :evidence do
+    []
   end
 end

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -413,7 +413,6 @@ describe "Appeals API v2", type: :request do
       get "/api/v2/appeals", headers: headers
 
       json = JSON.parse(response.body)
-
       # test for the 200 status-code
       expect(response).to be_success
       # check to make sure the right amount of appeals are returned

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -413,6 +413,7 @@ describe "Appeals API v2", type: :request do
       get "/api/v2/appeals", headers: headers
 
       json = JSON.parse(response.body)
+
       # test for the 200 status-code
       expect(response).to be_success
       # check to make sure the right amount of appeals are returned


### PR DESCRIPTION
Resolves #{9153}

### Description
Made each of the Appeal Status serializers stand alone that way we can remove attributes that do not apply to HLR and SC.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. tested in command line to verify that the attributes: type, aod,  and docket are not in the json for HLR and SC

{:data=>
  [{:id=>"HLR9",
    :type=>"higherLevelReview",
    :attributes=>
     {:appealIds=>["HLR9"],
      :updated=>"2019-02-03T15:08:56-05:00",
      :incompleteHistory=>false,
      :active=>true,
      :description=>nil,
      :location=>"aoj",
      :aoj=>nil,
      :programArea=>nil,
      :status=>{:type=>:hlr_received},
      :alerts=>nil,
      :issues=>[],
      :events=>nil,
      :evidence=>[]}},
   {:id=>"HLR10",
    :type=>"higherLevelReview",
    :attributes=>
     {:appealIds=>["HLR10"],
      :updated=>"2019-02-03T15:08:56-05:00",
      :incompleteHistory=>false,
      :active=>false,
      :description=>nil,
      :location=>"aoj",
      :aoj=>nil,
      :programArea=>nil,
      :status=>{:type=>:hlr_closed},
      :alerts=>nil,
      :issues=>[],
      :events=>nil,
      :evidence=>[]}}]}

 {:data=>
  [{:id=>"SC1",
    :type=>"supplementalClaim",
    :attributes=>
     {:appealIds=>["SC1"],
      :updated=>"2019-02-03T15:13:53-05:00",
      :incompleteHistory=>false,
      :active=>false,
      :description=>nil,
      :location=>"aoj",
      :aoj=>"vba",
      :programArea=>"compensation",
      :status=>{:type=>:sc_closed},
      :alerts=>nil,
      :issues=>[],
      :events=>nil,
      :evidence=>[]}}]}

