### PR TITLE
Adding `find_or_create_by_file_number_or_ssn`

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -197,7 +197,7 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number)
+    @veteran ||= Veteran.find_or_create_by_file_number_or_ssn(veteran_file_number)
   end
 
   def veteran_ssn

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -200,6 +200,15 @@ class Veteran < ApplicationRecord
       end
     end
 
+    def find_or_create_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
+      if file_number_or_ssn.to_s.length == 9
+        find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name) ||
+          find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name)
+      else
+        find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)
+      end
+    end
+
     private
 
     def find_by_ssn(ssn, sync_name: false)
@@ -207,6 +216,13 @@ class Veteran < ApplicationRecord
       return unless file_number
 
       find_and_maybe_backfill_name(file_number, sync_name: sync_name)
+    end
+
+    def find_or_create_by_ssn(ssn, sync_name: false)
+      file_number = BGSService.new.fetch_file_number_by_ssn(ssn)
+      return unless file_number
+
+      find_or_create_by_file_number(file_number, sync_name: sync_name)
     end
 
     def find_and_maybe_backfill_name(file_number, sync_name: false)

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -507,6 +507,78 @@ describe Veteran do
     end
   end
 
+  describe ".find_or_create_by_file_number_or_ssn" do
+    let(:file_number) { "123456789" }
+    let(:ssn) { file_number.to_s.reverse } # our fakes do this
+    let!(:veteran) { create(:veteran, file_number: file_number) }
+
+    it "fetches based on file_number" do
+      expect(described_class.find_or_create_by_file_number_or_ssn(file_number)).to eq(veteran)
+    end
+
+    it "fetches based on SSN" do
+      expect(described_class.find_or_create_by_file_number_or_ssn(ssn)).to eq(veteran)
+    end
+
+    context "does not exist in Caseflow" do
+      before do
+        veteran.destroy! # leaves it in BGS
+      end
+
+      it "returns a new Veteran by SSN" do
+        new_veteran = described_class.find_or_create_by_file_number_or_ssn(ssn)
+
+        expect(new_veteran.file_number).to eq(file_number)
+        expect(new_veteran.id).to_not eq(veteran.id)
+      end
+
+      it "returns a new Veteran by file number" do
+        new_veteran = described_class.find_or_create_by_file_number_or_ssn(file_number)
+
+        expect(new_veteran.ssn).to eq(ssn)
+        expect(new_veteran.id).to_not eq(veteran.id)
+      end
+    end
+
+    context "exists in BGS with different name than in Caseflow" do
+      before do
+        Fakes::BGSService.veteran_records[veteran.file_number][:last_name] = "Changed"
+      end
+
+      context "sync_name flag is true" do
+        let(:sync_name) { true }
+
+        it "updates Caseflow cache when found by file number" do
+          expect(described_class.find_by(file_number: file_number)[:last_name]).to eq "Smith"
+          expect(described_class.find_or_create_by_file_number_or_ssn(file_number, sync_name: sync_name)).to eq(veteran)
+          expect(veteran.reload.last_name).to eq "Changed"
+        end
+
+        it "updates Caseflow cache when found by SSN" do
+          expect(described_class.find_by(file_number: file_number)[:last_name]).to eq "Smith"
+          expect(described_class.find_or_create_by_file_number_or_ssn(ssn, sync_name: sync_name)).to eq(veteran)
+          expect(veteran.reload.last_name).to eq "Changed"
+        end
+      end
+
+      context "sync_name flag is false" do
+        let(:sync_name) { false }
+
+        it "does not update Caseflow cache when found by file number" do
+          expect(described_class.find_by(file_number: file_number)[:last_name]).to eq "Smith"
+          expect(described_class.find_or_create_by_file_number_or_ssn(file_number, sync_name: sync_name)).to eq(veteran)
+          expect(veteran.reload.last_name).to eq "Smith"
+        end
+
+        it "does not update Caseflow cache when found by SSN" do
+          expect(described_class.find_by(file_number: file_number)[:last_name]).to eq "Smith"
+          expect(described_class.find_or_create_by_file_number_or_ssn(ssn, sync_name: sync_name)).to eq(veteran)
+          expect(veteran.reload.last_name).to eq "Smith"
+        end
+      end
+    end
+  end
+
   describe "#stale_name?" do
     let(:first_name) { "Jane" }
     let(:last_name) { "Doe" }


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/appeals-support/issues/3997

### Description
Dispatch users are encountering 500's when they try to reference the veteran record for an appeal where the bfcorlid is a SSN, but the BGS record is referenced by a file number.

This PR updates the legacy_appeal's `veteran` method to find_or_create_by either file_number or ssn.

