### PR TITLE
Add VBMS error class for file number does not exist

### DIFF
--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -82,7 +82,7 @@ class VBMSError < RuntimeError
     "The contention is connected to an issue in ratings and cannot be deleted." => "CannotDeleteContention",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3467/events/292533/
-    "The ClaimDateDt value must be a valid date for a claim." => "ClaimDateInvalid"
+    "The ClaimDateDt value must be a valid date for a claim." => "ClaimDateInvalid",
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3894/events/308951/
     "File Number does not exist within the system." => "FilenumberDoesNotExist"

--- a/app/exceptions/vbms_error.rb
+++ b/app/exceptions/vbms_error.rb
@@ -23,6 +23,7 @@ class VBMSError < RuntimeError
   class BadClaim < Caseflow::Error::VBMS; end
   class CannotDeleteContention < Caseflow::Error::VBMS; end
   class ClaimDateInvalid < Caseflow::Error::VBMS; end
+  class FilenumberDoesNotExist < Caseflow::Error::VBMS; end
 
   attr_accessor :body, :code, :request
 
@@ -82,6 +83,9 @@ class VBMSError < RuntimeError
 
     # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3467/events/292533/
     "The ClaimDateDt value must be a valid date for a claim." => "ClaimDateInvalid"
+
+    # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3894/events/308951/
+    "File Number does not exist within the system." => "FilenumberDoesNotExist"
   }.freeze
 
   class << self

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -40,9 +40,7 @@ class ExternalApi::VBMSService
 
     begin
       documents = send_and_log_request(veteran_file_number, request)
-    rescue VBMS::HTTPError => e
-      raise unless e.body.include?("File Number does not exist within the system.")
-
+    rescue VBMS::FilenumberDoesNotExist
       alternative_file_number = ExternalApi::BGSService.new.fetch_veteran_info(veteran_file_number)[:claim_number]
 
       raise if alternative_file_number == veteran_file_number


### PR DESCRIPTION
If we get the "File Number does not exist within the system." error, try VBMS call again with the claim_id.

This may have been rescuing the wrong error class, preventing the "try again".

I tried the call with the "alternate file number" in one case, and it did work.