### PR TITLE
Removing asyncable from record_synced_by_job

### DIFF
--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -21,9 +21,8 @@ class UpdateAppellantRepresentationJob < CaseflowJob
     appeals_to_update.each do |a|
       sync_record = a.record_synced_by_job.find_or_create_by(sync_job_name: UpdateAppellantRepresentationJob.name)
 
-      sync_record.attempted!
       appeal_new_task_count, appeal_closed_task_count = TrackVeteranTask.sync_tracking_tasks(a)
-      sync_record.processed!
+      sync_record.update!(processed_at: Time.zone.now)
 
       new_task_count += appeal_new_task_count
       closed_task_count += appeal_closed_task_count

--- a/app/models/record_synced_by_job.rb
+++ b/app/models/record_synced_by_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class RecordSyncedByJob < ApplicationRecord
-  include Asyncable
-
   belongs_to :record, polymorphic: true
 
   def self.next_records_to_process(records, limit)

--- a/db/migrate/20190401192800_remove_columns_from_record_synced_by_job.rb
+++ b/db/migrate/20190401192800_remove_columns_from_record_synced_by_job.rb
@@ -1,0 +1,9 @@
+class RemoveColumnsFromRecordSyncedByJob < ActiveRecord::Migration[5.1]
+  def change
+    safety_assured do
+      remove_column :record_synced_by_jobs, :submitted_at
+      remove_column :record_synced_by_jobs, :attempted_at
+      remove_column :record_synced_by_jobs, :last_submitted_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -760,13 +760,10 @@ ActiveRecord::Schema.define(version: 20190402195624) do
   end
 
   create_table "record_synced_by_jobs", force: :cascade do |t|
-    t.datetime "attempted_at"
     t.string "error"
-    t.datetime "last_submitted_at"
     t.datetime "processed_at"
     t.bigint "record_id"
     t.string "record_type"
-    t.datetime "submitted_at"
     t.string "sync_job_name"
     t.index ["record_type", "record_id"], name: "index_record_synced_by_jobs_on_record_type_and_record_id"
   end

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -66,7 +66,7 @@ describe UpdateAppellantRepresentationJob do
         UpdateAppellantRepresentationJob.perform_now
 
         legacy_appeals.each do |appeal|
-          expect(appeal.reload.record_synced_by_job.first.processed?).to eq(true)
+          expect(appeal.reload.record_synced_by_job.first.processed_at.nil?).to eq(false)
           expect(appeal.tasks.where(type: TrackVeteranTask.name).first.assigned_to)
             .to eq(vso_for_legacy_appeal[appeal.id].first)
         end


### PR DESCRIPTION
Remove Asyncable from record_synced_by_job. We inherited from Asyncable to try and use the same patterns as other jobs. However, it was overkill for this job since it already has a natural retry mechanism. If the job fails, it will retry an hour later. All we really need is a `processed_at` time.
