### PR TITLE
Add index on appeal to available_hearing_locations

### DIFF
--- a/db/migrate/20190307194302_add_index_to_available_hearing_locations.rb
+++ b/db/migrate/20190307194302_add_index_to_available_hearing_locations.rb
@@ -1,0 +1,11 @@
+class AddIndexToAvailableHearingLocations < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 1800000" # 30 minutes
+
+    add_index :available_hearing_locations, [:appeal_type, :appeal_id], algorithm: :concurrently
+  ensure
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190306224527) do
+ActiveRecord::Schema.define(version: 20190307194302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -126,6 +126,7 @@ ActiveRecord::Schema.define(version: 20190306224527) do
     t.datetime "updated_at", null: false
     t.string "veteran_file_number"
     t.string "zip_code"
+    t.index ["appeal_type", "appeal_id"], name: "index_available_hearing_locations_on_appeal_type_and_appeal_id"
     t.index ["veteran_file_number"], name: "index_available_hearing_locations_on_veteran_file_number"
   end
 


### PR DESCRIPTION
**Why**: New Relic is flagging `ScheduleHearingTask#tasks_for_ro` as a
slow DB query due to this call:
```
SELECT "available_hearing_locations".*
FROM "available_hearing_locations"
WHERE "available_hearing_locations"."appeal_type" = $1
AND "available_hearing_locations"."appeal_id" IN ()
```
This is because there was no index on appeal_type and appeal_id.

To see the difference between not having an index and having one, I ran
`explain` on the query. Here are the results for this query:
```ruby
incomplete_tasks = ScheduleHearingTask.where(
  "status = ? OR status = ?",
  Constants.TASK_STATUSES.assigned.to_sym,
  Constants.TASK_STATUSES.in_progress.to_sym
).includes(
  :assigned_to,
  :assigned_by,
  appeal: [:available_hearing_locations],
  attorney_case_reviews: [:attorney]
).explain
```

**Before:**

```
EXPLAIN for:
SELECT "available_hearing_locations".*
FROM "available_hearing_locations"
WHERE "available_hearing_locations"."appeal_type" = $1
AND "available_hearing_locations"."appeal_id"
IN (90, 108, 117, 88, 89) [["appeal_type", "Appeal"]]

QUERY PLAN
------------------------------------------------------------------------
Seq Scan on available_hearing_locations (cost=0.00..17.69 rows=1 width=169)
```

**After**:
```
EXPLAIN for:
SELECT "available_hearing_locations".*
FROM "available_hearing_locations"
WHERE "available_hearing_locations"."appeal_type" = $1
AND "available_hearing_locations"."appeal_id"
IN (90, 108, 117, 88, 89) [["appeal_type", "Appeal"]]

QUERY PLAN
------------------------------------------------------------------------
Seq Scan on available_hearing_locations  (cost=0.00..1.38 rows=14 width=163)
```
The cost is much lower after adding the index.


