### PR TITLE
Added feature test to protect Veteran appeal sort in Assign Hearings

### DIFF
--- a/spec/feature/hearing_schedule/schedule_veteran_spec.rb
+++ b/spec/feature/hearing_schedule/schedule_veteran_spec.rb
@@ -23,25 +23,35 @@ RSpec.feature "Schedule Veteran For A Hearing" do
     let!(:vacols_case) do
       create(
         :case, :central_office_hearing,
-        bfcorlid: "123454787S"
+        bfcorlid: "123454787S",
+        bfcurloc: "CASEFLOW"
+      )
+    end
+    let!(:legacy_appeal) do
+      create(
+        :legacy_appeal, vacols_case: vacols_case
+      )
+    end
+    let!(:schedule_hearing_task) do
+      create(
+        :schedule_hearing_task, appeal: legacy_appeal
       )
     end
 
     let!(:veteran) { create(:veteran, file_number: "123454787") }
 
-    scenario "Schedule Veteran for central hearing",
-             skip: "This test passes on local but fails intermittently on circle" do
+    scenario "Schedule Veteran for central hearing" do
       visit "hearings/schedule/assign"
       expect(page).to have_content("Regional Office")
-      click_dropdown(index: 7)
+      click_dropdown(text: "Central")
       click_button("Legacy Veterans Waiting")
-      appeal_link = page.find(:xpath, "//tbody/tr/td[1]/a")
+      appeal_link = page.find(:xpath, "//tbody/tr/td[2]/a")
       appeal_link.click
       expect(page).not_to have_content("loading to VACOLS.", wait: 30)
       expect(page).to have_content("Currently active tasks", wait: 30)
       click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
       expect(page).to have_content("Time")
-      click_dropdown(name: "veteranHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
       radio_link = find(".cf-form-radio-option", match: :first)
       radio_link.click
       click_button("Schedule")
@@ -61,7 +71,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
       create(
         :hearing_day,
         request_type: HearingDay::REQUEST_TYPES[:video],
-        scheduled_for: Time.zone.today + 160,
+        scheduled_for: Time.zone.today + 60.days,
         regional_office: "RO39"
       )
     end
@@ -71,19 +81,30 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         :case, :video_hearing_requested,
         folder: create(:folder, tinum: "docket-number"),
         bfcorlid: "123456789S",
+        bfcurloc: "CASEFLOW",
         bfregoff: "RO39"
       )
     end
-
+    let!(:legacy_appeal) do
+      create(
+        :legacy_appeal,
+        vacols_case: vacols_case,
+        closest_regional_office: "RO39"
+      )
+    end
+    let!(:schedule_hearing_task) do
+      create(
+        :schedule_hearing_task, appeal: legacy_appeal
+      )
+    end
     let!(:veteran) { create(:veteran, file_number: "123456789") }
 
-    scenario "Schedule Veteran for video",
-             skip: "This test passes on local but fails intermittently on circle" do
+    scenario "Schedule Veteran for video" do
       visit "hearings/schedule/assign"
       expect(page).to have_content("Regional Office")
-      click_dropdown(index: 12)
+      click_dropdown(text: "Denver, CO")
       click_button("Legacy Veterans Waiting")
-      appeal_link = page.find(:xpath, "//tbody/tr/td[1]/a")
+      appeal_link = page.find(:xpath, "//tbody/tr/td[2]/a")
       appeal_link.click
       expect(page).not_to have_content("loading to VACOLS.", wait: 30)
       expect(page).to have_content("Currently active tasks", wait: 30)
@@ -281,6 +302,133 @@ RSpec.feature "Schedule Veteran For A Hearing" do
 
       click_on "Back to Hearing Schedule"
       expect(page).to have_content("Denver")
+    end
+  end
+
+  context "When list of veterans displays in Legacy Veterans Waiting" do
+    let!(:hearing_day) { create(:hearing_day) }
+    let!(:schedule_hearing_task1) do
+      create(
+        :schedule_hearing_task, appeal: create(
+          :legacy_appeal,
+          vacols_case: create(
+            :case, :central_office_hearing,
+            :type_cavc_remand,
+            bfcorlid: "123454787S",
+            bfcurloc: "CASEFLOW",
+            folder: create(
+              :folder,
+              ticknum: "91",
+              tinum: "1545678",
+              titrnum: "123454787S"
+            )
+          )
+        )
+      )
+    end
+    let!(:veteran1) { create(:veteran, file_number: "123454787") }
+    let!(:schedule_hearing_task2) do
+      create(
+        :schedule_hearing_task, appeal: create(
+          :legacy_appeal,
+          vacols_case: create(
+            :case,
+            :central_office_hearing,
+            :aod,
+            :type_original,
+            bfcorlid: "123454788S",
+            bfcurloc: "CASEFLOW",
+            folder: create(
+              :folder,
+              ticknum: "92",
+              tinum: "1645621",
+              titrnum: "123454788S"
+            )
+          )
+        )
+      )
+    end
+    let!(:veteran2) { create(:veteran, file_number: "123454788") }
+    let!(:schedule_hearing_task3) do
+      create(
+        :schedule_hearing_task, appeal: create(
+          :legacy_appeal,
+          vacols_case: create(
+            :case,
+            :central_office_hearing,
+            :aod,
+            :type_original,
+            bfcorlid: "323454787S",
+            bfcurloc: "CASEFLOW",
+            folder: create(
+              :folder,
+              ticknum: "93",
+              tinum: "1645678",
+              titrnum: "323454787S"
+            )
+          )
+        )
+      )
+    end
+    let!(:veteran3) { create(:veteran, file_number: "323454787") }
+    let!(:schedule_hearing_task4) do
+      create(
+        :schedule_hearing_task, appeal: create(
+          :legacy_appeal,
+          vacols_case: create(
+            :case,
+            :central_office_hearing,
+            :type_original,
+            bfcorlid: "123454789S",
+            bfcurloc: "CASEFLOW",
+            folder: create(
+              :folder,
+              ticknum: "94",
+              tinum: "1445678",
+              titrnum: "123454789S"
+            )
+          )
+        )
+      )
+    end
+    let!(:veteran4) { create(:veteran, file_number: "123454789") }
+    let!(:schedule_hearing_task5) do
+      create(
+        :schedule_hearing_task, appeal: create(
+          :legacy_appeal,
+          vacols_case: create(
+            :case,
+            :central_office_hearing,
+            :type_original,
+            bfcorlid: "523454787S",
+            bfcurloc: "CASEFLOW",
+            folder: create(
+              :folder,
+              ticknum: "95",
+              tinum: "1445695",
+              titrnum: "523454787S"
+            )
+          )
+        )
+      )
+    end
+    let!(:veteran5) { create(:veteran, file_number: "523454787") }
+
+    scenario "Verify docket order is CVAC, AOD, then regular." do
+      visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Central")
+      click_button("Legacy Veterans Waiting")
+      table_row = page.find("tr", id: "table-row-0")
+      expect(table_row).to have_content("1545678")
+      table_row = page.find("tr", id: "table-row-1")
+      expect(table_row).to have_content("1645621")
+      table_row = page.find("tr", id: "table-row-2")
+      expect(table_row).to have_content("1645678")
+      table_row = page.find("tr", id: "table-row-3")
+      expect(table_row).to have_content("1445678")
+      table_row = page.find("tr", id: "table-row-4")
+      expect(table_row).to have_content("1445695")
     end
   end
 end


### PR DESCRIPTION
Resolves #9458 

### Description
Added a feature test to confirm that the Assign Hearings pages for Veterans awaiting scheduling are sorted in the correct manner.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Run new test
2. Confirm it goes green.

