### PR TITLE
Use new facols docker image 20190502

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             POSTGRES_DB: caseflow_certification_test
 
       # This is our homespun VACOLS container. An oracle db with some special sauce.
-      - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:version_4
+      - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:20190502
 
       # This is the circleci provided Redis container.
       - image: circleci/redis:4.0.10

--- a/config/database.yml
+++ b/config/database.yml
@@ -105,6 +105,6 @@ test_vacols:
   database: "(DESCRIPTION=
     (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=localhost)(PORT=1521)))
     (RECV_TIMEOUT=120)(SEND_TIMEOUT=5)
-    (CONNECT_DATA=(SERVICE_NAME=BVAP.localdomain))
+    (CONNECT_DATA=(SID=BVAP))
   )"
 

--- a/lib/tasks/local/vacols.rake
+++ b/lib/tasks/local/vacols.rake
@@ -11,7 +11,6 @@ namespace :local do
 
       facols_is_ready = false
 
-      # rubocop:disable Lint/HandleExceptions
       180.times do
         begin
           if VACOLS::Case.count == 0 &&
@@ -20,15 +19,14 @@ namespace :local do
             facols_is_ready = true
             break
           end
-        rescue StandardError
+        rescue StandardError => error
+          puts error
+          sleep 1
         end
-
-        sleep 1
       end
-      # rubocop:enable Lint/HandleExceptions
 
       unless facols_is_ready
-        fail "Gave up waiting for FACOLS to get ready and we won't leave alone"
+        fail "Gave up waiting for FACOLS to get ready"
       end
     end
 


### PR DESCRIPTION
Building FACOLS Oracle Docker image pre-loaded with VACOLS schema, using https://github.com/oracle/docker-images/blob/master/OracleDatabase/SingleInstance/