### PR TITLE
Removing link to travel board docket

### DIFF
--- a/client/app/hearingSchedule/components/DetailsSections.jsx
+++ b/client/app/hearingSchedule/components/DetailsSections.jsx
@@ -44,9 +44,10 @@ export const Overview = ({
   <DetailsOverview columns={[
     {
       label: 'Hearing Date',
-      value: <Link to={`/schedule/docket/${hearingDayId}`}>
-        <strong>{DateUtil.formatDateStr(scheduledFor)}</strong>
-      </Link>
+      value: readableRequestType === 'Travel' ? <strong>{DateUtil.formatDateStr(scheduledFor)}</strong> :
+        <Link to={`/schedule/docket/${hearingDayId}`}>
+          <strong>{DateUtil.formatDateStr(scheduledFor)}</strong>
+        </Link>
     },
     {
       label: 'Docket Number',


### PR DESCRIPTION
Resolves https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3785/

Users can navigate to the hearing details page for travel board hearings. That page contains a link to the daily docket which is unsupported for travel board hearings. This PR updates the hearing details page such that the link doesn't exist for travel board hearings.
