### PR TITLE
Remove closed end product status

### DIFF
--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -7,11 +7,10 @@ class EndProduct
     "PEND" => "Pending",
     "CLR" => "Cleared",
     "CAN" => "Canceled",
-    "CLD" => "Closed",
     "RW" => "Ready to work"
   }.freeze
 
-  INACTIVE_STATUSES = %w[CAN CLR CLD].freeze
+  INACTIVE_STATUSES = %w[CAN CLR].freeze
 
   RAMP_CODES = {
     "682HLRRRAMP" => "Higher-Level Review Rating",

--- a/client/constants/EP_STATUSES.json
+++ b/client/constants/EP_STATUSES.json
@@ -1,6 +1,5 @@
 {
   "CLR": "Cleared",
-  "CLD": "Closed",
   "RW": "Ready to work",
   "PEND": "Pending",
   "CAN": "Cancelled",

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -125,14 +125,6 @@ RSpec.feature "Search" do
                   :end_product_establishment,
                   source: higher_level_review,
                   veteran_file_number: appeal.veteran_file_number,
-                  synced_status: "CLD"
-                )
-              end
-              let!(:end_product_establishment_5) do
-                create(
-                  :end_product_establishment,
-                  source: higher_level_review,
-                  veteran_file_number: appeal.veteran_file_number,
                   synced_status: "RW"
                 )
               end
@@ -144,7 +136,6 @@ RSpec.feature "Search" do
                   )
                   expect(find(".cf-other-reviews-table > tbody")).to_not have_content("Canceled")
                   expect(find(".cf-other-reviews-table > tbody")).to_not have_content("Cleared")
-                  expect(find(".cf-other-reviews-table > tbody")).to_not have_content("Closed")
                   expect(find(".cf-other-reviews-table > tbody")).to_not have_content("Ready to work")
                 end
               end
@@ -169,14 +160,12 @@ RSpec.feature "Search" do
                   end_product_establishment_2.commit!
                   end_product_establishment_3.commit!
                   end_product_establishment_4.commit!
-                  end_product_establishment_5.commit!
                   higher_level_review.establish!
                 end
 
                 it "shows the end product status" do
                   expect(find(".cf-other-reviews-table > tbody")).to have_content("Canceled")
                   expect(find(".cf-other-reviews-table > tbody")).to have_content("Cleared")
-                  expect(find(".cf-other-reviews-table > tbody")).to have_content("Closed")
                   expect(find(".cf-other-reviews-table > tbody")).to have_content("Ready to work")
                 end
 


### PR DESCRIPTION
connects #9086

It turns out the "CLD" status in VBMS means "Cleared", and that "Closed" is not a real status.