### PR TITLE
Include issues submitted in future in submitted but not submitted_and…

### DIFF
--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -131,6 +131,10 @@ module Asyncable
   end
 
   def submitted?
+    !!self[self.class.submitted_at_column]
+  end
+
+  def submitted_and_ready?
     !!self[self.class.submitted_at_column] && self[self.class.submitted_at_column] <= Time.zone.now
   end
 

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -42,7 +42,7 @@ class DecisionDocument < ApplicationRecord
   def process!
     return if processed?
 
-    fail NotYetSubmitted unless submitted?
+    fail NotYetSubmitted unless submitted_and_ready?
 
     attempted!
     upload_to_vbms!

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -334,7 +334,7 @@ class RequestIssue < ApplicationRecord
   def sync_decision_issues!
     return if processed?
 
-    fail NotYetSubmitted unless submitted?
+    fail NotYetSubmitted unless submitted_and_ready?
 
     attempted!
 

--- a/spec/models/decision_document_spec.rb
+++ b/spec/models/decision_document_spec.rb
@@ -1,4 +1,3 @@
-require "rails_helper"
 require "support/intake_helpers"
 
 describe DecisionDocument do
@@ -117,7 +116,8 @@ describe DecisionDocument do
         expect(board_grant_effectuation.decision_sync_submitted_at).to eq(Time.zone.now + 1.day)
 
         # because we set delay, neither "submitted" nor queued.
-        expect(board_grant_effectuation).to_not be_submitted
+        expect(board_grant_effectuation).to be_submitted
+        expect(board_grant_effectuation).to_not be_submitted_and_ready
         expect(DecisionIssueSyncJob).to_not have_been_enqueued.with(board_grant_effectuation)
       end
     end
@@ -127,7 +127,7 @@ describe DecisionDocument do
     subject { decision_document.process! }
 
     before do
-      allow(decision_document).to receive(:submitted?).and_return(true)
+      allow(decision_document).to receive(:submitted_and_ready?).and_return(true)
       allow(VBMSService).to receive(:upload_document_to_vbms).and_call_original
       allow(VBMSService).to receive(:establish_claim!).and_call_original
       allow(VBMSService).to receive(:create_contentions!).and_call_original

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -909,7 +909,7 @@ describe EndProductEstablishment do
                 :request_issue,
                 review_request: epe.source,
                 end_product_establishment: epe,
-                decision_sync_submitted_at: Time.zone.now
+                decision_sync_submitted_at: Time.zone.now + 1.second
               )
             end
 

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -103,7 +103,8 @@ describe RequestIssue do
     end
 
     it "respects the delay" do
-      expect(rating_request_issue.submitted?).to eq(false)
+      expect(rating_request_issue.submitted_and_ready?).to eq(false)
+      expect(rating_request_issue.submitted?).to eq(true)
       expect(nonrating_request_issue.submitted?).to eq(true)
 
       todo = RequestIssue.requires_processing


### PR DESCRIPTION
Connects #9064

Show issues that have been submitted, even if they aren't to be processed until the future, in the list of submitted issues.