### PR TITLE
Automatically create HearingTask as parent of all new ScheduleHearingTasks

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -100,17 +100,7 @@ class RootTask < GenericTask
     end
 
     def create_hearing_schedule_task!(appeal, parent)
-      hearing_task = HearingTask.create!(
-        appeal: appeal,
-        assigned_to: Bva.singleton,
-        parent: parent
-      )
-
-      ScheduleHearingTask.create!(
-        appeal: appeal,
-        parent: hearing_task,
-        assigned_to: HearingsManagement.singleton
-      )
+      ScheduleHearingTask.create!(appeal: appeal, parent: parent, assigned_to: HearingsManagement.singleton)
     end
 
     def create_subtasks!(appeal, parent)

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -6,7 +6,7 @@
 # Once completed, a DispositionTask is created.
 
 class ScheduleHearingTask < GenericTask
-  before_create :check_parent_type
+  before_create :create_parent_hearing_task
   after_update :update_location_in_vacols
 
   class << self
@@ -57,13 +57,9 @@ class ScheduleHearingTask < GenericTask
     "Schedule hearing"
   end
 
-  def check_parent_type
-    if parent.type != "HearingTask"
-      fail(
-        Caseflow::Error::InvalidParentTask,
-        task_type: self.class.name,
-        assignee_type: assigned_to.class.name
-      )
+  def create_parent_hearing_task
+    if parent.type != HearingTask.name
+      self.parent = HearingTask.create(appeal: appeal, parent: parent, assigned_to: Bva.singleton)
     end
   end
 

--- a/app/models/tasks/transcription_task.rb
+++ b/app/models/tasks/transcription_task.rb
@@ -58,15 +58,6 @@ class TranscriptionTask < GenericTask
     # ScheduleHearingTask assigned to the hearing branch
     hearing_task.cancel_task_and_child_subtasks
 
-    new_hearing_task = HearingTask.create!(
-      appeal: appeal,
-      parent: hearing_task.parent,
-      assigned_to: Bva.singleton
-    )
-    ScheduleHearingTask.create!(
-      appeal: appeal,
-      parent: new_hearing_task,
-      assigned_to: HearingsManagement.singleton
-    )
+    ScheduleHearingTask.create!(appeal: appeal, parent: hearing_task.parent, assigned_to: HearingsManagement.singleton)
   end
 end

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -343,14 +343,8 @@ class AppealRepository
 
     # Create the schedule hearing tasks
     LegacyAppeal.where(vacols_id: ids.map(&:first) - vacols_ids_with_schedule_tasks).each do |appeal|
-      parent = HearingTask.create!(
-        appeal: appeal,
-        parent: RootTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
-      ) { |task| task.assigned_to = Bva.singleton }
-      ScheduleHearingTask.create!(appeal: appeal) do |task|
-        task.assigned_to = HearingsManagement.singleton
-        task.parent = parent
-      end
+      root_task = RootTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
+      ScheduleHearingTask.create!(appeal: appeal, parent: root_task, assigned_to: HearingsManagement.singleton)
 
       update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
     end

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -23,12 +23,16 @@ describe ScheduleHearingTask do
     end
   end
 
-  context "Create a ScheduleHearingTas with parent other than HearingTask type." do
+  context "Create a ScheduleHearingTask with parent other than HearingTask type." do
     let(:root_parent) { FactoryBot.create(:root_task, appeal: appeal) }
-    let(:schedule_hearing) { create(:schedule_hearing_task, parent: root_parent) }
+    let(:schedule_hearing) do
+      FactoryBot.create(:schedule_hearing_task, parent: root_parent, assigned_to: HearingsManagement.singleton)
+    end
 
-    it "should throw an error" do
-      expect { schedule_hearing }.to raise_error(Caseflow::Error::InvalidParentTask)
+    it "creates a HearingTask in between the input parent and the ScheduleHearingTask" do
+      expect { schedule_hearing }.to_not raise_error
+      expect(schedule_hearing.parent).to be_a(HearingTask)
+      expect(schedule_hearing.parent.parent).to eq(root_parent)
     end
   end
 


### PR DESCRIPTION
Connects #9543. Prepares for us to add logic on the front-end that creates a new `ScheduleHearingTask`, automatically creates the parent `HearingTask`, and closes any other active `HearingTask`s and their children.

We only create `ScheduleHearingTask` and `HearingTask`s in 3 places, and every time we create one, we create the other as well. This PR makes it so we automatically create the parent `HearingTask` when we create the child `ScheduleHearingTask`.