### PR TITLE
Create a ChangeHearingDispositionTask when hearings held more than 2 days ago have no disposition

### DIFF
--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -45,7 +45,6 @@ class HearingDispositionChangeJob < CaseflowJob
     task_count_for[label.to_sym] += 1
   end
 
-  # postponed hearings should be acted upon immediately and related tasks closed; don't take action here
   def update_task_by_hearing_disposition(task)
     label = disposition_label(task.hearing)
 

--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -45,41 +45,41 @@ class HearingDispositionChangeJob < CaseflowJob
     task_count_for[label.to_sym] += 1
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
+  # postponed hearings should be acted upon immediately and related tasks closed; don't take action here
   def update_task_by_hearing_disposition(task)
-    hearing = task.hearing
-    label = hearing.disposition
+    label = disposition_label(task.hearing)
 
-    # rubocop:disable Lint/EmptyWhen
-    case hearing.disposition
+    case label
     when Constants.HEARING_DISPOSITION_TYPES.held
       task.hold!
     when Constants.HEARING_DISPOSITION_TYPES.cancelled
       task.cancel!
-    when Constants.HEARING_DISPOSITION_TYPES.postponed
-      # Postponed hearings should be acted on immediately and the related tasks should be closed. Do not take any
-      # action here.
     when Constants.HEARING_DISPOSITION_TYPES.no_show
       task.no_show!
-    when nil
-      # We allow judges and hearings staff 2 days to make changes to the hearing's disposition. If it has been more
-      # than 2 days since the hearing was held and there is no disposition then remind the hearings staff.
-      label = if hearing.scheduled_for < 48.hours.ago
-                task.create_change_hearing_disposition_task_and_complete
-                :stale
-              else
-                :between_one_and_two_days_old
-              end
-    else
-      # Expect to never reach this block since all dispositions should be accounted for above. If we run into this
-      # case we ignore it and will investigate and potentially incorporate that fix here. Until then we're fine.
-      label = :unknown_disposition
+    when :stale
+      # complete the DispositionTask and create a ChangeHearingDispositionTask to
+      # remind staff to update the hearing's disposition
+      task.create_change_hearing_disposition_task_and_complete
     end
-    # rubocop:enable Lint/EmptyWhen
 
     label
   end
-  # rubocop:enable Metrics/CyclomaticComplexity
+
+  def disposition_label(hearing)
+    if Constants.HEARING_DISPOSITION_TYPES.to_h.value?(hearing.disposition)
+      hearing.disposition
+    elsif hearing.disposition.nil?
+      if hearing.scheduled_for < 48.hours.ago
+        # stale if there's no disposition after 2 days
+        :stale
+      else
+        :between_one_and_two_days_old
+      end
+    else
+      # we should never reach this, but will investigate if we do
+      :unknown_disposition
+    end
+  end
 
   def log_info(start_time, task_count_for, error_count, hearing_ids, err = nil)
     duration = time_ago_in_words(start_time)

--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -54,6 +54,8 @@ class HearingDispositionChangeJob < CaseflowJob
       task.hold!
     when Constants.HEARING_DISPOSITION_TYPES.cancelled
       task.cancel!
+    when Constants.HEARING_DISPOSITION_TYPES.postponed
+      task.postpone!
     when Constants.HEARING_DISPOSITION_TYPES.no_show
       task.no_show!
     when :stale

--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -65,7 +65,7 @@ class HearingDispositionChangeJob < CaseflowJob
       # We allow judges and hearings staff 2 days to make changes to the hearing's disposition. If it has been more
       # than 2 days since the hearing was held and there is no disposition then remind the hearings staff.
       label = if hearing.scheduled_for < 48.hours.ago
-                # Logic will be added as part of #9833.
+                task.create_change_hearing_disposition_task_and_complete
                 :stale
               else
                 :between_one_and_two_days_old

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -139,10 +139,14 @@ class Task < ApplicationRecord
 
     return reassign(params[:reassign], current_user) if params[:reassign]
 
-    params["instructions"] = [instructions, params["instructions"]].flatten if params.key?("instructions")
+    params["instructions"] = flattened_instructions(params)
     update!(params)
 
     [self]
+  end
+
+  def flattened_instructions(params)
+    [instructions, params.dig(:instructions).presence].flatten.compact
   end
 
   def hide_from_queue_table_view

--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -10,6 +10,7 @@ class DispositionTask < GenericTask
   delegate :hearing, to: :hearing_task, allow_nil: true
 
   class HearingDispositionNotCanceled < StandardError; end
+  class HearingDispositionNotPostponed < StandardError; end
   class HearingDispositionNotNoShow < StandardError; end
   class HearingDispositionNotHeld < StandardError; end
 
@@ -75,6 +76,14 @@ class DispositionTask < GenericTask
     end
 
     update!(status: Constants.TASK_STATUSES.cancelled)
+  end
+
+  def postpone!
+    if hearing&.disposition != Constants.HEARING_DISPOSITION_TYPES.postponed
+      fail HearingDispositionNotPostponed
+    end
+
+    schedule_later
   end
 
   def no_show!

--- a/spec/feature/hearing_schedule/change_hearing_disposition_spec.rb
+++ b/spec/feature/hearing_schedule/change_hearing_disposition_spec.rb
@@ -4,28 +4,113 @@ require "rails_helper"
 
 RSpec.feature "Change hearing disposition" do
   let(:current_full_name) { "Leonela Harbold" }
-  let(:current_user) { FactoryBot.create(:user, full_name: current_full_name, css_id: "BVATWARNER", station_id: 101) }
+  let(:hearing_user) { FactoryBot.create(:user, full_name: current_full_name, css_id: "BVATWARNER", station_id: 101) }
   let(:hearing_day) { FactoryBot.create(:hearing_day) }
   let(:veteran) { FactoryBot.create(:veteran, first_name: "Chibueze", last_name: "Vanscoy", file_number: 800_888_001) }
   let(:appeal) { FactoryBot.create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number) }
+  let(:veteran_link_text) { "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})" }
   let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
   let(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
   let(:hearing) { FactoryBot.create(:hearing, appeal: appeal, hearing_day: hearing_day) }
   let!(:association) { FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task) }
   let!(:change_task) { FactoryBot.create(:change_hearing_disposition_task, parent: hearing_task, appeal: appeal) }
-  let(:instructions_text) { "This is why I'm postponing this hearing." }
+  let(:instructions_text) { "This is why I'm changing this hearing's disposition." }
 
   before do
-    OrganizationsUser.add_user_to_organization(current_user, HearingAdmin.singleton)
-    OrganizationsUser.add_user_to_organization(current_user, HearingsManagement.singleton)
-    User.authenticate!(user: current_user)
+    OrganizationsUser.add_user_to_organization(hearing_user, HearingAdmin.singleton)
+    OrganizationsUser.add_user_to_organization(hearing_user, HearingsManagement.singleton)
+    User.authenticate!(user: hearing_user)
+  end
+
+  context "there are transcription and mail team members" do
+    let(:mail_user) { FactoryBot.create(:user, full_name: "Chinelo Mbanefo") }
+    let(:transcription_user) { FactoryBot.create(:user, full_name: "Li Hua Meng") }
+
+    before do
+      OrganizationsUser.add_user_to_organization(mail_user, MailTeam.singleton)
+      OrganizationsUser.add_user_to_organization(transcription_user, TranscriptionTeam.singleton)
+    end
+
+    scenario "change hearing disposition to held" do
+      step "visit the hearing admin organization queue and click on the veteran's name" do
+        visit "/organizations/#{HearingAdmin.singleton.url}"
+        expect(page).to have_content("Unassigned (1)")
+        click_on veteran_link_text
+      end
+
+      step "change the hearing disposition to held" do
+        click_dropdown(prompt: "Select an action", text: "Change hearing disposition")
+        click_dropdown(prompt: "Select", text: "Held", container: ".cf-modal-body")
+        fill_in "Notes", with: instructions_text
+        click_button("Submit")
+        expect(page).to have_content("Successfully changed hearing disposition to Held")
+      end
+
+      step "return to the hearing admin organization queue and verify that the task is no longer there" do
+        click_queue_switcher COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_TEAM_CASES_LABEL % HearingAdmin.singleton.name
+        expect(page).to have_content("Unassigned (0)")
+      end
+
+      step "visit and verify that the evidence submission window task is in the mail team queue" do
+        User.authenticate!(user: mail_user)
+        visit "/organizations/#{MailTeam.singleton.url}"
+        expect(page).to have_content("Unassigned (1)")
+        expect(page).to have_content veteran_link_text
+        expect(page).to have_content "Evidence Submission Window Task"
+      end
+
+      step "visit and verify that the transcription task is in the transcription team queue" do
+        User.authenticate!(user: transcription_user)
+        visit "/organizations/#{TranscriptionTeam.singleton.url}"
+        expect(page).to have_content("Unassigned (1)")
+        expect(page).to have_content veteran_link_text
+        expect(page).to have_content "Transcription Task"
+      end
+    end
+  end
+
+  context "there's a BVA team member" do
+    let(:bva_user) { FactoryBot.create(:user, full_name: "Sun Ma") }
+
+    before do
+      OrganizationsUser.add_user_to_organization(bva_user, Bva.singleton)
+    end
+
+    scenario "change hearing disposition to cancelled" do
+      step "visit the hearing admin organization queue and click on the veteran's name" do
+        visit "/organizations/#{HearingAdmin.singleton.url}"
+        expect(page).to have_content("Unassigned (1)")
+        click_on veteran_link_text
+      end
+
+      step "change the hearing disposition to cancelled" do
+        click_dropdown(prompt: "Select an action", text: "Change hearing disposition")
+        click_dropdown(prompt: "Select", text: "Cancelled", container: ".cf-modal-body")
+        fill_in "Notes", with: instructions_text
+        click_button("Submit")
+        expect(page).to have_content("Successfully changed hearing disposition to Cancelled")
+      end
+
+      step "return to the hearing admin organization queue and verify that the task is no longer there" do
+        click_queue_switcher COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_TEAM_CASES_LABEL % HearingAdmin.singleton.name
+        expect(page).to have_content("Unassigned (0)")
+      end
+
+      step "visit and verify that the hearing task is completed in the bva queue" do
+        User.authenticate!(user: bva_user)
+        visit "/organizations/#{Bva.singleton.url}"
+        click_on COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE
+        expect(page).to have_content veteran_link_text
+        expect(page).to have_content "Hearing Task"
+      end
+    end
   end
 
   scenario "change hearing disposition to postponed" do
     step "visit the hearing admin organization queue and click on the veteran's name" do
       visit "/organizations/#{HearingAdmin.singleton.url}"
       expect(page).to have_content("Unassigned (1)")
-      click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+      click_on veteran_link_text
     end
 
     step "change the hearing disposition to postponed" do
@@ -36,7 +121,7 @@ RSpec.feature "Change hearing disposition" do
       expect(page).to have_content("Successfully changed hearing disposition to Postponed")
     end
 
-    step "return to the hearing admin organization queue and verify that the task is gone" do
+    step "return to the hearing admin organization queue and verify that the task is no longer there" do
       click_queue_switcher COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_TEAM_CASES_LABEL % HearingAdmin.singleton.name
       expect(page).to have_content("Unassigned (0)")
     end
@@ -44,13 +129,41 @@ RSpec.feature "Change hearing disposition" do
     step "visit the hearings management organization queue and verify that the schedule hearing task is there" do
       click_queue_switcher COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_TEAM_CASES_LABEL % HearingsManagement.singleton.name
       expect(page).to have_content("Unassigned (1)")
-      click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+      click_on veteran_link_text
       expect(page).to have_content(ScheduleHearingTask.last.label)
     end
 
     step "verify that the instructions are visible on the schedule hearing task" do
       find("#currently-active-tasks button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).click
       expect(page).to have_content(instructions_text)
+    end
+  end
+
+  scenario "change hearing disposition to no_show" do
+    step "visit the hearing admin organization queue and click on the veteran's name" do
+      visit "/organizations/#{HearingAdmin.singleton.url}"
+      expect(page).to have_content("Unassigned (1)")
+      click_on veteran_link_text
+    end
+
+    step "change the hearing disposition to cancelled" do
+      click_dropdown(prompt: "Select an action", text: "Change hearing disposition")
+      click_dropdown(prompt: "Select", text: "No Show", container: ".cf-modal-body")
+      fill_in "Notes", with: instructions_text
+      click_button("Submit")
+      expect(page).to have_content("Successfully changed hearing disposition to No Show")
+    end
+
+    step "return to the hearing admin organization queue and verify that the task is no longer unassigned" do
+      click_queue_switcher COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_TEAM_CASES_LABEL % HearingAdmin.singleton.name
+      expect(page).to have_content("Unassigned (0)")
+    end
+
+    step "verify that there's a NoShowHearingTask with a hold in the assigned queue" do
+      click_on "Assigned (2)"
+      find("td", text: "No Show Hearing Task").find(:xpath, "ancestor::tr").click_on veteran_link_text
+      no_show_active_row = find("dd", text: "NoShowHearingTask").find(:xpath, "ancestor::tr")
+      expect(no_show_active_row).to have_content("DAYS ON HOLD 0 of 25", normalize_ws: true)
     end
   end
 

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -97,10 +97,16 @@ describe HearingDispositionChangeJob do
       context "when hearing was scheduled to take place more than 2 days ago" do
         let(:scheduled_for) { 3.days.ago }
 
-        it "returns a label indicating that the hearing is stale and does not change the task" do
-          attributes_before = task.attributes
+        it "returns a label indicating that the hearing is stale, completes the task, and creates a new task" do
+          expect(ChangeHearingDispositionTask.count).to eq 0
+
           expect(subject).to eq(:stale)
-          expect(task.attributes).to eq(attributes_before)
+
+          expect(task.closed_at).to_not be_nil
+          expect(task.status).to eq Constants.TASK_STATUSES.completed
+          expect(ChangeHearingDispositionTask.count).to eq 1
+          expect(ChangeHearingDispositionTask.first.appeal).to eq task.appeal
+          expect(ChangeHearingDispositionTask.first.parent).to eq task.parent
         end
       end
 

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -43,6 +43,7 @@ describe HearingDispositionChangeJob do
   end
 
   describe ".update_task_by_hearing_disposition" do
+    let(:attributes_date_fields) { %w[assigned_at created_at updated_at] }
     subject { HearingDispositionChangeJob.new.update_task_by_hearing_disposition(task) }
 
     context "when hearing has a disposition" do
@@ -83,9 +84,9 @@ describe HearingDispositionChangeJob do
       context "when the disposition is not an expected disposition" do
         let(:disposition) { "FAKE_DISPOSITION" }
         it "returns a label indicating that the hearing disposition is unknown and not change the task" do
-          attributes_before = task.attributes
+          attributes_before = task.attributes.except(*attributes_date_fields)
           expect(subject).to eq(:unknown_disposition)
-          expect(task.reload.attributes).to eq(attributes_before)
+          expect(task.reload.attributes.except(*attributes_date_fields)).to eq(attributes_before)
         end
       end
     end
@@ -113,9 +114,9 @@ describe HearingDispositionChangeJob do
         let(:scheduled_for) { 25.hours.ago }
 
         it "returns a label indicating that the hearing was recently held and does not change the task" do
-          attributes_before = task.attributes
+          attributes_before = task.attributes.except(*attributes_date_fields)
           expect(subject).to eq(:between_one_and_two_days_old)
-          expect(task.reload.attributes).to eq(attributes_before)
+          expect(task.reload.attributes.except(*attributes_date_fields)).to eq(attributes_before)
         end
       end
     end

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -66,10 +66,9 @@ describe HearingDispositionChangeJob do
 
       context "when disposition is postponed" do
         let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.postponed }
-        it "returns a label matching the hearing disposition and not change the task" do
-          attributes_before = task.attributes
+        it "returns a label matching the hearing disposition and call DispositionTask.postpone!" do
+          expect(task).to receive(:postpone!).exactly(1).times
           expect(subject).to eq(disposition)
-          expect(task.attributes).to eq(attributes_before)
         end
       end
 
@@ -86,7 +85,7 @@ describe HearingDispositionChangeJob do
         it "returns a label indicating that the hearing disposition is unknown and not change the task" do
           attributes_before = task.attributes
           expect(subject).to eq(:unknown_disposition)
-          expect(task.attributes).to eq(attributes_before)
+          expect(task.reload.attributes).to eq(attributes_before)
         end
       end
     end
@@ -116,7 +115,7 @@ describe HearingDispositionChangeJob do
         it "returns a label indicating that the hearing was recently held and does not change the task" do
           attributes_before = task.attributes
           expect(subject).to eq(:between_one_and_two_days_old)
-          expect(task.attributes).to eq(attributes_before)
+          expect(task.reload.attributes).to eq(attributes_before)
         end
       end
     end

--- a/spec/models/tasks/disposition_task_spec.rb
+++ b/spec/models/tasks/disposition_task_spec.rb
@@ -20,10 +20,10 @@ describe DispositionTask do
     describe "hearing disposition of cancelled" do
       let(:params) do
         {
-          status: "cancelled",
+          status: Constants.TASK_STATUSES.cancelled,
           business_payloads: {
             values: {
-              disposition: "cancelled"
+              disposition: Constants.HEARING_DISPOSITION_TYPES.cancelled
             }
           }
         }.with_indifferent_access
@@ -35,17 +35,17 @@ describe DispositionTask do
         subject
 
         expect(Hearing.count).to eq 1
-        expect(Hearing.first.disposition).to eq "cancelled"
+        expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.cancelled
       end
     end
 
     describe "hearing disposition of held" do
       let(:params) do
         {
-          status: "cancelled",
+          status: Constants.TASK_STATUSES.cancelled,
           business_payloads: {
             values: {
-              disposition: "held"
+              disposition: Constants.HEARING_DISPOSITION_TYPES.held
             }
           }
         }.with_indifferent_access
@@ -57,17 +57,17 @@ describe DispositionTask do
         subject
 
         expect(Hearing.count).to eq 1
-        expect(Hearing.first.disposition).to eq "held"
+        expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.held
       end
     end
 
     describe "hearing disposition of no_show" do
       let(:params) do
         {
-          status: "cancelled",
+          status: Constants.TASK_STATUSES.cancelled,
           business_payloads: {
             values: {
-              disposition: "no_show"
+              disposition: Constants.HEARING_DISPOSITION_TYPES.no_show
             }
           }
         }.with_indifferent_access
@@ -79,17 +79,17 @@ describe DispositionTask do
         subject
 
         expect(Hearing.count).to eq 1
-        expect(Hearing.first.disposition).to eq "no_show"
+        expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.no_show
       end
     end
 
     describe "hearing disposition of postponed" do
       let(:params) do
         {
-          status: "cancelled",
+          status: Constants.TASK_STATUSES.cancelled,
           business_payloads: {
             values: {
-              disposition: "postponed",
+              disposition: Constants.HEARING_DISPOSITION_TYPES.postponed,
               after_disposition_update: after_disposition_update
             }
           }
@@ -107,10 +107,10 @@ describe DispositionTask do
           subject
 
           expect(Hearing.count).to eq 1
-          expect(Hearing.first.disposition).to eq "postponed"
+          expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.postponed
           expect(HearingTask.count).to eq 2
-          expect(HearingTask.first.status).to eq "cancelled"
-          expect(DispositionTask.first.status).to eq "cancelled"
+          expect(HearingTask.first.status).to eq Constants.TASK_STATUSES.cancelled
+          expect(DispositionTask.first.status).to eq Constants.TASK_STATUSES.cancelled
           expect(ScheduleHearingTask.count).to eq 1
           expect(ScheduleHearingTask.first.parent.id).to eq HearingTask.last.id
         end
@@ -124,7 +124,7 @@ describe DispositionTask do
           it "adds the instructions to both the DispositionTask and the ScheduleHearingTask" do
             subject
 
-            expect(DispositionTask.first.status).to eq "cancelled"
+            expect(DispositionTask.first.status).to eq Constants.TASK_STATUSES.cancelled
             expect(DispositionTask.first.instructions).to eq [instructions_text]
             expect(ScheduleHearingTask.count).to eq 1
             expect(ScheduleHearingTask.first.instructions).to eq [instructions_text]
@@ -145,11 +145,11 @@ describe DispositionTask do
         it "creates a new HearingTask and ScheduleHearingTask with admin action" do
           subject
 
-          expect(Hearing.first.disposition).to eq "postponed"
           expect(Hearing.count).to eq 1
+          expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.postponed
           expect(HearingTask.count).to eq 2
-          expect(HearingTask.first.status).to eq "cancelled"
-          expect(DispositionTask.first.status).to eq "cancelled"
+          expect(HearingTask.first.status).to eq Constants.TASK_STATUSES.cancelled
+          expect(DispositionTask.first.status).to eq Constants.TASK_STATUSES.cancelled
           expect(ScheduleHearingTask.count).to eq 1
           expect(ScheduleHearingTask.first.parent.id).to eq HearingTask.last.id
           expect(HearingAdminActionIncarceratedVeteranTask.count).to eq 1
@@ -173,18 +173,17 @@ describe DispositionTask do
           subject
 
           expect(Hearing.count).to eq 2
-          expect(Hearing.first.disposition).to eq "postponed"
+          expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.postponed
           expect(Hearing.last.hearing_location.facility_id).to eq "vba_370"
           expect(Hearing.last.scheduled_time.strftime("%I:%M%p")).to eq "12:30PM"
           expect(HearingTask.count).to eq 2
-          expect(HearingTask.first.status).to eq "cancelled"
+          expect(HearingTask.first.status).to eq Constants.TASK_STATUSES.cancelled
           expect(HearingTask.last.hearing_task_association.hearing.id).to eq Hearing.last.id
           expect(DispositionTask.count).to eq 2
-          expect(DispositionTask.first.status).to eq "cancelled"
+          expect(DispositionTask.first.status).to eq Constants.TASK_STATUSES.cancelled
         end
       end
     end
-
   end
 
   describe ".create_disposition_task!" do

--- a/spec/models/tasks/disposition_task_spec.rb
+++ b/spec/models/tasks/disposition_task_spec.rb
@@ -221,6 +221,35 @@ describe DispositionTask do
     end
   end
 
+  describe ".create_change_hearing_disposition_task_and_complete" do
+    let(:appeal) { FactoryBot.create(:appeal) }
+    let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+    let(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
+    let!(:disposition_task) do
+      FactoryBot.create(
+        :disposition_task,
+        parent: hearing_task,
+        appeal: appeal,
+        status: Constants.TASK_STATUSES.in_progress
+      )
+    end
+
+    subject { disposition_task.create_change_hearing_disposition_task_and_complete }
+
+    it "completes the disposition task and creates a new change hearing disposition task" do
+      expect(disposition_task.status).to_not eq Constants.TASK_STATUSES.completed
+      expect(ChangeHearingDispositionTask.count).to eq 0
+
+      subject
+
+      expect(disposition_task.status).to eq Constants.TASK_STATUSES.completed
+      expect(ChangeHearingDispositionTask.count).to eq 1
+      change_hearing_disposition_task = ChangeHearingDispositionTask.first
+      expect(change_hearing_disposition_task.appeal).to eq appeal
+      expect(change_hearing_disposition_task.parent).to eq hearing_task
+    end
+  end
+
   context "disposition updates" do
     let(:disposition) { nil }
     let(:appeal) { FactoryBot.create(:appeal) }


### PR DESCRIPTION
Resolves #9833

### Description
- adds creating a `ChangeHearingDispositionTask` to the `HearingDispositionChangeJob`
- makes necessary connections so that any disposition submitted with the modal created in #10313 will be handled correctly