### PR TITLE
change judgetask to judge assign task, refresh ama tasks after distribution is complete, don't spam server

### DIFF
--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -63,11 +63,11 @@ class Docket
     appeals.map do |appeal|
       Rails.logger.info("Assigning judge task for appeal #{appeal.id}")
       task = JudgeAssignTask.create!(appeal: appeal,
-                               parent: appeal.root_task,
-                               appeal_type: Appeal.name,
-                               assigned_at: Time.zone.now,
-                               assigned_to: judge,
-                               action: "assign")
+                                     parent: appeal.root_task,
+                                     appeal_type: Appeal.name,
+                                     assigned_at: Time.zone.now,
+                                     assigned_to: judge,
+                                     action: "assign")
       Rails.logger.info("Assigned judge task with task id #{task.id} to #{task.assigned_to.css_id}")
 
       Rails.logger.info("Closing distribution task for appeal #{appeal.id}")

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -62,7 +62,7 @@ class Docket
   def assign_judge_tasks_for_appeals(appeals, judge)
     appeals.map do |appeal|
       Rails.logger.info("Assigning judge task for appeal #{appeal.id}")
-      task = JudgeTask.create!(appeal: appeal,
+      task = JudgeAssignTask.create!(appeal: appeal,
                                parent: appeal.root_task,
                                appeal_type: Appeal.name,
                                assigned_at: Time.zone.now,


### PR DESCRIPTION
We don't use `JudgeTask` anymore, we use subclasses of it, `JudgeAssignTask` and `JudgeReviewTask`