### PR TITLE
Use assigned_at date if placed_on_hold_at is nil.

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -135,7 +135,7 @@ class TasksController < ApplicationController
       appeal: task.appeal,
       user: current_user,
       query_vbms: false,
-      date_to_compare_with: task.placed_on_hold_at || task.assigned_at || Time.zone.at(0)
+      date_to_compare_with: task.placed_on_hold_at || task.assigned_at
     )
     render json: { new_documents: new_documents_for_user.process! }
   rescue StandardError => e

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -128,8 +128,14 @@ class TasksController < ApplicationController
   end
 
   def new_documents
+    # For attorneys, the tasks in their on hold tab are all colocated tasks that they have assigned (see
+    # attorney_queue.rb). Because these tasks use the assigned_at date as their placed_on_hold_at, use assigned_at if
+    # placed_on_hold_at is null.
     new_documents_for_user = NewDocumentsForUser.new(
-      appeal: task.appeal, user: current_user, query_vbms: false, date_to_compare_with: task.placed_on_hold_at
+      appeal: task.appeal,
+      user: current_user,
+      query_vbms: false,
+      date_to_compare_with: task.placed_on_hold_at || task.assigned_at || Time.zone.at(0)
     )
     render json: { new_documents: new_documents_for_user.process! }
   rescue StandardError => e

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -9,7 +9,35 @@ RSpec.feature "Task queue" do
         :ama_attorney_task,
         :on_hold,
         assigned_to: attorney_user,
-        placed_on_hold_at: 4.days.ago
+        placed_on_hold_at: 2.days.ago
+      )
+    end
+
+    let!(:attorney_task_new_docs) do
+      FactoryBot.create(
+        :ama_attorney_task,
+        :on_hold,
+        assigned_to: attorney_user,
+        placed_on_hold_at: 4.days.ago,
+        appeal: attorney_task.appeal
+      )
+    end
+
+    let!(:colocated_task) do
+      FactoryBot.create(
+        :ama_colocated_task,
+        assigned_by: attorney_user,
+        assigned_at: 2.days.ago,
+        appeal: create(:appeal)
+      )
+    end
+
+    let!(:colocated_task_new_docs) do
+      FactoryBot.create(
+        :ama_colocated_task,
+        assigned_by: attorney_user,
+        assigned_at: 4.days.ago,
+        appeal: attorney_task.appeal
       )
     end
 
@@ -39,16 +67,28 @@ RSpec.feature "Task queue" do
     context "the on-hold task is attached to an appeal with documents" do
       let!(:documents) do
         ["NOD", "BVA Decision", "SSOC"].map do |t|
-          FactoryBot.build(:document, type: t, upload_date: 3.days.ago, file_number: paper_appeal.veteran_file_number)
+          FactoryBot.create(
+            :document,
+            type: t,
+            upload_date: 3.days.ago,
+            file_number: attorney_task.appeal.veteran_file_number
+          )
         end
       end
 
-      before do
-        allow_any_instance_of(NewDocumentsForUser).to receive(:process!) { documents }
+      let!(:more_documents) do
+        ["NOD", "BVA Decision", "SSOC"].map do |t|
+          FactoryBot.create(
+            :document,
+            type: t,
+            upload_date: 3.days.ago,
+            file_number: colocated_task.appeal.veteran_file_number
+          )
+        end
       end
 
       it "shows the correct number of tasks on hold" do
-        expect(page).to have_content(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 1))
+        expect(page).to have_content(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 4))
       end
 
       it "shows a new documents icon in the on hold tab" do
@@ -56,8 +96,9 @@ RSpec.feature "Task queue" do
       end
 
       it "shows a new documents icon next to the on hold task" do
-        page.find(:button, format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 1)).click
-        expect(find("tbody td #NEW")).to have_content("NEW")
+        page.find(:button, format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 4)).click
+        expect(first("tbody td #NEW")).to have_content("NEW")
+        expect(find_all("tbody td #NEW").length).to eq(2)
       end
     end
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature "Task queue" do
 
     let(:vacols_tasks) { QueueRepository.tasks_for_user(attorney_user.css_id) }
     let(:attorney_on_hold_tasks) do
-      Task.where(status: :on_hold, assigned_to: attorney_user)
+      Task.where(status: :on_hold, assigned_to: attorney_user) + ColocatedTask.where(assigned_by: attorney_user)
     end
 
     before do


### PR DESCRIPTION
Resolves #9671

### Description
In attorney queues FE, on_hold tasks don't have a placed_on_hold_at date but rather use the assigned_at date instead. This ticket uses the assigned_at date on the BE to look for new docs

### Acceptance Criteria
- [ ] No 500s on new_documents in production for attorney queues
