### PR TITLE
Fix error where new Veteran creation causes BGS error for VSOs

### DIFF
--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -146,7 +146,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number)
+    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number, sync_name: false)
   end
 
   def remove_issues!

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -146,7 +146,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number, sync_name: false)
+    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number)
   end
 
   def remove_issues!

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -238,14 +238,15 @@ class Veteran < ApplicationRecord
       # Check to see if veteran is accessible to make sure bgs_record is
       # a hash and not :not_found. Also if it's not found, bgs_record returns
       # a symbol that will blow up, so check if bgs_record is a hash first.
-      Rails.logger.warn(
-        %(
-        find_and_maybe_backfill_name sync_name:#{sync_name} current_user:#{RequestStore[:current_user].try(:css_id)}
-        veteran:#{file_number} accessible:#{veteran.accessible?} is_a?Hash:#{veteran.bgs_record.is_a?(Hash)}
-        )
-      )
-
       if sync_name && veteran.accessible? && veteran.bgs_record.is_a?(Hash) && veteran.stale_name?
+
+        Rails.logger.warn(
+          %(
+          find_and_maybe_backfill_name sync_name:#{sync_name} current_user:#{RequestStore[:current_user].try(:css_id)}
+          veteran:#{file_number} accessible:#{veteran.accessible?} is_a?Hash:#{veteran.bgs_record.is_a?(Hash)}
+          )
+        )
+
         veteran.update!(
           first_name: veteran.bgs_record[:first_name],
           last_name: veteran.bgs_record[:last_name],

--- a/spec/feature/intake/veteran_name_caching_spec.rb
+++ b/spec/feature/intake/veteran_name_caching_spec.rb
@@ -53,7 +53,7 @@ feature "Higher-Level Review" do
 
     step "EPs use the updated Veteran name" do
       # TODO: logging adds additional check
-      expect(bgs).to have_received(:fetch_veteran_info).exactly(6).times
+      expect(bgs).to have_received(:fetch_veteran_info).exactly(5).times
 
       veteran.reload
 


### PR DESCRIPTION
Resolves these errors: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3712/

Moves logging inside the conditional block that relies on `sync_name` being true. The log statement was accessing `veteran.bgs_record ` which made a request to BGS even if `sync_name` was false. This caused the task serializer to throw an error instead of simply return `nil` when accessing an attribute of the `Veteran` record that comes from BGS if the current user does not have the appropriate sensitivity level.

Related slack conversation: https://dsva.slack.com/archives/C6E41RE92/p1550607327292500