### PR TITLE
Only send relevant fields to backend from hp daily docket

### DIFF
--- a/client/app/hearings/containers/DailyDocketContainer.jsx
+++ b/client/app/hearings/containers/DailyDocketContainer.jsx
@@ -34,9 +34,21 @@ export class DailyDocketContainer extends React.Component {
     }
   };
 
+  formatHearing = (hearing) => {
+    return {
+      prepped: hearing.prepped,
+      notes: hearing.notes,
+      disposition: hearing.disposition,
+      aod: hearing.aod,
+      hold_open: hearing.hold_open,
+      transcript_requested: hearing.transcript_requested,
+      evidence_window_waived: hearing.evidence_window_waived
+    };
+  };
+
   saveHearing = (hearing) => () => {
     ApiUtil.patch(`/hearings/${hearing.external_id}`, { data: {
-      hearing
+      hearing: this.formatHearing(hearing)
     } }).
       then((response) => {
         this.props.handleSaveHearingSuccess(JSON.parse(response.text), this.props.date);


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/appeals-support/issues/5012

We've had several support requests where the hearing date has unexpectedly changed. I believe this is happening from the hearing prep daily docket. We previously sent the entire hearing object to the backend when updating a hearing, so if the time was formatted differently because of a timezone, those changes can get persisted to the database. I updated the hearing prep frontend to only send fields that are editable from the hearing prep daily docket.
