### PR TITLE
Set assigned_by when assigning case to attorney

### DIFF
--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -139,7 +139,7 @@ class QueueRepository
                                       attrs.merge(modifying_user: judge.vacols_uniq_id, work_product: nil))
         end
 
-        create_decass_record(attrs.merge(adding_user: judge.vacols_uniq_id))
+        create_decass_record(attrs.merge(adding_user: judge.vacols_uniq_id, modifying_user: judge.vacols_uniq_id))
       end
     end
 

--- a/spec/repositories/queue_repository_spec.rb
+++ b/spec/repositories/queue_repository_spec.rb
@@ -40,6 +40,7 @@ describe QueueRepository do
         expect(decass.deatty).to eq attorney_staff.sattyid
         expect(decass.deteam).to eq attorney_staff.stitle[0..2]
         expect(decass.deadusr).to eq judge_staff.slogid
+        expect(decass.demdusr).to eq judge_staff.slogid
         expect(decass.deadtim).to eq VacolsHelper.local_date_with_utc_timezone
         expect(decass.dedeadline).to eq VacolsHelper.local_date_with_utc_timezone + 30.days
         expect(decass.deassign).to eq VacolsHelper.local_date_with_utc_timezone


### PR DESCRIPTION
**Why**: When viewing a case, or fetching it via the API, we want to
display by whom it was assigned, which corresponds to the `demdusr`
field in VACOLS. When we first assign a case to an attorney in Caseflow,
we were only updating the `adding_user` (`deadusr` in VACOLS), which
meant that when viewing the case, the `assigned_by` attribute was `nil`.

To fix this, we make sure to set `modifying_user` as well when assigning
a case to an attorney.

Resolves issue reported by Paul Saindon in Slack: https://dsva.slack.com/archives/CD5DAQNCU/p1550664439006200