### PR TITLE
Add task_id index on attorney_case_reviews

### DIFF
--- a/db/migrate/20190307210920_add_index_to_attorney_case_reviews.rb
+++ b/db/migrate/20190307210920_add_index_to_attorney_case_reviews.rb
@@ -1,0 +1,11 @@
+class AddIndexToAttorneyCaseReviews < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 1800000" # 30 minutes
+
+    add_index :attorney_case_reviews, :task_id, algorithm: :concurrently
+  ensure
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190306224527) do
+ActiveRecord::Schema.define(version: 20190307210920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 20190306224527) do
     t.boolean "untimely_evidence", default: false
     t.datetime "updated_at", null: false
     t.string "work_product"
+    t.index ["task_id"], name: "index_attorney_case_reviews_on_task_id"
   end
 
   create_table "available_hearing_locations", force: :cascade do |t|


### PR DESCRIPTION
**Why**: Just like #9847, `ScheduleHearingTask#tasks_for_ro` caused
another slow query. This time due to a missing index for task_id on
the attorney_case_reviews table.

**Before**:
```
EXPLAIN for:
SELECT "attorney_case_reviews".*
FROM "attorney_case_reviews"
WHERE "attorney_case_reviews"."task_id"
IN ('113', '116', '119', '206', '234')

QUERY PLAN
---------------------------------------------------------------------
Seq Scan on attorney_case_reviews (cost=0.00..16.01 rows=9 width=190)
```

**After**:
```
EXPLAIN for:
SELECT "attorney_case_reviews".*
FROM "attorney_case_reviews"
WHERE "attorney_case_reviews"."task_id"
IN ('113', '116', '119', '206', '234')

QUERY PLAN
--------------------------------------------------------------------
Seq Scan on attorney_case_reviews (cost=0.00..1.05 rows=3 width=104)
```