### PR TITLE
Appeal Status: updating how get the scheduled hearing

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -506,7 +506,7 @@ class Appeal < DecisionReview
   def scheduled_hearing
     # Appeal Status api assumes that there can be multiple hearings that have happened in the past but only
     # one that is currently scheduled. Will get this by getting the hearing whose scheduled date is in the future.
-    @scheduled_hearing ||= tasks.active.where(type: DispositionTask.name)&.first&.hearing
+    @scheduled_hearing ||= hearings.find { |hearing| hearing.scheduled_for >= Time.zone.today }
   end
 
   def api_scheduled_hearing_type
@@ -536,7 +536,7 @@ class Appeal < DecisionReview
   end
 
   def hearing_pending?
-    tasks.active.where(type: DispositionTask.name).any?
+    scheduled_hearing.present?
   end
 
   def evidence_submission_hold_pending?

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -506,7 +506,7 @@ class Appeal < DecisionReview
   def scheduled_hearing
     # Appeal Status api assumes that there can be multiple hearings that have happened in the past but only
     # one that is currently scheduled. Will get this by getting the hearing whose scheduled date is in the future.
-    @scheduled_hearing ||= hearings.find { |hearing| hearing.scheduled_for >= Time.zone.today }
+    @scheduled_hearing ||= tasks.active.where(type: DispositionTask.name)&.first&.hearing
   end
 
   def api_scheduled_hearing_type


### PR DESCRIPTION
Resolves #10625

### Description
Change to address the NoMethodError being seen because the scheduled hearing is nil.
Updated hearing_pending? to check if scheduled_hearing exists instead of using the DispositionTask because a DispositionTask can still be active after a hearing has taken if a disposition has not been selected.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. unit tests pass

*Schema Changes Only*

* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [ ] #appeals-schema notified with summary and link to this PR
