### PR TITLE
Removing hardcoded hearing ids

### DIFF
--- a/spec/feature/hearing_prep/daily_docket_spec.rb
+++ b/spec/feature/hearing_prep/daily_docket_spec.rb
@@ -6,25 +6,31 @@ RSpec.feature "Hearing prep" do
 
     let!(:vacols_staff) { create(:staff, user: current_user) }
 
-    before do
+    let!(:case_hearing) do
       create(:case_hearing,
              board_member: vacols_staff.sattyid,
              hearing_type: HearingDay::REQUEST_TYPES[:central],
              hearing_date: Time.zone.today + 25.days,
              folder_nr: create(:case).bfkey)
+    end
+
+    let!(:hearing) do
       create(:hearing, hearing_day: create(:hearing_day, judge: current_user, scheduled_for: 1.year.from_now))
     end
 
     scenario "Legacy daily docket saves to the backend" do
       visit "/hearings/dockets/" + 25.days.from_now.to_date.to_s
       expect(page).to have_content("Daily Docket")
+
+      legacy_hearing = LegacyHearing.find_by(vacols_id: case_hearing.hearing_pkseq)
+
       fill_in "Notes", with: "This is a note about the hearing!"
-      find(".checkbox-wrapper-1-prep").find(".cf-form-checkbox").click
-      find(".dropdown-1-disposition").click
+      find(".checkbox-wrapper-#{legacy_hearing.id}-prep").find(".cf-form-checkbox").click
+      find(".dropdown-#{legacy_hearing.id}-disposition").click
       find("#react-select-2--option-1").click
-      find(".dropdown-1-aod").click
+      find(".dropdown-#{legacy_hearing.id}-aod").click
       find("#react-select-3--option-2").click
-      find(".dropdown-1-hold_open").click
+      find(".dropdown-#{legacy_hearing.id}-hold_open").click
       find("#react-select-4--option-2").click
       find("label", text: "Transcript Requested").click
 
@@ -34,23 +40,23 @@ RSpec.feature "Hearing prep" do
       expect(page).to have_content("60 days")
       expect(page).to have_content("None")
       expect(find_field("Transcript Requested", visible: false)).to be_checked
-      expect(find_field("1-prep", visible: false)).to be_checked
+      expect(find_field("#{legacy_hearing.id}-prep", visible: false)).to be_checked
     end
 
     scenario "AMA daily docket saves to the backend" do
       visit "/hearings/dockets/" + Hearing.first.scheduled_for.to_date.to_s
       expect(page).to have_content("Daily Docket")
-      fill_in "1.notes", with: "This is a note about the hearing!"
-      find(".checkbox-wrapper-1-prep").find(".cf-form-checkbox").click
-      find(".dropdown-1-disposition").click
+      fill_in "Notes", with: "This is a note about the hearing!"
+      find(".checkbox-wrapper-#{hearing.id}-prep").find(".cf-form-checkbox").click
+      find(".dropdown-#{hearing.id}-disposition").click
       find("#react-select-2--option-1").click
       find("label", text: "Yes, Waive 90 Day Hold").click
 
       visit "/hearings/dockets/" + Hearing.first.scheduled_for.to_date.to_s
       expect(page).to have_content("This is a note about the hearing!")
       expect(page).to have_content("No Show")
-      expect(find_field("1.evidence_window_waived", visible: false)).to be_checked
-      expect(find_field("1-prep", visible: false)).to be_checked
+      expect(find_field("#{hearing.id}.evidence_window_waived", visible: false)).to be_checked
+      expect(find_field("#{hearing.id}-prep", visible: false)).to be_checked
     end
   end
 end

--- a/spec/feature/hearing_schedule/daily_docket_spec.rb
+++ b/spec/feature/hearing_schedule/daily_docket_spec.rb
@@ -82,9 +82,7 @@ RSpec.feature "Hearing Schedule Daily Docket" do
       expect(page).to have_content("No Show")
       expect(page).to have_content("This is a note about the hearing!")
       expect(find_field("Transcript Requested", visible: false)).to be_checked
-      # For unknown reasons, in feature tests, the hearing time is displayed as 3:30am. I
-      # created a ticket that we can look into after February.
-      # expect(page).to have_content("8:30 am")
+      expect(find_field("9:00", visible: false)).to be_checked
     end
   end
 


### PR DESCRIPTION
Fixes flaky daily docket hearing prep tests.

