### PR TITLE
Remove disabled but valid Rubocop offenses

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -110,7 +110,6 @@ class ApplicationController < ApplicationBaseController
   end
   helper_method :logo_path
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def application_urls
     urls = [{
       title: "Queue",
@@ -136,7 +135,6 @@ class ApplicationController < ApplicationBaseController
     # Only return the URL list if the user has applications to switch between
     (urls.length > 1) ? urls : nil
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
   helper_method :application_urls
 
   def dropdown_urls
@@ -180,8 +178,6 @@ class ApplicationController < ApplicationBaseController
     # :nocov:
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def case_search_home_page
     if feature_enabled?(:case_search_home_page)
       return false if current_user.admin?
@@ -194,8 +190,6 @@ class ApplicationController < ApplicationBaseController
     false
   end
   helper_method :case_search_home_page
-  # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def deny_vso_access
     redirect_to "/unauthorized" if current_user&.vso_employee?

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -59,7 +59,6 @@ class DistributionsController < ApplicationController
     }, status: :forbidden
   end
 
-  # rubocop:disable Metrics/MethodLength
   def json_error(error)
     case error
     when :not_judge
@@ -78,9 +77,8 @@ class DistributionsController < ApplicationController
       {
         "error": error,
         "title": "Cases in your queue are waiting to be assigned",
-        # rubocop:disable Metrics/LineLength
-        "detail": "Please assign all cases that have been waiting in your assignment queue for more than 30 days before requesting more."
-        # rubocop:enable Metrics/LineLength
+        "detail": "Please assign all cases that have been waiting in your " \
+                  "assignment queue for more than 30 days before requesting more."
       }
     when :different_user
       {
@@ -102,7 +100,6 @@ class DistributionsController < ApplicationController
       }
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def feature_enabled?
     FeatureToggle.enabled?(:automatic_case_distribution, user: current_user)

--- a/app/controllers/reader/documents_controller.rb
+++ b/app/controllers/reader/documents_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Reader::DocumentsController < Reader::ApplicationController
-  # rubocop:disable Metrics/MethodLength
   def index
     respond_to do |format|
       format.html { return render "reader/appeal/index" }
@@ -27,7 +26,6 @@ class Reader::DocumentsController < Reader::ApplicationController
 
     render error.serialize_response
   end
-  # rubocop:enable Metrics/MethodLength
 
   def show
     render "reader/appeal/index"

--- a/app/controllers/special_issues_controller.rb
+++ b/app/controllers/special_issues_controller.rb
@@ -31,22 +31,21 @@ class SpecialIssuesController < ApplicationController
     redirect_to "/unauthorized" unless current_user.appeal_has_task_assigned_to_user?(appeal)
   end
 
-  # rubocop:disable Metrics/LineLength
   def special_issue_params
-    params.require("special_issues").permit(:rice_compliance, :private_attorney_or_agent,
-                                            :waiver_of_overpayment, :pension_united_states, :vamc, :incarcerated_veterans,
-                                            :dic_death_or_accrued_benefits_united_states, :vocational_rehab,
-                                            :foreign_claim_compensation_claims_dual_claims_appeals, :manlincon_compliance,
-                                            :hearing_including_travel_board_video_conference, :home_loan_guaranty, :insurance,
-                                            :national_cemetery_administration, :spina_bifida, :radiation, :nonrating_issue,
-                                            :us_territory_claim_philippines, :contaminated_water_at_camp_lejeune, :mustard_gas,
-                                            :education_gi_bill_dependents_educational_assistance_scholars,
-                                            :foreign_pension_dic_all_other_foreign_countries,
-                                            :foreign_pension_dic_mexico_central_and_south_america_caribb,
-                                            :us_territory_claim_american_samoa_guam_northern_mariana_isla,
-                                            :us_territory_claim_puerto_rico_and_virgin_islands)
+    params.require("special_issues")
+      .permit(:rice_compliance, :private_attorney_or_agent,
+              :waiver_of_overpayment, :pension_united_states, :vamc, :incarcerated_veterans,
+              :dic_death_or_accrued_benefits_united_states, :vocational_rehab,
+              :foreign_claim_compensation_claims_dual_claims_appeals, :manlincon_compliance,
+              :hearing_including_travel_board_video_conference, :home_loan_guaranty, :insurance,
+              :national_cemetery_administration, :spina_bifida, :radiation, :nonrating_issue,
+              :us_territory_claim_philippines, :contaminated_water_at_camp_lejeune, :mustard_gas,
+              :education_gi_bill_dependents_educational_assistance_scholars,
+              :foreign_pension_dic_all_other_foreign_countries,
+              :foreign_pension_dic_mexico_central_and_south_america_caribb,
+              :us_territory_claim_american_samoa_guam_northern_mariana_isla,
+              :us_territory_claim_puerto_rico_and_virgin_islands)
   end
-  # rubocop:enable Metrics/LineLength
 
   def record_not_found
     render json: {

--- a/app/mappers/power_of_attorney_mapper.rb
+++ b/app/mappers/power_of_attorney_mapper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ModuleLength
 module PowerOfAttorneyMapper
   include AddressMapper
 
@@ -165,4 +164,3 @@ module PowerOfAttorneyMapper
     "WOUNDED WARRIOR PROJECT" => "2"
   }.freeze
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/mappers/zip_code_to_lat_lng_mapper.rb
+++ b/app/mappers/zip_code_to_lat_lng_mapper.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Style/HashSyntax
 module ZipCodeToLatLngMapper
 	# source: https://www.census.gov/geo/maps-data/data/gazetteer2018.html
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -5,7 +5,6 @@
 # This is the type of appeal created by the Veterans Appeals Improvement and Modernization Act (AMA),
 # which went into effect Feb 19, 2019.
 
-# rubocop:disable Metrics/ClassLength
 class Appeal < DecisionReview
   include Taskable
 
@@ -404,8 +403,6 @@ class Appeal < DecisionReview
     end
   end
 
-  # rubocop:disable CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def fetch_pre_decision_status
     if pending_schedule_hearing_task?
       :pending_hearing_scheduling
@@ -438,11 +435,7 @@ class Appeal < DecisionReview
       :other_close
     end
   end
-  # rubocop:enable CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable CyclomaticComplexity
   def fetch_details_for_status
     case fetch_status
     when :bva_decision
@@ -474,8 +467,6 @@ class Appeal < DecisionReview
       {}
     end
   end
-  # rubocop:enable CyclomaticComplexity
-  # rubocop:enable Metrics/MethodLength
 
   def post_bva_dta_decision_status_details
     issue_list = remanded_sc_decision_issues
@@ -732,4 +723,3 @@ class Appeal < DecisionReview
       end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/appeal_series.rb
+++ b/app/models/appeal_series.rb
@@ -136,7 +136,6 @@ class AppealSeries < ApplicationRecord
     end
   end
 
-  # rubocop:disable CyclomaticComplexity
   def fetch_status
     case latest_appeal.status
     when "Advance"
@@ -190,7 +189,6 @@ class AppealSeries < ApplicationRecord
     end
   end
 
-  # rubocop:disable MethodLength
   def disambiguate_status_complete
     case latest_appeal.disposition
     when "Allowed", "Denied"
@@ -216,7 +214,6 @@ class AppealSeries < ApplicationRecord
       :other_close
     end
   end
-  # rubocop:enable MethodLength
 
   def disambiguate_status_remand
     post_decision_ssocs = latest_appeal.ssoc_dates.select { |ssoc| ssoc > latest_appeal.decision_date }
@@ -225,7 +222,6 @@ class AppealSeries < ApplicationRecord
     :remand
   end
 
-  # rubocop:disable MethodLength
   def details_for_status
     case status
     when :scheduled_hearing
@@ -267,6 +263,4 @@ class AppealSeries < ApplicationRecord
       {}
     end
   end
-  # rubocop:enable MethodLength
-  # rubocop:enable CyclomaticComplexity
 end

--- a/app/models/appeal_series_issues.rb
+++ b/app/models/appeal_series_issues.rb
@@ -69,8 +69,6 @@ class AppealSeriesIssues
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def last_action_for_issues(issues)
     issues.reduce(date: nil, type: nil) do |memo, issue|
       if issue.close_date && (memo[:date].nil? || issue.close_date > memo[:date])
@@ -95,8 +93,6 @@ class AppealSeriesIssues
       memo
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
   def last_action_type_from_disposition(disposition)
     LAST_ACTION_TYPE_FOR_DISPOSITIONS.keys.find do |type|

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -88,8 +88,6 @@ class DecisionReview < ApplicationRecord
     id.to_s
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def ui_hash
     {
       veteran: {
@@ -115,8 +113,6 @@ class DecisionReview < ApplicationRecord
       processedInCaseflow: processed_in_caseflow?
     }
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
 
   def timely_issue?(decision_date)
     return true unless receipt_date && decision_date

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -3,7 +3,6 @@
 class DecisionReviewIntake < Intake
   include RunAsyncable
 
-  # rubocop:disable Metrics/AbcSize
   def ui_hash
     super.merge(
       receipt_date: detail.receipt_date,
@@ -23,7 +22,6 @@ class DecisionReviewIntake < Intake
     cancel!(reason: "system_error")
     raise
   end
-  # rubocop:enable Metrics/AbcSize
 
   def cancel_detail!
     detail&.remove_claimants!

--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -6,13 +6,13 @@ class HearingRequestDocket < Docket
   end
 
   # CMGTODO: should only return genpop appeals.
-  # rubocop:disable Lint/UnusedMethodArgument
-  def age_of_n_oldest_priority_appeals(num)
+  def age_of_n_oldest_priority_appeals(_num)
     []
   end
 
   # CMGTODO
-  def distribute_appeals(distribution, priority: false, genpop: "any", limit: 1)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def distribute_appeals(_distribution, priority: false, genpop: "any", limit: 1)
     []
   end
   # rubocop:enable Lint/UnusedMethodArgument

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -11,7 +11,6 @@ class LegacyDocket
     "legacy"
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def count(priority: nil, ready: nil)
     counts_by_priority_and_readiness.inject(0) do |sum, row|
       next sum unless (priority.nil? || (priority ? 1 : 0) == row["priority"]) &&
@@ -20,7 +19,6 @@ class LegacyDocket
       sum + row["n"]
     end
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def weight
     count(priority: false) + nod_count * NOD_ADJUSTMENT

--- a/app/models/full_name.rb
+++ b/app/models/full_name.rb
@@ -21,7 +21,6 @@ class FullName
   # :form => Russell, Shane, A
   # :readable_mi_formatted => Shane A. Russell (middle inital formatted)
   # :readable_fi_last_formatted => M. Jordan
-  # rubocop:disable Metrics/AbcSize
   def formatted(format)
     case format
     when :readable_full
@@ -38,5 +37,4 @@ class FullName
       fail InvalidFormatError
     end
   end
-  # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -154,7 +154,6 @@ class Hearing < ApplicationRecord
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
   def quick_to_hash(_current_user_id)
     serializable_hash(
       methods: [
@@ -184,9 +183,7 @@ class Hearing < ApplicationRecord
       except: [:military_service]
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
-  # rubocop:disable Metrics/MethodLength
   def to_hash(_current_user_id)
     serializable_hash(
       methods: [
@@ -224,7 +221,6 @@ class Hearing < ApplicationRecord
       ]
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
   def to_hash_for_worksheet(current_user_id)
     serializable_hash(

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -148,7 +148,6 @@ class HearingDay < ApplicationRecord
       end
     end
 
-    # rubocop:disable Metrics/AbcSize
     def upcoming_days_for_vso_user(start_date, end_date, user)
       hearing_days_with_ama_hearings = HearingDay.includes(hearings: [appeal: [tasks: :assigned_to]])
         .where("DATE(scheduled_for) between ? and ?", start_date, end_date).select do |hearing_day|
@@ -175,7 +174,6 @@ class HearingDay < ApplicationRecord
 
       hearing_days_with_ama_hearings + hearing_days_with_vacols_hearings
     end
-    # rubocop:enable Metrics/AbcSize
 
     def load_days(start_date, end_date, regional_office = nil)
       if regional_office.nil?

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -245,8 +245,6 @@ class Issue
     legacy_appeal.ssoc_dates.any? { |ssoc_date| close_date > ssoc_date }
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def friendly_description_for_codes(code_array)
     issue_description = code_array.reduce(Constants::ISSUE_INFO) do |levels, code|
       return nil unless levels[code]
@@ -280,8 +278,6 @@ class Issue
 
     issue_description
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
   class << self
     def repository

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -6,7 +6,6 @@
 # The source of truth for legacy appeals is VACOLS, but legacy appeals may also be worked in Caseflow.
 # Legacy appeals have VACOLS and BGS as dependencies.
 
-# rubocop:disable Metrics/ClassLength
 class LegacyAppeal < ApplicationRecord
   include AppealConcern
   include AssociatedVacolsModel
@@ -999,4 +998,3 @@ class LegacyAppeal < ApplicationRecord
     end
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class RequestIssue < ApplicationRecord
   include Asyncable
   include HasBusinessLine
@@ -266,7 +265,6 @@ class RequestIssue < ApplicationRecord
     closed_at if withdrawn?
   end
 
-  # rubocop:disable Metrics/MethodLength
   def ui_hash
     {
       id: id,
@@ -290,7 +288,6 @@ class RequestIssue < ApplicationRecord
       withdrawal_date: withdrawal_date
     }
   end
-  # rubocop:enable Metrics/MethodLength
 
   def approx_decision_date_of_issue_being_contested
     return if is_unidentified
@@ -644,8 +641,6 @@ class RequestIssue < ApplicationRecord
     rating_with_issue[:issues].find { |issue| issue[:reference_id] == contested_rating_issue_reference_id }
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def check_for_eligible_previous_review!
     return unless eligible?
     return unless contested_issue
@@ -666,8 +661,6 @@ class RequestIssue < ApplicationRecord
 
     self.ineligible_due_to_id = contested_issue.source_request_issues.first&.id if ineligible_reason
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
   def check_for_before_ama!
     return unless eligible? && should_check_for_before_ama?
@@ -780,4 +773,3 @@ class RequestIssue < ApplicationRecord
     decision_review.tasks.active.any?
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -29,8 +29,6 @@ class GenericTask < Task
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def available_actions(user)
     return [] unless user
 
@@ -60,8 +58,6 @@ class GenericTask < Task
 
     []
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
 
   def available_hearing_admin_actions(user)
     user_has_access = HearingAdmin.singleton.user_has_access?(user)

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -287,7 +287,6 @@ class VACOLS::Case < VACOLS::Record
     VACOLS::Representative.where(repcorkey: bfcorkey)
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.batch_update_vacols_location(location, vacols_ids)
     unless location
       Rails.logger.error "THERE IS A BUG IN YOUR CODE! It attempted to assign a case to a falsey location. " \
@@ -338,7 +337,6 @@ class VACOLS::Case < VACOLS::Record
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def previous_active_location
     conn = self.class.connection

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -235,9 +235,6 @@ class VACOLS::CaseDocket < VACOLS::Record
       .count
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   def self.distribute_nonpriority_appeals(judge, genpop, range, limit, dry_run = false)
     fail DocketNumberCentennialLoop if Time.zone.now.year >= 2030
 
@@ -288,13 +285,7 @@ class VACOLS::CaseDocket < VACOLS::Record
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/MethodLength
   def self.distribute_priority_appeals(judge, genpop, limit, dry_run = false)
     conn = connection
 
@@ -337,9 +328,6 @@ class VACOLS::CaseDocket < VACOLS::Record
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
 
   # :nocov:
 end

--- a/app/models/vacols/note.rb
+++ b/app/models/vacols/note.rb
@@ -44,7 +44,6 @@ class VACOLS::Note < VACOLS::Record
       "#{bfkey}D#{count + 1}"
     end
 
-    # rubocop:disable MethodLength
     def create!(note)
       validate!(note)
 
@@ -71,7 +70,6 @@ class VACOLS::Note < VACOLS::Record
       end
       primary_key
     end
-    # rubocop:enable MethodLength
 
     def find_active_by_user_and_type(note)
       VACOLS::Note.find_by(

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -280,7 +280,6 @@ class Veteran < ApplicationRecord
       veteran
     end
 
-    # rubocop:disable Metrics/MethodLength
     def create_by_file_number(file_number)
       veteran = Veteran.new(file_number: file_number)
 
@@ -310,7 +309,6 @@ class Veteran < ApplicationRecord
     rescue ActiveRecord::RecordNotUnique
       find_by(file_number: file_number)
     end
-    # rubocop:enable Metrics/MethodLength
 
     def before_create_veteran_by_file_number
       # noop - used to simulate race conditions

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -25,7 +25,6 @@ class QueueRepository
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def appeals_by_vacols_ids(vacols_ids)
       appeals = MetricsService.record("VACOLS: fetch appeals and associated info for tasks",
                                       service: :vacols,
@@ -57,7 +56,6 @@ class QueueRepository
       appeals.map(&:save)
       appeals
     end
-    # rubocop:enable Metrics/MethodLength
 
     def reassign_case_to_judge!(vacols_id:, created_in_vacols_date:, judge_vacols_user_id:, decass_attrs:)
       decass_record = find_decass_record(vacols_id, created_in_vacols_date)

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 class AppealRepository
   class AppealNotValidToClose < StandardError; end
   class AppealNotValidToReopen < StandardError
@@ -87,8 +86,6 @@ class AppealRepository
     cases.map { |case_record| build_appeal(case_record, true) }
   end
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
   def self.appeals_by_vbms_id_with_preloaded_status_api_attrs(vbms_id)
     MetricsService.record("VACOLS: appeals_by_vbms_id_with_preloaded_status_api_attrs",
                           service: :vacols,
@@ -122,8 +119,6 @@ class AppealRepository
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/AbcSize
 
   def self.appeals_ready_for_hearing(vbms_id)
     cases = MetricsService.record("VACOLS: appeals_ready_for_hearing",
@@ -399,7 +394,6 @@ class AppealRepository
   # Close an undecided appeal (prematurely, such as for a withdrawal or a VAIMA opt in)
   # WARNING: some parts of this action are not automatically reversable, and must
   # be reversed by hand
-  # rubocop:disable Metrics/MethodLength
   def self.close_undecided_appeal!(appeal:, user:, closed_on:, disposition_code:)
     case_record = appeal.case_record
     folder_record = case_record.folder
@@ -441,7 +435,6 @@ class AppealRepository
       close_associated_hearings(case_record)
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   # Close a remand (prematurely, such as for a withdrawal or a VAIMA opt in)
   # Remands need to be closed without overwriting the disposition data. A new
@@ -450,7 +443,6 @@ class AppealRepository
   #
   # WARNING: some parts of this action are not automatically reversable, and must
   # be reversed by hand
-  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def self.close_remand!(appeal:, user:, closed_on:, disposition_code:)
     case_record = appeal.case_record
     folder_record = case_record.folder
@@ -526,9 +518,7 @@ class AppealRepository
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
-  # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
   def self.reopen_undecided_appeal!(appeal:, user:, safeguards:, reopen_issues: true)
     case_record = appeal.case_record
     folder_record = case_record.folder
@@ -584,9 +574,7 @@ class AppealRepository
       end
     end
   end
-  # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
-  # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
   def self.reopen_remand!(appeal:, user:, disposition_code:)
     case_record = appeal.case_record
     folder_record = case_record.folder
@@ -622,7 +610,6 @@ class AppealRepository
       VACOLS::CaseIssue.where(isskey: follow_up_appeal_key).delete_all
     end
   end
-  # rubocop:enable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/MethodLength
 
   def self.certify(appeal:, certification:)
     certification_date = AppealRepository.dateshift_to_utc Time.zone.now
@@ -783,4 +770,3 @@ class AppealRepository
   end
   # :nocov:
 end
-# rubocop:enable Metrics/ClassLength

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -88,7 +88,6 @@ class ExternalApi::EfolderService
     Rails.application.config.efolder_key.to_s
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.send_efolder_request(endpoint, user, headers = {}, method: :get)
     DBService.release_db_connections
 
@@ -114,5 +113,4 @@ class ExternalApi::EfolderService
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/services/form8_pdf_service.rb
+++ b/app/services/form8_pdf_service.rb
@@ -47,7 +47,6 @@ class Form8PdfService
   # Rubocop complains about the number of conditions here,
   # but IMO it's pretty clear and I don't want to break it up
   # just for the sake of it.
-  # rubocop:disable Metrics/CyclomaticComplexity
   def self.pdf_values_for(form8, field_locations)
     field_locations.each_with_object({}) do |(attribute, location), pdf_values|
       next pdf_values unless (value = form8.send(attribute))
@@ -109,7 +108,6 @@ class Form8PdfService
     # Remove it from the tmp_location, leaving it only in final_location
     File.delete(tmp_location)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.output_location_for(form8)
     File.join(Rails.root, "tmp", "pdfs", form8.pdf_filename)

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -4,7 +4,6 @@ require "benchmark"
 
 # see https://dropwizard.github.io/metrics/3.1.0/getting-started/ for abstractions on metric types
 class MetricsService
-  # rubocop:disable Metrics/MethodLength
   def self.record(description, service: nil, name: "unknown")
     return_value = nil
     app = RequestStore[:application] || "other"
@@ -51,7 +50,6 @@ class MetricsService
       increment_datadog_counter("request_attempt", service, name, app)
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   private_class_method def self.increment_datadog_counter(metric_name, service, endpoint_name, app_name)
     DataDogService.increment_counter(

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -173,7 +173,7 @@ class VaDotGovAddressValidator
     )
   end
 
-  def get_state_code(va_dot_gov_address) # rubocop:disable Metrics/CyclomaticComplexity
+  def get_state_code(va_dot_gov_address)
     return "DC" if appeal.is_a?(LegacyAppeal) && appeal.hearing_request_type == :central_office
 
     state_code = case va_dot_gov_address[:country_code]

--- a/bin/update
+++ b/bin/update
@@ -1,10 +1,8 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# rubocop:disable Style/MixinUsage
 require "pathname"
 require "fileutils"
-include FileUtils
 
 # path to your application root.
 APP_ROOT = Pathname.new File.expand_path("..", __dir__)
@@ -13,7 +11,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+Dir.chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
@@ -30,4 +28,3 @@ chdir APP_ROOT do
   puts "\n== Restarting application server =="
   system! "bin/rails restart"
 end
-# rubocop:enable Style/MixinUsage

--- a/config.ru
+++ b/config.ru
@@ -37,11 +37,9 @@ date_pattern = '\d+-\d+-\d+'
 # '/idt/api/v1/appeals/39e82104-e590-4b2e-8d23-6182db0809f8' -> '/idt/api/v1/appeals/:uuid'
 uuid_pattern = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
 
-# rubocop:disable Style/PercentLiteralDelimiters
-id_regex = %r'/(?:#{numeric_id_pattern}|#{certification_id_pattern})(/|$)'
-date_regex = %r'/#{date_pattern}(/|$)'
-uuid_regex = %r'/#{uuid_pattern}(/|$)'
-# rubocop:enable Style/PercentLiteralDelimiters
+id_regex = %r{/(?:#{numeric_id_pattern}|#{certification_id_pattern})(/|$)}
+date_regex = %r{/#{date_pattern}(/|$)}
+uuid_regex = %r{/#{uuid_pattern}(/|$)}
 
 label_builder = lambda do |env, code|
   {

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -4,8 +4,7 @@ PaperTrail::Rails::Engine.eager_load!
 module PaperTrail
   class Version < ActiveRecord::Base
     def user
-      # rubocop:disable Style/RedundantSelf
-      User.find(self.whodunnit.to_i)
+      User.find(whodunnit.to_i)
     end
   end
 end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -179,7 +179,6 @@ module Caseflow::Error
       @error_code = error_code
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
     def self.from_vbms_error(error)
       case error.body
       when /PIF is already in use/
@@ -199,7 +198,6 @@ module Caseflow::Error
         error
       end
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
   end
 
   class MissingTimerMethod < StandardError; end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ClassLength
 require "bgs"
 require "fakes/end_product_store"
 
@@ -20,10 +19,6 @@ class Fakes::BGSService
   cattr_accessor :generate_tracked_items_requests
   attr_accessor :client
 
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/LineLength
   def self.create_veteran_records
     return if @veteran_records_created
 
@@ -245,9 +240,6 @@ class Fakes::BGSService
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/LineLength
 
   def self.all_grants
     default_date = 10.days.ago.to_formatted_s(:short_date)
@@ -373,7 +365,6 @@ class Fakes::BGSService
       }
     ]
   end
-  # rubocop:enable Metrics/MethodLength
 
   def self.existing_full_grants
     [
@@ -387,7 +378,6 @@ class Fakes::BGSService
     ]
   end
 
-  # rubocop:disable Metrics/MethodLength
   def self.existing_partial_grants
     [
       {
@@ -413,7 +403,6 @@ class Fakes::BGSService
       }
     ]
   end
-  # rubocop:enable Metrics/MethodLength
 
   def self.no_grants
     []
@@ -478,7 +467,6 @@ class Fakes::BGSService
     (self.class.veteran_records || {})[vbms_id]
   end
 
-  # rubocop:disable Metrics/MethodLength
   def fetch_person_info(participant_id)
     # This is a limited set of test data, more fields are available.
     if participant_id == "5382910292"
@@ -505,7 +493,6 @@ class Fakes::BGSService
       }
     end
   end
-  # rubocop:enable Metrics/MethodLength
 
   def can_access?(vbms_id)
     current_user = RequestStore[:current_user]
@@ -543,7 +530,6 @@ class Fakes::BGSService
     []
   end
 
-  # rubocop:disable Metrics/MethodLength
   def fetch_poas_by_participant_ids(participant_ids)
     get_hash_of_poa_from_bgs_poas(
       participant_ids.map do |participant_id|
@@ -570,7 +556,6 @@ class Fakes::BGSService
       end
     )
   end
-  # rubocop:enable Metrics/MethodLength
 
   def fetch_limited_poas_by_claim_ids(claim_ids)
     result = {}
@@ -821,4 +806,3 @@ class Fakes::BGSService
   end
   # rubocop:enable Metrics/MethodLength
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -56,7 +56,6 @@ class Fakes::VBMSService
     @hold_request = false
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
   def self.fetch_document_file(document)
     path =
       case document.vbms_document_id.to_i
@@ -77,7 +76,6 @@ class Fakes::VBMSService
       end
     IO.binread(path)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def self.quick_document_count_for_appeal(appeal, user)
     response = fetch_documents_for(appeal, user)

--- a/lib/generators/vacols/case.rb
+++ b/lib/generators/vacols/case.rb
@@ -96,10 +96,8 @@ class Generators::Vacols::Case
         bfdcertool: "2017-05-24 00:00:00 UTC"
       }
     end
+    # rubocop:enable Metrics/MethodLength
 
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/PerceivedComplexity
     def create(attrs = {})
       custom_case_attrs = attrs[:case_attrs].nil? ? {} : attrs[:case_attrs]
       custom_case_attrs = case_attrs.merge(custom_case_attrs)
@@ -143,9 +141,5 @@ class Generators::Vacols::Case
 
       VACOLS::Case.create(custom_case_attrs)
     end
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/PerceivedComplexity
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -51,7 +51,9 @@ namespace :ci do
     require "simplecov"
     $stdout.sync = true
 
-    api_url = "https://circleci.com/api/v1.1/project/github/#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}/#{ENV['CIRCLE_BUILD_NUM']}/artifacts" # rubocop:disable Metrics/LineLength
+    api_url = "https://circleci.com/api/v1.1/project/github/" \
+              "#{ENV['CIRCLE_PROJECT_USERNAME']}/#{ENV['CIRCLE_PROJECT_REPONAME']}/" \
+              "#{ENV['CIRCLE_BUILD_NUM']}/artifacts"
     coverage_dir = "~/coverage/combined"
     SimpleCov.coverage_dir(coverage_dir)
     # Set the merge_timeout very large so that we don't exclude results

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -9,10 +9,6 @@ task :lint do
   puts "running scss-lint..."
   scss_result = ShellCommand.run("scss-lint --color")
 
-  opts = ENV["CI"] ? "--parallel" : "--auto-correct"
-  puts "running rubocop..."
-  rubocop_result = ShellCommand.run("rubocop #{opts} --color")
-
   puts "running fasterer..."
   fasterer_result = ShellCommand.run("bundle exec fasterer")
 
@@ -21,7 +17,7 @@ task :lint do
   eslint_result = ShellCommand.run("cd ./client && yarn run #{eslint_cmd}")
 
   puts "\n"
-  if scss_result && rubocop_result && eslint_result && fasterer_result
+  if scss_result && eslint_result && fasterer_result
     puts Rainbow("Passed. Everything looks stylish! " \
       "But there may have been auto-corrections that you now need to check in.").green
   else

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -77,27 +77,52 @@ FactoryBot.define do
       end
 
       after(:build) do |task|
-        # rubocop:disable Metrics/LineLength
         example_instructions = {
           ihp: "Hello. It appears that the VSO has not reviewed this case and has not provided an IHP.",
-          poa_clarification: "We received some correspondence from the Veteran's attorney in November indicating the attorney wants to withdraw from representation of the Veteran. I don't see any paperwork from the Veteran appointing a new rep or otherwise acknowledging the withdraw of the old one. Please contact the Veteran to clarify if they have current representation. If the Veteran no longer wishes the current representative to act on his behalf, please get that in writing.",
-          hearing_clarification: "A March statement filed by the Veteran indicates that they desired a 'Televideo conference hearing' for all their appeals. No hearing was scheduled. Please clarify whether the Veteran still desires a Board hearing, and, if so, please reroute as necessary to schedule one. Thanks!",
-          aoj: "Please clarify whether the Veteran desires AOJ review of any evidence, to include VA treatment records dated through June, submitted since an April statement of the case. Thank you!",
-          extension: "The Veteran's POA submitted a letter requesting a 90 day extension. Please send letter granting the extension.",
-          missing_hearing_transcripts: "Good evening, could you please return this to the hearing branch as the hearing was just held and the transcripts are not yet available. Thank you.",
+          poa_clarification: "We received some correspondence from the Veteran's attorney in November " \
+                             "indicating the attorney wants to withdraw from representation of the Veteran. " \
+                             "I don't see any paperwork from the Veteran appointing a new rep or otherwise " \
+                             "acknowledging the withdraw of the old one. Please contact the Veteran to " \
+                             "clarify if they have current representation. If the Veteran no longer " \
+                             "wishes the current representative to act on his behalf, please get that in writing.",
+          hearing_clarification: "A March statement filed by the Veteran indicates that they desired " \
+                                 "a 'Televideo conference hearing' for all their appeals. No hearing " \
+                                 "was scheduled. Please clarify whether the Veteran still desires a " \
+                                 "Board hearing, and, if so, please reroute as necessary to schedule one. Thanks!",
+          aoj: "Please clarify whether the Veteran desires AOJ review of any evidence, to include VA " \
+               "treatment records dated through June, submitted since an April statement of the case. Thank you!",
+          extension: "The Veteran's POA submitted a letter requesting a 90 day extension. Please send " \
+                     "letter granting the extension.",
+          missing_hearing_transcripts: "Good evening, could you please return this to the hearing " \
+                                       "branch as the hearing was just held and the transcripts are " \
+                                       "not yet available. Thank you.",
           unaccredited_rep: "Unaccredited rep",
-          foia: "The Veteran's representative submitted FOIA request in December of last year, which was acknowledged the same month. To date, there has been no response provided. Please follow up on the FOIA request.",
-          retired_vlj: "VLJ Snuffy conducted the hearing in June. Since they are now retired, the Veteran needs to be provided notice of this and an opportunity to request hearing before another VLJ.",
+          foia: "The Veteran's representative submitted FOIA request in December of last year, which " \
+                "was acknowledged the same month. To date, there has been no response provided. " \
+                "Please follow up on the FOIA request.",
+          retired_vlj: "VLJ Snuffy conducted the hearing in June. Since they are now retired, the " \
+                       "Veteran needs to be provided notice of this and an opportunity to request " \
+                       "hearing before another VLJ.",
           arneson: "email was sent re Arneson letter/ the Veteran needing to be offered a third hearing.",
-          new_rep_arguments: "The Veteran recently switched to a new POA. Please determine if the new POA will provide new arguments for the issues on appeal.",
-          pending_scanning_vbms: "There is a pending scanning banner in VBMS indicating documents from November are pending scanning. The last documents uploaded to the file are from October. Please hold the case in abeyance for 2 weeks to allow the documents to be uploaded and the PSB to clear.",
-          address_verification: "VACOLS and Caseflow lists two different addresses for the Veteran. From reviewing the recent documents in the file, it appears that the address in Caseflow is the most recent address. Please verify the Veteran's current address and update VACOLS if warranted.",
-          schedule_hearing: "The Veteran has requested a Board hearing as to all appealed issues. To date, no Board hearing has been scheduled.",
-          missing_records: "The Veteran had a Board Video Conference Hearing in September with Judge Snuffy. The Hearing transcripts are not of record.",
-          translation: "There are multiple document files that still require translation from Spanish to English. The files in Spanish have been marked in Caseflow. Please have these documents translated. Thank you!",
+          new_rep_arguments: "The Veteran recently switched to a new POA. Please determine if the " \
+                             "new POA will provide new arguments for the issues on appeal.",
+          pending_scanning_vbms: "There is a pending scanning banner in VBMS indicating documents " \
+                                 "from November are pending scanning. The last documents uploaded " \
+                                 "to the file are from October. Please hold the case in abeyance " \
+                                 "for 2 weeks to allow the documents to be uploaded and the PSB to clear.",
+          address_verification: "VACOLS and Caseflow lists two different addresses for the Veteran. " \
+                                "From reviewing the recent documents in the file, it appears that " \
+                                "the address in Caseflow is the most recent address. Please verify " \
+                                "the Veteran's current address and update VACOLS if warranted.",
+          schedule_hearing: "The Veteran has requested a Board hearing as to all appealed issues. " \
+                            "To date, no Board hearing has been scheduled.",
+          missing_records: "The Veteran had a Board Video Conference Hearing in September with " \
+                          "Judge Snuffy. The Hearing transcripts are not of record.",
+          translation: "There are multiple document files that still require translation from " \
+                       "Spanish to English. The files in Spanish have been marked in Caseflow. " \
+                       "Please have these documents translated. Thank you!",
           other: "Please request a waiver of AOJ consideration for new evidence"
         }
-        # rubocop:enable Metrics/LineLength
 
         action = task.action || Constants::CO_LOCATED_ADMIN_ACTIONS.keys.sample
         task.update!(action: action, instructions: [example_instructions[action.to_sym]]) if task.instructions.empty?

--- a/spec/fake_date_helper.rb
+++ b/spec/fake_date_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module FakeDateHelper
-  # rubocop:disable Metrics/CyclomaticComplexity
   def get_unique_dates_between(start_date, end_date, num_of_dates,
                                exclude_weekends = true)
     dates = Set.new
@@ -33,7 +32,6 @@ module FakeDateHelper
 
     dates.to_a
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
 
   def get_unique_dates_for_ro_between(ro_name, schedule_period, num_of_dates)
     get_unique_dates_between(schedule_period.start_date, schedule_period.end_date, num_of_dates).map do |date|

--- a/spec/models/appeal_history_spec.rb
+++ b/spec/models/appeal_history_spec.rb
@@ -257,9 +257,8 @@ describe AppealHistory do
 
       context "when the issue description is ambiguous" do
         let(:description_1) do
-          # rubocop:disable Metrics/LineLength
-          "really really really really really really really really long note From appeal merged on #{500.days.ago.strftime('%m/%d/%y')} (76"
-          # rubocop:enable Metrics/LineLength
+          "really really really really really really really really long note " \
+          "From appeal merged on #{500.days.ago.strftime('%m/%d/%y')} (76"
         end
 
         let(:description_2) { "" }
@@ -275,9 +274,8 @@ describe AppealHistory do
 
       context "when there are multiple issues, some ambiguous" do
         let(:description_1) do
-          # rubocop:disable Metrics/LineLength
-          "really really really really really really really really long note From appeal merged on #{500.days.ago.strftime('%m/%d/%y')} (76"
-          # rubocop:enable Metrics/LineLength
+          "really really really really really really really really long note " \
+          "From appeal merged on #{500.days.ago.strftime('%m/%d/%y')} (76"
         end
 
         let(:description_2) do

--- a/spec/models/contention_spec.rb
+++ b/spec/models/contention_spec.rb
@@ -1,11 +1,10 @@
 # frozen_string_literal: true
 
 describe Contention do
-  # rubocop:disable Metrics/LineLength
   let(:utf8_text) do
-    "The claim of entitlement to compensation under 38 U.S.C. § 1151 for ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ is remanded."
+    "The claim of entitlement to compensation under 38 U.S.C. § 1151 for " \
+    "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ is remanded."
   end
-  # rubocop:enable Metrics/LineLength
 
   subject { described_class.new(utf8_text) }
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -695,9 +695,19 @@ describe EndProductEstablishment do
       context "when VBMS/BGS has a transient internal error" do
         before do
           # from https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3116/
-          # rubocop:disable Metrics/LineLength
-          sample_transient_error_body = '<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Header/><env:Body><env:Fault><faultcode xmlns:ns1="http://www.w3.org/2003/05/soap-envelope">ns1:Server</faultcode><faultstring>gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception - Security Verification Exception GUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</faultstring><detail><cdm:faultDetailBean xmlns:cdm="http://vbms.vba.va.gov/cdm" cdm:message="gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception - Security Verification Exception GUID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" cdm:exceptionClassName="gov.va.vba.vbms.ws.VbmsWSException" cdm:uid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" cdm:serverException="true"/></detail></env:Fault></env:Body></env:Envelope>'
-          # rubocop:enable Metrics/LineLength
+          sample_transient_error_body = '<env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">' \
+                                        "<env:Header/><env:Body><env:Fault>" \
+                                        '<faultcode xmlns:ns1="http://www.w3.org/2003/05/soap-envelope">' \
+                                        "ns1:Server</faultcode><faultstring>gov.va.vba.vbms.ws.VbmsWSException: " \
+                                        "WssVerification Exception - Security Verification Exception GUID: " \
+                                        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</faultstring><detail>" \
+                                        '<cdm:faultDetailBean xmlns:cdm="http://vbms.vba.va.gov/cdm" ' \
+                                        'cdm:message="gov.va.vba.vbms.ws.VbmsWSException: WssVerification Exception' \
+                                        " - Security Verification Exception GUID: " \
+                                        "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+                                        ' cdm:exceptionClassName="gov.va.vba.vbms.ws.VbmsWSException" ' \
+                                        'cdm:uid="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" ' \
+                                        'cdm:serverException="true"/></detail></env:Fault></env:Body></env:Envelope>'
 
           error = VBMS::HTTPError.new(500, sample_transient_error_body)
           allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(error)
@@ -711,9 +721,10 @@ describe EndProductEstablishment do
       context "when VBMS/BGS has a transient network error" do
         before do
           # from https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2888/
-          # rubocop:disable Metrics/LineLength
-          error = Errno::ETIMEDOUT.new('Connection timed out - Connection timed out - connect(2) for "bepprod.vba.va.gov" port 443 (bepprod.vba.va.gov:443)')
-          # rubocop:enable Metrics/LineLength
+          error = Errno::ETIMEDOUT.new(
+            "Connection timed out - Connection timed out - connect(2) for " \
+            '"bepprod.vba.va.gov" port 443 (bepprod.vba.va.gov:443)'
+          )
 
           allow_any_instance_of(BGSService).to receive(:get_end_products).and_raise(error)
         end


### PR DESCRIPTION
**Why**: By disabling offenses we actually care about, such as
complexity and class length, it allows classes or methods to get even
bigger and more complex indefinitely.

Now that we are using Code Climate, we can remove all of the
`rubocop:disable` statements we care about because Code Climate will
only complain about new offenses, not existing ones.