### PR TITLE
Check BGS access before loading case details page

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -3,6 +3,7 @@
 class AppealsController < ApplicationController
   before_action :react_routed
   before_action :set_application, only: [:document_count]
+  before_action :verify_bgs_sensitivity, only: [:show]
   # Only whitelist endpoints VSOs should have access to.
   skip_before_action :deny_vso_access, only: [:index, :power_of_attorney, :show_case_list, :show, :veteran, :hearings]
 
@@ -151,6 +152,10 @@ class AppealsController < ApplicationController
 
   def set_application
     RequestStore.store[:application] = "queue"
+  end
+
+  def verify_bgs_sensitivity
+    fail(ActionForbiddenError) unless BGSService.new.can_access?(appeal.veteran_file_number)
   end
 
   def json_appeals(appeals)

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -344,7 +344,9 @@
   "TEAM_MANAGEMENT_IHP_WRITING_VSO_OPTION": "IHP-writing VSO",
   "TEAM_MANAGEMENT_FIELD_VSO_OPTION": "Field VSO",
 
+  "ACCESS_DENIED_TITLE": "Additional access needed",
   "UNAUTHORIZED_PAGE_ACCESS_MESSAGE": "You aren't authorized to use this part of Caseflow yet.",
+  "CASE_DETAILS_LOADING_FAILURE_TITLE": "Unable to load this case",
 
   "JUDGE_ASSIGN_TASK_LABEL": "assign",
   "JUDGE_DECISION_REVIEW_TASK_LABEL": "review",

--- a/client/app/components/LoadingDataDisplay.jsx
+++ b/client/app/components/LoadingDataDisplay.jsx
@@ -3,13 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LoadingScreen from './LoadingScreen';
 import StatusMessage from './StatusMessage';
+import COPY from '../../COPY.json';
 
 const PROMISE_RESULTS = {
   SUCCESS: 'SUCCESS',
   FAILURE: 'FAILURE'
 };
 
-const accessDeniedTitle = { title: 'Additional access needed' };
+const accessDeniedTitle = { title: COPY.ACCESS_DENIED_TITLE };
 const accessDeniedMsg = <div>
         It looks like you do not have the necessary level of access to view this information.<br />
         Please check with your application administrator before trying again.</div>;

--- a/client/app/queue/CaseDetailsLoadingScreen.jsx
+++ b/client/app/queue/CaseDetailsLoadingScreen.jsx
@@ -7,6 +7,7 @@ import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
 import { prepareAppealForStore, prepareAllTasksForStore } from './utils';
 import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import COPY from '../../COPY.json';
 
 import { onReceiveAppealDetails, onReceiveTasks, setAttorneysOfJudge, fetchAllAttorneys } from './QueueActions';
 
@@ -81,7 +82,7 @@ class CaseDetailLoadingScreen extends React.PureComponent {
         message: 'Loading this case...'
       }}
       failStatusMessageProps={{
-        title: 'Unable to load this case'
+        title: COPY.CASE_DETAILS_LOADING_FAILURE_TITLE
       }}
       failStatusMessageChildren={failStatusMessageChildren}>
       {this.props.children}

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -901,4 +901,73 @@ RSpec.feature "Case details" do
       end
     end
   end
+
+  describe "Case details page access control" do
+    let(:queue_home_path) { "/queue" }
+    let(:case_details_page_path) { "/queue/appeals/#{appeal.external_id}" }
+
+    context "when the current user does not have high enough BGS sensitivity level" do
+      before do
+        allow_any_instance_of(BGSService).to receive(:can_access?).and_return(false)
+      end
+
+      context "when the appeal is a legacy appeal" do
+        let!(:appeal) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+
+        # Assign a task to the current user so that a row appears on the queue page.
+        let!(:task) { FactoryBot.create(:ama_attorney_task, appeal: appeal, assigned_to: attorney_user) }
+
+        context "when we navigate directly to the case details page" do
+          it "displays a loading failed message on the case details page" do
+            visit(case_details_page_path)
+            expect(page).to have_content(COPY::CASE_DETAILS_LOADING_FAILURE_TITLE)
+            expect(page).to have_current_path(case_details_page_path)
+          end
+        end
+
+        context "when we click into the case details page from the queue table view" do
+          it "displays a loading failed message on the case details page" do
+            visit(queue_home_path)
+            click_on("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")
+            expect(page).to have_content(COPY::CASE_DETAILS_LOADING_FAILURE_TITLE)
+            expect(page).to have_current_path(case_details_page_path)
+          end
+        end
+      end
+    end
+
+    context "when the current user has high enough BGS sensitivity level" do
+      before do
+        allow_any_instance_of(BGSService).to receive(:can_access?).and_return(true)
+      end
+
+      context "when the appeal is a legacy appeal" do
+        let!(:appeal) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+
+        # Assign a task to the current user so that a row appears on the queue page.
+        let!(:task) { FactoryBot.create(:ama_attorney_task, appeal: appeal, assigned_to: attorney_user) }
+
+        context "when we navigate directly to the case details page" do
+          it "displays a loading failed message on the case details page" do
+            visit(case_details_page_path)
+            expect(page).to_not have_content(COPY::CASE_DETAILS_LOADING_FAILURE_TITLE)
+            # The presence of the task snapshot element indicates that the case details page loaded.
+            expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL)
+            expect(page).to have_current_path(case_details_page_path)
+          end
+        end
+
+        context "when we click into the case details page from the queue table view" do
+          it "displays a loading failed message on the case details page" do
+            visit(queue_home_path)
+            click_on("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")
+            expect(page).to_not have_content(COPY::CASE_DETAILS_LOADING_FAILURE_TITLE)
+            # The presence of the task snapshot element indicates that the case details page loaded.
+            expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL)
+            expect(page).to have_current_path(case_details_page_path)
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #7922. Makes a request to BGS to confirm the current user can access the appeal on the case details page (for sensitivity reasons or POA reasons).

Currently just displays the failure to load screen. We should display a more precise error message in the future, but I think this is a fine solution for the time being. Open to discussion though!