### PR TITLE
Eager load available hearing locations

### DIFF
--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -34,7 +34,7 @@ class ScheduleHearingTask < GenericTask
         "status = ? OR status = ?",
         Constants.TASK_STATUSES.assigned.to_sym,
         Constants.TASK_STATUSES.in_progress.to_sym
-      ).includes(:assigned_to, :assigned_by, :appeal, attorney_case_reviews: [:attorney])
+      ).includes(:assigned_to, :assigned_by, appeal: [:available_hearing_locations], attorney_case_reviews: [:attorney])
 
       appeal_tasks = incomplete_tasks.joins(
         "INNER JOIN appeals ON appeals.id = appeal_id AND tasks.appeal_type = 'Appeal'"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -691,11 +691,11 @@ ActiveRecord::Schema.define(version: 20190227003709) do
   end
 
   create_table "ramp_closed_appeals", id: :serial, force: :cascade, comment: "Keeps track of legacy appeals that are closed or partially closed in VACOLS due to being transitioned to a RAMP election.  This data can be used to rollback the RAMP Election if needed." do |t|
-    t.datetime "closed_on", comment: "The date that the legacy appeal was closed in VACOLS and opted into RAMP."
-    t.date "nod_date", comment: "The date when the Veteran filed a notice of disagreement for the original claims decision in the legacy system - the step before a Veteran receives a Statement of the Case and before they file a Form 9."
+    t.datetime "closed_on", comment: "The datetime that the legacy appeal was closed in VACOLS and opted into RAMP."
+    t.date "nod_date", comment: "The date when the Veteran filed a Notice of Disagreement for the original claims decision in the legacy system."
     t.string "partial_closure_issue_sequence_ids", comment: "If the entire legacy appeal could not be closed and moved to the RAMP Election, the VACOLS sequence IDs of issues on the legacy appeal which were closed are stored here, indicating that it was a partial closure.", array: true
     t.integer "ramp_election_id", comment: "The ID of the RAMP election that closed the legacy appeal."
-    t.string "vacols_id", null: false, comment: "The VACOLS ID of the legacy appeal that has been closed and opted into RAMP."
+    t.string "vacols_id", null: false, comment: "The VACOLS BFKEY of the legacy appeal that has been closed and opted into RAMP."
   end
 
   create_table "ramp_election_rollbacks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -691,11 +691,11 @@ ActiveRecord::Schema.define(version: 20190227003709) do
   end
 
   create_table "ramp_closed_appeals", id: :serial, force: :cascade, comment: "Keeps track of legacy appeals that are closed or partially closed in VACOLS due to being transitioned to a RAMP election.  This data can be used to rollback the RAMP Election if needed." do |t|
-    t.datetime "closed_on", comment: "The datetime that the legacy appeal was closed in VACOLS and opted into RAMP."
-    t.date "nod_date", comment: "The date when the Veteran filed a Notice of Disagreement for the original claims decision in the legacy system."
+    t.datetime "closed_on", comment: "The date that the legacy appeal was closed in VACOLS and opted into RAMP."
+    t.date "nod_date", comment: "The date when the Veteran filed a notice of disagreement for the original claims decision in the legacy system - the step before a Veteran receives a Statement of the Case and before they file a Form 9."
     t.string "partial_closure_issue_sequence_ids", comment: "If the entire legacy appeal could not be closed and moved to the RAMP Election, the VACOLS sequence IDs of issues on the legacy appeal which were closed are stored here, indicating that it was a partial closure.", array: true
     t.integer "ramp_election_id", comment: "The ID of the RAMP election that closed the legacy appeal."
-    t.string "vacols_id", null: false, comment: "The VACOLS BFKEY of the legacy appeal that has been closed and opted into RAMP."
+    t.string "vacols_id", null: false, comment: "The VACOLS ID of the legacy appeal that has been closed and opted into RAMP."
   end
 
   create_table "ramp_election_rollbacks", force: :cascade do |t|


### PR DESCRIPTION
We are not eager loading hearing locations resulting in very long load times.

### Testing Plan
1. Refresh schedule hearing page with and without change and notice bullet complains without the change, but not with the change.

