### PR TITLE
Paginate async jobs page

### DIFF
--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -59,11 +59,11 @@ class AsyncableJobsController < ApplicationController
   end
 
   def page_size
-    50 # TODO: allowed param?
+    10 # TODO: allowed param?
   end
 
   def current_page
-    allowed_params[:page] || 1
+    (allowed_params[:page] || 1).to_i
   end
 
   def page_start

--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -59,7 +59,7 @@ class AsyncableJobsController < ApplicationController
   end
 
   def page_size
-    10 # TODO: allowed param?
+    50 # TODO: allowed param?
   end
 
   def current_page

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -5,7 +5,7 @@ class AsyncableJobs
   attr_reader :page, :page_size, :total_jobs, :total_pages
 
   def self.models
-    @models ||= ActiveRecord::Base.descendants
+    ActiveRecord::Base.descendants
       .select { |c| c.included_modules.include?(Asyncable) }
       .reject(&:abstract_class?)
   end

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -2,9 +2,11 @@
 
 class AsyncableJobs
   attr_accessor :jobs
+  attr_reader :page, :page_size, :total_jobs, :total_pages
 
-  def initialize(page: 1)
+  def initialize(page: 1, page_size: 50)
     @page = page
+    @page_size = page_size
     @jobs = gather_jobs
   end
 
@@ -21,12 +23,21 @@ class AsyncableJobs
 
   private
 
-  # TODO: how to support paging when coallescing so many different models?
   def gather_jobs
     expired_jobs = []
     models.each do |klass|
       expired_jobs << klass.potentially_stuck
     end
-    expired_jobs.flatten.sort_by(&:sort_by_last_submitted_at)
+    jobs = expired_jobs.flatten.sort_by(&:sort_by_last_submitted_at)
+    @total_jobs = jobs.length
+    @total_pages = (total_jobs / page_size).to_i
+    @total_pages += 1 if total_jobs % page_size
+    jobs.slice(page_start, page_size)
+  end
+
+  def page_start
+    return 0 if page < 2
+
+    (page - 1) * page_size
   end
 end

--- a/app/views/asyncable_jobs/index.html.erb
+++ b/app/views/asyncable_jobs/index.html.erb
@@ -7,6 +7,8 @@
     flash: flash,
     serverJobs: {
       jobs: jobs.map(&:asyncable_ui_hash),
+      models: AsyncableJobs.models.map(&:name),
+      pagination: pagination,
       fetchedAt: Time.zone.now,
       asyncableJobKlass: allowed_params[:asyncable_job_klass]
     }

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -211,7 +211,7 @@ class AsyncableJobsPage extends React.PureComponent {
       let newPage = idx + 1;
 
       if (newPage !== this.props.pagination.current_page) {
-        let newUrl = `{window.location.href.split('?')[0]}?page=${newPage}`;
+        let newUrl = `${window.location.href.split('?')[0]}?page=${newPage}`;
 
         window.location = newUrl;
       }

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -208,11 +208,11 @@ class AsyncableJobsPage extends React.PureComponent {
     };
 
     const pageUpdater = (idx) => {
-      //console.log("pageUpdater", idx);
       let newPage = idx + 1;
+
       if (newPage !== this.props.pagination.current_page) {
-        let newUrl = window.location.href.split('?')[0] + '?page=' + newPage;
-        console.log(newUrl);
+        let newUrl = `{window.location.href.split('?')[0]}?page=${newPage}`;
+
         window.location = newUrl;
       }
     };

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import Button from '../../components/Button';
 import Table from '../../components/Table';
+import Pagination from '../../components/Pagination';
 
 import ApiUtil from '../../util/ApiUtil';
 
@@ -114,18 +115,40 @@ class AsyncableJobsPage extends React.PureComponent {
     return moment(datetime).format(DATE_TIME_FORMAT);
   }
 
+  modelNameLinks = () => {
+    let links = [];
+
+    for (let modelName of this.props.models.sort()) {
+      let modelLink = <span key={modelName} className="cf-model-jobs-link">
+        <a href={`/asyncable_jobs/${modelName}/jobs`}>{modelName}</a>
+      </span>;
+
+      links.push(modelLink);
+    }
+
+    return links;
+  }
+
   render = () => {
     const rowObjects = this.props.jobs;
 
     if (rowObjects.length === 0) {
-      return 'Success! There are no pending jobs.';
+      return <div>
+        <h1>Success! There are no pending jobs.</h1>
+        <div>
+          <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}
+          &nbsp;&#183;&nbsp;
+          <a href="/jobs">All jobs</a>
+          <div>{this.modelNameLinks()}</div>
+        </div>
+      </div>;
     }
 
     const columns = [
       {
         header: 'Name',
-        valueFunction: (job) => {
-          return <a href={`/asyncable_jobs/${job.klass}/jobs`}>{job.klass}</a>;
+        valueFunction: (job, rowId) => {
+          return <a title={`row ${rowId}`} href={`/asyncable_jobs/${job.klass}/jobs`}>{job.klass}</a>;
         }
       },
       {
@@ -184,14 +207,33 @@ class AsyncableJobsPage extends React.PureComponent {
       return rowObject.restarted ? 'cf-success' : '';
     };
 
+    const pageUpdater = (idx) => {
+      //console.log("pageUpdater", idx);
+      let newPage = idx + 1;
+      if (newPage !== this.props.pagination.current_page) {
+        let newUrl = window.location.href.split('?')[0] + '?page=' + newPage;
+        console.log(newUrl);
+        window.location = newUrl;
+      }
+    };
+
     return <div className="cf-asyncable-jobs-table">
       <h1>{this.props.asyncableJobKlass} Jobs</h1>
       <div>
         <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}
         &nbsp;&#183;&nbsp;
         <a href="/jobs">All jobs</a>
+        <div>{this.modelNameLinks()}</div>
       </div>
+      <hr />
       <Table columns={columns} rowObjects={rowObjects} rowClassNames={rowClassNames} slowReRendersAreOk />
+      <Pagination
+        currentPage={this.props.pagination.current_page}
+        currentCases={rowObjects.length}
+        totalCases={this.props.pagination.total_jobs}
+        totalPages={this.props.pagination.total_pages}
+        pageSize={this.props.pagination.page_size}
+        updatePage={pageUpdater} />
     </div>;
   }
 }
@@ -200,6 +242,8 @@ const JobsPage = connect(
   (state) => ({
     jobs: state.jobs,
     fetchedAt: state.fetchedAt,
+    models: state.models,
+    pagination: state.pagination,
     asyncableJobKlass: state.asyncableJobKlass
   })
 )(AsyncableJobsPage);

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -10,7 +10,7 @@ class Pagination extends React.PureComponent {
 
   // pagination button is zero-based but we are one-based so fake out the currentPage.
   currentPageIndex = () => {
-    this.props.currentPage - 1;
+    return this.props.currentPage - 1;
   }
 
   handleNext = () => {

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -55,7 +55,7 @@ class Pagination extends React.PureComponent {
     // Create the range
     let currentCaseRange = `${beginningCaseNumber}-${endingCaseNumber}`;
     // Create the entire summary
-    const paginationSummary = `Viewing ${currentCaseRange} of ${totalCases} total cases`;
+    const paginationSummary = `Viewing ${currentCaseRange} of ${totalCases} total`;
     // Render the page buttons
     let pageButtons = [];
     let paginationButtons = [];

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -9,15 +9,18 @@ class Pagination extends React.PureComponent {
   };
 
   // pagination button is zero-based but we are one-based so fake out the currentPage.
+  currentPageIndex = () => {
+    this.props.currentPage - 1;
+  }
 
   handleNext = () => {
-    const nextPageIndex = this.props.currentPage;
+    const nextPageIndex = this.currentPageIndex() + 1;
 
     this.props.updatePage(nextPageIndex);
   };
 
   handlePrevious = () => {
-    const previousPageIndex = this.props.currentPage - 2;
+    const previousPageIndex = this.currentPageIndex() - 1;
 
     this.props.updatePage(previousPageIndex);
   };
@@ -26,7 +29,7 @@ class Pagination extends React.PureComponent {
     return (
       <PaginationButton
         key={`pagination-button-${indexOfPage}`}
-        currentPage={this.props.currentPage - 1}
+        currentPage={this.currentPageIndex()}
         index={indexOfPage}
         handleChange={this.handleChange} />
     );

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import PaginationButton from './PaginationButton';
+
+class Pagination extends React.PureComponent {
+  handleChange = (index) => {
+    this.props.updatePage(index);
+  };
+
+  // pagination button is zero-based but we are one-based so fake out the currentPage.
+
+  handleNext = () => {
+    const nextPageIndex = this.props.currentPage;
+
+    this.props.updatePage(nextPageIndex);
+  };
+
+  handlePrevious = () => {
+    const previousPageIndex = this.props.currentPage - 2;
+
+    this.props.updatePage(previousPageIndex);
+  };
+
+  generatePaginationButton = (indexOfPage) => {
+    return (
+      <PaginationButton
+        key={`pagination-button-${indexOfPage}`}
+        currentPage={this.props.currentPage - 1}
+        index={indexOfPage}
+        handleChange={this.handleChange} />
+    );
+  };
+
+  generateBlankButton = (key) => {
+    return <button disabled key={`blank-button-${key}`}>...</button>;
+  };
+
+  render() {
+    const {
+      totalPages,
+      currentPage,
+      pageSize,
+      totalCases,
+      currentCases
+    } = this.props;
+
+    // If there are no pages, there is no data, so the range should be 0-0.
+    // Otherwise, the beginning of the range is the previous amount of cases + 1
+    const beginningCaseNumber = (currentPage * pageSize) - pageSize + 1;
+    // If there are no pages, there is no data, so the range should be 0-0.
+    // Otherwise, the end of the range is the previous amount of cases + 
+    // the amount of data in the current page.
+    const endingCaseNumber = beginningCaseNumber + currentCases - 1;
+    // Create the range
+    let currentCaseRange = `${beginningCaseNumber}-${endingCaseNumber}`;
+    // Create the entire summary
+    const paginationSummary = `Viewing ${currentCaseRange} of ${totalCases} total cases`;
+    // Render the page buttons
+    let pageButtons = [];
+    let paginationButtons = [];
+
+    if (totalPages > 5) {
+      const indexOfLastPage = totalPages - 1;
+      const firstPageButton = this.generatePaginationButton(0);
+      const lastPageButton = this.generatePaginationButton(indexOfLastPage);
+
+      if (currentPage < 3) {
+        pageButtons = [...Array(4)].map((number, index) =>
+          this.generatePaginationButton(index)
+        );
+        pageButtons.push(this.generateBlankButton(1));
+        pageButtons.push(lastPageButton);
+      } else if (currentPage > totalPages - 4) {
+        pageButtons.push(firstPageButton);
+        pageButtons.push(this.generateBlankButton(1));
+
+        const last4PageButtons = [...Array(4)].map((number, index) =>
+          this.generatePaginationButton(totalPages - (4 - index))
+        );
+
+        pageButtons = pageButtons.concat(last4PageButtons);
+      } else {
+        pageButtons.push(firstPageButton);
+        pageButtons.push(this.generateBlankButton(1));
+        pageButtons.push(this.generatePaginationButton(currentPage - 1));
+        pageButtons.push(this.generatePaginationButton(currentPage));
+        pageButtons.push(this.generatePaginationButton(currentPage + 1));
+        pageButtons.push(this.generateBlankButton(2));
+        pageButtons.push(lastPageButton);
+      }
+    } else {
+      pageButtons = [...Array(totalPages)].map((number, index) => 
+        this.generatePaginationButton(index)
+      );
+    }
+
+    if (totalPages > 1) {
+      paginationButtons.push(
+        <button
+          key="previous-button"
+          disabled={currentPage === 1}
+          onClick={() => this.handlePrevious()}>
+          Previous
+        </button>
+      );
+      paginationButtons = paginationButtons.concat(pageButtons);
+      paginationButtons.push(
+        <button
+          key="next-button"
+          disabled={currentPage === totalPages}
+          onClick={() => this.handleNext()}>
+          Next
+        </button>
+      );
+    }
+
+    return (
+      <div className="cf-pagination">
+        <div className="cf-pagination-summary">
+          {paginationSummary}
+        </div>
+        <div className="cf-pagination-pages">
+          {paginationButtons}
+        </div>
+      </div>
+    );
+  }
+}
+
+Pagination.propTypes = {
+  pageSize: PropTypes.number.isRequired,
+  currentPage: PropTypes.number.isRequired,
+  currentCases: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  totalCases: PropTypes.number.isRequired,
+  updatePage: PropTypes.func.isRequired
+};
+
+export default Pagination;

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -90,7 +90,7 @@ class Pagination extends React.PureComponent {
         pageButtons.push(lastPageButton);
       }
     } else {
-      pageButtons = [...Array(totalPages)].map((number, index) => 
+      pageButtons = [...Array(totalPages)].map((number, index) =>
         this.generatePaginationButton(index)
       );
     }

--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -3,3 +3,9 @@
   overflow: auto;
   display: inline-block;
 }
+
+.cf-model-jobs-link {
+  margin-right: 8px;
+  padding-right: 8px;
+  border-right: 1px solid $color-gray-light;
+}

--- a/spec/controllers/asyncable_jobs_controller_spec.rb
+++ b/spec/controllers/asyncable_jobs_controller_spec.rb
@@ -78,8 +78,15 @@ describe AsyncableJobsController, type: :controller do
           get :index, as: :html, params: { asyncable_job_klass: "HigherLevelReview" }
 
           expect(response.status).to eq 200
-          expect(response.body).to match(/HigherLevelReview/)
-          expect(response.body).to_not match(/SupplementalClaim/)
+          expect(response.body).to match(/"asyncableJobKlass":"HigherLevelReview"/)
+        end
+      end
+
+      context "#pagination" do
+        it "paginates based on asyncable_job_klass" do
+          get :index, as: :html, params: { asyncable_job_klass: "HigherLevelReview" }
+
+          expect(subject.send(:pagination)).to eq(total_pages: 1, total_jobs: 1, current_page: 1, page_size: 50)
         end
       end
 

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -42,6 +42,11 @@ feature "Asyncable Jobs index" do
   let!(:request_issues_update) do
     create(:request_issues_update, last_submitted_at: 6.days.ago, submitted_at: 6.days.ago)
   end
+  let!(:request_issues) do
+    50.times do
+      create(:request_issue, decision_sync_last_submitted_at: 1.day.ago) # fewer days to sort others first
+    end
+  end
 
   describe "index page" do
     it "shows jobs that look potentially stuck" do
@@ -78,9 +83,20 @@ feature "Asyncable Jobs index" do
       expect(hlr.establishment_submitted_at).to be_within(1.second).of 8.days.ago
     end
 
+    it "allows user to page through jobs" do
+      visit "/jobs"
+
+      expect(page).to have_content("Viewing 1-50 of 54 total")
+
+      find("[name=page-button-1]").click
+
+      expect(current_url).to match(/\?page=2/)
+      expect(page).to have_content("Viewing 51-54 of 54 total")
+    end
+
     context "zero unprocessed jobs" do
       before do
-        AsyncableJobs.new.jobs.each(&:clear_error!).each(&:processed!)
+        AsyncableJobs.new(page_size: 100).jobs.each(&:clear_error!).each(&:processed!)
       end
 
       it "shows nice message" do

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -3,6 +3,8 @@
 describe Intake do
   before do
     Timecop.freeze(Time.utc(2018, 1, 1, 12, 0, 0))
+
+    RequestStore[:current_user] = user
   end
 
   class TestIntake < Intake

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -78,13 +78,13 @@ describe AsyncableJobs do
     end
   end
 
-  describe "#models" do
+  describe ".models" do
     it "returns list of Asyncable-consuming models" do
-      expect(subject.models).to include(HigherLevelReview)
+      expect(described_class.models).to include(HigherLevelReview)
     end
 
     it "rejects abstract classes" do
-      expect(subject.models).to_not include(DecisionReview)
+      expect(described_class.models).to_not include(DecisionReview)
     end
   end
 

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -87,4 +87,14 @@ describe AsyncableJobs do
       expect(subject.models).to_not include(DecisionReview)
     end
   end
+
+  describe "#total_jobs" do
+    subject { described_class.new(page: 2, page_size: 4) }
+
+    it "paginates" do
+      expect(subject.jobs.length).to eq(2)
+      expect(subject.total_jobs).to eq(6)
+      expect(subject.total_pages).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
connects #10444 

### Description

Our backlog of async jobs can run into the 1000s which makes loading on a single page prohibitive.

This change implements pagination feature for the /jobs page, and adds subnav to easily filter by job type.

<img width="1117" alt="Screen Shot 2019-04-23 at 2 04 11 PM" src="https://user-images.githubusercontent.com/1205061/56609999-17e70900-65d4-11e9-8789-a94001c0216d.png">

