### PR TITLE
Include URL when creating JudgeTeams

### DIFF
--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -4,7 +4,7 @@ class JudgeTeam < Organization
   end
 
   def self.create_for_judge(user)
-    create!(name: user.css_id).tap do |org|
+    create!(name: user.css_id, url: user.css_id.downcase).tap do |org|
       OrganizationsUser.make_user_admin(user, org)
     end
   end

--- a/spec/models/judge_team_spec.rb
+++ b/spec/models/judge_team_spec.rb
@@ -12,6 +12,7 @@ describe JudgeTeam do
         expect(judge.organizations.length).to eq(1)
         expect(judge.administered_teams.length).to eq(1)
         expect(judge.administered_teams.first.class).to eq(JudgeTeam)
+        expect(judge.administered_teams.first.url).to eq(judge.css_id.downcase)
       end
     end
   end


### PR DESCRIPTION
All of our existing `JudgeTeam`s have URLs that are the lowercased versions of their CSS IDs. This PR includes that logic in the method to create `JudgeTeam`s.