### PR TITLE
Resync EP status on claim review edit

### DIFF
--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -3,6 +3,12 @@
 class ClaimReviewController < ApplicationController
   before_action :verify_access, :react_routed, :verify_feature_enabled, :set_application
 
+  def edit
+    # force sync on initial edit call so that we have latest EP status.
+    # This helps prevent us editing something that recently closed upstream.
+    claim_review.sync_end_product_establishments!
+  end
+
   def update
     if request_issues_update.perform!
       render_success

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -126,6 +126,14 @@ class ClaimReview < DecisionReview
     end
   end
 
+  def sync_end_product_establishments!
+    end_product_establishments.each do |epe|
+      epe.veteran = veteran
+      binding.pry
+      epe.sync!
+    end
+  end
+
   def cleared_ep?
     end_product_establishments.any? { |ep| ep.status_cleared?(sync: true) }
   end

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -127,9 +127,9 @@ class ClaimReview < DecisionReview
   end
 
   def sync_end_product_establishments!
+    # re-use the same veteran object so we only cache End Products once.
     end_product_establishments.each do |epe|
       epe.veteran = veteran
-      binding.pry
       epe.sync!
     end
   end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -173,8 +173,6 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def sync!
-
-    binding.pry
     # There is no need to sync end_product_status if the status
     # is already inactive since an EP can never leave that state
     return true unless status_active?
@@ -184,8 +182,6 @@ class EndProductEstablishment < ApplicationRecord
     # this VBMS call is slow and will cause the transaction below
     # to timeout in some cases.
     contentions
-
-    binding.pry
 
     transaction do
       update!(

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -173,6 +173,8 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def sync!
+
+    binding.pry
     # There is no need to sync end_product_status if the status
     # is already inactive since an EP can never leave that state
     return true unless status_active?
@@ -182,6 +184,8 @@ class EndProductEstablishment < ApplicationRecord
     # this VBMS call is slow and will cause the transaction below
     # to timeout in some cases.
     contentions
+
+    binding.pry
 
     transaction do
       update!(

--- a/lib/fakes/end_product_store.rb
+++ b/lib/fakes/end_product_store.rb
@@ -39,4 +39,10 @@ class Fakes::EndProductStore
   def deflate_and_store(veteran_id, end_products)
     self.class.cache_store.set(veteran_id, end_products.to_json)
   end
+
+  def update_ep_status(veteran_id, claim_id, new_status)
+    eps = fetch_and_inflate(veteran_id)
+    eps[claim_id.to_sym][:status_type_code] = new_status
+    deflate_and_store(veteran_id, eps)
+  end
 end

--- a/spec/controllers/higher_level_reviews_controller_spec.rb
+++ b/spec/controllers/higher_level_reviews_controller_spec.rb
@@ -17,6 +17,10 @@ describe HigherLevelReviewsController, type: :controller do
   let(:user) { create(:default_user) }
 
   describe "#edit" do
+    before do
+      hlr.establish!
+    end
+
     it "finds by UUID" do
       get :edit, params: { claim_id: hlr.uuid }
 
@@ -24,8 +28,6 @@ describe HigherLevelReviewsController, type: :controller do
     end
 
     it "finds by EPE reference_id" do
-      hlr.end_product_establishments.first.update!(reference_id: "abc123")
-
       get :edit, params: { claim_id: hlr.end_product_establishments.first.reference_id }
 
       expect(response.status).to eq 200

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -10,10 +10,6 @@ feature "Higher Level Review Edit issues" do
     FeatureToggle.enable!(:intakeAma)
 
     Timecop.freeze(post_ama_start_date)
-
-    # skip the sync call since all edit requests require resyncing
-    # currently, we're not mocking out vbms and bgs
-    allow_any_instance_of(EndProductEstablishment).to receive(:sync!).and_return(nil)
   end
 
   after do
@@ -1093,8 +1089,8 @@ feature "Higher Level Review Edit issues" do
         ep = higher_level_review.reload.end_product_establishments.first.result
         ep_store = Fakes::EndProductStore.new
         ep_store.update_ep_status(veteran.file_number, ep.claim_id, "CLR")
-      end 
-      
+      end
+
       it "syncs on initial GET" do
         expect(higher_level_review.end_product_establishments.first.last_synced_at).to be_nil
 
@@ -1121,6 +1117,10 @@ feature "Higher Level Review Edit issues" do
     before do
       FeatureToggle.enable!(:remove_decision_reviews, users: [current_user.css_id])
       OrganizationsUser.add_user_to_organization(current_user, non_comp_org)
+
+      # skip the sync call since all edit requests require resyncing
+      # currently, we're not mocking out vbms and bgs
+      allow_any_instance_of(EndProductEstablishment).to receive(:sync!).and_return(nil)
     end
 
     after do

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -1088,6 +1088,22 @@ feature "Higher Level Review Edit issues" do
       end
     end
 
+    context "when EPs have cleared very recently" do
+      before do
+        ep = higher_level_review.reload.end_product_establishments.first.result
+        ep_store = Fakes::EndProductStore.new
+        ep_store.update_ep_status(veteran.file_number, ep.claim_id, "CLR")
+      end 
+      
+      it "syncs on initial GET" do
+        expect(higher_level_review.end_product_establishments.first.last_synced_at).to be_nil
+
+        visit "higher_level_reviews/#{rating_ep_claim_id}/edit/"
+        expect(page).to have_current_path("/higher_level_reviews/#{rating_ep_claim_id}/edit/cleared_eps")
+        expect(page).to have_content("Issues Not Editable")
+      end
+    end
+
     context "when withdraw decision reviews is enabled" do
       before { FeatureToggle.enable!(:withdraw_decision_review, users: [current_user.css_id]) }
       after { FeatureToggle.disable!(:withdraw_decision_review, users: [current_user.css_id]) }

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -10,10 +10,6 @@ feature "Supplemental Claim Edit issues" do
     FeatureToggle.enable!(:intakeAma)
 
     Timecop.freeze(post_ama_start_date)
-
-    # skip the sync call since all edit requests require resyncing
-    # currently, we're not mocking out vbms and bgs
-    allow_any_instance_of(EndProductEstablishment).to receive(:sync!).and_return(nil)
   end
 
   after do
@@ -550,6 +546,22 @@ feature "Supplemental Claim Edit issues" do
       end
     end
 
+    context "when EPs have cleared very recently" do
+      before do
+        ep = supplemental_claim.reload.end_product_establishments.first.result
+        ep_store = Fakes::EndProductStore.new
+        ep_store.update_ep_status(veteran.file_number, ep.claim_id, "CLR")
+      end
+
+      it "syncs on initial GET" do
+        expect(supplemental_claim.end_product_establishments.first.last_synced_at).to be_nil
+
+        visit "supplemental_claims/#{rating_ep_claim_id}/edit/"
+        expect(page).to have_current_path("/supplemental_claims/#{rating_ep_claim_id}/edit/cleared_eps")
+        expect(page).to have_content("Issues Not Editable")
+      end
+    end
+
     context "when withdraw decision reviews is enabled" do
       before { FeatureToggle.enable!(:withdraw_decision_review, users: [current_user.css_id]) }
       after { FeatureToggle.disable!(:withdraw_decision_review, users: [current_user.css_id]) }
@@ -567,6 +579,10 @@ feature "Supplemental Claim Edit issues" do
     before do
       FeatureToggle.enable!(:remove_decision_reviews, users: [current_user.css_id])
       OrganizationsUser.add_user_to_organization(current_user, non_comp_org)
+
+      # skip the sync call since all edit requests require resyncing
+      # currently, we're not mocking out vbms and bgs
+      allow_any_instance_of(EndProductEstablishment).to receive(:sync!).and_return(nil)
     end
 
     after do

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -879,4 +879,23 @@ describe ClaimReview do
       expect(hlr.claim_veteran).to eq(veteran)
     end
   end
+
+  describe "#sync_end_product_establishments!" do
+    let!(:veteran) { create(:veteran) }
+    let!(:claim_review) { create(:higher_level_review, veteran_file_number: veteran.file_number) }
+    let!(:end_product_establishment) do
+      create(:end_product_establishment, source: claim_review, veteran_file_number: veteran.file_number)
+    end
+
+    before do
+      claim_review.create_issues!([rating_request_issue])
+      claim_review.establish!
+    end
+
+    it "syncs all EPEs" do
+      expect(claim_review.end_product_establishments.first.last_synced_at).to be_nil
+      claim_review.reload.sync_end_product_establishments!
+      expect(claim_review.end_product_establishments.first.last_synced_at).to_not be_nil
+    end
+  end
 end


### PR DESCRIPTION
connects #10102 

## Description

Fixes bug where an EP is closed more recently than the regular sync cron job has run and a user tries to edit the claim review. This is similar to #9519 for the sync at start of Intake.