### PR TITLE
Common Hearing Modal Inputs

### DIFF
--- a/app/controllers/regional_offices_controller.rb
+++ b/app/controllers/regional_offices_controller.rb
@@ -18,6 +18,8 @@ class RegionalOfficesController < ApplicationController
       hearing_days: hearing_days.map do |day|
         {
           hearing_id: day[:id],
+          regional_office: ro,
+          timezone: RegionalOffice::CITIES[ro][:timezone],
           scheduled_for: day[:scheduled_for],
           request_type: day[:request_type],
           room: day[:room],

--- a/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
@@ -63,8 +63,8 @@ class AssignHearingForm extends React.Component {
 
     return {
       ...errorMessages,
-      hasErrorMessages: errorMessages.hearingDay || errorMessages.hearingLocation ||
-        errorMessages.hearingTime
+      hasErrorMessages: (errorMessages.hearingDay || errorMessages.hearingLocation ||
+        errorMessages.hearingTime) !== false
     };
   }
 

--- a/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import moment from 'moment';
 import _ from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -9,20 +8,9 @@ import {
   AppealHearingLocationsDropdown,
   HearingDateDropdown
 } from '../../../components/DataDropdowns';
-import HearingTime from './HearingTime';
+import HearingTime, { getAssignHearingTime } from './HearingTime';
 
 import { onChangeFormData } from '../../../components/common/actions';
-
-export const getAssignHearingTime = (time, day) => {
-
-  return {
-    // eslint-disable-next-line id-length
-    h: time.split(':')[0],
-    // eslint-disable-next-line id-length
-    m: time.split(':')[1],
-    offset: moment.tz(day.hearingDate, day.timezone || 'America/New_York').format('Z')
-  };
-};
 
 class AssignHearingForm extends React.Component {
 
@@ -82,6 +70,14 @@ class AssignHearingForm extends React.Component {
     };
   }
 
+  onChange = (newValues) => {
+    this.props.onChange({
+      ...newValues,
+      errorMessages: this.getErrorMessages(newValues),
+      apiFormattedValues: this.getApiFormattedValues(newValues)
+    });
+  }
+
   onRegionalOfficeChange = (regionalOffice) => {
     const newValues = {
       regionalOffice,
@@ -90,21 +86,7 @@ class AssignHearingForm extends React.Component {
       hearingDay: null
     };
 
-    this.props.onChange({
-      ...newValues,
-      errorMessages: this.getErrorMessages(newValues),
-      apiFormattedValues: this.getApiFormattedValues(newValues)
-    });
-  }
-
-  onChange = (key, value) => {
-    const newValues = { [key]: value };
-
-    this.props.onChange({
-      ...newValues,
-      errorMessages: this.getErrorMessages(newValues),
-      apiFormattedValues: this.getApiFormattedValues(newValues)
-    });
+    this.onChange(newValues);
   }
 
   render() {
@@ -128,14 +110,14 @@ class AssignHearingForm extends React.Component {
               _.isEmpty(appeal.availableHearingLocations)}
             staticHearingLocations={appeal.availableHearingLocations}
             value={hearingLocation}
-            onChange={(value) => this.onChange('hearingLocation', value)}
+            onChange={(value) => this.onChange({ hearingLocation: value })}
           />
           <HearingDateDropdown
             errorMessage={showErrorMessages ? errorMessages.hearingDay : ''}
             key={`hearingDate__${regionalOffice}`}
             regionalOffice={regionalOffice}
             value={hearingDay}
-            onChange={(value) => this.onChange('hearingDay', value)}
+            onChange={(value) => this.onChange({ hearingDay: value })}
             validateValueOnMount
           />
           <HearingTime
@@ -143,7 +125,7 @@ class AssignHearingForm extends React.Component {
             key={`hearingTime__${regionalOffice}`}
             regionalOffice={regionalOffice}
             value={hearingTime}
-            onChange={(value) => this.onChange('hearingTime', value)}
+            onChange={(value) => this.onChange({ hearingTime: value })}
           />
         </React.Fragment>}
       </div>

--- a/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
@@ -3,6 +3,8 @@ import _ from 'lodash';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
+import ApiUtil from '../../../util/ApiUtil';
+
 import {
   RegionalOfficeDropdown,
   AppealHearingLocationsDropdown,
@@ -66,7 +68,7 @@ class AssignHearingForm extends React.Component {
       hearing_time: values.hearingDay && values.hearingTime ?
         getAssignHearingTime(values.hearingTime, values.hearingDay) : null,
       hearing_day_id: values.hearingDay ? values.hearingDay.hearingId : null,
-      hearing_location: values.hearingLocation
+      hearing_location: values.hearingLocation ? ApiUtil.convertToSnakeCase(values.hearingLocation) : null
     };
   }
 

--- a/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
@@ -125,8 +125,8 @@ class AssignHearingForm extends React.Component {
             regionalOffice={regionalOffice}
             appealId={appeal.externalId}
             dynamic={regionalOffice !== appeal.closestRegionalOffice ||
-              _.isEmpty(appeal.staticHearingLocations)}
-            staticHearingLocations={appeal.staticHearingLocations}
+              _.isEmpty(appeal.availableHearingLocations)}
+            staticHearingLocations={appeal.availableHearingLocations}
             value={hearingLocation}
             onChange={(value) => this.onChange('hearingLocation', value)}
           />

--- a/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/AssignHearingForm.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import moment from 'moment';
+import _ from 'lodash';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import {
+  RegionalOfficeDropdown,
+  AppealHearingLocationsDropdown,
+  HearingDateDropdown
+} from '../../../components/DataDropdowns';
+import HearingTime from './HearingTime';
+
+import { onChangeFormData } from '../../../components/common/actions';
+
+export const getAssignHearingTime = (time, day) => {
+
+  return {
+    // eslint-disable-next-line id-length
+    h: time.split(':')[0],
+    // eslint-disable-next-line id-length
+    m: time.split(':')[1],
+    offset: moment.tz(day.hearingDate, day.timezone || 'America/New_York').format('Z')
+  };
+};
+
+class AssignHearingForm extends React.Component {
+
+  /*
+    This duplicates a lot of the logic from AssignHearingModal.jsx
+    TODO: refactor so both of these modals use the same components
+  */
+  componentWillMount() {
+
+    const { initialRegionalOffice, initialHearingDate, initialHearingTime } = this.props;
+
+    const values = {
+      regionalOffice: initialRegionalOffice || null,
+      hearingLocation: null,
+      hearingTime: initialHearingTime || null,
+      hearingDay: initialHearingDate || null
+    };
+
+    this.props.onChange({
+      ...values,
+      errorMessages: this.getErrorMessages(values),
+      apiFormattedValues: this.getApiFormattedValues(values)
+    });
+  }
+
+  getErrorMessages = (newValues) => {
+    const values = {
+      ...this.props.values,
+      ...newValues
+    };
+
+    const errorMessages = {
+      hearingDay: values.hearingDay && values.hearingDay.hearingId ?
+        false : 'Please select a hearing date',
+      hearingLocation: values.hearingLocation ? false : 'Please select a hearing location',
+      hearingTime: values.hearingTime ? false : 'Please select a hearing time'
+    };
+
+    return {
+      ...errorMessages,
+      hasErrorMessages: errorMessages.hearingDay || errorMessages.hearingLocation ||
+        errorMessages.hearingTime
+    };
+  }
+
+  getApiFormattedValues = (newValues) => {
+    const values = {
+      ...this.props.values,
+      ...newValues
+    };
+
+    return {
+      hearing_time: values.hearingDay && values.hearingTime ?
+        getAssignHearingTime(values.hearingTime, values.hearingDay) : null,
+      hearing_day_id: values.hearingDay ? values.hearingDay.hearingId : null,
+      hearing_location: values.hearingLocation
+    };
+  }
+
+  onRegionalOfficeChange = (regionalOffice) => {
+    const newValues = {
+      regionalOffice,
+      hearingLocation: null,
+      hearingTime: null,
+      hearingDay: null
+    };
+
+    this.props.onChange({
+      ...newValues,
+      errorMessages: this.getErrorMessages(newValues),
+      apiFormattedValues: this.getApiFormattedValues(newValues)
+    });
+  }
+
+  onChange = (key, value) => {
+    const newValues = { [key]: value };
+
+    this.props.onChange({
+      ...newValues,
+      errorMessages: this.getErrorMessages(newValues),
+      apiFormattedValues: this.getApiFormattedValues(newValues)
+    });
+  }
+
+  render() {
+    const { appeal, showErrorMessages, values } = this.props;
+    const { regionalOffice, hearingLocation, hearingDay, hearingTime, errorMessages } = values;
+
+    return (
+      <div>
+        <RegionalOfficeDropdown
+          value={regionalOffice}
+          onChange={this.onRegionalOfficeChange}
+          validateValueOnMount
+        />
+        {regionalOffice && <React.Fragment>
+          <AppealHearingLocationsDropdown
+            errorMessage={showErrorMessages ? errorMessages.hearingLocation : ''}
+            key={`hearingLocation__${regionalOffice}`}
+            regionalOffice={regionalOffice}
+            appealId={appeal.externalId}
+            dynamic={regionalOffice !== appeal.closestRegionalOffice ||
+              _.isEmpty(appeal.staticHearingLocations)}
+            staticHearingLocations={appeal.staticHearingLocations}
+            value={hearingLocation}
+            onChange={(value) => this.onChange('hearingLocation', value)}
+          />
+          <HearingDateDropdown
+            errorMessage={showErrorMessages ? errorMessages.hearingDay : ''}
+            key={`hearingDate__${regionalOffice}`}
+            regionalOffice={regionalOffice}
+            value={hearingDay}
+            onChange={(value) => this.onChange('hearingDay', value)}
+            validateValueOnMount
+          />
+          <HearingTime
+            errorMessage={showErrorMessages ? errorMessages.hearingTime : ''}
+            key={`hearingTime__${regionalOffice}`}
+            regionalOffice={regionalOffice}
+            value={hearingTime}
+            onChange={(value) => this.onChange('hearingTime', value)}
+          />
+        </React.Fragment>}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  values: state.components.forms.assignHearing || {}
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  onChange: (value) => onChangeFormData('assignHearing', value)
+}, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(AssignHearingForm);

--- a/client/app/hearingSchedule/components/modalForms/HearingTime.jsx
+++ b/client/app/hearingSchedule/components/modalForms/HearingTime.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { TIME_OPTIONS } from '../../../hearings/constants/constants';
+import { css } from 'glamor';
+import RadioField from '../../../components/RadioField';
+import SearchableDropdown from '../../../components/SearchableDropdown';
+
+const formStyling = css({
+  '& .cf-form-radio-option:not(:last-child)': {
+    display: 'inline-block',
+    marginRight: '25px'
+  },
+  marginBottom: 0
+});
+
+export default class HearingTime extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOther: false
+    };
+  }
+
+  getTimeOptions = () => {
+    const { regionalOffice } = this.props;
+
+    if (regionalOffice === 'C') {
+      return [
+        { displayText: '9:00 am',
+          value: '9:00' },
+        { displayText: '1:00 pm',
+          value: '13:00' },
+        { displayText: 'Other',
+          value: 'other' }
+      ];
+    }
+
+    return [
+      { displayText: '8:30 am',
+        value: '8:30' },
+      { displayText: '12:30 pm',
+        value: '12:30' },
+      { displayText: 'Other',
+        value: 'other' }
+    ];
+  }
+
+  onRadioChange = (value) => {
+    if (value === 'other') {
+      this.setState({ isOther: true });
+      this.props.onChange(null);
+    } else {
+      this.setState({ isOther: false });
+      this.props.onChange(value);
+    }
+  }
+
+  render() {
+    const { errorMessage, value } = this.props;
+
+    return (
+      <React.Fragment>
+        <span {...formStyling}>
+          <RadioField
+            errorMessage={errorMessage}
+            name="time"
+            label="Time"
+            strongLabel
+            options={this.getTimeOptions()}
+            onChange={this.onRadioChange}
+            value={this.state.isOther ? 'other' : value} />
+        </span>
+        {this.state.isOther && <SearchableDropdown
+          name="optionalTime"
+          placeholder="Select a time"
+          options={TIME_OPTIONS}
+          value={value}
+          onChange={this.props.onChange}
+          hideLabel />}
+      </React.Fragment>
+    );
+  }
+}

--- a/client/app/hearingSchedule/components/modalForms/HearingTime.jsx
+++ b/client/app/hearingSchedule/components/modalForms/HearingTime.jsx
@@ -1,8 +1,20 @@
 import React from 'react';
-import { TIME_OPTIONS } from '../../../hearings/constants/constants';
+import moment from 'moment';
 import { css } from 'glamor';
 import RadioField from '../../../components/RadioField';
 import SearchableDropdown from '../../../components/SearchableDropdown';
+import { TIME_OPTIONS } from '../../../hearings/constants/constants';
+
+export const getAssignHearingTime = (time, day) => {
+
+  return {
+    // eslint-disable-next-line id-length
+    h: time.split(':')[0],
+    // eslint-disable-next-line id-length
+    m: time.split(':')[1],
+    offset: moment.tz(day.hearingDate, day.timezone || 'America/New_York').format('Z')
+  };
+};
 
 const formStyling = css({
   '& .cf-form-radio-option:not(:last-child)': {

--- a/client/app/hearingSchedule/components/modalForms/ScheduleHearingLaterWithAdminActionForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/ScheduleHearingLaterWithAdminActionForm.jsx
@@ -53,7 +53,7 @@ class ScheduleHearingLaterWithAdminActionForm extends React.Component {
           name="postponementReason"
           options={adminActionOptions}
           value={values.withAdminActionKlass}
-          onChange={(val) => this.onChange({ withAdminActionKlass: val })}
+          onChange={(val) => this.onChange({ withAdminActionKlass: val ? val.value : null })}
         />
         <TextareaField
           label="Instructions"

--- a/client/app/hearingSchedule/components/modalForms/ScheduleHearingLaterWithAdminActionForm.jsx
+++ b/client/app/hearingSchedule/components/modalForms/ScheduleHearingLaterWithAdminActionForm.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import SearchableDropdown from '../../../components/SearchableDropdown';
+import TextareaField from '../../../components/TextareaField';
+
+import { onChangeFormData } from '../../../components/common/actions';
+
+class ScheduleHearingLaterWithAdminActionForm extends React.Component {
+
+  getErrorMessages = (newValues) => {
+    const values = {
+      ...this.props.values,
+      ...newValues
+    };
+
+    return {
+      withAdminActionKlass: values.withAdminActionKlass ? false : 'Please enter an action',
+      hasErrorMessages: !values.withAdminActionKlass
+    };
+  }
+
+  getApiFormattedValues = (newValues) => {
+    const values = {
+      ...this.props.values,
+      ...newValues
+    };
+
+    return {
+      with_admin_action_klass: values.withAdminActionKlass,
+      admin_action_instructions: values.adminActionInstructions
+    };
+  }
+
+  onChange = (value) => {
+    this.props.onChange({
+      ...value,
+      errorMessages: this.getErrorMessages(value),
+      apiFormattedValues: this.getApiFormattedValues(value)
+    });
+  }
+
+  render () {
+    const { adminActionOptions, values, showErrorMessages } = this.props;
+
+    return (
+      <div>
+        <SearchableDropdown
+          errorMessage={showErrorMessages ? values.errorMessages.withAdminActionKlass : ''}
+          label="Select Reason"
+          strongLabel
+          name="postponementReason"
+          options={adminActionOptions}
+          value={values.withAdminActionKlass}
+          onChange={(val) => this.onChange({ withAdminActionKlass: val })}
+        />
+        <TextareaField
+          label="Instructions"
+          strongLabel
+          name="adminActionInstructions"
+          value={values.adminActionInstructions}
+          onChange={(val) => this.onChange({ adminActionInstructions: val })}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  values: state.components.forms.scheduleHearingLaterWithAdminAction || {}
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  onChange: (value) => onChangeFormData('scheduleHearingLaterWithAdminAction', value)
+}, dispatch);
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps)(ScheduleHearingLaterWithAdminActionForm);


### PR DESCRIPTION
This PR creates common components for Hearing Modals

- `AssignHearingForm`
  - Regional Office
  - Hearing Location
  - Hearing Date
  - Hearing Time

- `ScheduleHearingLaterWithAdminActionForm`
  - Admin Action selection
  - Admin Action Instructions

The main motivation is to offload most of the redux updating logic, form validation, and data transformations (for an API endpoint) to the component so that we do not have to rewrite that logic in every modal that they are used.

All form data is stored in redux under `state.components.forms[formName]` with a state that looks somethings like this:

```javascript
{
  hearingDay: {},
  hearingLocation: {}
  hearingTime: "9:30",
  errorMessages: {
    hearingDay: false|'Please set...',
    hearingLocation: false|'Please set...'
    hearingTime: false|'Please set...',
    hasErrorMessages: true
  },
  apiFormattedValues: {
    hearing_day_id: 5,
    hearing_location: {},
    hearing_time: { h: 5, m: 10, offset: '-05:00' }
  }
}
```

In the modal container, like usual, you can access the form values through redux. A modal's `validateForm` method would then look something like:

```javascript
validateForm = () => {
  const { assignHearingForm: { errorMessages } } = this.props;
   
  return !errorMessages.hasErrorMessages;
}
```

and when generating a payload you can just use the form's `apiFormattedValues`

```javascript
getAssignHearingPayload = () => {
  return {
      new_hearing_attrs: this.props.assignHearingForm.apiFormattedValues
   };
}
```


