### PR TITLE
Add Lock Icon to Lock Hearing Schedule Day

### DIFF
--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -19,7 +19,7 @@ import StatusMessage from '../../components/StatusMessage';
 import { DISPOSITION_OPTIONS, TIME_OPTIONS } from '../../hearings/constants/constants';
 import { getTime, getTimeInDifferentTimeZone, getTimeWithoutTimeZone, formatDateStr } from '../../util/DateUtil';
 import DocketTypeBadge from '../../components/DocketTypeBadge';
-import { crossSymbolHtml, pencilSymbol } from '../../components/RenderFunctions';
+import { crossSymbolHtml, pencilSymbol, lockIcon } from '../../components/RenderFunctions';
 import {
   RegionalOfficeDropdown,
   HearingDateDropdown,
@@ -518,7 +518,10 @@ export default class DailyDocket extends React.Component {
           <Button
             linkStyling
             onClick={this.props.onDisplayLockModal} >
-            <span {...css({ marginRight: '5px' })}>
+            <span {...css({ position: 'absolute',
+              '& > svg > g > g': { fill: '#0071bc' } })}>{lockIcon()}</span>
+            <span {...css({ marginRight: '5px',
+              marginLeft: '16px' })}>
               {this.props.dailyDocket.lock ? 'Unlock Hearing Day' : 'Lock Hearing Day'}
             </span>
           </Button>&nbsp;&nbsp;


### PR DESCRIPTION
Resolves ##9164

### Description
This pr adds a lock icon to the daily docket.

### Acceptance Criteria
- [x] Verify the lock icon is located next to the Lock Hearing Day link.

### Testing Plan
1. Go to Daily Docket and verify if lock icon is next to  Lock Hearing Day link.

<img width="1234" alt="screen shot 2019-02-06 at 10 20 06 am" src="https://user-images.githubusercontent.com/23080951/52351470-d4c7c180-29f8-11e9-94fe-a653c6f116e3.png">
