### PR TITLE
Allow generic document uploads to VBMS via IDT

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -17,10 +17,6 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
     render(json: { message: e.message }, status: :bad_request)
   end
 
-  rescue_from Caseflow::Error::DocumentUploadFailedInVBMS do |e|
-    render(e.serialize_response)
-  end
-
   rescue_from ActiveRecord::RecordNotFound do |_e|
     render(json: { message: "Record not found" }, status: :not_found)
   end

--- a/app/controllers/idt/api/v1/upload_vbms_document_controller.rb
+++ b/app/controllers/idt/api/v1/upload_vbms_document_controller.rb
@@ -1,0 +1,24 @@
+class Idt::Api::V1::UploadVbmsDocumentController < Idt::Api::V1::BaseController
+  protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token, only: [:create]
+  before_action :verify_access
+
+  rescue_from StandardError do |e|
+    Raven.capture_exception(e)
+    if e.class.method_defined?(:serialize_response)
+      render(e.serialize_response)
+    else
+      render json: { message: "Unexpected error: #{e.message}" }, status: :internal_server_error
+    end
+  end
+
+  def create
+    result = PrepareDocumentUploadToVbms.new(request.parameters).call
+
+    if result.success?
+      render json: { message: "Document successfully queued for upload." }
+    else
+      render json: result.errors[0], status: :bad_request
+    end
+  end
+end

--- a/app/jobs/upload_document_to_vbms_job.rb
+++ b/app/jobs/upload_document_to_vbms_job.rb
@@ -1,0 +1,11 @@
+class UploadDocumentToVbmsJob < CaseflowJob
+  queue_as :low_priority
+  application_attr :idt
+
+  def perform(document)
+    RequestStore.store[:application] = "idt"
+    RequestStore.store[:current_user] = User.system_user
+
+    UploadDocumentToVbms.new(document).call
+  end
+end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -10,6 +10,7 @@ class Appeal < DecisionReview
 
   # decision_documents is effectively a has_one until post decisional motions are supported
   has_many :decision_documents
+  has_many :vbms_uploaded_documents
   has_many :remand_supplemental_claims, as: :decision_review_remanded, class_name: "SupplementalClaim"
 
   has_one :special_issue_list

--- a/app/models/concerns/uploadable_document.rb
+++ b/app/models/concerns/uploadable_document.rb
@@ -6,10 +6,6 @@ module UploadableDocument
   end
 
   # :nocov:
-  def upload_date
-    Time.zone.now
-  end
-
   def source
     fail "#{self.class} is missing source"
   end

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -33,7 +33,6 @@ class BvaDispatchTask < GenericTask
         delay = decision_document.decision_date.future? ? decision_document.decision_date : 0
         decision_document.submit_for_processing!(delay: delay)
 
-        # TODO: remove this unless statement when all decision documents require async processing
         unless decision_document.processed?
           ProcessDecisionDocumentJob.perform_later(decision_document.id)
         end

--- a/app/models/vbms_uploaded_document.rb
+++ b/app/models/vbms_uploaded_document.rb
@@ -1,0 +1,6 @@
+class VbmsUploadedDocument < ApplicationRecord
+  belongs_to :appeal, optional: false
+  validates :document_type, presence: true
+
+  attr_accessor :file
+end

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -84,7 +84,7 @@ class ExternalApi::VBMSService
       content_hash: content_hash,
       filename: filename,
       file_number: appeal.veteran_file_number,
-      va_receive_date: uploadable_document.upload_date,
+      va_receive_date: Time.zone.now,
       doc_type: uploadable_document.document_type_id,
       source: uploadable_document.source,
       subject: uploadable_document.document_type,

--- a/app/workflows/prepare_document_upload_to_vbms.rb
+++ b/app/workflows/prepare_document_upload_to_vbms.rb
@@ -1,0 +1,50 @@
+class PrepareDocumentUploadToVbms
+  include ActiveModel::Model
+
+  validates :appeal_id, :file, presence: true
+  validate :valid_document_type
+
+  def initialize(params)
+    @params = params.slice(:appeal_id, :document_type, :file)
+    @document_type = @params[:document_type]
+    @file = @params[:file]
+  end
+
+  def call
+    @success = valid?
+    if success
+      document = VbmsUploadedDocument.create(document_params)
+      UploadDocumentToVbmsJob.perform_later(document)
+    end
+
+    FormResponse.new(success: success, errors: [response_errors])
+  end
+
+  private
+
+  attr_reader :document_type, :file, :params, :success
+
+  def appeal_id
+    Appeal.find_by(uuid: params[:appeal_id])&.id
+  end
+
+  def valid_document_type
+    errors.add(:document_type, "is not recognized") unless Document.type_id(document_type)
+  end
+
+  def document_params
+    {
+      appeal_id: appeal_id,
+      document_type: document_type,
+      file: file
+    }
+  end
+
+  def response_errors
+    return if success
+
+    {
+      message: errors.full_messages.join(", ")
+    }
+  end
+end

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -1,0 +1,86 @@
+class UploadDocumentToVbms
+  S3_SUB_BUCKET = "idt-uploaded-documents".freeze
+
+  delegate :document_type, to: :document
+
+  def initialize(document)
+    @document = document
+  end
+
+  def call
+    return if document.processed_at
+
+    cache_file!
+    submit_for_processing!
+    upload_to_vbms!
+    set_processed_at_to_current_time
+  rescue StandardError => err
+    save_rescued_error!(err.to_s)
+    raise err
+  end
+
+  # We have to always download the file from s3 to make sure it exists locally
+  # instead of storing it on the server and relying that it will be there
+  def pdf_location
+    S3Service.fetch_file(s3_location, output_location)
+    output_location
+  end
+
+  def source
+    "BVA"
+  end
+
+  def document_type_id
+    Document.type_id(document_type)
+  end
+
+  private
+
+  attr_reader :document
+
+  def cache_file!
+    S3Service.store_file(s3_location, Base64.decode64(document.file))
+  end
+
+  def submit_for_processing!
+    when_to_start = Time.zone.now
+
+    document.update!(
+      last_submitted_at: when_to_start,
+      submitted_at: when_to_start,
+      processed_at: nil,
+      attempted_at: when_to_start
+    )
+  end
+
+  def upload_to_vbms!
+    return if document.uploaded_to_vbms_at
+
+    VBMSService.upload_document_to_vbms(appeal, self)
+    document.update!(uploaded_to_vbms_at: Time.zone.now)
+  end
+
+  def set_processed_at_to_current_time
+    document.update!(processed_at: Time.zone.now)
+  end
+
+  def save_rescued_error!(error)
+    document.update!(error: error)
+  end
+
+  def s3_location
+    UploadDocumentToVbms::S3_SUB_BUCKET + "/" + pdf_name
+  end
+
+  def output_location
+    File.join(Rails.root, "tmp", "pdfs", pdf_name)
+  end
+
+  def pdf_name
+    "appeal-#{appeal.external_id}-doc-#{document.id}.pdf"
+  end
+
+  def appeal
+    document.appeal
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
         get 'appeals', to: 'appeals#list'
         get 'appeals/:appeal_id', to: 'appeals#details'
         post 'appeals/:appeal_id/outcode', to: 'appeals#outcode'
+        post 'appeals/:appeal_id/upload_document', to: 'upload_vbms_document#create'
         get 'judges', to: 'judges#index'
         get 'user', to: 'users#index'
       end

--- a/db/migrate/20190220014413_create_vbms_uploaded_documents.rb
+++ b/db/migrate/20190220014413_create_vbms_uploaded_documents.rb
@@ -1,0 +1,15 @@
+class CreateVbmsUploadedDocuments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :vbms_uploaded_documents do |t|
+      t.belongs_to :appeal, null: false
+      t.datetime :attempted_at
+      t.string :document_type, null: false
+      t.string :error
+      t.datetime :last_submitted_at
+      t.datetime :processed_at
+      t.datetime :submitted_at
+      t.datetime :uploaded_to_vbms_at
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -982,6 +982,20 @@ ActiveRecord::Schema.define(version: 20190222224704) do
     t.index ["station_id", "css_id"], name: "index_users_on_station_id_and_css_id", unique: true
   end
 
+  create_table "vbms_uploaded_documents", force: :cascade do |t|
+    t.bigint "appeal_id", null: false
+    t.datetime "attempted_at"
+    t.datetime "created_at", null: false
+    t.string "document_type", null: false
+    t.string "error"
+    t.datetime "last_submitted_at"
+    t.datetime "processed_at"
+    t.datetime "submitted_at"
+    t.datetime "updated_at", null: false
+    t.datetime "uploaded_to_vbms_at"
+    t.index ["appeal_id"], name: "index_vbms_uploaded_documents_on_appeal_id"
+  end
+
   create_table "versions", id: :serial, force: :cascade do |t|
     t.datetime "created_at"
     t.string "event", null: false

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -130,13 +130,6 @@ module Caseflow::Error
     end
   end
 
-  class DocumentUploadFailedInVBMS < SerializableError
-    def initialize(args)
-      @code = args[:code] || 502
-      @message = args[:message]
-    end
-  end
-
   class TooManyChildTasks < SerializableError
     def initialize(args)
       @task_id = args[:task_id]

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -1,40 +1,13 @@
 RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
   describe "GET /idt/api/v1/appeals" do
     let(:user) { create(:user, css_id: "TEST_ID", full_name: "George Michael") }
-
     let(:token) do
       key, token = Idt::Token.generate_one_time_key_and_proposed_token
       Idt::Token.activate_proposed_token(key, user.css_id)
       token
     end
 
-    context "when request header does not contain token" do
-      it "response should error" do
-        get :list
-        expect(response.status).to eq 400
-      end
-    end
-
-    context "when request header contains invalid token" do
-      before { request.headers["TOKEN"] = "3289fn893rnqi8hf3nf" }
-
-      it "responds with an error" do
-        get :list
-        expect(response.status).to eq 403
-      end
-    end
-
-    context "when request header contains inactive token" do
-      before do
-        _key, t = Idt::Token.generate_one_time_key_and_proposed_token
-        request.headers["TOKEN"] = t
-      end
-
-      it "responds with an error" do
-        get :list
-        expect(response.status).to eq 403
-      end
-    end
+    it_behaves_like "IDT access verification", :get, :list
 
     context "when request header contains valid token" do
       context "and user is a judge" do

--- a/spec/controllers/idt/api/v1/upload_vbms_document_controller_spec.rb
+++ b/spec/controllers/idt/api/v1/upload_vbms_document_controller_spec.rb
@@ -1,0 +1,114 @@
+require "rails_helper"
+
+RSpec.describe Idt::Api::V1::UploadVbmsDocumentController, type: :controller do
+  describe "POST /idt/api/v1/appeals/:appeal_id/upload_document" do
+    let(:user) { create(:user) }
+    let(:appeal) { create(:appeal) }
+    let(:valid_document_type) { "BVA Decision" }
+    let(:params) do
+      { appeal_id: appeal.uuid,
+        file: "JVBERi0xLjMNCiXi48/TDQoNCjEgMCBvYmoNCjw8DQovVHlwZSAvQ2F0YW",
+        document_type: valid_document_type }
+    end
+
+    describe "authorization" do
+      it_behaves_like "IDT access verification", :post, :create, appeal_id: "123"
+    end
+
+    describe "validations" do
+      before do
+        OrganizationsUser.add_user_to_organization(user, BvaDispatch.singleton)
+        key, t = Idt::Token.generate_one_time_key_and_proposed_token
+        Idt::Token.activate_proposed_token(key, user.css_id)
+        request.headers["TOKEN"] = t
+        create(:staff, :attorney_role, sdomainid: user.css_id)
+      end
+
+      context "when document_type param is missing" do
+        it "throws an error" do
+          post :create, params: { appeal_id: appeal.uuid, file: "foo" }
+          err_msg = JSON.parse(response.body)["message"]
+
+          expect(err_msg).to eq "Document type is not recognized"
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context "document_type is blank" do
+        it "throws an error" do
+          post :create, params: { appeal_id: appeal.uuid, document_type: "", file: "foo" }
+          err_msg = JSON.parse(response.body)["message"]
+
+          expect(err_msg).to eq "Document type is not recognized"
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context "document_type is present but invalid" do
+        it "throws an error" do
+          post :create, params: { appeal_id: appeal.uuid, document_type: "foo", file: "foo" }
+          err_msg = JSON.parse(response.body)["message"]
+
+          expect(err_msg).to eq "Document type is not recognized"
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context "file param is missing" do
+        it "throws an error" do
+          post :create, params: { appeal_id: appeal.uuid, document_type: valid_document_type }
+          err_msg = JSON.parse(response.body)["message"]
+
+          expect(err_msg).to eq "File can't be blank"
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context "file param is blank" do
+        it "throws an error" do
+          post :create, params: { appeal_id: appeal.uuid, document_type: valid_document_type, file: "" }
+          err_msg = JSON.parse(response.body)["message"]
+
+          expect(err_msg).to eq "File can't be blank"
+          expect(response.status).to eq(400)
+        end
+      end
+
+      context "UploadDocumentToVbmsJob raises an error" do
+        it "throws an error" do
+          allow(UploadDocumentToVbmsJob).to receive(:perform_later).and_raise("job error")
+          post :create, params: params
+          err_msg = JSON.parse(response.body)["message"]
+
+          expect(err_msg).to eq "Unexpected error: job error"
+          expect(response.status).to eq(500)
+        end
+      end
+
+      context "all parameters are valid" do
+        it "returns a successful message and creates a new VbmsUploadedDocument" do
+          expect { post :create, params: params }.to change(VbmsUploadedDocument, :count).by(1)
+
+          success_message = JSON.parse(response.body)["message"]
+
+          expect(success_message).to eq "Document successfully queued for upload."
+          expect(response.status).to eq(200)
+        end
+
+        it "queues the document for upload to VBMS" do
+          uploaded_document = instance_double(VbmsUploadedDocument)
+          document_params = {
+            appeal_id: appeal.id,
+            document_type: params[:document_type],
+            file: params[:file]
+          }
+          expect(VbmsUploadedDocument).to receive(:create).with(document_params).and_return(uploaded_document)
+
+          expect(UploadDocumentToVbmsJob).to receive(:perform_later).with(uploaded_document)
+
+          post :create, params: params
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/vbms_uploaded_document.rb
+++ b/spec/factories/vbms_uploaded_document.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :vbms_uploaded_document do
+    appeal { create(:appeal) }
+    document_type { "Status Letter" }
+    file { "JVBERi0xLjMNCiXi48/TDQoNCjEgMCBvYmoNCjw8DQovVHlwZSAvQ2F0YW" }
+  end
+end

--- a/spec/jobs/upload_document_to_vbms_job_spec.rb
+++ b/spec/jobs/upload_document_to_vbms_job_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe UploadDocumentToVbmsJob do
+  describe ".perform" do
+    it "calls #process! on document" do
+      document = VbmsUploadedDocument.new(appeal_id: "123", file: "foo", document_type: "bar")
+
+      service = instance_double(UploadDocumentToVbms)
+      expect(UploadDocumentToVbms).to receive(:new).with(document).and_return(service)
+      expect(service).to receive(:call)
+
+      UploadDocumentToVbmsJob.perform_now(document)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,13 +11,6 @@ require "spec_helper"
 require "fake_date_helper"
 require "rspec/rails"
 require "react_on_rails"
-require_relative "support/fake_pdf_service"
-require_relative "support/sauce_driver"
-require_relative "support/database_cleaner"
-require_relative "support/download_helper"
-require_relative "support/clear_cache"
-require_relative "support/feature_helper"
-require_relative "support/date_time_helper"
 require "timeout"
 
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -35,7 +28,7 @@ require "timeout"
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/shared_examples/idt_access_verification.rb
+++ b/spec/support/shared_examples/idt_access_verification.rb
@@ -1,0 +1,71 @@
+shared_examples "IDT access verification" do |http_method, action, params|
+  describe "access verification before_action" do
+    let(:user) { create(:user, css_id: "TEST_ID", full_name: "George Michael") }
+
+    let(:token) do
+      key, token = Idt::Token.generate_one_time_key_and_proposed_token
+      Idt::Token.activate_proposed_token(key, user.css_id)
+      token
+    end
+
+    context "when request header does not contain token" do
+      it "response should error" do
+        if params
+          public_send(http_method, action, params: params)
+        else
+          public_send(http_method, action)
+        end
+        expect(response.status).to eq 400
+      end
+    end
+
+    context "when request header contains invalid token" do
+      before { request.headers["TOKEN"] = "3289fn893rnqi8hf3nf" }
+
+      it "responds with an error" do
+        if params
+          public_send(http_method, action, params: params)
+        else
+          public_send(http_method, action)
+        end
+        expect(response.status).to eq 403
+      end
+    end
+
+    context "when request header contains inactive token" do
+      before do
+        _key, t = Idt::Token.generate_one_time_key_and_proposed_token
+        request.headers["TOKEN"] = t
+      end
+
+      it "responds with an error" do
+        if params
+          public_send(http_method, action, params: params)
+        else
+          public_send(http_method, action)
+        end
+
+        expect(response.status).to eq 403
+      end
+    end
+
+    context "when request header contains valid token but the user is not authorized" do
+      before do
+        request.headers["TOKEN"] = token
+      end
+
+      it "responds with an error" do
+        if params
+          public_send(http_method, action, params: params)
+        else
+          public_send(http_method, action)
+        end
+
+        err_msg = JSON.parse(response.body)["message"]
+
+        expect(err_msg).to eq "User must be attorney, judge, dispatch, or intake"
+        expect(response.status).to eq 403
+      end
+    end
+  end
+end

--- a/spec/workflows/upload_document_to_vbms_spec.rb
+++ b/spec/workflows/upload_document_to_vbms_spec.rb
@@ -1,0 +1,118 @@
+require "rails_helper"
+
+describe UploadDocumentToVbms do
+  before do
+    Timecop.freeze(Time.utc(2020, 1, 1, 19, 0, 0))
+  end
+
+  let(:veteran) { create(:veteran) }
+  let(:appeal) do
+    create(:appeal, number_of_claimants: 1, veteran_file_number: veteran.file_number)
+  end
+  let(:document) do
+    create(
+      :vbms_uploaded_document,
+      uploaded_to_vbms_at: uploaded_to_vbms_at,
+      appeal: appeal,
+      processed_at: processed_at
+    )
+  end
+  let(:uploaded_to_vbms_at) { nil }
+  let(:processed_at) { nil }
+  let!(:doc_to_upload) { UploadDocumentToVbms.new(document) }
+
+  describe "#pdf_location" do
+    it "fetches file from s3 and returns temporary location" do
+      pdf_name = "appeal-#{document.appeal.external_id}-doc-#{document.id}.pdf"
+      expect(Caseflow::Fakes::S3Service).to receive(:fetch_file)
+      expect(doc_to_upload.pdf_location)
+        .to eq File.join(Rails.root, "tmp", "pdfs", pdf_name)
+    end
+  end
+
+  describe "#source" do
+    it "is hardcoded to BVA" do
+      expect(doc_to_upload.source).to eq "BVA"
+    end
+  end
+
+  describe "#document_type_id" do
+    it "fetches the ID corresponding to the document type string" do
+      expect(doc_to_upload.document_type_id).to eq 482
+    end
+  end
+
+  describe "#document_type" do
+    it "reads it from the document instance" do
+      expect(doc_to_upload.document_type).to eq document.document_type
+    end
+  end
+
+  context "#call" do
+    subject { doc_to_upload.call }
+
+    before do
+      allow(VBMSService).to receive(:upload_document_to_vbms).and_call_original
+    end
+
+    it "caches the file" do
+      expected_path = "idt-uploaded-documents/appeal-#{document.appeal.external_id}-doc-#{document.id}.pdf"
+
+      expect(S3Service).to receive(:store_file).with(expected_path, /PDF/)
+
+      subject
+
+      expect(document.submitted_at).to eq(Time.zone.now)
+    end
+
+    context "the document has already been uploaded" do
+      let(:uploaded_to_vbms_at) { Time.zone.now }
+
+      it "does not reupload the document" do
+        subject
+        expect(VBMSService).to_not have_received(:upload_document_to_vbms)
+      end
+    end
+
+    context "there was no upload error" do
+      it "uploads document" do
+        subject
+
+        expect(VBMSService).to have_received(:upload_document_to_vbms).with(
+          document.appeal, doc_to_upload
+        )
+
+        expect(document.uploaded_to_vbms_at).to eq(Time.zone.now)
+        expect(document.processed_at).to_not be_nil
+      end
+    end
+
+    context "when there was an upload error" do
+      before do
+        allow(VBMSService).to receive(:upload_document_to_vbms).and_raise("Some VBMS error")
+      end
+
+      it "saves document as attempted but not processed and saves the error" do
+        expect { subject }.to raise_error("Some VBMS error")
+
+        expect(document.attempted_at).to eq(Time.zone.now)
+        expect(document.processed_at).to be_nil
+        expect(document.error).to eq("Some VBMS error")
+      end
+    end
+
+    context "the document has already been processed" do
+      let(:processed_at) { Time.zone.now }
+
+      it "does not do anything" do
+        expect(S3Service).to_not receive(:store_file)
+
+        subject
+
+        expect(VBMSService).to_not have_received(:upload_document_to_vbms)
+        expect(document.submitted_at).to be_nil
+        expect(document.processed_at).to_not be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Paul Saindon has requested the ability to upload any type of
document to VBMS via an IDT endpoint.

**How**:
- Create a new `vbms_uploaded_documents` DB table with various
timestamps used by the `Asyncable` module to track the upload process,
similar to the `decision_documents` table (which might be refactored
later to use this new table).
- Create a new endpoint for uploading documents at:
`idt/api/v1/appeals/:appeal_id/upload_document`. This endpoint requires
the following parameters: `appeal_id` (the appeal's UUID), `file`: a
Base64-encoded file, and `document_type`, a string description of the
document.
- The controller calls a Service Object that validates that the appeal
exists, that a file is present, and that the `document_type` is
registered in the Caseflow Commons Document Types:
https://github.com/department-of-veterans-affairs/caseflow-commons/blob/master/app/models/caseflow/document_types.rb
If everything is valid, the file is uploaded to VBMS via a background
job.

Resolves #8641

Test Plan:
Work with Paul to test doc uploads to VBMS in UAT