### PR TITLE
Fix VSO tracking task error by setting status

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -71,7 +71,10 @@ class RootTask < GenericTask
         TrackVeteranTask.create!(
           appeal: appeal,
           parent: parent,
-          assigned_to: vso_organization
+          assigned_to: vso_organization,
+
+          # Avoid permissions errors outlined in Github ticket #9389 by setting status here.
+          status: Constants.TASK_STATUSES.in_progress
         )
       end
     end


### PR DESCRIPTION
Resolves #9389.

After this is deployed we should run the following command in the production rails console to update the status for `TrackVeteranTask`s created before this change was live:

```ruby
rails c> TrackVeteranTask.where(status: Constants.TASK_STATUSES.assigned).update_all(status: Constants.TASK_STATUSES.in_progress)
```