### PR TITLE
Rename vsos() functions to representatives()

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -326,7 +326,7 @@ class Appeal < DecisionReview
     claimants.map(&:power_of_attorney)
   end
 
-  def vsos
+  def representatives
     vso_participant_ids = power_of_attorneys.map(&:participant_id) - [nil]
     Vso.where(participant_id: vso_participant_ids)
   end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -334,14 +334,14 @@ class LegacyAppeal < ApplicationRecord
     end
   end
 
-  delegate :representatives, to: :case_record
+  delegate :vacols_representatives, to: :case_record
 
-  def vsos
+  def representatives
     Vso.where(participant_id: [power_of_attorney.bgs_participant_id] - [nil])
   end
 
   def contested_claim
-    representatives.any? { |r| r.reptype == "C" }
+    vacols_representatives.any? { |r| r.reptype == "C" }
   end
 
   def claimant
@@ -368,12 +368,12 @@ class LegacyAppeal < ApplicationRecord
 
   # reptype C is a contested claimant
   def contested_claimants
-    representatives.where(reptype: "C").map(&:as_claimant)
+    vacols_representatives.where(reptype: "C").map(&:as_claimant)
   end
 
   # reptype D is contested claimant attorney, reptype E is contested claimant agent
   def contested_claimant_agents
-    representatives.where(reptype: %w[D E]).map(&:as_claimant)
+    vacols_representatives.where(reptype: %w[D E]).map(&:as_claimant)
   end
 
   def docket_name

--- a/app/models/organizations/vso.rb
+++ b/app/models/organizations/vso.rb
@@ -6,6 +6,7 @@ class Vso < Organization
   def user_has_access?(user)
     return false unless user.roles.include?("VSO")
 
+    # TODO: Do we need to rename User.vsos_user_represents?
     participant_ids = user.vsos_user_represents.map { |poa| poa[:participant_id] }
     participant_ids.include?(participant_id)
   end
@@ -15,7 +16,7 @@ class Vso < Organization
   end
 
   def should_write_ihp?(appeal)
-    ihp_writing_configs.include?(appeal.docket_type) && appeal.vsos.include?(self)
+    ihp_writing_configs.include?(appeal.docket_type) && appeal.representatives.include?(self)
   end
 
   private

--- a/app/models/organizations/vso.rb
+++ b/app/models/organizations/vso.rb
@@ -1,30 +1,3 @@
 # frozen_string_literal: true
 
-class Vso < Representative
-  after_initialize :set_role
-
-  def user_has_access?(user)
-    return false unless user.roles.include?("VSO")
-
-    participant_ids = user.vsos_user_represents.map { |poa| poa[:participant_id] }
-    participant_ids.include?(participant_id)
-  end
-
-  def can_receive_task?(_task)
-    false
-  end
-
-  def should_write_ihp?(appeal)
-    ihp_writing_configs.include?(appeal.docket_type) && appeal.representatives.include?(self)
-  end
-
-  private
-
-  def set_role
-    self.role = "VSO"
-  end
-
-  def ihp_writing_configs
-    vso_config&.ihp_dockets || [Constants.AMA_DOCKETS.evidence_submission, Constants.AMA_DOCKETS.direct_review]
-  end
-end
+class Vso < Representative; end

--- a/app/models/organizations/vso.rb
+++ b/app/models/organizations/vso.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-<<<<<<< HEAD
-class Vso < Organization
+class Vso < Representative
   after_initialize :set_role
 
   def user_has_access?(user)
     return false unless user.roles.include?("VSO")
 
-    # TODO: Do we need to rename User.vsos_user_represents?
     participant_ids = user.vsos_user_represents.map { |poa| poa[:participant_id] }
     participant_ids.include?(participant_id)
   end
@@ -30,6 +28,3 @@ class Vso < Organization
     vso_config&.ihp_dockets || [Constants.AMA_DOCKETS.evidence_submission, Constants.AMA_DOCKETS.direct_review]
   end
 end
-=======
-class Vso < Representative; end
->>>>>>> master

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -15,7 +15,7 @@ class Representative < Organization
   end
 
   def should_write_ihp?(appeal)
-    ihp_writing_configs.include?(appeal.docket_type) && appeal.vsos.include?(self)
+    ihp_writing_configs.include?(appeal.docket_type) && appeal.representatives.include?(self)
   end
 
   private

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -41,7 +41,7 @@ class HearingTask < GenericTask
   def update_legacy_appeal_location
     location = if hearing&.held?
                  LegacyAppeal::LOCATION_CODES[:transcription]
-               elsif appeal.vsos.empty?
+               elsif appeal.representatives.empty?
                  LegacyAppeal::LOCATION_CODES[:case_storage]
                else
                  LegacyAppeal::LOCATION_CODES[:service_organization]

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -59,7 +59,7 @@ class RootTask < GenericTask
     end
 
     def create_ihp_tasks!(appeal, parent)
-      appeal.vsos.select { |org| org.should_write_ihp?(appeal) }.map do |vso_organization|
+      appeal.representatives.select { |org| org.should_write_ihp?(appeal) }.map do |vso_organization|
         # For some RAMP appeals, this method may run twice.
         existing_task = InformalHearingPresentationTask.find_by(
           appeal: appeal,
@@ -77,7 +77,7 @@ class RootTask < GenericTask
     # private
 
     def create_vso_tracking_tasks(appeal, parent)
-      appeal.vsos.map do |vso_organization|
+      appeal.representatives.map do |vso_organization|
         TrackVeteranTask.create!(
           appeal: appeal,
           parent: parent,

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -134,7 +134,7 @@ class ScheduleHearingTask < GenericTask
 
   def withdraw_hearing
     if appeal.is_a?(LegacyAppeal)
-      location = if appeal.vsos.empty?
+      location = if appeal.representatives.empty?
                    LegacyAppeal::LOCATION_CODES[:case_storage]
                  else
                    LegacyAppeal::LOCATION_CODES[:service_organization]

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -35,19 +35,19 @@ class TrackVeteranTask < GenericTask
     closed_task_count = 0
 
     active_tracking_tasks = appeal.tasks.active.where(type: TrackVeteranTask.name)
-    cached_vsos = active_tracking_tasks.map(&:assigned_to)
-    fresh_vsos = appeal.vsos
+    cached_representatives = active_tracking_tasks.map(&:assigned_to)
+    fresh_representatives = appeal.representatives
 
     # Create a TrackVeteranTask for each VSO that does not already have one.
-    new_vsos = fresh_vsos - cached_vsos
-    new_vsos.each do |new_vso|
+    new_representatives = fresh_representatives - cached_representatives
+    new_representatives.each do |new_vso|
       TrackVeteranTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
       new_task_count += 1
     end
 
     # Close all TrackVeteranTasks for VSOs that are no longer representing the appellant.
-    outdated_vsos = cached_vsos - fresh_vsos
-    active_tracking_tasks.select { |t| outdated_vsos.include?(t.assigned_to) }.each do |task|
+    outdated_representatives = cached_representatives - fresh_representatives
+    active_tracking_tasks.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
       task.update!(status: Constants.TASK_STATUSES.cancelled)
       closed_task_count += 1
     end

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -280,7 +280,7 @@ class VACOLS::Case < VACOLS::Record
     self.class.batch_update_vacols_location(location, [bfkey])
   end
 
-  def representatives
+  def vacols_representatives
     result = VACOLS::Representative.where(repkey: bfkey)
     return result if result.present?
 

--- a/lib/generators/legacy_appeal.rb
+++ b/lib/generators/legacy_appeal.rb
@@ -37,7 +37,7 @@ class Generators::LegacyAppeal
         appellant_city: "Huntingdon",
         appellant_state: "TN",
         docket_number: 4198,
-        case_record: OpenStruct.new(representatives: [OpenStruct.new(reptype: "C")])
+        case_record: OpenStruct.new(vacols_representatives: [OpenStruct.new(reptype: "C")])
       }
     end
     # rubocop:enable Metrics/MethodLength

--- a/lib/tasks/local/vacols.rake
+++ b/lib/tasks/local/vacols.rake
@@ -120,7 +120,7 @@ namespace :local do
 
       cases = VACOLS::Case.includes(
         :folder,
-        :representatives,
+        :vacols_representatives,
         :correspondent,
         :case_issues,
         :notes,
@@ -140,7 +140,7 @@ namespace :local do
       # to the Helpers::Sanitizers class.
       write_csv(VACOLS::Case, cases, sanitizer)
       write_csv(VACOLS::Folder, cases.map(&:folder), sanitizer)
-      write_csv(VACOLS::Representative, cases.map(&:representatives), sanitizer)
+      write_csv(VACOLS::Representative, cases.map(&:vacols_representatives), sanitizer)
       write_csv(VACOLS::Correspondent, cases.map(&:correspondent), sanitizer)
       write_csv(VACOLS::CaseIssue, cases.map(&:case_issues), sanitizer)
       write_csv(VACOLS::Note, cases.map(&:notes), sanitizer)

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature "Hearings tasks workflows" do
       context "when the appellant is represented by a VSO" do
         before do
           FactoryBot.create(:vso)
-          allow_any_instance_of(LegacyAppeal).to receive(:vsos) { Vso.all }
+          allow_any_instance_of(LegacyAppeal).to receive(:representatives) { Vso.all }
         end
 
         it "marks all Caseflow tasks complete and sets the VACOLS location correctly" do
@@ -113,7 +113,7 @@ RSpec.feature "Hearings tasks workflows" do
       context "when the appellant is represented by a VSO" do
         before do
           FactoryBot.create(:vso)
-          allow_any_instance_of(Appeal).to receive(:vsos) { Vso.all }
+          allow_any_instance_of(Appeal).to receive(:representatives) { Vso.all }
         end
 
         context "when the VSO is not supposed to write an IHP for this appeal" do

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -31,8 +31,8 @@ describe UpdateAppellantRepresentationJob do
         vso_for_appeal[appeal.id] = []
       end
 
-      allow_any_instance_of(Appeal).to receive(:vsos) { |a| vso_for_appeal[a.id] }
-      allow_any_instance_of(LegacyAppeal).to receive(:vsos) { |a| vso_for_legacy_appeal[a.id] }
+      allow_any_instance_of(Appeal).to receive(:representatives) { |a| vso_for_appeal[a.id] }
+      allow_any_instance_of(LegacyAppeal).to receive(:representatives) { |a| vso_for_legacy_appeal[a.id] }
     end
 
     it "runs the job as expected" do
@@ -112,8 +112,8 @@ describe UpdateAppellantRepresentationJob do
         vso_for_appeal[appeal.id] = error_indicator
       end
 
-      allow_any_instance_of(Appeal).to receive(:vsos) do |a|
-        fail "No vsos for appeal ID #{a.id}" if error_indicator == vso_for_appeal[a.id]
+      allow_any_instance_of(Appeal).to receive(:representatives) do |a|
+        fail "No representatives for appeal ID #{a.id}" if error_indicator == vso_for_appeal[a.id]
 
         vso_for_appeal[a.id]
       end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -523,10 +523,10 @@ describe Appeal do
       end
     end
 
-    context "#vsos" do
-      it "returns all vsos this appeal has that exist in our DB" do
-        expect(appeal.vsos.count).to eq(1)
-        expect(appeal.vsos.first.name).to eq("Paralyzed Veterans Of America")
+    context "#representatives" do
+      it "returns all representatives this appeal has that exist in our DB" do
+        expect(appeal.representatives.count).to eq(1)
+        expect(appeal.representatives.first.name).to eq("Paralyzed Veterans Of America")
       end
 
       context "when there is no VSO" do
@@ -540,10 +540,10 @@ describe Appeal do
         let(:appeal) do
           create(:appeal, claimants: [create(:claimant, participant_id: participant_id_with_nil)])
         end
-        let!(:vsos) { Vso.create(name: "Test VSO") }
+        let!(:vso) { Vso.create(name: "Test VSO") }
 
         it "does not return VSOs with nil participant_id" do
-          expect(appeal.vsos).to eq([])
+          expect(appeal.representatives).to eq([])
         end
       end
     end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2335,16 +2335,16 @@ describe LegacyAppeal do
     end
   end
 
-  context "#vsos" do
+  context "#representatives" do
     context "when there is no VSO" do
       before do
         allow_any_instance_of(PowerOfAttorney).to receive(:bgs_participant_id).and_return(nil)
       end
-      let!(:vsos) { Vso.create(name: "Test VSO") }
+      let!(:vso) { Vso.create(name: "Test VSO") }
       let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
 
       it "does not return VSOs with nil participant_id" do
-        expect(appeal.vsos).to eq([])
+        expect(appeal.representatives).to eq([])
       end
     end
   end

--- a/spec/models/tasks/track_veteran_task_spec.rb
+++ b/spec/models/tasks/track_veteran_task_spec.rb
@@ -49,7 +49,7 @@ describe TrackVeteranTask do
     subject { TrackVeteranTask.sync_tracking_tasks(appeal) }
 
     context "when the appeal has no VSOs" do
-      before { allow_any_instance_of(Appeal).to receive(:vsos).and_return([]) }
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([]) }
 
       context "when there are no existing TrackVeteranTasks" do
         it "does not create or cancel any TrackVeteranTasks" do
@@ -75,7 +75,7 @@ describe TrackVeteranTask do
 
     context "when the appeal has two VSOs" do
       let(:representing_vsos) { FactoryBot.create_list(:vso, 2) }
-      before { allow_any_instance_of(Appeal).to receive(:vsos).and_return(representing_vsos) }
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return(representing_vsos) }
 
       context "when there are no existing TrackVeteranTasks" do
         it "creates 2 new TrackVeteranTasks" do

--- a/spec/models/vso_spec.rb
+++ b/spec/models/vso_spec.rb
@@ -96,7 +96,7 @@ describe Vso do
     let(:docket) { nil }
     let(:appeal) { FactoryBot.create(:appeal, docket_type: docket) }
 
-    before { allow_any_instance_of(Appeal).to receive(:vsos).and_return(poas) }
+    before { allow_any_instance_of(Appeal).to receive(:representatives).and_return(poas) }
 
     subject { vso.should_write_ihp?(appeal) }
 


### PR DESCRIPTION
Connects #9527 (step 2 of 4).

Renames existing `vsos` functions to `representatives` to explicitly recognize that issues on appeal may be represented by private attorneys (and agents and one-time reps) in addition to VSOs.