### PR TITLE
Removing judges' reschedule permissions

### DIFF
--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -33,7 +33,7 @@ class DispositionTask < GenericTask
   end
 
   def available_actions(user)
-    if JudgeTeam.for_judge(user) || HearingsManagement.singleton.user_has_access?(user)
+    if HearingsManagement.singleton.user_has_access?(user)
       [Constants.TASK_ACTIONS.POSTPONE_HEARING.to_h]
     else
       []


### PR DESCRIPTION
Resolves #10556 

### Description
Judges should only be able to postpone from the daily docket. This removes their ability to postpone from the Case Details page.
