### PR TITLE
Use .any? instead of .count > 0

### DIFF
--- a/app/services/add_series_id_to_documents_service.rb
+++ b/app/services/add_series_id_to_documents_service.rb
@@ -4,7 +4,7 @@ class AddSeriesIdToDocumentsService < ApplicationJob
   def self.add_series_ids(appeal)
     documents_to_check = Document.where(file_number: appeal.veteran_file_number).where(series_id: nil)
 
-    if documents_to_check.count > 0
+    if documents_to_check.load.any?
       document_series = VBMSService.fetch_document_series_for(appeal)
 
       version_to_series_hash = document_series.reduce({}) do |map, document_versions|

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -73,7 +73,7 @@ class DocumentFetcher
     previous_documents = Document.where(series_id: document.series_id).order(:id)
       .where.not(vbms_document_id: ids)
 
-    if previous_documents.count > 0
+    if previous_documents.any?
       document.copy_metadata_from_document(previous_documents.last)
     end
 


### PR DESCRIPTION
**Why**: `.count` performs a SQL `COUNT` query, which gets slower the
more rows there are in a table. One of the most frequent exceptions in
production, and the one that is affecting the most unique users, is a
Postgres statement timeout when attempting to count documents where the
`series_id` is NULL and where `vbms_document_id` is not in an array of
various IDs. Example:
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3411/

Based on the DB ID of the last Document in production, it looks like we
have over 34 million documents, and presumably there are enough of them
with a `nil` `series_id` that trying to count them takes longer than the
30 seconds we are allowing via the `statement_timeout` setting in
`database.yml`. As an aside, that value is very high. Global statement
timeouts should be set as low as possible, and increased only if
necessary for specific transactions.

The line of code that is causing this slow `COUNT` query is in
`document_fetcher.rb`, where the following queries are made:
```ruby
previous_documents = Document.where(series_id: document.series_id).
  order(:id).
  where.not(vbms_document_id: ids)

if previous_documents.count > 0
  document.copy_metadata_from_document(previous_documents.last)
end
```
Note that the only reason we were performing a count is to make sure the
first query returned at least one result. ActiveRecord provides more
efficient methods to determine if a query returned any results, such as
`.any?`. Instead of using `COUNT`, it will use `SELECT  1 AS one` with
a `LIMIT` of 1.

When only a subset of an `ActiveRecord::Relation` will be used, as in
`previous_documents.last` above, then `.any?` should be used. However,
if the code will iterate over the entire results, then either
`.load.any?` or `.present?` should be used, which is why I used
`.load.any?` in `add_series_id_to_documents_service.rb`.

In general `count` should be avoided unless we know for sure that we
want to run a SQL `COUNT` query. There are other occurrences of
`.count > 0` in this repo that I will clean up in a separate PR.

For more details, I highly recommend this excellent blog post by
Nate Berkopec, author of "The Complete Guide to Rails Performance":
https://www.speedshop.co/2019/01/10/three-activerecord-mistakes.html
