### PR TITLE
make caseflow loading spinner smaller

### DIFF
--- a/client/app/components/LoadingScreen.jsx
+++ b/client/app/components/LoadingScreen.jsx
@@ -4,13 +4,15 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import { css } from 'glamor';
 
 const centerTextStyling = css({
-  textAlign: 'center'
+  textAlign: 'center',
+  height: '300px',
+  marginTop: '75px'
 });
 
 const LoadingScreen = ({ spinnerColor, message }) =>
   <AppSegment filledBackground>
     <div {...centerTextStyling}>
-      {loadingSymbolHtml('', '300px', spinnerColor)}
+      {loadingSymbolHtml('', '150px', spinnerColor)}
       <p>{message}</p>
     </div>
   </AppSegment>;


### PR DESCRIPTION
### Description
Makes the Caseflow loading spinner smaller.

After:
(spinner at `150px`)
![screenshot 2019-02-13 11 19 24](https://user-images.githubusercontent.com/2928395/52737509-61d2c380-2f81-11e9-93be-b694860be323.png)

(here's another version, with height of `100px` and margins adjusted accordingly)
<img width="542" alt="screenshot 2019-02-13 11 19 02" src="https://user-images.githubusercontent.com/2928395/52737537-6f884900-2f81-11e9-8326-f682cf613a09.png">

Before:
![screenshot 2019-02-13 11 07 15](https://user-images.githubusercontent.com/2928395/52737546-72833980-2f81-11e9-9a79-0a14da810656.png)
