### PR TITLE
Add space before Digital Service in link at bottom of page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -190,7 +190,7 @@
     <div class="cf-app-width">
       <div class="cf-push-left">
         <span title="<%= build_date %>">Built</span> with <abbr title="love">&#9825;</abbr> by the
-        <a href="https://www.usds.gov/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>
+        <a href="https://www.usds.gov/"> Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>
       </div>
       <div class="cf-push-right">
         <a target="_blank" href="<%= feedback_url %>" onClick="ga('send', 'event', { eventCategory: 'Menu', eventAction: 'ClickFeedback', eventLabel: 'Feedback', eventValue: 1});">


### PR DESCRIPTION
Fixing this:

<img width="374" alt="screen shot 2019-02-05 at 3 07 30 pm" src="https://user-images.githubusercontent.com/6589610/52310319-d7260f00-2957-11e9-8135-56016b1945f6.png">

