### PR TITLE
Hearing Schedule assign hearing page times out

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -120,7 +120,8 @@ class TasksController < ApplicationController
       data: ActiveModelSerializers::SerializableResource.new(
         tasks,
         user: current_user,
-        role: user_role
+        role: user_role,
+        exclude_extra_fields: true
       ).as_json[:data]
     }
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -220,9 +220,19 @@ class Appeal < DecisionReview
            :gender,
            :date_of_birth,
            :age,
-           :closest_regional_office,
-           :available_hearing_locations,
            :country, to: :veteran, prefix: true
+
+  def veteran_if_exists
+    @veteran_if_exists ||= Veteran.find_by_file_number(veteran_file_number)
+  end
+
+  def veteran_closest_regional_office
+    veteran_if_exists&.closest_regional_office
+  end
+
+  def veteran_available_hearing_locations
+    veteran_if_exists&.available_hearing_locations
+  end
 
   delegate :city,
            :state, to: :appellant, prefix: true

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -83,23 +83,44 @@ class WorkQueue::TaskSerializer < ActiveModel::Serializer
   end
 
   attribute :previous_task do
-    {
-      assigned_at: object.previous_task.try(:assigned_at)
-    }
+    if @instance_options[:exclude_extra_fields]
+      {
+        assigned_at: nil
+      }
+    else
+      {
+        assigned_at: object.previous_task.try(:assigned_at)
+      }
+    end
   end
 
   attribute :document_id do
-    object.latest_attorney_case_review ? object.latest_attorney_case_review.document_id : nil
+    if @instance_options[:exclude_extra_fields]
+      nil
+    else
+      object.latest_attorney_case_review ? object.latest_attorney_case_review.document_id : nil
+    end
   end
 
   attribute :decision_prepared_by do
-    {
-      first_name: object.prepared_by_display_name ? object.prepared_by_display_name.first : nil,
-      last_name: object.prepared_by_display_name ? object.prepared_by_display_name.last : nil
-    }
+    if @instance_options[:exclude_extra_fields]
+      {
+        first_name: nil,
+        last_name: nil
+      }
+    else
+      {
+        first_name: object.prepared_by_display_name ? object.prepared_by_display_name.first : nil,
+        last_name: object.prepared_by_display_name ? object.prepared_by_display_name.last : nil
+      }
+    end
   end
 
   attribute :available_actions do
-    object.available_actions_unwrapper(@instance_options[:user])
+    if @instance_options[:exclude_extra_fields]
+      nil
+    else
+      object.available_actions_unwrapper(@instance_options[:user])
+    end
   end
 end


### PR DESCRIPTION
### Description
The assign hearing page is timing out for what appears to be two reasons.

1. For AMA appeals we're looking up Veteran information for each appeal we're returning.
2. For all appeals, we're doing some inefficient look ups to return fields we don't strictly even need (around document_ids and attorney case review objects). We're making these conditional to reduce load times.
