### PR TITLE
Can use quick_to_hash for open hearing days

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -188,7 +188,7 @@ class HearingDay < ApplicationRecord
           nil
         else
           HearingDay.to_hash(value[:hearing_day]).slice(:id, :scheduled_for, :request_type, :room).tap do |day|
-            day[:hearings] = scheduled_hearings.map { |hearing| hearing.to_hash(current_user_id) }
+            day[:hearings] = scheduled_hearings.map { |hearing| hearing.quick_to_hash(current_user_id) }
             day[:total_slots] = total_slots
           end
         end


### PR DESCRIPTION
We don't need any BGS information in the open hearing days query.
