### PR TITLE
Handle nil user in AmaDocumentIdPolicy

### DIFF
--- a/app/policies/ama_document_id_policy.rb
+++ b/app/policies/ama_document_id_policy.rb
@@ -5,7 +5,7 @@ class AmaDocumentIdPolicy
   end
 
   def editable?
-    return false unless case_review
+    return false unless case_review && user
 
     [case_review.attorney_id, case_review.reviewing_judge_id].include?(user.id)
   end

--- a/spec/policies/ama_document_id_policy_spec.rb
+++ b/spec/policies/ama_document_id_policy_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe AmaDocumentIdPolicy do
+  describe "#editable?" do
+    context "when case_review is nil" do
+      it "returns false" do
+        policy = AmaDocumentIdPolicy.new(user: User.new, case_review: nil)
+
+        expect(policy.editable?).to eq false
+      end
+    end
+
+    context "when user is nil" do
+      it "returns false" do
+        policy = AmaDocumentIdPolicy.new(user: nil, case_review: build(:attorney_case_review))
+
+        expect(policy.editable?).to eq false
+      end
+    end
+
+    context "when user id matches the case review's attorney_id" do
+      it "returns true" do
+        policy = AmaDocumentIdPolicy.new(
+          user: User.new(id: 1),
+          case_review: build(:attorney_case_review, attorney_id: 1)
+        )
+
+        expect(policy.editable?).to eq true
+      end
+    end
+
+    context "when user id matches the case review's reviewing_judge_id" do
+      it "returns true" do
+        policy = AmaDocumentIdPolicy.new(
+          user: User.new(id: 1),
+          case_review: build(:attorney_case_review, reviewing_judge_id: 1)
+        )
+
+        expect(policy.editable?).to eq true
+      end
+    end
+
+    context "when user id does not match the case review's reviewing_judge_id or attorney_id" do
+      it "returns false" do
+        policy = AmaDocumentIdPolicy.new(
+          user: User.new(id: 1),
+          case_review: build(:attorney_case_review, reviewing_judge_id: 2, attorney_id: 3)
+        )
+
+        expect(policy.editable?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: A user is not always passed to the policy. For example, when
someone views an appeal in reader `reader/appeal_controller` is called,
which then calls the `work_queue/appeal_serializer` without passing in
a user. The serializer has a `can_edit_document_id` attribute that calls
`AmaDocumentIdPolicy` but passes a nil user, which causes `editable?`
to throw an exception.

Resolves Sentry errors such as this one:
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3480/
