### PR TITLE
Reduce UpdateAppellantRepresentationJob slack messages

### DIFF
--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -7,13 +7,12 @@ class UpdateAppellantRepresentationJob < CaseflowJob
   include ActionView::Helpers::DateHelper
   queue_as :low_priority
 
+  APP_NAME = "caseflow_job"
+  METRIC_GROUP_NAME = self.class.name.underscore
   TOTAL_NUMBER_OF_APPEALS_TO_UPDATE = 1000
 
   def perform
     start_time = Time.zone.now
-    new_task_count = 0
-    closed_task_count = 0
-    error_count = 0
 
     # Set user to system_user to avoid sensitivity errors
     RequestStore.store[:current_user] = User.system_user
@@ -24,19 +23,19 @@ class UpdateAppellantRepresentationJob < CaseflowJob
       appeal_new_task_count, appeal_closed_task_count = TrackVeteranTask.sync_tracking_tasks(a)
       sync_record.update!(processed_at: Time.zone.now)
 
-      new_task_count += appeal_new_task_count
-      closed_task_count += appeal_closed_task_count
+      increment_task_count("new", a.id, appeal_new_task_count)
+      increment_task_count("closed", a.id, appeal_closed_task_count)
 
       # TODO: Add an alert if we've been running for longer than x number of minutes?
     rescue StandardError => e
       # Rescue from errors when looping over appeals so that we attempt to sync tracking tasks for each appeal.
       Raven.capture_exception(e, extra: { appeal_id: a.id })
-      error_count += 1
+      increment_task_count("error", a.id)
     end
 
-    log_info(start_time, new_task_count, closed_task_count, error_count)
+    record_runtime(start_time)
   rescue StandardError => e
-    log_info(start_time, new_task_count, closed_task_count, error_count, e)
+    log_error(start_time, e)
   end
 
   def appeals_to_update
@@ -78,16 +77,40 @@ class UpdateAppellantRepresentationJob < CaseflowJob
     Appeal.joins(:tasks).where("tasks.type = ? AND tasks.status NOT IN (?)", "RootTask", Task.inactive_statuses)
   end
 
-  def log_info(start_time, new_task_count, closed_task_count, error_count, err = nil)
-    duration = time_ago_in_words(start_time)
-    result = err ? "failed" : "completed"
-    msg = "UpdateAppellantRepresentationJob #{result} after running for #{duration}." \
-          " Created #{new_task_count} new tracking tasks and closed #{closed_task_count} existing tracking tasks." \
-          " Encountered errors for #{error_count} individual appeals."
+  def record_runtime(start_time)
+    job_duration_seconds = Time.zone.now - start_time
 
-    msg += " Fatal error: #{err.message}" if err
+    DataDogService.emit_gauge(
+      app_name: APP_NAME,
+      metric_group: METRIC_GROUP_NAME,
+      metric_name: "runtime",
+      metric_value: job_duration_seconds
+    )
+  end
+
+  def increment_task_count(task_effect, appeal_id, count = 1)
+    count.times do
+      DataDogService.increment_counter(
+        app_name: APP_NAME,
+        metric_group: METRIC_GROUP_NAME,
+        metric_name: "tasks",
+        attrs: {
+          effect: task_effect,
+          appeal_id: appeal_id
+        }
+      )
+    end
+  end
+
+  def log_error(start_time, err)
+    duration = time_ago_in_words(start_time)
+    msg = "UpdateAppellantRepresentationJob failed after running for #{duration}. Fatal error: #{err.message}"
+
     Rails.logger.info(msg)
-    Rails.logger.info(err.backtrace.join("\n")) if err
+    Rails.logger.info(err.backtrace.join("\n"))
+
     slack_service.send_notification(msg)
+
+    record_runtime(start_time)
   end
 end


### PR DESCRIPTION
Connects #10227.

This PR updates the hourly `UpdateAppellantRepresentationJob` to send data directly to DataDog and only sends messages to slack if it failed completely.

Once we are sending data to DataDog we will set up monitors and alerts around those monitors. We aren't currently taking any action on the successful slack messages we receive from this job so I don't think there is much risk to there being a delay between this change being released live and the DataDog monitors being created (though ticket #10227 will not be complete until those monitors are created). Happy to entertain differing opinions though!