### PR TITLE
add file-level comments for every task class

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,7 @@
+##
+# Base model for all tasks in Caseflow.
+# Tasks represent work to be done by judges, attorneys, VSOs, and anyone else who touches a Veteran's appeal.
+
 class Task < ApplicationRecord
   acts_as_tree
 

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -1,7 +1,7 @@
 ##
 # Task tracking work done by attorneys at BVA. Attorneys are assigned tasks by judges.
 # Attorney tasks include:
-#   - reviewing judge decisions
+#   - writing draft decisions for judges
 #   - adding admin actions (like translating documents)
 
 class AttorneyTask < Task

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -1,3 +1,9 @@
+##
+# Task tracking work done by attorneys at BVA. Attorneys are assigned tasks by judges.
+# Attorney tasks include:
+#   - reviewing judge decisions
+#   - adding admin actions (like translating documents)
+
 class AttorneyTask < Task
   validates :assigned_by, presence: true
   validates :parent, presence: true, if: :ama?

--- a/app/models/tasks/board_grant_effectuation_task.rb
+++ b/app/models/tasks/board_grant_effectuation_task.rb
@@ -1,3 +1,8 @@
+##
+# A task to track when the Board issues a benefit that is not compensation or pension,
+# like education or a loan guaranty, otherwise known as an "effectuation task".
+# This task is created for the appropriate business line(s) based on the benefit type(s) of the decision issue(s).
+
 class BoardGrantEffectuationTask < DecisionReviewTask
   include BusinessLineTask
 

--- a/app/models/tasks/board_grant_effectuation_task.rb
+++ b/app/models/tasks/board_grant_effectuation_task.rb
@@ -1,5 +1,5 @@
 ##
-# A task to track when the Board issues a benefit that is not compensation or pension,
+# A task to track when the Board grants a benefit that is not compensation or pension,
 # like education or a loan guaranty, otherwise known as an "effectuation task".
 # This task is created for the appropriate business line(s) based on the benefit type(s) of the decision issue(s).
 

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -1,3 +1,7 @@
+##
+# Task assigned to BVA Dispatch team members whenever a judge completes a case review.
+# This indicates that an appeal is decided and the appellant is about to be notified of the decision.
+
 class BvaDispatchTask < GenericTask
   class << self
     def create_from_root_task(root_task)

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -2,6 +2,9 @@
 # Any task assigned to a colocated team at the BVA, which is any team that handles admin actions at BVA.
 # Colocated teams perform actions like:
 #  - translating documents
+#  - scheduling hearings
+#  - handling FOIA requests
+# Note: Full list of colocated tasks in /client/constants/CO_LOCATED_ADMIN_ACTIONS.json
 
 class ColocatedTask < Task
   validates :action, inclusion: { in: Constants::CO_LOCATED_ADMIN_ACTIONS.keys.map(&:to_s) }

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -1,3 +1,8 @@
+##
+# Any task assigned to a colocated team at the BVA, which is any team that handles admin actions at BVA.
+# Colocated teams perform actions like:
+#  - translating documents
+
 class ColocatedTask < Task
   validates :action, inclusion: { in: Constants::CO_LOCATED_ADMIN_ACTIONS.keys.map(&:to_s) }
   validates :assigned_by, presence: true

--- a/app/models/tasks/decision_review_task.rb
+++ b/app/models/tasks/decision_review_task.rb
@@ -1,3 +1,7 @@
+##
+# Task for a business line at BVA (e.g., Vocational Rehab & Employment) to review a decision from a judge relating to
+# non-compensation benefits like education or loan guarantys.
+
 class DecisionReviewTask < GenericTask
   attr_reader :error_code
 

--- a/app/models/tasks/distribution_task.rb
+++ b/app/models/tasks/distribution_task.rb
@@ -1,3 +1,6 @@
+##
+# Task that signals that an appeal is ready for distribution to a judge, including for auto case distribution.
+
 class DistributionTask < GenericTask
   # Prevent this task from being marked complete
   # when a child task (e.g. evidence submission)

--- a/app/models/tasks/evidence_submission_window_task.rb
+++ b/app/models/tasks/evidence_submission_window_task.rb
@@ -1,3 +1,7 @@
+##
+# Task that signals that a case now has a 90-day window for appellant to submit additional evidence.
+# The evidence window may be waived by an appellant.
+
 class EvidenceSubmissionWindowTask < GenericTask
   include TimeableTask
 

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -1,3 +1,9 @@
+##
+# Model for tasks in generic organizational task queues. Supports common actions like:
+#   - marking tasks complete
+#   - assigning a task to a team
+#   - assigning a task to an individual
+
 class GenericTask < Task
   before_create :verify_org_task_unique
 

--- a/app/models/tasks/hearing_admin_action_task.rb
+++ b/app/models/tasks/hearing_admin_action_task.rb
@@ -1,5 +1,7 @@
 ##
-# Task for a hearing coordinator to schedule a Veteran for a hearing.
+# Tasks that block scheduling a Veteran for a hearing.
+# A hearing coordinator must resolve these before scheduling a Veteran.
+# Subclasses of various admin actions are defined below.
 
 class HearingAdminActionTask < GenericTask
   validates :parent, presence: true

--- a/app/models/tasks/hearing_admin_action_task.rb
+++ b/app/models/tasks/hearing_admin_action_task.rb
@@ -1,3 +1,6 @@
+##
+# Task for a hearing coordinator to schedule a Veteran for a hearing.
+
 class HearingAdminActionTask < GenericTask
   validates :parent, presence: true
   validate :on_hold_duration_is_set, on: :update

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -1,5 +1,7 @@
 ##
-# Task tracking a Veterans Law Judge hearing.
+# A task used to track all related hearing subtasks.
+# A hearing task is associated with a hearing record in Caseflow and might have several child tasks to resolve
+# in order to schedule a hearing, hold it, and mark the disposition.
 
 class HearingTask < GenericTask
   has_one :hearing_task_association

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -1,3 +1,6 @@
+##
+# Task tracking a Veterans Law Judge hearing.
+
 class HearingTask < GenericTask
   has_one :hearing_task_association
 end

--- a/app/models/tasks/hold_hearing_task.rb
+++ b/app/models/tasks/hold_hearing_task.rb
@@ -1,7 +1,8 @@
 ##
-# Task assigned to the BvaOrganization after a hearing is scheduled.
-# Created after the ScheduleHearingTask is completed and the hearing is scheduled.
-# Marked complete when the hearing is held.
+# Task assigned to the BvaOrganization after a hearing is scheduled, created after the ScheduleHearingTask is completed.
+# When the associated hearing's disposition is set, the appropriate tasks are set as children
+#   (e.g., TranscriptionTask, EvidenceWindowTask, etc.).
+# The task is marked complete when these children tasks are completed.
 
 class HoldHearingTask < GenericTask
   class << self

--- a/app/models/tasks/hold_hearing_task.rb
+++ b/app/models/tasks/hold_hearing_task.rb
@@ -1,3 +1,8 @@
+##
+# Task assigned to the BvaOrganization after a hearing is scheduled.
+# Created after the ScheduleHearingTask is completed and the hearing is scheduled.
+# Marked complete when the hearing is held.
+
 class HoldHearingTask < GenericTask
   class << self
     def create_hold_hearing_task!(appeal, parent, hearing)

--- a/app/models/tasks/informal_hearing_presentation_task.rb
+++ b/app/models/tasks/informal_hearing_presentation_task.rb
@@ -1,3 +1,8 @@
+##
+# A task assigned to VSOs representing Veterans who have elected not to have a hearing.
+# VSOs will submit an IHP on behalf of a veteran and is a chance for final arguments before a case is sent to the Board.
+# BVA typically (but not always) waits for an IHP to be submitted before making a decision.
+
 class InformalHearingPresentationTask < GenericTask
   # TODO: figure out how long IHP tasks will take to expire,
   # then make them timeable

--- a/app/models/tasks/informal_hearing_presentation_task.rb
+++ b/app/models/tasks/informal_hearing_presentation_task.rb
@@ -1,6 +1,6 @@
 ##
-# A task assigned to VSOs representing Veterans who have elected not to have a hearing.
-# VSOs will submit an IHP on behalf of a veteran and is a chance for final arguments before a case is sent to the Board.
+# Task assigned to VSOs to submit an Informal Hearing Presentation for Veterans who have elected not to have a hearing.
+# IHPs are a chance for VSOs to make final arguments before a case is sent to the Board.
 # BVA typically (but not always) waits for an IHP to be submitted before making a decision.
 
 class InformalHearingPresentationTask < GenericTask

--- a/app/models/tasks/judge_assign_task.rb
+++ b/app/models/tasks/judge_assign_task.rb
@@ -1,3 +1,6 @@
+##
+# Task for a judge to assign tasks to attorneys.
+
 class JudgeAssignTask < JudgeTask
   def additional_available_actions(_user)
     [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]

--- a/app/models/tasks/judge_decision_review_task.rb
+++ b/app/models/tasks/judge_decision_review_task.rb
@@ -1,3 +1,6 @@
+##
+# Task for a judge to review decisions.
+
 class JudgeDecisionReviewTask < JudgeTask
   def additional_available_actions(_user)
     judge_checkout_label = if ama?

--- a/app/models/tasks/judge_quality_review_task.rb
+++ b/app/models/tasks/judge_quality_review_task.rb
@@ -1,3 +1,6 @@
+##
+# A task created when the Quality Review team returns a task to the assigning judge.
+
 class JudgeQualityReviewTask < JudgeTask
   def additional_available_actions(_user)
     [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h, Constants.TASK_ACTIONS.MARK_COMPLETE.to_h]

--- a/app/models/tasks/judge_quality_review_task.rb
+++ b/app/models/tasks/judge_quality_review_task.rb
@@ -1,5 +1,5 @@
 ##
-# A task created when the Quality Review team returns a task to the assigning judge.
+# Task for to complete a case or assign it to an attorney after it's returned to the judge by the quality review team.
 
 class JudgeQualityReviewTask < JudgeTask
   def additional_available_actions(_user)

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -1,3 +1,7 @@
+##
+# Parent class for all tasks to be completed by judges, including
+# JudgeQualityReviewTasks, JudgeDecisionReviewTasks, and JudgeAssignTasks.
+
 class JudgeTask < Task
   def available_actions(user)
     additional_available_actions(user).unshift(Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h)

--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -1,3 +1,12 @@
+##
+# Task to track when the mail team receives any appeal-related mail from an appellant.
+# Mail is processed by a mail team member, and then a corresponding task is then assigned to an organization.
+# Tasks are assigned to organizations, including VLJ Support, AOD team, Privacy team, and Lit Support, and include:
+#   - add Evidence or Argument
+#   - changing Power of Attorney
+#   - advance a case on docket (AOD)
+#   - withdrawing an appeal
+
 class MailTask < GenericTask
   # Skip unique verification for mail tasks since multiple mail tasks of each type can be created.
   def verify_org_task_unique; end

--- a/app/models/tasks/quality_review_task.rb
+++ b/app/models/tasks/quality_review_task.rb
@@ -1,3 +1,6 @@
+##
+# Task to track when an appeal has been randomly selected to be quality reviewed by the Quality Review team.
+
 class QualityReviewTask < GenericTask
   def available_actions(user)
     return super if assigned_to != user

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -1,3 +1,7 @@
+##
+# Root task that tracks an appeal all the way through the appeal lifecycle.
+# This task is closed when an appeal has been completely resolved.
+
 class RootTask < GenericTask
   # Set assignee to the Bva organization automatically so we don't have to set it when we create RootTasks.
   after_initialize :set_assignee, if: -> { assigned_to_id.nil? }

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -1,3 +1,6 @@
+##
+# Task to track when a hearing should be scheduled for a veteran making a claim.
+
 class ScheduleHearingTask < GenericTask
   after_update :update_location_in_vacols
 

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -1,5 +1,7 @@
 ##
-# Task to track when a hearing should be scheduled for a veteran making a claim.
+# Task to schedule a hearing for a veteran making a claim.
+# Created by the intake process for any appeal electing to have a hearing.
+# Once completed, a HoldHearingTask is created.
 
 class ScheduleHearingTask < GenericTask
   after_update :update_location_in_vacols

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -1,3 +1,6 @@
+##
+# Task created when creating RootTasks for appeals represented by VSOs.
+
 class TrackVeteranTask < GenericTask
   def available_actions(_user)
     []

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -1,5 +1,8 @@
 ##
-# Task created when creating RootTasks for appeals represented by VSOs.
+# Task created for appellant representatives to track appeals that have been received by the Board.
+# Created either when:
+#   - a RootTask is created for an appeal represented by a VSO
+#   - the power of attorney changes on an appeal
 
 class TrackVeteranTask < GenericTask
   def available_actions(_user)

--- a/app/models/tasks/translation_task.rb
+++ b/app/models/tasks/translation_task.rb
@@ -1,5 +1,6 @@
 ##
-# Task to track when documents are submitted that need to be translated.
+# Task automatically assigned after intake to the Translation organization when a case originates
+# from an RO in Puerto Rico or the Phillipines.
 
 class TranslationTask < GenericTask
   def self.create_from_root_task(root_task)

--- a/app/models/tasks/translation_task.rb
+++ b/app/models/tasks/translation_task.rb
@@ -1,3 +1,6 @@
+##
+# Task to track when documents are submitted that need to be translated.
+
 class TranslationTask < GenericTask
   def self.create_from_root_task(root_task)
     create!(assigned_to: Translation.singleton, parent_id: root_task.id, appeal: root_task.appeal)

--- a/app/models/tasks/veteran_record_request.rb
+++ b/app/models/tasks/veteran_record_request.rb
@@ -1,3 +1,6 @@
+##
+# Created whenever an Appeal request issue has a benefit_type that is not compensation or pension.
+
 class VeteranRecordRequest < GenericTask
   include BusinessLineTask
 


### PR DESCRIPTION
### Description
Add file-level comments to describe every class inheriting from the `Task` model.

(This PR is borne from https://github.com/department-of-veterans-affairs/caseflow/issues/9310, where we were working through trying to understand each type of `Task` and whether it should be cancellable or not.)
