### PR TITLE
Fix flakey case details spec

### DIFF
--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -66,21 +66,21 @@ FactoryBot.define do
       after(:build) do |task|
         # rubocop:disable Metrics/LineLength
         example_instructions = {
-          ihp: "Hello.  It appears that the VSO has not reviewed this case and has not provided an IHP.  ",
-          poa_clarification: "We received some correspondence from the Veteran's attorney in November indicating the attorney  wants to withdraw from representation of the Veteran.  I don't see any paperwork from the Veteran appointing a new rep or otherwise acknowledging the withdraw of the old one.  Please contact the Veteran to clarify if they have current representation.  If the Veteran no longer wishes the current representative to act on his behalf, please get that in writing.    ",
-          hearing_clarification: "A March statement filed by the Veteran indicates that they desired a 'Televideo conference hearing' for all their appeals.  No hearing was scheduled.  Please clarify whether the Veteran still desires a Board hearing, and, if so, please reroute as necessary to schedule one.   Thanks!",
-          aoj: "Please clarify whether the Veteran desires AOJ review of any evidence, to include VA treatment records dated through June, submitted since an April statement of the case.  Thank you!",
+          ihp: "Hello. It appears that the VSO has not reviewed this case and has not provided an IHP.",
+          poa_clarification: "We received some correspondence from the Veteran's attorney in November indicating the attorney wants to withdraw from representation of the Veteran. I don't see any paperwork from the Veteran appointing a new rep or otherwise acknowledging the withdraw of the old one. Please contact the Veteran to clarify if they have current representation. If the Veteran no longer wishes the current representative to act on his behalf, please get that in writing.",
+          hearing_clarification: "A March statement filed by the Veteran indicates that they desired a 'Televideo conference hearing' for all their appeals. No hearing was scheduled. Please clarify whether the Veteran still desires a Board hearing, and, if so, please reroute as necessary to schedule one. Thanks!",
+          aoj: "Please clarify whether the Veteran desires AOJ review of any evidence, to include VA treatment records dated through June, submitted since an April statement of the case. Thank you!",
           extension: "The Veteran's POA submitted a letter requesting a 90 day extension. Please send letter granting the extension.",
           missing_hearing_transcripts: "Good evening, could you please return this to the hearing branch as the hearing was just held and the transcripts are not yet available. Thank you.",
           unaccredited_rep: "Unaccredited rep",
-          foia: "The Veteran's representative submitted FOIA request in December of last year, which was acknowledged the same month. To date, there has been no response provided.  Please follow up on the FOIA request.",
+          foia: "The Veteran's representative submitted FOIA request in December of last year, which was acknowledged the same month. To date, there has been no response provided. Please follow up on the FOIA request.",
           retired_vlj: "VLJ Snuffy conducted the hearing in June. Since they are now retired, the Veteran needs to be provided notice of this and an opportunity to request hearing before another VLJ.",
           arneson: "email was sent re Arneson letter/ the Veteran needing to be offered a third hearing.",
           new_rep_arguments: "The Veteran recently switched to a new POA. Please determine if the new POA will provide new arguments for the issues on appeal.",
-          pending_scanning_vbms: "There is a pending scanning banner in VBMS indicating documents from November are pending scanning.  The last documents uploaded to the file are from October.  Please hold the case in abeyance for 2 weeks to allow the documents to be uploaded and the PSB to clear.",
+          pending_scanning_vbms: "There is a pending scanning banner in VBMS indicating documents from November are pending scanning. The last documents uploaded to the file are from October. Please hold the case in abeyance for 2 weeks to allow the documents to be uploaded and the PSB to clear.",
           address_verification: "VACOLS and Caseflow lists two different addresses for the Veteran. From reviewing the recent documents in the file, it appears that the address in Caseflow is the most recent address. Please verify the Veteran's current address and update VACOLS if warranted.",
-          schedule_hearing: "The Veteran has requested a Board hearing as to all appealed issues.  To date, no Board hearing has been scheduled. ",
-          missing_records: "The Veteran had a Board Video Conference Hearing in September with Judge  Snuffy. The Hearing transcripts are not of record. ",
+          schedule_hearing: "The Veteran has requested a Board hearing as to all appealed issues. To date, no Board hearing has been scheduled.",
+          missing_records: "The Veteran had a Board Video Conference Hearing in September with Judge Snuffy. The Hearing transcripts are not of record.",
           translation: "There are multiple document files that still require translation from Spanish to English. The files in Spanish have been marked in Caseflow. Please have these documents translated. Thank you!",
           other: "Please request a waiver of AOJ consideration for new evidence"
         }

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -532,7 +532,7 @@ RSpec.feature "Case details" do
 
         expect(page).to have_content("TASK\n#{Constants::CO_LOCATED_ADMIN_ACTIONS[on_hold_task.action]}")
         find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).click
-        expect(page).to have_content("TASK INSTRUCTIONS\n#{on_hold_task.instructions[0].squeeze(' ')}")
+        expect(page).to have_content("TASK INSTRUCTIONS\n#{on_hold_task.instructions[0].squeeze(' ').strip}")
         expect(page).to have_content("#{assigner_name.first[0]}. #{assigner_name.last}")
 
         expect(Task.find(on_hold_task.id).status).to eq("on_hold")


### PR DESCRIPTION
**Why**: Capybara 3.x no longer normalizes whitespace. So, if the input
text has extra whitespace, like the Task factory did, but the HTML
output doesn't, then comparing the two will fail.

Resolves #10158