### PR TITLE
Add Locations to Appeals Migration

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -6,6 +6,7 @@ class Appeal < DecisionReview
   has_many :appeal_views, as: :appeal
   has_many :claims_folder_searches, as: :appeal
   has_many :hearings
+  has_many :available_hearing_locations, as: :appeal, class_name: "AvailableHearingLocations"
 
   # decision_documents is effectively a has_one until post decisional motions are supported
   has_many :decision_documents

--- a/app/models/hearings/available_hearing_locations.rb
+++ b/app/models/hearings/available_hearing_locations.rb
@@ -1,3 +1,4 @@
 class AvailableHearingLocations < ApplicationRecord
   belongs_to :veteran, foreign_key: :file_number, primary_key: :veteran_file_number
+  belongs_to :appeal, polymorphic: true
 end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -14,6 +14,7 @@ class LegacyAppeal < ApplicationRecord
   has_many :claims_folder_searches, as: :appeal
   has_many :tasks, as: :appeal
   has_one :special_issue_list, as: :appeal
+  has_many :available_hearing_locations, as: :appeal, class_name: "AvailableHearingLocations"
   accepts_nested_attributes_for :worksheet_issues, allow_destroy: true
 
   class UnknownLocationError < StandardError; end

--- a/db/migrate/20190214214208_add_available_hearing_locations_to_appeals.rb
+++ b/db/migrate/20190214214208_add_available_hearing_locations_to_appeals.rb
@@ -1,0 +1,9 @@
+class AddAvailableHearingLocationsToAppeals < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :available_hearing_locations, :veteran_file_number, true
+    add_column :available_hearing_locations, :appeal_id, :integer, null: true
+    add_column :available_hearing_locations, :appeal_type, :string, null: true
+    add_column :legacy_appeals, :closest_regional_office, :string
+    add_column :appeals, :closest_regional_office, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190212142949) do
+ActiveRecord::Schema.define(version: 20190214214208) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 20190212142949) do
   end
 
   create_table "appeals", force: :cascade do |t|
+    t.string "closest_regional_office"
     t.string "docket_type"
     t.datetime "established_at"
     t.datetime "establishment_attempted_at"
@@ -111,6 +112,8 @@ ActiveRecord::Schema.define(version: 20190212142949) do
 
   create_table "available_hearing_locations", force: :cascade do |t|
     t.string "address"
+    t.integer "appeal_id"
+    t.string "appeal_type"
     t.string "city"
     t.string "classification"
     t.datetime "created_at", null: false
@@ -120,7 +123,7 @@ ActiveRecord::Schema.define(version: 20190212142949) do
     t.string "name"
     t.string "state"
     t.datetime "updated_at", null: false
-    t.string "veteran_file_number", null: false
+    t.string "veteran_file_number"
     t.string "zip_code"
     t.index ["veteran_file_number"], name: "index_available_hearing_locations_on_veteran_file_number"
   end
@@ -583,6 +586,7 @@ ActiveRecord::Schema.define(version: 20190212142949) do
 
   create_table "legacy_appeals", force: :cascade do |t|
     t.bigint "appeal_series_id"
+    t.string "closest_regional_office"
     t.boolean "contaminated_water_at_camp_lejeune", default: false
     t.boolean "dic_death_or_accrued_benefits_united_states", default: false
     t.string "dispatched_to_station"


### PR DESCRIPTION
1st step of reworking AHL job to geomatch on appeals and not veteran

- adds `closest_regional_office` column to Appeal and LegacyAppeal
- adds reference to `AvailableHearingLocations` to Appeal/LegacyAppeal
- removes `null: false` from `veteran_file_number` on `AvailableHearingLocations`