### PR TITLE
Add disposition to ignored columns

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -10,6 +10,7 @@ class RequestIssue < ApplicationRecord
     review_request_id
     review_request_type
     description
+    disposition
   ]
 
   include Asyncable


### PR DESCRIPTION
prevents the app from blowing up during the deploy