### PR TITLE
explicitly capture EPE id in Raven rescue logging

### DIFF
--- a/app/jobs/end_product_sync_job.rb
+++ b/app/jobs/end_product_sync_job.rb
@@ -6,6 +6,10 @@ class EndProductSyncJob < CaseflowJob
   def perform(end_product_establishment_id)
     RequestStore.store[:current_user] = User.system_user
 
-    EndProductEstablishment.find(end_product_establishment_id).sync!
+    begin
+      EndProductEstablishment.find(end_product_establishment_id).sync!
+    rescue StandardError => err
+      Raven.capture_exception(err, extra: { end_product_establishment_id: end_product_establishment_id })
+    end
   end
 end

--- a/spec/jobs/end_product_sync_job_spec.rb
+++ b/spec/jobs/end_product_sync_job_spec.rb
@@ -10,6 +10,10 @@ describe EndProductSyncJob do
            established_at: 4.days.ago)
   end
 
+  let(:bgs_error) do
+    BGS::ShareError.new("More EPs more problems")
+  end
+
   context "#perform" do
     it "syncs the end product establishment" do
       EndProductSyncJob.perform_now(end_product_establishment.id)
@@ -17,5 +21,14 @@ describe EndProductSyncJob do
       expect(RequestStore.store[:current_user].id).to eq(User.system_user.id)
       expect(end_product_establishment.reload.last_synced_at).to_not eq(nil)
     end
+  end
+
+  it "saves Exception messages and logs error" do
+    allow(Raven).to receive(:capture_exception) { @raven_called = true }
+    allow_any_instance_of(EndProductEstablishment).to receive(:sync!).and_raise(bgs_error)
+
+    EndProductSyncJob.perform_now(end_product_establishment.id)
+
+    expect(@raven_called).to eq(true)
   end
 end


### PR DESCRIPTION
The regular sync job was not logging the EPE id on failure.
