### PR TITLE
Do not require diagnostic code for ama cases on the front end

### DIFF
--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -162,7 +162,7 @@ class SelectDispositionsView extends React.PureComponent {
     const { decisionIssue } = this.state;
 
     return decisionIssue.benefit_type && decisionIssue.disposition &&
-      decisionIssue.description && decisionIssue.diagnostic_code;
+      decisionIssue.description;
   }
 
   saveDecision = () => {
@@ -345,7 +345,6 @@ class SelectDispositionsView extends React.PureComponent {
         />
         <h3>{COPY.DECISION_ISSUE_MODAL_DIAGNOSTIC_CODE}</h3>
         <SearchableDropdown
-          errorMessage={highlightModal && !decisionIssue.diagnostic_code ? 'This field is required' : null}
           name="Diagnostic code"
           placeholder={COPY.DECISION_ISSUE_MODAL_DIAGNOSTIC_CODE}
           hideLabel

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -571,7 +571,12 @@ RSpec.feature "AmaQueue" do
         number_of_claimants: 1,
         request_issues: [
           FactoryBot.create(:request_issue, contested_issue_description: "Tinnitus", notes: "Tinnitus note"),
-          FactoryBot.create(:request_issue, contested_issue_description: "Knee pain", notes: "Knee pain note")
+          FactoryBot.create(
+            :request_issue,
+            contested_issue_description: "Knee pain",
+            notes: "Knee pain note",
+            contested_rating_issue_diagnostic_code: nil
+          )
         ]
       )
     end
@@ -639,6 +644,7 @@ RSpec.feature "AmaQueue" do
         # Add a second decision issue
         all("button", text: "+ Add decision", count: 2)[1].click
         expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+        expect(page.find(".dropdown-Diagnostic.code")).to have_content("Diagnostic code")
 
         fill_in "Text Box", with: "test"
 
@@ -646,6 +652,7 @@ RSpec.feature "AmaQueue" do
         find("div", class: "Select-option", text: "Remanded").click
 
         click_on "Save"
+        expect(page).not_to have_content("This field is required")
         click_on "Continue"
 
         expect(page).to have_content("Select Remand Reasons")


### PR DESCRIPTION
Resolves #9633

### Description
Remove the requirement for an issue to have a diagnostic code on the front end for AMA cases. This is already not required on the back end.

### Acceptance Criteria
- [ ] Attorneys can submit a decision for an issue without entering a diagnostic code for the issue on an AMA case

### Testing Plan
1. Open the case details page of any AMA case
2. Confirm this case has any issue with a diagnostic code
![screen shot 2019-03-06 at 10 01 21 pm](https://user-images.githubusercontent.com/45575454/53929354-758eb880-405b-11e9-8802-f961bfe2a1aa.png)
3. Open the rails console and run
```ruby
pry(main)> a = Appeal.find_by(uuid: "<uuid-of-case>")
pry(main)> a.request_issues.update_all(contested_rating_issue_diagnostic_code: nil)
```
4. Refresh the case details page and confirm the issue no longer has a diagnostic code.
![screen shot 2019-03-06 at 10 04 19 pm](https://user-images.githubusercontent.com/45575454/53929456-d1f1d800-405b-11e9-9951-b2a8a5f1ba83.png)
5. Click "Select an action"...>"Decision ready for review"
6. Click "+ Add decision" for the issue that previously had a diagnostic code.
7. Complete the Disposition and Description sections, leaving the Diagnostic Code blank
8. Hit "Save" and note the form submits without error or warning that the Diagnostic Code input is required.