### PR TITLE
Preserve VBMS::HTTPError body and code

### DIFF
--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -22,9 +22,14 @@ class VBMSError < RuntimeError
   class BadClaim < Caseflow::Error::VBMS; end
   class CannotDeleteContention < Caseflow::Error::VBMS; end
 
+  attr_accessor :body, :code, :request
+
   def initialize(error)
     super(error.message).tap do |result|
       result.set_backtrace(error.backtrace)
+      result.body = error.try(:body)
+      result.code = error.try(:code)
+      result.request = error.try(:request)
     end
   end
 

--- a/spec/exceptions/vbms_error_spec.rb
+++ b/spec/exceptions/vbms_error_spec.rb
@@ -12,6 +12,14 @@ describe VBMSError do
       expect(vbms_error.message).to eq("oop!")
       expect(vbms_error.backtrace).to eq(trace)
     end
+
+    it "copies over code and body" do
+      orig_error = VBMS::HTTPError.new(500, "oops")
+      vbms_error = described_class.new(orig_error)
+
+      expect(vbms_error.body).to eq("oops")
+      expect(vbms_error.code).to eq(500)
+    end
   end
 
   describe ".from_vbms_http_error" do


### PR DESCRIPTION
Fixes bug where Caseflow::Error::EstablishClaimFailedInVBMS expects something that acts like VBMS::HTTPError