### PR TITLE
Add bummr and derailed_benchmarks dev gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,6 +105,8 @@ group :test, :development, :demo do
 end
 
 group :development do
+  gem "bummr", "= 0.3.2", require: false
+  gem "derailed_benchmarks"
   gem "dotenv-rails"
   gem "fasterer", require: false
   gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,7 @@ GEM
     aws-sdk-resources (2.10.112)
       aws-sdk-core (= 2.10.112)
     aws-sigv4 (1.0.2)
+    benchmark-ips (2.7.2)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     bourbon (4.2.7)
@@ -141,6 +142,9 @@ GEM
     bullet (5.9.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bummr (0.3.2)
+      rainbow
+      thor
     bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -191,6 +195,14 @@ GEM
       octokit (~> 4.7)
       terminal-table (~> 1)
     database_cleaner (1.7.0)
+    derailed_benchmarks (1.3.5)
+      benchmark-ips (~> 2)
+      get_process_mem (~> 0)
+      heapy (~> 0)
+      memory_profiler (~> 0)
+      rack (>= 1)
+      rake (> 10, < 13)
+      thor (~> 0.19)
     diff-lcs (1.3)
     docile (1.1.5)
     dogstatsd-ruby (3.2.0)
@@ -218,6 +230,7 @@ GEM
     foreman (0.84.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
+    get_process_mem (0.2.3)
     git (1.5.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -237,6 +250,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
+    heapy (0.1.4)
     holidays (6.4.0)
     httpclient (2.8.3)
     httpi (2.4.3)
@@ -270,6 +284,7 @@ GEM
     lumberjack (1.0.13)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    memory_profiler (0.9.12)
     method_source (0.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -520,6 +535,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
+  bummr (= 0.3.2)
   bundler-audit
   business_time (~> 0.9.3)
   byebug
@@ -529,6 +545,7 @@ DEPENDENCIES
   connect_vbms!
   danger (~> 5.10)
   database_cleaner
+  derailed_benchmarks
   dogstatsd-ruby
   dotenv-rails
   factory_bot_rails (~> 4.8)


### PR DESCRIPTION
**Why**: bummr is very useful for updating multiple gems at once using
separate commits. derailed_benchmarks is great for finding memory and
other performance issues.

The reason for pointing at the master branch for bummr is that there is
a bug in version 0.4.0 and the fix that is on master hasn't been
released yet. See: lpender/bummr#58

References:
https://github.com/lpender/bummr
https://github.com/schneems/derailed_benchmarks