### PR TITLE
rename specific error classes to avoid rails reload error

### DIFF
--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -1,7 +1,28 @@
 # frozen_string_literal: true
 
+# base class should inherit from StandardError
+class Caseflow::Error::VBMS < StandardError
+  alias body message
+end
+
 # Wraps known VBMS errors so that we can better triage what gets reported in Sentry alerts.
+# Inherits from RuntimeError like VBMS::HTTPError does.
 class VBMSError < RuntimeError
+
+  class IncidentFlash < Caseflow::Error::VBMS; end
+  class Transient < Caseflow::Error::VBMS; end
+  class RatedIssueMissing < Caseflow::Error::VBMS; end
+  class DocumentTooBig < Caseflow::Error::VBMS; end
+  class Security < Caseflow::Error::VBMS; end
+  class DownForMaintenance < Caseflow::Error::VBMS; end
+  class BadPostalCode < Caseflow::Error::VBMS; end
+  class ClaimNotFound < Caseflow::Error::VBMS; end
+  class PIFExistsForEPCode < Caseflow::Error::VBMS; end
+  class DuplicateEP < Caseflow::Error::VBMS; end
+  class UserNotAuthorized < Caseflow::Error::VBMS; end
+  class BadClaim < Caseflow::Error::VBMS; end
+  class CannotDeleteContention < Caseflow::Error::VBMS; end
+
   def initialize(error)
     super(error.message).tap do |result|
       result.set_backtrace(error.backtrace)
@@ -10,42 +31,42 @@ class VBMSError < RuntimeError
 
   KNOWN_ERRORS = {
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3288/
-    "additional review due to an Incident Flash" => "VBMS::IncidentFlashError",
+    "additional review due to an Incident Flash" => "IncidentFlash",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4035/
-    "Could not access remote service at" => "VBMS::TransientError",
+    "Could not access remote service at" => "Transient",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3405/
-    "Unable to associate rated issue, rated issue does not exist" => "VBMS::RatedIssueMissingError",
+    "Unable to associate rated issue, rated issue does not exist" => "RatedIssueMissing",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3894/
-    "Requested result set exceeds acceptable size." => "VBMS::DocumentTooBigError",
+    "Requested result set exceeds acceptable size." => "DocumentTooBig",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3293/
-    "WssVerification Exception - Security Verification Exception" => "VBMS::SecurityError",
+    "WssVerification Exception - Security Verification Exception" => "Security",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3965/
-    "VBMS is currently unavailable due to maintenance." => "VBMS::DownForMaintenanceError",
+    "VBMS is currently unavailable due to maintenance." => "DownForMaintenance",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3274/
-    "The data value of the PostalCode did not satisfy" => "VBMS::BadPostalCodeError",
+    "The data value of the PostalCode did not satisfy" => "BadPostalCode",
 
-    "ClaimNotFoundException thrown in findContentions for ClaimID" => "VBMS::ClaimNotFoundError",
+    "ClaimNotFoundException thrown in findContentions for ClaimID" => "ClaimNotFound",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3276/events/270914/
-    "A PIF for this EP code already exists." => "VBMS::PIFExistsForEPCodeError",
+    "A PIF for this EP code already exists." => "PIFExistsForEPCode",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3288/events/271178/
-    "A duplicate claim for this EP code already exists in CorpDB" => "VBMS::DuplicateEPError",
+    "A duplicate claim for this EP code already exists in CorpDB" => "DuplicateEP",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3467/events/276980/
-    "User is not authorized." => "VBMS::UserNotAuthorizedError",
+    "User is not authorized." => "UserNotAuthorized",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3467/events/278342/
-    "Unable to establish claim: " => "VBMS::BadClaimError",
+    "Unable to establish claim: " => "BadClaim",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4164/events/279584/
-    "The contention is connected to an issue in ratings and cannot be deleted." => "VBMS::CannotDeleteContentionError"
+    "The contention is connected to an issue in ratings and cannot be deleted." => "CannotDeleteContention"
   }.freeze
 
   class << self
@@ -55,7 +76,9 @@ class VBMSError < RuntimeError
       KNOWN_ERRORS.each do |msg_str, error_class_name|
         next unless error_message =~ /#{msg_str}/
 
-        new_error = error_class_name.constantize.new(vbms_http_error)
+        error_class = "VBMSError::#{error_class_name}".constantize
+
+        new_error = error_class.new(vbms_http_error)
         break
       end
       new_error ||= new(vbms_http_error)
@@ -73,20 +96,3 @@ class VBMSError < RuntimeError
     end
   end
 end
-
-class Caseflow::Error::VBMS < StandardError
-  alias body message
-end
-class VBMSIncidentFlashError < Caseflow::Error::VBMS; end
-class VBMSTransientError < Caseflow::Error::VBMS; end
-class VBMSRatedIssueMissingError < Caseflow::Error::VBMS; end
-class VBMSDocumentTooBigError < Caseflow::Error::VBMS; end
-class VBMSSecurityError < Caseflow::Error::VBMS; end
-class VBMSDownForMaintenanceError < Caseflow::Error::VBMS; end
-class VBMSBadPostalCodeError < Caseflow::Error::VBMS; end
-class VBMSClaimNotFoundError < Caseflow::Error::VBMS; end
-class VBMSPIFExistsForEPCodeError < Caseflow::Error::VBMS; end
-class VBMSDuplicateEPError < Caseflow::Error::VBMS; end
-class VBMSUserNotAuthorizedError < Caseflow::Error::VBMS; end
-class VBMSBadClaimError < Caseflow::Error::VBMS; end
-class VBMSCannotDeleteContentionError < Caseflow::Error::VBMS; end

--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -8,7 +8,6 @@ end
 # Wraps known VBMS errors so that we can better triage what gets reported in Sentry alerts.
 # Inherits from RuntimeError like VBMS::HTTPError does.
 class VBMSError < RuntimeError
-
   class IncidentFlash < Caseflow::Error::VBMS; end
   class Transient < Caseflow::Error::VBMS; end
   class RatedIssueMissing < Caseflow::Error::VBMS; end

--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -77,16 +77,16 @@ end
 class Caseflow::Error::VBMS < StandardError
   alias body message
 end
-class VBMS::IncidentFlashError < Caseflow::Error::VBMS; end
-class VBMS::TransientError < Caseflow::Error::VBMS; end
-class VBMS::RatedIssueMissingError < Caseflow::Error::VBMS; end
-class VBMS::DocumentTooBigError < Caseflow::Error::VBMS; end
-class VBMS::SecurityError < Caseflow::Error::VBMS; end
-class VBMS::DownForMaintenanceError < Caseflow::Error::VBMS; end
-class VBMS::BadPostalCodeError < Caseflow::Error::VBMS; end
-class VBMS::ClaimNotFoundError < Caseflow::Error::VBMS; end
-class VBMS::PIFExistsForEPCodeError < Caseflow::Error::VBMS; end
-class VBMS::DuplicateEPError < Caseflow::Error::VBMS; end
-class VBMS::UserNotAuthorizedError < Caseflow::Error::VBMS; end
-class VBMS::BadClaimError < Caseflow::Error::VBMS; end
-class VBMS::CannotDeleteContentionError < Caseflow::Error::VBMS; end
+class VBMSIncidentFlashError < Caseflow::Error::VBMS; end
+class VBMSTransientError < Caseflow::Error::VBMS; end
+class VBMSRatedIssueMissingError < Caseflow::Error::VBMS; end
+class VBMSDocumentTooBigError < Caseflow::Error::VBMS; end
+class VBMSSecurityError < Caseflow::Error::VBMS; end
+class VBMSDownForMaintenanceError < Caseflow::Error::VBMS; end
+class VBMSBadPostalCodeError < Caseflow::Error::VBMS; end
+class VBMSClaimNotFoundError < Caseflow::Error::VBMS; end
+class VBMSPIFExistsForEPCodeError < Caseflow::Error::VBMS; end
+class VBMSDuplicateEPError < Caseflow::Error::VBMS; end
+class VBMSUserNotAuthorizedError < Caseflow::Error::VBMS; end
+class VBMSBadClaimError < Caseflow::Error::VBMS; end
+class VBMSCannotDeleteContentionError < Caseflow::Error::VBMS; end

--- a/spec/exceptions/vbms_error_spec.rb
+++ b/spec/exceptions/vbms_error_spec.rb
@@ -22,7 +22,7 @@ describe VBMSError do
         let(:error) { VBMS::HTTPError.new(500, err_str) }
 
         it "re-casts the exception to a #{err_class}" do
-          expect(subject).to be_a(err_class.constantize)
+          expect(subject).to be_a("VBMSError::#{err_class}".constantize)
         end
       end
     end

--- a/spec/models/ramp_election_spec.rb
+++ b/spec/models/ramp_election_spec.rb
@@ -198,7 +198,7 @@ describe RampElection do
 
         context "when the error is caught by VBMSError wrapper" do
           let(:vbms_error) do
-            VBMS::DuplicateEPError.new("A duplicate claim for this EP code already exists in CorpDB.")
+            VBMSError::DuplicateEP.new("A duplicate claim for this EP code already exists in CorpDB.")
           end
 
           it "raises a parsed EstablishClaimFailedInVBMS error" do


### PR DESCRIPTION
## Description

Fixes local development `reload!` where we got a TypeError with Rails confused about superclass.