### PR TITLE
set on hold task on hold duration to `25` instead of `25.days`

### DIFF
--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -93,7 +93,7 @@ class DispositionTask < GenericTask
 
     no_show_hearing_task.update!(
       status: Constants.TASK_STATUSES.on_hold,
-      on_hold_duration: 25.days
+      on_hold_duration: 25
     )
   end
 

--- a/spec/models/tasks/disposition_task_spec.rb
+++ b/spec/models/tasks/disposition_task_spec.rb
@@ -319,7 +319,7 @@ describe DispositionTask do
           expect(no_show_hearing_task.placed_on_hold_at).to_not be_nil
           expect(no_show_hearing_task.on_hold_expired?).to be_falsey
           expect(no_show_hearing_task.status).to eq Constants.TASK_STATUSES.on_hold
-          expect(no_show_hearing_task.on_hold_duration).to eq 25.days
+          expect(no_show_hearing_task.on_hold_duration).to eq 25
         end
       end
 


### PR DESCRIPTION
Resolves #10340 

This fixes a bug that set on hold durations of NoShowHearingTasks in seconds instead of days. There were 168 tasks in production that had these incorrect durations, which Lowell and I fixed as shown in the transcript below:

```ruby
> NoShowHearingTask.where('on_hold_duration = 2160000').pluck(:id, :type, :on_hold_duration).count
# 168

> NoShowHearingTask.where('on_hold_duration = 2160000').pluck(:id, :type, :on_hold_duration)
# [[170348, "NoShowHearingTask", 2160000], [170349, "NoShowHearingTask", 2160000], [170351, "NoShowHearingTask", 2160000], [170352, "NoShowHearingTask", 2160000], [170353, "NoShowHearingTask", 2160000], [170354, "NoShowHearingTask", 2160000], [170355, "NoShowHearingTask", 2160000], [170360, "NoShowHearingTask", 2160000], [170361, "NoShowHearingTask", 2160000], [170366, "NoShowHearingTask", 2160000], [170367, "NoShowHearingTask", 2160000], [170368, "NoShowHearingTask", 2160000], [170371, "NoShowHearingTask", 2160000], [170372, "NoShowHearingTask", 2160000], [170375, "NoShowHearingTask", 2160000], [164646, "NoShowHearingTask", 2160000], [164647, "NoShowHearingTask", 2160000], [164648, "NoShowHearingTask", 2160000], [164649, "NoShowHearingTask", 2160000], [164650, "NoShowHearingTask", 2160000], [164651, "NoShowHearingTask", 2160000], [164654, "NoShowHearingTask", 2160000], [164655, "NoShowHearingTask", 2160000], [164656, "NoShowHearingTask", 2160000], [164657, "NoShowHearingTask", 2160000], [164662, "NoShowHearingTask", 2160000], [164663, "NoShowHearingTask", 2160000], [164664, "NoShowHearingTask", 2160000], [164665, "NoShowHearingTask", 2160000], [164666, "NoShowHearingTask", 2160000], [164667, "NoShowHearingTask", 2160000], [164668, "NoShowHearingTask", 2160000], [164669, "NoShowHearingTask", 2160000], [165748, "NoShowHearingTask", 2160000], [165749, "NoShowHearingTask", 2160000], [165750, "NoShowHearingTask", 2160000], [165751, "NoShowHearingTask", 2160000], [165752, "NoShowHearingTask", 2160000], [165753, "NoShowHearingTask", 2160000], [165754, "NoShowHearingTask", 2160000], [165755, "NoShowHearingTask", 2160000], [165756, "NoShowHearingTask", 2160000], [165757, "NoShowHearingTask", 2160000], [165758, "NoShowHearingTask", 2160000], [165759, "NoShowHearingTask", 2160000], [165760, "NoShowHearingTask", 2160000], [165761, "NoShowHearingTask", 2160000], [165764, "NoShowHearingTask", 2160000], [165769, "NoShowHearingTask", 2160000], [166568, "NoShowHearingTask", 2160000], [166569, "NoShowHearingTask", 2160000], [166570, "NoShowHearingTask", 2160000], [166571, "NoShowHearingTask", 2160000], [166572, "NoShowHearingTask", 2160000], [166573, "NoShowHearingTask", 2160000], [166574, "NoShowHearingTask", 2160000], [166577, "NoShowHearingTask", 2160000], [166578, "NoShowHearingTask", 2160000], [166579, "NoShowHearingTask", 2160000], [166580, "NoShowHearingTask", 2160000], [166581, "NoShowHearingTask", 2160000], [166582, "NoShowHearingTask", 2160000], [166583, "NoShowHearingTask", 2160000], [166584, "NoShowHearingTask", 2160000], [166588, "NoShowHearingTask", 2160000], [166589, "NoShowHearingTask", 2160000], [166604, "NoShowHearingTask", 2160000], [166592, "NoShowHearingTask", 2160000], [166607, "NoShowHearingTask", 2160000], [166608, "NoShowHearingTask", 2160000], [166609, "NoShowHearingTask", 2160000], [166612, "NoShowHearingTask", 2160000], [169277, "NoShowHearingTask", 2160000], [169278, "NoShowHearingTask", 2160000], [169279, "NoShowHearingTask", 2160000], [169280, "NoShowHearingTask", 2160000], [169281, "NoShowHearingTask", 2160000], [169282, "NoShowHearingTask", 2160000], [169283, "NoShowHearingTask", 2160000], [169284, "NoShowHearingTask", 2160000], [169285, "NoShowHearingTask", 2160000], [169286, "NoShowHearingTask", 2160000], [169287, "NoShowHearingTask", 2160000], [169288, "NoShowHearingTask", 2160000], [169289, "NoShowHearingTask", 2160000], [169290, "NoShowHearingTask", 2160000], [169291, "NoShowHearingTask", 2160000], [169292, "NoShowHearingTask", 2160000], [169293, "NoShowHearingTask", 2160000], [169294, "NoShowHearingTask", 2160000], [169295, "NoShowHearingTask", 2160000], [169296, "NoShowHearingTask", 2160000], [169297, "NoShowHearingTask", 2160000], [169298, "NoShowHearingTask", 2160000], [169299, "NoShowHearingTask", 2160000], [169300, "NoShowHearingTask", 2160000], [169302, "NoShowHearingTask", 2160000], [169305, "NoShowHearingTask", 2160000], [169308, "NoShowHearingTask", 2160000], [169309, "NoShowHearingTask", 2160000], [166859, "NoShowHearingTask", 2160000], [166860, "NoShowHearingTask", 2160000], [166861, "NoShowHearingTask", 2160000], [166862, "NoShowHearingTask", 2160000], [166863, "NoShowHearingTask", 2160000], [166864, "NoShowHearingTask", 2160000], [166866, "NoShowHearingTask", 2160000], [166869, "NoShowHearingTask", 2160000], [166870, "NoShowHearingTask", 2160000], [166871, "NoShowHearingTask", 2160000], [166872, "NoShowHearingTask", 2160000], [166873, "NoShowHearingTask", 2160000], [166874, "NoShowHearingTask", 2160000], [166875, "NoShowHearingTask", 2160000], [166876, "NoShowHearingTask", 2160000], [166877, "NoShowHearingTask", 2160000], [166878, "NoShowHearingTask", 2160000], [166879, "NoShowHearingTask", 2160000], [166880, "NoShowHearingTask", 2160000], [163379, "NoShowHearingTask", 2160000], [163380, "NoShowHearingTask", 2160000], [163381, "NoShowHearingTask", 2160000], [163382, "NoShowHearingTask", 2160000], [163384, "NoShowHearingTask", 2160000], [163385, "NoShowHearingTask", 2160000], [163386, "NoShowHearingTask", 2160000], [163387, "NoShowHearingTask", 2160000], [163388, "NoShowHearingTask", 2160000], [163389, "NoShowHearingTask", 2160000], [163392, "NoShowHearingTask", 2160000], [163393, "NoShowHearingTask", 2160000], [163394, "NoShowHearingTask", 2160000], [163395, "NoShowHearingTask", 2160000], [163396, "NoShowHearingTask", 2160000], [163397, "NoShowHearingTask", 2160000], [163398, "NoShowHearingTask", 2160000], [163399, "NoShowHearingTask", 2160000], [163402, "NoShowHearingTask", 2160000], [163403, "NoShowHearingTask", 2160000], [163404, "NoShowHearingTask", 2160000], [163405, "NoShowHearingTask", 2160000], [163406, "NoShowHearingTask", 2160000], [163407, "NoShowHearingTask", 2160000], [163408, "NoShowHearingTask", 2160000], [163413, "NoShowHearingTask", 2160000], [163414, "NoShowHearingTask", 2160000], [163416, "NoShowHearingTask", 2160000], [163422, "NoShowHearingTask", 2160000], [163424, "NoShowHearingTask", 2160000], [163425, "NoShowHearingTask", 2160000], [163429, "NoShowHearingTask", 2160000], [163430, "NoShowHearingTask", 2160000], [163434, "NoShowHearingTask", 2160000], [163435, "NoShowHearingTask", 2160000], [163436, "NoShowHearingTask", 2160000], [163437, "NoShowHearingTask", 2160000], [163438, "NoShowHearingTask", 2160000], [163439, "NoShowHearingTask", 2160000], [163440, "NoShowHearingTask", 2160000], [163441, "NoShowHearingTask", 2160000], [163442, "NoShowHearingTask", 2160000], [163443, "NoShowHearingTask", 2160000], [163445, "NoShowHearingTask", 2160000], [163446, "NoShowHearingTask", 2160000], [163447, "NoShowHearingTask", 2160000], [163448, "NoShowHearingTask", 2160000], [163449, "NoShowHearingTask", 2160000], [163454, "NoShowHearingTask", 2160000]]

> tasks = NoShowHearingTask.where('on_hold_duration = 2160000')
> tasks.count
# 168

> tasks.update_all(on_hold_duration: 25)

> Task.where('on_hold_duration > 1000').count
# 0

```