### PR TITLE
Dismiss dropdowns when clicking outside of the menu

### DIFF
--- a/client/app/components/DropdownButton.jsx
+++ b/client/app/components/DropdownButton.jsx
@@ -21,6 +21,21 @@ export default class DropdownButton extends React.Component {
     this.state = {
       menu: false
     };
+    this.wrapperRef = null;
+  }
+
+  componentDidMount = () => document.addEventListener('mousedown', this.onClickOutside);
+
+  componentWillUnmount = () => document.removeEventListener('mousedown', this.onClickOutside);
+
+  setWrapperRef = (node) => this.wrapperRef = node
+
+  onClickOutside = (event) => {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target) && this.state.menu) {
+      this.setState({
+        menu: false
+      });
+    }
   }
 
   onMenuClick = () => {
@@ -45,7 +60,7 @@ export default class DropdownButton extends React.Component {
       </ul>;
     };
 
-    return <div className="cf-dropdown" {...dropdownBtnContainer}>
+    return <div className="cf-dropdown" ref={this.setWrapperRef} {...dropdownBtnContainer}>
       <a {...dropdownBtn}
         onClick={this.onMenuClick}
         className="cf-dropdown-trigger usa-button usa-button-secondary">

--- a/client/app/queue/components/QueueSelectorDropdown.jsx
+++ b/client/app/queue/components/QueueSelectorDropdown.jsx
@@ -2,25 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 
-import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
+import DropdownButton from '../../components/DropdownButton'
 import COPY from '../../../COPY.json';
 
 // NOTE: parent container needs to be given 'position: relative'
-const styles = {
-  dropdownTrigger: css({
-    marginRight: 0
-  }),
-  dropdownButton: css({
-    position: 'absolute',
-    top: '48px',
-    right: '40px'
-  }),
-  dropdownList: css({
-    top: '3.55rem',
-    right: '0',
-    width: '26rem'
-  })
-};
+const style = css({
+  position: 'absolute',
+  top: '48px',
+  right: '40px'
+});
 
 export default class QueueSelectorDropdown extends React.Component {
   constructor(props) {
@@ -38,38 +28,24 @@ export default class QueueSelectorDropdown extends React.Component {
 
   render = () => {
     const { items } = this.props;
-    let dropdownButtonList;
 
     if (items.length < 1) {
       return null;
     }
 
-    if (this.state.menu) {
-      dropdownButtonList = <ul className="cf-dropdown-menu active" {...styles.dropdownList}>
-        {items.map((item) => {
-          const linkProps = {
-            className: 'usa-button-secondary usa-button',
-            onClick: this.toggleMenuVisible,
-            href: item.href,
-            to: item.to
-          };
+    const list = items.map((item) => {
+      return {
+        title: item.label,
+        target: item.to || item.href
+      };
+    });
 
-          return <li key={item.key}>
-            <Link {...linkProps}>
-              {item.label}
-            </Link>
-          </li>;
-        })}
-      </ul>;
-    }
-
-    return <div className="cf-dropdown" {...styles.dropdownButton}>
-      <a onClick={this.toggleMenuVisible}
-        className="cf-dropdown-trigger usa-button usa-button-secondary"
-        {...styles.dropdownTrigger}>
-        {COPY.CASE_LIST_TABLE_QUEUE_DROPDOWN_LABEL}
-      </a>
-      {dropdownButtonList}
+    return <div className="cf-dropdown" {...style}>
+      <DropdownButton
+        lists={list}
+        onClick={this.toggleMenuVisible}
+        label={COPY.CASE_LIST_TABLE_QUEUE_DROPDOWN_LABEL}
+      />
     </div>;
   }
 }

--- a/client/app/queue/components/QueueSelectorDropdown.jsx
+++ b/client/app/queue/components/QueueSelectorDropdown.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 
-import DropdownButton from '../../components/DropdownButton'
+import DropdownButton from '../../components/DropdownButton';
 import COPY from '../../../COPY.json';
 
 // NOTE: parent container needs to be given 'position: relative'


### PR DESCRIPTION
Resolves #8972

### Description
Added ability to click outside of the dropdown component to dismiss it. Modified the QueueSelectorDropdown to use a component we already have rather then a custom one.

### Acceptance Criteria
- [x] Dropdown in queue can be dismissed by clicking anywhere but the dropdown itself

### Testing Plan
1. Go to a Judge's queue such a BVAEBECKER's
2. Click the "Select view" dropdown
3. Click outside of the dropdown
4. Notice the menu closes

![Untitled](https://user-images.githubusercontent.com/45575454/55363864-9278a900-54ac-11e9-87b3-8e413a923128.gif)