### PR TITLE
Add uniq index on claimants table to avoid duplicate participant ids

### DIFF
--- a/db/migrate/20190222161423_add_uniq_index_to_claimants.rb
+++ b/db/migrate/20190222161423_add_uniq_index_to_claimants.rb
@@ -2,7 +2,7 @@ class AddUniqIndexToClaimants < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
   def change
-  	add_index :claimants, [:participant_id, :review_request_id, :review_request_type], name: "uniq_index_on_participant_id_review_request", unique: true, algorithm: :concurrently
+    add_index :claimants, [:participant_id, :review_request_id, :review_request_type], name: "uniq_index_on_participant_id_review_request", unique: true, algorithm: :concurrently
   end
 end
 

--- a/db/migrate/20190222161423_add_uniq_index_to_claimants.rb
+++ b/db/migrate/20190222161423_add_uniq_index_to_claimants.rb
@@ -1,0 +1,8 @@
+class AddUniqIndexToClaimants < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+  	add_index :claimants, [:participant_id, :review_request_id, :review_request_type], name: "uniq_index_on_participant_id_review_request", unique: true, algorithm: :concurrently
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -106,7 +106,6 @@ ActiveRecord::Schema.define(version: 20190222161423) do
     t.boolean "overtime", default: false
     t.integer "reviewing_judge_id"
     t.string "task_id"
-    t.boolean "untimely_evidence", default: false
     t.datetime "updated_at", null: false
     t.string "work_product"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190221004127) do
+ActiveRecord::Schema.define(version: 20190222161423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema.define(version: 20190221004127) do
     t.boolean "overtime", default: false
     t.integer "reviewing_judge_id"
     t.string "task_id"
+    t.boolean "untimely_evidence", default: false
     t.datetime "updated_at", null: false
     t.string "work_product"
   end
@@ -214,6 +215,7 @@ ActiveRecord::Schema.define(version: 20190221004127) do
     t.string "payee_code"
     t.bigint "review_request_id", null: false
     t.string "review_request_type", null: false
+    t.index ["participant_id", "review_request_id", "review_request_type"], name: "uniq_index_on_participant_id_review_request", unique: true
     t.index ["review_request_type", "review_request_id"], name: "index_claimants_on_review_request"
   end
 


### PR DESCRIPTION
Resolves #9336 

### Description
Add uniq constraint at the DB level to avoid claimant duplicates


