### PR TITLE
Add endpoint for creating timed holds

### DIFF
--- a/app/controllers/tasks/place_hold_controller.rb
+++ b/app/controllers/tasks/place_hold_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Tasks::PlaceHoldController < TasksController
+  def create
+    TimedHoldTask.create_from_parent(task, **create_params.to_h.symbolize_keys)
+
+    render json: { tasks: json_tasks(task.appeal.tasks.includes(*task_includes)) }
+  rescue ActiveRecord::RecordInvalid => error
+    invalid_record_error(error.record)
+  end
+
+  private
+
+  def task
+    @task ||= Task.find(params[:task_id])
+  end
+
+  def create_params
+    params.require(:task).permit(:days_on_hold, :instructions).merge(assigned_by: current_user)
+  end
+end

--- a/app/models/tasks/timed_hold_task.rb
+++ b/app/models/tasks/timed_hold_task.rb
@@ -47,6 +47,7 @@ class TimedHoldTask < GenericTask
 
   # We cancel the siblings after we have created the new task so that the parent task stays on hold.
   def cancel_active_siblings
-    siblings.select(&:active?).each { |sibling_task| sibling_task.update!(status: Constants.TASK_STATUSES.cancelled) }
+    siblings.select { |sibling_task| sibling_task.active? && sibling_task.is_a?(TimedHoldTask) }
+      .each { |sibling_task| sibling_task.update!(status: Constants.TASK_STATUSES.cancelled) }
   end
 end

--- a/app/models/tasks/timed_hold_task.rb
+++ b/app/models/tasks/timed_hold_task.rb
@@ -7,9 +7,21 @@ class TimedHoldTask < GenericTask
   include TimeableTask
 
   before_create :verify_parent_task_presence
+  after_create :cancel_active_siblings
 
   attr_accessor :days_on_hold
-  validates :days_on_hold, presence: true, inclusion: { in: 1..100 }
+  validates :days_on_hold, presence: true, inclusion: { in: 1..100 }, on: :create
+
+  def self.create_from_parent(parent_task, days_on_hold:, assigned_by: nil, instructions: nil)
+    create!(
+      appeal: parent_task.appeal,
+      assigned_by: assigned_by || parent_task.assigned_to,
+      assigned_to: parent_task.assigned_to,
+      parent: parent_task,
+      days_on_hold: days_on_hold&.to_i,
+      instructions: [instructions].compact.flatten
+    )
+  end
 
   def when_timer_ends
     update!(status: :completed) if active?
@@ -31,5 +43,10 @@ class TimedHoldTask < GenericTask
 
   def verify_parent_task_presence
     fail(Caseflow::Error::InvalidParentTask, message: "TimedHoldTasks must have parent tasks") unless parent
+  end
+
+  # We cancel the siblings after we have created the new task so that the parent task stays on hold.
+  def cancel_active_siblings
+    siblings.select(&:active?).each { |t| t.update!(status: Constants.TASK_STATUSES.cancelled) }
   end
 end

--- a/app/models/tasks/timed_hold_task.rb
+++ b/app/models/tasks/timed_hold_task.rb
@@ -47,6 +47,6 @@ class TimedHoldTask < GenericTask
 
   # We cancel the siblings after we have created the new task so that the parent task stays on hold.
   def cancel_active_siblings
-    siblings.select(&:active?).each { |t| t.update!(status: Constants.TASK_STATUSES.cancelled) }
+    siblings.select(&:active?).each { |sibling_task| sibling_task.update!(status: Constants.TASK_STATUSES.cancelled) }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -217,6 +217,7 @@ Rails.application.routes.draw do
     member do
       post :reschedule
     end
+    resources(:place_hold, only: [:create], controller: 'tasks/place_hold')
   end
   resources :judge_assign_tasks, only: [:create]
 

--- a/spec/controllers/tasks/place_hold_controller_spec.rb
+++ b/spec/controllers/tasks/place_hold_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe Tasks::PlaceHoldController, type: :controller do
+  describe "POST tasks/:id/place_hold" do
+    let(:user) { FactoryBot.create(:user) }
+
+    let(:parent) { FactoryBot.create(:generic_task) }
+    let(:parent_id) { parent.id }
+    let(:days_on_hold) { 30 }
+    let(:instructions) { "Placing task on hold for 30 days" }
+    let(:params) { { days_on_hold: days_on_hold, instructions: instructions } }
+
+    subject { post(:create, params: { task_id: parent_id, task: params }) }
+
+    before do
+      User.authenticate!(user: user)
+    end
+
+    context "with the correct parameters" do
+      it "creates the TimedHoldTask for the task" do
+        subject
+
+        expect(response.status).to eq(200)
+        response_body = JSON.parse(response.body)["tasks"]["data"]
+        expect(response_body.length).to eq(2)
+
+        expect(parent.reload.status).to eq(Constants.TASK_STATUSES.on_hold)
+        timed_hold_task = parent.children.first
+        expect(timed_hold_task).to be_a(TimedHoldTask)
+        expect(timed_hold_task.instructions).to eq([instructions])
+        expect(timed_hold_task.assigned_by).to eq(user)
+
+        task_timer = timed_hold_task.task_timers.first
+        expect(task_timer).to be_a(TaskTimer)
+        expect(task_timer.submitted_at.to_date).to eq((Time.zone.now + days_on_hold.days).to_date)
+      end
+    end
+
+    context "with a non-existent parent_id" do
+      let(:parent_id) { parent.id + 999 }
+
+      it "returns an error" do
+        subject
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -4,13 +4,13 @@ describe TimedHoldTask do
   let(:task) { FactoryBot.create(:timed_hold_task) }
 
   describe ".create!" do
+    let(:appeal) { FactoryBot.create(:appeal) }
+    let(:parent) { FactoryBot.create(:generic_task) }
     let(:initial_args) do
-      {
-        appeal: FactoryBot.create(:appeal),
+      { appeal: appeal,
         assigned_to: FactoryBot.create(:user),
         days_on_hold: 18,
-        parent: FactoryBot.create(:generic_task)
-      }
+        parent: parent }
     end
 
     subject { TimedHoldTask.create!(**args) }
@@ -46,6 +46,81 @@ describe TimedHoldTask do
 
       it "creates task successfully" do
         expect(subject).to be_an_instance_of(TimedHoldTask)
+      end
+    end
+
+    describe "after_create(:cancel_active_siblings)" do
+      let(:args) { initial_args }
+
+      context "when there are no sibling tasks" do
+        it "creates task successfully" do
+          expect(subject).to be_an_instance_of(TimedHoldTask)
+        end
+      end
+
+      context "when there are closed sibling tasks" do
+        let!(:cancelled_sibling) do
+          FactoryBot.create(:timed_hold_task, **args.merge(status: Constants.TASK_STATUSES.cancelled))
+        end
+        let!(:completed_sibling) do
+          FactoryBot.create(:timed_hold_task, **args.merge(status: Constants.TASK_STATUSES.completed))
+        end
+
+        it "does not change the status of the closed sibling tasks" do
+          expect(subject.active?).to be_truthy
+          expect(cancelled_sibling.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(completed_sibling.status).to eq(Constants.TASK_STATUSES.completed)
+        end
+      end
+
+      context "when there is an active sibling task" do
+        let!(:existing_timed_hold_task) { FactoryBot.create(:timed_hold_task, **args) }
+
+        it "cancels the existing sibling tasks" do
+          expect(subject.active?).to be_truthy
+          expect(existing_timed_hold_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+        end
+      end
+    end
+  end
+
+  describe ".create_from_parent", focus: true do
+    let(:parent) { FactoryBot.create(:generic_task) }
+
+    let(:days_on_hold) { 4 }
+    let(:assigned_by) { FactoryBot.create(:user) }
+    let(:instructions) { "" }
+
+    let(:initial_args) do
+      { days_on_hold: days_on_hold,
+        assigned_by: assigned_by,
+        instructions: instructions }
+    end
+
+    subject { TimedHoldTask.create_from_parent(parent, **args) }
+
+    context "when there is no days_on_hold argument" do
+      let(:args) { initial_args.reject { |key, _| key == :days_on_hold } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when there is no assigner argument" do
+      let(:args) { initial_args.reject { |key, _| key == :assigned_by } }
+
+      it "sets assigned_by to parent assigned_to" do
+        expect(subject.assigned_by).to eq(parent.assigned_to)
+      end
+    end
+
+    context "when all arguments are set" do
+      let(:args) { initial_args }
+
+      it "sets appeal and places parent task on hold" do
+        expect(subject.appeal).to eq(parent.appeal)
+        expect(parent.status).to eq(Constants.TASK_STATUSES.on_hold)
       end
     end
   end

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -84,7 +84,7 @@ describe TimedHoldTask do
     end
   end
 
-  describe ".create_from_parent", focus: true do
+  describe ".create_from_parent" do
     let(:parent) { FactoryBot.create(:generic_task) }
 
     let(:days_on_hold) { 4 }


### PR DESCRIPTION
Connects #9207. Implements approach 3 outlined in the tech spec from #10512.

Adds an endpoint (`/tasks/:task_id/place_hold`) to create a timed hold task for an existing task.