### PR TITLE
Add foreign key on all tables with user_id

### DIFF
--- a/db/migrate/20190312154538_add_user_id_f_ks.rb
+++ b/db/migrate/20190312154538_add_user_id_f_ks.rb
@@ -1,0 +1,23 @@
+class AddUserIdFKs < ActiveRecord::Migration[5.1]
+  def change
+    [
+     "advance_on_docket_motions",
+     "appeal_views",
+     "claims_folder_searches",
+     "dispatch_tasks",
+     "document_views",
+     "end_product_establishments",
+     "hearing_views",
+     "intakes",
+     "legacy_hearings",
+     "organizations_users",
+     "ramp_election_rollbacks",
+     "reader_users",
+     "request_issues_updates",
+     "schedule_periods",
+     "user_quotas",
+    ].each do |tbl|
+       add_foreign_key tbl, :users
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190307210920) do
+ActiveRecord::Schema.define(version: 20190312154538) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20190307210920) do
     t.datetime "updated_at", null: false
     t.string "veteran_file_number"
     t.string "zip_code"
+    t.index ["appeal_type", "appeal_id"], name: "index_available_hearing_locations_on_appeal_type_and_appeal_id"
     t.index ["veteran_file_number"], name: "index_available_hearing_locations_on_veteran_file_number"
   end
 
@@ -1035,9 +1036,24 @@ ActiveRecord::Schema.define(version: 20190307210920) do
     t.index ["deleted_at"], name: "index_worksheet_issues_on_deleted_at"
   end
 
+  add_foreign_key "advance_on_docket_motions", "users"
   add_foreign_key "annotations", "users"
   add_foreign_key "api_views", "api_keys"
+  add_foreign_key "appeal_views", "users"
   add_foreign_key "certifications", "users"
+  add_foreign_key "claims_folder_searches", "users"
+  add_foreign_key "dispatch_tasks", "users"
+  add_foreign_key "document_views", "users"
+  add_foreign_key "end_product_establishments", "users"
+  add_foreign_key "hearing_views", "users"
+  add_foreign_key "intakes", "users"
   add_foreign_key "legacy_appeals", "appeal_series"
+  add_foreign_key "legacy_hearings", "users"
+  add_foreign_key "organizations_users", "users"
   add_foreign_key "ramp_closed_appeals", "ramp_elections"
+  add_foreign_key "ramp_election_rollbacks", "users"
+  add_foreign_key "reader_users", "users"
+  add_foreign_key "request_issues_updates", "users"
+  add_foreign_key "schedule_periods", "users"
+  add_foreign_key "user_quotas", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,7 +127,6 @@ ActiveRecord::Schema.define(version: 20190312154538) do
     t.datetime "updated_at", null: false
     t.string "veteran_file_number"
     t.string "zip_code"
-    t.index ["appeal_type", "appeal_id"], name: "index_available_hearing_locations_on_appeal_type_and_appeal_id"
     t.index ["veteran_file_number"], name: "index_available_hearing_locations_on_veteran_file_number"
   end
 

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -24,7 +24,7 @@ namespace :users do
   def models_with_user_id
     load_all_models unless @models_with_user_id
     @models_with_user_id ||= ActiveRecord::Base.descendants.reject(&:abstract_class?)
-      .select { |c| c.attribute_names.include?("user_id") }
+      .select { |c| c.attribute_names.include?("user_id") }.uniq
   end
 
   def report_user_related_records(user)

--- a/spec/models/ramp_election_spec.rb
+++ b/spec/models/ramp_election_spec.rb
@@ -376,9 +376,11 @@ describe RampElection do
   context "#successful_intake" do
     subject { ramp_election.successful_intake }
 
+    let(:user) { create(:user) }
+
     let!(:last_successful_intake) do
       RampElectionIntake.create!(
-        user_id: "123",
+        user: user,
         completion_status: "success",
         completed_at: 2.days.ago,
         detail: ramp_election
@@ -387,7 +389,7 @@ describe RampElection do
 
     let!(:penultimate_successful_intake) do
       RampElectionIntake.create!(
-        user_id: "123",
+        user: user,
         completion_status: "success",
         completed_at: 3.days.ago,
         detail: ramp_election
@@ -396,7 +398,7 @@ describe RampElection do
 
     let!(:unsuccessful_intake) do
       RampElectionIntake.create!(
-        user_id: "123",
+        user: user,
         completion_status: "error",
         completed_at: 1.day.ago,
         detail: ramp_election


### PR DESCRIPTION
connects #9444

### Description
Adds a real foreign key constraint to all tables with a `user_id` column, to prevent accidentally deleting a user referenced elsewhere.