### PR TITLE
Close tracking tasks when we close the root task

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -15,6 +15,7 @@ class Task < ApplicationRecord
 
   before_update :set_timestamps
   after_update :update_parent_status, if: :status_changed_to_completed_and_has_parent?
+  after_update :update_children_status, if: :status_changed_to_completed?
 
   enum status: {
     Constants.TASK_STATUSES.assigned.to_sym => Constants.TASK_STATUSES.assigned,
@@ -357,8 +358,14 @@ class Task < ApplicationRecord
     parent.when_child_task_completed
   end
 
+  def update_children_status; end
+
+  def status_changed_to_completed?
+    saved_change_to_attribute?("status") && completed?
+  end
+
   def status_changed_to_completed_and_has_parent?
-    saved_change_to_attribute?("status") && completed? && parent
+    status_changed_to_completed? && parent
   end
 
   def users_to_options(users)

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -18,7 +18,7 @@ class BvaDispatchTask < GenericTask
       create_decision_document!(params)
 
       task.update!(status: Constants.TASK_STATUSES.completed)
-      task.root_task.update!(status: Constants.TASK_STATUSES.completed)
+      task.root_task.close!
     rescue ActiveRecord::RecordInvalid => e
       raise(Caseflow::Error::OutcodeValidationFailure, message: e.message) if e.message.match?(/^Validation failed:/)
 

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -18,7 +18,7 @@ class BvaDispatchTask < GenericTask
       create_decision_document!(params)
 
       task.update!(status: Constants.TASK_STATUSES.completed)
-      task.root_task.close!
+      task.root_task.update!(status: Constants.TASK_STATUSES.completed)
     rescue ActiveRecord::RecordInvalid => e
       raise(Caseflow::Error::OutcodeValidationFailure, message: e.message) if e.message.match?(/^Validation failed:/)
 

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -7,6 +7,11 @@ class RootTask < GenericTask
 
   def when_child_task_completed; end
 
+  def update_children_status
+    children.where(type: TrackVeteranTask.name).where.not(status: Constants.TASK_STATUSES.completed)
+      .update_all(status: Constants.TASK_STATUSES.completed)
+  end
+
   def hide_from_task_snapshot
     true
   end
@@ -26,12 +31,6 @@ class RootTask < GenericTask
 
   def actions_available?(_user)
     true
-  end
-
-  def close!
-    children.where(type: TrackVeteranTask.name).where.not(status: Constants.TASK_STATUSES.completed)
-      .update_all(status: Constants.TASK_STATUSES.completed)
-    update!(status: Constants.TASK_STATUSES.completed)
   end
 
   class << self

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -28,6 +28,12 @@ class RootTask < GenericTask
     true
   end
 
+  def close!
+    children.where(type: TrackVeteranTask.name).where.not(status: Constants.TASK_STATUSES.completed)
+      .update_all(status: Constants.TASK_STATUSES.completed)
+    update!(status: Constants.TASK_STATUSES.completed)
+  end
+
   class << self
     def create_root_and_sub_tasks!(appeal)
       root_task = create!(appeal: appeal)

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -188,11 +188,11 @@ describe RootTask do
     end
   end
 
-  describe ".close" do
+  describe ".update_children_status" do
     let!(:root_task) { FactoryBot.create(:root_task) }
     let!(:appeal) { root_task.appeal }
 
-    subject { root_task.close! }
+    subject { root_task.update_children_status }
 
     context "when there are multiple children tasks" do
       let!(:generic_task) { FactoryBot.create(:generic_task, appeal: appeal, parent: root_task) }

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -187,4 +187,22 @@ describe RootTask do
       end
     end
   end
+
+  describe ".close" do
+    let!(:root_task) { FactoryBot.create(:root_task) }
+    let!(:appeal) { root_task.appeal }
+
+    subject { root_task.close! }
+
+    context "when there are multiple children tasks" do
+      let!(:generic_task) { FactoryBot.create(:generic_task, appeal: appeal, parent: root_task) }
+      let!(:tracking_task) { FactoryBot.create(:track_veteran_task, appeal: appeal, parent: root_task) }
+
+      it "should close the tracking task but not the generic task" do
+        expect { subject }.to_not raise_error
+        expect(tracking_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
+        expect(generic_task.reload.status).to_not eq(Constants.TASK_STATUSES.completed)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #7905. This PR adds code to close `TrackVeteranTask`s related to an appeal when that appeal is outcoded (and creates a method on `RootTask` that we can use to attach other events to if we'd like). This change limits the set of appeals that will show up in a VSO's "All cases" view now because we will be closing the tracking tasks. Additionally, it reduces the population of tasks that we will need to cancel when an appellant's representation changes (this code doesn't exist, but will be completed by part of #7905).