### PR TITLE
Fix demo data for AABSHIRE

### DIFF
--- a/spec/factories/vacols/case_hearing.rb
+++ b/spec/factories/vacols/case_hearing.rb
@@ -51,8 +51,8 @@ FactoryBot.define do
       end
 
       if evaluator.user
-        user = evaluator.user
-        staff_record = VACOLS::Staff.find_by(sdomainid: user.css_id) || create(:staff, :attorney_judge_role, user: user)
+        existing_staff_record = VACOLS::Staff.where(sdomainid: evaluator.user.css_id, svlj: %w[A J], sactive: "A").first
+        staff_record = existing_staff_record || create(:staff, :attorney_judge_role, user: evaluator.user)
         hearing.board_member = staff_record.sattyid
       end
     end

--- a/spec/factories/vacols/case_hearing.rb
+++ b/spec/factories/vacols/case_hearing.rb
@@ -51,7 +51,9 @@ FactoryBot.define do
       end
 
       if evaluator.user
-        hearing.board_member = create(:staff, :attorney_judge_role, user: evaluator.user).sattyid
+        user = evaluator.user
+        staff_record = VACOLS::Staff.find_by(sdomainid: user.css_id) || create(:staff, :attorney_judge_role, user: user)
+        hearing.board_member = staff_record.sattyid
       end
     end
   end


### PR DESCRIPTION
This PR fixes a bug where we were accidentally creating a second row in `vacols.staff` for our test judge "AABSHIRE". This change fixes it by only creating a new row in `vacols.staff` if a row does not already exist for that user.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/56699443-72ab5e00-66c3-11e9-8701-75ef5c36487a.png) | ![image](https://user-images.githubusercontent.com/32683958/56699448-750db800-66c3-11e9-862c-d242cb3cf0c8.png)

## Test plan
* Re-seed the database
* Log in as "AABSHIRE"
* Visit `/queue`
* Observe that you are viewing the judge queue (instead of the attorney queue)
* Open the rails console
* run `VACOLS::Staff.where(sdomainid: "BVAAABSHIRE").count`
* Observe that the number 1 is output (instead of 2)