### PR TITLE
Judge view of hearing schedule

### DIFF
--- a/app/controllers/hearing_schedule_controller.rb
+++ b/app/controllers/hearing_schedule_controller.rb
@@ -32,7 +32,7 @@ class HearingScheduleController < ApplicationController
   end
 
   def verify_view_hearing_schedule_access
-    verify_authorized_roles("Edit HearSched", "Build HearSched", "RO ViewHearSched", "VSO")
+    verify_authorized_roles("Edit HearSched", "Build HearSched", "RO ViewHearSched", "VSO", "Hearing Prep")
   end
 
   def verify_hearings_or_reader_access

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -124,23 +124,17 @@ class HearingDay < ApplicationRecord
     end
 
     def upcoming_days_for_judge(start_date, end_date, user)
-      caseflow_assigned_hearing_days_and_hearings = HearingDay.includes(:hearings)
-        .where("DATE(scheduled_for) between ? and ?", start_date, end_date).select do |hearing_day|
-        hearing_day.judge == user || hearing_day.hearings.any? { |hearing| hearing.judge == user }
-      end
-
-      remaining_hearing_days = HearingDay.where("DATE(scheduled_for) between ? and ?", start_date, end_date)
-        .where.not(id: caseflow_assigned_hearing_days_and_hearings.pluck(:id)).order(:scheduled_for).limit(1000)
-
-      vacols_hearings_for_remaining_hearing_days = HearingRepository.fetch_hearings_for_parents_assigned_to_judge(
-        remaining_hearing_days.pluck(:id), user
+      hearing_days_in_range = HearingDay.includes(:hearings)
+        .where("DATE(scheduled_for) between ? and ?", start_date, end_date)
+      vacols_hearings = HearingRepository.fetch_hearings_for_parents_assigned_to_judge(
+        hearing_days_in_range.first(1000).pluck(:id), user
       )
 
-      hearing_days_with_vacols_hearings = remaining_hearing_days.reject do |hearing_day|
-        vacols_hearings_for_remaining_hearing_days[hearing_day.id.to_s].nil?
+      hearing_days_in_range.select do |hearing_day|
+        hearing_day.judge == user ||
+          hearing_day.hearings.any? { |hearing| hearing.judge == user } ||
+          !vacols_hearings[hearing_day.id.to_s].nil?
       end
-
-      caseflow_assigned_hearing_days_and_hearings + hearing_days_with_vacols_hearings
     end
 
     # rubocop:disable Metrics/AbcSize

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -136,8 +136,8 @@ class HearingDay < ApplicationRecord
         remaining_hearing_days.pluck(:id), user
       )
 
-      hearing_days_with_vacols_hearings = remaining_hearing_days.select do |hearing_day|
-        !vacols_hearings_for_remaining_hearing_days[hearing_day.id.to_s].nil?
+      hearing_days_with_vacols_hearings = remaining_hearing_days.reject do |hearing_day|
+        vacols_hearings_for_remaining_hearing_days[hearing_day.id.to_s].nil?
       end
 
       caseflow_assigned_hearing_days_and_hearings + hearing_days_with_vacols_hearings

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -70,6 +70,14 @@ class VACOLS::CaseHearing < VACOLS::Record
       select_hearings.where(vdkey: hearing_day_ids).where("hearing_date > ?", Date.new(2019, 1, 1))
     end
 
+    def hearings_for_hearing_days_assigned_to_judge(hearing_day_ids, judge)
+      id = connection.quote(judge.css_id.upcase)
+
+      select_hearings.where(vdkey: hearing_day_ids)
+        .where("hearing_date > ?", Date.new(2019, 1, 1))
+        .where("staff.sdomainid = #{id}")
+    end
+
     def for_appeal(appeal_vacols_id)
       select_hearings.where(folder_nr: appeal_vacols_id)
     end

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -31,6 +31,11 @@ class HearingRepository
         .group_by { |hearing| hearing.hearing_day_id.to_s }
     end
 
+    def fetch_hearings_for_parents_assigned_to_judge(hearing_day_ids, judge)
+      hearings_for(VACOLS::CaseHearing.hearings_for_hearing_days_assigned_to_judge(hearing_day_ids, judge))
+        .group_by { |hearing| hearing.hearing_day_id.to_s }
+    end
+
     def load_issues(hearings)
       children_hearings = hearings.select { |h| h.master_record == false }
       issues = VACOLS::CaseIssue.descriptions(children_hearings.map(&:appeal_vacols_id))

--- a/spec/feature/hearing_schedule/list_schedule_spec.rb
+++ b/spec/feature/hearing_schedule/list_schedule_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature "List Schedule" do
       scenario "No buttons are visible" do
         visit "hearings/schedule"
 
-        expect(page).to have_content(COPY::HEARING_SCHEDULE_VIEW_PAGE_HEADER_NONBOARD_USER)
+        expect(page).to have_content(COPY::HEARING_SCHEDULE_VIEW_PAGE_HEADER)
         expect(page).to_not have_content("Schedule Veterans")
         expect(page).to_not have_content("Build Schedule")
         expect(page).to_not have_content("Add Hearing Date")
@@ -78,7 +78,7 @@ RSpec.feature "List Schedule" do
     context "No hearing day or hearings assigned to judge" do
       let!(:hearing_day) { create(:hearing_day) }
 
-      scenario "Correct hearing day is displayed" do
+      scenario "Correct hearing days are displayed" do
         visit "hearings/schedule"
 
         expect(page).to_not have_content(Hearing::HEARING_TYPES[HearingDay.first.request_type.to_sym])
@@ -88,7 +88,7 @@ RSpec.feature "List Schedule" do
     context "Hearing day assigned to judge" do
       let!(:hearing_day) { create(:hearing_day, judge: current_user) }
 
-      scenario "Correct hearing day is displayed" do
+      scenario "Correct hearing days are displayed" do
         visit "hearings/schedule"
 
         expect(page).to have_content(Hearing::HEARING_TYPES[HearingDay.first.request_type.to_sym])
@@ -97,17 +97,25 @@ RSpec.feature "List Schedule" do
 
     context "Hearing day assigned to different judge with one legacy hearing assigned to judge" do
       let!(:hearing_day) { create(:hearing_day) }
+      let!(:vacols_staff) { create(:staff, user: current_user) }
+      let!(:case_hearing) { create(:case_hearing, vdkey: hearing_day.id, board_member: vacols_staff.sattyid) }
 
-      scenario "Correct hearing day is displayed" do
+      scenario "Correct hearing days are displayed" do
         visit "hearings/schedule"
+
+        expect(page).to have_content(Hearing::HEARING_TYPES[HearingDay.first.request_type.to_sym])
       end
     end
 
     context "Hearing day assigned to different judge with one AMA hearing assigned to judge" do
       let!(:hearing_day) { create(:hearing_day) }
+      let!(:hearing) { create(:hearing, :with_tasks, hearing_day: hearing_day) }
 
-      scenario "Correct hearing day is displayed" do
+      scenario "Correct hearing days are displayed" do
+        hearing.update!(judge: current_user)
         visit "hearings/schedule"
+
+        expect(page).to have_content(Hearing::HEARING_TYPES[HearingDay.first.request_type.to_sym])
       end
     end
   end

--- a/spec/feature/hearing_schedule/list_schedule_spec.rb
+++ b/spec/feature/hearing_schedule/list_schedule_spec.rb
@@ -57,6 +57,61 @@ RSpec.feature "List Schedule" do
         expect(page).to_not have_content("Add Hearing Date")
       end
     end
+
+    context "Judge permissions" do
+      let!(:current_user) { User.authenticate!(css_id: "BVATWARNER", roles: ["Hearing Prep"]) }
+
+      scenario "No buttons are visible" do
+        visit "hearings/schedule"
+
+        expect(page).to have_content(COPY::HEARING_SCHEDULE_VIEW_PAGE_HEADER_NONBOARD_USER)
+        expect(page).to_not have_content("Schedule Veterans")
+        expect(page).to_not have_content("Build Schedule")
+        expect(page).to_not have_content("Add Hearing Date")
+      end
+    end
+  end
+
+  context "Judge view" do
+    let!(:current_user) { User.authenticate!(css_id: "BVATWARNER", roles: ["Hearing Prep"]) }
+
+    context "No hearing day or hearings assigned to judge" do
+      let!(:hearing_day) { create(:hearing_day) }
+
+      scenario "Correct hearing day is displayed" do
+        visit "hearings/schedule"
+
+        expect(page).to_not have_content(Hearing::HEARING_TYPES[HearingDay.first.request_type.to_sym])
+      end
+    end
+
+    context "Hearing day assigned to judge" do
+      let!(:hearing_day) { create(:hearing_day, judge: current_user) }
+
+      scenario "Correct hearing day is displayed" do
+        visit "hearings/schedule"
+
+        expect(page).to have_content(Hearing::HEARING_TYPES[HearingDay.first.request_type.to_sym])
+      end
+    end
+
+    context "Hearing day assigned to different judge with one legacy hearing assigned to judge" do
+      let!(:hearing_day) { create(:hearing_day) }
+
+      scenario "Correct hearing day is displayed" do
+        visit "hearings/schedule"
+
+      end
+    end
+
+    context "Hearing day assigned to different judge with one AMA hearing assigned to judge" do
+      let!(:hearing_day) { create(:hearing_day) }
+
+      scenario "Correct hearing day is displayed" do
+        visit "hearings/schedule"
+
+      end
+    end
   end
 
   context "VSO user view" do

--- a/spec/feature/hearing_schedule/list_schedule_spec.rb
+++ b/spec/feature/hearing_schedule/list_schedule_spec.rb
@@ -100,7 +100,6 @@ RSpec.feature "List Schedule" do
 
       scenario "Correct hearing day is displayed" do
         visit "hearings/schedule"
-
       end
     end
 
@@ -109,7 +108,6 @@ RSpec.feature "List Schedule" do
 
       scenario "Correct hearing day is displayed" do
         visit "hearings/schedule"
-
       end
     end
   end


### PR DESCRIPTION
Resolves #10409 

### Description
This PR creates a judge view of hearing schedule. Judges are able to see hearing days if either the hearing day is assigned to them or the hearing day contains any hearings that are assigned to them.


