### PR TITLE
Revert ruby-oci8 to 2.2.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :production, :staging, :ssh_forwarding, :development, :test do
   # Oracle DB
   gem "activerecord-oracle_enhanced-adapter"
   # set require: 'oci8' here because bootsnap creates a warning: https://github.com/rails/rails/issues/32811#issuecomment-386541855
-  gem "ruby-oci8", require: "oci8"
+  gem "ruby-oci8", "~> 2.2.5.1", require: "oci8"
 end
 
 group :test, :development, :demo do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,7 +433,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
-    ruby-oci8 (2.2.7)
+    ruby-oci8 (2.2.5.1)
     ruby-plsql (0.6.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
@@ -585,7 +585,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop (~> 0.52)
-  ruby-oci8
+  ruby-oci8 (~> 2.2.5.1)
   sass-rails (~> 5.0)
   scss_lint
   sentry-raven


### PR DESCRIPTION
**Why**: When we upgraded it to 2.2.7, it caused the deploy to fail.
We are rolling back now and following up with an investigation.