### PR TITLE
Cutover to contention_removed_at from removed_at on request_issues

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -100,7 +100,7 @@ class EndProductEstablishment < ApplicationRecord
 
   def remove_contention!(for_object)
     VBMSService.remove_contention!(contention_for_object(for_object))
-    for_object.update!(removed_at: Time.zone.now)
+    for_object.update!(contention_removed_at: Time.zone.now)
   end
 
   # Committing an end product establishment is a way to signify that any other actions performed
@@ -238,7 +238,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def active_request_issues
-    request_issues.select { |request_issue| request_issue.removed_at.nil? && request_issue.status_active? }
+    request_issues.select { |request_issue| request_issue.contention_removed_at.nil? && request_issue.status_active? }
   end
 
   def associated_rating

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -52,7 +52,6 @@ class RequestIssue < ApplicationRecord
 
   # TODO: this is a temporary callback in order to synchronize columns. Remove after data is migrated
   before_save :set_decision_sync_last_submitted_at
-  before_save :set_contention_removed_at
 
   class ErrorCreatingDecisionIssue < StandardError
     def initialize(request_issue_id)
@@ -170,7 +169,7 @@ class RequestIssue < ApplicationRecord
     def find_active_by_contested_rating_issue_reference_id(rating_issue_reference_id)
       request_issue = unscoped.find_by(
         contested_rating_issue_reference_id: rating_issue_reference_id,
-        removed_at: nil,
+        contention_removed_at: nil,
         ineligible_reason: nil
       )
 
@@ -182,7 +181,7 @@ class RequestIssue < ApplicationRecord
     def find_active_by_contested_decision_id(contested_decision_issue_id)
       request_issue = unscoped.find_by(
         contested_decision_issue_id: contested_decision_issue_id,
-        removed_at: nil,
+        contention_removed_at: nil,
         ineligible_reason: nil
       )
 
@@ -757,10 +756,6 @@ class RequestIssue < ApplicationRecord
 
   def set_decision_sync_last_submitted_at
     self.decision_sync_last_submitted_at = last_submitted_at
-  end
-
-  def set_contention_removed_at
-    self.contention_removed_at = removed_at
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -172,7 +172,7 @@ feature "Higher Level Review Edit issues" do
         contention_reference_id: "123",
         benefit_type: "compensation",
         ineligible_reason: nil,
-        removed_at: nil
+        contention_removed_at: nil
       )
     end
 
@@ -1035,7 +1035,6 @@ feature "Higher Level Review Edit issues" do
       expect(new_request_issue.description).to eq("Left knee granted")
       expect(request_issue.reload.decision_review_id).to_not be_nil
       expect(request_issue).to be_closed
-      expect(request_issue.removed_at).to eq(Time.zone.now)
       expect(request_issue.contention_removed_at).to eq(Time.zone.now)
       expect(request_issue.closed_at).to eq(Time.zone.now)
       expect(request_issue.closed_status).to eq("removed")

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -498,7 +498,6 @@ feature "Supplemental Claim Edit issues" do
       new_request_issue = supplemental_claim.reload.open_request_issues.first
       expect(new_request_issue.description).to eq("Left knee granted")
       expect(request_issue.reload.decision_review).to_not be_nil
-      expect(request_issue.removed_at).to eq(Time.zone.now)
       expect(request_issue.contention_removed_at).to eq(Time.zone.now)
       expect(request_issue.closed_at).to eq(Time.zone.now)
       expect(request_issue).to be_closed

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -524,7 +524,6 @@ describe EndProductEstablishment do
       subject
 
       expect(Fakes::VBMSService).to have_received(:remove_contention!).once.with(contention)
-      expect(for_object.removed_at).to eq(Time.zone.now)
       expect(for_object.contention_removed_at).to eq(Time.zone.now)
     end
 
@@ -535,7 +534,6 @@ describe EndProductEstablishment do
 
       it "does not remove contentions" do
         expect { subject }.to raise_error(vbms_error)
-        expect(for_object.removed_at).to be_nil
         expect(for_object.contention_removed_at).to be_nil
       end
     end
@@ -742,20 +740,20 @@ describe EndProductEstablishment do
 
   context "#cancel_unused_end_product!" do
     subject { end_product_establishment.cancel_unused_end_product! }
-    let(:removed_at) { nil }
+    let(:contention_removed_at) { nil }
     let!(:request_issues) do
       [
         create(
           :request_issue,
           end_product_establishment: end_product_establishment,
           decision_review: source,
-          removed_at: removed_at
+          contention_removed_at: contention_removed_at
         )
       ]
     end
 
     context "when there are no active request issues" do
-      let(:removed_at) { 1.day.ago }
+      let(:contention_removed_at) { 1.day.ago }
       it "cancels the end product and closes request issues" do
         subject
         expect(end_product_establishment.reload.synced_status).to eq("CAN")

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -423,7 +423,7 @@ describe RequestIssue do
           contested_rating_issue_reference_id: higher_level_review_reference_id,
           contention_reference_id: contention_reference_id,
           end_product_establishment: active_epe,
-          removed_at: nil,
+          contention_removed_at: nil,
           ineligible_reason: nil
         )
       end

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -290,7 +290,6 @@ describe RequestIssuesUpdate do
 
           removed_issue = RequestIssue.find_by(id: existing_legacy_opt_in_request_issue_id)
           expect(removed_issue.decision_review).to_not be_nil
-          expect(removed_issue.removed_at).to_not be_nil
           expect(removed_issue.contention_removed_at).to_not be_nil
           expect(removed_issue).to be_closed
           expect(removed_issue).to be_removed


### PR DESCRIPTION
connects #8239

Prod looking good.
```
irb(main):003:0> RequestIssue.where("removed_at != contention_removed_at")
[2019-02-21 11:43:27 -0500]   RequestIssue Load (2.8ms)  SELECT  "request_issues"."id", "request_issues"."contention_reference_id", "request_issues"."issue_category", "request_issues"."decision_date", "request_issues"."disposition", "request_issues"."end_product_establishment_id", "request_issues"."removed_at", "request_issues"."rating_issue_associated_at", "request_issues"."parent_request_issue_id", "request_issues"."notes", "request_issues"."is_unidentified", "request_issues"."ineligible_due_to_id", "request_issues"."untimely_exemption", "request_issues"."untimely_exemption_notes", "request_issues"."ineligible_reason", "request_issues"."ramp_claim_id", "request_issues"."decision_sync_submitted_at", "request_issues"."decision_sync_attempted_at", "request_issues"."decision_sync_processed_at", "request_issues"."decision_sync_error", "request_issues"."vacols_id", "request_issues"."vacols_sequence_id", "request_issues"."created_at", "request_issues"."benefit_type", "request_issues"."contested_decision_issue_id", "request_issues"."veteran_participant_id", "request_issues"."contested_rating_issue_diagnostic_code", "request_issues"."decision_review_type", "request_issues"."decision_review_id", "request_issues"."contested_rating_issue_reference_id", "request_issues"."contested_rating_issue_profile_date", "request_issues"."contested_issue_description", "request_issues"."nonrating_issue_description", "request_issues"."unidentified_issue_text", "request_issues"."last_submitted_at", "request_issues"."closed_at", "request_issues"."closed_status", "request_issues"."decision_sync_last_submitted_at", "request_issues"."contention_removed_at" FROM "request_issues" WHERE (removed_at != contention_removed_at) LIMIT $1  [["LIMIT", 11]]
=> #<ActiveRecord::Relation []>
```

```
irb(main):004:0> RequestIssue.where.not(removed_at: nil).where(contention_removed_at: nil)
[2019-02-21 11:55:17 -0500]   RequestIssue Load (2.4ms)  SELECT  "request_issues"."id", "request_issues"."contention_reference_id", "request_issues"."issue_category", "request_issues"."decision_date", "request_issues"."disposition", "request_issues"."end_product_establishment_id", "request_issues"."removed_at", "request_issues"."rating_issue_associated_at", "request_issues"."parent_request_issue_id", "request_issues"."notes", "request_issues"."is_unidentified", "request_issues"."ineligible_due_to_id", "request_issues"."untimely_exemption", "request_issues"."untimely_exemption_notes", "request_issues"."ineligible_reason", "request_issues"."ramp_claim_id", "request_issues"."decision_sync_submitted_at", "request_issues"."decision_sync_attempted_at", "request_issues"."decision_sync_processed_at", "request_issues"."decision_sync_error", "request_issues"."vacols_id", "request_issues"."vacols_sequence_id", "request_issues"."created_at", "request_issues"."benefit_type", "request_issues"."contested_decision_issue_id", "request_issues"."veteran_participant_id", "request_issues"."contested_rating_issue_diagnostic_code", "request_issues"."decision_review_type", "request_issues"."decision_review_id", "request_issues"."contested_rating_issue_reference_id", "request_issues"."contested_rating_issue_profile_date", "request_issues"."contested_issue_description", "request_issues"."nonrating_issue_description", "request_issues"."unidentified_issue_text", "request_issues"."last_submitted_at", "request_issues"."closed_at", "request_issues"."closed_status", "request_issues"."decision_sync_last_submitted_at", "request_issues"."contention_removed_at" FROM "request_issues" WHERE ("request_issues"."removed_at" IS NOT NULL) AND "request_issues"."contention_removed_at" IS NULL LIMIT $1  [["LIMIT", 11]]
=> #<ActiveRecord::Relation []>
```