### PR TITLE
Allow MailTasks to be created for dispatched appeals

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -39,6 +39,10 @@ class RootTask < GenericTask
     true
   end
 
+  def actions_allowable?(_user)
+    true
+  end
+
   def assigned_to_label
     COPY::CASE_LIST_TABLE_CASE_STORAGE_LABEL
   end

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -30,7 +30,7 @@ import {
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import {
   appealWithDetailSelector,
-  actionableTasksForAppeal
+  scheduleHearingTasksForAppeal
 } from '../selectors';
 import { onReceiveAmaTasks, onReceiveAppealDetails } from '../QueueActions';
 import { prepareAppealForStore } from '../utils';
@@ -381,10 +381,7 @@ class AssignHearingModal extends React.PureComponent {
 }
 
 const mapStateToProps = (state, ownProps) => ({
-  scheduleHearingTask: _.find(
-    actionableTasksForAppeal(state, { appealId: ownProps.appealId }),
-    (task) => task.type === 'ScheduleHearingTask' && task.status !== 'completed'
-  ),
+  scheduleHearingTask: scheduleHearingTasksForAppeal(state, { appealId: ownProps.appealId })[0],
   openHearing: _.find(
     appealWithDetailSelector(state, ownProps).hearings,
     (hearing) => hearing.disposition === null

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -118,20 +118,16 @@ export const appealWithDetailSelector = createSelector(
   (appeals, appealId) => appeals[appealId]
 );
 
-export const getTasksForAppeal = createSelector(
-  [getTasks, getAmaTasks, getAppealId],
-  (tasks, amaTasks, appealId) => {
-    return incompleteTasksSelector(_.filter(tasks, (task) => task.externalAppealId === appealId).
-      concat(_.filter(amaTasks, (task) => task.externalAppealId === appealId)));
-  }
-);
-
 export const getAllTasksForAppeal = createSelector(
   [getTasks, getAmaTasks, getAppealId],
   (tasks, amaTasks, appealId) => {
     return _.filter(tasks, (task) => task.externalAppealId === appealId).
       concat(_.filter(amaTasks, (task) => task.externalAppealId === appealId));
   }
+);
+
+export const incompleteTasksForAppeal = createSelector(
+  [getAllTasksForAppeal], (tasks) => incompleteTasksSelector(tasks)
 );
 
 export const getUnassignedOrganizationalTasks = createSelector(
@@ -152,7 +148,7 @@ export const getCompletedOrganizationalTasks = createSelector(
 );
 
 export const tasksForAppealAssignedToUserSelector = createSelector(
-  [getTasksForAppeal, getUserCssId],
+  [incompleteTasksForAppeal, getUserCssId],
   (tasks, cssId) => {
     return _.filter(tasks, (task) => task.assignedTo.cssId === cssId);
   }
@@ -204,7 +200,12 @@ export const completeTasksByAssigneeCssIdSelector = createSelector(
 );
 
 export const actionableTasksForAppeal = createSelector(
-  [getTasksForAppeal], (tasks) => _.filter(tasks, (task) => task.availableActions.length)
+  [getAllTasksForAppeal], (tasks) => _.filter(tasks, (task) => task.availableActions.length)
+);
+
+export const scheduleHearingTasksForAppeal = createSelector(
+  [actionableTasksForAppeal],
+  (tasks) => _.filter(incompleteTasksSelector(tasks), (task) => task.type === 'ScheduleHearingTask')
 );
 
 export const rootTasksForAppeal = createSelector(


### PR DESCRIPTION
Resolves an issue [identified by Ivy's team last week](https://dsva.slack.com/archives/C6E41RE92/p1554323146081200).

We previously did not allow the creation of `MailTask`s for dispatched appeals because we hid the "+ Add a new task" link. This PR enables the creation of `MailTask`s for dispatched appeals by un-hiding that link.