### PR TITLE
Temporarily disable hearing badge

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -64,6 +64,7 @@ class AppealsController < ApplicationController
     }
   end
 
+  # :nocov:
   def hearings
     most_recently_held_hearing = appeal.hearings
       .select { |hearing| hearing.disposition.to_s == Constants.HEARING_DISPOSITION_TYPES.held }
@@ -83,6 +84,7 @@ class AppealsController < ApplicationController
         {}
       end
   end
+  # :nocov:
 
   # For legacy appeals, veteran address and birth/death dates are
   # the only data that is being pulled from BGS, the rest are from VACOLS for now

--- a/client/app/queue/AssignedCasesPage.jsx
+++ b/client/app/queue/AssignedCasesPage.jsx
@@ -84,7 +84,6 @@ class AssignedCasesPage extends React.Component<Props> {
         onTaskAssignment={(params) => props.reassignTasksToUser(params)}
         selectedTasks={selectedTasks} />
       <TaskTable
-        includeHearingBadge
         includeSelect
         includeDetailsLink
         includeType

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -163,7 +163,6 @@ export default (connect(mapStateToProps, mapDispatchToProps)(AttorneyTaskListVie
 const TaskTableTab = ({ description, tasks }) => <React.Fragment>
   <p className="cf-margin-top-0" >{description}</p>
   <TaskTable
-    includeHearingBadge
     includeDetailsLink
     includeType
     includeDocketNumber

--- a/client/app/queue/BeaamAppealListView.jsx
+++ b/client/app/queue/BeaamAppealListView.jsx
@@ -23,7 +23,6 @@ class BeaamListView extends React.PureComponent {
           {messages.error.detail}
         </Alert>}
         <TaskTable
-          includeHearingBadge
           includeDetailsLink
           includeType
           includeDocketNumber

--- a/client/app/queue/CaseListTable.jsx
+++ b/client/app/queue/CaseListTable.jsx
@@ -1,13 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import _ from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { css } from 'glamor';
 
 import CaseDetailsLink from './CaseDetailsLink';
 import DocketTypeBadge from '../components/DocketTypeBadge';
-import HearingBadge from './components/HearingBadge';
 import Table from '../components/Table';
 import { COLORS } from '../constants/AppConstants';
 import { clearCaseListSearch } from './CaseList/CaseListActions';
@@ -15,7 +13,6 @@ import { clearCaseListSearch } from './CaseList/CaseListActions';
 import { DateString } from '../util/DateUtil';
 import { renderAppealType } from './utils';
 import COPY from '../../COPY.json';
-import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES.json';
 
 const currentAssigneeStyling = css({
   color: COLORS.GREEN
@@ -77,27 +74,6 @@ class CaseListTable extends React.PureComponent {
         valueFunction: (appeal) => labelForLocation(appeal.locationCode, this.props.userCssId)
       }
     ];
-
-    const doAnyAppealsHaveHeldHearings = Boolean(
-      _.find(this.props.appeals, (appeal) => {
-        return appeal.hearings.
-          filter((hearing) => hearing.disposition === HEARING_DISPOSITION_TYPES.held).
-          length;
-      }));
-
-    if (doAnyAppealsHaveHeldHearings) {
-      const hearingColumn = {
-        valueFunction: (appeal) => {
-          const hearings = appeal.hearings.
-            filter((hearing) => hearing.disposition === HEARING_DISPOSITION_TYPES.held).
-            sort((h1, h2) => h1.date < h2.date ? 1 : -1);
-
-          return <HearingBadge hearing={hearings[0]} />;
-        }
-      };
-
-      columns.unshift(hearingColumn);
-    }
 
     return columns;
   }

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -119,7 +119,6 @@ const NewTasksTab = connect(
     return <React.Fragment>
       <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION}</p>
       <TaskTable
-        includeHearingBadge
         includeDetailsLink
         includeTask
         includeRegionalOffice={props.belongsToHearingSchedule}
@@ -141,7 +140,6 @@ const PendingTasksTab = connect(
     return <React.Fragment>
       <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION}</p>
       <TaskTable
-        includeHearingBadge
         includeDetailsLink
         includeTask
         includeRegionalOffice={props.belongsToHearingSchedule}
@@ -163,7 +161,6 @@ const OnHoldTasksTab = connect(
     return <React.Fragment>
       <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
       <TaskTable
-        includeHearingBadge
         includeDetailsLink
         includeTask
         includeRegionalOffice={props.belongsToHearingSchedule}

--- a/client/app/queue/JudgeDecisionReviewTaskListView.jsx
+++ b/client/app/queue/JudgeDecisionReviewTaskListView.jsx
@@ -54,7 +54,6 @@ class JudgeDecisionReviewTaskListView extends React.PureComponent {
       </p>;
     } else {
       tableContent = <TaskTable
-        includeHearingBadge
         includeTask
         includeDetailsLink
         includeDocumentId

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -132,7 +132,6 @@ export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
   <TaskTable
-    includeHearingBadge
     includeDetailsLink
     includeTask
     includeRegionalOffice={organizationName === 'Hearings Management'}
@@ -147,7 +146,6 @@ const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <Re
 const TaskTableWithUserColumnTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
   <TaskTable
-    includeHearingBadge
     includeDetailsLink
     includeTask
     includeRegionalOffice={organizationName === 'Hearings Management'}

--- a/client/app/queue/UnassignedCasesPage.jsx
+++ b/client/app/queue/UnassignedCasesPage.jsx
@@ -72,7 +72,6 @@ class UnassignedCasesPage extends React.PureComponent<Props> {
           }
           {!this.props.distributionCompleteCasesLoading &&
             <TaskTable
-              includeHearingBadge
               includeSelect
               includeDetailsLink
               includeType

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -148,16 +148,15 @@ describe('ColocatedTaskListView', () => {
 
       const cells = wrapper.find('td');
 
-      expect(cells).to.have.length(7);
+      expect(cells).to.have.length(6);
       const wrappers = [];
 
       for (let i = 0; i < cells.length; i++) {
         wrappers.push(cells.at(i));
       }
-      const [hearings, caseDetails, columnTasks, types, docketNumber, daysWaiting, documents] = wrappers;
+      const [caseDetails, columnTasks, types, docketNumber, daysWaiting, documents] = wrappers;
       const task = taskNewAssigned;
 
-      expect(hearings.text()).to.include('');
       expect(caseDetails.text()).to.include(appeal.veteranFullName);
       expect(caseDetails.text()).to.include(appeal.veteranFullName);
       expect(caseDetails.text()).to.include(appeal.veteranFileNumber);
@@ -228,14 +227,14 @@ describe('ColocatedTaskListView', () => {
 
       const cells = wrapper.find('td');
 
-      expect(cells).to.have.length(7);
+      expect(cells).to.have.length(6);
       const wrappers = [];
 
       for (let i = 0; i < cells.length; i++) {
         wrappers.push(cells.at(i));
       }
       {
-        const [daysOnHold, documents] = wrappers.slice(5);
+        const [daysOnHold, documents] = wrappers.slice(4);
 
         expect(daysOnHold.text()).to.equal('1 of 30');
         expect(documents.html()).to.include(`/reader/appeal/${taskWithNewDocs.externalAppealId}/documents`);
@@ -300,15 +299,14 @@ describe('ColocatedTaskListView', () => {
 
       const cells = wrapper.find('td');
 
-      expect(cells).to.have.length(7);
+      expect(cells).to.have.length(6);
       const wrappers = [];
 
       for (let i = 0; i < cells.length; i++) {
         wrappers.push(cells.at(i));
       }
-      const [hearings, caseDetails, columnTasks, types, docketNumber, daysOnHold, documents] = wrappers;
+      const [caseDetails, columnTasks, types, docketNumber, daysOnHold, documents] = wrappers;
 
-      expect(hearings.text()).to.include('');
       expect(caseDetails.text()).to.include(appeal.veteranFullName);
       expect(caseDetails.text()).to.include(appeal.veteranFileNumber);
       expect(columnTasks.text()).to.include(CO_LOCATED_ADMIN_ACTIONS[task.label]);

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -191,61 +191,61 @@ RSpec.feature "Search" do
       end
     end
 
-    context "queue case search for appeals that have hearings" do
-      context "a case in the search view has a hearing" do
-        let!(:today) { Time.zone.today }
-        let!(:hearings) do
-          [
-            create(:case_hearing, :disposition_held, hearing_date: today - 4.days),
-            create(:case_hearing, :disposition_no_show, hearing_date: today - 3.days),
-            create(:case_hearing, :disposition_postponed, hearing_date: today - 2.days)
-          ]
-        end
+    # context "queue case search for appeals that have hearings" do
+    #   context "a case in the search view has a hearing" do
+    #     let!(:today) { Time.zone.today }
+    #     let!(:hearings) do
+    #       [
+    #         create(:case_hearing, :disposition_held, hearing_date: today - 4.days),
+    #         create(:case_hearing, :disposition_no_show, hearing_date: today - 3.days),
+    #         create(:case_hearing, :disposition_postponed, hearing_date: today - 2.days)
+    #       ]
+    #     end
 
-        let!(:appeal_with_hearing) do
-          FactoryBot.create(
-            :legacy_appeal,
-            :with_veteran,
-            vacols_case: FactoryBot.create(
-              :case,
-              case_hearings: hearings
-            )
-          )
-        end
+    #     let!(:appeal_with_hearing) do
+    #       FactoryBot.create(
+    #         :legacy_appeal,
+    #         :with_veteran,
+    #         vacols_case: FactoryBot.create(
+    #           :case,
+    #           case_hearings: hearings
+    #         )
+    #       )
+    #     end
 
-        before do
-          visit "/search"
-          fill_in "searchBarEmptyList", with: appeal_with_hearing.sanitized_vbms_id
-          click_on "Search"
-        end
+    #     before do
+    #       visit "/search"
+    #       fill_in "searchBarEmptyList", with: appeal_with_hearing.sanitized_vbms_id
+    #       click_on "Search"
+    #     end
 
-        it "table row displays a badge if a case has a hearing" do
-          expect(page).to have_selector(".cf-hearing-badge")
-          expect(find(".cf-hearing-badge")).to have_content("H")
-        end
+    #     it "table row displays a badge if a case has a hearing" do
+    #       expect(page).to have_selector(".cf-hearing-badge")
+    #       expect(find(".cf-hearing-badge")).to have_content("H")
+    #     end
 
-        it "shows information for the most recently held hearing" do
-          expect(page).to have_css(
-            ".__react_component_tooltip div ul li:nth-child(3) strong span",
-            visible: :hidden,
-            text: 4.days.ago.strftime("%m/%d/%y")
-          )
-        end
-      end
+    #     it "shows information for the most recently held hearing" do
+    #       expect(page).to have_css(
+    #         ".__react_component_tooltip div ul li:nth-child(3) strong span",
+    #         visible: :hidden,
+    #         text: 4.days.ago.strftime("%m/%d/%y")
+    #       )
+    #     end
+    #   end
 
-      context "no cases in the search view have hearings" do
-        before do
-          visit "/search"
-          fill_in "searchBarEmptyList", with: appeal.sanitized_vbms_id
-          click_on "Search"
-        end
+    #   context "no cases in the search view have hearings" do
+    #     before do
+    #       visit "/search"
+    #       fill_in "searchBarEmptyList", with: appeal.sanitized_vbms_id
+    #       click_on "Search"
+    #     end
 
-        it "table does not display a column for a badge if no cases have hearings" do
-          docket_column_header = find("table.cf-case-list-table > thead > tr > th:first-child > span")
-          expect(docket_column_header).to have_content(COPY::CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE)
-        end
-      end
-    end
+    #     it "table does not display a column for a badge if no cases have hearings" do
+    #       docket_column_header = find("table.cf-case-list-table > thead > tr > th:first-child > span")
+    #       expect(docket_column_header).to have_content(COPY::CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE)
+    #     end
+    #   end
+    # end
 
     context "when no appeals found" do
       before do

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -52,39 +52,39 @@ RSpec.feature "Task queue" do
       expect(find("tbody").find_all("tr").length).to eq(vacols_tasks.length)
     end
 
-    context "hearings" do
-      context "if a task has a hearing" do
-        let!(:attorney_task_with_hearing) do
-          FactoryBot.create(
-            :ama_attorney_task,
-            :in_progress,
-            assigned_to: attorney_user
-          )
-        end
+    # context "hearings" do
+    #   context "if a task has a hearing" do
+    #     let!(:attorney_task_with_hearing) do
+    #       FactoryBot.create(
+    #         :ama_attorney_task,
+    #         :in_progress,
+    #         assigned_to: attorney_user
+    #       )
+    #     end
 
-        let!(:hearing) { create(:hearing, appeal: attorney_task_with_hearing.appeal, disposition: "held") }
+    #     let!(:hearing) { create(:hearing, appeal: attorney_task_with_hearing.appeal, disposition: "held") }
 
-        before do
-          visit "/queue"
-        end
+    #     before do
+    #       visit "/queue"
+    #     end
 
-        it "shows the hearing badge" do
-          expect(page).to have_selector(".cf-hearing-badge")
-          expect(find(".cf-hearing-badge")).to have_content("H")
-        end
-      end
+    #     it "shows the hearing badge" do
+    #       expect(page).to have_selector(".cf-hearing-badge")
+    #       expect(find(".cf-hearing-badge")).to have_content("H")
+    #     end
+    #   end
 
-      context "if no tasks have hearings" do
-        it "does not show the hearing badge" do
-          expect(page).not_to have_selector(".cf-hearing-badge")
-        end
-      end
-    end
+    #   context "if no tasks have hearings" do
+    #     it "does not show the hearing badge" do
+    #       expect(page).not_to have_selector(".cf-hearing-badge")
+    #     end
+    #   end
+    # end
 
     it "supports custom sorting" do
-      docket_number_column_header = page.find(:xpath, "//thead/tr/th[3]/span/span[1]")
+      docket_number_column_header = page.find(:xpath, "//thead/tr/th[2]/span/span[1]")
       docket_number_column_header.click
-      docket_number_column_vals = page.find_all(:xpath, "//tbody/tr/td[4]/span[3]")
+      docket_number_column_vals = page.find_all(:xpath, "//tbody/tr/td[3]/span[3]")
       expect(docket_number_column_vals.map(&:text)).to eq vacols_tasks.map(&:docket_number).sort.reverse
       docket_number_column_header.click
       expect(docket_number_column_vals.map(&:text)).to eq vacols_tasks.map(&:docket_number).sort.reverse


### PR DESCRIPTION
Disables the hearing badge on queue tables until we can resolve the bugs we are seeing where appeal IDs are not defined (https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2991/).