### PR TITLE
Remove renamed decision issue fields

### DIFF
--- a/db/migrate/20190503191516_remove_renamed_decision_issue_columns.rb
+++ b/db/migrate/20190503191516_remove_renamed_decision_issue_columns.rb
@@ -1,0 +1,8 @@
+class RemoveRenamedDecisionIssueColumns < ActiveRecord::Migration[5.1]
+  def change
+    safety_assured do
+      remove_column :decision_issues, :profile_date, :datetime
+      remove_column :decision_issues, :promulgation_date, :datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190430225016) do
+ActiveRecord::Schema.define(version: 20190503191516) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -266,8 +266,6 @@ ActiveRecord::Schema.define(version: 20190430225016) do
     t.string "disposition", comment: "The disposition for a decision issue. Dispositions made in Caseflow and dispositions made in VBMS can have different values."
     t.date "end_product_last_action_date", comment: "After an end product gets synced with a status of CLR (cleared), the end product's last_action_date is saved on any decision issues that are created as a result. This is used as a proxy for decision date for non-rating issues that are processed in VBMS because they don't have a rating profile date, and the exact decision date is not available."
     t.string "participant_id", null: false, comment: "The Veteran's participant id."
-    t.datetime "profile_date", comment: "The profile date of the rating that a decision issue resulted in (if applicable). The profile_date is used as an identifier for the rating, and is the date that most closely maps to what the Veteran writes down as the decision date."
-    t.datetime "promulgation_date", comment: "The promulgation date of the rating that a decision issue resulted in (if applicable). It is used for calculating whether a decision issue is within the timeliness window to be appealed or get a higher level review."
     t.string "rating_issue_reference_id", comment: "Identifies the specific issue on the rating that resulted from the decision issue (a rating can have multiple issues). This is unique per rating issue."
     t.datetime "rating_profile_date", comment: "The profile date of the rating that a decision issue resulted in (if applicable). The profile_date is used as an identifier for the rating, and is the date that most closely maps to what the Veteran writes down as the decision date."
     t.datetime "rating_promulgation_date", comment: "The promulgation date of the rating that a decision issue resulted in (if applicable). It is used for calculating whether a decision issue is within the timeliness window to be appealed or get a higher level review."


### PR DESCRIPTION
connects #8239

Remove these columns, as they have been renamed.

*Schema Changes Only*

* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
