### PR TITLE
Fix metric group name we send to DataDog

### DIFF
--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -8,7 +8,7 @@ class UpdateAppellantRepresentationJob < CaseflowJob
   queue_as :low_priority
 
   APP_NAME = "caseflow_job"
-  METRIC_GROUP_NAME = self.class.name.underscore
+  METRIC_GROUP_NAME = UpdateAppellantRepresentationJob.name.underscore
   TOTAL_NUMBER_OF_APPEALS_TO_UPDATE = 1000
 
   def perform

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -35,7 +35,7 @@ describe UpdateAppellantRepresentationJob do
       allow_any_instance_of(LegacyAppeal).to receive(:vsos) { |a| vso_for_legacy_appeal[a.id] }
     end
 
-    it "runs the job as expected", focus: true do
+    it "runs the job as expected" do
       expect_any_instance_of(UpdateAppellantRepresentationJob).to_not receive(:log_error).with(anything, anything)
       expect(DataDogService).to receive(:emit_gauge).with(
         app_name: "caseflow_job",

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -35,9 +35,14 @@ describe UpdateAppellantRepresentationJob do
       allow_any_instance_of(LegacyAppeal).to receive(:vsos) { |a| vso_for_legacy_appeal[a.id] }
     end
 
-    it "runs the job as expected" do
-      expect_any_instance_of(UpdateAppellantRepresentationJob).to receive(:record_runtime).exactly(1).times
+    it "runs the job as expected", focus: true do
       expect_any_instance_of(UpdateAppellantRepresentationJob).to_not receive(:log_error).with(anything, anything)
+      expect(DataDogService).to receive(:emit_gauge).with(
+        app_name: "caseflow_job",
+        metric_group: "update_appellant_representation_job",
+        metric_name: "runtime",
+        metric_value: anything
+      )
 
       UpdateAppellantRepresentationJob.perform_now
     end


### PR DESCRIPTION
Connects #10227.

Currently we call the `metric_group` "class". This PR fixes that to instead call the `metric_group` "update_appellant_representation_job" as we had intended.