### PR TITLE
Adjust regex format for DecisionDocument citations to suit Legacy App…

### DIFF
--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -11,7 +11,7 @@ class DecisionDocument < ApplicationRecord
   has_many :end_product_establishments, as: :source
   has_many :effectuations, class_name: "BoardGrantEffectuation"
 
-  validates :citation_number, format: { with: /\AA\d{8}\Z/i }
+  validates :citation_number, format: { with: /\AA?\d{8}\Z/i }
 
   attr_writer :file
 
@@ -35,7 +35,7 @@ class DecisionDocument < ApplicationRecord
   end
 
   def submit_for_processing!(delay: 0)
-    update_decision_issue_decision_dates! if ama?
+    update_decision_issue_decision_dates! if appeal.is_a?(Appeal)
     return no_processing_required! unless upload_enabled?
 
     cache_file!
@@ -50,7 +50,7 @@ class DecisionDocument < ApplicationRecord
     attempted!
     upload_to_vbms!
 
-    if FeatureToggle.enabled?(:create_board_grant_effectuations) && ama?
+    if FeatureToggle.enabled?(:create_board_grant_effectuations) && appeal.is_a?(Appeal)
       create_board_grant_effectuations!
       process_board_grant_effectuations!
       appeal.create_remand_supplemental_claims!
@@ -132,9 +132,5 @@ class DecisionDocument < ApplicationRecord
     fail NoFileError unless @file
 
     S3Service.store_file(s3_location, Base64.decode64(@file))
-  end
-
-  def ama?
-    appeal.class.name == Appeal.name
   end
 end

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -11,7 +11,7 @@ class BvaDispatchTask < GenericTask
     end
 
     def outcode(appeal, params, user)
-      if appeal.class.name == Appeal.name
+      if appeal.is_a?(Appeal)
         tasks = where(appeal: appeal, assigned_to: user)
         throw_error_if_no_tasks_or_if_task_is_completed(appeal, tasks, user)
         task = tasks[0]
@@ -21,7 +21,7 @@ class BvaDispatchTask < GenericTask
       params[:appeal_type] = appeal.class.name
       create_decision_document!(params)
 
-      if appeal.class.name == Appeal.name
+      if appeal.is_a?(Appeal)
         task.update!(status: Constants.TASK_STATUSES.completed)
         task.root_task.update!(status: Constants.TASK_STATUSES.completed)
         appeal.request_issues.each(&:close_decided_issue!)


### PR DESCRIPTION
We added outcode for Legacy appeals which have citations in different format 12345678 vs A12345678. This PR makes it possible for DecisionDocument to have citation in this format. 

Also, I adopted @pkarman suggestion to check if appeal is AMA. (see https://github.com/department-of-veterans-affairs/caseflow/pull/10218#discussion_r272709299)

See https://dsva.slack.com/archives/CD5DAQNCU/p1554389553010300
