### PR TITLE
do not show payee code if payee code is null

### DIFF
--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -8,6 +8,10 @@ const getNonVeteranClaimant = (intakeData) => {
     return relationship.value === intakeData.claimant;
   });
 
+  if (!intakeData.payeeCode) {
+    return claimant[0].displayText;
+  }
+
   return `${claimant[0].displayText} (payee code ${intakeData.payeeCode})`;
 };
 


### PR DESCRIPTION
For appeals, payee code is not set so the UI displays it as null. This removes the payee code from being displayed if it is null.

<img width="1100" alt="screen shot 2019-02-13 at 4 16 40 pm" src="https://user-images.githubusercontent.com/577629/52753392-48467180-2fab-11e9-9563-7493ae54febf.png">