### PR TITLE
Attempt to fix flakey reader spec

### DIFF
--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -961,7 +961,7 @@ RSpec.feature "Reader" do
       click_on documents[0].type
       find("h3", text: "Document information").click
       find("#document_description-edit").click
-
+      find("#document_description-save")
       fill_in "document_description", with: "Another New Description"
 
       find("#document_description").send_keys [:enter]


### PR DESCRIPTION
**Why**: Since switching to the headless driver in Circle CI, this
particular test has been flakey. Waiting to see the "Save" link seemed
to work for another similar test, so we are trying the same thing here.

