### PR TITLE
Replace chromedriver-helper with webdrivers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,6 @@ group :test, :development, :demo do
   # Testing tools
   gem "capybara"
   gem "capybara-screenshot"
-  gem "chromedriver-helper"
   gem "danger", "~> 5.10"
   gem "database_cleaner"
   gem "factory_bot_rails", "~> 4.8"
@@ -101,6 +100,7 @@ group :test, :development, :demo do
   gem "simplecov", git: "https://github.com/colszowka/simplecov.git", require: false
   gem "sniffybara", git: "https://github.com/department-of-veterans-affairs/sniffybara.git", branch: "mb-update-capybara-click"
   gem "timecop"
+  gem "webdrivers"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,10 @@ GEM
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
+    webdrivers (3.8.0)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -600,6 +604,7 @@ DEPENDENCIES
   timecop
   tzinfo-data
   uglifier (>= 1.3.0)
+  webdrivers
 
 BUNDLED WITH
    1.17.3

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -3,6 +3,7 @@
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "selenium-webdriver"
+require "webdrivers"
 
 Sniffybara::Driver.configuration_file = File.expand_path("VA-axe-configuration.json", __dir__)
 
@@ -71,5 +72,3 @@ Capybara.default_max_wait_time = 5
 # Capybara uses puma by default, but for some reason, some of our tests don't
 # pass with puma. See: https://github.com/teamcapybara/capybara/issues/2170
 Capybara.server = :webrick
-
-Chromedriver.set_version "2.45"


### PR DESCRIPTION
**Why**: The former says in bold on their README that they are no longer
maintaining it and that people should use webdrivers instead.

The latter has a very useful feature that will automatically use
the right version of chromedriver based on the version of Chrome that
is installed on the machine.
