### PR TITLE
Remove request issue id from remand reasons table

### DIFF
--- a/app/models/remand_reason.rb
+++ b/app/models/remand_reason.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class RemandReason < ApplicationRecord
-  self.ignored_columns = %w[request_issue_id]
   validates :code, inclusion: { in: Constants::AMA_REMAND_REASONS_BY_ID.values.map(&:keys).flatten }
   validates :post_aoj, inclusion: { in: [true, false] }
   belongs_to :decision_issue

--- a/db/migrate/20190411161143_remove_request_issue_id_from_remand_reasons.rb
+++ b/db/migrate/20190411161143_remove_request_issue_id_from_remand_reasons.rb
@@ -1,0 +1,5 @@
+class RemoveRequestIssueIdFromRemandReasons < ActiveRecord::Migration[5.1]
+  def change
+  	safety_assured { remove_column :remand_reasons, :request_issue_id }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190411010006) do
+ActiveRecord::Schema.define(version: 20190411161143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -775,10 +775,8 @@ ActiveRecord::Schema.define(version: 20190411010006) do
     t.datetime "created_at", null: false
     t.integer "decision_issue_id"
     t.boolean "post_aoj"
-    t.bigint "request_issue_id"
     t.datetime "updated_at", null: false
     t.index ["decision_issue_id"], name: "index_remand_reasons_on_decision_issue_id"
-    t.index ["request_issue_id"], name: "index_remand_reasons_on_request_issue_id"
   end
 
   create_table "request_decision_issues", force: :cascade, comment: "Join table for the has and belongs to many to many relationship between request issues and decision issues." do |t|


### PR DESCRIPTION
This is the last PR to remove request_issue_id from remand_reasons. All older records were migrated to reference remand reasons through a decision_issue_id.  

*Schema Changes Only*

* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [ ] #appeals-schema notified with summary and link to this PR
