### PR TITLE
Add decision timeliness to decision_in_progress details

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -403,6 +403,7 @@ class Appeal < DecisionReview
   # rubocop:enable Metrics/PerceivedComplexity
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable CyclomaticComplexity
   def fetch_details_for_status
     case fetch_status
     when :bva_decision
@@ -417,25 +418,30 @@ class Appeal < DecisionReview
       post_bva_dta_decision_status_details
     when :bva_decision_effectuation
       {
-        bvaDecisionDate: decision_event_date,
-        aojDecisionDate: decision_effectuation_event_date
+        bva_decision_date: decision_event_date,
+        aoj_decision_date: decision_effectuation_event_date
       }
     when :pending_hearing_scheduling
       {
         type: "video"
       }
+    when :decision_in_progress
+      {
+        decision_timeliness: AppealSeries::DECISION_TIMELINESS
+      }
     else
       {}
     end
   end
+  # rubocop:enable CyclomaticComplexity
   # rubocop:enable Metrics/MethodLength
 
   def post_bva_dta_decision_status_details
     issue_list = remanded_sc_decision_issues
     {
       issues: api_issues_for_status_details_issues(issue_list),
-      bvaDecisionDate: decision_event_date,
-      aojDecisionDate: remand_decision_event_date
+      bva_decision_date: decision_event_date,
+      aoj_decision_date: remand_decision_event_date
     }
   end
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1097,8 +1097,8 @@ describe Appeal do
       it "effectuation had an ep" do
         status = appeal.status_hash
         expect(status[:type]).to eq(:bva_decision_effectuation)
-        expect(status[:details][:bvaDecisionDate].to_date).to eq((receipt_date + 60.days).to_date)
-        expect(status[:details][:aojDecisionDate].to_date).to eq((receipt_date + 100.days).to_date)
+        expect(status[:details][:bva_decision_date].to_date).to eq((receipt_date + 60.days).to_date)
+        expect(status[:details][:aoj_decision_date].to_date).to eq((receipt_date + 100.days).to_date)
       end
     end
 
@@ -1198,8 +1198,8 @@ describe Appeal do
             { description: "Partial loss of upper jaw", disposition: "granted" },
             description: "Partial loss of hard palate", disposition: "denied"
           )
-          expect(status[:details][:bvaDecisionDate]).to eq((receipt_date + 60.days).to_date)
-          expect(status[:details][:aojDecisionDate]).to eq((receipt_date + 101.days).to_date)
+          expect(status[:details][:bva_decision_date]).to eq((receipt_date + 60.days).to_date)
+          expect(status[:details][:aoj_decision_date]).to eq((receipt_date + 101.days).to_date)
         end
       end
 
@@ -1213,8 +1213,8 @@ describe Appeal do
             { description: "Partial loss of hard palate", disposition: "remanded" },
             description: "Partial loss of hard palate", disposition: "remanded"
           )
-          expect(status[:details][:bvaDecisionDate]).to be_nil
-          expect(status[:details][:aojDecisionDate]).to be_nil
+          expect(status[:details][:bva_decision_date]).to be_nil
+          expect(status[:details][:aoj_decision_date]).to be_nil
         end
       end
     end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1052,7 +1052,7 @@ describe Appeal do
       it "waiting for a decision" do
         status = appeal.status_hash
         expect(status[:type]).to eq(:decision_in_progress)
-        expect(status[:details]).to be_empty
+        expect(status[:details][:decision_timeliness]).to eq([1, 2])
       end
     end
 


### PR DESCRIPTION
Resolves #9430 

### Description
This is needed for MVP as the front-end will expect to have this information in order to display the `decision_in_progress` status.