### PR TITLE
Add created_at to decision issues

### DIFF
--- a/db/migrate/20190215194659_add_created_at_to_decision_issues.rb
+++ b/db/migrate/20190215194659_add_created_at_to_decision_issues.rb
@@ -1,0 +1,5 @@
+class AddCreatedAtToDecisionIssues < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decision_issues, :created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190215145907) do
+ActiveRecord::Schema.define(version: 20190215194659) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -245,6 +245,7 @@ ActiveRecord::Schema.define(version: 20190215145907) do
   create_table "decision_issues", force: :cascade do |t|
     t.string "benefit_type"
     t.date "caseflow_decision_date"
+    t.datetime "created_at"
     t.integer "decision_review_id"
     t.string "decision_review_type"
     t.string "decision_text"

--- a/spec/models/decision_issue_spec.rb
+++ b/spec/models/decision_issue_spec.rb
@@ -76,6 +76,11 @@ describe DecisionIssue do
   context "#save" do
     subject { decision_issue.save }
 
+    it "sets created at" do
+      subject
+      expect(decision_issue).to have_attributes(created_at: Time.zone.now)
+    end
+
     context "when description is not set" do
       let(:description) { nil }
 


### PR DESCRIPTION
This field is on `request_issues` and even though it's not used, it can be helpful in debugging and understanding the data. So we should probably add it.

connects #8239