### PR TITLE
Do not apply before_ama check to Supplemental Claims

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -672,7 +672,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def should_check_for_before_ama?
-    !is_unidentified && !ramp_claim_id && !vacols_id
+    !is_unidentified && !ramp_claim_id && !vacols_id && !decision_review&.is_a?(SupplementalClaim)
   end
 
   def check_for_legacy_issue_not_withdrawn!

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -67,7 +67,7 @@ class AddedIssue extends React.PureComponent {
       } else if (issue.eligibleForSocOptIn === false) {
         errorMsg = INELIGIBLE_REQUEST_ISSUES.legacy_appeal_not_eligible;
       }
-    } else if (issue.beforeAma) {
+    } else if (issue.beforeAma && formType !== 'supplemental_claim') {
       errorMsg = INELIGIBLE_REQUEST_ISSUES.before_ama;
     }
 

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -13,24 +13,28 @@ feature "Intake Confirmation Page" do
 
   describe "when completing a claim review" do
     describe "Confirmation copy" do
+      context "HRL allows ineligible issues to remain due to untimeliness" do
+        let(:claim_review_type) { :higher_level_review }
+
+        it "does not show edit in VBMS or tracked item if there is no End Product" do
+          start_claim_review(claim_review_type)
+
+          visit "/intake"
+          click_intake_continue
+          click_intake_add_issue
+          # Add only one ineligible issue, so there will be no eligible issues
+          add_intake_nonrating_issue(date: before_ama_date.strftime("%m/%d/%Y"))
+          add_untimely_exemption_response("Yes")
+          click_intake_finish
+          expect(page).to have_content("Intake completed")
+          expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
+          expect(page).to_not have_content("Informal Conference Tracked Item")
+          expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
+        end
+      end
+
       [:higher_level_review, :supplemental_claim].each do |claim_review_type|
         describe "given a #{claim_review_type}" do
-          it "does not show edit in VBMS or tracked item if there is no End Product" do
-            start_claim_review(claim_review_type)
-
-            visit "/intake"
-            click_intake_continue
-            click_intake_add_issue
-            # Add only one ineligible issue, so there will be no eligible issues
-            add_intake_nonrating_issue(date: before_ama_date.strftime("%m/%d/%Y"))
-            add_untimely_exemption_response("Yes") if claim_review_type == :higher_level_review
-            click_intake_finish
-            expect(page).to have_content("Intake completed")
-            expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
-            expect(page).to_not have_content("Informal Conference Tracked Item")
-            expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
-          end
-
           it "shows EP related content if there is an end product created" do
             start_claim_review(claim_review_type)
 

--- a/spec/feature/intake/intake_edit_confirmation_spec.rb
+++ b/spec/feature/intake/intake_edit_confirmation_spec.rb
@@ -98,21 +98,26 @@ feature "Intake Edit Confirmation" do
             expect(page).to have_current_path("/#{edit_path}/confirmation")
             expect(page).to have_content("There is still an unidentified issue")
           end
+        end
+      end
 
-          it "does not say edit in VBMS if there are no end products" do
-            visit edit_path
-            click_intake_add_issue
-            click_intake_no_matching_issues
-            add_intake_nonrating_issue(date: (decision_review.receipt_date - 2.years).strftime("%D"))
-            add_untimely_exemption_response("Yes") if claim_review_type == :higher_level_review
-            click_remove_intake_issue(1)
-            click_remove_issue_confirmation
-            click_edit_submit
+      describe "HLR only behavior" do
+        let(:decision_review) { create(:higher_level_review, veteran_file_number: create(:veteran).file_number) }
+        let(:edit_path) { "higher_level_reviews/#{decision_review.uuid}/edit" }
 
-            expect(page).to have_current_path("/#{edit_path}/confirmation")
-            expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being canceled")
-            expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
-          end
+        it "does not say edit in VBMS if there are no end products" do
+          visit edit_path
+          click_intake_add_issue
+          click_intake_no_matching_issues
+          add_intake_nonrating_issue(date: (decision_review.receipt_date - 2.years).mdY)
+          add_untimely_exemption_response("Yes")
+          click_remove_intake_issue(1)
+          click_remove_issue_confirmation
+          click_edit_submit
+
+          expect(page).to have_current_path("/#{edit_path}/confirmation")
+          expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being canceled")
+          expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
         end
       end
     end

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -613,15 +613,19 @@ feature "Supplemental Claim Intake" do
       # add before_ama ratings
       click_intake_add_issue
       add_intake_rating_issue("Non-RAMP Issue before AMA Activation")
-      expect(page).to have_content(
+      expect(page).to_not have_content(
         "6. Non-RAMP Issue before AMA Activation #{ineligible_constants.before_ama}"
       )
+      expect(page).to have_content("6. Non-RAMP Issue before AMA Activation")
 
       # Eligible because it comes from a RAMP decision
       click_intake_add_issue
       add_intake_rating_issue("Issue before AMA Activation from RAMP")
       expect(page).to have_content(
         "7. Issue before AMA Activation from RAMP Decision date:"
+      )
+      expect(page).to_not have_content(
+        "7. Issue before AMA Activation from RAMP Decision date: #{ineligible_constants.before_ama}"
       )
 
       click_intake_add_issue
@@ -631,22 +635,24 @@ feature "Supplemental Claim Intake" do
         description: "A nonrating issue before AMA",
         date: (profile_date - 400.days).mdY
       )
-      expect(page).to have_content(
+      expect(page).to_not have_content(
         "A nonrating issue before AMA #{ineligible_constants.before_ama}"
       )
+      expect(page).to have_content("A nonrating issue before AMA")
 
       click_intake_finish
 
       expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
       expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
+
       success_checklist = find("ul.cf-success-checklist")
-      expect(success_checklist).to_not have_content("Non-RAMP issue before AMA Activation")
-      expect(success_checklist).to_not have_content("A nonrating issue before AMA")
+      expect(success_checklist).to have_content("Non-RAMP Issue before AMA Activation")
+      expect(success_checklist).to have_content("A nonrating issue before AMA")
 
       ineligible_checklist = find("ul.cf-ineligible-checklist")
-      expect(ineligible_checklist).to have_content("Non-RAMP Issue before AMA Activation is ineligible")
-      expect(ineligible_checklist).to have_content("A nonrating issue before AMA is ineligible")
+      expect(ineligible_checklist).to_not have_content("Non-RAMP Issue before AMA Activation is ineligible")
+      expect(ineligible_checklist).to_not have_content("A nonrating issue before AMA is ineligible")
 
       expect(SupplementalClaim.find_by(
                id: supplemental_claim.id,
@@ -702,10 +708,8 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                decision_review: supplemental_claim,
                contested_issue_description: "Non-RAMP Issue before AMA Activation",
-               end_product_establishment_id: nil,
-               closed_status: :ineligible,
-               ineligible_reason: :before_ama
-             )).to_not be_nil
+               end_product_establishment_id: nil
+             )).to_not be_ineligible
 
       expect(RequestIssue.find_by(
                decision_review: supplemental_claim,
@@ -718,10 +722,8 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                decision_review: supplemental_claim,
                nonrating_issue_description: "A nonrating issue before AMA",
-               closed_status: :ineligible,
-               ineligible_reason: :before_ama,
                end_product_establishment_id: nil
-             )).to_not be_nil
+             )).to_not be_ineligible
 
       duplicate_request_issues = RequestIssue.where(contested_rating_issue_reference_id: duplicate_reference_id)
       expect(duplicate_request_issues.count).to eq(2)

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -709,7 +709,7 @@ feature "Supplemental Claim Intake" do
                decision_review: supplemental_claim,
                contested_issue_description: "Non-RAMP Issue before AMA Activation",
                end_product_establishment_id: nil
-             )).to_not be_ineligible
+             )).to be_eligible
 
       expect(RequestIssue.find_by(
                decision_review: supplemental_claim,
@@ -723,7 +723,7 @@ feature "Supplemental Claim Intake" do
                decision_review: supplemental_claim,
                nonrating_issue_description: "A nonrating issue before AMA",
                end_product_establishment_id: nil
-             )).to_not be_ineligible
+             )).to be_eligible
 
       duplicate_request_issues = RequestIssue.where(contested_rating_issue_reference_id: duplicate_reference_id)
       expect(duplicate_request_issues.count).to eq(2)

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -708,7 +708,7 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                decision_review: supplemental_claim,
                contested_issue_description: "Non-RAMP Issue before AMA Activation",
-               end_product_establishment_id: nil
+               end_product_establishment_id: end_product_establishment.id
              )).to be_eligible
 
       expect(RequestIssue.find_by(
@@ -722,7 +722,7 @@ feature "Supplemental Claim Intake" do
       expect(RequestIssue.find_by(
                decision_review: supplemental_claim,
                nonrating_issue_description: "A nonrating issue before AMA",
-               end_product_establishment_id: nil
+               end_product_establishment_id: non_rating_end_product_establishment.id
              )).to be_eligible
 
       duplicate_request_issues = RequestIssue.where(contested_rating_issue_reference_id: duplicate_reference_id)

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1047,7 +1047,7 @@ describe RequestIssue do
           nonrating_request_issue.validate_eligibility!
 
           expect(nonrating_request_issue.ineligible_reason).to_not eq("before_ama")
-          expect(nonrating_request_issue).to_not be_ineligible
+          expect(nonrating_request_issue).to be_eligible
         end
       end
 

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1033,6 +1033,24 @@ describe RequestIssue do
         expect(rating_request_issue.ineligible_reason).to eq("before_ama")
       end
 
+      context "decision review is a Supplemental Claim" do
+        let(:review) do
+          create(
+            :supplemental_claim,
+            veteran_file_number: veteran.file_number,
+            legacy_opt_in_approved: legacy_opt_in_approved
+          )
+        end
+
+        it "does not apply before AMA checks" do
+          nonrating_request_issue.decision_date = DecisionReview.ama_activation_date - 5.days
+          nonrating_request_issue.validate_eligibility!
+
+          expect(nonrating_request_issue.ineligible_reason).to_not eq("before_ama")
+          expect(nonrating_request_issue).to_not be_ineligible
+        end
+      end
+
       context "rating issue is from a RAMP decision" do
         let(:ramp_claim_id) { "ramp_claim_id" }
 


### PR DESCRIPTION
connects #9922 

### Description
Do not apply `before_ama` eligibility check to Supplemental Claims, per clarification from AMO.