### PR TITLE
Route back button to correct place after dispatch

### DIFF
--- a/client/app/queue/LegacySelectDispositionsView.jsx
+++ b/client/app/queue/LegacySelectDispositionsView.jsx
@@ -145,7 +145,9 @@ class LegacySelectDispositionsView extends React.PureComponent {
       columns.splice(1, 0, {
         header: 'Actions',
         valueFunction: (issue) => {
-          return <Link to={`/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/dispositions/edit/${issue.id}`}>
+          return <Link
+            replace to={`/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/dispositions/edit/${issue.id}`}
+          >
             Edit Issue
           </Link>;
         }
@@ -189,7 +191,9 @@ class LegacySelectDispositionsView extends React.PureComponent {
         bodyStyling={tbodyStyling}
       />
       {appeal.isLegacyAppeal && <div {...marginLeft(1.5)}>
-        <Link to={`/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/dispositions/add`}>Add Issue</Link>
+        <Link
+          replace to={`/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/dispositions/add`}
+        >Add Issue</Link>
       </div>}
     </QueueFlowPage>;
   };

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,7 @@
     "client/node_modules"
   ],
   "dependencies": {
-    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#f8928f5",
+    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#25f4e03",
     "@fortawesome/fontawesome-free": "^5.3.1",
     "babel-core": "^6.18.2",
     "babel-loader": "^7.1.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -61,9 +61,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#f8928f5":
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#25f4e03":
   version "2.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#f8928f503fd4efc34cbc1f7b2f79612c13571412"
+  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#25f4e03acc155dfbb12b9f715ee0ddd36ef7c720"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -123,9 +123,7 @@ RSpec.feature "Judge checkout flow" do
         click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
 
         click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_LEGACY_CHECKOUT.label)
-
         click_label "vamc"
-
         click_on "Continue"
 
         # Ensure we can reload the flow and the special issue is saved
@@ -146,6 +144,10 @@ RSpec.feature "Judge checkout flow" do
 
         expect(page).to have_content("Review Dispositions")
         expect(page.find_all(".issue-disposition-dropdown").length).to eq 1
+
+        click_on "Edit Issue"
+        click_on "Delete Issue"
+        click_on "Delete issue"
 
         click_on "Continue"
         expect(page).to have_content("Evaluate Decision")
@@ -169,6 +171,11 @@ RSpec.feature "Judge checkout flow" do
         expect(page).to have_content(COPY::JUDGE_CHECKOUT_DISPATCH_SUCCESS_MESSAGE_TITLE % appeal.veteran_full_name)
 
         expect(VACOLS::Decass.find(appeal.vacols_id).de1touch).to eq "Y"
+
+        page.driver.go_back
+        appeal_id = LegacyAppeal.last.vacols_id
+
+        expect(page).to have_current_path("/queue/appeals/#{appeal_id}")
       end
     end
 


### PR DESCRIPTION
**Why**: If a judge edited or deleted an issue during the dispatch
checkout of a legacy appeal, and then clicked the browser back button
after the checkout, they would end up on the dispositions page instead
of the appeal details page. If they clicked on the Caseflow back button
on the dispositions page, it would try to take them to the special
issues page, which caused an exception to be sent to Sentry because the
judge no longer has permissions to edit the special issues for this
appeal.

This only happened when editing issues because the "Add Issue" and
"Delete Issue" links were React `Link`s, which by default add a new
entry to the `history` stack. By passing in the `replace` property, we
allow the current entry in the history stack to be replaced. This
required updating the `caseflow-frontend-toolkit` dependency to support
the `replace` property. Huge thanks to Hunter Schallhorn for figuring
this out and fixing it, and for Anya Roltsch for finding the steps to
reproduce.

Fixes #9899

