### PR TITLE
Allow JudgeTasks to have multiple child attorney tasks

### DIFF
--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -25,9 +25,7 @@ class JudgeTask < Task
   end
 
   def previous_task
-    fail Caseflow::Error::TooManyChildTasks, task_id: id if children_attorney_tasks.length > 1
-
-    children_attorney_tasks[0]
+    children_attorney_tasks.order(:assigned_at).last
   end
 
   #:nocov:

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -139,14 +139,6 @@ module Caseflow::Error
     end
   end
 
-  class TooManyChildTasks < SerializableError
-    def initialize(args)
-      @task_id = args[:task_id]
-      @code = args[:code] || 500
-      @message = args[:message] || "JudgeTask #{@task_id} has too many children"
-    end
-  end
-
   class ChildTaskAssignedToSameUser < SerializableError
     def initialize
       @code = 500

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -152,19 +152,43 @@ describe JudgeTask do
   end
 
   describe ".previous_task" do
-    it "should return the only child" do
-      parent = FactoryBot.create(:ama_judge_task, assigned_to: judge)
-      child = FactoryBot.create(:ama_attorney_task, assigned_to: attorney, status: "completed", parent: parent)
-
-      expect(parent.previous_task.id).to eq(child.id)
+    let(:parent) { FactoryBot.create(:ama_judge_task, assigned_to: judge) }
+    let!(:child) do
+      FactoryBot.create(
+        :ama_attorney_task,
+        assigned_to: attorney,
+        assigned_by: judge,
+        status: Constants.TASK_STATUSES.completed,
+        parent: parent
+      ).becomes(AttorneyTask)
     end
 
-    it "should throw an exception if there are too many children" do
-      parent = FactoryBot.create(:ama_judge_task, assigned_to: judge)
-      FactoryBot.create(:ama_attorney_task, assigned_to: attorney, status: "completed", parent: parent)
-      FactoryBot.create(:ama_attorney_task, assigned_to: attorney, status: "completed", parent: parent)
+    subject { parent.previous_task }
 
-      expect { parent.previous_task }.to raise_error(Caseflow::Error::TooManyChildTasks)
+    context "when there is only one child attorney task" do
+      it "returns the only child" do
+        expect(subject).to eq(child)
+      end
+    end
+
+    context "when there are two child attorney tasks that have been assigned" do
+      let!(:older_child_task) do
+        child.tap do |t|
+          t.assigned_at = Time.zone.now - 6.days
+          t.save!
+        end
+      end
+
+      let!(:newer_child_task) do
+        child.tap do |t|
+          t.assigned_at = Time.zone.now - 1.day
+          t.save!
+        end
+      end
+
+      it "should return the most recently assigned attorney task" do
+        expect(subject).to eq(newer_child_task)
+      end
     end
   end
 


### PR DESCRIPTION
This PR allows `JudgeTask`s to have multiple child attorney tasks (for example when QR returns a case to a judge and that judge wants to send that assign that case to one of their attorneys for corrections). The only place we use the `previous_task` method is [in serializers](https://github.com/department-of-veterans-affairs/caseflow/blob/daed2f16d8c97a39ab3c80539fb34a8dde224cce/app/models/serializers/work_queue/task_serializer.rb#L88) where it eventually gets used to [display the date the case was assigned](https://github.com/department-of-veterans-affairs/caseflow/blob/daed2f16d8c97a39ab3c80539fb34a8dde224cce/client/app/queue/EvaluateDecisionView.jsx#L198).

