### PR TITLE
Convert debmcom (comment) text to ASCII

### DIFF
--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -85,7 +85,8 @@ class QueueMapper
     convert_quality_to_vacols_code
     convert_one_touch_initiative_to_vacols_code
     convert_deficiencies_to_vacols_code
-    truncate_notes_at_350_characters
+    truncate_notes_at_350_characters_and_convert_to_ascii
+    truncate_comment_at_600_characters_and_convert_to_ascii
     add_modification_timestamp
   end
 
@@ -119,8 +120,12 @@ class QueueMapper
     end
   end
 
-  def truncate_notes_at_350_characters
+  def truncate_notes_at_350_characters_and_convert_to_ascii
     renamed_attributes[COLUMN_NAMES[:note]] = note[0..349].to_ascii if note
+  end
+
+  def truncate_comment_at_600_characters_and_convert_to_ascii
+    renamed_attributes[COLUMN_NAMES[:comment]] = comment[0..599].to_ascii if comment
   end
 
   def add_modification_timestamp
@@ -187,5 +192,9 @@ class QueueMapper
 
   def note
     decass_attrs[:note]
+  end
+
+  def comment
+    decass_attrs[:comment]
   end
 end

--- a/spec/mappers/queue_mapper_spec.rb
+++ b/spec/mappers/queue_mapper_spec.rb
@@ -95,13 +95,13 @@ describe QueueMapper do
       let(:info) do
         { work_product: "OMO - IME",
           overtime: true,
-          note: ("a" * 341) + "Véteran’s",
+          note: ("a" * 341) + "Véteran’s issue",
           reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
           document_id: "123456789.1234",
           modifying_user: "TESTSLOGID" }
       end
 
-      it "only converts all characters to ASCII" do
+      it "only keeps the first 350 characters and converts them to ASCII" do
         expect(subject[:deatcom]).to eq(("a" * 341) + "Veteran's")
       end
     end
@@ -117,6 +117,22 @@ describe QueueMapper do
 
       it "does not contain the deatcom key" do
         expect(subject.keys).to_not include :deatcom
+      end
+    end
+
+    context "when comment contains non-ASCII characters that make the length greater than 600" do
+      let(:info) do
+        { work_product: "OMO - IME",
+          overtime: true,
+          note: "test",
+          comment: ("a" * 575) + "“pleadings” and ‘motions” and",
+          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
+          document_id: "M1234567.1234",
+          modifying_user: "TESTSLOGID" }
+      end
+
+      it "only keeps the first 600 characters and converts them to ASCII" do
+        expect(subject[:debmcom]).to eq(("a" * 575) + "\"pleadings\" and 'motions\"")
       end
     end
 

--- a/spec/repositories/queue_repository_spec.rb
+++ b/spec/repositories/queue_repository_spec.rb
@@ -159,6 +159,18 @@ describe QueueRepository do
         expect(decass.reload.deatcom).to eq(("a" * 341) + "Veteran's")
       end
     end
+
+    context "when comment with multi-byte characters causes it to be greater than 600 characters" do
+      let(:decass_attrs) { { comment: ("a" * 575) + "“pleadings” and ‘motions”" } }
+      let(:date_added) { "2018-04-18".to_date }
+      let!(:decass) { create(:decass, defolder: vacols_case.bfkey, deadtim: date_added) }
+
+      it "converts multi-byte characters to ASCII (VACOLS Oracle DB is in ASCII format)" do
+        subject
+
+        expect(decass.reload.debmcom).to eq(("a" * 575) + "\"pleadings\" and 'motions\"")
+      end
+    end
   end
 
   context ".reassign_case_to_attorney!" do


### PR DESCRIPTION
**Why**: The DEBMCOM column in the Oracle DB is limited to 600
characters, and only supports ASCII characters. If a user types in a
comment that is 600 characters long, but contains multibyte characters,
it will end up being considered more than 600 characters long by the
Oracle DB.

**How**: Before saving the comment to VACOLS, truncate it to the first
600 characters, then convert them all to ASCII.

Resolves #8851

Acceptance Criteria: Entering a comment that's 600 characters long
and also contains multibyte characters, such as smart quotes (“”),
does not result in an exception.
