### PR TITLE
Restricting access to setting disposition

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,7 +122,9 @@ class ApplicationController < ApplicationBaseController
         link: "/hearings/dockets"
       }
     end
-    if current_user.can?("Build HearSched") || current_user.can?("Edit HearSched")
+    if current_user.can?("Build HearSched") ||
+       current_user.can?("Edit HearSched") ||
+       current_user.can?("RO ViewHearSched")
       urls << {
         title: "Hearing Schedule",
         link: "/hearings/schedule"

--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -30,8 +30,12 @@ class DispositionTask < GenericTask
     @hearing_task ||= parent
   end
 
-  def available_actions(_user)
-    [Constants.TASK_ACTIONS.POSTPONE_HEARING.to_h]
+  def available_actions(user)
+    if JudgeTeam.for_judge(user) || HearingsManagement.singleton.user_has_access?(user)
+      [Constants.TASK_ACTIONS.POSTPONE_HEARING.to_h]
+    else
+      []
+    end
   end
 
   def add_schedule_hearing_task_admin_actions_data(_user)

--- a/spec/models/tasks/disposition_task_spec.rb
+++ b/spec/models/tasks/disposition_task_spec.rb
@@ -9,6 +9,12 @@ describe DispositionTask do
     let!(:disposition_task) { DispositionTask.create_disposition_task!(appeal, hearing_task, hearing) }
     let(:after_disposition_update) { nil }
     let(:user) { FactoryBot.create(:user) }
+    let(:organization) { HearingsManagement.singleton }
+
+    before do
+      # Add user to hearing management branch
+      OrganizationsUser.add_user_to_organization(user, organization)
+    end
 
     let(:params) do
       {

--- a/spec/models/tasks/disposition_task_spec.rb
+++ b/spec/models/tasks/disposition_task_spec.rb
@@ -8,6 +8,7 @@ describe DispositionTask do
     let!(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
     let!(:disposition_task) { DispositionTask.create_disposition_task!(appeal, hearing_task, hearing) }
     let(:after_disposition_update) { nil }
+    let(:user) { FactoryBot.create(:user) }
 
     let(:params) do
       {
@@ -29,7 +30,7 @@ describe DispositionTask do
       end
 
       it "creates a new HearingTask and ScheduleHearingTask" do
-        disposition_task.update_from_params(params, nil)
+        disposition_task.update_from_params(params, user)
 
         expect(Hearing.first.disposition).to eq "postponed"
         expect(Hearing.count).to eq 1
@@ -52,7 +53,7 @@ describe DispositionTask do
       end
 
       it "creates a new HearingTask and ScheduleHearingTask with admin action" do
-        disposition_task.update_from_params(params, nil)
+        disposition_task.update_from_params(params, user)
 
         expect(Hearing.first.disposition).to eq "postponed"
         expect(Hearing.count).to eq 1
@@ -79,7 +80,7 @@ describe DispositionTask do
       end
 
       it "creates a new hearing with a new DispositionTask" do
-        disposition_task.update_from_params(params, nil)
+        disposition_task.update_from_params(params, user)
 
         expect(Hearing.count).to eq 2
         expect(Hearing.first.disposition).to eq "postponed"


### PR DESCRIPTION
This PR restricts access to who can update the disposition. Now only judges or members of the hearing management branch will be able to take that action.

I've also added the switch application dropdown for RO users.
