### PR TITLE
Filter away DTA Error on Supplemental Claim disposition choices

### DIFF
--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -29,7 +29,11 @@ class NonCompDecisionIssue extends React.PureComponent {
   }
 
   dispositionOptions = () => {
-    return DISPOSITION_OPTIONS.map((code) => {
+    const isSupplementalClaim = this.props.issue.review_request_title === 'Supplemental Claim';
+
+    return DISPOSITION_OPTIONS.filter((code) => {
+      return !isSupplementalClaim || code !== 'DTA Error';
+    }).map((code) => {
       return {
         value: code,
         label: code

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -83,9 +83,11 @@ feature "NonComp Dispositions Task Page" do
 
         expect(page).to have_content("National Cemetery Association")
 
-        fill_in_disposition(1, "DTA Error", "test description")
+        expect do
+          click_dropdown name: "disposition-issue-1", text: "DTA Error", wait: 1
+        end.to raise_error(Capybara::ElementNotFound)
 
-        expect(page).to have_content("Not an option")
+        expect(page).to_not have_content("DTA Error")
       end
     end
 
@@ -96,7 +98,7 @@ feature "NonComp Dispositions Task Page" do
       expect(page).to have_content("Decision")
       expect(page).to have_content(veteran.name)
       expect(page).to have_content(
-        "Prior decision date: #{hlr.request_issues[0].decision_date.strftime('%m/%d/%Y')}"
+        "Prior decision date: #{decision_review.request_issues[0].decision_date.strftime('%m/%d/%Y')}"
       )
       expect(page).to have_content(Constants.INTAKE_FORM_NAMES.higher_level_review)
     end
@@ -129,11 +131,11 @@ feature "NonComp Dispositions Task Page" do
       expect(page).to have_content(veteran.participant_id)
 
       # verify database updated
-      hlr.decision_issues.reload
-      expect(hlr.decision_issues.length).to eq(3)
-      expect(hlr.decision_issues.find_by(disposition: "Granted", description: nil)).to_not be_nil
-      expect(hlr.decision_issues.find_by(disposition: "DTA Error", description: "test description")).to_not be_nil
-      expect(hlr.decision_issues.find_by(disposition: "Denied", description: "denied")).to_not be_nil
+      dissues = decision_review.reload.decision_issues
+      expect(dissues.length).to eq(3)
+      expect(dissues.find_by(disposition: "Granted", description: nil)).to_not be_nil
+      expect(dissues.find_by(disposition: "DTA Error", description: "test description")).to_not be_nil
+      expect(dissues.find_by(disposition: "Denied", description: "denied")).to_not be_nil
 
       # verify that going to the completed task does not allow edits
       click_link veteran.name
@@ -181,7 +183,7 @@ feature "NonComp Dispositions Task Page" do
         visit dispositions_url
         click_on "Edit Issues"
 
-        expect(page).to have_current_path(hlr.reload.caseflow_only_edit_issues_url)
+        expect(page).to have_current_path(decision_review.reload.caseflow_only_edit_issues_url)
       end
     end
   end


### PR DESCRIPTION
connects #9247 

### Description
The Supplemental Claim type should not offer the disposition choice of DTA Error.