### PR TITLE
Separate QR feature test from other queue tests

### DIFF
--- a/spec/feature/hearing_schedule/schedule_veteran_spec.rb
+++ b/spec/feature/hearing_schedule/schedule_veteran_spec.rb
@@ -38,6 +38,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
     end
 
     let!(:veteran) { create(:veteran, file_number: "123454787") }
+    let!(:hearing_location_dropdown_label) { "Suggested Hearing Location" }
 
     scenario "Schedule Veteran for central hearing" do
       visit "hearings/schedule/assign"
@@ -50,6 +51,9 @@ RSpec.feature "Schedule Veteran For A Hearing" do
       expect(page).to have_content("Currently active tasks", wait: 30)
       click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
       expect(page).to have_content("Time")
+
+      # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
+      expect(page).to have_content(hearing_location_dropdown_label)
       click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
       find("label", text: "9:00 am").click
       click_button("Schedule")

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "AmaQueue" do
   def valid_document_id
     "12345-12345678"
   end
+
   context "user with case details role " do
     let!(:appeal) { FactoryBot.create(:appeal) }
     let(:no_queue_user) { FactoryBot.create(:user, roles: ["Case Details"]) }
@@ -31,6 +32,7 @@ RSpec.feature "AmaQueue" do
       end
     end
   end
+
   context "loads appellant detail view" do
     let(:attorney_first_name) { "Robby" }
     let(:attorney_last_name) { "McDobby" }
@@ -398,196 +400,6 @@ RSpec.feature "AmaQueue" do
         expect(page).to have_content(appeals.first.docket_number)
         expect(page).to_not have_content(appeals.second.docket_number)
       end
-    end
-  end
-
-  context "QR flow" do
-    let(:veteran_first_name) { "Marissa" }
-    let(:veteran_last_name) { "Vasquez" }
-    let(:veteran_full_name) { "#{veteran_first_name} #{veteran_last_name}" }
-    let!(:veteran) { FactoryBot.create(:veteran, first_name: veteran_first_name, last_name: veteran_last_name) }
-
-    let(:qr_user_name) { "QR User" }
-    let(:qr_user_name_short) { "Q. User" }
-    let!(:qr_user) { FactoryBot.create(:user, roles: ["Reader"], full_name: qr_user_name) }
-
-    let(:judge_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Javitz") }
-    let!(:judge_staff) { FactoryBot.create(:staff, :judge_role, user: judge_user) }
-
-    let(:attorney_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Nicole Apple") }
-    let!(:attorney_staff) { FactoryBot.create(:staff, :attorney_role, user: attorney_user) }
-
-    let!(:quality_review_organization) { QualityReview.singleton }
-    let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
-    let!(:appeal) { FactoryBot.create(:appeal, veteran_file_number: veteran.file_number) }
-    let!(:request_issue) { create(:request_issue, decision_review: appeal) }
-
-    let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
-    let!(:judge_task) do
-      FactoryBot.create(:ama_judge_task, appeal: appeal, parent: root_task, assigned_to: judge_user, status: :completed)
-    end
-    let!(:qr_task) do
-      FactoryBot.create(
-        :qr_task,
-        :in_progress,
-        assigned_to: quality_review_organization,
-        assigned_by: judge_user,
-        parent: root_task,
-        appeal: appeal
-      )
-    end
-
-    let!(:qr_instructions) { "Fix this case!" }
-
-    before do
-      ["Reba Janowiec", "Lee Jiang", "Pearl Jurs"].each do |judge_name|
-        FactoryBot.create(
-          :staff,
-          :judge_role,
-          user: FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: judge_name)
-        )
-      end
-
-      OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
-
-      FactoryBot.create(:staff, user: qr_user)
-      OrganizationsUser.add_user_to_organization(qr_user, quality_review_organization)
-      User.authenticate!(user: qr_user)
-    end
-
-    scenario "return case to judge" do
-      expect(QualityReviewTask.count).to eq 1
-      # step "QR user visits the quality review organization page and assigns the task to themself"
-      visit quality_review_organization.path
-      click_on veteran_full_name
-
-      find(".Select-control", text: "Select an action").click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label]).click
-
-      fill_in "taskInstructions", with: "Review the quality"
-      click_on "Submit"
-
-      expect(page).to have_content("Task assigned to #{qr_user_name}")
-
-      expect(QualityReviewTask.count).to eq 2
-
-      # step "QR user returns the case to a judge"
-      click_on "Caseflow"
-
-      click_on veteran_full_name
-
-      find(".Select-control", text: "Select an action").click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.RETURN_TO_JUDGE.to_h[:label]).click
-
-      expect(dropdown_selected_value(find(".cf-modal-body"))).to eq judge_user.full_name
-      fill_in "taskInstructions", with: qr_instructions
-
-      click_on "Submit"
-
-      expect(page).to have_content("On hold (3)")
-
-      # step "judge reviews case and assigns a task to an attorney"
-      User.authenticate!(user: judge_user)
-
-      visit "/queue"
-
-      click_on veteran_full_name
-
-      find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL, match: :first).click
-
-      expect(page).to have_content(qr_instructions)
-
-      find(".Select-control", text: "Select an action", match: :first).click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h[:label]).click
-
-      find(".Select-control", text: "Select a user").click
-      find("div", class: "Select-option", text: "Other").click
-
-      find(".Select-control", text: "Select a user").click
-      first("div", class: "Select-option", text: attorney_user.full_name).click
-      click_on "Submit"
-
-      expect(page).to have_content("Assigned 1 case")
-
-      # step "attorney completes task and returns the case to the judge"
-      User.authenticate!(user: attorney_user)
-
-      visit "/queue"
-
-      click_on veteran_full_name
-
-      find(".Select-control", text: "Select an action").click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h[:label]).click
-
-      expect(page).not_to have_content("Select special issues (optional)")
-
-      expect(page).to have_content("Add decisions")
-      all("button", text: "+ Add decision", count: 1)[0].click
-      expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
-
-      fill_in "Text Box", with: "test"
-      find(".Select-control", text: "Select disposition").click
-      find("div", class: "Select-option", text: "Allowed").click
-
-      click_on "Save"
-
-      click_on "Continue"
-
-      expect(page).to have_content("Submit Draft Decision for Review")
-
-      fill_in "Document ID:", with: valid_document_id
-      # the judge should be pre selected
-      expect(page).to have_content(judge_user.full_name)
-      fill_in "notes", with: "all done"
-
-      click_on "Continue"
-
-      expect(page).to have_content(
-        "Thank you for drafting #{veteran_full_name}'s decision. It's been sent to #{judge_user.full_name} for review."
-      )
-
-      # step "judge completes task"
-      User.authenticate!(user: judge_user)
-
-      visit "/queue"
-
-      click_on veteran_full_name
-
-      find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL, match: :first).click
-      expect(page).to have_content(qr_instructions)
-
-      find(".Select-control", text: "Select an action", match: :first).click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label]).click
-
-      expect(page).to have_content("Mark as complete")
-
-      click_on "Mark complete"
-
-      expect(page).to have_content("#{veteran_full_name}'s case has been marked complete")
-
-      # step "QR reviews case"
-      User.authenticate!(user: qr_user)
-
-      visit "/queue"
-
-      click_on veteran_full_name
-
-      expect(page).to have_content(COPY::CASE_TIMELINE_ATTORNEY_TASK)
-      find(".Select-control", text: "Select an action").click
-      find("div", class: "Select-option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label]).click
-
-      expect(page).to have_content("Mark as complete")
-
-      click_on "Mark complete"
-
-      expect(page).to have_content("#{veteran_full_name}'s case has been marked complete")
-      # ensure no duplicate org tasks
-      page.go_back
-      case_timeline_rows = page.find_all("table#case-timeline-table tbody tr")
-      quality_review_tasks_on_timeline = case_timeline_rows.select do |html_node|
-        html_node.has_content?("QualityReviewTask")
-      end
-      expect(quality_review_tasks_on_timeline.length).to eq(1)
     end
   end
 

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Quality Review worflow" do
+  let(:valid_document_id) { "12345-12345678" }
+
+  let(:veteran_first_name) { "Marissa" }
+  let(:veteran_last_name) { "Vasquez" }
+  let(:veteran_full_name) { "#{veteran_first_name} #{veteran_last_name}" }
+  let!(:veteran) { FactoryBot.create(:veteran, first_name: veteran_first_name, last_name: veteran_last_name) }
+
+  let(:qr_user_name) { "QR User" }
+  let(:qr_user_name_short) { "Q. User" }
+  let!(:qr_user) { FactoryBot.create(:user, roles: ["Reader"], full_name: qr_user_name) }
+
+  let(:judge_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Javitz") }
+  let!(:judge_staff) { FactoryBot.create(:staff, :judge_role, user: judge_user) }
+
+  let(:attorney_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Nicole Apple") }
+  let!(:attorney_staff) { FactoryBot.create(:staff, :attorney_role, user: attorney_user) }
+
+  let!(:quality_review_organization) { QualityReview.singleton }
+  let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
+  let!(:appeal) { FactoryBot.create(:appeal, veteran_file_number: veteran.file_number) }
+  let!(:request_issue) { create(:request_issue, decision_review: appeal) }
+
+  let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+  let!(:judge_task) do
+    FactoryBot.create(:ama_judge_task, appeal: appeal, parent: root_task, assigned_to: judge_user, status: :completed)
+  end
+  let!(:qr_task) do
+    FactoryBot.create(
+      :qr_task,
+      :in_progress,
+      assigned_to: quality_review_organization,
+      assigned_by: judge_user,
+      parent: root_task,
+      appeal: appeal
+    )
+  end
+
+  let!(:qr_instructions) { "Fix this case!" }
+
+  before do
+    ["Reba Janowiec", "Lee Jiang", "Pearl Jurs"].each do |judge_name|
+      FactoryBot.create(
+        :staff,
+        :judge_role,
+        user: FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: judge_name)
+      )
+    end
+
+    OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
+
+    FactoryBot.create(:staff, user: qr_user)
+    OrganizationsUser.add_user_to_organization(qr_user, quality_review_organization)
+    User.authenticate!(user: qr_user)
+  end
+
+  scenario "return case to judge" do
+    expect(QualityReviewTask.count).to eq 1
+    # step "QR user visits the quality review organization page and assigns the task to themself"
+    visit quality_review_organization.path
+    click_on veteran_full_name
+
+    find(".Select-control", text: "Select an action").click
+    find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label]).click
+
+    fill_in "taskInstructions", with: "Review the quality"
+    click_on "Submit"
+
+    expect(page).to have_content("Task assigned to #{qr_user_name}")
+
+    expect(QualityReviewTask.count).to eq 2
+
+    # step "QR user returns the case to a judge"
+    click_on "Caseflow"
+
+    click_on veteran_full_name
+
+    find(".Select-control", text: "Select an action").click
+    find("div", class: "Select-option", text: Constants.TASK_ACTIONS.RETURN_TO_JUDGE.to_h[:label]).click
+
+    expect(dropdown_selected_value(find(".cf-modal-body"))).to eq judge_user.full_name
+    fill_in "taskInstructions", with: qr_instructions
+
+    click_on "Submit"
+
+    expect(page).to have_content("On hold (3)")
+
+    # step "judge reviews case and assigns a task to an attorney"
+    User.authenticate!(user: judge_user)
+
+    visit "/queue"
+
+    click_on veteran_full_name
+
+    find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL, match: :first).click
+
+    expect(page).to have_content(qr_instructions)
+
+    find(".Select-control", text: "Select an action", match: :first).click
+    find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h[:label]).click
+
+    find(".Select-control", text: "Select a user").click
+    find("div", class: "Select-option", text: "Other").click
+
+    find(".Select-control", text: "Select a user").click
+    first("div", class: "Select-option", text: attorney_user.full_name).click
+    click_on "Submit"
+
+    expect(page).to have_content("Assigned 1 case")
+
+    # step "attorney completes task and returns the case to the judge"
+    User.authenticate!(user: attorney_user)
+
+    visit "/queue"
+
+    click_on veteran_full_name
+
+    find(".Select-control", text: "Select an action").click
+    find("div", class: "Select-option", text: Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h[:label]).click
+
+    expect(page).not_to have_content("Select special issues (optional)")
+
+    expect(page).to have_content("Add decisions")
+    all("button", text: "+ Add decision", count: 1)[0].click
+    expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+
+    fill_in "Text Box", with: "test"
+    find(".Select-control", text: "Select disposition").click
+    find("div", class: "Select-option", text: "Allowed").click
+
+    click_on "Save"
+
+    click_on "Continue"
+
+    expect(page).to have_content("Submit Draft Decision for Review")
+
+    fill_in "Document ID:", with: valid_document_id
+    # the judge should be pre selected
+    expect(page).to have_content(judge_user.full_name)
+    fill_in "notes", with: "all done"
+
+    click_on "Continue"
+
+    expect(page).to have_content(
+      "Thank you for drafting #{veteran_full_name}'s decision. It's been sent to #{judge_user.full_name} for review."
+    )
+
+    # step "judge completes task"
+    User.authenticate!(user: judge_user)
+
+    visit "/queue"
+
+    click_on veteran_full_name
+
+    find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL, match: :first).click
+    expect(page).to have_content(qr_instructions)
+
+    find(".Select-control", text: "Select an action", match: :first).click
+    find("div", class: "Select-option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label]).click
+
+    expect(page).to have_content("Mark as complete")
+
+    click_on "Mark complete"
+
+    expect(page).to have_content("#{veteran_full_name}'s case has been marked complete")
+
+    # step "QR reviews case"
+    User.authenticate!(user: qr_user)
+
+    visit "/queue"
+
+    click_on veteran_full_name
+
+    expect(page).to have_content(COPY::CASE_TIMELINE_ATTORNEY_TASK)
+    find(".Select-control", text: "Select an action").click
+    find("div", class: "Select-option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label]).click
+
+    expect(page).to have_content("Mark as complete")
+
+    click_on "Mark complete"
+
+    expect(page).to have_content("#{veteran_full_name}'s case has been marked complete")
+    # ensure no duplicate org tasks
+    page.go_back
+    case_timeline_rows = page.find_all("table#case-timeline-table tbody tr")
+    quality_review_tasks_on_timeline = case_timeline_rows.select do |html_node|
+      html_node.has_content?("QualityReviewTask")
+    end
+    expect(quality_review_tasks_on_timeline.length).to eq(1)
+  end
+end


### PR DESCRIPTION
Separate a feature test that occasionally times out ([example here](https://circleci.com/gh/department-of-veterans-affairs/caseflow/56429)) in the hopes that this will reduce the frequency of that happening.