### PR TITLE
prevent veteran from being a claimant

### DIFF
--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import RadioField from '../../components/RadioField';
 import SearchableDropdown from '../../components/SearchableDropdown';
-import { BOOLEAN_RADIO_OPTIONS, DECEASED_PAYEE_CODES, LIVING_PAYEE_CODES } from '../constants';
+import { BOOLEAN_RADIO_OPTIONS,
+  BOOLEAN_RADIO_OPTIONS_DISABLED_FALSE,
+  DECEASED_PAYEE_CODES,
+  LIVING_PAYEE_CODES } from '../constants';
 import COPY from '../../../COPY.json';
 
 export default class SelectClaimant extends React.PureComponent {
@@ -76,7 +79,9 @@ export default class SelectClaimant extends React.PureComponent {
 
     if (isVeteranDeceased) {
       // disable veteran claimant option if veteran is deceased
-      veteranClaimantOptions[0].disabled = true;
+      veteranClaimantOptions = BOOLEAN_RADIO_OPTIONS_DISABLED_FALSE;
+      // set claimant value to someone other than the veteran
+      setVeteranIsNotClaimant('true');
     }
 
     return <div className="cf-different-claimant">

--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -72,13 +72,20 @@ export default class SelectClaimant extends React.PureComponent {
       </div>;
     };
 
+    let veteranClaimantOptions = BOOLEAN_RADIO_OPTIONS;
+
+    if (isVeteranDeceased) {
+      // disable veteran claimant option if veteran is deceased
+      veteranClaimantOptions[0].disabled = true;
+    }
+
     return <div className="cf-different-claimant">
       <RadioField
         name="different-claimant-option"
         label="Is the claimant someone other than the Veteran?"
         strongLabel
         vertical
-        options={BOOLEAN_RADIO_OPTIONS}
+        options={veteranClaimantOptions}
         onChange={setVeteranIsNotClaimant}
         errorMessage={veteranIsNotClaimantError}
         value={veteranIsNotClaimant === null ? null : veteranIsNotClaimant.toString()}

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -58,6 +58,14 @@ export const BOOLEAN_RADIO_OPTIONS = [
     displayText: 'Yes' }
 ];
 
+export const BOOLEAN_RADIO_OPTIONS_DISABLED_FALSE = [
+  { value: 'false',
+    displayText: 'No',
+    disabled: true },
+  { value: 'true',
+    displayText: 'Yes' }
+];
+
 export const REQUEST_STATE = {
   NOT_STARTED: 'NOT_STARTED',
   IN_PROGRESS: 'IN_PROGRESS',

--- a/client/app/intake/pages/appeal/review.jsx
+++ b/client/app/intake/pages/appeal/review.jsx
@@ -90,6 +90,7 @@ class Review extends React.PureComponent {
 
 const SelectClaimantConnected = connect(
   ({ appeal, intake }) => ({
+    isVeteranDeceased: intake.veteran.isDeceased,
     veteranIsNotClaimant: appeal.veteranIsNotClaimant,
     veteranIsNotClaimantError: appeal.veteranIsNotClaimantError,
     claimant: appeal.claimant,

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
               expect(response_body["attributes"]["issues"].first["program"]).to eq "Compensation"
               expect(response_body["attributes"]["issues"].second["program"]).to eq "Compensation"
               expect(response_body["attributes"]["status"]).to eq nil
-              expect(response_body["attributes"]["veteran_is_deceased"]).to eq true
+              expect(response_body["attributes"]["veteran_is_deceased"]).to eq false
               expect(response_body["attributes"]["veteran_ssn"]).to eq ama_appeals.first.veteran_ssn
               expect(response_body["attributes"]["veteran_death_date"]).to eq "05/25/2016"
               expect(response_body["attributes"]["appellant_is_not_veteran"]).to eq true

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
               expect(response_body["attributes"]["status"]).to eq nil
               expect(response_body["attributes"]["veteran_is_deceased"]).to eq false
               expect(response_body["attributes"]["veteran_ssn"]).to eq ama_appeals.first.veteran_ssn
-              expect(response_body["attributes"]["veteran_death_date"]).to eq "05/25/2016"
+              expect(response_body["attributes"]["veteran_death_date"]).to eq nil
               expect(response_body["attributes"]["appellant_is_not_veteran"]).to eq true
               expect(response_body["attributes"]["appellants"][0]["first_name"])
                 .to eq ama_appeals.first.appellant_first_name

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
           first_name: "Bob",
           last_name: "Smith",
           date_of_birth: "01/10/1935",
-          date_of_death: "05/25/2016",
+          date_of_death: nil,
           name_suffix: "II",
           ssn: "987654321",
           sex: "M",

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -24,12 +24,14 @@ feature "Appeal Intake" do
 
   let(:veteran_file_number) { "223344555" }
 
+  let(:date_of_death) { nil }
   let!(:veteran) do
     Generators::Veteran.build(
       file_number: veteran_file_number,
       first_name: "Ed",
       last_name: "Merica",
-      participant_id: "55443322"
+      participant_id: "55443322",
+      date_of_death: date_of_death
     )
   end
 
@@ -86,6 +88,19 @@ feature "Appeal Intake" do
   end
 
   let(:no_ratings_err) { Rating::NilRatingProfileListError.new("none!") }
+
+  context "veteran is deceased" do
+    let(:date_of_death) { Time.zone.today - 1.day }
+
+    scenario "veteran cannot be claimant" do
+      create(:appeal, veteran_file_number: veteran.file_number)
+      intake = AppealIntake.new(veteran_file_number: veteran.file_number, user: current_user)
+      intake.start!
+
+      visit "/intake"
+      expect(page).to have_css("input[disabled][id=different-claimant-option_false]", visible: false)
+    end
+  end
 
   it "cancels an intake in progress when there is a NilRatingProfileListError" do
     allow_any_instance_of(Fakes::BGSService).to receive(:fetch_ratings_in_range).and_raise(no_ratings_err)

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -94,11 +94,7 @@ feature "Appeal Intake" do
 
     scenario "veteran cannot be claimant" do
       create(:appeal, veteran_file_number: veteran.file_number)
-      intake = AppealIntake.new(veteran_file_number: veteran.file_number, user: current_user)
-      intake.start!
-
-      visit "/intake"
-      expect(page).to have_css("input[disabled][id=different-claimant-option_false]", visible: false)
+      check_deceased_veteran_claimant(AppealIntake.new(veteran_file_number: veteran.file_number, user: current_user))
     end
   end
 

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -93,6 +93,8 @@ feature "Appeal Intake" do
     let(:date_of_death) { Time.zone.today - 1.day }
 
     scenario "veteran cannot be claimant" do
+      # save the veteran first, otherwise creating an appeal will create a new veteran
+      veteran.save!
       create(:appeal, veteran_file_number: veteran.file_number)
       check_deceased_veteran_claimant(AppealIntake.new(veteran_file_number: veteran.file_number, user: current_user))
     end

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -110,11 +110,9 @@ feature "Higher-Level Review" do
 
     scenario "veteran cannot be claimant" do
       create(:higher_level_review, veteran_file_number: veteran.file_number)
-      intake = HigherLevelReviewIntake.new(veteran_file_number: veteran.file_number, user: current_user)
-      intake.start!
-
-      visit "/intake"
-      expect(page).to have_css("input[disabled][id=different-claimant-option_false]", visible: false)
+      check_deceased_veteran_claimant(
+        HigherLevelReviewIntake.new(veteran_file_number: veteran.file_number, user: current_user)
+      )
     end
   end
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -26,8 +26,12 @@ feature "Higher-Level Review" do
 
   let(:veteran_file_number) { "123412345" }
 
+  let(:date_of_death) { nil }
   let(:veteran) do
-    Generators::Veteran.build(file_number: veteran_file_number, first_name: "Ed", last_name: "Merica")
+    Generators::Veteran.build(file_number: veteran_file_number,
+                              first_name: "Ed",
+                              last_name: "Merica",
+                              date_of_death: date_of_death)
   end
 
   let(:veteran_no_ratings) do
@@ -99,6 +103,19 @@ feature "Higher-Level Review" do
         { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" }
       ]
     )
+  end
+
+  context "veteran is deceased" do
+    let(:date_of_death) { Time.zone.today - 1.day }
+
+    scenario "veteran cannot be claimant" do
+      create(:higher_level_review, veteran_file_number: veteran.file_number)
+      intake = HigherLevelReviewIntake.new(veteran_file_number: veteran.file_number, user: current_user)
+      intake.start!
+
+      visit "/intake"
+      expect(page).to have_css("input[disabled][id=different-claimant-option_false]", visible: false)
+    end
   end
 
   it "Creates an end product and contentions for it" do

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -113,11 +113,9 @@ feature "Supplemental Claim Intake" do
 
     scenario "veteran cannot be claimant" do
       create(:supplemental_claim, veteran_file_number: veteran.file_number)
-      intake = SupplementalClaimIntake.new(veteran_file_number: veteran.file_number, user: current_user)
-      intake.start!
-
-      visit "/intake"
-      expect(page).to have_css("input[disabled][id=different-claimant-option_false]", visible: false)
+      check_deceased_veteran_claimant(
+        SupplementalClaimIntake.new(veteran_file_number: veteran.file_number, user: current_user)
+      )
     end
   end
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -171,7 +171,6 @@ RSpec.feature "Case details" do
         expect(page).to have_content("About the Veteran")
         expect(page).to have_content(COPY::CASE_DETAILS_GENDER_FIELD_VALUE_FEMALE)
         expect(page).to have_content("1/10/1935")
-        expect(page).to have_content("5/25/2016")
         expect(page).to have_content(appeal.regional_office.city)
         expect(page).to have_content(appeal.veteran_address_line_1)
       end

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -494,6 +494,12 @@ module IntakeHelpers
     ).to_not be_nil
   end
 
+  def check_deceased_veteran_claimant(intake)
+    intake.start!
+    visit "/intake"
+    expect(page).to have_css("input[disabled][id=different-claimant-option_false]", visible: false)
+  end
+
   # rubocop:disable Metrics/AbcSize
   def verify_decision_issues_can_be_added_and_removed(page_url,
                                                       original_request_issue,


### PR DESCRIPTION
Connects #9417 

When the veteran is deceased, forces intake user to select another claimant.

<img width="836" alt="screen shot 2019-02-14 at 2 09 03 pm" src="https://user-images.githubusercontent.com/577629/52821500-d1b97a80-3063-11e9-8548-a1172df907b2.png">
