### PR TITLE
RO time zone showing despite correct logic in UI.

### DIFF
--- a/client/app/hearingSchedule/components/DailyDocket.jsx
+++ b/client/app/hearingSchedule/components/DailyDocket.jsx
@@ -161,7 +161,7 @@ export default class DailyDocket extends React.Component {
   };
 
   getHearingTime = (hearing) => {
-    if (hearing.requestType === 'Central') {
+    if (hearing.readableRequestType === 'Central') {
       return <div>{getTime(hearing.scheduledFor)} <br />
         {hearing.regionalOfficeName}
       </div>;

--- a/client/app/hearings/DailyDocket.jsx
+++ b/client/app/hearings/DailyDocket.jsx
@@ -187,7 +187,7 @@ export class DailyDocket extends React.PureComponent {
  };
 
   getRoTime = (hearing) => {
-    if (hearing.request_type === 'Central') {
+    if (hearing.readable_request_type === 'Central') {
       return <div>{getTime(hearing.scheduled_for)} <br />
         {hearing.regional_office_name}
       </div>;


### PR DESCRIPTION
Resolves #9459 

### Description
Reason was a change in property name from requestType to readableRequestType. Affected both prep and schedule daily dockets.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to Hearing Prep or Hearing Schedule
2. Select a Central Office hearing day
3. Confirm that only Central Office time zone shows in docket.

