### PR TITLE
Use regional office from session when setting timezone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,11 +244,8 @@ class ApplicationController < ApplicationBaseController
   end
 
   def set_timezone
-    Time.zone = timezone_based_on_ro || "America/Chicago"
-  end
-
-  def timezone_based_on_ro
-    (RegionalOffice::CITIES[session[:regional_office]] || {})[:timezone] if session[:regional_office]
+    Time.zone = session[:timezone] || current_user&.timezone
+    session[:timezone] ||= current_user&.timezone
   end
 
   # This is used in development mode to:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,7 +244,9 @@ class ApplicationController < ApplicationBaseController
   end
 
   def set_timezone
-    Time.zone = current_user.timezone if current_user
+    if session[:regional_office]
+      Time.zone = (RegionalOffice::CITIES[session[:regional_office]] || {})[:timezone] || "America/Chicago"
+    end 
   end
 
   # This is used in development mode to:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -246,7 +246,7 @@ class ApplicationController < ApplicationBaseController
   def set_timezone
     if session[:regional_office]
       Time.zone = (RegionalOffice::CITIES[session[:regional_office]] || {})[:timezone] || "America/Chicago"
-    end 
+    end
   end
 
   # This is used in development mode to:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -244,9 +244,11 @@ class ApplicationController < ApplicationBaseController
   end
 
   def set_timezone
-    if session[:regional_office]
-      Time.zone = (RegionalOffice::CITIES[session[:regional_office]] || {})[:timezone] || "America/Chicago"
-    end
+    Time.zone = timezone_based_on_ro || "America/Chicago"
+  end
+
+  def timezone_based_on_ro
+    (RegionalOffice::CITIES[session[:regional_office]] || {})[:timezone] if session[:regional_office]
   end
 
   # This is used in development mode to:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -311,7 +311,7 @@ class User < ApplicationRecord
 
       return nil if user_session.nil?
 
-      pg_user_id = session["pg_user_id"]
+      pg_user_id = session[:pg_user_id]
       css_id = user_session["id"]
       station_id = user_session["station_id"]
       user = pg_user_id ? find_by(id: pg_user_id) : find_by_css_id(css_id)
@@ -326,7 +326,7 @@ class User < ApplicationRecord
 
       user ||= create!(attrs.merge(css_id: css_id.upcase))
       user.update!(attrs.merge(last_login_at: Time.zone.now))
-      session["pg_user_id"] = user.id
+      session[:pg_user_id] = user.id
       user
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -129,6 +129,10 @@ class User < ApplicationRecord
     station_offices.is_a?(Array)
   end
 
+  def timezone
+    (RegionalOffice::CITIES[regional_office] || {})[:timezone] || "America/Chicago"
+  end
+
   # If user has never logged in, we might not have their full name in Caseflow DB.
   # So if we do not yet have the full name saved in Caseflow's DB, then
   # we want to fetch it from VACOLS, save it to the DB, then return it

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -322,7 +322,7 @@ class User < ApplicationRecord
 
       user ||= create!(attrs.merge(css_id: css_id.upcase))
       user.update!(attrs.merge(last_login_at: Time.zone.now))
-      session["pg_user_id"] =  user.id
+      session["pg_user_id"] = user.id
       user
     end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -26,16 +26,18 @@ RSpec.describe HomeController, type: :controller do
     context "when visitor is logged in" do
       let!(:current_user) { User.authenticate! }
 
-      it "should set timezone based on regional office" do
-        @request.session[:regional_office] = "RO84"
+      it "should set timezone in session if is not set" do
+        expect(@request.session[:timezone]).to eq nil
         get :index
-        expect(Time.zone.name).to eq "America/New_York"
+        expect(Time.zone.name).to eq current_user.timezone
+        expect(@request.session[:timezone]).to eq current_user.timezone
       end
 
-      it "should set to default timezone if no regional office" do
-        @request.session[:regional_office] = nil
+      it "should use session's value if is already set" do
+        @request.session[:timezone] = "America/Chicago"
         get :index
         expect(Time.zone.name).to eq "America/Chicago"
+        expect(@request.session[:timezone]).to eq "America/Chicago"
       end
     end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe HomeController, type: :controller do
       end
     end
 
+    context "when visitor is logged in" do
+      let!(:current_user) { User.authenticate! }
+
+      it "should set timezone based on regional office" do
+        @request.session[:regional_office] = "RO84"
+        get :index
+        expect(Time.zone.name).to eq "America/New_York"
+      end
+
+      it "should set to default timezone if no regional office" do
+        @request.session[:regional_office] = nil
+        get :index
+        expect(Time.zone.name).to eq "America/Chicago"
+      end
+    end
+
     context "when visitor is logged in, does not have a personal queue but does have case search access" do
       let!(:current_user) { User.authenticate! }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -97,20 +97,6 @@ describe User do
     end
   end
 
-  context "#timezone" do
-    context "when ro is set" do
-      subject { user.timezone }
-      before { user.regional_office = "RO84" }
-      it { is_expected.to eq("America/New_York") }
-    end
-
-    context "when ro isn't set" do
-      subject { user.timezone }
-      before { user.regional_office = nil }
-      it { is_expected.to eq("America/Chicago") }
-    end
-  end
-
   context "CSUM/CSEM users with 'System Admin' function" do
     before { user.roles = ["System Admin"] }
     before { Functions.client.del("System Admin") }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -97,6 +97,20 @@ describe User do
     end
   end
 
+  context "#timezone" do
+    context "when ro is set" do
+      subject { user.timezone }
+      before { user.regional_office = "RO84" }
+      it { is_expected.to eq("America/New_York") }
+    end
+
+    context "when ro isn't set" do
+      subject { user.timezone }
+      before { user.regional_office = nil }
+      it { is_expected.to eq("America/Chicago") }
+    end
+  end
+
   context "CSUM/CSEM users with 'System Admin' function" do
     before { user.roles = ["System Admin"] }
     before { Functions.client.del("System Admin") }


### PR DESCRIPTION
Resolves #10255 

### Description
1. When setting a timezone, do not query a user record each time
2. Store user's DB ID in session to make lookups faster

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

*Schema Changes Only*

* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [ ] #appeals-schema notified with summary and link to this PR
