### PR TITLE
Add route, controller and service for TableauServer logins

### DIFF
--- a/app/controllers/tableau_logins_controller.rb
+++ b/app/controllers/tableau_logins_controller.rb
@@ -1,8 +1,7 @@
 class TableauLoginsController < ApplicationController
-
   def login
     token = ExternalApi::TableauService.authenticate(current_user.username)
-    redirect_to "/unauthorized" and return if token == ExternalApi::TableauService::ERROR_CODE.to_s
+    redirect_to("/unauthorized") && return if token == ExternalApi::TableauService::ERROR_CODE.to_s
     redirect_to "https://bva-tableau.va.gov/trusted/#{token}/#{params[:path]}"
   rescue StandardError
     render "errors/500", layout: "application", status: :service_unavailable

--- a/app/controllers/tableau_logins_controller.rb
+++ b/app/controllers/tableau_logins_controller.rb
@@ -1,0 +1,10 @@
+class TableauLoginsController < ApplicationController
+
+  def login
+    token = ExternalApi::TableauService.authenticate(current_user.username)
+    redirect_to "/unauthorized" and return if token == ExternalApi::TableauService::ERROR_CODE.to_s
+    redirect_to "https://bva-tableau.va.gov/trusted/#{token}/#{params[:path]}"
+  rescue StandardError
+    render "errors/500", layout: "application", status: :service_unavailable
+  end
+end

--- a/app/services/external_api/tableau_service.rb
+++ b/app/services/external_api/tableau_service.rb
@@ -1,0 +1,11 @@
+class ExternalApi::TableauService
+  ERROR_CODE = -1
+
+  def self.authenticate(username)
+    uri = URI("http://i.bva-tableau.va.gov:81/trusted")
+    http = Net::HTTP.new(uri.host, uri.port)
+    req = Net::HTTP::Post.new(uri.path)
+    req.body = "username=#{username}"
+    http.request(req).body
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,7 @@ Rails.application.routes.draw do
 
   get "styleguide", to: "styleguide#show"
 
+  get "tableau-login", to: "tableau_logins#login"
 
   mount PdfjsViewer::Rails::Engine => "/pdfjs", as: 'pdfjs'
 


### PR DESCRIPTION
Resolves #9183 

### Testing Plan
This should be tested on prod instance 
1. Go to appeals.cf.ds.va.gov/tableau-login/
and after you login to CSS, make sure you are logged into Tableau
2. Go to appeals.cf.ds.va.gov/tableau-login/?path=someview
and make sure you see the view 



