### PR TITLE
Add asyncable canceled_at columns

### DIFF
--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -6,6 +6,7 @@
 class BoardGrantEffectuation < ApplicationRecord
   include HasBusinessLine
   include Asyncable
+  include DecisionSyncable
 
   belongs_to :appeal
   belongs_to :granted_decision_issue, class_name: "DecisionIssue"
@@ -25,32 +26,8 @@ class BoardGrantEffectuation < ApplicationRecord
   delegate :contention_text, to: :granted_decision_issue
   delegate :veteran, to: :appeal
 
-  class << self
-    # We don't need to retry these as frequently
-    def processing_retry_interval_hours
-      12
-    end
-
-    def submitted_at_column
-      :decision_sync_submitted_at
-    end
-
-    def attempted_at_column
-      :decision_sync_attempted_at
-    end
-
-    def processed_at_column
-      :decision_sync_processed_at
-    end
-
-    def error_column
-      :decision_sync_error
-    end
-
-    def last_submitted_at_column
-      :decision_sync_last_submitted_at
-    end
-  end
+  # don't need to try as frequently as default 3 hours
+  DEFAULT_REQUIRES_PROCESSING_RETRY_WINDOW_HOURS = 12
 
   def sync_decision_issues!
     return if processed?

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -140,7 +140,7 @@ module Asyncable
   end
 
   def canceled!
-     update!(self.class.canceled_at_column => Time.zone.now)
+    update!(self.class.canceled_at_column => Time.zone.now)
   end
 
   # There are sometimes cases where no processing required, and we can mark submitted and processed all in one

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -55,8 +55,16 @@ module Asyncable
       :error
     end
 
+    def canceled_at_column
+      :canceled_at
+    end
+
     def unexpired
       where(arel_table[last_submitted_at_column].gt(requires_processing_until))
+    end
+
+    def canceled
+      where.not(arel_table[canceled_at_column]: nil)
     end
 
     def processable
@@ -74,7 +82,7 @@ module Asyncable
     end
 
     def attemptable
-      previously_attempted_ready_for_retry.or(never_attempted)
+      previously_attempted_ready_for_retry.or(never_attempted).where(arel_table[canceled_at_column]: nil)
     end
 
     def order_by_oldest_submitted
@@ -188,6 +196,7 @@ module Asyncable
       self.class.last_submitted_at_column => Time.zone.now,
       self.class.processed_at_column => nil,
       self.class.attempted_at_column => nil,
+      self.class.canceled_at_column => nil,
       self.class.error_column => nil
     )
   end

--- a/app/models/concerns/decision_syncable.rb
+++ b/app/models/concerns/decision_syncable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DecisionSyncable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def last_submitted_at_column
+      :decision_sync_last_submitted_at
+    end
+
+    def submitted_at_column
+      :decision_sync_submitted_at
+    end
+
+    def attempted_at_column
+      :decision_sync_attempted_at
+    end
+
+    def processed_at_column
+      :decision_sync_processed_at
+    end
+
+    def error_column
+      :decision_sync_error
+    end
+
+    def canceled_at_column
+      :decision_sync_canceled_at
+    end
+  end
+end

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -48,6 +48,10 @@ class DecisionReview < ApplicationRecord
       :establishment_last_submitted_at
     end
 
+    def canceled_at_column
+      :establishment_canceled_at
+    end
+
     def ama_activation_date
       if FeatureToggle.enabled?(:use_ama_activation_date)
         Constants::DATES["AMA_ACTIVATION"].to_date

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -4,6 +4,7 @@
 class RequestIssue < ApplicationRecord
   include Asyncable
   include HasBusinessLine
+  include DecisionSyncable
 
   # how many days before we give up trying to sync decisions
   REQUIRES_PROCESSING_WINDOW_DAYS = 14
@@ -115,26 +116,6 @@ class RequestIssue < ApplicationRecord
   }.freeze
 
   class << self
-    def last_submitted_at_column
-      :decision_sync_last_submitted_at
-    end
-
-    def submitted_at_column
-      :decision_sync_submitted_at
-    end
-
-    def attempted_at_column
-      :decision_sync_attempted_at
-    end
-
-    def processed_at_column
-      :decision_sync_processed_at
-    end
-
-    def error_column
-      :decision_sync_error
-    end
-
     def rating
       where.not(
         contested_rating_issue_reference_id: nil

--- a/db/migrate/20190412182006_add_async_canceled_at.rb
+++ b/db/migrate/20190412182006_add_async_canceled_at.rb
@@ -1,0 +1,13 @@
+class AddAsyncCanceledAt < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appeals, :establishment_canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :higher_level_reviews, :establishment_canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :supplemental_claims, :establishment_canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :board_grant_effectuations, :decision_sync_canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :request_issues, :decision_sync_canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :request_issues_updates, :canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :decision_documents, :canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :task_timers, :canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+    add_column :vbms_uploaded_documents, :canceled_at, :datetime, comment: "Timestamp when job was abandoned"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
     t.string "docket_type", comment: "The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
     t.datetime "established_at", comment: "Timestamp for when the appeal has successfully been intaken into Caseflow by the user."
     t.datetime "establishment_attempted_at", comment: "Timestamp for when the appeal's establishment was last attempted."
+    t.datetime "establishment_canceled_at", comment: "Timestamp when job was abandoned"
     t.string "establishment_error", comment: "The error message if attempting to establish the appeal resulted in an error. This gets cleared once the establishment is successful."
     t.datetime "establishment_last_submitted_at", comment: "Timestamp for when the the job is eligible to run (can be reset to restart the job)."
     t.datetime "establishment_processed_at", comment: "Timestamp for when the establishment has succeeded in processing."
@@ -137,6 +138,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
     t.string "contention_reference_id", comment: "The ID of the contention created in VBMS. Indicates successful creation of the contention. If the EP has been rated, this contention could have been connected to a rating issue. That connection is used to map the rating issue back to the decision issue."
     t.bigint "decision_document_id", comment: "The ID of the decision document which triggered this effectuation."
     t.datetime "decision_sync_attempted_at", comment: "When the EP is cleared, an asyncronous job attempts to map the resulting rating issue back to the decision issue. Timestamp representing the time the job was last attempted."
+    t.datetime "decision_sync_canceled_at", comment: "Timestamp when job was abandoned"
     t.string "decision_sync_error", comment: "Async job processing last error message. See description for decision_sync_attempted_at for the decision sync job description."
     t.datetime "decision_sync_last_submitted_at", comment: "Timestamp for when the the job is eligible to run (can be reset to restart the job)."
     t.datetime "decision_sync_processed_at", comment: "Async job processing completed timestamp. See description for decision_sync_attempted_at for the decision sync job description."
@@ -236,6 +238,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
     t.bigint "appeal_id", null: false
     t.string "appeal_type"
     t.datetime "attempted_at"
+    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
     t.string "citation_number", null: false
     t.datetime "created_at", null: false
     t.date "decision_date", null: false
@@ -560,6 +563,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
   create_table "higher_level_reviews", force: :cascade, comment: "Intake data for Higher Level Reviews." do |t|
     t.string "benefit_type", comment: "The benefit type selected by the Veteran on their form, also known as a Line of Business."
     t.datetime "establishment_attempted_at", comment: "Timestamp for the most recent attempt at establishing a claim."
+    t.datetime "establishment_canceled_at", comment: "Timestamp when job was abandoned"
     t.string "establishment_error", comment: "The error captured for the most recent attempt at establishing a claim if it failed.  This is removed once establishing the claim succeeds."
     t.datetime "establishment_last_submitted_at", comment: "Timestamp for the latest attempt at establishing the End Products for the Decision Review."
     t.datetime "establishment_processed_at", comment: "Timestamp for when the End Product Establishments for the Decision Review successfully finished processing."
@@ -805,6 +809,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
     t.bigint "decision_review_id", comment: "ID of the decision review that this request issue belongs to"
     t.string "decision_review_type", comment: "Class name of the decision review that this request issue belongs to"
     t.datetime "decision_sync_attempted_at", comment: "Async job processing last attempted timestamp"
+    t.datetime "decision_sync_canceled_at", comment: "Timestamp when job was abandoned"
     t.string "decision_sync_error", comment: "Async job processing last error message"
     t.datetime "decision_sync_last_submitted_at", comment: "Async job processing most recent start timestamp"
     t.datetime "decision_sync_processed_at", comment: "Async job processing completed timestamp"
@@ -838,6 +843,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
     t.integer "after_request_issue_ids", null: false, comment: "An array of the active request issue IDs after a user has finished editing a decision review. Used with before_request_issue_ids to determine appropriate actions (such as which contentions need to be added).", array: true
     t.datetime "attempted_at", comment: "Timestamp for when the request issue update processing was last attempted."
     t.integer "before_request_issue_ids", null: false, comment: "An array of the active request issue IDs previously on the decision review before this editing session. Used with after_request_issue_ids to determine appropriate actions (such as which contentions need to be removed).", array: true
+    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
     t.string "error", comment: "The error message if the last attempt at processing the request issues update was not successful."
     t.datetime "last_submitted_at", comment: "Timestamp for when the processing for the request issues update was last submitted. Used to determine how long to continue retrying the processing job. Can be reset to allow for additional retries."
     t.datetime "processed_at", comment: "Timestamp for when the request issue update successfully completed processing."
@@ -898,6 +904,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
     t.bigint "decision_review_remanded_id", comment: "If an Appeal or Higher Level Review decision is remanded, including Duty to Assist errors, it automatically generates a new Supplemental Claim.  If this Supplemental Claim was generated, then the ID of the original Decision Review with the remanded decision is stored here."
     t.string "decision_review_remanded_type", comment: "The type of the Decision Review remanded if applicable, used with decision_review_remanded_id to as a composite key to identify the remanded Decision Review."
     t.datetime "establishment_attempted_at", comment: "Timestamp for the most recent attempt at establishing a claim."
+    t.datetime "establishment_canceled_at", comment: "Timestamp when job was abandoned"
     t.string "establishment_error", comment: "The error captured for the most recent attempt at establishing a claim if it failed.  This is removed once establishing the claim succeeds."
     t.datetime "establishment_last_submitted_at", comment: "Timestamp for the latest attempt at establishing the End Products for the Decision Review."
     t.datetime "establishment_processed_at", comment: "Timestamp for when the End Product Establishments for the Decision Review successfully finished processing."
@@ -921,6 +928,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
 
   create_table "task_timers", force: :cascade, comment: "Task timers allow tasks to be run asynchronously after some future date, like EvidenceSubmissionWindowTask." do |t|
     t.datetime "attempted_at", comment: "Async timestamp for most recent attempt to run."
+    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
     t.datetime "created_at", null: false, comment: "Automatic timestamp for record creation."
     t.string "error", comment: "Async any error message from most recent failed attempt to run."
     t.datetime "last_submitted_at", comment: "Async timestamp for most recent job start."
@@ -1001,6 +1009,7 @@ ActiveRecord::Schema.define(version: 20190412184430) do
   create_table "vbms_uploaded_documents", force: :cascade do |t|
     t.bigint "appeal_id", null: false
     t.datetime "attempted_at"
+    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
     t.datetime "created_at", null: false
     t.string "document_type", null: false
     t.string "error"

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -132,9 +132,23 @@ describe ClaimReview do
       )
     end
 
+    let!(:claim_review_canceled) do
+      create(
+        :higher_level_review,
+        receipt_date: receipt_date,
+        establishment_canceled_at: 2.days.ago
+      )
+    end
+
     context ".unexpired" do
       it "matches reviews still inside the processing window" do
         expect(HigherLevelReview.unexpired).to eq([claim_review_requiring_processing])
+      end
+    end
+
+    context ".canceled" do
+      it "only returns canceled jobs" do
+        expect(HigherLevelReview.canceled).to eq([claim_review_canceled])
       end
     end
 
@@ -149,6 +163,7 @@ describe ClaimReview do
     context ".attemptable" do
       it "matches reviews that could be attempted" do
         expect(HigherLevelReview.attemptable).not_to include(claim_review_recently_attempted)
+        expect(HigherLevelReview.attemptable).not_to include(claim_review_canceled)
       end
     end
 

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -38,6 +38,12 @@ describe AsyncableJobs do
            establishment_error: "bad problem")
   end
 
+  let!(:sc_canceled) do
+    create(:supplemental_claim,
+           veteran_file_number: veteran.file_number,
+           establishment_canceled_at: 2.days.ago)
+  end
+
   describe "#jobs" do
     it "returns an Array of model instances that consume Asyncable concern" do
       expect(subject.jobs).to be_a(Array)
@@ -47,6 +53,7 @@ describe AsyncableJobs do
       expect(subject.jobs).to include(sc_not_submitted)
       expect(subject.jobs).to include(sc_not_attempted_expired)
       expect(subject.jobs).to include(sc_not_attempted)
+      expect(subject.jobs).to_not include(sc_canceled)
     end
 
     it "sorts by the submited_at column, descending order" do


### PR DESCRIPTION
connects #10233 

### Description
Some jobs will never finish processing. Marking them canceled should hide them from the /jobs page.

*Schema Changes Only*

* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
