### PR TITLE
Disable MissingSafeMethod and TooManyStatements

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -2,7 +2,7 @@
 detectors:
   # You can disable smells completely
   DuplicateMethodCall:
-    enabled:
+    enabled: false
   TooManyMethods:
     exclude:
       - RootTask
@@ -12,7 +12,11 @@ detectors:
       - Task
   IrresponsibleModule:
     enabled: false
+  MissingSafeMethod:
+    enabled: false
   NilCheck:
+    enabled: false
+  TooManyStatements:
     enabled: false
   UtilityFunction:
     public_methods_only: true


### PR DESCRIPTION
**Why**:
- MissingSafeMethod: We have been using bang methods for a while to
denote methods that make changes to veteran records or to an external
service. We want to keep using this pattern.

- TooManyStatements: We prefer to use Rubocop's `ABCSize` cop to
determine a method's complexity, than just simply counting any old
statement. For example, a method that calls 6 other methods in the same
class would pass Rubocop but not Reek.

This is based on feedback from the engineering team via a survey and
discussion.