### PR TITLE
Standardize loading spinner size inside empty containers

### DIFF
--- a/client/app/components/LoadingContainer.jsx
+++ b/client/app/components/LoadingContainer.jsx
@@ -12,7 +12,7 @@ export default class LoadingContainer extends React.Component {
       <div className="loadingContainer-positioning">
         <div className="loadingContainer-table">
           <div className="loadingContainer-table-cell">
-            {loadingSymbolHtml('', '50%', color)}
+            {loadingSymbolHtml('', '150px', color)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-on PR to https://github.com/department-of-veterans-affairs/caseflow/pull/9399

### Description
Changes the loading spinner size as seen inside the `DocketsContainer.jsx` view. 

After (note in the screenshot that some of the text has not loaded yet) : 
<img width="833" alt="screenshot 2019-02-22 11 36 20" src="https://user-images.githubusercontent.com/2928395/53256541-29746900-3696-11e9-94fe-efe25ee9deb0.png">

Before:
<img width="832" alt="screenshot 2019-02-22 11 36 25" src="https://user-images.githubusercontent.com/2928395/53256558-32fdd100-3696-11e9-8204-4ec8cf4ac280.png">
