### PR TITLE
Removing hardcoded dates in feature test

### DIFF
--- a/spec/feature/hearing_schedule/edit_hearing_day_spec.rb
+++ b/spec/feature/hearing_schedule/edit_hearing_day_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Edit a Hearing Day" do
   end
 
   let!(:hearing_day) do
-    create(:hearing_day, scheduled_for: Date.new(2019, 3, 15), request_type: "C", room: "2", judge_id: judge.id)
+    create(:hearing_day, request_type: "C", room: "2", judge_id: judge.id)
   end
 
   let!(:coordinator) do
@@ -25,7 +25,7 @@ RSpec.feature "Edit a Hearing Day" do
   context "When editing a Hearing Day" do
     scenario "Verify initial fields present when modal opened" do
       visit "hearings/schedule"
-      find_link("Fri 3/15/2019").click
+      find_link(hearing_day.scheduled_for.strftime("%a%_m/%d/%Y")).click
       expect(page).to have_content("Edit Hearing Day")
       expect(page).to have_content("No Veterans are scheduled for this hearing day.")
       find("button", text: "Edit Hearing Day").click
@@ -42,7 +42,7 @@ RSpec.feature "Edit a Hearing Day" do
 
   scenario "Verify room dropdown enabled when checkbox clicked" do
     visit "hearings/schedule"
-    find_link("Fri 3/15/2019").click
+    find_link(hearing_day.scheduled_for.strftime("%a%_m/%d/%Y")).click
     expect(page).to have_content("Edit Hearing Day")
     expect(page).to have_content("No Veterans are scheduled for this hearing day.")
     find("button", text: "Edit Hearing Day").click
@@ -61,7 +61,7 @@ RSpec.feature "Edit a Hearing Day" do
 
   scenario "Verify VLJ dropdown enabled when checkbox clicked" do
     visit "hearings/schedule"
-    find_link("Fri 3/15/2019").click
+    find_link(hearing_day.scheduled_for.strftime("%a%_m/%d/%Y")).click
     expect(page).to have_content("Edit Hearing Day")
     expect(page).to have_content("No Veterans are scheduled for this hearing day.")
     find("button", text: "Edit Hearing Day").click
@@ -80,7 +80,7 @@ RSpec.feature "Edit a Hearing Day" do
 
   scenario "Verify Coordinator dropdown enabled when checkbox clicked" do
     visit "hearings/schedule"
-    find_link("Fri 3/15/2019").click
+    find_link(hearing_day.scheduled_for.strftime("%a%_m/%d/%Y")).click
     expect(page).to have_content("Edit Hearing Day")
     expect(page).to have_content("No Veterans are scheduled for this hearing day.")
     find("button", text: "Edit Hearing Day").click

--- a/spec/feature/hearing_schedule/remove_hearing_day_spec.rb
+++ b/spec/feature/hearing_schedule/remove_hearing_day_spec.rb
@@ -8,18 +8,18 @@ RSpec.feature "Remove a Hearing Day" do
   end
 
   let!(:hearing_day) do
-    create(:hearing_day, scheduled_for: Date.new(2019, 3, 15), request_type: "C", room: "2")
+    create(:hearing_day, request_type: "C", room: "2")
   end
 
   context "When removing an existing hearing day" do
     scenario "select and remove a hearing day" do
       visit "hearings/schedule"
-      find_link("Fri 3/15/2019").click
+      find_link(hearing_day.scheduled_for.strftime("%a%_m/%d/%Y")).click
       expect(page).to have_content("Remove Hearing Day")
       expect(page).to have_content("No Veterans are scheduled for this hearing day.")
       find("button", text: "Remove Hearing Day").click
       text = "Once the hearing day is removed, users will no longer be able " \
-             "to schedule Veterans for this Central hearing day on Fri 3/15/2019."
+             "to schedule Veterans for this Central hearing day"
       expect(page).to have_content(text)
       find("button", text: "Confirm").click
       expect(page).to have_content("Welcome to Hearing Schedule!")


### PR DESCRIPTION
We hardcoded a date for hearing day, but when the date got to be more than 30 days in the past, our view schedule filter filtered out the date. I removed the hardcoded date.