### PR TITLE
Fix ActionController::ParameterMissing bugs

### DIFF
--- a/client/app/certification/CancelCertificationModal.jsx
+++ b/client/app/certification/CancelCertificationModal.jsx
@@ -114,7 +114,8 @@ export default class CancelCertificationModal extends BaseForm {
       return;
     }
 
-    let data = this.prepareData();
+    let cancellationAttributes = this.prepareData();
+    let data = { certification_cancellation: cancellationAttributes };
 
     return ApiUtil.post('/certification_cancellations', { data }).
       then(() => {

--- a/client/app/hearings/actions/Dockets.js
+++ b/client/app/hearings/actions/Dockets.js
@@ -324,7 +324,9 @@ export const setPrepped = (hearingId, hearingExternalId, prepped, date) => (disp
   dispatch(setHearingPrepped(payload,
     CATEGORIES.HEARING_WORKSHEET_PAGE));
 
-  ApiUtil.patch(`/hearings/${hearingExternalId}`, { data: { prepped } }).
+  let data = { hearing: { prepped } };
+
+  ApiUtil.patch(`/hearings/${hearingExternalId}`, { data }).
     then(() => {
       // request was successful
     },

--- a/spec/feature/certification/cancel_certification_spec.rb
+++ b/spec/feature/certification/cancel_certification_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Cancel certification" do
       FeatureToggle.disable!(:certification_v2)
     end
 
-    scenario "Validate Input Fields", skip: true do
+    scenario "Validate Input Fields" do
       visit "certifications/new/#{appeal.vacols_id}"
       click_on "Cancel Certification"
       expect(page).to have_content("Please explain why this case cannot be certified with Caseflow.")

--- a/spec/feature/hearing_prep/hearing_worksheet_spec.rb
+++ b/spec/feature/hearing_prep/hearing_worksheet_spec.rb
@@ -124,12 +124,16 @@ RSpec.feature "Hearing prep" do
         fill_in "appellant-vet-rep-name", with: "This is a rep name"
         fill_in "appellant-vet-witness", with: "This is a witness"
         fill_in "worksheet-military-service", with: "This is military service"
+        find("label", text: "Hearing Prepped").click
 
         visit "/hearings/" + ama_hearing.external_id.to_s + "/worksheet"
+
         expect(page).to have_content("This is a rep name")
         expect(page).to have_content("This is a witness")
         expect(page).to have_content("These are the notes being taken here")
         expect(page).to have_content("This is military service")
+        # Temporarily commented out until we fix issue #10621
+        # expect(page).to have_field("Hearing Prepped", checked: true, visible: false)
       end
 
       scenario "Can save preliminary impressions for ama hearings" do


### PR DESCRIPTION
**Why**: When we disabled parameter wrapping in #10508, we affected
a couple of scenarios that weren't covered by feature specs. When
parameter wrapping is enabled, if a required parameter is not passed
in the JSON payload, Rails will automatically include it based on the
controller name. For example, if `HearingsController` defines
`params.require(:hearing).permit(:prepped)`, but the payload only
passes in an attribute, such as `{ prepped: true }`, Rails will
automatically include the `hearing` key based on the name of the
controller.

So far, based on Sentry alerts, we have identified two React views that
were not passing in the required parameter, and therefore started
failing after we disabled parameter wrapping.