### PR TITLE
add intake fingerprint to js errors

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,7 +63,13 @@
     <script src="https://cdn.ravenjs.com/3.27.0/raven.min.js"></script>
     <script>
       Raven.config("<%= ENV["PUBLIC_SENTRY_DSN"] %>", {
-        release: "<%= Rails.application.config.build_version[:commit][0..6] %>"
+        release: "<%= Rails.application.config.build_version[:commit][0..6] %>",
+        dataCallback: function(data) {
+          if (Raven.caseflowAppName) {
+            data.fingerprint = ["{{default}}", Raven.caseflowAppName]
+          }
+          return data;
+        }
       }).install();
       <% if current_user && current_user.authenticated? %>
         Raven.setUserContext({

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
         release: "<%= Rails.application.config.build_version[:commit][0..6] %>",
         dataCallback: function(data) {
           if (Raven.caseflowAppName) {
-            data.fingerprint = ["{{default}}", Raven.caseflowAppName]
+            data.fingerprint = ["{{ default }}", Raven.caseflowAppName]
           }
           return data;
         }

--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'max-statements': 'off'
   },
   globals: {
-    $ReadOnly: true
+    $ReadOnly: true,
+    Raven: true
   }
 };

--- a/client/app/intake/index.js
+++ b/client/app/intake/index.js
@@ -21,6 +21,12 @@ const reducer = combineReducers({
 });
 
 class Intake extends React.PureComponent {
+  componentDidMount() {
+    if (window.Raven) {
+      Raven.caseflowAppName = 'intake';
+    }
+  }
+
   render() {
     const initialState = {
       intake: mapDataToInitialIntake(this.props),

--- a/client/app/intake/index.js
+++ b/client/app/intake/index.js
@@ -23,7 +23,7 @@ const reducer = combineReducers({
 class Intake extends React.PureComponent {
   componentDidMount() {
     if (window.Raven) {
-      Raven.caseflowAppName = 'intake';
+      window.Raven.caseflowAppName = 'intake';
     }
   }
 


### PR DESCRIPTION
Sentry alerts originating from different js apps (intake vs queue vs hearing etc) are often coalesced when they are raised in an external API call (see https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2991/events/)

Sentry [allows providing a custom fingerprint](https://blog.sentry.io/2018/01/18/setting-up-custom-fingerprints) (fingerprints are what group errors together). This PR illustrates one way we could set a custom fingerprint as each different js app boots, and configuring Raven to use the custom fingerprint if available.