### PR TITLE
Add URL to BVA dispatch organization

### DIFF
--- a/app/models/organizations/bva_dispatch.rb
+++ b/app/models/organizations/bva_dispatch.rb
@@ -1,6 +1,6 @@
 class BvaDispatch < Organization
   def self.singleton
-    BvaDispatch.first || BvaDispatch.create(name: "Board Dispatch")
+    BvaDispatch.first || BvaDispatch.create(name: "Board Dispatch", url: "board-dispatch")
   end
 
   def next_assignee(options = {})


### PR DESCRIPTION
Resolves #8694.

Ran the following in production to update the row in the production database and give the Board Dispatch team an org queue.

```ruby
  rails c> org = BvaDispatch.singleton
  rails c> org.update!(url: "board-dispatch")
```