### PR TITLE
Find and associated orphan hearing

### DIFF
--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -127,26 +127,24 @@ class DispositionTask < GenericTask
   end
 
   def mark_postponed(after_disposition_update:)
-    multi_transaction do
-      if hearing.is_a?(LegacyHearing)
-        hearing.update_caseflow_and_vacols(disposition: "postponed")
-      else
-        hearing.update(disposition: "postponed")
-      end
+    if hearing.is_a?(LegacyHearing)
+      hearing.update_caseflow_and_vacols(disposition: "postponed")
+    else
+      hearing.update(disposition: "postponed")
+    end
 
-      case after_disposition_update[:action]
-      when "reschedule"
-        new_hearing_attrs = after_disposition_update[:new_hearing_attrs]
-        reschedule(
-          hearing_day_id: new_hearing_attrs[:hearing_day_id], hearing_time: new_hearing_attrs[:hearing_time],
-          hearing_location: new_hearing_attrs[:hearing_location]
-        )
-      when "schedule_later"
-        schedule_later(
-          with_admin_action_klass: after_disposition_update[:with_admin_action_klass],
-          instructions: after_disposition_update[:admin_action_instructions]
-        )
-      end
+    case after_disposition_update[:action]
+    when "reschedule"
+      new_hearing_attrs = after_disposition_update[:new_hearing_attrs]
+      reschedule(
+        hearing_day_id: new_hearing_attrs[:hearing_day_id], hearing_time: new_hearing_attrs[:hearing_time],
+        hearing_location: new_hearing_attrs[:hearing_location]
+      )
+    when "schedule_later"
+      schedule_later(
+        with_admin_action_klass: after_disposition_update[:with_admin_action_klass],
+        instructions: after_disposition_update[:admin_action_instructions]
+      )
     end
   end
 

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -147,6 +147,14 @@ module Caseflow::Error
     end
   end
 
+  class UnassociatedHearingTask < SerializableError
+    def initialize(args)
+      @task_id = args[:task_id]
+      @code = args[:code] || 500
+      @message = args[:message] || "HearingTask #{@task_id} has no associated hearings"
+    end
+  end
+
   class ChildTaskAssignedToSameUser < SerializableError
     def initialize
       @code = 500


### PR DESCRIPTION
Resolves https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4105/

There are occasionally HearingTasks with DispositionTasks that do not have associated hearings. Rather than run a script in the console, this PR patches DispositionTask to associate a hearing as needed.
