### PR TITLE
Add check for nil

### DIFF
--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -69,12 +69,14 @@ class DocumentFetcher
   def create_new_document!(document, ids)
     document.save!
 
-    # Find the most recent saved document with the given series_id that is not in the list of ids passed.
-    previous_documents = Document.where(series_id: document.series_id).order(:id)
-      .where.not(vbms_document_id: ids)
+    if document.series_id
+      # Find the most recent saved document with the given series_id that is not in the list of ids passed.
+      previous_documents = Document.where(series_id: document.series_id).order(:id)
+        .where.not(vbms_document_id: ids)
 
-    if previous_documents.any?
-      document.copy_metadata_from_document(previous_documents.last)
+      if previous_documents.any?
+        document.copy_metadata_from_document(previous_documents.last)
+      end
     end
 
     document

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -141,6 +141,42 @@ describe DocumentFetcher do
       end
     end
 
+    context "when the series id is nil" do
+      let(:series_id) { nil }
+      let!(:saved_documents) do
+        [
+          Generators::Document.create(type: "Form 9", series_id: series_id, category_procedural: true),
+          Generators::Document.create(type: "NOD", series_id: series_id, category_medical: true)
+        ]
+      end
+      let(:older_comment) { "OLD_TEST_COMMENT" }
+      let(:comment) { "TEST_COMMENT" }
+      let!(:existing_annotations) do
+        [
+          Generators::Annotation.create(
+            comment: older_comment,
+            x: 1,
+            y: 2,
+            document_id: saved_documents[0].id
+          ),
+          Generators::Annotation.create(
+            comment: comment,
+            x: 1,
+            y: 2,
+            document_id: saved_documents[1].id
+          )
+        ]
+      end
+
+      it "doesn't copy metadata" do
+        expect(Document.count).to eq(2)
+        expect(Document.first.type).to eq(saved_documents[0].type)
+
+        returned_documents = document_service.find_or_create_documents!
+        expect(returned_documents.first.reload.annotations.count).to eq(0)
+      end
+    end
+
     context "when there are documents with same series_id" do
       let!(:saved_documents) do
         [


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/appeals-support/issues/4083

VBMS has two ids for each document. A series_id and a version_id. Multiple document versions can belong to the same series, but each version gets its own version. When VBMS made this change we created a method to copy over metadata (like comments) from old versions of the documents to the new versions since we didn't want people to loose their comments/tags/etc. However, it seems like a lot of documents now have a series_id of null. So we began associating null series_id documents with each other and copying over the metadata.

This PR is a short term fix, which explicitly checks for null and doesn't copy things over if it is null. The next step is to dig in further and figure out why we're getting so many nulls.