### PR TITLE
Fix impersonation in production

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -61,12 +61,14 @@ class SessionsController < ApplicationController
 
   def remove_user_from_session
     session.delete(:regional_office)
+    session.delete(:user_pg_id)
     session.delete("user")
   end
 
   def add_user_to_session(user_id)
     user = User.find(user_id)
     session["user"] = user.to_session_hash
+    session[:user_pg_id] = user.id
     session[:regional_office] = user.users_regional_office
     RequestStore[:current_user] = user
   end

--- a/app/controllers/test/users_controller.rb
+++ b/app/controllers/test/users_controller.rb
@@ -83,6 +83,7 @@ class Test::UsersController < ApplicationController
     User.clear_current_user # for testing only
 
     session["user"] = User.authentication_service.get_user_session(params[:id])
+    session[:pg_user_id] = params[:id]
     head :ok
   end
 
@@ -94,6 +95,7 @@ class Test::UsersController < ApplicationController
     return head :not_found if user.nil?
 
     session["user"] = user.to_session_hash
+    session[:pg_user_id] = user.id
     # We keep track of current user to use when logging out
     session["global_admin"] = current_user.id
     RequestStore[:current_user] = user


### PR DESCRIPTION
Set `user_pg_id` when impersonating users in production and locally. Fixes logout.