### PR TITLE
Check for Undefined Values in Dropdowns

### DIFF
--- a/client/app/components/DataDropdowns/AppealHearingLocations.jsx
+++ b/client/app/components/DataDropdowns/AppealHearingLocations.jsx
@@ -84,7 +84,7 @@ class AppealHearingLocationsDropdown extends React.Component {
       appealId, regionalOffice, dropdownName
     } = this.props;
 
-    if (options || isFetching) {
+    if (options || isFetching || _.isUndefined(regionalOffice)) {
       return;
     }
 

--- a/client/app/components/DataDropdowns/HearingCoordinator.jsx
+++ b/client/app/components/DataDropdowns/HearingCoordinator.jsx
@@ -59,7 +59,7 @@ class HearingCoordinatorDropdown extends React.Component {
         strongLabel
         readOnly={readOnly}
         value={this.getSelectedOption()}
-        onChange={(option) => onChange(option.value, option.label)}
+        onChange={(option) => onChange((option || {}).value, (option || {}).label)}
         options={this.props.hearingCoordinators.options}
         errorMessage={errorMessage}
         placeholder={placeholder} />


### PR DESCRIPTION
Resolves https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4065/

On initial page load, dropdowns some times get passed undefined values before Redux store has been set. 