### PR TITLE
Consider an EP preexisting only if it is active

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -439,6 +439,8 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def find_open_modifier
+    fail NoAvailableModifiers unless valid_modifiers.any?
+
     return valid_modifiers.first if valid_modifiers.count == 1
 
     valid_modifiers.each do |modifier|

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -137,7 +137,7 @@ class EndProductEstablishment < ApplicationRecord
 
   # Find an end product that has the traits of the end product that should be created.
   def preexisting_end_product
-    @preexisting_end_product ||= veteran.end_products.find { |ep| end_product_to_establish.matches?(ep) }
+    @preexisting_end_product ||= veteran.end_products.find { |ep| ep.active? && end_product_to_establish.matches?(ep) }
   end
 
   def cancel_unused_end_product!

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -439,8 +439,6 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def find_open_modifier
-    fail NoAvailableModifiers unless valid_modifiers.any?
-
     return valid_modifiers.first if valid_modifiers.count == 1
 
     valid_modifiers.each do |modifier|

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -311,6 +311,7 @@ describe RampElectionIntake do
           expect(intake.detail.established_at).to_not be_nil
           expect(veteran_end_products.count).to eq 3
           expect(veteran_end_products.map(&:claim_id)).to include(preexisting_ep.claim_id)
+          expect(intake.detail.end_product_establishment.reference_id).to_not eq(preexisting_ep.claim_id)
         end
       end
 


### PR DESCRIPTION
connects #9476 

Related to:

* https://github.com/department-of-veterans-affairs/appeals-support/issues/3938
* https://github.com/department-of-veterans-affairs/caseflow/issues/7638
