### PR TITLE
VA.gov will need the docket type to be in camelCase

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -459,9 +459,13 @@ class Appeal < DecisionReview
   end
 
   def fetch_docket_type
-    return :new_evidence if evidence_submission_docket?
+    api_values = {
+      "direct_review" => "directReview",
+      "hearing" => "hearingRequest",
+      "evidence_submission" => "evidenceSubmission"
+    }
 
-    docket_name
+    api_values[docket_name]
   end
 
   def docket_switch_deadline

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -505,7 +505,7 @@ describe "Appeals API v2", type: :request do
       expect(json["data"][2]["attributes"]["alerts"]).to be_nil
       expect(json["data"][2]["attributes"]["aoj"]).to eq("other")
       expect(json["data"][2]["attributes"]["programArea"]).to eq("compensation")
-      expect(json["data"][2]["attributes"]["docket"]["type"]).to eq("new_evidence")
+      expect(json["data"][2]["attributes"]["docket"]["type"]).to eq("evidenceSubmission")
       expect(json["data"][2]["attributes"]["docket"]["month"]).to eq(Date.new(2018, 9, 1).to_s)
       expect(json["data"][2]["attributes"]["docket"]["switchDueDate"]).to eq((rating_promulgated_date + 365.days).to_s)
       expect(json["data"][2]["attributes"]["docket"]["eligibleToSwitch"]).to eq(true)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1114,7 +1114,7 @@ describe Appeal do
         docket = appeal.docket_hash
 
         expect(docket).not_to be_nil
-        expect(docket[:type]).to eq(docket_type)
+        expect(docket[:type]).to eq("directReview")
         expect(docket[:month]).to eq(october_docket_date.to_date)
         expect(docket[:switchDueDate]).to eq((promulgation_date2 + 365.days))
         expect(docket[:eligibleToSwitch]).to eq(true)
@@ -1132,7 +1132,7 @@ describe Appeal do
         docket = appeal.docket_hash
 
         expect(docket).not_to be_nil
-        expect(docket[:type]).to eq(docket_type)
+        expect(docket[:type]).to eq("directReview")
         expect(docket[:month]).to eq(october_docket_date.to_date)
         expect(docket[:switchDueDate]).to be_nil
         expect(docket[:eligibleToSwitch]).to eq(false)


### PR DESCRIPTION
So my ticket was wrong. The change is pretty straightforward. Here's why I think it's needed. TL;DR: The mismatch of snake_case for values and camelCase for keys finally bit us.

After MVP, we'll be adding a `eta` hash to the `docket` hash. I anticipated that it would look like:

```json
"eta": {
  "direct_review": "2020-01-01",
  "new_evidence": "2025-01-01",
  "hearing": "2025-01-01"
}
```

This enables us to look up `docket.type` in `docket.eta` to find the ETA of the currently selected docket, as well as to use all of the other estimates to provide alternative ETA if the Veteran wants to switch dockets.

Only it won't look like that, because we have our serializer set to turn all keys into camelCase. So it comes out like:

```json
"eta": {
  "directReview": "2020-01-01",
  "newEvidence": "2025-01-01",
  "hearing": "2025-01-01"
}
```

Bleargh. Now we end up needing to do a whole bunch of mapping between snake_case and camelCase depending on whether what we're looking at came from a key or a value.

We can solve it by just changing `docket.type` to use the same values as we'll use for the keys of `docket.eta`. It's compounding the inconsistency, but it's certainly a lot less messy on the front end, and not too weird on the Caseflow side, I think.