### PR TITLE
revert change to use key from react virtualized

### DIFF
--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -124,14 +124,14 @@ export class PdfFile extends React.PureComponent {
     }
   }
 
-  getPage = ({ rowIndex, columnIndex, style, key, isVisible }) => {
+  getPage = ({ rowIndex, columnIndex, style, isVisible }) => {
     const pageIndex = (this.columnCount * rowIndex) + columnIndex;
 
     if (pageIndex >= this.props.pdfDocument.pdfInfo.numPages) {
-      return <div key={key} style={style} />;
+      return <div key={(this.columnCount * rowIndex) + columnIndex} style={style} />;
     }
 
-    return <div key={key} style={style}>
+    return <div key={pageIndex} style={style}>
       <PdfPage
         documentId={this.props.documentId}
         file={this.props.file}


### PR DESCRIPTION
Resolves #4829
See issue https://github.com/department-of-veterans-affairs/appeals-support/issues/4829.
revert change to use react virtualized keys, which was an unnecessary change in the 1000+ pages PR, use page number instead. keys were being reused when going from single to multiple column layouts, which was incorrect