### PR TITLE
Fix Caseflow::Error::ActionForbiddenError argument error

### DIFF
--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -33,7 +33,7 @@ module Caseflow::Error
   class FetchHearingLocationsJobError < SerializableError; end
 
   class ActionForbiddenError < SerializableError
-    def initialize(args)
+    def initialize(args = {})
       @code = args[:code] || 403
       @message = args[:message] || "Action forbidden"
     end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -920,7 +920,7 @@ RSpec.feature "Case details" do
         context "when we navigate directly to the case details page" do
           it "displays a loading failed message on the case details page" do
             visit(case_details_page_path)
-            expect(page).to have_content(COPY::CASE_DETAILS_LOADING_FAILURE_TITLE)
+            expect(page).to have_content(COPY::ACCESS_DENIED_TITLE)
             expect(page).to have_current_path(case_details_page_path)
           end
         end
@@ -929,7 +929,7 @@ RSpec.feature "Case details" do
           it "displays a loading failed message on the case details page" do
             visit(queue_home_path)
             click_on("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")
-            expect(page).to have_content(COPY::CASE_DETAILS_LOADING_FAILURE_TITLE)
+            expect(page).to have_content(COPY::ACCESS_DENIED_TITLE)
             expect(page).to have_current_path(case_details_page_path)
           end
         end

--- a/spec/lib/caseflow/error_spec.rb
+++ b/spec/lib/caseflow/error_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "Caseflow::Error" do
+  describe "ActionForbiddenError" do
+    let(:error_type) { Caseflow::Error::ActionForbiddenError }
+
+    context "when there are no input arguments" do
+      subject { fail(Caseflow::Error::ActionForbiddenError) }
+
+      it "raises the correct type of error" do
+        expect { subject }.to raise_error do |error|
+          expect(error).to be_a(error_type)
+        end
+      end
+    end
+
+    context "when the input hash contains a single element" do
+      let(:message_text) { "This action is not allowed" }
+      let(:args) { { message: message_text } }
+
+      subject { fail(Caseflow::Error::ActionForbiddenError, args) }
+
+      it "raises the correct type of error with the correct parameter" do
+        expect { subject }.to raise_error do |error|
+          expect(error).to be_a(error_type)
+          expect(error.message).to eq(message_text)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves `ArgumentError: wrong number of arguments (given 0, expected 1)` errors [we have been getting](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4497/) because we were initializing `Caseflow::Error::ActionForbiddenError` objects without passing any arguments. All of `Caseflow::Error::ActionForbiddenError`'s properties has defaults so this PR allows the instantiation of `Caseflow::Error::ActionForbiddenError`s without any input arguments.