### PR TITLE
Remove can_access_v2 BGS feature toggle

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -182,7 +182,7 @@ class ExternalApi::BGSService
       MetricsService.record("BGS: can_access? (find_by_file_number): #{vbms_id}",
                             service: :bgs,
                             name: "can_access?") do
-        client.can_access?(vbms_id, FeatureToggle.enabled?(:can_access_v2, user: current_user))
+        client.can_access?(vbms_id, true)
       end
     end
   end


### PR DESCRIPTION
Resolves #10439.

This feature has been toggled on for all users [since July 2018](https://github.com/department-of-veterans-affairs/appeals-deployment/pull/1592/files). This PR replaces  the call to `FeatureToggle` which will always return true to the boolean `true`.