### PR TITLE
Fix Raven context reporting

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -7,12 +7,16 @@ class ApplicationJob < ActiveJob::Base
     attr_reader :app_name
   end
 
-  before_perform do |job|
+  around_perform do |job, block|
     # setup debug context
     Raven.tags_context(job: job.class.name, queue: job.queue_name)
     Raven.extra_context(application: self.class.app_name.to_s)
     if self.class.app_name.present?
       RequestStore.store[:application] = "#{self.class.app_name}_job"
     end
+
+    block.call
+
+    Raven::Context.clear!
   end
 end

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -80,6 +80,8 @@ class ClaimReview < DecisionReview
   # If any external calls fail, it is safe to call this multiple times until
   # establishment_processed_at is successfully set.
   def establish!
+    return if processed?
+
     attempted!
 
     if processed_in_caseflow? && end_product_establishments.any?

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -80,8 +80,6 @@ class ClaimReview < DecisionReview
   # If any external calls fail, it is safe to call this multiple times until
   # establishment_processed_at is successfully set.
   def establish!
-    return if processed?
-
     attempted!
 
     if processed_in_caseflow? && end_product_establishments.any?
@@ -102,7 +100,7 @@ class ClaimReview < DecisionReview
     process_legacy_issues!
 
     clear_error!
-    processed!
+    processed! # note this will be set only once even if re-attempted later via RequestIssuesUpdate.establish!
   end
 
   def invalid_modifiers


### PR DESCRIPTION
Raven.extra_context is a class method that must be cleared after each job.

See https://docs.sentry.io/clients/ruby/context/#rack-http-context
