### PR TITLE
Issue 9420 - Give Transcription Team edit capabilities in Hearing Details page

### DIFF
--- a/app/views/hearing_schedule/index.html.erb
+++ b/app/views/hearing_schedule/index.html.erb
@@ -4,7 +4,8 @@
     userDisplayName: current_user.display_name,
     userRoleAssign: current_user.can?('Assign HearSched'),
     userRoleBuild: current_user.can?('Build HearSched'),
-    userInHearingsOrganization: HearingsManagement.singleton.users.include?(current_user),
+    userInHearingsOrganization: (HearingsManagement.singleton.users.include?(current_user) ||
+        TranscriptionTeam.singleton.users.include?(current_user)),
     userId: current_user.id,
     userCssId: current_user.css_id,
     dropdownUrls: dropdown_urls,


### PR DESCRIPTION
Resolves #9420 

### Description
Added Transcription Team to list of users that can edit Hearing Details page.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Set yourself up as Transcription Team user.
2. Go to Hearing Details page
3. Confirm you can edit the hearing


