### PR TITLE
Rename HoldHearingTask to DispositionTask

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -517,7 +517,7 @@ class Appeal < DecisionReview
 
   def hearing_pending?
     # This isn't available yet.
-    # tasks.active.where(type: HoldHearingTask.name).any?
+    # tasks.active.where(type: DispositionTask.name).any?
   end
 
   def evidence_submission_hold_pending?

--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -1,0 +1,15 @@
+class DispositionTask < GenericTask
+  class << self
+    def create_disposition_task!(appeal, parent, hearing)
+      DispositionTask.create!(
+        appeal: appeal,
+        parent: parent,
+        assigned_to: Bva.singleton
+      )
+
+      if parent.is_a? HearingTask
+        HearingTaskAssociation.create!(hearing: hearing, hearing_task: parent)
+      end
+    end
+  end
+end

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -95,7 +95,7 @@ class ScheduleHearingTask < GenericTask
         hearing_location = task_payloads[:values][:hearing_location]
 
         hearing = slot_new_hearing(hearing_day_id, hearing_type, hearing_time, hearing_location)
-        HoldHearingTask.create_hold_hearing_task!(appeal, parent, hearing)
+        DispositionTask.create_disposition_task!(appeal, parent, hearing)
       elsif params[:status] == Constants.TASK_STATUSES.cancelled
         withdraw_hearing
       end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1,0 +1,61 @@
+namespace :tasks do
+  # usage:
+  # Change all HoldHearingTasks to DispositionTasks (dry run)
+  #   $ bundle exec rake tasks:change_type[HoldHearingTask,DispositionTask]"
+  # Change all HoldHearingTasks to DispositionTasks (execute)
+  #   $ bundle exec rake tasks:change_type[HoldHearingTask,DispositionTask,false]"
+  # Change HoldHearingTasks matching passed ids to DispositionTasks (dry run)
+  #   $ bundle exec rake tasks:change_type[HoldHearingTask,DispositionTask,12,13,14,15,16]"
+  # Change HoldHearingTasks matching passed ids to DispositionTasks (execute)
+  #   $ bundle exec rake tasks:change_type[HoldHearingTask,DispositionTask,false,12,13,14,15,16]"
+  desc "change tasks from one type to another"
+  task :change_type, [:from_type, :to_type, :dry_run] => :environment do |_, args|
+    Rails.logger.tagged("rake tasks:change_type") { Rails.logger.info("Invoked with: #{args.to_a.join(', ')}") }
+    extras = args.extras
+    dry_run = args.dry_run&.to_s&.strip&.upcase != "FALSE"
+    if dry_run && args.dry_run.to_i > 0
+      extras.unshift(args.dry_run)
+    end
+
+    if dry_run
+      puts "*** DRY RUN"
+      puts "*** pass 'false' as the third argument to execute"
+    end
+
+    from_class = Object.const_get(args.from_type)
+    to_class = Object.const_get(args.to_type)
+    [from_class, to_class].each do |check_class|
+      unless Task.descendants.include?(check_class)
+        abort "#{check_class.name} is not a valid Task type!"
+      end
+
+      if check_class.descendants.count > 0
+        puts "*WARNING* #{check_class.name} has #{check_class.descendants.count} descendants"
+      end
+    end
+
+    target_tasks = if extras.any?
+                     from_class.find(extras)
+                   else
+                     from_class.all
+                   end
+
+    if target_tasks.count == 0
+      abort "There aren't any #{from_class.name}s available to change."
+    end
+
+    ids = target_tasks.map(&:id)
+    change = dry_run ? "Would change" : "Changing"
+    revert = dry_run ? "Would revert" : "Revert"
+    message = "#{change} #{target_tasks.count} #{from_class.name}s with ids #{ids.join(', ')} into #{to_class.name}s"
+    puts message
+    puts "#{revert} with: bundle exec rake tasks:change_type[#{to_class.name},#{from_class.name},#{ids.join(',')}]"
+
+    if !dry_run
+      Rails.logger.tagged("rake tasks:change_type") { Rails.logger.info(message) }
+      target_tasks.each do |task|
+        task.update!(type: to_class.name)
+      end
+    end
+  end
+end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1,4 +1,7 @@
 namespace :tasks do
+  class InvalidTaskType < StandardError; end
+  class NoTasksToChange < StandardError; end
+
   # usage:
   # Change all HoldHearingTasks to DispositionTasks (dry run)
   #   $ bundle exec rake tasks:change_type[HoldHearingTask,DispositionTask]"
@@ -26,11 +29,7 @@ namespace :tasks do
     to_class = Object.const_get(args.to_type)
     [from_class, to_class].each do |check_class|
       unless Task.descendants.include?(check_class)
-        abort "#{check_class.name} is not a valid Task type!"
-      end
-
-      if check_class.descendants.count > 0
-        puts "*WARNING* #{check_class.name} has #{check_class.descendants.count} descendants"
+        fail InvalidTaskType, "#{check_class.name} is not a valid Task type!"
       end
     end
 
@@ -41,7 +40,7 @@ namespace :tasks do
                    end
 
     if target_tasks.count == 0
-      abort "There aren't any #{from_class.name}s available to change."
+      fail NoTasksToChange, "There aren't any #{from_class.name}s available to change."
     end
 
     ids = target_tasks.map(&:id)

--- a/scripts/back_fill_hearing_task_associations.rb
+++ b/scripts/back_fill_hearing_task_associations.rb
@@ -1,6 +1,6 @@
 # Script to backfill HearingTaskAssociation data in production.
 #
-# Identify all HoldHearingTasks
+# Identify all DispositionTasks
 # Check if their parent HearingTask has an existing HearingTaskAssociation entry
 # Find hearing associated with HearingTask using appeal id
 # Create HearingTaskAssociation with Hearing and HearingTask info
@@ -9,8 +9,8 @@
 # Date:   Feb 19, 2019
 #
 
-# All HoldHearingTasks are for Legacy Appeals in prod. Total 156 as of AM Feb 25th 2019
-hearing_tasks = Task.where(type: "HoldHearingTask", appeal_type: "LegacyAppeal").map(&:parent)
+# All DispositionTasks are for Legacy Appeals in prod. Total 156 as of AM Feb 25th 2019
+hearing_tasks = Task.where(type: "DispositionTask", appeal_type: "LegacyAppeal").map(&:parent)
 
 task_association_exists = 0
 nbr_of_task_associations_created = 0

--- a/scripts/back_fill_hearing_tasks.rb
+++ b/scripts/back_fill_hearing_tasks.rb
@@ -1,4 +1,4 @@
-# Backfill a HearingTask as parent of a ScheduleHearingTask and HoldHearingTask
+# Backfill a HearingTask as parent of a ScheduleHearingTask and DispositionTask
 # for Legacy Appeals.
 #
 # If an appeal has multiple ScheduleHearingTasks we group them by created_at and create
@@ -9,7 +9,7 @@
 #
 
 legacy_sched_hear_tasks = Task
-  .where("(type='ScheduleHearingTask' OR type='HoldHearingTask') AND appeal_type='LegacyAppeal'")
+  .where("(type='ScheduleHearingTask' OR type='DispositionTask') AND appeal_type='LegacyAppeal'")
   .select do |task|
   task.parent.type == "RootTask"
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -86,6 +86,16 @@ FactoryBot.define do
       appeal { create(:appeal) }
     end
 
+    factory :ama_hold_hearing_task, class: HoldHearingTask do
+      type { HoldHearingTask.name }
+      appeal { create(:appeal) }
+    end
+
+    factory :ama_disposition_task, class: DispositionTask do
+      type { DispositionTask.name }
+      appeal { create(:appeal) }
+    end
+
     factory :ama_judge_decision_review_task, class: JudgeDecisionReviewTask do
       type { JudgeDecisionReviewTask.name }
       appeal { create(:appeal) }

--- a/spec/lib/tasks/tasks_spec.rb
+++ b/spec/lib/tasks/tasks_spec.rb
@@ -130,19 +130,7 @@ describe "task rake tasks" do
       it "tells the caller that there are no tasks to change" do
         expected_output = "There aren't any #{from_task_name}s available to change."
         expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
-        expect { subject }.to raise_error(SystemExit).with_message(expected_output)
-      end
-
-      context "a task class with descendants is passed" do
-        let(:from_task) { JudgeTask }
-
-        it "warns about passing a task class with descendants" do
-          expected_warning = "*WARNING* #{from_task_name} has #{from_task.descendants.count} descendants"
-          expected_output = "There aren't any #{from_task_name}s available to change."
-          expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
-          expect { subject }.to output("#{expected_warning}\n#{expected_output}").to_stdout
-          expect { subject }.to raise_error(SystemExit).with_message(expected_output)
-        end
+        expect { subject }.to raise_error(NoTasksToChange).with_message(expected_output)
       end
     end
 
@@ -153,7 +141,7 @@ describe "task rake tasks" do
       it "warns about passing a class that's not a task" do
         expected_output = "#{from_task_name} is not a valid Task type!"
         expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
-        expect { subject }.to raise_error(SystemExit).with_message(expected_output)
+        expect { subject }.to raise_error(InvalidTaskType).with_message(expected_output)
       end
     end
   end

--- a/spec/lib/tasks/tasks_spec.rb
+++ b/spec/lib/tasks/tasks_spec.rb
@@ -1,0 +1,160 @@
+require "rails_helper"
+require "rake"
+
+describe "task rake tasks" do
+  before do
+    Rake.application.rake_require "tasks/tasks"
+    Rake::Task.define_task(:environment)
+  end
+
+  describe "tasks:change_type" do
+    let(:from_task) { HoldHearingTask }
+    let(:from_task_name) { from_task.name }
+    let(:to_task) { DispositionTask }
+    let(:to_task_name) { to_task.name }
+
+    subject do
+      Rake::Task["tasks:change_type"].reenable
+      Rake::Task["tasks:change_type"].invoke(*args)
+    end
+
+    context "there are tasks to change" do
+      let(:task_count) { 10 }
+      let(:subset_count) { 6 }
+      let!(:hold_hearing_tasks) { FactoryBot.create_list(:ama_hold_hearing_task, task_count) }
+
+      context "no dry run variable is passed" do
+        let(:args) { [from_task_name, to_task_name] }
+
+        it "only describes what changes will be made" do
+          count = from_task.count
+          ids = from_task.all.map(&:id)
+          expected_output = <<~OUTPUT
+            *** DRY RUN
+            *** pass 'false' as the third argument to execute
+            Would change #{count} #{from_task_name}s with ids #{ids.join(', ')} into #{to_task_name}s
+            Would revert with: bundle exec rake tasks:change_type[#{to_task_name},#{from_task_name},#{ids.join(',')}]
+          OUTPUT
+          expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+          expect { subject }.to output(expected_output).to_stdout
+          expect(from_task.count).to eq task_count
+          expect(from_task.all.map(&:id)).to eq ids
+          expect(to_task.any?).to be_falsey
+        end
+      end
+
+      context "dry run is set to false" do
+        let(:args) { [from_task_name, to_task_name, "false"] }
+
+        it "makes the requested changes" do
+          count = from_task.count
+          ids = from_task.all.map(&:id)
+          expected_output = <<~OUTPUT
+            Changing #{count} #{from_task_name}s with ids #{ids.join(', ')} into #{to_task_name}s
+            Revert with: bundle exec rake tasks:change_type[#{to_task_name},#{from_task_name},#{ids.join(',')}]
+          OUTPUT
+          expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+          expect(Rails.logger).to receive(:info).with(
+            "Changing #{task_count} #{from_task_name}s with ids #{ids.join(', ')} into #{to_task_name}s"
+          )
+          expect { subject }.to output(expected_output).to_stdout
+          expect(to_task.count).to eq task_count
+          expect(to_task.all.map(&:id)).to eq ids
+          expect(from_task.any?).to be_falsey
+        end
+      end
+
+      context "id numbers are passed" do
+        context "dry run is set to false" do
+          let(:args) { [from_task_name, to_task_name, "false", *change_ids] }
+          let(:change_ids) { [] }
+
+          context "all the id numbers match existing tasks" do
+            let(:change_ids) { hold_hearing_tasks.map(&:id)[0..subset_count - 1] }
+
+            it "makes the requested changes" do
+              count = change_ids.count
+              expected_output = <<~OUTPUT
+                Changing #{count} #{from_task_name}s with ids #{change_ids.join(', ')} into #{to_task_name}s
+                Revert with: bundle exec rake tasks:change_type[#{to_task_name},#{from_task_name},#{change_ids.join(',')}]
+              OUTPUT
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect(Rails.logger).to receive(:info).with(
+                "Changing #{subset_count} #{from_task_name}s with ids #{change_ids.join(', ')} into #{to_task_name}s"
+              )
+              expect { subject }.to output(expected_output).to_stdout
+              expect(to_task.count).to eq count
+              expect(to_task.all.map(&:id)).to eq change_ids
+              expect(from_task.count).to eq task_count - subset_count
+            end
+          end
+
+          context "some of the id numbers do not match existing tasks" do
+            let!(:other_task) { FactoryBot.create(:ama_judge_decision_review_task) }
+            let(:change_ids) { hold_hearing_tasks.map(&:id)[0..subset_count - 1] + [other_task.id] }
+
+            it "raises an error" do
+              message_pattern = /Couldn't find all #{from_task_name}s with 'id'/
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect { subject }.to raise_error(ActiveRecord::RecordNotFound).with_message(message_pattern)
+            end
+          end
+        end
+
+        context "no dry run variable is passed" do
+          let(:args) { [from_task_name, to_task_name, *change_ids] }
+          let(:change_ids) { hold_hearing_tasks.map(&:id)[0..subset_count - 1] }
+
+          it "correctly describes what changes will be made" do
+            count = change_ids.count
+            joined = change_ids.join(",")
+            expected_output = <<~OUTPUT
+              *** DRY RUN
+              *** pass 'false' as the third argument to execute
+              Would change #{count} #{from_task_name}s with ids #{change_ids.join(', ')} into #{to_task_name}s
+              Would revert with: bundle exec rake tasks:change_type[#{to_task_name},#{from_task_name},#{joined}]
+            OUTPUT
+            expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+            expect { subject }.to output(expected_output).to_stdout
+            expect(from_task.count).to eq task_count
+            expect(to_task.any?).to be_falsey
+          end
+        end
+      end
+    end
+
+    context "there are no tasks to change" do
+      let(:hold_hearing_tasks) { [] }
+      let(:args) { [from_task_name, to_task_name, "false"] }
+
+      it "tells the caller that there are no tasks to change" do
+        expected_output = "There aren't any #{from_task_name}s available to change."
+        expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+        expect { subject }.to raise_error(SystemExit).with_message(expected_output)
+      end
+
+      context "a task class with descendants is passed" do
+        let(:from_task) { JudgeTask }
+
+        it "warns about passing a task class with descendants" do
+          expected_warning = "*WARNING* #{from_task_name} has #{from_task.descendants.count} descendants"
+          expected_output = "There aren't any #{from_task_name}s available to change."
+          expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+          expect { subject }.to output("#{expected_warning}\n#{expected_output}").to_stdout
+          expect { subject }.to raise_error(SystemExit).with_message(expected_output)
+        end
+      end
+    end
+
+    context "a non task class is passed" do
+      let(:from_task) { JudgeTeam }
+      let(:args) { [from_task_name, to_task_name, false] }
+
+      it "warns about passing a class that's not a task" do
+        expected_output = "#{from_task_name} is not a valid Task type!"
+        expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+        expect { subject }.to raise_error(SystemExit).with_message(expected_output)
+      end
+    end
+  end
+end

--- a/spec/models/tasks/hold_hearing_task_spec.rb
+++ b/spec/models/tasks/hold_hearing_task_spec.rb
@@ -1,0 +1,45 @@
+describe HoldHearingTask do
+  describe ".create_hold_hearing_task!" do
+    let(:appeal) { FactoryBot.create(:appeal) }
+    let(:parent) { nil }
+    let!(:hearing) { FactoryBot.create(:hearing, appeal: appeal) }
+
+    subject { described_class.create_hold_hearing_task!(appeal, parent, hearing) }
+
+    context "parent is a HearingTask" do
+      let(:parent) { FactoryBot.create(:hearing_task, appeal: appeal) }
+
+      it "creates a HoldHearingTask and a HearingTaskAssociation" do
+        expect(HoldHearingTask.all.count).to eq 0
+        expect(HearingTaskAssociation.all.count).to eq 0
+
+        subject
+
+        expect(HoldHearingTask.all.count).to eq 1
+        expect(HoldHearingTask.first.appeal).to eq appeal
+        expect(HoldHearingTask.first.parent).to eq parent
+        expect(HoldHearingTask.first.assigned_to).to eq Bva.singleton
+        expect(HearingTaskAssociation.all.count).to eq 1
+        expect(HearingTaskAssociation.first.hearing).to eq hearing
+        expect(HearingTaskAssociation.first.hearing_task).to eq parent
+      end
+    end
+
+    context "parent is a RootTask" do
+      let(:parent) { FactoryBot.create(:root_task, appeal: appeal) }
+
+      it "creates a HoldHearingTask but no HearingTaskAssociation" do
+        expect(HoldHearingTask.all.count).to eq 0
+        expect(HearingTaskAssociation.all.count).to eq 0
+
+        subject
+
+        expect(HoldHearingTask.all.count).to eq 1
+        expect(HoldHearingTask.first.appeal).to eq appeal
+        expect(HoldHearingTask.first.parent).to eq parent
+        expect(HoldHearingTask.first.assigned_to).to eq Bva.singleton
+        expect(HearingTaskAssociation.all.count).to eq 0
+      end
+    end
+  end
+end

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -79,11 +79,11 @@ describe ScheduleHearingTask do
         expect(Hearing.first.appeal).to eq(schedule_hearing_task.appeal)
       end
 
-      it "creates a HoldHearingTask and associated object" do
+      it "creates a DispositionTask and associated object" do
         schedule_hearing_task.update_from_params(update_params, hearings_user)
 
-        expect(HoldHearingTask.count).to eq(1)
-        expect(HoldHearingTask.first.appeal).to eq(schedule_hearing_task.appeal)
+        expect(DispositionTask.count).to eq(1)
+        expect(DispositionTask.first.appeal).to eq(schedule_hearing_task.appeal)
         expect(HearingTaskAssociation.count).to eq(1)
         expect(HearingTaskAssociation.first.hearing).to eq(Hearing.first)
         expect(HearingTaskAssociation.first.hearing_task).to eq(HearingTask.first)


### PR DESCRIPTION
Connects #9538

### Description
Changes `HoldHearingTask`s to `DispositionTask`s and adds a rake task named `tasks:change_type` that can be used to change the type of old `HoldHearingTask`s in the database after this PR is merged.
