### PR TITLE
Veteran find or create fix

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -117,7 +117,7 @@ class IntakesController < ApplicationController
   def new_intake
     @new_intake ||= Intake.build(
       user: current_user,
-      veteran_file_number: veteran_file_number,
+      veteran: veteran,
       form_type: params[:form_type]
     )
   end
@@ -126,10 +126,9 @@ class IntakesController < ApplicationController
     @intake ||= Intake.where(user: current_user).find(params[:id])
   end
 
-  def veteran_file_number
+  def veteran
     # param could be file number or SSN. Make sure we return file number.
-    veteran = Veteran.find_by_file_number_or_ssn(params[:file_number], sync_name: true)
-    veteran ? veteran.file_number : params[:file_number]
+    @veteran ||= Veteran.find_or_create_by_file_number_or_ssn(params[:file_number], sync_name: true)
   end
 
   def success_message

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -117,8 +117,7 @@ class IntakesController < ApplicationController
   def new_intake
     @new_intake ||= Intake.build(
       user: current_user,
-      veteran: veteran,
-      veteran_file_number: params[:file_number],
+      veteran_or_file_number: veteran || params[:file_number],
       form_type: params[:form_type]
     )
   end

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -127,7 +127,6 @@ class IntakesController < ApplicationController
   end
 
   def veteran
-    # param could be file number or SSN. Make sure we return file number.
     @veteran ||= Veteran.find_or_create_by_file_number_or_ssn(params[:file_number], sync_name: true)
   end
 

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -118,6 +118,7 @@ class IntakesController < ApplicationController
     @new_intake ||= Intake.build(
       user: current_user,
       veteran: veteran,
+      veteran_file_number: params[:file_number],
       form_type: params[:form_type]
     )
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -31,6 +31,7 @@ class Intake < ApplicationRecord
   }.freeze
 
   attr_reader :error_data
+  attr_writer :veteran
 
   def self.in_progress
     where(completed_at: nil).where(started_at: IN_PROGRESS_EXPIRES_AFTER.ago..Time.zone.now)
@@ -40,13 +41,14 @@ class Intake < ApplicationRecord
     where(completed_at: nil).where(started_at: Time.zone.at(0)...IN_PROGRESS_EXPIRES_AFTER.ago)
   end
 
-  def self.build(form_type:, veteran_file_number:, user:)
+  def self.build(form_type:, veteran:, user:)
     intake_classname = FORM_TYPES[form_type.to_sym]
 
     fail FormTypeNotSupported unless intake_classname
 
     intake_classname.constantize.new(
-      veteran_file_number: veteran_file_number,
+      veteran: veteran,
+      veteran_file_number: veteran.try(:file_number),
       user: user
     )
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -48,7 +48,7 @@ class Intake < ApplicationRecord
 
     intake_classname.constantize.new(
       veteran: veteran,
-      veteran_file_number: veteran.try(:file_number),
+      veteran_file_number: veteran.file_number,
       user: user
     )
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -47,7 +47,7 @@ class Intake < ApplicationRecord
     fail FormTypeNotSupported unless intake_classname
 
     veteran = veteran_or_file_number.is_a?(Veteran) ? veteran_or_file_number : nil
-    veteran_file_number = veteran.nil? ? veteran_or_file_number : veteran.file_number
+    veteran_file_number = veteran ? veteran.file_number : veteran_or_file_number
 
     intake_classname.constantize.new(
       veteran: veteran,

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -1,5 +1,6 @@
 class Intake < ApplicationRecord
   class FormTypeNotSupported < StandardError; end
+  class VeteranOrFileNumberRequired < StandardError; end
 
   belongs_to :user
   belongs_to :detail, polymorphic: true
@@ -41,14 +42,16 @@ class Intake < ApplicationRecord
     where(completed_at: nil).where(started_at: Time.zone.at(0)...IN_PROGRESS_EXPIRES_AFTER.ago)
   end
 
-  def self.build(form_type:, veteran:, user:)
+  def self.build(form_type:, veteran: nil, veteran_file_number: nil, user:)
     intake_classname = FORM_TYPES[form_type.to_sym]
 
     fail FormTypeNotSupported unless intake_classname
 
+    fail VeteranOrFileNumberRequired unless veteran || veteran_file_number
+
     intake_classname.constantize.new(
-      veteran: veteran,
-      veteran_file_number: veteran.file_number,
+      veteran: veteran || Veteran.find_or_create_by_file_number(veteran_file_number),
+      veteran_file_number: veteran_file_number || veteran.file_number,
       user: user
     )
   end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -198,7 +198,6 @@ class Veteran < ApplicationRecord
     end
 
     def find_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
-      binding.pry
       if file_number_or_ssn.to_s.length == 9
         find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
           find_by_ssn(file_number_or_ssn, sync_name: sync_name)
@@ -235,8 +234,6 @@ class Veteran < ApplicationRecord
     def find_and_maybe_backfill_name(file_number, sync_name: false)
       veteran = find_by(file_number: file_number)
       return nil unless veteran
-
-      binding.pry
 
       # Check to see if veteran is accessible to make sure bgs_record is
       # a hash and not :not_found. Also if it's not found, bgs_record returns

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -198,6 +198,7 @@ class Veteran < ApplicationRecord
     end
 
     def find_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
+      binding.pry
       if file_number_or_ssn.to_s.length == 9
         find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
           find_by_ssn(file_number_or_ssn, sync_name: sync_name)
@@ -234,6 +235,8 @@ class Veteran < ApplicationRecord
     def find_and_maybe_backfill_name(file_number, sync_name: false)
       veteran = find_by(file_number: file_number)
       return nil unless veteran
+
+      binding.pry
 
       # Check to see if veteran is accessible to make sure bgs_record is
       # a hash and not :not_found. Also if it's not found, bgs_record returns

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -243,7 +243,7 @@ class Veteran < ApplicationRecord
           %(
           find_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
           )
-
+        )
         if veteran.accessible? && veteran.bgs_record.is_a?(Hash) && veteran.stale_name?
           veteran.update!(
             first_name: veteran.bgs_record[:first_name],
@@ -270,8 +270,6 @@ class Veteran < ApplicationRecord
       Rails.logger.warn(
         %(create_by_file_number file_number:#{file_number} found:true accessible:#{veteran.accessible?})
       )
-
-      binding.pry
 
       before_create_veteran_by_file_number # Used to simulate race conditions
       veteran.tap do |v|

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -243,7 +243,6 @@ class Veteran < ApplicationRecord
           %(
           find_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
           )
-        )
 
         if veteran.accessible? && veteran.bgs_record.is_a?(Hash) && veteran.stale_name?
           veteran.update!(
@@ -271,6 +270,8 @@ class Veteran < ApplicationRecord
       Rails.logger.warn(
         %(create_by_file_number file_number:#{file_number} found:true accessible:#{veteran.accessible?})
       )
+
+      binding.pry
 
       before_create_veteran_by_file_number # Used to simulate race conditions
       veteran.tap do |v|

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -271,19 +271,17 @@ class Veteran < ApplicationRecord
         %(create_by_file_number file_number:#{file_number} found:true accessible:#{veteran.accessible?})
       )
 
+      return veteran unless veteran.accessible?
+
       before_create_veteran_by_file_number # Used to simulate race conditions
       veteran.tap do |v|
-        v.update!(participant_id: v.ptcpnt_id)
-        # Check to see if veteran is accessible to make sure
-        # bgs_record is a hash and not :not_found
-        if v.accessible?
-          v.update!(
-            first_name: v.bgs_record[:first_name],
-            last_name: v.bgs_record[:last_name],
-            middle_name: v.bgs_record[:middle_name],
-            name_suffix: v.bgs_record[:name_suffix]
-          )
-        end
+        v.update!(
+          participant_id: v.ptcpnt_id,
+          first_name: v.bgs_record[:first_name],
+          last_name: v.bgs_record[:last_name],
+          middle_name: v.bgs_record[:middle_name],
+          name_suffix: v.bgs_record[:name_suffix]
+        )
       end
     rescue ActiveRecord::RecordNotUnique
       find_by(file_number: file_number)

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -22,13 +22,27 @@ RSpec.describe IntakesController do
       expect(Intake.last.veteran_file_number).to eq(file_number)
     end
 
-    context "veteran does not yet exist in our db" do
-      let(:file_number) { "999887777" }
+    context "veteran name is out of sync with BGS" do
       let!(:veteran) { create(:veteran, file_number: file_number, first_name: nil, last_name: nil) }
       before { Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica") }
 
-      it "will create a Veteran record in our db with name populated" do
-        #expect(Veteran.find_by_file_number_or_ssn(file_number).first_name).to be_nil
+      it "will update the Veteran name in Caseflow" do
+        post :create, params: { file_number: file_number, form_type: "higher_level_review" }
+        expect(response.status).to eq(200)
+        vet = Veteran.find_by_file_number_or_ssn(file_number)
+        expect(vet).to_not be_nil
+        expect(vet.first_name).to eq "Ed"
+        expect(vet.last_name).to eq "Merica"
+      end
+    end
+
+    context "veteran in BGS but not yet in Caseflow" do
+      let(:file_number) { "999887777" }
+      let!(:veteran) {} # no-op
+      before { Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica") }
+
+      it "will create the Veteran in Caseflow" do
+        expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
         post :create, params: { file_number: file_number, form_type: "higher_level_review" }
         expect(response.status).to eq(200)
         vet = Veteran.find_by_file_number_or_ssn(file_number)

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -21,6 +21,22 @@ RSpec.describe IntakesController do
       expect(response.status).to eq(200)
       expect(Intake.last.veteran_file_number).to eq(file_number)
     end
+
+    context "veteran does not yet exist in our db" do
+      let(:file_number) { "999887777" }
+      let!(:veteran) { create(:veteran, file_number: file_number, first_name: nil, last_name: nil) }
+      before { Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica") }
+
+      it "will create a Veteran record in our db with name populated" do
+        #expect(Veteran.find_by_file_number_or_ssn(file_number).first_name).to be_nil
+        post :create, params: { file_number: file_number, form_type: "higher_level_review" }
+        expect(response.status).to eq(200)
+        vet = Veteran.find_by_file_number_or_ssn(file_number)
+        expect(vet).to_not be_nil
+        expect(vet.first_name).to eq "Ed"
+        expect(vet.last_name).to eq "Merica"
+      end
+    end
   end
 
   describe "#complete" do

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe IntakesController do
 
       it "does not create Veteran db record in Caseflow" do
         expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
+        expect(Intake.find_by(veteran_file_number: file_number)).to be_nil
         post :create, params: { file_number: file_number, form_type: "higher_level_review" }
         expect(response.status).to eq(422)
         expect(controller.send(:new_intake).error_code).to eq("veteran_not_accessible")

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -67,11 +67,9 @@ RSpec.describe IntakesController do
       it "does not create Veteran db record in Caseflow" do
         expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
         post :create, params: { file_number: file_number, form_type: "higher_level_review" }
-        binding.pry
         expect(response.status).to eq(422)
         expect(controller.send(:new_intake).error_code).to eq("veteran_not_accessible")
         expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
-        binding.pry
       end
     end
   end

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -52,13 +52,10 @@ RSpec.describe IntakesController do
       end
     end
 
-    context "vetern in BGS and not accessible to user" do
+    context "veteran in BGS and not accessible to user" do
       before do
         Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica")
-        Fakes::BGSService.inaccessible_appeal_vbms_ids = [file_number]
-      end
-      after do
-        Fakes::BGSService.inaccessible_appeal_vbms_ids = []
+        allow_any_instance_of(Veteran).to receive(:accessible?).and_return(false)
       end
 
       let(:file_number) { "999887777" }

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe IntakesController do
         expect(response.status).to eq(422)
         expect(controller.send(:new_intake).error_code).to eq("veteran_not_accessible")
         expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
+        expect(Intake.find_by(veteran_file_number: file_number)).to_not be_nil
       end
     end
   end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -38,13 +38,13 @@ describe Intake do
     )
   end
 
-  let!(:veteran) { Generators::Veteran.build(file_number: "64205050", country: country) }
+  let!(:veteran) { Generators::Veteran.build(file_number: veteran_file_number, country: country) }
 
   let(:completion_status) { nil }
   let(:completion_started_at) { nil }
 
   context ".build" do
-    subject { Intake.build(form_type: form_type, veteran_file_number: veteran_file_number, user: user) }
+    subject { Intake.build(form_type: form_type, veteran: veteran, user: user) }
 
     context "when form_type is supported" do
       let(:form_type) { "ramp_election" }
@@ -430,6 +430,8 @@ describe Intake do
 
     context "veteran not found in bgs" do
       let(:veteran_file_number) { "11111111" }
+
+      before { Fakes::BGSService.veteran_records[veteran_file_number] = nil }
 
       it "adds veteran_not_found and returns false" do
         expect(subject).to eq(false)

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -44,7 +44,11 @@ describe Intake do
   let(:completion_started_at) { nil }
 
   context ".build" do
-    subject { Intake.build(form_type: form_type, veteran: veteran, user: user) }
+    let(:form_type) { "higher_level_review" }
+
+    subject do
+      Intake.build(form_type: form_type, veteran: veteran, veteran_file_number: veteran_file_number, user: user)
+    end
 
     context "when form_type is supported" do
       let(:form_type) { "ramp_election" }
@@ -58,6 +62,23 @@ describe Intake do
 
       it "raises error" do
         expect { subject }.to raise_error(Intake::FormTypeNotSupported)
+      end
+    end
+
+    context "when veteran is nil" do
+      let(:veteran) { nil }
+
+      it "falls back to veteran_file_number" do
+        expect(subject.veteran.file_number).to eq(veteran_file_number)
+      end
+    end
+
+    context "when veteran_file_number is nil" do
+      let(:veteran) { Generators::Veteran.build(file_number: "64205050", country: country) }
+      let(:veteran_file_number) { nil }
+
+      it "falls back to veteran" do
+        expect(subject.veteran.file_number).to eq("64205050")
       end
     end
   end

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -47,7 +47,7 @@ describe Intake do
     let(:form_type) { "higher_level_review" }
 
     subject do
-      Intake.build(form_type: form_type, veteran: veteran, veteran_file_number: veteran_file_number, user: user)
+      Intake.build(form_type: form_type, veteran_or_file_number: veteran || veteran_file_number, user: user)
     end
 
     context "when form_type is supported" do


### PR DESCRIPTION
connects #9448 

## Description

This change refactors the `Intake.build` method to take a `Veteran` instance instead of a file number. This should reduce the number of calls to upstream services.

This change also affects the logic for when a `Veteran` record is created. It will only be created if both `found?` and `accessible?` are true.