### PR TITLE
Mark jobs before Oct 1 processed

### DIFF
--- a/db/migrate/20190206154117_mark_jobs_prior20181001_processed.rb
+++ b/db/migrate/20190206154117_mark_jobs_prior20181001_processed.rb
@@ -1,7 +1,9 @@
 class MarkJobsPrior20181001Processed < ActiveRecord::Migration[5.1]
   def up
-    [:higher_level_reviews, :supplemental_claims].each do |tbl|
-      execute "UPDATE #{tbl} SET establishment_processed_at=establishment_submitted_at WHERE establishment_attempted_at IS NULL AND establishment_submitted_at < '2018-10-01'"
+    safety_assured do
+      [:higher_level_reviews, :supplemental_claims].each do |tbl|
+        execute "UPDATE #{tbl} SET establishment_processed_at=establishment_submitted_at WHERE establishment_attempted_at IS NULL AND establishment_submitted_at < '2018-10-01'"
+      end
     end
   end
 

--- a/db/migrate/20190206154117_mark_jobs_prior20181001_processed.rb
+++ b/db/migrate/20190206154117_mark_jobs_prior20181001_processed.rb
@@ -1,0 +1,10 @@
+class MarkJobsPrior20181001Processed < ActiveRecord::Migration[5.1]
+  def up
+    [:higher_level_reviews, :supplemental_claims].each do |tbl|
+      execute "UPDATE #{tbl} SET establishment_processed_at=establishment_submitted_at WHERE establishment_attempted_at IS NULL AND establishment_submitted_at < '2018-10-01'"
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190205201919) do
+ActiveRecord::Schema.define(version: 20190206154117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Should only really affect UAT since the related tables are not in active use in production yet.

Should reduce the noise on the /jobs page.