### PR TITLE
Suggested Hearing Locations dropdown not sorting properly

### DIFF
--- a/client/app/components/DataDropdowns/AppealHearingLocations.jsx
+++ b/client/app/components/DataDropdowns/AppealHearingLocations.jsx
@@ -189,7 +189,7 @@ const mapStateToProps = (state, props) => {
   return {
     dropdownName: name,
     appealHearingLocations: state.components.dropdowns[name] ? {
-      options: state.components.dropdowns[name].options,
+      options: _.orderBy(state.components.dropdowns[name].options, ['value.distance'], ['asc']),
       isFetching: state.components.dropdowns[name].isFetching,
       errorMsg: state.components.dropdowns[name].errorMsg
     } : {}

--- a/client/app/hearingSchedule/components/AssignHearingsTabs.jsx
+++ b/client/app/hearingSchedule/components/AssignHearingsTabs.jsx
@@ -161,6 +161,11 @@ export default class AssignHearingsTabs extends React.Component {
     /* Select first entry which should be shortest distance. */
     const location = sortedLocations[0];
 
+    return this.formatSuggestedHearingLocation(location);
+
+  };
+
+  formatSuggestedHearingLocation = (location) => {
     if (!location) {
       return '';
     }
@@ -171,7 +176,7 @@ export default class AssignHearingsTabs extends React.Component {
       <div>{`${city}, ${state} ${getFacilityType(location)}`}</div>
       <div>{`Distance: ${distance} miles away`}</div>
     </span>;
-  };
+  }
 
   availableVeteransRows = (appeals, { tab }) => {
     const filteredBy = this.state[tab].filteredBy;
@@ -245,7 +250,7 @@ export default class AssignHearingsTabs extends React.Component {
         isAdvancedOnDocket: hearing.aod
       }),
       docketNumber: this.getHearingDocketTag(hearing),
-      suggestedLocation: this.getSuggestedHearingLocation(hearing.location),
+      suggestedLocation: this.formatSuggestedHearingLocation(hearing.location),
       time: this.getHearingTime(hearing.scheduledFor, hearing.regionalOfficeTimezone)
     }));
   };

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -76,7 +76,8 @@ class AssignHearingModal extends React.PureComponent {
     }
 
     if (appeal.availableHearingLocations) {
-      const location = appeal.availableHearingLocations[0];
+      const sortedLocations = _.orderBy(appeal.availableHearingLocations, ['distance'], ['asc']);
+      const location = sortedLocations[0];
 
       if (location) {
         this.props.onHearingLocationChange({


### PR DESCRIPTION
Resolves #9780 

### Description
Properly sorted suggested hearing locations by distance ascending and ensured the selected value when opening the modal is the location closest to the veteran. Also fixed a bug introduced in a previous PR that affected the hearing location chosen after hearing was scheduled in AssignHearingTabs.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to Schedule Hearing
2. Select RO with veterans waiting for hearing to be scheduled
3. Select veteran
4. Confirm that the modal displays the Suggested Hearing Locations in distance order ascending.
5. Confirm the default selected location value is the one closest to the veteran.


