### PR TITLE
Fix width of error message on jobs page

### DIFF
--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -1,0 +1,5 @@
+.cf-job-error {
+  max-width: 200px;
+  overflow: auto;
+  display: inline-block;
+}

--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -9,6 +9,7 @@
 @import '_stats.scss';
 @import '_intake.scss';
 @import '_noncomp.scss';
+@import '_jobs.scss';
 @import 'dispatch/_dispatch.scss';
 @import 'reader/_reader_styles_root.scss';
 @import 'hearings/_hearings_styles_root.scss';


### PR DESCRIPTION
Some browsers do not add a horizontal scroll bar for the whole page when the table is too wide to fit. Since the error message is the variable width value, hardcode its max width and tell it to scroll.

![screen shot 2019-02-04 at 9 31 11 am](https://user-images.githubusercontent.com/1205061/52218214-c7c39a80-285f-11e9-82e9-6f11cd05f6dd.png)
