### PR TITLE
Ensure response is JSON before parsing

### DIFF
--- a/client/app/components/LoadingDataDisplay.jsx
+++ b/client/app/components/LoadingDataDisplay.jsx
@@ -55,7 +55,11 @@ class LoadingDataDisplay extends React.PureComponent {
           return;
         }
 
-        const errors = response.response ? JSON.parse(response.response.text).errors : null;
+        let errors;
+
+        if (response.response && response.response.type === 'application/json') {
+          errors = JSON.parse(response.response.text).errors;
+        }
 
         this.setState({
           promiseResult: PROMISE_RESULTS.FAILURE,


### PR DESCRIPTION
[Resolves 115 errors in parsing json when dealing with loading errors](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4804/)