### PR TITLE
Update User.organization_queue_user? method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -180,7 +180,7 @@ class User < ApplicationRecord
   end
 
   def organization_queue_user?
-    FeatureToggle.enabled?(:organization_queue, user: self)
+    organizations.any?
   end
 
   def granted?(thing)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -560,4 +560,23 @@ describe User do
       end
     end
   end
+
+  describe ".organization_queue_user?" do
+    let(:user) { FactoryBot.create(:user) }
+
+    subject { user.organization_queue_user? }
+
+    context "when the current user is not a member of any organizations" do
+      it "returns false" do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context "when the user is a member of some organizations" do
+      before { OrganizationsUser.add_user_to_organization(user, FactoryBot.create(:organization)) }
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #10432. VLJ support staff were not being properly identified as "organizational queue users". This PR fixes that.