### PR TITLE
only search for select in the modal body

### DIFF
--- a/spec/feature/queue/privacy_team_spec.rb
+++ b/spec/feature/queue/privacy_team_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature "Privacy team tasks and queue" do
         find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.label).click
 
         # Assignee dropdown selector should be hidden.
-        expect(find_all(".Select-control").count).to eq(0)
+        expect(find_all(".cf-modal-body .Select-control").count).to eq(0)
         fill_in("taskInstructions", with: instructions_text)
         find("button", text: "Submit").click
 
@@ -69,7 +69,7 @@ RSpec.feature "Privacy team tasks and queue" do
         find("div", class: "Select-option", text: Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.label).click
 
         # Assignee dropdown selector should be hidden.
-        expect(find_all(".Select-control").count).to eq(0)
+        expect(find_all(".cf-modal-body .Select-control").count).to eq(0)
         fill_in("taskInstructions", with: instructions_text)
         find("button", text: "Submit").click
 


### PR DESCRIPTION
### Description
This test was flaking on larger monitors when the select control on the page behind the modal was still visible and therefore included in `find_all(".Select-control")`. The changes restrict the search for the select control to the modal body, which is where the test is concerned with it appearing.