### PR TITLE
Update Reek config for Utility Function offense

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -5,6 +5,8 @@ detectors:
     enabled: false
   NilCheck:
     enabled: false
+  UtilityFunction:
+    public_methods_only: true
 
 ### Directory specific configuration
 # You can configure smells on a per-directory base.


### PR DESCRIPTION
**Why**: We only care about this offense for public methods.

