### PR TITLE
remove parent_request_issue_id

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -8,7 +8,6 @@ class RequestIssue < ApplicationRecord
     review_request_id
     review_request_type
     description
-    parent_request_issue_id
   ]
 
   include Asyncable


### PR DESCRIPTION
Fixes `ActiveRecord::StatementInvalid: PG::UndefinedColumn: ERROR:  column request_issues.parent_request_issue_id does not exist` for https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3818/

