### PR TITLE
Treat EPE w/o a synced status as active

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -194,7 +194,7 @@ class EndProductEstablishment < ApplicationRecord
 
   def status_active?(sync: false)
     sync! if sync
-    !EndProduct::INACTIVE_STATUSES.include?(synced_status)
+    synced_status.nil? || !EndProduct::INACTIVE_STATUSES.include?(synced_status)
   end
 
   def associate_rating_request_issues!

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -202,6 +202,23 @@ describe RequestIssue do
         expect(RequestIssue.find_active_by_contested_rating_issue_reference_id(rating_issue.reference_id)).to be_nil
       end
     end
+
+    context "EPE does not yet have a synced status" do
+      let(:active_rating_request_issue) do
+        rating_request_issue.tap do |ri|
+          ri.update!(end_product_establishment: create(:end_product_establishment))
+        end
+      end
+
+      let(:rating_issue) do
+        RatingIssue.new(reference_id: active_rating_request_issue.contested_rating_issue_reference_id)
+      end
+
+      it "treats EPE as active" do
+        in_review = RequestIssue.find_active_by_contested_rating_issue_reference_id(rating_issue.reference_id)
+        expect(in_review).to eq(rating_request_issue)
+      end
+    end
   end
 
   context "#end_product_code" do


### PR DESCRIPTION
connects #9376 

### Description
Fixes a race condition. When an `EndProductEstablishment` has been created but not yet established upstream, treat it as active for the purposes of identifying duplicate request issues on future intakes.

**Why**

Because EPE is performed asynchronously, there is an unspecified period of time between creating the EPE and it receiving a synced status after establishing upstream End Product(s). During that period of time, we don't want another request issue created that would eventually be a duplicate.