### PR TITLE
Do not create Veteran record unless accessible

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -272,19 +272,17 @@ class Veteran < ApplicationRecord
         %(create_by_file_number file_number:#{file_number} found:true accessible:#{veteran.accessible?})
       )
 
+      return veteran unless veteran.accessible?
+
       before_create_veteran_by_file_number # Used to simulate race conditions
       veteran.tap do |v|
-        v.update!(participant_id: v.ptcpnt_id)
-        # Check to see if veteran is accessible to make sure
-        # bgs_record is a hash and not :not_found
-        if v.accessible?
-          v.update!(
-            first_name: v.bgs_record[:first_name],
-            last_name: v.bgs_record[:last_name],
-            middle_name: v.bgs_record[:middle_name],
-            name_suffix: v.bgs_record[:name_suffix]
-          )
-        end
+        v.update!(
+          participant_id: v.ptcpnt_id,
+          first_name: v.bgs_record[:first_name],
+          last_name: v.bgs_record[:last_name],
+          middle_name: v.bgs_record[:middle_name],
+          name_suffix: v.bgs_record[:name_suffix]
+        )
       end
     rescue ActiveRecord::RecordNotUnique
       find_by(file_number: file_number)

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -21,6 +21,56 @@ RSpec.describe IntakesController do
       expect(response.status).to eq(200)
       expect(Intake.last.veteran_file_number).to eq(file_number)
     end
+
+    context "veteran name is out of sync with BGS" do
+      let!(:veteran) { create(:veteran, file_number: file_number, first_name: nil, last_name: nil) }
+      before { Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica") }
+
+      it "will update the Veteran name in Caseflow" do
+        post :create, params: { file_number: file_number, form_type: "higher_level_review" }
+        expect(response.status).to eq(200)
+        vet = Veteran.find_by_file_number_or_ssn(file_number)
+        expect(vet).to_not be_nil
+        expect(vet.first_name).to eq "Ed"
+        expect(vet.last_name).to eq "Merica"
+      end
+    end
+
+    context "veteran in BGS but not yet in Caseflow" do
+      let(:file_number) { "999887777" }
+      let!(:veteran) {} # no-op
+      before { Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica") }
+
+      it "will create the Veteran in Caseflow" do
+        expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
+        post :create, params: { file_number: file_number, form_type: "higher_level_review" }
+        expect(response.status).to eq(200)
+        vet = Veteran.find_by_file_number_or_ssn(file_number)
+        expect(vet).to_not be_nil
+        expect(vet.first_name).to eq "Ed"
+        expect(vet.last_name).to eq "Merica"
+      end
+    end
+
+    context "veteran in BGS and not accessible to user" do
+      before do
+        Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica")
+        allow_any_instance_of(Veteran).to receive(:accessible?).and_return(false)
+      end
+
+      let(:file_number) { "999887777" }
+      let!(:veteran) {} # no-op
+
+      it "does not create Veteran db record in Caseflow" do
+        expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
+        expect(Intake.find_by(veteran_file_number: file_number)).to be_nil
+        post :create, params: { file_number: file_number, form_type: "higher_level_review" }
+        expect(response.status).to eq(422)
+        expect(controller.send(:new_intake).error_code).to eq("veteran_not_accessible")
+        expect(Veteran.find_by_file_number_or_ssn(file_number)).to be_nil
+        expect(Intake.find_by(veteran_file_number: file_number)).to_not be_nil
+      end
+    end
   end
 
   describe "#complete" do


### PR DESCRIPTION
connects #9448 

## Description

This change affects the logic for when a `Veteran` record is created. It will only be created if both `found?` and `accessible?` are true.
