### PR TITLE
Skip the after_commit callback to just test the error handling

### DIFF
--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -127,6 +127,7 @@ describe Distribution do
 
     context "when the job errors" do
       it "marks the distribution as error" do
+        described_class.skip_callback(:commit, :after, :enqueue_distribution_job)
         allow_any_instance_of(LegacyDocket).to receive(:distribute_priority_appeals).and_raise(StandardError)
         expect { subject.distribute! }.to raise_error(StandardError)
         expect(subject.status).to eq("error")


### PR DESCRIPTION
Fixes (we hope) a flakey test: https://circleci.com/gh/department-of-veterans-affairs/caseflow/52036

Since we only want to test the error handling, skipping the callback that enqueues the job on `create` will isolate the `distribute!` method.

Moreover, the job itself swallows errors and logs them, so skipping the `StartDistributionJob` piece altogether helps reduce the number of moving parts.
