### PR TITLE
ProcessDecisionDocumentJob use the id of the DecisionDocument

### DIFF
--- a/app/jobs/process_decision_document_job.rb
+++ b/app/jobs/process_decision_document_job.rb
@@ -2,10 +2,10 @@ class ProcessDecisionDocumentJob < CaseflowJob
   queue_as :low_priority
   application_attr :intake
 
-  def perform(decision_document)
+  def perform(decision_document_id)
     RequestStore.store[:application] = "idt"
     RequestStore.store[:current_user] = User.system_user
 
-    decision_document.process!
+    DecisionDocument.find(decision_document_id).process!
   end
 end

--- a/app/jobs/sync_reviews_job.rb
+++ b/app/jobs/sync_reviews_job.rb
@@ -56,7 +56,7 @@ class SyncReviewsJob < CaseflowJob
 
   def reprocess_decision_documents(limit)
     DecisionDocument.requires_processing.limit(limit).each do |decision_document|
-      ProcessDecisionDocumentJob.perform_later(decision_document)
+      ProcessDecisionDocumentJob.perform_later(decision_document.id)
     end
   end
 end

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -33,7 +33,7 @@ class BvaDispatchTask < GenericTask
 
         # TODO: remove this unless statement when all decision documents require async processing
         unless decision_document.processed?
-          ProcessDecisionDocumentJob.perform_later(decision_document)
+          ProcessDecisionDocumentJob.perform_later(decision_document.id)
         end
       end
     end

--- a/spec/jobs/process_decision_document_job_spec.rb
+++ b/spec/jobs/process_decision_document_job_spec.rb
@@ -2,11 +2,12 @@ require "rails_helper"
 
 describe ProcessDecisionDocumentJob do
   context ".perform" do
-    subject { ProcessDecisionDocumentJob.perform_now(decision_document) }
+    subject { ProcessDecisionDocumentJob.perform_now(decision_document.id) }
 
-    let(:decision_document) { build(:decision_document) }
+    let(:decision_document) { create(:decision_document) }
 
     it "processes the decision document" do
+      allow(DecisionDocument).to receive(:find).with(decision_document.id).and_return(decision_document)
       expect(decision_document).to receive(:process!)
       subject
     end

--- a/spec/jobs/sync_reviews_job_spec.rb
+++ b/spec/jobs/sync_reviews_job_spec.rb
@@ -139,7 +139,7 @@ describe SyncReviewsJob do
       it "starts jobs to reprocess them" do
         expect do
           SyncReviewsJob.perform_now
-        end.to have_enqueued_job(ProcessDecisionDocumentJob).with(decision_document_needs_reprocessing).exactly(:once)
+        end.to have_enqueued_job(ProcessDecisionDocumentJob).with(decision_document_needs_reprocessing.id).exactly(:once)
       end
     end
   end

--- a/spec/jobs/sync_reviews_job_spec.rb
+++ b/spec/jobs/sync_reviews_job_spec.rb
@@ -139,7 +139,9 @@ describe SyncReviewsJob do
       it "starts jobs to reprocess them" do
         expect do
           SyncReviewsJob.perform_now
-        end.to have_enqueued_job(ProcessDecisionDocumentJob).with(decision_document_needs_reprocessing.id).exactly(:once)
+        end.to have_enqueued_job(
+          ProcessDecisionDocumentJob
+        ).with(decision_document_needs_reprocessing.id).exactly(:once)
       end
     end
   end


### PR DESCRIPTION
this will make it easier to debug issues related to decision
document processing.