### PR TITLE
Fix contention_id matching bug

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -194,6 +194,10 @@ class ClaimReview < DecisionReview
     fetch_issues_status(issue_list)
   end
 
+  def contention_records(_epe)
+    request_issues.active
+  end
+
   private
 
   def incomplete_tasks?

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -194,12 +194,12 @@ class ClaimReview < DecisionReview
     fetch_issues_status(issue_list)
   end
 
-  def contention_records(_epe)
-    request_issues.active
+  def contention_records(epe)
+    epe.request_issues.active
   end
 
-  def all_contention_records(_epe)
-    request_issues
+  def all_contention_records(epe)
+    epe.request_issues
   end
 
   private

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -198,6 +198,10 @@ class ClaimReview < DecisionReview
     request_issues.active
   end
 
+  def all_contention_records(_epe)
+    request_issues
+  end
+
   private
 
   def incomplete_tasks?

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -73,6 +73,10 @@ class DecisionDocument < ApplicationRecord
     end_product_establishment.sync_decision_issues! if end_product_establishment.status_cleared?
   end
 
+  def contention_records(epe)
+    effectuations.where(end_product_establishment: epe)
+  end
+
   private
 
   def create_board_grant_effectuations!

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -77,6 +77,10 @@ class DecisionDocument < ApplicationRecord
     effectuations.where(end_product_establishment: epe)
   end
 
+  def all_contention_records(epe)
+    contention_records(epe)
+  end
+
   private
 
   def create_board_grant_effectuations!

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -88,8 +88,7 @@ class EndProductEstablishment < ApplicationRecord
     # Currently not making any assumptions about the order in which VBMS returns
     # the created contentions. Instead find the issue by matching text.
 
-    # We don't care about duplicate text; we just care that every request issue
-    # has a contention.
+    # We don't care about duplicate text; we just care that every request issue has a contention.
     create_contentions_in_vbms(contentions).each do |contention|
       next if existing_contention_reference_ids.include?(contention.id)
 

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -44,6 +44,8 @@ class RequestIssuesUpdate < ApplicationRecord
     end
   end
 
+  # establish! is called async via DecisionReviewProcessJob.
+  # it is queued via submit_for_processing! in the perform! method above.
   def establish!
     attempted!
 

--- a/db/migrate/20190319144125_unique_contention_id.rb
+++ b/db/migrate/20190319144125_unique_contention_id.rb
@@ -1,0 +1,13 @@
+class UniqueContentionId < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :request_issues, [:contention_reference_id, :removed_at]
+    add_index :request_issues, :contention_reference_id, unique: true, algorithm: :concurrently
+  end
+
+  def down
+    add_index :request_issues, [:contention_reference_id, :removed_at], unique: true, algorithm: :concurrently
+    remove_index :request_issues, :contention_reference_id
+  end
+end

--- a/db/migrate/20190320140634_add_updated_at_request_issue.rb
+++ b/db/migrate/20190320140634_add_updated_at_request_issue.rb
@@ -1,0 +1,5 @@
+class AddUpdatedAtRequestIssue < ActiveRecord::Migration[5.1]
+  def change
+    add_column :request_issues, :updated_at, :datetime
+  end
+end

--- a/db/migrate/20190320215814_unique_contention_id_board_grant_effectuations.rb
+++ b/db/migrate/20190320215814_unique_contention_id_board_grant_effectuations.rb
@@ -1,0 +1,7 @@
+class UniqueContentionIdBoardGrantEffectuations < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :board_grant_effectuations, :contention_reference_id, unique: true, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190320140634) do
+ActiveRecord::Schema.define(version: 20190320215814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -142,6 +142,7 @@ ActiveRecord::Schema.define(version: 20190320140634) do
     t.bigint "granted_decision_issue_id", null: false
     t.datetime "last_submitted_at"
     t.index ["appeal_id"], name: "index_board_grant_effectuations_on_appeal_id"
+    t.index ["contention_reference_id"], name: "index_board_grant_effectuations_on_contention_reference_id", unique: true
     t.index ["decision_document_id"], name: "index_board_grant_effectuations_on_decision_document_id"
     t.index ["end_product_establishment_id"], name: "index_board_grant_effectuations_on_end_product_establishment_id"
     t.index ["granted_decision_issue_id"], name: "index_board_grant_effectuations_on_granted_decision_issue_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190313152622) do
+ActiveRecord::Schema.define(version: 20190320140634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -806,10 +806,11 @@ ActiveRecord::Schema.define(version: 20190313152622) do
     t.string "unidentified_issue_text"
     t.boolean "untimely_exemption"
     t.text "untimely_exemption_notes"
+    t.datetime "updated_at"
     t.string "vacols_id"
     t.integer "vacols_sequence_id"
     t.string "veteran_participant_id"
-    t.index ["contention_reference_id", "removed_at"], name: "index_request_issues_on_contention_reference_id_and_removed_at", unique: true
+    t.index ["contention_reference_id"], name: "index_request_issues_on_contention_reference_id", unique: true
     t.index ["contested_decision_issue_id"], name: "index_request_issues_on_contested_decision_issue_id"
     t.index ["contested_rating_issue_reference_id"], name: "index_request_issues_on_contested_rating_issue_reference_id"
     t.index ["decision_review_type", "decision_review_id"], name: "index_request_issues_on_decision_review_columns"

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -192,7 +192,7 @@ class Fakes::BGSService
         sc
       when "has_higher_level_review_with_vbms_claim_id"
         claim_id = "600118951"
-        contention_reference_id = 1234
+        contention_reference_id = veteran.file_number[0..4] + "1234"
         hlr = HigherLevelReview.find_or_create_by!(
           veteran_file_number: veteran.file_number
         )

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -169,10 +169,11 @@ class Fakes::VBMSService
     # Used to simulate a contention that fails to be created in VBMS
     contentions.delete(description: "FAIL ME")
 
-    # return fake list of contentions
-    contentions.map do |contention|
+    # generate new contentions and return list of all contentions on the claim.
+    contentions.each do |contention|
       Generators::Contention.build(text: contention[:description], claim_id: claim_id)
     end
+    Fakes::VBMSService.contention_records[claim_id]
   end
 
   def self.associate_rating_request_issues!(claim_id:, rating_issue_contention_map:)

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -123,7 +123,7 @@ class Fakes::VBMSService
     Rails.logger.info("Submitting claim to VBMS...")
     Rails.logger.info("Veteran data:\n #{veteran_hash}")
     Rails.logger.info("Claim data:\n #{claim_hash}")
-    Rails.logger.info("User:\n #{user}")
+    Rails.logger.info("User:\n #{user.inspect}")
 
     self.end_product_claim_ids_by_file_number ||= {}
 
@@ -164,7 +164,7 @@ class Fakes::VBMSService
     Rails.logger.info("File number: #{veteran_file_number}")
     Rails.logger.info("Claim id:\n #{claim_id}")
     Rails.logger.info("Contentions: #{contentions.inspect}")
-    Rails.logger.info("User:\n #{user}")
+    Rails.logger.info("User:\n #{user.inspect}")
 
     # Used to simulate a contention that fails to be created in VBMS
     contentions.delete(description: "FAIL ME")

--- a/lib/generators/contention.rb
+++ b/lib/generators/contention.rb
@@ -16,7 +16,7 @@ class Generators::Contention
 
     def build(attrs = {})
       attrs = default_attrs.merge(attrs)
-      claim_id = attrs.delete(:claim_id)
+      claim_id = attrs[:claim_id]
       disposition = attrs.delete(:disposition)
 
       OpenStruct.new(attrs).tap do |contention|

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -21,6 +21,11 @@ FactoryBot.define do
       nonrating_issue_description { "nonrating issue description" }
     end
 
+    trait :unidentified do
+      is_unidentified { true }
+      unidentified_issue_text { "unidentified issue description" }
+    end
+
     trait :removed do
       closed_at { Time.zone.now }
       closed_status { :removed }

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -222,8 +222,12 @@ feature "Appeal Edit issues" do
   end
 
   context "with multiple request issues with same data fields" do
-    let!(:duplicate_nonrating_request_issue) { create(:request_issue, nonrating_request_issue_attributes) }
-    let!(:duplicate_rating_request_issue) { create(:request_issue, rating_request_issue_attributes) }
+    let!(:duplicate_nonrating_request_issue) do
+      create(:request_issue, nonrating_request_issue_attributes.merge(contention_reference_id: "4444"))
+    end
+    let!(:duplicate_rating_request_issue) do
+      create(:request_issue, rating_request_issue_attributes.merge(contention_reference_id: "5555"))
+    end
 
     scenario "saves by id" do
       visit "appeals/#{appeal.uuid}/edit/"

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -219,7 +219,7 @@ feature "Higher Level Review Edit issues" do
         decision_review: higher_level_review,
         benefit_type: "compensation",
         contested_issue_description: "Non-RAMP Issue before AMA Activation",
-        contention_reference_id: "12345",
+        contention_reference_id: "23456",
         ineligible_reason: :before_ama
       )
     end
@@ -294,7 +294,7 @@ feature "Higher Level Review Edit issues" do
           contested_rating_issue_profile_date: rating_before_ama.profile_date,
           decision_review: higher_level_review,
           contested_issue_description: "Non-RAMP Issue before AMA Activation legacy",
-          contention_reference_id: "12345678",
+          contention_reference_id: "123456789",
           vacols_id: "vacols1",
           benefit_type: "compensation",
           vacols_sequence_id: "2"

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -635,35 +635,4 @@ feature "Supplemental Claim Edit issues" do
       end
     end
   end
-
-  context "review replaces one unidentified issue with another" do
-    let(:supplemental_claim) do
-      # reload to get uuid
-      create(:supplemental_claim, veteran_file_number: veteran.file_number).reload
-    end
-    let!(:existing_request_issues) do
-      [create(:request_issue, :unidentified, decision_review: supplemental_claim)]
-    end
-
-    before do
-      supplemental_claim.create_issues!(existing_request_issues)
-      supplemental_claim.establish!
-    end
-
-    it "does not re-use removed contention id" do
-      binding.pry
-      visit "supplemental_claims/#{supplemental_claim.uuid}/edit"
-
-      click_remove_intake_issue(1)
-      click_remove_issue_confirmation
-
-      # add unidentified issue
-      click_intake_add_issue
-      add_intake_unidentified_issue(existing_request_issues.first.unidentified_issue_text)
-
-      click_edit_submit_and_confirm
-
-      binding.pry
-    end
-  end
 end

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -635,4 +635,35 @@ feature "Supplemental Claim Edit issues" do
       end
     end
   end
+
+  context "review replaces one unidentified issue with another" do
+    let(:supplemental_claim) do
+      # reload to get uuid
+      create(:supplemental_claim, veteran_file_number: veteran.file_number).reload
+    end
+    let!(:existing_request_issues) do
+      [create(:request_issue, :unidentified, decision_review: supplemental_claim)]
+    end
+
+    before do
+      supplemental_claim.create_issues!(existing_request_issues)
+      supplemental_claim.establish!
+    end
+
+    it "does not re-use removed contention id" do
+      binding.pry
+      visit "supplemental_claims/#{supplemental_claim.uuid}/edit"
+
+      click_remove_intake_issue(1)
+      click_remove_issue_confirmation
+
+      # add unidentified issue
+      click_intake_add_issue
+      add_intake_unidentified_issue(existing_request_issues.first.unidentified_issue_text)
+
+      click_edit_submit_and_confirm
+
+      binding.pry
+    end
+  end
 end

--- a/spec/feature/queue/colocated_checkout_flow_spec.rb
+++ b/spec/feature/queue/colocated_checkout_flow_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature "Colocated checkout flows" do
       expect(colocated_action.instructions[1]).to eq instructions
     end
 
-    scenario "sends task to team" do
+    xscenario "sends task to team" do
       visit "/queue"
 
       appeal = translation_action.appeal
@@ -143,6 +143,7 @@ RSpec.feature "Colocated checkout flows" do
       vet_name = appeal.veteran_full_name
       click_on "#{vet_name.split(' ').first} #{vet_name.split(' ').last} (#{appeal.sanitized_vbms_id})"
 
+      # current flake: https://circleci.com/gh/department-of-veterans-affairs/caseflow/53427
       click_dropdown(index: 0)
 
       expect(page).to have_content(

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -465,7 +465,7 @@ describe RequestIssue do
           :request_issue,
           decision_review: previous_higher_level_review,
           contested_rating_issue_reference_id: higher_level_review_reference_id,
-          contention_reference_id: contention_reference_id,
+          contention_reference_id: "2222",
           end_product_establishment: active_epe,
           contention_removed_at: nil,
           ineligible_reason: nil
@@ -477,7 +477,7 @@ describe RequestIssue do
           :request_issue,
           decision_review: new_higher_level_review,
           contested_rating_issue_reference_id: higher_level_review_reference_id,
-          contention_reference_id: contention_reference_id,
+          contention_reference_id: "3333",
           ineligible_reason: :duplicate_of_rating_issue_in_active_review,
           ineligible_due_to: request_issue_in_active_review
         )
@@ -639,7 +639,13 @@ describe RequestIssue do
   end
 
   context "#previous_request_issue" do
-    let(:previous_higher_level_review) { create(:higher_level_review, receipt_date: review.receipt_date - 10.days) }
+    let(:previous_higher_level_review) do
+      create(
+        :higher_level_review,
+        veteran_file_number: veteran.file_number,
+        receipt_date: review.receipt_date - 10.days
+      )
+    end
 
     let(:previous_end_product_establishment) do
       create(
@@ -650,6 +656,8 @@ describe RequestIssue do
       )
     end
 
+    let(:previous_contention_ref_id) { "4444" }
+
     let!(:previous_request_issue) do
       create(
         :request_issue,
@@ -657,7 +665,7 @@ describe RequestIssue do
         contested_rating_issue_reference_id: higher_level_review_reference_id,
         contested_rating_issue_profile_date: profile_date,
         contested_issue_description: "a rating request issue",
-        contention_reference_id: contention_reference_id,
+        contention_reference_id: previous_contention_ref_id,
         end_product_establishment: previous_end_product_establishment
       ).tap(&:submit_for_processing!)
     end
@@ -672,7 +680,7 @@ describe RequestIssue do
     context "when contesting the same decision review" do
       let(:previous_contention) do
         Generators::Contention.build(
-          id: contention_reference_id,
+          id: previous_contention_ref_id,
           claim_id: previous_end_product_establishment.reference_id,
           disposition: "allowed"
         )

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -431,22 +431,24 @@ describe RequestIssuesUpdate do
         end
       end
 
-      context "when we add and remove an unidentified issue" do
-        let!(:unidentified1) { create(:request_issue, :unidentified, decision_review: review) }
-        let!(:unidentified2) { create(:request_issue, :unidentified, decision_review: review) }
+      context "when we add and remove unidentified issues" do
         let(:request_issues_data) do
-          [
-            { is_unidentified: true, decision_text: unidentified1.unidentified_issue_text },
-            { is_unidentified: true, decision_text: unidentified2.unidentified_issue_text }
-          ]
+          request_issues = []
+          10.times do |i|
+            issue = create(:request_issue, :unidentified, decision_review: review)
+            request_issues << { is_unidentified: true, decision_text: issue.unidentified_issue_text }
+          end
+          request_issues
         end
 
         it "does not re-use contention_reference_id" do
+          # start with existing rating request issues
           expect(review.reload.request_issues.pluck(:contention_reference_id).compact.uniq.count).to eq(2)
           subject
           review.reload
-          expect(review.request_issues.pluck(:contention_reference_id).compact.uniq.count).to eq(4)
-          expect(review.request_issues.active.count).to eq(2)
+          expect(review.request_issues.pluck(:contention_reference_id).compact.uniq.count).to eq(12)
+          # only unidentified are left
+          expect(review.request_issues.active.count).to eq(10)
         end
       end
 

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -431,6 +431,16 @@ describe RequestIssuesUpdate do
         end
       end
 
+      context "when we add and remove an unidentified issue" do
+        let(:unidentified1) { create(:request_issue, :unidentified, decision_review: review) }
+        let(:unidentified2) { create(:request_issue, :unidentified, decision_review: review) }
+        let(:request_issues_data) { [{ request_issue_id: unidentified1.id }, { request_issue_id: unidentified2.id }] }
+
+        it "does not re-use contention_reference_id" do
+
+        end
+      end
+
       def capture_raven_log
         allow(Raven).to receive(:capture_exception) { @raven_called = true }
       end

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -434,7 +434,7 @@ describe RequestIssuesUpdate do
       context "when we add and remove unidentified issues" do
         let(:request_issues_data) do
           request_issues = []
-          10.times do |i|
+          10.times do
             issue = create(:request_issue, :unidentified, decision_review: review)
             request_issues << { is_unidentified: true, decision_text: issue.unidentified_issue_text }
           end


### PR DESCRIPTION
connects #10041 

### Description

When identical contention text is used, EPE can fail to correctly distinguish new vs old contentions and misidentify the correct contention id to store on the Request Issue record.

Also adds a unique index on the `contention_reference_id` since VBMS has confirmed that those values are globally unique.