### PR TITLE
Removing undo column from the session

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -206,7 +206,7 @@ class User < ApplicationRecord
   end
 
   def to_session_hash
-    skip_attrs = %w[full_name created_at updated_at last_login_at]
+    skip_attrs = %w[full_name created_at updated_at last_login_at undo_record_merging]
     serializable_hash.merge("id" => css_id, "name" => full_name).except(*skip_attrs)
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,7 +57,6 @@ describe User do
       {
         "id" => css_id.upcase,
         "station_id" => "310",
-        "undo_record_merging" => nil,
         "css_id" => css_id.upcase,
         "email" => nil,
         "roles" => [],


### PR DESCRIPTION
Resolves #10066 

### Description
I believe we're getting this error https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4235/ because the column `undo_record_merging` is too large.

Removing that from the session.
