### PR TITLE
Automatically restart timed tasks with delay in the past

### DIFF
--- a/app/jobs/task_timer_job.rb
+++ b/app/jobs/task_timer_job.rb
@@ -20,12 +20,14 @@ class TaskTimerJob < CaseflowJob
     task_timer.with_lock do
       return if task_timer.processed?
 
+      task_timer.attempted!
       task_timer.task.when_timer_ends
       task_timer.processed!
     end
   rescue StandardError => e
     # Ensure errors are sent to Sentry, but don't block the job from continuing.
     # The next time the job runs, we'll process the unprocessed task timers again.
+    task_timer.update_error!(e.inspect)
     Raven.capture_exception(e)
   end
 end

--- a/app/models/concerns/timeable_task.rb
+++ b/app/models/concerns/timeable_task.rb
@@ -9,7 +9,10 @@ module TimeableTask
       fail Caseflow::Error::MissingTimerMethod unless method_defined?(:timer_ends_at)
 
       super(args).tap do |task|
-        TaskTimer.new(task: task).submit_for_processing!(delay: task.timer_ends_at)
+        timer = TaskTimer.new(task: task)
+        timer.submit_for_processing!(delay: task.timer_ends_at)
+        # if timer_ends_at is in the past, we automatically trigger processing now.
+        timer.restart! if timer.expired_without_processing?
       end
     end
   end

--- a/spec/jobs/task_timer_job_spec.rb
+++ b/spec/jobs/task_timer_job_spec.rb
@@ -63,7 +63,10 @@ describe TaskTimerJob do
 
     TaskTimerJob.perform_now
 
-    expect(timer.reload.processed_at).not_to eq(nil)
-    expect(error_timer.reload.processed_at).to eq(nil)
+    expect(timer.reload.processed_at).not_to be_nil
+    expect(timer.reload.attempted_at).not_to be_nil
+    expect(error_timer.reload.processed_at).to be_nil
+    expect(error_timer.error).to eq("RuntimeError")
+    expect(error_timer.attempted_at).to be_nil # because it was in a failed transaction
   end
 end

--- a/spec/models/concerns/timeable_task_spec.rb
+++ b/spec/models/concerns/timeable_task_spec.rb
@@ -19,6 +19,16 @@ describe TimeableTask do
     def timer_ends_at; end
   end
 
+  class OldTimedTask < GenericTask
+    include TimeableTask
+
+    def when_timer_ends; end
+
+    def timer_ends_at
+      NOW - 5.days
+    end
+  end
+
   before do
     Timecop.freeze(NOW)
   end
@@ -29,7 +39,19 @@ describe TimeableTask do
     task = SomeTimedTask.create!(appeal: appeal, assigned_to: Bva.singleton)
     timers = TaskTimer.where(task: task)
     expect(timers.length).to eq(1)
-    expect(timers.first.last_submitted_at).to eq(Time.zone.now + 5.days - 3.hours + 1.minute)
+    delayed_start = Time.zone.now + 5.days - 3.hours + 1.minute
+    expect(timers.first.last_submitted_at).to eq(delayed_start)
+    expect(timers.first.submitted_at).to eq(delayed_start)
+  end
+
+  it "queues itself when the delay is in the past" do
+    task = OldTimedTask.create!(appeal: appeal, assigned_to: Bva.singleton)
+    timers = TaskTimer.where(task: task)
+    expect(timers.length).to eq(1)
+    expect(timers.first.submitted_and_ready?).to eq(true)
+    expect(timers.first.last_submitted_at).to eq(NOW)
+    delay_in_the_past = Time.zone.now - 5.days - 3.hours + 1.minute
+    expect(timers.first.submitted_at).to eq(delay_in_the_past)
   end
 
   context "when not correctly configured" do


### PR DESCRIPTION
Some TaskTimer objects in production would never process because they had submitted at times in the past.
