### PR TITLE
Remove ama_decision_issues flag and remove all old code

### DIFF
--- a/app/controllers/case_reviews_controller.rb
+++ b/app/controllers/case_reviews_controller.rb
@@ -68,9 +68,7 @@ class CaseReviewsController < ApplicationController
   end
 
   def issues_params
-    # This is a combined list of params from the old and new issue editing methods.
-    # If new params like request_issue_ids exist in the request, we default to
-    # using the new issue editing flow.
+    # This is a combined list of params for ama and legacy appeals
     [
       :id,
       :disposition,

--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -1,23 +1,15 @@
-# This module has too many lines temporarily. There are a few deprecated methods that will be removed once
-# we turn on 'ama_decision_issues' flag
-# rubocop:disable Metrics/ModuleLength
 module IssueUpdater
   extend ActiveSupport::Concern
 
-  # Remove this method when feature flag 'ama_decision_issues' is enabled for all.
   def update_issue_dispositions_in_caseflow!
-    use_ama_decision_issues? ? delete_and_create_decision_issues! : update_issue_dispositions_deprecated!
-  rescue ActiveRecord::RecordInvalid => e
-    raise Caseflow::Error::AttorneyJudgeCheckoutError, message: e.message
-  end
-
-  def delete_and_create_decision_issues!
     return unless appeal
 
     # We will always delete and re-create decision issues on attorney/judge checkout
     appeal.decision_issues.destroy_all
     create_decision_issues!
     fail_if_not_all_request_issues_have_decision!
+  rescue ActiveRecord::RecordInvalid => e
+    raise Caseflow::Error::AttorneyJudgeCheckoutError, message: e.message
   end
 
   def update_issue_dispositions_in_vacols!
@@ -83,8 +75,7 @@ module IssueUpdater
   end
 
   def fail_if_count_mismatch!
-    existing_issues_count = legacy? ? appeal.undecided_issues.count : appeal.eligible_request_issues.count
-    if (issues || []).count != existing_issues_count
+    if (issues || []).count != appeal.undecided_issues.count
       msg = "Number of issues in the request does not match the number in the database"
       fail Caseflow::Error::AttorneyJudgeCheckoutError, message: msg
     end
@@ -106,42 +97,4 @@ module IssueUpdater
       end
     end
   end
-
-  # Delete this method when feature flag 'ama_decision_issues' is enabled for all
-  def use_ama_decision_issues?
-    FeatureToggle.enabled?(:ama_decision_issues, user: RequestStore.store[:current_user]) ||
-      issues&.first && issues.first[:request_issue_ids]
-  end
-
-  # Delete this method when feature flag 'ama_decision_issues' is enabled for all
-  def update_issue_dispositions_deprecated!
-    fail_if_invalid_issues_attrs!
-
-    (issues || []).each do |issue_attrs|
-      request_issue = appeal.request_issues.open.find_by(id: issue_attrs[:id]) if appeal
-      next unless request_issue
-
-      request_issue.update(disposition: issue_attrs[:disposition])
-
-      # If disposition was remanded and now is changed to another dispostion,
-      # delete all remand reasons associated with the request issue
-      update_remand_reasons_deprecated(request_issue, issue_attrs[:remand_reasons] || [])
-    end
-  end
-
-  # Delete this method when feature flag 'ama_decision_issues' is enabled for all
-  def update_remand_reasons_deprecated(request_issue, remand_reasons_attrs)
-    fail_if_no_remand_reasons!(request_issue, remand_reasons_attrs)
-    remand_reasons_attrs.each do |remand_reason_attrs|
-      request_issue.remand_reasons.find_or_initialize_by(code: remand_reason_attrs[:code]).tap do |record|
-        record.post_aoj = remand_reason_attrs[:post_aoj]
-        record.save!
-      end
-    end
-    # Delete remand reasons that are not part of the request
-    existing_codes = request_issue.reload.remand_reasons.pluck(:code)
-    codes_to_delete = existing_codes - remand_reasons_attrs.pluck(:code)
-    request_issue.remand_reasons.where(code: codes_to_delete).delete_all
-  end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -15,8 +15,7 @@
     featureToggles: {
       judge_case_review_checkout: FeatureToggle.enabled?(:judge_case_review_checkout, user: current_user),
       automatic_case_distribution: FeatureToggle.enabled?(:automatic_case_distribution, user: current_user),
-      attorney_assignment_to_colocated: FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: current_user),
-      ama_decision_issues: FeatureToggle.enabled?(:ama_decision_issues, user: current_user)
+      attorney_assignment_to_colocated: FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: current_user)
     }
   }) %>
 <% end %>

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -70,11 +70,8 @@ class CaseDetailsView extends React.PureComponent {
       appealId,
       appeal,
       error,
-      success,
-      featureToggles
+      success
     } = this.props;
-
-    const amaIssueType = featureToggles.ama_decision_issues || !_.isEmpty(appeal.decisionIssues);
 
     return <React.Fragment>
       {error && <div {...alertPaddingStyle}><Alert title={error.title} type="error">
@@ -96,10 +93,9 @@ class CaseDetailsView extends React.PureComponent {
         <hr {...horizontalRuleStyling} />
         <StickyNavContentArea>
           <CaseDetailsIssueList
-            amaIssueType={amaIssueType}
             title="Issues"
             isLegacyAppeal={appeal.isLegacyAppeal}
-            additionalHeaderContent={amaIssueType && appeal.canEditRequestIssues &&
+            additionalHeaderContent={appeal.canEditRequestIssues &&
               <span className="cf-push-right" {...anchorEditLinkStyling}>
                 <Link href={`/appeals/${appealId}/edit`}>{COPY.CORRECT_REQUEST_ISSUES_LINK}</Link>
               </span>}
@@ -125,12 +121,11 @@ CaseDetailsView.propTypes = {
 
 const mapStateToProps = (state, ownProps) => {
   const { success, error } = state.ui.messages;
-  const { veteranCaseListIsVisible, featureToggles } = state.ui;
+  const { veteranCaseListIsVisible } = state.ui;
 
   return {
     appeal: appealWithDetailSelector(state, { appealId: ownProps.appealId }),
     success,
-    featureToggles,
     error,
     veteranCaseListIsVisible
   };

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -133,8 +133,7 @@ class EvaluateDecisionView extends React.PureComponent {
       checkoutFlow,
       decision,
       userRole,
-      appealId,
-      amaDecisionIssues
+      appealId
     } = this.props;
 
     let loc = 'bva_dispatch';
@@ -144,7 +143,7 @@ class EvaluateDecisionView extends React.PureComponent {
       loc = 'omo_office';
       successMsg = sprintf(COPY.JUDGE_CHECKOUT_OMO_SUCCESS_MESSAGE_TITLE, appeal.veteranFullName);
     }
-    const issuesToPass = !appeal.isLegacyAppeal && amaDecisionIssues ? appeal.decisionIssues : appeal.issues;
+    const issuesToPass = appeal.isLegacyAppeal ? appeal.issues : appeal.decisionIssues;
     const payload = buildCaseReviewPayload(checkoutFlow, decision, userRole, issuesToPass, {
       location: loc,
       attorney_id: appeal.isLegacyAppeal ? task.assignedBy.pgId : appeal.assignedAttorney.id,

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -337,8 +337,7 @@ const mapStateToProps = (state, ownProps) => {
     task: taskById(state, { taskId: ownProps.taskId }),
     decision: state.queue.stagedChanges.taskDecision,
     userRole: state.ui.userRole,
-    error: state.ui.messages.error,
-    amaDecisionIssues: state.ui.featureToggles.ama_decision_issues || !_.isEmpty(appeal.decisionIssues)
+    error: state.ui.messages.error
   };
 };
 

--- a/client/app/queue/SelectDispositionsContainer.jsx
+++ b/client/app/queue/SelectDispositionsContainer.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import _ from 'lodash';
 
 import LegacySelectDispositionsView from './LegacySelectDispositionsView';
 import SelectDispositionsView from './SelectDispositionsView';
 
 class SelectDispositionsContainer extends React.PureComponent {
   render = () => {
-    const { appeal, featureToggles, ...otherProps } = this.props;
+    const { appeal, ...otherProps } = this.props;
 
-    if (!appeal.isLegacyAppeal && (featureToggles.ama_decision_issues || !_.isEmpty(appeal.decisionIssues))) {
+    if (!appeal.isLegacyAppeal) {
       return <SelectDispositionsView {...otherProps} />;
     }
 
@@ -18,8 +17,7 @@ class SelectDispositionsContainer extends React.PureComponent {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  appeal: state.queue.stagedChanges.appeals[ownProps.appealId],
-  featureToggles: state.ui.featureToggles
+  appeal: state.queue.stagedChanges.appeals[ownProps.appealId]
 });
 
 export default connect(mapStateToProps, null)(SelectDispositionsContainer);

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -44,12 +44,11 @@ class SelectRemandReasonsView extends React.Component {
   goToPrevStep = () => _.each(this.state.renderedChildren, (child) => child.updateStoreIssue());
 
   goToNextStep = () => {
-    const { issues, appealId, appeal, amaDecisionIssues } = this.props;
+    const { issues, appealId, appeal } = this.props;
     const {
       issuesRendered,
       renderedChildren
     } = this.state;
-    const useDecisionIssues = !appeal.isLegacyAppeal && (amaDecisionIssues || !_.isEmpty(appeal.decisionIssues));
 
     if (issuesRendered < issues.length) {
       this.setState({ issuesRendered: Math.min(issuesRendered + 1, issues.length) });
@@ -59,7 +58,7 @@ class SelectRemandReasonsView extends React.Component {
 
     const updatedIssues = _.map(renderedChildren, (child) => child.updateStoreIssue());
 
-    const appealIssues = useDecisionIssues ? appeal.decisionIssues : appeal.issues;
+    const appealIssues = appeal.isLegacyAppeal ? appeal.issues : appeal.decisionIssues;
 
     const mergedIssueUpdates = _.map(appealIssues, (issue) => {
       const updatedIssue = _.find(updatedIssues, { id: issue.id });
@@ -71,7 +70,7 @@ class SelectRemandReasonsView extends React.Component {
       return issue;
     });
 
-    const attributes = useDecisionIssues ? { decisionIssues: mergedIssueUpdates } : { issues: mergedIssueUpdates };
+    const attributes = appeal.isLegacyAppeal ? { issues: mergedIssueUpdates } : { decisionIssues: mergedIssueUpdates };
 
     this.props.editStagedAppeal(appealId, attributes);
 
@@ -128,16 +127,14 @@ SelectRemandReasonsView.propTypes = {
 
 const mapStateToProps = (state, ownProps) => {
   const appeal = state.queue.stagedChanges.appeals[ownProps.appealId];
-  const issues = ((state.ui.featureToggles.ama_decision_issues || !_.isEmpty(appeal.decisionIssues)) &&
-    !appeal.isLegacyAppeal) ? appeal.decisionIssues : appeal.issues;
+  const issues = appeal.isLegacyAppeal ? appeal.issues : appeal.decisionIssues;
 
   return {
     appeal,
     issues: _.filter(issues, (issue) => [
       VACOLS_DISPOSITIONS.REMANDED, ISSUE_DISPOSITIONS.REMANDED
     ].includes(issue.disposition)),
-    ..._.pick(state.ui, 'userRole'),
-    amaDecisionIssues: state.ui.featureToggles.ama_decision_issues
+    ..._.pick(state.ui, 'userRole')
   };
 };
 

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -115,11 +115,10 @@ class SubmitDecisionView extends React.PureComponent {
       checkoutFlow,
       decision,
       userRole,
-      judges,
-      amaDecisionIssues
+      judges
     } = this.props;
 
-    const issuesToPass = !isLegacyAppeal && amaDecisionIssues ? decisionIssues : issues;
+    const issuesToPass = isLegacyAppeal ? issues : decisionIssues;
     const payload = buildCaseReviewPayload(checkoutFlow, decision,
       userRole, issuesToPass, { isLegacyAppeal });
 
@@ -246,8 +245,7 @@ const mapStateToProps = (state, ownProps) => {
     decision,
     error,
     userRole,
-    highlightFormItems,
-    amaDecisionIssues: state.ui.featureToggles.ama_decision_issues || !_.isEmpty(appeal && appeal.decisionIssues)
+    highlightFormItems
   };
 };
 

--- a/client/app/queue/components/CaseDetailsIssueList.jsx
+++ b/client/app/queue/components/CaseDetailsIssueList.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { css } from 'glamor';
 
 import { getIssueDiagnosticCodeLabel } from '../utils';
-import ISSUE_DISPOSITIONS_BY_ID from '../../../constants/ISSUE_DISPOSITIONS_BY_ID.json';
 import ISSUE_INFO from '../../../constants/ISSUE_INFO.json';
 import CaseDetailsDescriptionList from './CaseDetailsDescriptionList';
 import ContestedIssues from './ContestedIssues';
@@ -25,7 +24,7 @@ const headingStyling = css({
 });
 
 export default function CaseDetailsIssueList(props) {
-  if (!props.isLegacyAppeal && props.amaIssueType) {
+  if (!props.isLegacyAppeal) {
     return <ContestedIssues
       requestIssues={props.issues}
       decisionIssues={props.decisionIssues}
@@ -36,21 +35,11 @@ export default function CaseDetailsIssueList(props) {
     {props.issues.map((issue, i) =>
       <div key={i} {...singleIssueContainerStyling}>
         <h3 {...headingStyling}>Issue {1 + i}</h3>
-        { props.isLegacyAppeal ?
-          <LegacyIssueDetails>{issue}</LegacyIssueDetails> :
-          <AmaIssueDetails>{issue}</AmaIssueDetails>
-        }
+        { <LegacyIssueDetails>{issue}</LegacyIssueDetails> }
       </div>
     )}
   </React.Fragment>;
 }
-
-const AmaIssueDetails = (props) => <CaseDetailsDescriptionList>
-  <dt>Description</dt><dd>{props.children.description}</dd>
-  {props.children.disposition && <React.Fragment>
-    <dt>Disposition</dt><dd>{ISSUE_DISPOSITIONS_BY_ID[props.children.disposition]}</dd>
-  </React.Fragment>}
-</CaseDetailsDescriptionList>;
 
 const LegacyIssueDetails = (props) => {
   const issue = props.children;

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -64,9 +64,8 @@ class IssueRemandReasonsOptions extends React.PureComponent {
   }
 
   updateIssue = (remandReasons) => {
-    const { appeal, issueId, amaDecisionIssues } = this.props;
-    const useDecisionIssues = !appeal.isLegacyAppeal && amaDecisionIssues;
-    const issues = useDecisionIssues ? appeal.decisionIssues : appeal.issues;
+    const { appeal, issueId } = this.props;
+    const issues = appeal.isLegacyAppeal ? appeal.issues : appeal.decisionIssues;
 
     return {
       ..._.find(issues, (issue) => issue.id === issueId),
@@ -299,8 +298,7 @@ class IssueRemandReasonsOptions extends React.PureComponent {
 
 const mapStateToProps = (state, ownProps) => {
   const appeal = state.queue.stagedChanges.appeals[ownProps.appealId];
-  const amaDecisionIssues = state.ui.featureToggles.ama_decision_issues || !_.isEmpty(appeal.decisionIssues);
-  const issues = (amaDecisionIssues && !appeal.isLegacyAppeal) ? appeal.decisionIssues : appeal.issues;
+  const issues = appeal.isLegacyAppeal ? appeal.issues : appeal.decisionIssues;
 
   return {
     appeal,
@@ -308,8 +306,7 @@ const mapStateToProps = (state, ownProps) => {
       VACOLS_DISPOSITIONS.REMANDED, ISSUE_DISPOSITIONS.REMANDED
     ].includes(issue.disposition)),
     issue: _.find(issues, (issue) => issue.id === ownProps.issueId),
-    highlight: state.ui.highlightFormItems,
-    amaDecisionIssues
+    highlight: state.ui.highlightFormItems
   };
 };
 

--- a/scripts/enable_features_dev.rb
+++ b/scripts/enable_features_dev.rb
@@ -51,10 +51,6 @@ json_config = <<EOS.strip_heredoc
           enable_all: true
         },
         {
-          feature: "ama_decision_issues",
-          enable_all: true
-        },
-        {
           feature: "use_representative_info_from_bgs",
           enable_all: true
         },

--- a/spec/controllers/case_reviews_controller_spec.rb
+++ b/spec/controllers/case_reviews_controller_spec.rb
@@ -25,46 +25,7 @@ RSpec.describe CaseReviewsController, type: :controller do
         let(:judge_task) { create(:ama_judge_task, assigned_to: judge, parent: root_task) }
         let(:task) { create(:ama_attorney_task, assigned_to: attorney, assigned_by: judge, parent: judge_task) }
 
-        context "when all parameters are present to create Draft Decision with old issue format" do
-          let(:params) do
-            {
-              "type": "AttorneyCaseReview",
-              "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
-              "reviewing_judge_id": judge.id,
-              "work_product": "Decision",
-              "document_id": "12345678.1234",
-              "overtime": true,
-              "note": "something",
-              "issues": [{ "disposition": "allowed", "id": request_issue1.id },
-                         { "disposition": "remanded", "id": request_issue2.id,
-                           "remand_reasons": [{ "code": "va_records", "post_aoj": true }] }]
-            }
-          end
-          let!(:bva_dispatch_task_count_before) { BvaDispatchTask.count }
-
-          it "should be successful" do
-            post :complete, params: { task_id: task.id, tasks: params }
-            expect(response.status).to eq 200
-            response_body = JSON.parse(response.body)
-            expect(response_body["task"]["document_id"]).to eq "12345678.1234"
-            expect(response_body["task"]["overtime"]).to eq true
-            expect(response_body["task"]["note"]).to eq "something"
-            expect(response_body.keys).to include "issues"
-            # TODO: uncomment when we use decision issues
-            # expect(response_body["issues"]["decision_issues"].size).to eq 2
-            expect(response_body["issues"]["request_issues"].size).to eq 2
-            expect(request_issue1.reload.disposition).to eq "allowed"
-            expect(request_issue2.reload.disposition).to eq "remanded"
-            expect(task.reload.status).to eq "completed"
-            expect(task.closed_at).to_not eq nil
-            expect(task.parent.reload.status).to eq "assigned"
-            expect(task.parent.type).to eq JudgeDecisionReviewTask.name
-
-            expect(bva_dispatch_task_count_before).to eq(BvaDispatchTask.count)
-          end
-        end
-
-        context "when new issue format" do
+        context "when creating a draft decision" do
           context "when missing dispositions" do
             let(:params) do
               {
@@ -154,7 +115,6 @@ RSpec.describe CaseReviewsController, type: :controller do
             let!(:bva_dispatch_task_count_before) { BvaDispatchTask.count }
 
             it "should be successful" do
-              FeatureToggle.enable!(:ama_decision_issues)
               post :complete, params: { task_id: task.id, tasks: params }
               expect(response.status).to eq 200
               response_body = JSON.parse(response.body)
@@ -189,7 +149,6 @@ RSpec.describe CaseReviewsController, type: :controller do
               expect(task.parent.type).to eq JudgeDecisionReviewTask.name
 
               expect(bva_dispatch_task_count_before).to eq(BvaDispatchTask.count)
-              FeatureToggle.disable!(:ama_decision_issues)
             end
           end
         end
@@ -219,8 +178,16 @@ RSpec.describe CaseReviewsController, type: :controller do
               "comment": "do this",
               "factors_not_considered": %w[theory_contention relevant_records],
               "areas_for_improvement": ["process_violations"],
-              "issues": [{ "disposition": "denied", "id": request_issue1.id },
-                         { "disposition": "remanded", "id": request_issue2.id,
+              "issues": [{ "disposition": "denied",
+                           "request_issue_ids": [request_issue1.id],
+                           "description": "wonderful life",
+                           "benefit_type": "pension",
+                           "diagnostic_code": "5001" },
+                         { "disposition": "remanded",
+                           "request_issue_ids": [request_issue2.id],
+                           "description": "wonderful life",
+                           "benefit_type": "pension",
+                           "diagnostic_code": "5001",
                            "remand_reasons": [{ "code": "va_records", "post_aoj": true }] }]
             }
           end
@@ -239,12 +206,8 @@ RSpec.describe CaseReviewsController, type: :controller do
             expect(response_body["task"]["comment"]).to eq "do this"
             expect(response_body["task"]["factors_not_considered"]).to eq %w[theory_contention relevant_records]
             expect(response_body["task"]["areas_for_improvement"]).to eq ["process_violations"]
-            expect(response_body.keys).to include "issues"
-            # TODO: uncomment when we use decision issues
-            # expect(response_body["issues"]["decision_issues"].size).to eq 2
-            expect(response_body["issues"]["request_issues"].size).to eq 2
-            expect(request_issue1.reload.disposition).to eq "denied"
-            expect(request_issue2.reload.disposition).to eq "remanded"
+            expect(request_issue1.decision_issues.first.disposition).to eq "denied"
+            expect(request_issue2.decision_issues.first.disposition).to eq "remanded"
             expect(task.reload.status).to eq "completed"
             expect(task.closed_at).to_not eq nil
 
@@ -255,7 +218,7 @@ RSpec.describe CaseReviewsController, type: :controller do
             expect(dispatch_task.assigned_to).to eq(BvaDispatch.singleton) if dispatch_task
           end
 
-          context "When case is being QRed" do
+          context "when case is being QRed" do
             let(:qr_user) { create(:user) }
             let!(:quality_review_organization_task) do
               create(:qr_task, assigned_to: QualityReview.singleton, parent: root_task)

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -750,9 +750,29 @@ RSpec.feature "AmaQueue" do
 
         expect(page).not_to have_content("Select special issues (optional)")
 
-        expect(page).to have_content("Select Dispositions")
-        click_dropdown({ prompt: "Select disposition", text: "Allowed" }, find("#table-row-0"))
-        click_dropdown({ prompt: "Select disposition", text: "Remanded" }, find("#table-row-1"))
+        expect(page).to have_content("Add decisions")
+
+        # Add a first decision issue
+        all("button", text: "+ Add decision", count: 2)[0].click
+        expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+
+        fill_in "Text Box", with: "test"
+
+        find(".Select-control", text: "Select disposition").click
+        find("div", class: "Select-option", text: "Allowed").click
+
+        click_on "Save"
+
+        # Add a second decision issue
+        all("button", text: "+ Add decision", count: 2)[1].click
+        expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+
+        fill_in "Text Box", with: "test"
+
+        find(".Select-control", text: "Select disposition").click
+        find("div", class: "Select-option", text: "Remanded").click
+
+        click_on "Save"
         click_on "Continue"
 
         expect(page).to have_content("Select Remand Reasons")
@@ -797,9 +817,7 @@ RSpec.feature "AmaQueue" do
 
         expect(page).not_to have_content("Select special issues (optional)")
 
-        expect(page).to have_content("Select Dispositions")
-        expect(dropdown_selected_value(find("#table-row-0"))).to eq "Allowed"
-        expect(dropdown_selected_value(find("#table-row-1"))).to eq "Remanded"
+        expect(page).to have_content("Add decisions")
         click_on "Continue"
 
         expect(page).to have_content("Select Remand Reasons")

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -496,7 +496,7 @@ RSpec.feature "AmaQueue" do
 
       expect(page).not_to have_content("Select special issues (optional)")
 
-      expect(page).to have_content("Select Dispositions")
+      expect(page).to have_content("Add decisions")
 
       click_on "Continue"
 
@@ -623,9 +623,29 @@ RSpec.feature "AmaQueue" do
 
         expect(page).not_to have_content("Select special issues (optional)")
 
-        expect(page).to have_content("Select Dispositions")
-        click_dropdown({ prompt: "Select disposition", text: "Allowed" }, find("#table-row-0"))
-        click_dropdown({ prompt: "Select disposition", text: "Remanded" }, find("#table-row-1"))
+        expect(page).to have_content("Add decisions")
+
+        # Add a first decision issue
+        all("button", text: "+ Add decision", count: 2)[0].click
+        expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+
+        fill_in "Text Box", with: "test"
+
+        find(".Select-control", text: "Select disposition").click
+        find("div", class: "Select-option", text: "Allowed").click
+
+        click_on "Save"
+
+        # Add a second decision issue
+        all("button", text: "+ Add decision", count: 2)[1].click
+        expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+
+        fill_in "Text Box", with: "test"
+
+        find(".Select-control", text: "Select disposition").click
+        find("div", class: "Select-option", text: "Remanded").click
+
+        click_on "Save"
         click_on "Continue"
 
         expect(page).to have_content("Select Remand Reasons")
@@ -670,9 +690,10 @@ RSpec.feature "AmaQueue" do
 
         expect(page).not_to have_content("Select special issues (optional)")
 
-        expect(page).to have_content("Select Dispositions")
-        expect(dropdown_selected_value(find("#table-row-0"))).to eq "Allowed"
-        expect(dropdown_selected_value(find("#table-row-1"))).to eq "Remanded"
+        expect(page).to have_content("Add decisions")
+        expect(page).to have_content("Allowed")
+        expect(page).to have_content("Remanded")
+
         click_on "Continue"
 
         expect(page).to have_content("Select Remand Reasons")

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -339,18 +339,16 @@ RSpec.feature "Case details" do
   end
 
   context "when an appeal has an issue that is ineligible" do
-    let(:eligible_issue_cnt) { 5 }
-    let(:ineligible_issue_cnt) { 3 }
     let(:issues) do
       [
         build_list(
           :request_issue,
-          eligible_issue_cnt,
+          1,
           contested_issue_description: "Knee pain"
         ),
         build_list(
           :request_issue,
-          ineligible_issue_cnt,
+          1,
           contested_issue_description: "Sunburn",
           ineligible_reason: :untimely
         )
@@ -361,8 +359,8 @@ RSpec.feature "Case details" do
     scenario "only eligible issues should appear in case details page" do
       visit "/queue/appeals/#{appeal.uuid}"
 
-      expect(page).to have_content("Issue #{eligible_issue_cnt}")
-      expect(page).to_not have_content("Issue #{eligible_issue_cnt + 1}")
+      expect(page).to have_content("Knee pain")
+      expect(page).to_not have_content("Sunburn")
     end
   end
 
@@ -557,7 +555,8 @@ RSpec.feature "Case details" do
 
         it "should display sorted issues" do
           visit "/queue/appeals/#{appeal.uuid}"
-          expect(page).to have_content(issue_description + " Issue 2 DESCRIPTION " + issue_description2)
+          text = issue_description + " Diagnostic code: 5008 Issue Benefit type: Compensation " + issue_description2
+          expect(page).to have_content(text)
         end
       end
     end

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -14,11 +14,11 @@ RSpec.feature "Judge checkout flow" do
         number_of_claimants: 1,
         request_issues: FactoryBot.build_list(
           :request_issue, 1,
-          contested_issue_description: "Tinnitus",
-          disposition: "allowed"
+          contested_issue_description: "Tinnitus"
         )
       )
     end
+    let!(:decision_issue) { create(:decision_issue, decision_review: appeal, request_issues: appeal.request_issues) }
 
     let(:root_task) { FactoryBot.create(:root_task) }
     let(:parent_task) do
@@ -56,7 +56,7 @@ RSpec.feature "Judge checkout flow" do
       click_on "(#{appeal.veteran_file_number})"
 
       click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.label)
-      # Request Issues screen
+      # Decision Issues screen
       click_on "Continue"
       expect(page).to have_content("Evaluate Decision")
 


### PR DESCRIPTION
Resolves #9306 

### Description
We enabled `ama_decision_issues` flag for all users so we can get rid of the old code.


