### PR TITLE
Reset veteran invalid in redux

### DIFF
--- a/client/app/intake/reducers/appeal.js
+++ b/client/app/intake/reducers/appeal.js
@@ -106,6 +106,8 @@ export const mapDataToInitialAppeal = (data = { serverIntake: {} }) => (
     reviewIntakeError: null,
     completeIntakeErrorCode: null,
     completeIntakeErrorData: null,
+    veteranValid: null,
+    veteranInvalidFields: null,
     requestStatus: {
       submitReview: REQUEST_STATE.NOT_STARTED
     }


### PR DESCRIPTION
The Veteran is getting an invalid Veteran error on the Add Issues page for a valid Veteran.  I don't know if this will fix it, but the user did have one invalid Veteran in their intake history (due to having an invalid file number), and if the redux store didn't get reset maybe the error persisted.