### PR TITLE
AMA dispositions are stored as strings, not symbols

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -65,7 +65,7 @@ class HearingDay < ApplicationRecord
   end
 
   def open_hearings
-    hearings.reject { |hearing| [:postponed, :cancelled].include?(hearing.disposition) }
+    hearings.reject { |hearing| %w[postponed cancelled].include?(hearing.disposition) }
   end
 
   def to_hash
@@ -169,7 +169,7 @@ class HearingDay < ApplicationRecord
     def filter_non_scheduled_hearings(hearings)
       hearings.select do |hearing|
         if hearing.is_a?(Hearing)
-          ![:postponed, :canceled].include?(hearing.disposition)
+          !%w[postponed cancelled].include?(hearing.disposition)
         else
           hearing.vacols_record.hearing_disp != "P" && hearing.vacols_record.hearing_disp != "C"
         end

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -134,7 +134,7 @@ describe HearingDay do
 
       before do
         6.times do
-          create(:hearing, hearing_day: hearing_day, disposition: :postponed)
+          create(:hearing, hearing_day: hearing_day, disposition: "postponed")
           create(:case_hearing, vdkey: hearing_day.id, hearing_disp: "C")
         end
       end


### PR DESCRIPTION
We were assuming dispositions were stored as symbols when filtering out hearings that could be scheduled over, but they're stored as strings. This PR updates our logic to use strings.