### PR TITLE
Force User create to always UPCASE CSS ID

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -298,9 +298,9 @@ class User < ApplicationRecord
 
       return nil if user.nil?
 
-      # we ignore station_id since id should be globally unique.
+      # TODO: ignore station_id since id should be globally unique.
       css_id = user["id"]
-      existing_user = find_by_css_id(css_id)
+      existing_user = find_by("UPPER(css_id)=UPPER(?) AND station_id=?", css_id, user["station_id"])
       return existing_user if existing_user
 
       create!(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -301,9 +301,8 @@ class User < ApplicationRecord
       # TODO: ignore station_id since id should be globally unique.
       css_id = user["id"]
       existing_user = find_by("UPPER(css_id)=UPPER(?) AND station_id=?", css_id, user["station_id"])
-      return existing_user if existing_user
 
-      create!(
+      existing_user ||= create!(
         css_id: css_id.upcase,
         station_id: user["station_id"],
         full_name: user["name"],
@@ -311,6 +310,14 @@ class User < ApplicationRecord
         roles: user["roles"],
         regional_office: session[:regional_office]
       )
+      existing_user.tap do |u|
+        u.update!(
+          full_name: user["name"],
+          email: user["email"],
+          roles: user["roles"],
+          regional_office: session[:regional_office]
+        )
+      end
     end
 
     def find_by_css_id_or_create_with_default_station_id(css_id)

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -2,11 +2,11 @@ namespace :users do
   desc "find duplicates and suggest which one(s) to delete"
   task dedupe: :environment do
     users = User.all
-    css_ids = users.map(&:css_id)
+    css_ids = users.map(&:css_id).map(&:downcase)
     dupes = css_ids.select { |e| css_ids.count(e) > 1 }.uniq
     dupes.each do |css_id|
       puts "Duplicate: #{css_id}"
-      users = User.where(css_id: css_id)
+      users = User.where("LOWER(css_id)=LOWER(?)", css_id)
       users.each do |user|
         stats = Intake.user_stats(user)
         [

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,0 +1,33 @@
+namespace :users do
+  desc "find duplicates and suggest which one(s) to delete"
+  task dedupe: :environment do
+    users = User.all
+    css_ids = users.map(&:css_id)
+    dupes = css_ids.select { |e| css_ids.count(e) > 1 }.uniq
+    dupes.each do |css_id|
+      puts "Duplicate: #{css_id}"
+      users = User.where(css_id: css_id)
+      users.each do |user|
+        stats = Intake.user_stats(user)
+        [
+          AdvanceOnDocketMotion,
+          Annotation,
+          AppealView,
+          Certification,
+          Dispatch::Task,
+          EndProductEstablishment,
+          RampElectionRollback,
+          SchedulePeriod
+        ].each do |cls|
+          num = cls.where(user_id: user.id).count
+          if num > 0
+            puts "#{user.id} has #{num} #{cls}"
+          end
+        end
+        if stats.empty?
+          puts "#{user.inspect} has zero intake stats and may be a candidate to merge/delete"
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -1,12 +1,28 @@
 namespace :users do
+  desc "coerce all user css_id values to UPCASE where possible"
+  task upcase: :environment do
+    User.all.each do |user|
+      css_id = user.css_id
+      next if css_id == css_id.upcase
+
+      # look for any duplicates in alternate casings
+      matches = User.where("UPPER(css_id)=UPPER(?)", css_id)
+      if matches.count > 1
+        puts "Cannot upcase #{css_id} because duplicates exist in alternate casings"
+        next
+      end
+      user.update!(css_id: css_id.upcase)
+    end
+  end
+
   desc "find duplicates and suggest which one(s) to delete"
   task dedupe: :environment do
     users = User.all
-    css_ids = users.map(&:css_id).map(&:downcase)
+    css_ids = users.map(&:css_id).map(&:upcase)
     dupes = css_ids.select { |e| css_ids.count(e) > 1 }.uniq
     dupes.each do |css_id|
       puts "Duplicate: #{css_id}"
-      users = User.where("LOWER(css_id)=LOWER(?)", css_id)
+      users = User.where("UPPER(css_id)=UPPER(?)", css_id)
       users.each do |user|
         stats = Intake.user_stats(user)
         [

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,7 @@ describe User do
     subject { User.find_by_css_id_or_create_with_default_station_id(css_id) }
 
     it "forces the css id to UPCASE" do
+      expect(css_id.upcase).to_not eq(css_id)
       expect(subject.css_id).to eq(css_id.upcase)
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 describe User do
-  let(:session) { { "user" => { "id" => "123", "station_id" => "310", "name" => "Tom Brady" } } }
+  let(:css_id) { "TomBrady" }
+  let(:session) { { "user" => { "id" => css_id, "station_id" => "310", "name" => "Tom Brady" } } }
   let(:user) { User.from_session(session) }
 
   before(:all) do
@@ -24,6 +25,14 @@ describe User do
     end
   end
 
+  context ".find_by_css_id_or_create_with_default_station_id" do
+    subject { User.find_by_css_id_or_create_with_default_station_id(css_id) }
+
+    it "forces the css id to UPCASE" do
+      expect(subject.css_id).to eq(css_id.upcase)
+    end
+  end
+
   context "#regional_office" do
     context "when RO can't be determined using station_id" do
       subject { user.regional_office }
@@ -43,13 +52,13 @@ describe User do
 
     let(:result) do
       {
-        "id" => "123",
+        "id" => css_id.upcase,
         "station_id" => "310",
-        "css_id" => "123",
+        "css_id" => css_id.upcase,
         "email" => nil,
         "roles" => [],
         "selected_regional_office" => nil,
-        :display_name => "123",
+        :display_name => css_id.upcase,
         "name" => "Tom Brady"
       }
     end
@@ -116,12 +125,12 @@ describe User do
         session["user"]["id"] = "Shaner"
         user.regional_office = "RO77"
       end
-      it { is_expected.to eq("Shaner (RO77)") }
+      it { is_expected.to eq("SHANER (RO77)") }
     end
 
     context "when just username is set" do
       before { session["user"]["id"] = "Shaner" }
-      it { is_expected.to eq("Shaner") }
+      it { is_expected.to eq("SHANER") }
     end
   end
 
@@ -146,18 +155,18 @@ describe User do
 
     context "when roles don't contain the thing but user is granted the function" do
       before { session["user"]["roles"] = ["Do the other thing!"] }
-      before { Functions.grant!("Do the thing", users: ["123"]) }
+      before { Functions.grant!("Do the thing", users: [css_id.upcase]) }
       it { is_expected.to be_truthy }
     end
 
     context "when roles contains the thing but user is denied" do
       before { session["user"]["roles"] = ["Do the thing"] }
-      before { Functions.deny!("Do the thing", users: ["123"]) }
+      before { Functions.deny!("Do the thing", users: [css_id.upcase]) }
       it { is_expected.to be_falsey }
     end
 
     context "when system admin and roles don't contain the thing" do
-      before { Functions.grant!("System Admin", users: ["123"]) }
+      before { Functions.grant!("System Admin", users: [css_id.upcase]) }
       before { session["user"]["roles"] = ["Do the other thing"] }
       it { is_expected.to be_truthy }
     end
@@ -178,7 +187,7 @@ describe User do
     end
 
     context "when user with roles that contain admin" do
-      before { Functions.grant!("System Admin", users: ["123"]) }
+      before { Functions.grant!("System Admin", users: [css_id.upcase]) }
       it { is_expected.to be_truthy }
     end
   end
@@ -304,12 +313,12 @@ describe User do
     end
 
     context "when user with roles that contain admin" do
-      before { Functions.grant!("System Admin", users: ["123"]) }
+      before { Functions.grant!("System Admin", users: [css_id.upcase]) }
       it { is_expected.to be_truthy }
     end
 
     context "when user with grant that contain Admin Intake" do
-      before { Functions.grant!("Admin Intake", users: ["123"]) }
+      before { Functions.grant!("Admin Intake", users: [css_id.upcase]) }
       it { is_expected.to be_truthy }
     end
 
@@ -430,6 +439,7 @@ describe User do
         expect(subject.roles).to eq(["Do the thing"])
         expect(subject.regional_office).to eq("283")
         expect(subject.full_name).to eq("Anne Merica")
+        expect(subject.css_id).to eq("TOMBRADY")
       end
 
       it "persists user to DB" do


### PR DESCRIPTION
connects #9572 
connects #9444 

## Description

As step 1 in cleaning up the User table, prevent any new User records from being created with lowercase CSS ID.

The rake tasks in this PR will be used in a future step in UAT/prod but were helpful locally during development of this PR.