### PR TITLE
Stop connecting intakes to previous ramp election

### DIFF
--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -163,8 +163,4 @@ class RampElectionIntake < Intake
       update!(detail: existing_ramp_election)
     end
   end
-
-  def veteran_ramp_elections
-    RampElection.where(veteran_file_number: veteran_file_number)
-  end
 end

--- a/app/models/ramp_election_intake.rb
+++ b/app/models/ramp_election_intake.rb
@@ -141,7 +141,9 @@ class RampElectionIntake < Intake
   end
 
   def new_intake_ramp_election
-    @new_intake_ramp_election ||= matching_ramp_election_with_notice_date || veteran_ramp_elections.build
+    @new_intake_ramp_election ||= RampElection.new(
+      veteran_file_number: veteran_file_number
+    )
   end
 
   def existing_ramp_election
@@ -160,10 +162,6 @@ class RampElectionIntake < Intake
       detail.destroy!
       update!(detail: existing_ramp_election)
     end
-  end
-
-  def matching_ramp_election_with_notice_date
-    veteran_ramp_elections.where(established_at: nil).where.not(notice_date: nil).first
   end
 
   def veteran_ramp_elections

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -441,13 +441,12 @@ describe RampElectionIntake do
         create(:ramp_election, veteran_file_number: "64205555", notice_date: 5.days.ago)
       end
 
-      it "saves intake and sets detail to a new ramp election" do
+      it "creates a new RAMP Election and does not set detail to the existing RAMP Election" do
         expect(subject).to be_truthy
 
         expect(intake.detail).to have_attributes(
-          id: ramp_election.id,
           veteran_file_number: "64205555",
-          notice_date: 5.days.ago.to_date
+          notice_date: nil
         )
       end
     end

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -448,6 +448,10 @@ describe RampElectionIntake do
           veteran_file_number: "64205555",
           notice_date: nil
         )
+
+        expect(intake.detail).to_not have_attributes(
+          id: ramp_election.id
+        )
       end
     end
 


### PR DESCRIPTION
connects #10523

This is causing a bug where a Ramp Election has multiple RampElectionIntakes instead of one RampElectionIntake, which is causing issues for EP Establishment because it's using the user who processed the older intake on "intake_processed_by"