### PR TITLE
Use !empty? or .any? instead of .count > 0

### DIFF
--- a/app/models/dispatch/task.rb
+++ b/app/models/dispatch/task.rb
@@ -226,7 +226,7 @@ class Dispatch::Task < ApplicationRecord
   end
 
   def assign_user(user)
-    fail(UserAlreadyHasTaskError) if user.dispatch_tasks.to_complete.where(type: type).count > 0
+    fail(UserAlreadyHasTaskError) if user.dispatch_tasks.to_complete.where(type: type).any?
 
     assign_attributes(
       user: user,
@@ -262,7 +262,7 @@ class Dispatch::Task < ApplicationRecord
   end
 
   def no_open_tasks_for_appeal
-    if self.class.to_complete_task_for_appeal(appeal).count > 0
+    if self.class.to_complete_task_for_appeal(appeal).any?
       errors.add(:appeal, "Uncompleted task already exists for this appeal")
     end
   end

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -37,7 +37,7 @@ class HearingDay < ApplicationRecord
   end
 
   def confirm_no_children_records
-    fail HearingDayHasChildrenRecords if vacols_children_records.count > 0 || hearings.count > 0
+    fail HearingDayHasChildrenRecords if !vacols_children_records.empty? || !hearings.empty?
   end
 
   def vacols_children_records

--- a/app/models/judge.rb
+++ b/app/models/judge.rb
@@ -22,7 +22,7 @@ class Judge
   end
 
   def docket?(date)
-    upcoming_hearings_on(date).count > 0
+    !upcoming_hearings_on(date).empty?
   end
 
   def upcoming_hearings_on(date, is_fetching_issues = false)

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -646,7 +646,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def appeal_active?
-    review_request.tasks.where.not(status: Constants.TASK_STATUSES.completed).count > 0
+    review_request.tasks.where.not(status: Constants.TASK_STATUSES.completed).any?
   end
 
   def copy_review_request_to_decision_review


### PR DESCRIPTION
**Why**: When checking if an array contains elements, `!empty` (or
`size > 0`) is faster than `count > 0`. `count` should rarely be used in
a Rails application.

When checking if an ActiveRecord::Relation contains results, `.any?` is
preferred because it runs a `SELECT 1 AS one LIMIT 1` SQL query as
opposed to a `COUNT`, which can be very slow on a large table. In all
of the instances changed in this PR, we don't care about the actual
count of elements, so `count` is not the right choice.

Recommended reading:
https://www.speedshop.co/2019/01/10/three-activerecord-mistakes.html
