### PR TITLE
Add fasterer gem to catch performance issues

### DIFF
--- a/.fasterer.yml
+++ b/.fasterer.yml
@@ -1,0 +1,16 @@
+speedups:
+  # Disabled because argument is actually faster.
+  # See https://github.com/DamirSvrtan/fasterer/issues/37
+  fetch_with_argument_vs_block: false
+  # Disabled for now because the while loop version is uglier and harder to
+  # read, so we'll only change it on a case by case basis if it makes a
+  # significant difference
+  each_with_index_vs_while: false
+
+exclude_paths:
+  # These files are ignored because some methods are being incorrectly flagged,
+  # and fasterer doesn't yet have a way to disable a check on a single method
+  # like Rubocop.
+  - "db/seeds.rb"
+  - "vendor/**/*.rb"
+  - "app/mappers/zip_code_to_lat_lng_mapper.rb"

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ tags
 # Ignore hidden files
 .*
 !.dockerignore
+!.fasterer.yml
 
 # React on Rails
 npm-debug.log*

--- a/Gemfile
+++ b/Gemfile
@@ -106,6 +106,7 @@ end
 
 group :development do
   gem "dotenv-rails"
+  gem "fasterer", require: false
   gem "foreman"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   # gem 'spring', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,7 @@ GEM
     cliver (0.3.2)
     coderay (1.1.2)
     colored2 (3.1.2)
+    colorize (0.8.1)
     concurrent-ruby (1.1.3)
     connection_pool (2.2.1)
     cork (0.3.0)
@@ -210,6 +211,9 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
+    fasterer (0.4.2)
+      colorize (~> 0.7)
+      ruby_parser (>= 3.12.0)
     ffi (1.9.25)
     foreman (0.84.0)
       thor (~> 0.19.1)
@@ -416,6 +420,8 @@ GEM
     ruby-plsql (0.6.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    ruby_parser (3.12.0)
+      sexp_processor (~> 4.9)
     rubyzip (1.2.2)
     safe_shell (1.1.0)
     sass (3.5.5)
@@ -448,6 +454,7 @@ GEM
       rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
+    sexp_processor (4.11.0)
     shellany (0.0.1)
     shoryuken (3.1.11)
       aws-sdk-core (>= 2)
@@ -526,6 +533,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails (~> 4.8)
   faker
+  fasterer
   foreman
   guard-rspec
   holidays (~> 6.4)

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -63,14 +63,15 @@ class IssuesController < ApplicationController
   end
 
   def issue_params
-    params.require("issues")
+    safe_params = params.require("issues")
       .permit(:note,
               :program,
               :issue,
               :level_1,
               :level_2,
               :level_3).to_h
-      .merge!(vacols_user_id: current_user.vacols_uniq_id)
+    safe_params[:vacols_user_id] = current_user.vacols_uniq_id
+    safe_params
   end
 
   def create_params

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -144,7 +144,7 @@ class Appeal < DecisionReview
   end
 
   def reviewing_judge_name
-    task = tasks.order(:created_at).select { |t| t.is_a?(JudgeTask) }.last
+    task = tasks.order(created_at: :desc).detect { |t| t.is_a?(JudgeTask) }
     task ? task.assigned_to.try(:full_name) : ""
   end
 

--- a/app/models/appeal_history.rb
+++ b/app/models/appeal_history.rb
@@ -53,7 +53,7 @@ class AppealHistory
 
     # Each appeal tree gets a series ID; assign all of its descendant nodes that ID.
     appeal_tree_roots.each_with_index do |root, sid|
-      traverse_appeal_tree(root) { |node| node[:series_id] = sid }
+      traverse_appeal_tree(root, sid) { |node| node[:series_id] = sid }
 
       merge_table[sid] = sid
     end
@@ -124,9 +124,11 @@ class AppealHistory
     remove_instance_variable :@roots
   end
 
-  def traverse_appeal_tree(node, &block)
-    block.call(node)
-    node[:children].each { |child| traverse_appeal_tree(child, &block) }
+  def traverse_appeal_tree(node, sid)
+    yield(node)
+    node[:children].each do |child|
+      traverse_appeal_tree(child, sid) { |child_node| child_node[:series_id] = sid }
+    end
   end
 
   def find_parent_appeal(appeal)

--- a/app/models/appeal_series.rb
+++ b/app/models/appeal_series.rb
@@ -83,17 +83,11 @@ class AppealSeries < ApplicationRecord
     @issues ||= AppealSeriesIssues.new(appeal_series: self).all
   end
 
-  # rubocop:disable CyclomaticComplexity
   def description
     ordered_issues = latest_appeal.issues
       .select(&:codes?)
-      .sort do |a, b|
-        dc_comparison = (a.diagnostic_code.nil? ? 1 : 0) <=> (b.diagnostic_code.nil? ? 1 : 0)
-
-        next dc_comparison unless dc_comparison == 0
-
-        a.vacols_sequence_id <=> b.vacols_sequence_id
-      end
+      .sort_by(&:vacols_sequence_id)
+      .partition(&:diagnostic_code).flatten
 
     return "VA needs to record issues" if ordered_issues.empty?
 
@@ -106,21 +100,19 @@ class AppealSeries < ApplicationRecord
 
     "#{marquee_issue_description}#{comma} and #{issue_count} #{'other'.pluralize(issue_count)}"
   end
-  # rubocop:enable CyclomaticComplexity
 
   private
 
   def fetch_latest_appeal
-    active_appeals.first || appeals_by_decision_date.first
+    latest_active_appeal_by_last_location_change_date || latest_appeal_by_decision_date
   end
 
-  def active_appeals
-    appeals.select(&:active?)
-      .sort { |x, y| y.last_location_change_date <=> x.last_location_change_date }
+  def latest_active_appeal_by_last_location_change_date
+    appeals.select(&:active?).max_by(&:last_location_change_date)
   end
 
-  def appeals_by_decision_date
-    appeals.sort { |x, y| y.decision_date <=> x.decision_date }
+  def latest_appeal_by_decision_date
+    appeals.max_by(&:decision_date)
   end
 
   def fetch_docket
@@ -130,7 +122,7 @@ class AppealSeries < ApplicationRecord
   end
 
   def last_soc_date
-    events.select { |event| [:soc, :ssoc].include? event.type }.last.date.to_date
+    events.reverse.detect { |event| [:soc, :ssoc].include? event.type }.date.to_date
   end
 
   def issues_for_last_decision

--- a/app/models/concerns/taskable.rb
+++ b/app/models/concerns/taskable.rb
@@ -2,10 +2,10 @@ module Taskable
   extend ActiveSupport::Concern
 
   def assigned_attorney
-    tasks.select { |t| t.is_a?(AttorneyTask) }.first.try(:assigned_to)
+    tasks.detect { |t| t.is_a?(AttorneyTask) }.try(:assigned_to)
   end
 
   def assigned_judge
-    tasks.select { |t| t.is_a?(JudgeTask) }.first.try(:assigned_to)
+    tasks.detect { |t| t.is_a?(JudgeTask) }.try(:assigned_to)
   end
 end

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -28,7 +28,7 @@ class DecisionReviewIntake < Intake
     detail.errors.messages
   end
 
-  def complete!(request_params, &additional_transactions)
+  def complete!(request_params)
     return if complete? || pending?
 
     req_issues = request_params[:request_issues] || []
@@ -36,7 +36,7 @@ class DecisionReviewIntake < Intake
       start_completion!
       detail.request_issues.destroy_all unless detail.request_issues.empty?
       detail.create_issues!(build_issues(req_issues))
-      additional_transactions.call
+      yield
       complete_with_status!(:success)
     end
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -236,9 +236,9 @@ class Document < ApplicationRecord
       RequestStore.store[:application] == "reader"
   end
 
-  def match_vbms_document_using(vbms_documents, &date_match_test)
+  def match_vbms_document_using(vbms_documents)
     match = vbms_documents.detect do |doc|
-      date_match_test.call(doc) && doc.type?(type)
+      yield(doc) && doc.type?(type)
     end
 
     match ? merge_with(match) : self

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -806,10 +806,9 @@ class LegacyAppeal < ApplicationRecord
       AppealRepository
     end
 
-    # rubocop:disable Metrics/ParameterLists
     # Wraps the closure of appeals in a transaction
     # add additional code inside the transaction by passing a block
-    def close(appeal: nil, appeals: nil, user:, closed_on:, disposition:, &inside_transaction)
+    def close(appeal: nil, appeals: nil, user:, closed_on:, disposition:)
       fail "Only pass either appeal or appeals" if appeal && appeals
 
       repository.transaction do
@@ -822,10 +821,9 @@ class LegacyAppeal < ApplicationRecord
           )
         end
 
-        inside_transaction.call if block_given?
+        yield if block_given?
       end
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def reopen(appeals:, user:, disposition:, safeguards: true, reopen_issues: true)
       repository.transaction do

--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -1,6 +1,6 @@
 class JudgeTeam < Organization
   def self.for_judge(user)
-    user.administered_teams.select { |team| team.is_a?(JudgeTeam) }.first
+    user.administered_teams.detect { |team| team.is_a?(JudgeTeam) }
   end
 
   def self.create_for_judge(user)

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -178,16 +178,7 @@ class VACOLS::CaseHearing < VACOLS::Record
   end
 
   def master_record_type
-    return :video if folder_nr.match?(/VIDEO/)
-  rescue NoMethodError => e
-    Rails.logger.error("Null Folder Error Condition: #{hearing_pkseq}")
-    Raven.capture.exception(e)
-    Raven.extra_context(
-      hearing_pkseq: hearing_pkseq,
-      hearing_date: hearing_date,
-      folder_nr: folder_nr,
-      board_member: board_member
-    )
+    :video if folder_nr&.include?("VIDEO")
   end
 
   def update_hearing!(hearing_info)

--- a/app/repositories/user_repository.rb
+++ b/app/repositories/user_repository.rb
@@ -39,9 +39,11 @@ class UserRepository
 
       results = {}
       users.each do |user|
-        results.merge!(user.sattyid => { css_id: user.sdomainid,
-                                         first_name: user.snamef,
-                                         last_name: user.snamel })
+        results[user.sattyid] = {
+          css_id: user.sdomainid,
+          first_name: user.snamef,
+          last_name: user.snamel
+        }
       end
       results
     end

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -25,7 +25,7 @@ class AppealRepository
     # Associate the cases we pulled from VACOLS to the appeals of the tasks.
     tasks.each do |t|
       if t.appeal.is_a?(LegacyAppeal)
-        case_record = cases.select { |cr| cr.id == t.appeal.vacols_id }.first
+        case_record = cases.detect { |cr| cr.id == t.appeal.vacols_id }
         set_vacols_values(appeal: t.appeal, case_record: case_record) if case_record
       end
     end

--- a/config/initializers/copy.rb
+++ b/config/initializers/copy.rb
@@ -1,4 +1,4 @@
 COPY = Module.new
 
 json_obj = JSON.parse(File.read(File.join(Rails.root, "client", "COPY.json")))
-json_obj.keys.each { |k| COPY.const_set(k, json_obj[k]) }
+json_obj.each_key { |k| COPY.const_set(k, json_obj[k]) }

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -11,6 +11,9 @@ task :lint do
   puts "running rubocop..."
   rubocop_result = ShellCommand.run("rubocop #{opts} --color")
 
+  puts "running fasterer..."
+  fasterer_result = ShellCommand.run("bundle exec fasterer")
+
   puts "\nrunning eslint..."
   eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"
   eslint_result = ShellCommand.run("cd ./client && yarn run #{eslint_cmd}")
@@ -19,7 +22,7 @@ task :lint do
   flow_result = ShellCommand.run("cd ./client && yarn run flow check")
 
   puts "\n"
-  if scss_result && rubocop_result && eslint_result && flow_result
+  if scss_result && rubocop_result && eslint_result && flow_result && fasterer_result
     puts Rainbow("Passed. Everything looks stylish! " \
       "But there may have been auto-corrections that you now need to check in.").green
   else

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -619,7 +619,7 @@ feature "Appeal Intake" do
            )).to_not be_nil
 
     duplicate_request_issues = RequestIssue.where(contested_rating_issue_reference_id: duplicate_reference_id)
-    ineligible_issue = duplicate_request_issues.select(&:duplicate_of_rating_issue_in_active_review?).first
+    ineligible_issue = duplicate_request_issues.detect(&:duplicate_of_rating_issue_in_active_review?)
 
     expect(duplicate_request_issues.count).to eq(2)
     expect(duplicate_request_issues).to include(request_issue_in_progress)

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1012,7 +1012,7 @@ feature "Higher-Level Review" do
       duplicate_request_issues = RequestIssue.where(contested_rating_issue_reference_id: duplicate_reference_id)
       expect(duplicate_request_issues.count).to eq(2)
 
-      ineligible_issue = duplicate_request_issues.select(&:duplicate_of_rating_issue_in_active_review?).first
+      ineligible_issue = duplicate_request_issues.detect(&:duplicate_of_rating_issue_in_active_review?)
       expect(duplicate_request_issues).to include(request_issue_in_progress)
       expect(ineligible_issue).to_not eq(request_issue_in_progress)
       expect(ineligible_issue.contention_reference_id).to be_nil
@@ -1022,7 +1022,7 @@ feature "Higher-Level Review" do
       hlr_request_issues = RequestIssue.where(contested_rating_issue_reference_id: higher_level_review_reference_id)
       expect(hlr_request_issues.count).to eq(2)
 
-      ineligible_due_to_previous_hlr = hlr_request_issues.select(&:higher_level_review_to_higher_level_review?).first
+      ineligible_due_to_previous_hlr = hlr_request_issues.detect(&:higher_level_review_to_higher_level_review?)
       expect(hlr_request_issues).to include(previous_request_issue)
       expect(ineligible_due_to_previous_hlr).to_not eq(previous_request_issue)
       expect(ineligible_due_to_previous_hlr.contention_reference_id).to be_nil

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -702,7 +702,7 @@ feature "Supplemental Claim Intake" do
       duplicate_request_issues = RequestIssue.where(contested_rating_issue_reference_id: duplicate_reference_id)
       expect(duplicate_request_issues.count).to eq(2)
 
-      ineligible_issue = duplicate_request_issues.select(&:duplicate_of_rating_issue_in_active_review?).first
+      ineligible_issue = duplicate_request_issues.detect(&:duplicate_of_rating_issue_in_active_review?)
       expect(ineligible_issue).to_not eq(request_issue_in_progress)
       expect(ineligible_issue.contention_reference_id).to be_nil
       expect(RequestIssue.find_by(contested_rating_issue_reference_id: old_reference_id).eligible?).to eq(true)

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -1093,8 +1093,7 @@ RSpec.feature "Reader" do
     end
 
     context "Tags" do
-      # :nocov:
-      scenario "adding and deleting tags", skip: true do
+      scenario "adding and deleting tags" do
         TAG1 = "Medical".freeze
         TAG2 = "Law document".freeze
 
@@ -1130,12 +1129,8 @@ RSpec.feature "Reader" do
         # getting remove buttons of all tags
         cancel_icons = page.all(".Select-value-icon", count: 1)
 
-        # rubocop:disable all
         # delete all tags
-        for i in (cancel_icons.length - 1).downto(0)
-          cancel_icons[i].click
-        end
-        # rubocop:enable all
+        cancel_icons[0].click
 
         # expecting the page not to have any tags
         expect(page).not_to have_css(SELECT_VALUE_LABEL_CLASS, text: DOC2_TAG1)
@@ -1148,7 +1143,6 @@ RSpec.feature "Reader" do
         # verify that the tags on the previous document still exist
         expect(page).to have_css(SELECT_VALUE_LABEL_CLASS, count: 4)
       end
-      # :nocov:
 
       context "Share tags among all documents in a case" do
         scenario "Shouldn't show auto suggestions" do

--- a/spec/models/appeal_series_spec.rb
+++ b/spec/models/appeal_series_spec.rb
@@ -448,11 +448,12 @@ describe AppealSeries do
         [
           create(:case_issue, issseq: 1, issprog: "02", isscode: "17", isslev1: "02"),
           create(:case_issue, issseq: 2, issprog: "02", isscode: "15", isslev1: "03", isslev2: "5252"),
-          create(:case_issue, issseq: 3, issprog: "02", isscode: "15", isslev1: "03", isslev2: "9432")
+          create(:case_issue, issseq: 3, issprog: "02", isscode: "12", isslev1: "05"),
+          create(:case_issue, issseq: 4, issprog: "02", isscode: "15", isslev1: "03", isslev2: "9432")
         ]
       end
 
-      it { is_expected.to eq("Service connection, limitation of thigh motion (flexion), and 2 others") }
+      it { is_expected.to eq("Service connection, limitation of thigh motion (flexion), and 3 others") }
     end
 
     context "when those issues do not have commas" do

--- a/spec/models/queues/generic_queue_spec.rb
+++ b/spec/models/queues/generic_queue_spec.rb
@@ -22,7 +22,7 @@ describe GenericQueue do
         tasks = GenericQueue.new(user: user).tasks
         expect(tasks.size).to eq(task_count + 1)
 
-        expired_on_hold_task = tasks.select { |t| t.id == on_hold_task.id }.first
+        expired_on_hold_task = tasks.detect { |t| t.id == on_hold_task.id }
         expect(expired_on_hold_task.status).to eq("in_progress")
       end
     end

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -32,12 +32,12 @@ describe ColocatedTask do
           expect(vacols_case.bfcurloc).to be_nil
           expect(Task.where(type: ColocatedTask.name).count).to eq 0
 
-          team_task = subject.select { |t| t.assigned_to.is_a?(Colocated) }.first
+          team_task = subject.detect { |t| t.assigned_to.is_a?(Colocated) }
           expect(team_task.valid?).to be true
           expect(team_task.status).to eq(Constants.TASK_STATUSES.on_hold)
           expect(team_task.assigned_to).to eq(Colocated.singleton)
 
-          user_task = subject.select { |t| t.assigned_to.is_a?(User) }.first
+          user_task = subject.detect { |t| t.assigned_to.is_a?(User) }
           expect(user_task.valid?).to be true
           expect(user_task.status).to eq "assigned"
           expect(user_task.assigned_at).to_not eq nil

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -87,7 +87,7 @@ describe RootTask do
 
         it "creates a tracking task assigned to the VSO" do
           expect(appeal.tasks.select { |t| t.is_a?(TrackVeteranTask) }.length).to eq(1)
-          expect(appeal.tasks.select { |t| t.is_a?(TrackVeteranTask) }.first.assigned_to).to eq(pva)
+          expect(appeal.tasks.detect { |t| t.is_a?(TrackVeteranTask) }.assigned_to).to eq(pva)
         end
       end
     end

--- a/spec/models/vacols/case_hearing_spec.rb
+++ b/spec/models/vacols/case_hearing_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe VACOLS::CaseHearing do
+  describe "#master_record_type" do
+    it "returns nil if folder_nr is nil" do
+      hearing = create(:case_hearing, folder_nr: nil)
+
+      expect(hearing.master_record_type).to be_nil
+    end
+  end
+
+  it "returns :video if folder_nr contains the string VIDEO" do
+    hearing = create(:case_hearing, folder_nr: "VIDEO 123")
+
+    expect(hearing.master_record_type).to eq :video
+  end
+
+  it "returns nil if folder_nr does not contain the string VIDEO" do
+    hearing = create(:case_hearing, folder_nr: "123")
+
+    expect(hearing.master_record_type).to be_nil
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -114,14 +114,12 @@ ActiveJob::Base.queue_adapter = :test
 # Convenience methods for stubbing current user
 module StubbableUser
   module ClassMethods
+    attr_writer :stub
+
     def clear_stub!
       Functions.delete_all_keys!
       @stub = nil
       @system_user = nil
-    end
-
-    def stub=(user)
-      @stub = user
     end
 
     def authenticate!(css_id: nil, roles: nil, user: nil)


### PR DESCRIPTION
**Why**:
In Ruby and in Rails, there are multiple ways of achieving of
the same result. However, they are not always equal in terms of
performance, and choosing the wrong one can have a significant impact.

For example, we recently had daily DB statement timeouts between January
22 and February 6 that caused the AWS RDS CPU utilization to increase by
about 5-10x the normal rate. This was caused by using `.count > 0` to
check if an ActiveRecord query contained any results. This query was on
the Documents table, which has been quickly growing in size. `COUNT`
queries in Postgres are known to be slow, and get slower as the table
grows.

If all we want to know is if the query returned any results at all, that
means we don't care about the actual count, and therefore we don't need
to perform a `COUNT` query. Instead, we can use
`ActiveRecord::Relation#any?` which performs a much faster SQL query
that uses `SELECT 1 AS one` with a `LIMIT` of 1.

The [fasterer](https://github.com/DamirSvrtan/fasterer) gem was inspired
by the [fast-ruby](https://github.com/JuanitoFatas/fast-ruby) repo,
which in turn was inspired by a great
[talk on Ruby performance](https://www.youtube.com/watch?v=fGFM_UrSp70)
by Erik Michaels-Ober.

It analyzes the code for slow idioms and lets you know which version is
faster. This is a great way to learn something new and to level up the
whole team. The gem doesn't currently track all of the examples in the
fast-ruby repo, but it does track some of the most common mistakes. I
plan on contributing to the gem to add more checks.

The 4 most common slow idioms we had were:

- `select`ing from an array and then calling `.first` or `.last` instead
of `detect`
- Using `Hash#merge!` instead of `Hash#[]=` when only merging one
element
- Sorting using the idiom `sort { |a, b| a.foo <=> b.foo }` instead of
`sort_by(&:foo)`. Relatedly, using `sort_by` and then `.first` or
`.last` instead of `min_by` and `max_by` respectively.
- Passing in a block argument and using `block.call` instead of just
calling `yield`.

In most cases, the faster code also had the additional advantage of making the
code easier to read and understand.