### PR TITLE
Do not select child classes of DispositionTasks in HearingDispositionChangeJob

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -21,6 +21,7 @@ detectors:
   UtilityFunction:
     public_methods_only: true
     exclude:
+      - HearingDispositionChangeJob
       - Helpers::AppealHearingHelper#available_hearing_locations
       - Helpers::AppealHearingHelper#hearings
 

--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -15,9 +15,7 @@ class HearingDispositionChangeJob < CaseflowJob
     # Set user to system_user to avoid sensitivity errors
     RequestStore.store[:current_user] = User.system_user
 
-    tasks = DispositionTask.active.where.not(status: Constants.TASK_STATUSES.on_hold)
-
-    tasks.each do |task|
+    hearing_disposition_tasks.each do |task|
       # Skip task unless there is a hearing associated with the task and it was held more than a day ago.
       next unless task&.hearing&.scheduled_for &.< 24.hours.ago
 
@@ -33,6 +31,10 @@ class HearingDispositionChangeJob < CaseflowJob
     log_info(start_time, task_count_for, error_count, hearing_ids)
   rescue StandardError => error
     log_info(start_time, task_count_for, error_count, hearing_ids, error)
+  end
+
+  def hearing_disposition_tasks
+    Task.active.where(type: DispositionTask.name).where.not(status: Constants.TASK_STATUSES.on_hold)
   end
 
   def task_count_for

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -42,6 +42,32 @@ describe HearingDispositionChangeJob do
     FactoryBot.create(:disposition_task, appeal: appeal, parent: parent_hearing_task)
   end
 
+  describe ".hearing_disposition_tasks" do
+    subject { HearingDispositionChangeJob.new.hearing_disposition_tasks }
+
+    # Property: Class that subclasses DispositionTask.
+    context "when there are ChangeHearingDispositionTasks" do
+      let!(:disposition_tasks) do
+        FactoryBot.create_list(:disposition_task, 6, parent: FactoryBot.create(:hearing_task))
+      end
+      let!(:change_disposition_tasks) do
+        FactoryBot.create_list(:change_hearing_disposition_task, 3, parent: FactoryBot.create(:hearing_task))
+      end
+
+      it "only returns the DispositionTasks" do
+        # Confirm that the ChangeHearingDispositionTasks are in the database.
+        expect(ChangeHearingDispositionTask.active.where.not(status: Constants.TASK_STATUSES.on_hold).count).to(
+          eq(change_disposition_tasks.length)
+        )
+
+        tasks = subject
+
+        expect(tasks.length).to eq(disposition_tasks.length)
+        expect(tasks.pluck(:type).uniq).to eq([DispositionTask.name])
+      end
+    end
+  end
+
   describe ".update_task_by_hearing_disposition" do
     let(:attributes_date_fields) { %w[assigned_at created_at updated_at] }
     subject { HearingDispositionChangeJob.new.update_task_by_hearing_disposition(task) }

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -238,7 +238,9 @@ describe HearingDispositionChangeJob do
     context "when there is an error outside of the loop" do
       let(:error_msg) { "FAKE ERROR MESSAGE HERE" }
 
-      before { allow(DispositionTask).to receive(:active).and_raise(error_msg) }
+      before do
+        expect_any_instance_of(HearingDispositionChangeJob).to receive(:hearing_disposition_tasks).and_raise(error_msg)
+      end
 
       it "sends the correct number of arguments to log_info" do
         args = Array.new(5, anything)


### PR DESCRIPTION
This PR resolves a bug that spawns [`Caseflow::Error::DuplicateOrgTask` errors](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4673/) because we are trying to create [`ChangeHearingDispositionTask`s](https://github.com/department-of-veterans-affairs/caseflow/blob/847914c3779ab2cf8ef89688aa1f473354e39a29/app/models/tasks/change_hearing_disposition_task.rb#L6) off of [existing `ChangeHearingDispositionTask`s](https://github.com/department-of-veterans-affairs/caseflow/blob/847914c3779ab2cf8ef89688aa1f473354e39a29/app/jobs/hearing_disposition_change_job.rb#L63).