### PR TITLE
Clean up IHP tasks for AMA hearing docket

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -119,7 +119,6 @@ class RootTask < GenericTask
           create_evidence_submission_task!(appeal, distribution_task)
         elsif appeal.hearing_docket?
           create_hearing_schedule_task!(appeal, distribution_task)
-          create_ihp_tasks!(appeal, distribution_task)
         else
           vso_tasks = create_ihp_tasks!(appeal, distribution_task)
           # If the appeal is direct docket and there are no ihp tasks,

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -132,23 +132,6 @@ describe RootTask do
         expect(ScheduleHearingTask.find_by(appeal: appeal).parent.parent.class.name).to eq("DistributionTask")
       end
 
-      context "when VSO writes IHPs for hearing docket cases" do
-        let(:appeal) do
-          FactoryBot.create(
-            :appeal,
-            docket_type: Constants.AMA_DOCKETS.hearing,
-            claimants: [FactoryBot.create(:claimant, participant_id: participant_id_with_pva)]
-          )
-        end
-
-        before { allow_any_instance_of(Vso).to receive(:should_write_ihp?).with(anything).and_return(true) }
-
-        it "creates an IHP task" do
-          RootTask.create_root_and_sub_tasks!(appeal)
-          expect(InformalHearingPresentationTask.find_by(appeal: appeal).assigned_to).to eq(pva)
-        end
-      end
-
       context "when VSO does not writes IHPs for hearing docket cases" do
         let(:appeal) do
           FactoryBot.create(


### PR DESCRIPTION
Resolves #9512

### Description
In code, we've stopped creating IHP tasks in `RootTask`'s `create_subtasks!` method.

In the console, these are the steps we took to clean up legacy tasks:

```ruby
# get total IHP tasks on hearing docket AMA appeals
InformalHearingPresentationTask.all.map(&:appeal).select { |a| a.hearing_docket? }.count
# => 372

# get all IHP tasks on hearing docket AMA appeals without hearings that are: active, assigned to PVA, and a child of a DistributionTask
tasks = InformalHearingPresentationTask.all.select do |t|
  t.appeal.hearing_docket? &&
    t.active? &&
    t.assigned_to != Organization.find(1) &&
    t.parent.type == "DistributionTask" &&
    t.appeal.hearings.count == 0
end

tasks.count
# => 352

# the 20 missing IHP tasks either have a RootTask as a parent
# and/or have an appeal with 1 or more hearings
InformalHearingPresentationTask.all.select { |t| t.appeal.hearing_docket? && (t.parent.type != "DistributionTask" || t.appeal.hearings.count != 0) }.count
# => 20

tasks.pluck(:id)
# => [32340, 32454, 32695, 265, 298, 496, 515, 731, 765, 773, 783, 990, 1113, 1083, 1087, 1176, 1689, 1692, 1694, 1783, 1802, 18151, 19207, 19213, 19622, 19689, 19233, 19807, 19608, 19596, 19598, 19321, 19982, 19450, 19997, 19810, 19662, 19980, 20107, 20211, 21059, 21013, 22732, 23489, 23469, 33303, 27334, 29475, 29501, 29570, 30395, 31327, 33525, 33693, 33850, 33913, 35088, 36089, 33992, 36245, 34095, 36153, 34098, 34037, 36119, 36183, 36122, 35497, 34274, 35605, 34256, 34231, 34263, 36717, 35640, 6682, 6792, 6778, 6916, 8065, 8091, 8085, 8070, 10333, 503, 395, 390, 385, 375, 431, 339, 338, 337, 336, 334, 333, 320, 304, 301, 299, 300, 302, 297, 296, 295, 293, 294, 291, 535, 286, 287, 288, 306, 309, 312, 314, 316, 318, 319, 321, 323, 325, 327, 329, 341, 343, 344, 345, 980, 898, 1607, 283, 281, 282, 927, 929, 996, 280, 1300, 277, 278, 279, 938, 1001, 1004, 267, 268, 269, 270, 941, 264, 1288, 261, 260, 993, 1075, 256, 257, 255, 254, 346, 1483, 1077, 957, 250, 1081, 248, 1485, 1497, 448, 474, 424, 469, 7801, 492, 1134, 505, 524, 618, 615, 931, 8103, 649, 667, 1500, 953, 972, 1706, 843, 911, 21272, 21294, 1316, 967, 974, 1108, 1121, 20593, 1274, 19626, 1488, 1611, 970, 1085, 1091, 1068, 1282, 1270, 1714, 1326, 1331, 20254, 1160, 1162, 1700, 1704, 1481, 1494, 1343, 20105, 1717, 20006, 19929, 1833, 19973, 19187, 20047, 20054, 19874, 21274, 19995, 20016, 19966, 19508, 19851, 20387, 20408, 29489, 23555, 19877, 19958, 21730, 21752, 32920, 32542, 13914, 15423, 17385, 17378, 17714, 17726, 19180, 19183, 19484, 19487, 19475, 19353, 19340, 19586, 19898, 19347, 19281, 19361, 19356, 19606, 19367, 19705, 19528, 19416, 19410, 19380, 19970, 19515, 19676, 19440, 19647, 19857, 19976, 20062, 20073, 20113, 20128, 20130, 20204, 20169, 20199, 20349, 20655, 20436, 20679, 20442, 20558, 20535, 20570, 20514, 20458, 20466, 20483, 20635, 20589, 20611, 20669, 20614, 20970, 20934, 20944, 20950, 20956, 20958, 20972, 21061, 21129, 21141, 21216, 21177, 21676, 21311, 21807, 21744, 21720, 21848, 22132, 22109, 22146, 21983, 22101, 22009, 22116, 22542, 22665, 22549, 22700, 22530, 23003, 23143, 23074, 23216, 22994, 23069, 23020, 23317, 23536, 23464, 24475, 24757, 25530, 25895, 26722, 29884, 29840, 30022, 34535]

# cancel all these tasks
tasks.each do |t|
  t.status = Constants.TASK_STATUSES.cancelled
  t.instructions = [] if t.instructions.nil?
  t.instructions << "Canceling as a part of issue #9512"
  t.save!
end

# get the other tasks
others = InformalHearingPresentationTask.all.select do |t|
  t.appeal.hearing_docket? &&
    t.active? &&
    (t.parent.type != "DistributionTask" || t.appeal.hearings.count != 0)
end

others.count
# => 17

others.pluck(:id)
# => [392, 303, 1698, 1769, 6870, 34068, 10342, 361, 272, 313, 249, 445, 657, 19308, 19940, 20324, 24388]

# and cancel them as well
others.each do |t|
  t.status = Constants.TASK_STATUSES.cancelled
  t.instructions = [] if t.instructions.nil?
  t.instructions << "Canceling as a part of issue #9512"
  t.save!
end

# did we miss anything?
InformalHearingPresentationTask.select { |t| t.active? && t.appeal.hearing_docket? }
# => []
```
