### PR TITLE
Fix for showing draft dispositions through API

### DIFF
--- a/app/models/appeal_series_issues.rb
+++ b/app/models/appeal_series_issues.rb
@@ -59,6 +59,7 @@ class AppealSeriesIssues
       next [] unless ELIGIBLE_TYPES.include? appeal.type
 
       appeal.issues.reject(&:merged?).each do |issue|
+        issue.appeal = appeal
         issue.cavc_decisions = appeal.cavc_decisions.select do |cavc_decision|
           cavc_decision.issue_vacols_sequence_id == issue.vacols_sequence_id
         end
@@ -74,8 +75,11 @@ class AppealSeriesIssues
         type = last_action_type_from_disposition(issue.disposition)
 
         if type
-          memo[:date] = issue.close_date
-          memo[:type] = type
+          # Prevent draft decisions from being shared publicly
+          unless [:allowed, :denied, :remand].include?(type) && issue.appeal.activated?
+            memo[:date] = issue.close_date
+            memo[:type] = type
+          end
         end
       end
 

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -16,6 +16,11 @@ class Issue
     @labels
   end
 
+  attr_writer :appeal
+  def appeal
+    @appeal ||= LegacyAppeal.find_or_create_by_vacols_id(id)
+  end
+
   attr_writer :cavc_decisions
   def cavc_decisions
     # This should probably always be preloaded to avoid each issue triggering an additional VACOLS query.

--- a/spec/models/appeal_series_issues_spec.rb
+++ b/spec/models/appeal_series_issues_spec.rb
@@ -22,8 +22,7 @@ describe AppealSeriesIssues do
     create(:legacy_appeal, vacols_case: create(
       :case,
       :type_post_remand,
-      :disposition_remanded,
-      bfddec: 6.months.ago,
+      bfmpro: "ACT",
       case_issues: post_remand_issues
     ))
   end
@@ -86,6 +85,26 @@ describe AppealSeriesIssues do
         expect(subject.last[:active]).to be_falsey
         expect(subject.last[:last_action]).to eq(:allowed)
         expect(subject.last[:date]).to eq(6.months.ago.to_date)
+      end
+
+      context "when there is a draft decision" do
+        let(:post_remand_issues) do
+          [create(:case_issue,
+                  :disposition_allowed,
+                  issdcls: 1.day.ago,
+                  issseq: 1,
+                  issprog: "02",
+                  isscode: "15",
+                  isslev1: "03",
+                  isslev2: "5252")]
+        end
+
+        it "does not show the draft disposition" do
+          expect(subject.length).to eq(2)
+          expect(subject.first[:active]).to be_truthy
+          expect(subject.first[:date]).to eq(6.months.ago.to_date)
+          expect(subject.first[:last_action]).to eq(:remand)
+        end
       end
     end
 


### PR DESCRIPTION
The Board received a report of a VA.gov user being able to see a draft decision on the Issues tab. In addition to recording the draft disposition, VACOLS is marking the issue as having a close date, bypassing the existing check (unclear whether this has always been the case or is a regression). This adds a check of the status of the appeal itself to ensure that we do not show Board dispositions (allowed, denied, remanded) of an issue while it is active at the Board.