### PR TITLE
Fix edge case where contention text with UTF-8 char exceeds 255 bytes

### DIFF
--- a/app/models/contention.rb
+++ b/app/models/contention.rb
@@ -11,6 +11,19 @@ class Contention
   def text
     return unless description
 
-    (description.length > 255) ? "#{description.slice(0, 252)}..." : description
+    (description.bytesize > 255) ? truncated_description : description
+  end
+
+  private
+
+  def truncated_description
+    trimmed = []
+    description.split("").each do |char|
+      break if trimmed.join("").bytesize >= 252
+
+      trimmed << char
+    end
+    trimmed.pop if trimmed.join("").bytesize > 252
+    "#{trimmed.join('')}..."
   end
 end

--- a/spec/models/contention_spec.rb
+++ b/spec/models/contention_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe Contention do
+  # rubocop:disable Metrics/LineLength
+  let(:utf8_text) do
+    "The claim of entitlement to compensation under 38 U.S.C. § 1151 for ¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ is remanded."
+  end
+  # rubocop:enable Metrics/LineLength
+
+  subject { described_class.new(utf8_text) }
+
+  describe "#text" do
+    it "truncates description to 255 bytes" do
+      expect(utf8_text.length).to eq(176)
+      expect(utf8_text.bytesize).to eq(272)
+      expect(subject.text.bytesize).to eq(254) # 255 would break a multi-byte codepoint
+    end
+  end
+end


### PR DESCRIPTION
connects #8695 #10421

### Description
Ruby differentiates `length` of a string (the number of characters or codepoints) from the `bytesize` of a string (the number of bytes to represent the encoding of the string). The VBMS limit is 255 bytes but we were testing for characters.

This change makes sure we fit into the allowed byte size, while preserving as many of the original codepoints (characters) as possible.