### PR TITLE
Allow HearingDispositionChangeJob without any tasks

### DIFF
--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -30,9 +30,9 @@ class HearingDispositionChangeJob < CaseflowJob
       error_count += 1
     end
 
-    log_info(start_time, @task_count_for, error_count, hearing_ids)
+    log_info(start_time, task_count_for, error_count, hearing_ids)
   rescue StandardError => error
-    log_info(start_time, @task_count_for, error_count, hearing_ids, error)
+    log_info(start_time, task_count_for, error_count, hearing_ids, error)
   end
 
   def task_count_for

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -350,5 +350,11 @@ describe HearingDispositionChangeJob do
         subject
       end
     end
+
+    context "when there are no DispositionTasks to be processed" do
+      it "runs successfully but does not do any work" do
+        expect { subject }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
Fix to resolve [a bug we see from time to time](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4731/) caused by the script never calling `task_count_for()`, therefore never setting the `@task_count_for` instance variable, causing the program to attempt to loop over `nil`.