### PR TITLE
Fix for incorrect enum being used for legacy Appeals Status API

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -108,14 +108,12 @@ class LegacyAppeal < ApplicationRecord
   }.freeze
   # rubocop:enable Metrics/LineLength
 
-  # TODO: the type code should be the base value, and should be
-  #       converted to be human readable, not vis-versa
-  # TODO: integrate with Constants::LEGACY_APPEAL_TYPES_BY_ID
+  # Codes for Appeals Status API
   TYPE_CODES = {
     "Original" => "original",
     "Post Remand" => "post_remand",
     "Reconsideration" => "reconsideration",
-    "Court Remand" => "cavc_remand",
+    "Court Remand" => "post_cavc_remand",
     "Clear and Unmistakable Error" => "cue"
   }.freeze
 


### PR DESCRIPTION
VA.gov reported an issue that can be traced to us not using the correct enum for the `appeal.type`. This corrects the API to match the documentation, vets-api, and VA.gov.