### PR TITLE
Upgrade Nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "aasm", "4.11.0"
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
 gem "acts_as_tree"
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "54955cfc95e528394bf1975285edc6bc23cfaf7d"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "0232bb817e66c2956506755d6b99b172cb156d46"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,9 @@ gem "jquery-rails"
 gem "loofah", ">= 2.2.3"
 gem "moment_timezone-rails"
 gem "newrelic_rpm"
-# nokogiri versions before 1.8.3 are affected by CVE-2018-8048. Explicitly define nokogiri version here to avoid that.
-# https://github.com/sparklemotion/nokogiri/pull/1746
-gem "nokogiri", "1.8.5"
+# nokogiri versions before 1.10.3 are affected by CVE-2019-11068. Explicitly define nokogiri version here to avoid that.
+# https://github.com/sparklemotion/nokogiri/issues/1892
+gem "nokogiri", "1.10.3"
 gem "paper_trail", "8.1.2"
 # Used to speed up reporting
 gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,11 +37,11 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 54955cfc95e528394bf1975285edc6bc23cfaf7d
-  ref: 54955cfc95e528394bf1975285edc6bc23cfaf7d
+  revision: 0232bb817e66c2956506755d6b99b172cb156d46
+  ref: 0232bb817e66c2956506755d6b99b172cb156d46
   specs:
     bgs (0.2)
-      nokogiri (~> 1.8.2)
+      nokogiri (~> 1.10)
       savon (~> 2.11)
 
 GIT
@@ -288,7 +288,7 @@ GEM
     memory_profiler (0.9.12)
     method_source (0.9.2)
     mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     moment_timezone-rails (0.5.0)
     momentjs-rails (2.20.1)
@@ -304,8 +304,8 @@ GEM
     newrelic_rpm (6.0.0.351)
     nio4r (2.3.1)
     no_proxy_fix (0.1.2)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.3)
+      mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -564,7 +564,7 @@ DEPENDENCIES
   loofah (>= 2.2.3)
   moment_timezone-rails
   newrelic_rpm
-  nokogiri (= 1.8.5)
+  nokogiri (= 1.10.3)
   paper_trail (= 8.1.2)
   parallel
   paranoia (~> 2.2)


### PR DESCRIPTION
CircleCI reported security vulnerability for version 1.8.5. Upgrades Nokogiri to version 1.10.3

```
Name: nokogiri
Version: 1.8.5
Advisory: CVE-2019-11068
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1892
Title: Nokogiri gem, via libxslt, is affected by improper access control vulnerability
Solution: upgrade to >= 1.10.3

Vulnerabilities found!

Failed. Security vulnerabilities were found. Find the dependency in Gemfile.lock, then specify a safe version of the dependency in the Gemfile (preferred) or snooze the CVE in security.rake for a week.
```