### PR TITLE
Temporarily disable document updated modal

### DIFF
--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -240,7 +240,7 @@ export class PdfViewer extends React.Component {
             featureToggles={this.props.featureToggles}
           />
         </div>
-        {doc.wasUpdated && this.updatedDocumentModal()}
+        {doc.wasUpdated}
         {this.props.deleteAnnotationModalIsOpenFor && <Modal
           buttons={[
             { classNames: ['cf-modal-link', 'cf-btn-link'],

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -1442,11 +1442,8 @@ RSpec.feature "Reader" do
       expect(page).to have_content("Reader")
       click_on Document.last.type
 
-      expect(page).to have_content("This document has been updated")
-
-      click_on "Got It"
-      expect(page).to_not have_content("This document has been updated")
       expect(page).to have_content("test comment")
+      expect(page).to_not have_content("This document has been updated")
     end
   end
 end


### PR DESCRIPTION
**Why**: There was a bug where we were updating metadata for documents
with `nil` series_id. Any documents in that state will display a
popup saying the document was updated, which is annoying to some users.
As a temporary fix, we are disabling the modal altogether.
