### PR TITLE
Switch User unique index to only use css_id

### DIFF
--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -37,7 +37,7 @@ class LegacyWorkQueue
       if css_id && (css_id == user&.css_id) && (user&.station_id == User::BOARD_STATION_ID)
         user
       elsif css_id
-        User.find_or_create_by(css_id: css_id, station_id: User::BOARD_STATION_ID)
+        User.find_by_css_id_or_create_with_default_station_id(css_id)
       end
     end
   end

--- a/app/models/vacols/case_assignment.rb
+++ b/app/models/vacols/case_assignment.rb
@@ -18,10 +18,7 @@ class VACOLS::CaseAssignment < VACOLS::Record
 
   def assigned_by
     assigned_by_user_id = if assigned_by_css_id
-                            User.find_or_create_by(
-                              css_id: assigned_by_css_id,
-                              station_id: User::BOARD_STATION_ID
-                            ).id
+                            User.find_by_css_id_or_create_with_default_station_id(assigned_by_css_id).id
                           end
 
     OpenStruct.new(

--- a/app/repositories/attorney_repository.rb
+++ b/app/repositories/attorney_repository.rb
@@ -4,7 +4,7 @@ class AttorneyRepository
   def self.find_all_attorneys
     records = VACOLS::Staff.where(sactive: "A").where.not(sattyid: nil)
     records.select(&:sdomainid).map do |record|
-      User.find_or_create_by(css_id: record.sdomainid, station_id: User::BOARD_STATION_ID)
+      User.find_by_css_id_or_create_with_default_station_id(record.sdomainid)
     end
   end
 end

--- a/app/repositories/judge_repository.rb
+++ b/app/repositories/judge_repository.rb
@@ -3,7 +3,7 @@
 class JudgeRepository
   def self.find_all_judges
     judge_records.select(&:sdomainid).map do |record|
-      User.find_or_create_by(css_id: record.sdomainid, station_id: User::BOARD_STATION_ID)
+      User.find_by_css_id_or_create_with_default_station_id(record.sdomainid)
     end
   end
 

--- a/db/migrate/20190329211019_users_unique_css_id.rb
+++ b/db/migrate/20190329211019_users_unique_css_id.rb
@@ -1,0 +1,11 @@
+class UsersUniqueCssId < ActiveRecord::Migration[5.1]
+  def up
+    safety_assured { execute "create unique index index_users_unique_css_id on users using btree (upper(css_id))" }
+    remove_index(:users, [:station_id, :css_id])
+  end
+
+  def down
+    safety_assured { execute "drop index index_users_unique_css_id" }
+    add_index(:users, [:station_id, :css_id], unique: true, algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190328163217) do
+ActiveRecord::Schema.define(version: 20190329211019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -987,7 +987,7 @@ ActiveRecord::Schema.define(version: 20190328163217) do
     t.string "selected_regional_office"
     t.string "station_id", null: false
     t.datetime "updated_at"
-    t.index ["station_id", "css_id"], name: "index_users_on_station_id_and_css_id", unique: true
+    t.index "upper((css_id)::text)", name: "index_users_unique_css_id", unique: true
   end
 
   create_table "vbms_uploaded_documents", force: :cascade do |t|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     full_name { "Lauren Roth" }
 
     factory :default_user do
-      css_id { "DSUSER" }
+      css_id { "DEFAULT_USER" }
       full_name { "Lauren Roth" }
       email { "test@example.com" }
       roles { ["Certify Appeal"] }

--- a/spec/feature/switch_user_spec.rb
+++ b/spec/feature/switch_user_spec.rb
@@ -8,10 +8,8 @@ RSpec.feature "Test Users for Demo" do
     ENV["DEPLOY_ENV"] = "development"
     BGSService.end_product_records = { default: BGSService.all_grants }
 
-    User.create(station_id: "283", css_id: User::FUNCTIONS.sample)
-    User.create(station_id: "ABC", css_id: User::FUNCTIONS.sample)
-    User.create(station_id: "283", css_id: "ANNE MERICA")
-    User.authenticate!
+    3.times { create(:user) }
+    User.authenticate! # creates the DSUSER account
   end
 
   scenario "We can switch between users in the database in demo mode" do

--- a/spec/models/concerns/round_robin_assigner_concern_spec.rb
+++ b/spec/models/concerns/round_robin_assigner_concern_spec.rb
@@ -67,7 +67,7 @@ describe RoundRobinAssigner do
     end
 
     context "when the list_of_assignees is a populated array" do
-      let(:assignees) { %w[Harry Hermione Ron] }
+      let(:assignees) { %w[Harry Hermione Ron].map(&:upcase) }
       let(:iterations) { 4 }
       let(:total_distribution_count) { iterations * assignees.length }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -461,29 +461,20 @@ describe User do
       it { is_expected.to be_nil }
     end
 
-    context "2 users exist with different case css id" do
-      let(:station_id) { 123 }
-      let!(:user1) { create(:user, css_id: "foobar", station_id: station_id) }
-      let!(:user2) { create(:user, css_id: "FOOBAR", station_id: station_id) }
+    context "user exists with different station_id" do
+      let(:station_id) { "123" }
+      let(:new_station_id) { "456" }
+      let!(:existing_user) { create(:user, css_id: "foobar", station_id: station_id) }
 
       before do
-        session["user"]["station_id"] = station_id
+        session["user"]["station_id"] = new_station_id
+        session["user"]["id"] = existing_user.css_id
       end
 
-      context "css id is lower" do
-        before { session["user"]["id"] = user1.css_id }
+      it "updates station_id from session" do
+        subject
 
-        it "prefers exact case match" do
-          expect(subject.css_id).to eq user1.css_id
-        end
-      end
-
-      context "css is UPPER" do
-        before { session["user"]["id"] = user2.css_id }
-
-        it "prefers exact case match" do
-          expect(subject.css_id).to eq user2.css_id
-        end
+        expect(existing_user.reload.station_id).to eq(new_station_id)
       end
     end
   end

--- a/spec/services/user_reporter_spec.rb
+++ b/spec/services/user_reporter_spec.rb
@@ -2,13 +2,12 @@
 
 describe UserReporter do
   let!(:user_UC) { create(:user, css_id: "FOOBAR") }
-  let!(:user_dc) { create(:user, css_id: "foobar") }
 
   describe "#report" do
     it "includes all users regardless of case" do
       reporter = described_class.new("foobar")
       expect(reporter.report).to eq([])
-      expect(reporter.user_ids).to include(user_UC.id, user_dc.id)
+      expect(reporter.user_ids).to include(user_UC.id)
     end
   end
 
@@ -17,59 +16,6 @@ describe UserReporter do
       reporter = described_class.new("foobar")
       reporter.report
       expect(described_class.models_with_user_id).to include(model: Intake, column: :user_id)
-    end
-  end
-
-  describe "merging" do
-    let(:duplicate_css_id) { "TeSt_CsS_iD" }
-    let!(:user) { create(:user, css_id: "TEST_CSS_ID") }
-    let!(:duplicate_user) { create(:user, css_id: duplicate_css_id) }
-
-    let!(:associated_hearing_day) { create(:hearing_day, judge_id: duplicate_user.id) }
-    let!(:associated_task) { create(:task, assigned_to: duplicate_user) }
-    let!(:associated_appeal_view) { DocumentView.create!(document_id: "123", user: duplicate_user) }
-
-    describe "#merge_all_users_with_uppercased_user" do
-      it "combines the users" do
-        described_class.new(user).merge_all_users_with_uppercased_user
-
-        expect(associated_hearing_day.reload.judge_id).to eq(user.id)
-        expect(associated_task.reload.assigned_to_id).to eq(user.id)
-        expect(associated_appeal_view.reload.user_id).to eq(user.id)
-      end
-
-      context "when records with unique constraints are duplicated" do
-        let!(:duplicate_appeal) { create(:appeal) }
-        let!(:second_duplicate_appeal) { create(:appeal) }
-        let!(:appeal) { create(:appeal) }
-
-        let!(:duplicated_appeal_view_old) { AppealView.create(appeal: duplicate_appeal, user_id: duplicate_user.id) }
-        let!(:duplicated_appeal_view_new) { AppealView.create(appeal: duplicate_appeal, user_id: user.id) }
-
-        let!(:second_duplicated_appeal_view_old) do
-          AppealView.create(appeal: second_duplicate_appeal, user_id: duplicate_user.id)
-        end
-        let!(:second_duplicated_appeal_view_new) do
-          AppealView.create(appeal: second_duplicate_appeal, user_id: user.id)
-        end
-
-        let!(:appeal_view) { AppealView.create(appeal: appeal, user_id: duplicate_user.id) }
-
-        let!(:duplicated_reader_user) { ReaderUser.create(user_id: duplicate_user.id) }
-        let!(:reader_user) { ReaderUser.create(user_id: user.id) }
-
-        it "deletes the old record's violating rows" do
-          described_class.new(user).merge_all_users_with_uppercased_user
-
-          expect(AppealView.where(appeal: duplicate_appeal, user_id: duplicate_user.id)).to_not exist
-          expect(AppealView.where(appeal: duplicate_appeal, user_id: user.id)).to exist
-          expect(AppealView.where(appeal: second_duplicate_appeal, user_id: duplicate_user.id)).to_not exist
-          expect(AppealView.where(appeal: second_duplicate_appeal, user_id: user.id)).to exist
-          expect(AppealView.where(appeal: appeal, user_id: user.id)).to exist
-          expect(ReaderUser.where(user_id: duplicate_user.id)).to_not exist
-          expect(ReaderUser.where(user_id: user.id)).to exist
-        end
-      end
     end
   end
 end

--- a/spec/support/clear_cache.rb
+++ b/spec/support/clear_cache.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
   config.after(:each) do
     Rails.cache.clear
     REDIS_NAMESPACES.each { |namespace| delete_matched(namespace: namespace) }
-  rescue Errno::ENOENT => err
+  rescue Errno::ENOENT, Errno::ENOTEMPTY => err
     # flakey at CircleCI. Don't fail tests because of this.
     Rails.logger.error(err)
   end


### PR DESCRIPTION
connects #9572 #9444 

### Description

Switches the unique index on the `users` table to focus exclusively on case-insensitive CSS ID, ignoring the station ID. This achieves a few things:

* CSS ID always uppercase
* Station ID may change over time but Active Directory guarantees one unique CSS ID per person.
* Station ID is always updated based on the current auth session, to reflect whatever CSS does upstream.