### PR TITLE
Fix flakey dropdown menu feature test behavior

### DIFF
--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -71,22 +71,27 @@ module FeatureHelper
     container.find(selector, **keyword_args)
   end
 
-  def click_dropdown_menu_item(dropdown, selector, keyword_args)
-    dropdown.sibling(".Select-menu-outer").find(selector, **keyword_args).click
+  # sometimes the dropdown menu hasn't appeared after the first click
+  def try_clicking_dropdown_menu_item(dropdown, selector, keyword_args)
+    tries = 3
+    until dropdown_menu_visible?(dropdown) || tries <= 0
+      dropdown.click
+      tries -= 1
+    end
+
+    click_dropdown_menu_item(dropdown, selector, keyword_args)
   end
 
-  def try_clicking_dropdown_menu_item(dropdown, selector, keyword_args)
-    begin
-      click_dropdown_menu_item(dropdown, selector, keyword_args)
-    rescue Capybara::ElementNotFound
-      begin
-        dropdown.find(".Select-placeholder").click
-        click_dropdown_menu_item(dropdown, selector, keyword_args)
-      rescue Capybara::ElementNotFound
-        dropdown.find(".Select-value").click
-        click_dropdown_menu_item(dropdown, selector, keyword_args)
-      end
-    end
+  def dropdown_menu_visible?(dropdown)
+    dropdown.sibling(".Select-menu-outer")
+  rescue Capybara::ElementNotFound
+    false
+  else
+    true
+  end
+
+  def click_dropdown_menu_item(dropdown, selector, keyword_args)
+    dropdown.sibling(".Select-menu-outer").find(selector, **keyword_args).click
   end
 
   def generate_text(length)

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -29,9 +29,7 @@ module FeatureHelper
       selector = "div[id$='--option-#{options[:index]}']"
     end
 
-    menu_selector = ".Select-menu-outer"
-    dropdown.sibling(menu_selector).find(selector, **keyword_args).click
-    expect(container).to_not have_css(menu_selector)
+    try_clicking_dropdown_menu_item(dropdown, selector, keyword_args)
   end
 
   def dropdown_selected_value(container = page)
@@ -71,6 +69,24 @@ module FeatureHelper
     keyword_args[:wait] = options[:wait] if options[:wait].present? && options[:wait] > 0
 
     container.find(selector, **keyword_args)
+  end
+
+  def click_dropdown_menu_item(dropdown, selector, keyword_args)
+    dropdown.sibling(".Select-menu-outer").find(selector, **keyword_args).click
+  end
+
+  def try_clicking_dropdown_menu_item(dropdown, selector, keyword_args)
+    begin
+      click_dropdown_menu_item(dropdown, selector, keyword_args)
+    rescue Capybara::ElementNotFound
+      begin
+        dropdown.find(".Select-placeholder").click
+        click_dropdown_menu_item(dropdown, selector, keyword_args)
+      rescue Capybara::ElementNotFound
+        dropdown.find(".Select-value").click
+        click_dropdown_menu_item(dropdown, selector, keyword_args)
+      end
+    end
   end
 
   def generate_text(length)

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -29,7 +29,9 @@ module FeatureHelper
       selector = "div[id$='--option-#{options[:index]}']"
     end
 
-    dropdown.sibling(".Select-menu-outer").find(selector, **keyword_args).click
+    menu_selector = ".Select-menu-outer"
+    dropdown.sibling(menu_selector).find(selector, **keyword_args).click
+    expect(container).to_not have_css(menu_selector)
   end
 
   def dropdown_selected_value(container = page)


### PR DESCRIPTION
Resolves #9396

### Description
Checks to make sure the dropdown menu has appeared before trying to select from it; tries clicking on the component again if it hasn't appeared.