### PR TITLE
adding legacy appeal to the appeal status output list

### DIFF
--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -53,6 +53,7 @@ class Api::V2::AppealsController < Api::ApplicationController
     @appeals ||= Appeal.where(veteran_file_number: veteran_file_number)
   end
 
+  # rubocop:disable Metrics/MethodLength
   def all_reviews_and_appeals
     hlr_json = ActiveModelSerializers::SerializableResource.new(
       hlrs,
@@ -73,13 +74,14 @@ class Api::V2::AppealsController < Api::ApplicationController
     ).as_json
 
     legacy_appeal_json = ActiveModelSerializers::SerializableResource.new(
-          legacy_appeals,
-          each_serializer: ::V2::LegacyAppealStatusSerializer,
-          key_transform: :camel_lower
-        ).as_json
+      legacy_appeals,
+      each_serializer: ::V2::LegacyAppealStatusSerializer,
+      key_transform: :camel_lower
+    ).as_json
 
     { data: hlr_json[:data] + sc_json[:data] + appeal_json[:data] + legacy_appeal_json[:data] }
   end
+  # rubocop:enable Metrics/MethodLength
 
   def vbms_id
     @vbms_id ||= LegacyAppeal.convert_file_number_to_vacols(veteran_file_number)

--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -72,7 +72,13 @@ class Api::V2::AppealsController < Api::ApplicationController
       key_transform: :camel_lower
     ).as_json
 
-    { data: hlr_json[:data] + sc_json[:data] + appeal_json[:data] }
+    legacy_appeal_json = ActiveModelSerializers::SerializableResource.new(
+          legacy_appeals,
+          each_serializer: ::V2::LegacyAppealStatusSerializer,
+          key_transform: :camel_lower
+        ).as_json
+
+    { data: hlr_json[:data] + sc_json[:data] + appeal_json[:data] + legacy_appeal_json[:data] }
   end
 
   def vbms_id

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -392,10 +392,10 @@ class Appeal < DecisionReview
       :evidentiary_period
     elsif at_vso?
       :at_vso
-    elsif !distributed_to_a_judge?
-      :on_docket
-    elsif distributed_to_a_judge? && decision_issues.empty?
+    elsif distributed_to_a_judge?
       :decision_in_progress
+    else
+      :on_docket
     end
   end
 


### PR DESCRIPTION
Resolves #9421

### Description
Adding legacy appeal to the output list.
Also fixing a logic bug, if an appeal is active the catch all status should be "on_docket"

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. unit and feature test pass

