### PR TITLE
Silence transient VBMS errors in Sentry

### DIFF
--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -35,6 +35,9 @@ class VBMSError < RuntimeError
   end
 
   KNOWN_ERRORS = {
+    # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4403/events/293678/
+    "FAILED FOR UNKNOWN REASONS" => "Transient",
+
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3288/
     "additional review due to an Incident Flash" => "IncidentFlash",
 

--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -17,6 +17,9 @@ class DecisionReviewProcessJob < CaseflowJob
 
     begin
       return_value = decision_review.establish!
+    rescue VBMSError::Transient => err
+      decision_review.update_error!(err.inspect)
+      # no need to tell Sentry about it
     rescue StandardError => err
       decision_review.update_error!(err.inspect)
       Raven.capture_exception(err)


### PR DESCRIPTION
connects #9799 

### Description

Add a new Transient VBMS error match, and do not log transient errors to Sentry (similar to what we already do for transient BGS errors).