### PR TITLE
Store class name on unreported errors since it means more

### DIFF
--- a/app/jobs/decision_issue_sync_job.rb
+++ b/app/jobs/decision_issue_sync_job.rb
@@ -10,7 +10,7 @@ class DecisionIssueSyncJob < CaseflowJob
     begin
       request_issue_or_effectuation.sync_decision_issues!
     rescue Rating::NilRatingProfileListError, Rating::LockedRatingError, Rating::BackfilledRatingError => err
-      request_issue_or_effectuation.update_error!(err.to_s)
+      request_issue_or_effectuation.update_error!(err.class.to_s)
       # no Raven report, just noise. This just means nothing new has happened.
     rescue StandardError => err
       request_issue_or_effectuation.update_error!(err.to_s)

--- a/spec/jobs/decision_issue_sync_job_spec.rb
+++ b/spec/jobs/decision_issue_sync_job_spec.rb
@@ -18,7 +18,7 @@ describe DecisionIssueSyncJob do
 
     subject
 
-    expect(request_issue.decision_sync_error).to eq("none!")
+    expect(request_issue.decision_sync_error).to eq("Rating::NilRatingProfileListError")
     expect(@raven_called).to eq(false)
   end
 


### PR DESCRIPTION
See https://dsva.slack.com/archives/CFBLH2LR4/p1551470810028200

We don't store the exception class name on a few normal decision sync errors, but the class name is more meaningful than the actual exception message string.
