### PR TITLE
Fix N+1 query in eager_load_legacy_appeals_for_tasks

### DIFF
--- a/app/models/queues/generic_queue.rb
+++ b/app/models/queues/generic_queue.rb
@@ -12,7 +12,9 @@ class GenericQueue
   private
 
   def relevant_tasks
-    Task.incomplete_or_recently_closed.where(assigned_to: user)
+    Task.incomplete_or_recently_closed
+      .where(assigned_to: user)
+      .includes(*task_includes)
   end
 
   def relevant_attorney_tasks
@@ -20,6 +22,16 @@ class GenericQueue
 
     # If the user is a judge there will be attorneys in the list, if the user is not a judge the list of attorneys will
     # be an empty set and this function will also then return an empty set.
-    AttorneyTask.incomplete_or_recently_closed.where(assigned_to: Judge.new(user).attorneys)
+    AttorneyTask.incomplete_or_recently_closed
+      .where(assigned_to: Judge.new(user).attorneys)
+      .includes(*task_includes)
+  end
+
+  def task_includes
+    [
+      :appeal,
+      :assigned_by,
+      :assigned_to
+    ]
   end
 end


### PR DESCRIPTION
Looking at the New Relic transaction for
`Organizations::TasksController#index`, I noticed over 1000 DB calls per
transaction, which I traced to
`AppealRepository.eager_load_legacy_appeals_for_tasks` which is calling
`.map(&:appeal)` on the `tasks`, which causes an invidual query to the
DB for each appeal.

Since the tasks array comes from `GenericQueue#tasks`, that is where
the `includes` should be added.

You can test this in the Rails console:

```ruby
tasks = Task.all
tasks.
  select { |t| t.appeal.is_a?(LegacyAppeal) }.
  map(&:appeal).pluck(:vacols_id)
```
This will result in a bunch of DB calls.

```ruby
tasks = Task.all.includes(:appeal)
tasks.
  select { |t| t.appeal.is_a?(LegacyAppeal) }.
  map(&:appeal).pluck(:vacols_id)
```
This will result in 4 DB calls.
