### PR TITLE
Search for user by user pg id instead of css id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -208,7 +208,7 @@ class User < ApplicationRecord
 
   def to_session_hash
     skip_attrs = %w[full_name created_at updated_at last_login_at]
-    serializable_hash.merge("id" => css_id, "name" => full_name).except(*skip_attrs)
+    serializable_hash.merge("id" => css_id, "name" => full_name, "pg_user_id" => id).except(*skip_attrs)
   end
 
   def station_offices
@@ -311,9 +311,10 @@ class User < ApplicationRecord
 
       return nil if user_session.nil?
 
+      pg_user_id = user_session["pg_user_id"]
       css_id = user_session["id"]
       station_id = user_session["station_id"]
-      user = find_by_css_id(css_id)
+      user = pg_user_id ? find_by(id: pg_user_id) : find_by_css_id(css_id)
 
       attrs = {
         station_id: station_id,
@@ -325,6 +326,7 @@ class User < ApplicationRecord
 
       user ||= create!(attrs.merge(css_id: css_id.upcase))
       user.update!(attrs.merge(last_login_at: Time.zone.now))
+      user_session["pg_user_id"] = user.id
       user
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,6 +58,7 @@ describe User do
         "id" => css_id.upcase,
         "station_id" => "310",
         "css_id" => css_id.upcase,
+        "pg_user_id" => user.id,
         "email" => nil,
         "roles" => [],
         "selected_regional_office" => nil,
@@ -443,6 +444,7 @@ describe User do
       end
 
       it do
+        expect(User).to receive(:find_by_css_id)
         is_expected.to be_an_instance_of(User)
         expect(subject.roles).to eq(["Do the thing"])
         expect(subject.regional_office).to eq("283")
@@ -453,6 +455,13 @@ describe User do
 
       it "persists user to DB" do
         expect(User.find(subject.id)).to be_truthy
+      end
+
+      it "searches by user id when it is in session" do
+        user = create(:user)
+        expect(User).to_not receive(:find_by_css_id)
+        session["user"]["pg_user_id"] = user.id
+        expect(subject).to eq user
       end
     end
 


### PR DESCRIPTION
### Description
We call `find_by("UPPER(css_id)=UPPER(?)", css_id)` in the User model on every request. This may or may not be causing intermittent `ActiveRecord::ConnectionTimeoutError`. Let's search by User.id to make it more efficient. 


### Testing Plan
1. Tests pass
2. Ensure logout works
3. Ensure can change users locally in the browser

