### PR TITLE
Allow HearingChangeDispositionJob to accept hearing dispositions as either strings or symbols

### DIFF
--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -42,24 +42,24 @@ class HearingDispositionChangeJob < CaseflowJob
   end
 
   def increment_task_count_for(label)
-    task_count_for[label.to_sym] += 1
+    task_count_for[label] += 1
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def update_task_by_hearing_disposition(task)
     hearing = task.hearing
-    label = hearing.disposition
+    label = hearing.disposition&.to_sym
 
     # rubocop:disable Lint/EmptyWhen
-    case hearing.disposition
-    when Constants.HEARING_DISPOSITION_TYPES.held
+    case hearing.disposition&.to_sym
+    when Constants.HEARING_DISPOSITION_TYPES.held.to_sym
       task.hold!
-    when Constants.HEARING_DISPOSITION_TYPES.cancelled
+    when Constants.HEARING_DISPOSITION_TYPES.cancelled.to_sym
       task.cancel!
-    when Constants.HEARING_DISPOSITION_TYPES.postponed
+    when Constants.HEARING_DISPOSITION_TYPES.postponed.to_sym
       # Postponed hearings should be acted on immediately and the related tasks should be closed. Do not take any
       # action here.
-    when Constants.HEARING_DISPOSITION_TYPES.no_show
+    when Constants.HEARING_DISPOSITION_TYPES.no_show.to_sym
       task.no_show!
     when nil
       # We allow judges and hearings staff 2 days to make changes to the hearing's disposition. If it has been more


### PR DESCRIPTION
Connects #9832.

Hearing dispositions [can be either strings or symbols](https://github.com/department-of-veterans-affairs/caseflow/issues/10225). The code prior to this PR assumed that dispositions would be only strings. This PR updates to allow for dispositions to be either strings or symbols.