### PR TITLE
Issues weren't displaying correctly on AMA HW

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -118,7 +118,7 @@ class Hearing < ApplicationRecord
 
   def worksheet_issues
     request_issues.map do |request_issue|
-      HearingIssueNote.select("*").joins(:request_issue)
+      HearingIssueNote.joins(:request_issue)
         .find_or_create_by(request_issue: request_issue, hearing: self).to_hash
     end
   end

--- a/app/models/hearing_issue_note.rb
+++ b/app/models/hearing_issue_note.rb
@@ -5,10 +5,16 @@ class HearingIssueNote < ApplicationRecord
   belongs_to :hearing
 
   delegate :docket_name, to: :hearing
+  delegate :diagnostic_code, to: :request_issue
+  delegate :description, to: :request_issue
+  delegate :notes, to: :request_issue
+  delegate :benefit_type, to: :request_issue
+
+  alias program benefit_type
 
   def to_hash
     serializable_hash(
-      methods: :docket_name,
+      methods: [:docket_name, :diagnostic_code, :description, :notes, :program],
       include: [hearing: { methods: [:external_id] }]
     )
   end


### PR DESCRIPTION
Resolves #10260 

We weren't mapping issue fields correctly in the ContestedIssues component. This PR updates the HearingIssueNote model to pull in the correct information.
