### PR TITLE
Refresh EP status

### DIFF
--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -1,6 +1,15 @@
 class DecisionReviewIntake < Intake
   include RunAsyncable
 
+  # run during start!
+  def after_validated_pre_start!
+    veteran.end_products.each do |ep|
+      next unless ep.active? || ep.status_type_code.nil?
+      epe = EndProductEstablishment.find_by(reference_id: ep.claim_id, veteran_file_number: veteran.file_number)
+      epe.sync!
+    end
+  end
+
   def ui_hash(ama_enabled)
     super.merge(
       receipt_date: detail.receipt_date,

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -52,7 +52,9 @@ class DecisionReviewIntake < Intake
     veteran.end_products.each do |ep|
       next unless ep.active? || ep.status_type_code.nil?
 
-      EndProductEstablishment.find_by!(reference_id: ep.claim_id, veteran_file_number: veteran.file_number).sync!
+      epe = EndProductEstablishment.find_by!(reference_id: ep.claim_id, veteran_file_number: veteran.file_number)
+      epe.veteran = veteran
+      epe.sync!
     end
   end
 end

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -49,10 +49,8 @@ class DecisionReviewIntake < Intake
 
   # run during start!
   def after_validated_pre_start!
-    veteran.end_products.each do |ep|
-      next unless ep.active? || ep.status_type_code.nil?
-
-      epe = EndProductEstablishment.find_by!(reference_id: ep.claim_id, veteran_file_number: veteran.file_number)
+    epes = EndProductEstablishment.active.established.where(veteran_file_number: veteran.file_number)
+    epes.each do |epe|
       epe.veteran = veteran
       epe.sync!
     end

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -49,7 +49,7 @@ class DecisionReviewIntake < Intake
 
   # run during start!
   def after_validated_pre_start!
-    epes = EndProductEstablishment.active.established.where(veteran_file_number: veteran.file_number)
+    epes = EndProductEstablishment.established.where(veteran_file_number: veteran.file_number)
     epes.each do |epe|
       epe.veteran = veteran
       epe.sync!

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -36,8 +36,6 @@ class EndProductEstablishment < ApplicationRecord
       active.order("last_synced_at IS NOT NULL, last_synced_at ASC")
     end
 
-    private
-
     def established
       where.not("established_at IS NULL")
     end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -14,6 +14,9 @@ class EndProductEstablishment < ApplicationRecord
   belongs_to :source, polymorphic: true
   belongs_to :user
 
+  # allow @veteran to be assigned to save upstream calls
+  attr_writer :veteran
+
   CANCELED_STATUS = "CAN".freeze
   CLEARED_STATUS = "CLR".freeze
 

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -170,6 +170,7 @@ class Intake < ApplicationRecord
 
   # Optional step called after the intake is validated and not-yet-marked as started
   def after_validated_pre_start!
+    nil
   end
 
   def start_completion!

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -112,12 +112,14 @@ class Intake < ApplicationRecord
     if validate_start
       self.class.close_expired_intakes!
 
-      update(
+      after_validated_pre_start!
+
+      update!(
         started_at: Time.zone.now,
         detail: find_or_build_initial_detail
       )
     else
-      update(
+      update!(
         started_at: Time.zone.now,
         completed_at: Time.zone.now,
         completion_status: :error
@@ -164,6 +166,10 @@ class Intake < ApplicationRecord
   # Optional step to load data into the Caseflow DB that will be used for the intake
   def preload_intake_data!
     nil
+  end
+
+  # Optional step called after the intake is validated and not-yet-marked as started
+  def after_validated_pre_start!
   end
 
   def start_completion!

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -168,11 +168,6 @@ class Intake < ApplicationRecord
     nil
   end
 
-  # Optional step called after the intake is validated and not-yet-marked as started
-  def after_validated_pre_start!
-    nil
-  end
-
   def start_completion!
     update!(completion_started_at: Time.zone.now)
   end
@@ -248,6 +243,11 @@ class Intake < ApplicationRecord
   end
 
   private
+
+  # Optional step called after the intake is validated and not-yet-marked as started
+  def after_validated_pre_start!
+    nil
+  end
 
   def update_person!
     # Update the person when a claimant is created

--- a/spec/factories/end_product_establishment.rb
+++ b/spec/factories/end_product_establishment.rb
@@ -26,7 +26,8 @@ FactoryBot.define do
           claim_type_code: end_product_establishment.code,
           end_product_type_code: end_product_establishment.modifier,
           benefit_claim_id: end_product_establishment.reference_id,
-          last_action_date: 5.days.ago.to_formatted_s(:short_date)
+          last_action_date: 5.days.ago.to_formatted_s(:short_date),
+          status_type_code: end_product_establishment.synced_status
         }
       )
     end

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -24,7 +24,7 @@ describe HigherLevelReviewIntake do
   context "#start!" do
     subject { intake.start! }
 
-    let!(:existing_active_epe) do
+    let!(:active_epe) do
       create(
         :end_product_establishment,
         :active,
@@ -33,7 +33,7 @@ describe HigherLevelReviewIntake do
       )
     end
 
-    let!(:existing_canceled_epe) do
+    let!(:canceled_epe) do
       create(
         :end_product_establishment,
         :canceled,
@@ -44,7 +44,7 @@ describe HigherLevelReviewIntake do
 
     before do
       @synced = []
-      allow_any_instance_of(EndProductEstablishment).to receive(:sync!) do |epe|
+      allow_any_instance_of(EndProductEstablishment).to receive(:sync_source!) do |epe|
         @synced << epe.id
       end
     end
@@ -52,7 +52,7 @@ describe HigherLevelReviewIntake do
     it "syncs all active EPEs" do
       subject
 
-      expect(@synced).to eq [existing_active_epe.id]
+      expect(@synced).to eq [active_epe.id]
     end
   end
 

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -28,7 +28,8 @@ describe HigherLevelReviewIntake do
       create(
         :end_product_establishment,
         :active,
-        veteran_file_number: veteran_file_number
+        veteran_file_number: veteran_file_number,
+        established_at: Time.zone.yesterday
       )
     end
 
@@ -36,26 +37,22 @@ describe HigherLevelReviewIntake do
       create(
         :end_product_establishment,
         :canceled,
-        veteran_file_number: veteran_file_number
+        veteran_file_number: veteran_file_number,
+        established_at: Time.zone.yesterday
       )
     end
 
     before do
-      allow(EndProductEstablishment).to receive(:find_by)
-        .with(reference_id: existing_active_epe.reference_id, veteran_file_number: veteran_file_number)
-        .and_return(existing_active_epe)
-      allow(EndProductEstablishment).to receive(:find_by)
-        .with(reference_id: existing_canceled_epe.reference_id, veteran_file_number: veteran_file_number)
-        .and_return(existing_canceled_epe)
-      allow(existing_active_epe).to receive(:sync!).and_call_original
-      allow(existing_canceled_epe).to receive(:sync!).and_call_original
+      @synced = []
+      allow_any_instance_of(EndProductEstablishment).to receive(:sync!) do |epe|
+        @synced << epe.id
+      end
     end
 
     it "syncs all active EPEs" do
       subject
 
-      expect(existing_active_epe).to have_received(:sync!)
-      expect(existing_canceled_epe).to_not have_received(:sync!)
+      expect(@synced).to eq [existing_active_epe.id]
     end
   end
 


### PR DESCRIPTION
connects #9519 

### Description
Adds hook within the base `Intake` class to run `after_validated_pre_start!` within the `start!` method. For DecisionReview, implement that hook method and sync all active EndProductEstablishment records so that they reflect current status during intake.