### PR TITLE
Fix bug with clearing filters for a given column

### DIFF
--- a/client/app/components/TableFilter.jsx
+++ b/client/app/components/TableFilter.jsx
@@ -88,10 +88,11 @@ class TableFilter extends React.PureComponent {
   }
 
   clearFilteredByList = (columnName) => {
-    const oldList = this.props.filteredByList;
-    let newList = _.set(oldList, columnName, []);
+    const filterList = this.props.filteredByList;
 
-    this.props.updateFilters(newList);
+    filterList[columnName] = [];
+
+    this.props.updateFilters(filterList);
     this.props.toggleDropdownFilterVisibility(columnName);
   }
 


### PR DESCRIPTION
### Description
While adding filtering to other apps, I find a small bug with the clearing filters button in the filter dropdown. The `columnName` was set incorrectly in the `filteredByList` when clearing filters. The problem comes from the `columnName` sometimes having a `.` in it, which is a problem in using lodash's `_.set`, which interprets this `columnName` as a nested object (e.g., `filteredByList: { appeal: { caseType: [] }}`) instead of the entire key value (e.g., `filteredByList: { appeal.caseType: [] }`), which is what we want it to be.

This bug was **not** occurring on every click of the "Clear Filters" button. This would only be a problem when clicking the "Clear Filters" button in the dropdown when no filters were previously selected. This is a rare enough situation, but could happen, so definitely want to fix this.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

