### PR TITLE
Suppress transient error Sentry alerts

### DIFF
--- a/app/jobs/decision_issue_sync_job.rb
+++ b/app/jobs/decision_issue_sync_job.rb
@@ -14,6 +14,9 @@ class DecisionIssueSyncJob < CaseflowJob
     rescue Rating::NilRatingProfileListError, Rating::LockedRatingError, Rating::BackfilledRatingError => err
       request_issue_or_effectuation.update_error!(err.class.to_s)
       # no Raven report, just noise. This just means nothing new has happened.
+    rescue Errno::ETIMEDOUT => err
+      Rails.logger.error err
+      # no Raven report. We'll try again later.
     rescue StandardError => err
       request_issue_or_effectuation.update_error!(err.to_s)
       Raven.capture_exception(err)

--- a/app/jobs/end_product_sync_job.rb
+++ b/app/jobs/end_product_sync_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative '../exceptions/bgs_sync_error'
+require_relative "../exceptions/bgs_sync_error"
 
 # This job syncs an EndProductEstablishment (end product manager) with up to date BGS and VBMS data
 class EndProductSyncJob < CaseflowJob

--- a/app/jobs/end_product_sync_job.rb
+++ b/app/jobs/end_product_sync_job.rb
@@ -10,6 +10,9 @@ class EndProductSyncJob < CaseflowJob
 
     begin
       EndProductEstablishment.find(end_product_establishment_id).sync!
+    rescue TransientBGSSyncError => err
+      # we don't care about transient errors in Sentry since it will alert us. we'll just try again later.
+      Rails.logger.error err
     rescue StandardError => err
       Raven.capture_exception(err, extra: { end_product_establishment_id: end_product_establishment_id })
     end

--- a/app/jobs/end_product_sync_job.rb
+++ b/app/jobs/end_product_sync_job.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../exceptions/bgs_sync_error'
+
 # This job syncs an EndProductEstablishment (end product manager) with up to date BGS and VBMS data
 class EndProductSyncJob < CaseflowJob
   queue_as :low_priority
@@ -10,7 +12,7 @@ class EndProductSyncJob < CaseflowJob
 
     begin
       EndProductEstablishment.find(end_product_establishment_id).sync!
-    rescue TransientBGSSyncError => err
+    rescue ::TransientBGSSyncError => err
       # we don't care about transient errors in Sentry since it will alert us. we'll just try again later.
       Rails.logger.error err
     rescue StandardError => err


### PR DESCRIPTION
connects #9799 

### Description

Transient HTTP errors (particularly timeouts) can be ignored in background jobs because they will be automatically re-tried, and we have other mechanisms (e.g. Data Dog) for discovering systemic outtages.