### PR TITLE
Create new Representative class for VSOs and Private Bar

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -11,7 +11,7 @@ class Organizations::TasksController < OrganizationsController
       organization_name: organization.name,
       tasks: json_tasks(tasks),
       id: organization.id,
-      is_vso: organization.is_a?(::Vso)
+      is_vso: organization.is_a?(::Representative)
     }
   end
 
@@ -31,6 +31,6 @@ class Organizations::TasksController < OrganizationsController
   end
 
   def serializer
-    organization.is_a?(::Vso) ? WorkQueue::OrganizationTaskSerializer : WorkQueue::TaskSerializer
+    organization.is_a?(::Representative) ? WorkQueue::OrganizationTaskSerializer : WorkQueue::TaskSerializer
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -98,7 +98,7 @@ class TasksController < ApplicationController
     # VSO users will be able to see other VSO's tasks because we don't store that membership information in Caseflow.
     if current_user.vso_employee?
       # Return all tasks assigned to the current user or ANY VSO.
-      tasks = appeal.tasks.select { |t| t.assigned_to.is_a?(Vso) || current_user == t.assigned_to }
+      tasks = appeal.tasks.select { |t| t.assigned_to.is_a?(Representative) || current_user == t.assigned_to }
     else
       # DecisionReviewTask tasks are meant to be viewed on the /decision_reviews/:line-of-business route only.
       # This change filters them out from the Queue page

--- a/app/controllers/team_management_controller.rb
+++ b/app/controllers/team_management_controller.rb
@@ -10,9 +10,7 @@ class TeamManagementController < ApplicationController
         render json: {
           judge_teams: JudgeTeam.all.order(:id).map { |jt| serialize_org(jt) },
           vsos: Vso.all.order(:id).map { |vso| serialize_org(vso) },
-          other_orgs: Organization.all.order(:id).reject { |o| o.is_a?(JudgeTeam) || o.is_a?(Vso) }.map do |o|
-            serialize_org(o)
-          end
+          other_orgs: other_orgs.map { |org| serialize_org(org) }
         }
       end
     end
@@ -64,6 +62,10 @@ class TeamManagementController < ApplicationController
 
   def update_params
     params.require(:organization).permit(:name, :participant_id, :url)
+  end
+
+  def other_orgs
+    Organization.all.order(:id).reject { |org| org.is_a?(JudgeTeam) || org.is_a?(Representative) }
   end
 
   def serialize_org(org)

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -325,7 +325,7 @@ class Appeal < DecisionReview
 
   def vsos
     vso_participant_ids = power_of_attorneys.map(&:participant_id) - [nil]
-    Vso.where(participant_id: vso_participant_ids)
+    Representative.where(participant_id: vso_participant_ids)
   end
 
   def external_id

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -77,7 +77,7 @@ class Hearing < ApplicationRecord
   def assigned_to_vso?(user)
     appeal.tasks.any? do |task|
       task.type = TrackVeteranTask.name &&
-                  task.assigned_to.is_a?(Vso) &&
+                  task.assigned_to.is_a?(Representative) &&
                   task.assigned_to.user_has_access?(user) &&
                   task.active?
     end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -336,7 +336,7 @@ class LegacyAppeal < ApplicationRecord
   delegate :representatives, to: :case_record
 
   def vsos
-    Vso.where(participant_id: [power_of_attorney.bgs_participant_id] - [nil])
+    Representative.where(participant_id: [power_of_attorney.bgs_participant_id] - [nil])
   end
 
   def contested_claim

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -58,7 +58,7 @@ class LegacyHearing < ApplicationRecord
   def assigned_to_vso?(user)
     appeal.tasks.any? do |task|
       task.type = TrackVeteranTask.name &&
-                  task.assigned_to.is_a?(Vso) &&
+                  task.assigned_to.is_a?(Representative) &&
                   task.assigned_to.user_has_access?(user) &&
                   task.active?
     end

--- a/app/models/organizations/vso.rb
+++ b/app/models/organizations/vso.rb
@@ -1,30 +1,3 @@
 # frozen_string_literal: true
 
-class Vso < Organization
-  after_initialize :set_role
-
-  def user_has_access?(user)
-    return false unless user.roles.include?("VSO")
-
-    participant_ids = user.vsos_user_represents.map { |poa| poa[:participant_id] }
-    participant_ids.include?(participant_id)
-  end
-
-  def can_receive_task?(_task)
-    false
-  end
-
-  def should_write_ihp?(appeal)
-    ihp_writing_configs.include?(appeal.docket_type) && appeal.vsos.include?(self)
-  end
-
-  private
-
-  def set_role
-    self.role = "VSO"
-  end
-
-  def ihp_writing_configs
-    vso_config&.ihp_dockets || [Constants.AMA_DOCKETS.evidence_submission, Constants.AMA_DOCKETS.direct_review]
-  end
-end
+class Vso < Representative; end

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Representative < Organization
+  after_initialize :set_role
+
+  def user_has_access?(user)
+    return false unless user.roles.include?("VSO")
+
+    participant_ids = user.vsos_user_represents.map { |poa| poa[:participant_id] }
+    participant_ids.include?(participant_id)
+  end
+
+  def can_receive_task?(_task)
+    false
+  end
+
+  def should_write_ihp?(appeal)
+    ihp_writing_configs.include?(appeal.docket_type) && appeal.vsos.include?(self)
+  end
+
+  private
+
+  def set_role
+    self.role = "VSO"
+  end
+
+  def ihp_writing_configs
+    vso_config&.ihp_dockets || [Constants.AMA_DOCKETS.evidence_submission, Constants.AMA_DOCKETS.direct_review]
+  end
+end

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -30,7 +30,7 @@ class TasksForAppeal
   def tasks_assigned_to_user_or_any_other_vso_employee
     appeal.tasks
       .includes(*task_includes)
-      .select { |task| task.assigned_to.is_a?(Vso) || current_user == task.assigned_to }
+      .select { |task| task.assigned_to.is_a?(Representative) || current_user == task.assigned_to }
   end
 
   def all_tasks_except_for_decision_review_tasks

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -291,7 +291,7 @@ RSpec.describe TasksController, type: :controller do
       before do
         User.authenticate!(user: user)
         OrganizationsUser.add_user_to_organization(user, vso)
-        allow_any_instance_of(Vso).to receive(:user_has_access?).and_return(true)
+        allow_any_instance_of(Representative).to receive(:user_has_access?).and_return(true)
       end
 
       context "when creating a generic task" do

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -151,7 +151,7 @@ RSpec.feature "Case details" do
 
         before do
           OrganizationsUser.add_user_to_organization(vso_user, vso)
-          allow_any_instance_of(Vso).to receive(:user_has_access?).and_return(true)
+          allow_any_instance_of(Representative).to receive(:user_has_access?).and_return(true)
           User.authenticate!(user: vso_user)
         end
 

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Hearings tasks workflows" do
       context "when the appellant is represented by a VSO" do
         before do
           FactoryBot.create(:vso)
-          allow_any_instance_of(LegacyAppeal).to receive(:vsos) { Vso.all }
+          allow_any_instance_of(LegacyAppeal).to receive(:vsos) { Representative.all }
         end
 
         it "marks all Caseflow tasks complete and sets the VACOLS location correctly" do
@@ -113,11 +113,11 @@ RSpec.feature "Hearings tasks workflows" do
       context "when the appellant is represented by a VSO" do
         before do
           FactoryBot.create(:vso)
-          allow_any_instance_of(Appeal).to receive(:vsos) { Vso.all }
+          allow_any_instance_of(Appeal).to receive(:vsos) { Representative.all }
         end
 
         context "when the VSO is not supposed to write an IHP for this appeal" do
-          before { allow_any_instance_of(Vso).to receive(:should_write_ihp?) { false } }
+          before { allow_any_instance_of(Representative).to receive(:should_write_ihp?) { false } }
 
           it "marks the case ready for distribution" do
             mark_complete_and_verify_status(appeal, page, no_show_hearing_task)
@@ -131,7 +131,7 @@ RSpec.feature "Hearings tasks workflows" do
         end
 
         context "when the VSO is supposed to write an IHP for this appeal" do
-          before { allow_any_instance_of(Vso).to receive(:should_write_ihp?) { true } }
+          before { allow_any_instance_of(Representative).to receive(:should_write_ihp?) { true } }
 
           it "creates an IHP task as a child of the HearingTask" do
             mark_complete_and_verify_status(appeal, page, no_show_hearing_task)

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -190,7 +190,7 @@ RSpec.feature "Task queue" do
     let!(:vso_task) { FactoryBot.create(:ama_vso_task, :in_progress, assigned_to: vso) }
     before do
       User.authenticate!(user: vso_employee)
-      allow_any_instance_of(Vso).to receive(:user_has_access?).and_return(true)
+      allow_any_instance_of(Representative).to receive(:user_has_access?).and_return(true)
       visit(vso.path)
     end
 
@@ -225,7 +225,7 @@ RSpec.feature "Task queue" do
       FactoryBot.create_list(:informal_hearing_presentation_task, assigned_count, :on_hold, assigned_to: vso)
       FactoryBot.create_list(:track_veteran_task, tracking_task_count, assigned_to: vso)
 
-      allow_any_instance_of(Vso).to receive(:user_has_access?).and_return(true)
+      allow_any_instance_of(Representative).to receive(:user_has_access?).and_return(true)
       User.authenticate!(user: vso_employee)
       visit(vso.path)
     end

--- a/spec/models/representative_spec.rb
+++ b/spec/models/representative_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-describe Vso do
+describe Representative do
   let(:participant_id) { "123456" }
   let(:vso_participant_id) { "789" }
 
   let(:vso) do
-    Vso.create(
+    Representative.create(
       participant_id: vso_participant_id
     )
   end
@@ -33,7 +33,7 @@ describe Vso do
 
   describe ".create!" do
     it "sets the role to VSO" do
-      vso = Vso.create!(name: "Veterans' Service Org")
+      vso = Representative.create!(name: "Veterans' Service Org")
       expect(vso.role).to eq("VSO")
     end
   end
@@ -63,7 +63,7 @@ describe Vso do
 
     context "when the users participant_id is associated with a different VSO" do
       let(:vso) do
-        Vso.create(
+        Representative.create(
           participant_id: "999"
         )
       end

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -143,7 +143,7 @@ describe RootTask do
           )
         end
 
-        before { allow_any_instance_of(Vso).to receive(:should_write_ihp?).with(anything).and_return(false) }
+        before { allow_any_instance_of(Representative).to receive(:should_write_ihp?).with(anything).and_return(false) }
 
         it "creates no IHP tasks" do
           RootTask.create_root_and_sub_tasks!(appeal)


### PR DESCRIPTION
Connects #9527 (step 1 of 4).

Creates new `Representative` class that `Vso`, `FieldVso`, and eventually the new `PrivateBar` classes inherit from, and replaces references in the code to `Vso` that should really encompass all 3 of those entities.