### PR TITLE
Prevent Sentry Errors when option in Undefined on Dropdown

### DIFF
--- a/client/app/components/DataDropdowns/HearingDate.jsx
+++ b/client/app/components/DataDropdowns/HearingDate.jsx
@@ -103,7 +103,7 @@ class HearingDateDropdown extends React.Component {
         strongLabel
         readOnly={readOnly}
         value={this.getSelectedOption()}
-        onChange={(option) => onChange(option.value, option.label)}
+        onChange={(option) => onChange((option || {}).value, (option || {}).label)}
         options={this.props.hearingDates.options}
         errorMessage={errorMessage}
         placeholder={placeholder} />

--- a/client/app/components/DataDropdowns/HearingDate.jsx
+++ b/client/app/components/DataDropdowns/HearingDate.jsx
@@ -19,7 +19,7 @@ class HearingDateDropdown extends React.Component {
     const { hearingDates: { options }, validateValueOnMount, onChange } = this.props;
 
     if (!_.isEqual(prevProps.hearingDates.options, options) && validateValueOnMount) {
-      const option = this.getSelectedOption();
+      const option = this.getSelectedOption() || {};
 
       onChange(option.value, option.label);
     }


### PR DESCRIPTION
- `SearchableDropdown` sometimes passes an undefined option to onChange. This does not cause the page to fail but creates an unnecessary Sentry alert. This PR handles scenarios where option is undefined

