### PR TITLE
Only geomatch video hearings

### DIFF
--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -34,10 +34,32 @@ class ScheduleHearingTask < GenericTask
       appeal_tasks = incomplete_tasks.joins("INNER JOIN appeals ON appeals.id = appeal_id")
         .where("appeals.closest_regional_office = ?", regional_office)
 
-      legacy_appeal_tasks = incomplete_tasks.joins("INNER JOIN legacy_appeals ON legacy_appeals.id = appeal_id")
-        .where("legacy_appeals.closest_regional_office = ?", regional_office)
+      appeal_tasks + legacy_appeal_tasks(regional_office, incomplete_tasks)
+    end
 
-      appeal_tasks + legacy_appeal_tasks
+    private
+
+    def legacy_appeal_tasks(regional_office, incomplete_tasks)
+      joined_incomplete_tasks = incomplete_tasks.joins("INNER JOIN legacy_appeals ON legacy_appeals.id = appeal_id")
+
+      central_office_ids = VACOLS::Case.where(bfhr: 1, bfcurloc: "CASEFLOW").pluck(:bfkey)
+      central_office_legacy_appeal_ids = LegacyAppeal.where(vacols_id: central_office_ids).pluck(:id)
+
+      # For legacy appeals, we need to only provide a central office hearing if they explicitly
+      # chose one. Likewise, we can't use DC if it's the closest regional office unless they
+      # chose a central office hearing.
+      if regional_office == "C"
+        joined_incomplete_tasks.where("legacy_appeals.id IN (?)", central_office_legacy_appeal_ids)
+      else
+        tasks_by_ro = joined_incomplete_tasks.where("legacy_appeals.closest_regional_office = ?", regional_office)
+
+        # For context: https://github.com/rails/rails/issues/778#issuecomment-432603568
+        if central_office_legacy_appeal_ids.empty?
+          tasks_by_ro
+        else
+          tasks_by_ro.where("legacy_appeals.id NOT IN (?)", central_office_legacy_appeal_ids)
+        end
+      end
     end
   end
 

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -156,7 +156,7 @@ describe ScheduleHearingTask do
     end
   end
 
-  context ".legacy_tasks_for_ro" do
+  context ".tasks_for_ro" do
     let(:regional_office) { "RO17" }
     let(:number_of_cases) { 10 }
 
@@ -234,11 +234,7 @@ describe ScheduleHearingTask do
 
       before do
         AppealRepository.create_schedule_hearing_tasks.each do |appeal|
-          if appeal.hearing_request_type == :central_office
-            appeal.update(closest_regional_office: "C")
-          else
-            appeal.update(closest_regional_office: regional_office)
-          end
+          appeal.update(closest_regional_office: regional_office)
         end
       end
 
@@ -256,10 +252,6 @@ describe ScheduleHearingTask do
         expect(tasks.map { |task| task.appeal.vacols_id }).to match_array(video_cases.pluck(:bfkey))
       end
     end
-  end
-
-  context ".tasks_for_ro" do
-    let(:regional_office) { "RO17" }
 
     context "when there are AMA ScheduleHearingTasks" do
       let(:veteran_at_ro) { create(:veteran) }


### PR DESCRIPTION
### Description
Currently when trying to schedule CO hearings appellants who have asked for video hearings are being thrown into the list. This is because of a change we made where we removed some of the queries we were making when grabbing the list of Veterans to schedule.

### Testing Plan
1. Newly created test to ensure we only pull CO legacy hearings when users select "Central"

