### PR TITLE
Fix Docket Order sorting in Assign Hearings tabs

### DIFF
--- a/client/app/hearingSchedule/components/AssignHearingsTabs.jsx
+++ b/client/app/hearingSchedule/components/AssignHearingsTabs.jsx
@@ -178,6 +178,11 @@ export default class AssignHearingsTabs extends React.Component {
       return filteredBy === appeal.attributes.veteranAvailableHearingLocations[0].facilityId;
     });
 
+    /*
+      Sorting by docket number within each category of appeal:
+      CAVC, AOD and normal. Prepended * and + to docket number for
+      CAVC and AOD to group them first and second.
+     */
     const sortedByAodCavc = _.sortBy(filtered, (appeal) => {
       if (appeal.attributes.caseType === LEGACY_APPEAL_TYPES_BY_ID.cavc_remand) {
         return `*${appeal.attributes.docketNumber}`;

--- a/client/app/hearingSchedule/components/AssignHearingsTabs.jsx
+++ b/client/app/hearingSchedule/components/AssignHearingsTabs.jsx
@@ -180,12 +180,12 @@ export default class AssignHearingsTabs extends React.Component {
 
     const sortedByAodCavc = _.sortBy(filtered, (appeal) => {
       if (appeal.attributes.caseType === LEGACY_APPEAL_TYPES_BY_ID.cavc_remand) {
-        return 0;
+        return `*${appeal.attributes.docketNumber}`;
       } else if (appeal.attributes.aod) {
-        return 1;
+        return `+${appeal.attributes.docketNumber}`;
       }
 
-      return 2;
+      return appeal.attributes.docketNumber;
     });
 
     return _.map(sortedByAodCavc, (appeal, index) => ({


### PR DESCRIPTION
Resolves #9437 

### Description
Fixed the sorting logic in AssignHearingsTabs to properly sort within each category: CAVC, AOD and normal.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to Assign Hearings page
2. Go to Legacy Veterans Waiting tab
3. Confirm Veteran appeals are sorted by docket number within each category.

