### PR TITLE
Fixing VSO method when there is non POA

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -323,7 +323,7 @@ class Appeal < DecisionReview
   end
 
   def vsos
-    vso_participant_ids = power_of_attorneys.map(&:participant_id)
+    vso_participant_ids = power_of_attorneys.map(&:participant_id) - [nil]
     Vso.where(participant_id: vso_participant_ids)
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -335,7 +335,7 @@ class LegacyAppeal < ApplicationRecord
   delegate :representatives, to: :case_record
 
   def vsos
-    Vso.where(participant_id: [power_of_attorney.bgs_participant_id])
+    Vso.where(participant_id: [power_of_attorney.bgs_participant_id] - [nil])
   end
 
   def contested_claim

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -514,6 +514,24 @@ describe Appeal do
         expect(appeal.vsos.count).to eq(1)
         expect(appeal.vsos.first.name).to eq("Paralyzed Veterans Of America")
       end
+
+      context "when there is no VSO" do
+        let(:participant_id_with_nil) { "1234" }
+        before do
+          allow_any_instance_of(BGSService).to receive(:fetch_poas_by_participant_ids)
+            .with([participant_id_with_nil]).and_return(
+              participant_id_with_pva => nil
+            )
+        end
+        let(:appeal) do
+          create(:appeal, claimants: [create(:claimant, participant_id: participant_id_with_nil)])
+        end
+        let!(:vsos) { Vso.create(name: "Test VSO") }
+
+        it "does not return VSOs with nil participant_id" do
+          expect(appeal.vsos).to eq([])
+        end
+      end
     end
   end
 

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2351,4 +2351,18 @@ describe LegacyAppeal do
       end
     end
   end
+
+  context "#vsos" do
+    context "when there is no VSO" do
+      before do
+        allow_any_instance_of(PowerOfAttorney).to receive(:bgs_participant_id).and_return(nil)
+      end
+      let!(:vsos) { Vso.create(name: "Test VSO") }
+      let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
+
+      it "does not return VSOs with nil participant_id" do
+        expect(appeal.vsos).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #10234

### Description
When a Veteran has no POA, the participant_id is nil. In this case we look up any VSOs in our database with a nil POA. For some reason we've recently added a few. Looks like some field VSOs may not have a participant id. Regardless we don't want to pull in any VSO if the Veteran doesn't have representation.
