### PR TITLE
Add RequestIssues closed_at and closed_status

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -125,7 +125,7 @@ class Appeal < DecisionReview
   def eligible_request_issues
     # It's possible that two users create issues around the same time and the sequencer gets thrown off
     # (https://stackoverflow.com/questions/5818463/rails-created-at-timestamp-order-disagrees-with-id-order)
-    request_issues.select(&:eligible?).sort_by(&:id)
+    open_request_issues.select(&:eligible?).sort_by(&:id)
   end
 
   def issues

--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -42,7 +42,7 @@ module IssueUpdater
 
   def create_decision_issues!
     issues.each do |issue_attrs|
-      request_issues = appeal.request_issues.where(id: issue_attrs[:request_issue_ids])
+      request_issues = appeal.request_issues.open.where(id: issue_attrs[:request_issue_ids])
       next if request_issues.empty?
 
       decision_issue = DecisionIssue.create!(
@@ -118,7 +118,7 @@ module IssueUpdater
     fail_if_invalid_issues_attrs!
 
     (issues || []).each do |issue_attrs|
-      request_issue = appeal.request_issues.find_by(id: issue_attrs[:id]) if appeal
+      request_issue = appeal.request_issues.open.find_by(id: issue_attrs[:id]) if appeal
       next unless request_issue
 
       request_issue.update(disposition: issue_attrs[:disposition])

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -27,7 +27,7 @@ class ContestableIssue
         decision_issue_id: decision_issue.id,
         date: decision_issue.approx_decision_date,
         description: decision_issue.description,
-        source_request_issues: decision_issue.request_issues,
+        source_request_issues: decision_issue.request_issues.open,
         contesting_decision_review: contesting_decision_review
       )
     end

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -190,7 +190,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def active_nonrating_request_issues
-    @active_nonrating_request_issues ||= RequestIssue.nonrating.not_deleted
+    @active_nonrating_request_issues ||= RequestIssue.nonrating.not_closed
       .where(veteran_participant_id: veteran.participant_id)
       .where.not(id: request_issues.map(&:id))
       .select(&:status_active?)

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -196,6 +196,10 @@ class DecisionReview < ApplicationRecord
       .select(&:status_active?)
   end
 
+  def open_request_issues
+    request_issues.not_closed
+  end
+
   # do not confuse ui_hash with serializer. ui_hash for intake and intakeEdit. serializer for work queue.
   def serializer_class
     ::WorkQueue::DecisionReviewSerializer
@@ -210,10 +214,6 @@ class DecisionReview < ApplicationRecord
   end
 
   private
-
-  def open_request_issues
-    request_issues.not_closed
-  end
 
   def can_contest_rating_issues?
     fail Caseflow::Error::MustImplementInSubclass

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -100,7 +100,7 @@ class DecisionReview < ApplicationRecord
       legacyOptInApproved: legacy_opt_in_approved,
       legacyAppeals: serialized_legacy_appeals,
       ratings: serialized_ratings,
-      requestIssues: request_issues.map(&:ui_hash),
+      requestIssues: open_request_issues.map(&:ui_hash),
       decisionIssues: decision_issues.map(&:ui_hash),
       activeNonratingRequestIssues: active_nonrating_request_issues.map(&:ui_hash),
       contestableIssuesByDate: contestable_issues.map(&:serialize),
@@ -210,6 +210,10 @@ class DecisionReview < ApplicationRecord
   end
 
   private
+
+  def open_request_issues
+    request_issues.not_closed
+  end
 
   def can_contest_rating_issues?
     fail Caseflow::Error::MustImplementInSubclass

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -190,14 +190,14 @@ class DecisionReview < ApplicationRecord
   end
 
   def active_nonrating_request_issues
-    @active_nonrating_request_issues ||= RequestIssue.nonrating.not_closed
+    @active_nonrating_request_issues ||= RequestIssue.nonrating.open
       .where(veteran_participant_id: veteran.participant_id)
       .where.not(id: request_issues.map(&:id))
       .select(&:status_active?)
   end
 
   def open_request_issues
-    request_issues.not_closed
+    request_issues.open
   end
 
   # do not confuse ui_hash with serializer. ui_hash for intake and intakeEdit. serializer for work queue.

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -10,7 +10,7 @@ class DecisionReviewIntake < Intake
       legacy_opt_in_approved: detail.legacy_opt_in_approved,
       legacyAppeals: detail.serialized_legacy_appeals,
       ratings: detail.serialized_ratings,
-      requestIssues: detail.request_issues.map(&:ui_hash),
+      requestIssues: detail.request_issues.open.map(&:ui_hash),
       activeNonratingRequestIssues: detail.active_nonrating_request_issues.map(&:ui_hash),
       contestableIssuesByDate: detail.contestable_issues.map(&:serialize)
     )

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -336,8 +336,12 @@ class EndProductEstablishment < ApplicationRecord
     end
   end
 
+  def open_request_issues
+    request_issues.reject(&:closed?)
+  end
+
   def rating_request_issues
-    request_issues.select(&:rating?)
+    open_request_issues.select(&:rating?)
   end
 
   def unassociated_rating_request_issues
@@ -345,7 +349,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def eligible_request_issues
-    request_issues.select(&:eligible?)
+    open_request_issues.select(&:eligible?)
   end
 
   def eligible_rating_request_issues

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -131,6 +131,10 @@ class RequestIssue < ApplicationRecord
       where.not(review_request_id: nil)
     end
 
+    def not_closed
+      where(closed_at: nil)
+    end
+
     def unidentified
       where(
         contested_rating_issue_reference_id: nil,

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -136,7 +136,7 @@ class RequestIssue < ApplicationRecord
       where.not(review_request_id: nil)
     end
 
-    def not_closed
+    def open
       where(closed_at: nil)
     end
 

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -31,6 +31,7 @@ class RequestIssue < ApplicationRecord
   }
 
   enum closed_status: {
+    decided: "decided",
     removed: "removed"
   }
 

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -30,6 +30,10 @@ class RequestIssue < ApplicationRecord
     legacy_appeal_not_eligible: "legacy_appeal_not_eligible"
   }
 
+  enum closed_status: {
+    removed: "removed"
+  }
+
   # TEMPORARY CODE: used to keep decision_review and review_request in sync
   before_save :copy_review_request_to_decision_review
   before_save :set_contested_rating_issue_profile_date

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -76,7 +76,7 @@ class RequestIssuesUpdate < ApplicationRecord
   private
 
   def changes?
-    review.request_issues.count != @request_issues_data.count || !new_issues.empty?
+    review.request_issues.open.count != @request_issues_data.count || !new_issues.empty?
   end
 
   def new_issues
@@ -88,12 +88,12 @@ class RequestIssuesUpdate < ApplicationRecord
     before_issues
 
     @request_issues_data.map do |issue_data|
-      review.request_issues.find_or_build_from_intake_data(issue_data)
+      review.request_issues.open.find_or_build_from_intake_data(issue_data)
     end
   end
 
   def calculate_before_issues
-    review.request_issues.select(&:persisted?)
+    review.request_issues.open.select(&:persisted?)
   end
 
   def validate_before_perform

--- a/app/models/serializers/idt/v1/appeal_details_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_details_serializer.rb
@@ -85,7 +85,7 @@ class Idt::V1::AppealDetailsSerializer < ActiveModel::Serializer
         ).as_json[:data][:attributes]
       end
     else
-      object.request_issues.map do |issue|
+      object.request_issues.open.map do |issue|
         {
           id: issue.id,
           disposition: issue.disposition,

--- a/app/models/serializers/work_queue/beaam_serializer.rb
+++ b/app/models/serializers/work_queue/beaam_serializer.rb
@@ -50,6 +50,6 @@ class WorkQueue::BeaamSerializer < ActiveModel::Serializer
   end
 
   attribute :issue_count do
-    object.request_issues.count
+    object.request_issues.open.count
   end
 end

--- a/app/models/serializers/work_queue/decision_review_serializer.rb
+++ b/app/models/serializers/work_queue/decision_review_serializer.rb
@@ -1,6 +1,6 @@
 class WorkQueue::DecisionReviewSerializer < ActiveModel::Serializer
   attribute :issues do
-    object.request_issues.map do |issue|
+    object.request_issues.open.map do |issue|
       {
         id: issue.id,
         disposition: issue.disposition,

--- a/app/models/serializers/work_queue/decision_review_task_serializer.rb
+++ b/app/models/serializers/work_queue/decision_review_task_serializer.rb
@@ -33,7 +33,7 @@ class WorkQueue::DecisionReviewTaskSerializer < ActiveModel::Serializer
     {
       id: decision_review.external_id,
       isLegacyAppeal: false,
-      issueCount: decision_review.request_issues.count
+      issueCount: decision_review.open_request_issues.count
     }
   end
 

--- a/app/models/serializers/work_queue/veteran_record_request_serializer.rb
+++ b/app/models/serializers/work_queue/veteran_record_request_serializer.rb
@@ -33,7 +33,7 @@ class WorkQueue::VeteranRecordRequestSerializer < ActiveModel::Serializer
     {
       id: decision_review.external_id,
       isLegacyAppeal: false,
-      issueCount: decision_review.request_issues.count
+      issueCount: decision_review.open_request_issues.count
     }
   end
 

--- a/app/models/tasks/board_grant_effectuation_task.rb
+++ b/app/models/tasks/board_grant_effectuation_task.rb
@@ -18,7 +18,7 @@ class BoardGrantEffectuationTask < DecisionReviewTask
   private
 
   def request_issues_by_benefit_type
-    appeal.request_issues
+    appeal.request_issues.open
       .select { |issue| issue.benefit_type == business_line.url }
   end
 end

--- a/db/migrate/20190205195304_add_closed_at_to_request_issues.rb
+++ b/db/migrate/20190205195304_add_closed_at_to_request_issues.rb
@@ -4,7 +4,7 @@ class AddClosedAtToRequestIssues < ActiveRecord::Migration[5.1]
       add_column :request_issues, :closed_at, :datetime
       add_column :request_issues, :closed_status, :string
       now = Time.zone.now
-      execute "UPDATE request_issues SET closed_at = '#{now}', closed_status = 'removed' WHERE decision_review_id IS NULL"
+      execute "UPDATE request_issues SET closed_at = '#{now}', closed_status = 'removed' WHERE review_request_id IS NULL"
     end
   end
 

--- a/db/migrate/20190205195304_add_closed_at_to_request_issues.rb
+++ b/db/migrate/20190205195304_add_closed_at_to_request_issues.rb
@@ -1,0 +1,15 @@
+class AddClosedAtToRequestIssues < ActiveRecord::Migration[5.1]
+  def up
+    safety_assured do
+      add_column :request_issues, :closed_at, :datetime
+      add_column :request_issues, :closed_status, :string
+      now = Time.zone.now
+      execute "UPDATE request_issues SET closed_at = '#{now}', closed_status = 'removed' WHERE decision_review_id IS NULL"
+    end
+  end
+
+  def down
+    remove_column :request_issues, :closed_at
+    remove_column :request_issues, :closed_status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -758,6 +758,8 @@ ActiveRecord::Schema.define(version: 20190205201919) do
 
   create_table "request_issues", force: :cascade do |t|
     t.string "benefit_type", null: false
+    t.datetime "closed_at"
+    t.string "closed_status"
     t.integer "contention_reference_id"
     t.integer "contested_decision_issue_id"
     t.string "contested_issue_description"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -758,8 +758,6 @@ ActiveRecord::Schema.define(version: 20190205201919) do
 
   create_table "request_issues", force: :cascade do |t|
     t.string "benefit_type", null: false
-    t.datetime "closed_at"
-    t.string "closed_status"
     t.integer "contention_reference_id"
     t.integer "contested_decision_issue_id"
     t.string "contested_issue_description"

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -20,6 +20,11 @@ FactoryBot.define do
       nonrating_issue_description "nonrating issue description"
     end
 
+    trait :removed do
+      closed_at Time.zone.now
+      closed_status :removed
+    end
+
     trait :with_rating_decision_issue do
       transient do
         veteran_participant_id nil

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -889,7 +889,7 @@ feature "Higher Level Review Edit issues" do
       expect(nonrating_epe).to_not be_nil
 
       # expect the remove/re-add to create a new RequestIssue for same RatingIssue
-      expect(higher_level_review.reload.request_issues).to_not include(request_issue)
+      expect(higher_level_review.reload.open_request_issues).to_not include(request_issue)
 
       new_version_of_request_issue = higher_level_review.request_issues.find do |ri|
         ri.description == request_issue.description

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -996,10 +996,14 @@ feature "Higher Level Review Edit issues" do
       expect(page).to_not have_content("PTSD denied")
 
       # assert server has updated data
-      new_request_issue = higher_level_review.reload.request_issues.first
+      new_request_issue = higher_level_review.reload.open_request_issues.first
       expect(new_request_issue.description).to eq("Left knee granted")
-      expect(request_issue.reload.review_request_id).to be_nil
+      expect(request_issue.reload.review_request_id).to_not be_nil
+      expect(request_issue).to be_closed
       expect(request_issue.removed_at).to eq(Time.zone.now)
+      expect(request_issue.closed_at).to eq(Time.zone.now)
+      expect(request_issue.closed_status).to eq("removed")
+      expect(request_issue).to be_removed
       expect(new_request_issue.rating_issue_associated_at).to eq(Time.zone.now)
 
       # expect contentions to reflect issue update

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -495,10 +495,13 @@ feature "Supplemental Claim Edit issues" do
       expect(page).to_not have_content("PTSD denied")
 
       # assert server has updated data
-      new_request_issue = supplemental_claim.reload.request_issues.first
+      new_request_issue = supplemental_claim.reload.open_request_issues.first
       expect(new_request_issue.description).to eq("Left knee granted")
-      expect(request_issue.reload.review_request_id).to be_nil
+      expect(request_issue.reload.review_request).to_not be_nil
       expect(request_issue.removed_at).to eq(Time.zone.now)
+      expect(request_issue.closed_at).to eq(Time.zone.now)
+      expect(request_issue).to be_closed
+      expect(request_issue).to be_removed
       expect(new_request_issue.rating_issue_associated_at).to eq(Time.zone.now)
 
       # expect contentions to reflect issue update

--- a/spec/feature/queue/delete_request_issues_spec.rb
+++ b/spec/feature/queue/delete_request_issues_spec.rb
@@ -17,8 +17,9 @@ feature "correcting issues" do
       expect(page).to_not have_content "first request issue"
       expect(DecisionIssue.count).to eq 1
       expect(RequestDecisionIssue.count).to eq 1
-      expect(first_request_issue.reload.review_request_id).to be_nil
-      expect(first_request_issue.reload.review_request_type).to be_nil
+      expect(first_request_issue.reload.review_request).to_not be_nil
+      expect(first_request_issue).to be_closed
+      expect(first_request_issue).to be_removed
     end
   end
 
@@ -35,8 +36,9 @@ feature "correcting issues" do
       expect(page).to_not have_content "with many decision issues"
       expect(DecisionIssue.pluck(:id)).to eq [3]
       expect(RequestDecisionIssue.count).to eq 1
-      expect(request_issue.reload.review_request_id).to be_nil
-      expect(request_issue.reload.review_request_type).to be_nil
+      expect(request_issue.reload.review_request).to_not be_nil
+      expect(request_issue).to be_closed
+      expect(request_issue).to be_removed
     end
   end
 
@@ -57,8 +59,9 @@ feature "correcting issues" do
       expect(page).to_not have_content "with a shared decision issue"
       expect(DecisionIssue.pluck(:id)).to eq [1]
       expect(RequestDecisionIssue.count).to eq 1
-      expect(request_issue.reload.review_request_id).to be_nil
-      expect(request_issue.reload.review_request_type).to be_nil
+      expect(request_issue.reload.review_request).to_not be_nil
+      expect(request_issue).to be_closed
+      expect(request_issue).to be_removed
       expect(page).to_not have_content "Added to 2 issues"
       expect(page).to_not have_content "decision with id 2"
       expect(page).to have_content "decision with id 1"

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -151,6 +151,16 @@ describe RequestIssue do
     end
   end
 
+  context ".not_closed" do
+    subject { RequestIssue.not_closed }
+
+    let!(:closed_request_issue) { create(:request_issue, :removed) }
+
+    it "filters by whether the closed_at is nil" do
+      expect(subject.find_by(id: closed_request_issue.id)).to be_nil
+    end
+  end
+
   context ".find_active_by_contested_rating_issue_reference_id" do
     let(:active_rating_request_issue) do
       rating_request_issue.tap do |ri|

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -151,8 +151,8 @@ describe RequestIssue do
     end
   end
 
-  context ".not_closed" do
-    subject { RequestIssue.not_closed }
+  context ".open" do
+    subject { RequestIssue.open }
 
     let!(:closed_request_issue) { create(:request_issue, :removed) }
 

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -289,17 +289,17 @@ describe RequestIssuesUpdate do
           )
 
           removed_issue = RequestIssue.find_by(id: existing_legacy_opt_in_request_issue_id)
-          expect(removed_issue).to have_attributes(
-            review_request: nil
-          )
+          expect(removed_issue.review_request).to_not be_nil
           expect(removed_issue.removed_at).to_not be_nil
+          expect(removed_issue).to be_closed
+          expect(removed_issue).to be_removed
           expect(removed_issue.legacy_issue_optin.rollback_processed_at).to_not be_nil
 
           expect(Fakes::VBMSService).to have_received(:remove_contention!).with(request_issue_contentions.last)
 
-          new_map = rating_end_product_establishment.send(
+          new_map = rating_end_product_establishment.reload.send(
             :rating_issue_contention_map,
-            review.request_issues.reload
+            review.reload.open_request_issues
           )
 
           expect(Fakes::VBMSService).to have_received(:associate_rating_request_issues!).with(

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -545,10 +545,11 @@ module IntakeHelpers
 
     # check that decision_request_issue is closed
     updated_request_issue = RequestIssue.find_by(id: original_request_issue.id)
-    expect(updated_request_issue.review_request).to be_nil
+    expect(updated_request_issue.review_request).to_not be_nil
+    expect(updated_request_issue).to be_closed
 
     # check that new request issue is created contesting the decision issue
-    request_issues = review_request.reload.request_issues
+    request_issues = review_request.reload.open_request_issues
     first_request_issue = request_issues.find_by(contested_decision_issue_id: contested_decision_issues.first.id)
     second_request_issue = request_issues.find_by(contested_decision_issue_id: contested_decision_issues.second.id)
 


### PR DESCRIPTION
connects #9188 

### Description
Adds 2 new columns to track closed RequestIssues, instead of disassociating them from the `review_request`.