### PR TITLE
Fix VSO login when user has multiple ROs

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class SessionsController < ApplicationController
   skip_before_action :verify_authentication
+  skip_before_action :deny_vso_access
 
   def new
     # :nocov:

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -38,6 +38,33 @@ RSpec.feature "Login" do
     find("#react-select-2--option-0").click
   end
 
+  context "VSO user has multple RO values" do
+    let(:user) { create(:user, css_id: "ANNE MERICA", station_id: "351") }
+    let(:organization) { create(:organization) }
+
+    before do
+      Fakes::AuthenticationService.user_session = {
+        "id" => user.css_id,
+        "roles" => ["Certify Appeal"],
+        "station_id" => user.station_id,
+        "email" => "world@example.com"
+      }
+      OrganizationsUser.add_user_to_organization(user, organization)
+    end
+
+    scenario "user is presented with RO selection page" do
+      visit "organizations/#{organization.url}"
+
+      expect(current_path).to eq("/login")
+
+      select_ro_from_dropdown
+      click_on("Log in")
+
+      expect(page).to have_content(organization.name)
+      expect(current_path).to eq("/organizations/#{organization.url}")
+    end
+  end
+
   # :nocov:
   # https://stackoverflow.com/questions/36472930/session-sometimes-not-persisting-in-capybara-selenium-test
   scenario "with valid credentials",

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -42,26 +42,51 @@ RSpec.feature "Login" do
     let(:user) { create(:user, css_id: "ANNE MERICA", station_id: "351") }
     let(:organization) { create(:organization) }
 
-    before do
-      Fakes::AuthenticationService.user_session = {
-        "id" => user.css_id,
-        "roles" => ["Certify Appeal"],
-        "station_id" => user.station_id,
-        "email" => "world@example.com"
-      }
-      OrganizationsUser.add_user_to_organization(user, organization)
+    context "User is in the Org they are trying to view" do
+      before do
+        Fakes::AuthenticationService.user_session = {
+          "id" => user.css_id,
+          "roles" => ["Certify Appeal"],
+          "station_id" => user.station_id,
+          "email" => "world@example.com"
+        }
+        OrganizationsUser.add_user_to_organization(user, organization)
+      end
+
+      scenario "user is presented with RO selection page and redirects to initial location" do
+        visit "organizations/#{organization.url}"
+
+        expect(current_path).to eq("/login")
+
+        select_ro_from_dropdown
+        click_on("Log in")
+
+        expect(page).to have_content(organization.name)
+        expect(current_path).to eq("/organizations/#{organization.url}")
+      end
     end
 
-    scenario "user is presented with RO selection page" do
-      visit "organizations/#{organization.url}"
+    context "User is not in the Org they are trying to view" do
+      before do
+        Fakes::AuthenticationService.user_session = {
+          "id" => user.css_id,
+          "roles" => ["Certify Appeal"],
+          "station_id" => user.station_id,
+          "email" => "world@example.com"
+        }
+      end
 
-      expect(current_path).to eq("/login")
+      scenario "user is presented with RO selection page and gets 403 /unauthorized error" do
+        visit "organizations/#{organization.url}"
 
-      select_ro_from_dropdown
-      click_on("Log in")
+        expect(current_path).to eq("/login")
 
-      expect(page).to have_content(organization.name)
-      expect(current_path).to eq("/organizations/#{organization.url}")
+        select_ro_from_dropdown
+        click_on("Log in")
+
+        expect(page).to have_content("Unauthorized")
+        expect(current_path).to eq("/unauthorized")
+      end
     end
   end
 

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -42,14 +42,17 @@ RSpec.feature "Login" do
     let(:user) { create(:user, css_id: "ANNE MERICA", station_id: "351") }
     let(:organization) { create(:organization) }
 
+    before do
+      Fakes::AuthenticationService.user_session = {
+        "id" => user.css_id,
+        "roles" => ["VSO"],
+        "station_id" => user.station_id,
+        "email" => "world@example.com"
+      }
+    end
+
     context "User is in the Org they are trying to view" do
       before do
-        Fakes::AuthenticationService.user_session = {
-          "id" => user.css_id,
-          "roles" => ["VSO"],
-          "station_id" => user.station_id,
-          "email" => "world@example.com"
-        }
         OrganizationsUser.add_user_to_organization(user, organization)
       end
 
@@ -67,15 +70,6 @@ RSpec.feature "Login" do
     end
 
     context "User is not in the Org they are trying to view" do
-      before do
-        Fakes::AuthenticationService.user_session = {
-          "id" => user.css_id,
-          "roles" => ["VSO"],
-          "station_id" => user.station_id,
-          "email" => "world@example.com"
-        }
-      end
-
       scenario "user is presented with RO selection page and gets 403 /unauthorized error" do
         visit "organizations/#{organization.url}"
 

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Login" do
       before do
         Fakes::AuthenticationService.user_session = {
           "id" => user.css_id,
-          "roles" => ["Certify Appeal"],
+          "roles" => ["VSO"],
           "station_id" => user.station_id,
           "email" => "world@example.com"
         }
@@ -70,7 +70,7 @@ RSpec.feature "Login" do
       before do
         Fakes::AuthenticationService.user_session = {
           "id" => user.css_id,
-          "roles" => ["Certify Appeal"],
+          "roles" => ["VSO"],
           "station_id" => user.station_id,
           "email" => "world@example.com"
         }


### PR DESCRIPTION
### Description

Disables the `deny_vso_access` check on the /login page.

https://github.com/department-of-veterans-affairs/appeals-support/issues/4461