### PR TITLE
TaskController#create accepts multiple task types

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,7 +6,7 @@ class TasksController < ApplicationController
   before_action :verify_task_access, only: [:create]
   skip_before_action :deny_vso_access, only: [:create, :index, :update, :for_appeal]
 
-  TASK_CLASSES = {
+  TASK_CLASSES_LOOKUP = {
     ChangeHearingDispositionTask: ChangeHearingDispositionTask,
     ColocatedTask: ColocatedTask,
     AttorneyRewriteTask: AttorneyRewriteTask,
@@ -57,9 +57,14 @@ class TasksController < ApplicationController
   #   assigned_to_id: 23
   #  }
   def create
-    return invalid_type_error unless task_class
+    return invalid_type_error unless task_classes_valid?
 
-    tasks = task_class.create_many_from_params(create_params, current_user)
+    tasks = []
+    param_groups = create_params.group_by { |param| param[:type] }
+    param_groups.each do |task_type, param_group|
+      tasks << valid_task_classes[task_type.to_sym].create_many_from_params(param_group, current_user)
+    end
+    tasks.flatten!
 
     tasks_to_return = (queue_class.new(user: current_user).tasks + tasks).uniq
 
@@ -124,7 +129,7 @@ class TasksController < ApplicationController
   private
 
   def verify_task_access
-    if current_user.vso_employee? && task_class != InformalHearingPresentationTask
+    if current_user.vso_employee? && task_classes.exclude?(InformalHearingPresentationTask.name.to_sym)
       fail Caseflow::Error::ActionForbiddenError, message: "VSOs cannot create that task."
     end
   end
@@ -142,13 +147,21 @@ class TasksController < ApplicationController
   end
   helper_method :user
 
-  def task_class
+  def task_classes_valid?
+    valid_task_class_names = valid_task_classes.keys
+    (task_classes - valid_task_class_names).empty?
+  end
+
+  def task_classes
+    create_params.map { |param| param[:type]&.to_sym }.uniq.compact
+  end
+
+  def valid_task_classes
     additional_task_classes = Hash[
       *MailTask.subclasses.map { |subclass| [subclass.to_s.to_sym, subclass] }.flatten,
       *HearingAdminActionTask.subclasses.map { |subclass| [subclass.to_s.to_sym, subclass] }.flatten
     ]
-    classes = TASK_CLASSES.merge(additional_task_classes)
-    classes[create_params.first[:type].try(:to_sym)]
+    TASK_CLASSES_LOOKUP.merge(additional_task_classes)
   end
 
   def appeal
@@ -159,7 +172,7 @@ class TasksController < ApplicationController
     render json: {
       "errors": [
         "title": "Invalid Task Type Error",
-        "detail": "Task type is invalid, valid types: #{TASK_CLASSES.keys}"
+        "detail": "Task type is invalid, valid types: #{TASK_CLASSES_LOOKUP.keys}"
       ]
     }, status: :bad_request
   end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -247,6 +247,8 @@ RSpec.describe TasksController, type: :controller do
       FactoryBot.create(:staff, :attorney_role, sdomainid: attorney.css_id)
     end
 
+    subject { post :create, params: { tasks: params } }
+
     context "Attorney task" do
       context "when current user is a judge" do
         let(:ama_appeal) { create(:appeal) }
@@ -263,7 +265,8 @@ RSpec.describe TasksController, type: :controller do
         end
 
         it "should be successful" do
-          post :create, params: { tasks: params }
+          subject
+
           expect(response.status).to eq 200
 
           response_body = JSON.parse(response.body)["tasks"]["data"]
@@ -305,7 +308,8 @@ RSpec.describe TasksController, type: :controller do
         end
 
         it "should not be successful" do
-          post :create, params: { tasks: params }
+          subject
+
           expect(response.status).to eq 403
         end
       end
@@ -329,7 +333,8 @@ RSpec.describe TasksController, type: :controller do
         end
 
         it "should be successful" do
-          post :create, params: { tasks: params }
+          subject
+
           expect(response.status).to eq 200
         end
       end
@@ -367,7 +372,9 @@ RSpec.describe TasksController, type: :controller do
 
           it "should be successful" do
             expect(AppealRepository).to receive(:update_location!).exactly(1).times
-            post :create, params: { tasks: params }
+
+            subject
+
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(4)
@@ -414,7 +421,9 @@ RSpec.describe TasksController, type: :controller do
 
           it "should be successful" do
             expect(AppealRepository).to receive(:update_location!).exactly(1).times
-            post :create, params: { tasks: params }
+
+            subject
+
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(4)
@@ -449,7 +458,8 @@ RSpec.describe TasksController, type: :controller do
           end
 
           it "should be successful" do
-            post :create, params: { tasks: params }
+            subject
+
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(2)
@@ -471,7 +481,8 @@ RSpec.describe TasksController, type: :controller do
           end
 
           it "should be successful" do
-            post :create, params: { tasks: params }
+            subject
+
             expect(response.status).to eq 200
             response_body = JSON.parse(response.body)["tasks"]["data"]
             expect(response_body.size).to eq(2)
@@ -492,10 +503,65 @@ RSpec.describe TasksController, type: :controller do
           end
 
           it "should not be successful" do
-            post :create, params: { tasks: params }
+            subject
+
             expect(response.status).to eq 404
           end
         end
+      end
+    end
+
+    context "hearing user and hearing admin action tasks" do
+      let(:role) { :hearing_coordinator }
+      let!(:user) { create(:user, roles: ["Build HearSched"]) }
+      let!(:appeal) { FactoryBot.create(:appeal) }
+      let!(:schedule_hearing_task) { FactoryBot.create(:schedule_hearing_task, appeal: appeal) }
+      let(:incarcerated_instructions) { "Incarcerated veteran task instructions" }
+      let(:contested_instructions_1) { "Contested claimant task instructions" }
+      let(:contested_instructions_2) { "Instructions for another contested claimant task" }
+      let(:params) do
+        [
+          {
+            "instructions": incarcerated_instructions,
+            "type": "HearingAdminActionIncarceratedVeteranTask",
+            "external_id": appeal.external_id,
+            "parent_id": schedule_hearing_task.id.to_s
+          },
+          {
+            "instructions": contested_instructions_1,
+            "type": "HearingAdminActionContestedClaimantTask",
+            "external_id": appeal.external_id,
+            "parent_id": schedule_hearing_task.id.to_s
+          },
+          {
+            "instructions": contested_instructions_2,
+            "type": "HearingAdminActionContestedClaimantTask",
+            "external_id": appeal.external_id,
+            "parent_id": schedule_hearing_task.id.to_s
+          }
+        ]
+      end
+
+      before do
+        OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)
+      end
+
+      it "creates tasks with the correct types" do
+        expect(HearingAdminActionTask.count).to eq 0
+
+        subject
+
+        expect(HearingAdminActionTask.count).to eq 3
+        expect(HearingAdminActionTask.all.map(&:parent).uniq).to match_array([schedule_hearing_task])
+        expect(HearingAdminActionTask.all.map(&:appeal).uniq).to match_array([appeal])
+
+        expect(HearingAdminActionIncarceratedVeteranTask.count).to eq 1
+        expect(HearingAdminActionIncarceratedVeteranTask.first.instructions).to include incarcerated_instructions
+
+        expect(HearingAdminActionContestedClaimantTask.count).to eq 2
+        expect(
+          HearingAdminActionContestedClaimantTask.all.map(&:instructions).flatten
+        ).to match_array([contested_instructions_1, contested_instructions_2])
       end
     end
   end


### PR DESCRIPTION
Resolves #10513

### Description
The TasksController used to assume that all the tasks passed to `create` were the same type. With this change, the controller creates tasks in groups by type.
