### PR TITLE
Update Danger rules

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -18,10 +18,26 @@ if !git.modified_files.grep(/app\/models\/vacols/).empty?
 end
 
 # We should not disable Rubocop rules unless there's a very good reason
-if `git diff #{github.base_commit} | grep -E 'rubocop:disable'`.length > 1
+result = git.diff.flat_map do |chunk|
+  chunk.patch.lines.grep(/^\+\s*\w/).select { |added_line| added_line.match?(/rubocop:disable/) }
+end
+
+if !result.empty?
   warn(
     "This PR disables one or more Rubocop rules. " \
     "If there is a valid reason, please provide it in your commit message. " \
     "Otherwise, consider refactoring the code."
+  )
+end
+
+# Make sure DB changes don't affect `rake db:seed`
+result = git.diff.flat_map do |chunk|
+  chunk.patch.lines.grep(/^\+\s*\w/).select { |added_line| added_line.match?(/remove_column|rename_column|drop_table/) }
+end
+
+if !result.empty?
+  warn(
+    "This PR makes DB changes that might affect the local seeds. " \
+    "Please make sure `rake db:seed` still runs without issues."
   )
 end


### PR DESCRIPTION
**Why**: The rubocop rule was resulting in false positives. Now we are
only looking at the individual lines that have been added.

I've also added a new rule to detect DB changes that might affect `rake db:seed`.