### PR TITLE
Allow edit on hearings details for legacy hearing

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -89,6 +89,9 @@ class HearingsController < ApplicationController
                                      :transcript_requested,
                                      :prepped,
                                      :scheduled_for,
+                                     :judge_id,
+                                     :room,
+                                     :bva_poc,
                                      hearing_location_attributes: [
                                        :city, :state, :address,
                                        :facility_id, :facility_type,

--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -23,7 +23,7 @@ module HearingMapper
         folder_nr: hearing_info[:folder_nr],
         room: hearing_info[:room],
         bva_poc: hearing_info[:bva_poc],
-        judge_id: hearing_info[:judge_id]
+        judge_id: judge_to_vacols_format(hearing_info[:judge_id])
       }.select do |k, _v|
         hearing_info.keys.map(&:to_sym).include?(k)
         # only send updates to key/values that are passed
@@ -115,6 +115,10 @@ module HearingMapper
       fail(InvalidTranscriptRequestedError) if value && vacols_code.blank?
 
       vacols_code
+    end
+
+    def judge_to_vacols_format(value)
+      value.nil? ? nil : User.find(value).vacols_attorney_id
     end
   end
 end

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -81,7 +81,7 @@ class HearingDay < ApplicationRecord
   def update_children_records
     vacols_hearings.each do |hearing|
       hearing.update_caseflow_and_vacols(
-        **only_changed(room: room, bva_poc: bva_poc, judge_id: judge&.vacols_attorney_id)
+        **only_changed(room: room, bva_poc: bva_poc, judge_id: judge&.id)
       )
     end
 

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -175,34 +175,6 @@ class LegacyHearing < ApplicationRecord
     Hearing::HEARING_TYPES[request_type.to_sym]
   end
 
-  # rubocop:disable Metrics/MethodLength
-  def vacols_attributes
-    {
-      scheduled_for: scheduled_for,
-      type: type,
-      venue_key: venue_key,
-      vacols_record: vacols_record,
-      disposition: disposition,
-      aod: aod,
-      hold_open: hold_open,
-      transcript_requested: transcript_requested,
-      transcript_sent_date: transcript_sent_date,
-      notes: notes,
-      add_on: add_on,
-      representative: representative,
-      representative_name: representative_name,
-      vdkey: vdkey,
-      master_record: master_record,
-      veteran_first_name: veteran_first_name,
-      veteran_middle_initial: veteran_middle_initial,
-      veteran_last_name: veteran_last_name,
-      appellant_first_name: appellant_first_name,
-      appellant_middle_initial: appellant_middle_initial,
-      appellant_last_name: appellant_last_name,
-      appeal_vacols_id: appeal_vacols_id
-    }
-  end
-
   cache_attribute :cached_number_of_documents do
     begin
       number_of_documents
@@ -226,6 +198,7 @@ class LegacyHearing < ApplicationRecord
 
   delegate :external_id, to: :appeal, prefix: true
 
+  # rubocop:disable Metrics/MethodLength
   def to_hash(current_user_id)
     serializable_hash(
       methods: [
@@ -266,7 +239,10 @@ class LegacyHearing < ApplicationRecord
         :external_id,
         :veteran_file_number,
         :closest_regional_office,
-        :available_hearing_locations
+        :available_hearing_locations,
+        :bva_poc,
+        :room,
+        :judge_id
       ],
       except: [:military_service, :vacols_id]
     ).merge(

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -197,6 +197,11 @@ class HearingRepository
       date = HearingMapper.datetime_based_on_type(datetime: vacols_record.hearing_date,
                                                   regional_office_key: ro,
                                                   type: vacols_record.hearing_type)
+      judge_id = if vacols_record.css_id.nil?
+                   nil
+                 else
+                   User.find_by_css_id_or_create_with_default_station_id(vacols_record.css_id).id
+                 end
       {
         vacols_record: vacols_record,
         appeal_vacols_id: vacols_record.folder_nr,
@@ -230,7 +235,7 @@ class HearingRepository
         hearing_day_id: vacols_record.vdkey,
         master_record: false,
         bva_poc: vacols_record.vdbvapoc,
-        judge_id: vacols_record.board_member
+        judge_id: judge_id
       }
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -228,7 +228,9 @@ class HearingRepository
         request_type: vacols_record.hearing_type,
         scheduled_for: date,
         hearing_day_id: vacols_record.vdkey,
-        master_record: false
+        master_record: false,
+        bva_poc: vacols_record.vdbvapoc,
+        judge_id: vacols_record.board_member
       }
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/client/app/hearingSchedule/components/Details.jsx
+++ b/client/app/hearingSchedule/components/Details.jsx
@@ -42,6 +42,7 @@ class HearingDetails extends React.Component {
 
     this.state = {
       disabled: this.props.disabled,
+      isLegacy: this.props.hearing.docketName !== 'hearing',
       updated: false,
       loading: false,
       success: false,
@@ -165,6 +166,7 @@ class HearingDetails extends React.Component {
             setHearing={this.setHearing}
             transcription={transcriptionDetailsForm || {}}
             hearing={hearingDetailsForm || {}}
+            isLegacy={this.state.isLegacy}
             disabled={disabled} />
           <div>
             <a

--- a/client/app/hearingSchedule/components/Details.jsx
+++ b/client/app/hearingSchedule/components/Details.jsx
@@ -12,7 +12,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import * as DateUtil from '../../util/DateUtil';
 import ApiUtil from '../../util/ApiUtil';
 
-import DetailsSections, { Overview, LegacyWarning } from './DetailsSections';
+import DetailsSections, { Overview } from './DetailsSections';
 import { onChangeFormData } from '../../components/common/actions';
 
 const row = css({
@@ -42,7 +42,6 @@ class HearingDetails extends React.Component {
 
     this.state = {
       disabled: this.props.disabled,
-      isLegacy: this.props.hearing.docketName !== 'hearing',
       updated: false,
       loading: false,
       success: false,
@@ -136,7 +135,7 @@ class HearingDetails extends React.Component {
 
     const { hearingDetailsForm, transcriptionDetailsForm } = this.props;
 
-    const { disabled, success, error, isLegacy } = this.state;
+    const { disabled, success, error } = this.state;
 
     return (
       <AppSegment filledBackground>
@@ -161,15 +160,12 @@ class HearingDetails extends React.Component {
           <Overview hearing={this.props.hearing} />
           <div className="cf-help-divider" />
 
-          {!isLegacy &&
-            <DetailsSections
-              setTranscription={this.setTranscription}
-              setHearing={this.setHearing}
-              transcription={transcriptionDetailsForm || {}}
-              hearing={hearingDetailsForm || {}}
-              disabled={disabled} />}
-          {isLegacy &&
-            <LegacyWarning />}
+          <DetailsSections
+            setTranscription={this.setTranscription}
+            setHearing={this.setHearing}
+            transcription={transcriptionDetailsForm || {}}
+            hearing={hearingDetailsForm || {}}
+            disabled={disabled} />
           <div>
             <a
               className="button-link"

--- a/client/app/hearingSchedule/components/DetailsSections.jsx
+++ b/client/app/hearingSchedule/components/DetailsSections.jsx
@@ -307,44 +307,40 @@ const TranscriptionRequest = ({
   </div>
 );
 
-const Sections = ({ transcription, hearing, disabled, setHearing, setTranscription }) => {
-  const isLegacy = hearing.docketName !== 'hearing';
+const Sections = ({ transcription, hearing, disabled, setHearing, setTranscription, isLegacy }) => (
+  <React.Fragment>
+    <Details
+      hearing={hearing}
+      set={setHearing}
+      readOnly={disabled}
+      isLegacy={isLegacy} />
+    <div className="cf-help-divider" />
 
-  return (
-    <React.Fragment>
-      <Details
-        hearing={hearing}
-        set={setHearing}
-        readOnly={disabled}
-        isLegacy={isLegacy} />
-      <div className="cf-help-divider" />
+    {!isLegacy &&
+      <div>
+        <h2>Transcription Details</h2>
+        <TranscriptionDetails
+          transcription={transcription}
+          set={setTranscription}
+          readOnly={disabled} />
+        <div className="cf-help-divider" />
 
-      {!isLegacy &&
-        <div>
-          <h2>Transcription Details</h2>
-          <TranscriptionDetails
-            transcription={transcription}
-            set={setTranscription}
-            readOnly={disabled} />
-          <div className="cf-help-divider" />
+        <h2>Transcription Problem</h2>
+        <TranscriptionProblem
+          transcription={transcription}
+          set={setTranscription}
+          readOnly={disabled} />
+        <div className="cf-help-divider" />
 
-          <h2>Transcription Problem</h2>
-          <TranscriptionProblem
-            transcription={transcription}
-            set={setTranscription}
-            readOnly={disabled} />
-          <div className="cf-help-divider" />
-
-          <h2>Transcription Request</h2>
-          <TranscriptionRequest
-            hearing={hearing}
-            set={setHearing}
-            readOnly={disabled} />
-          <div className="cf-help-divider" />
-        </div>
-      }
-    </React.Fragment>
-  );
-};
+        <h2>Transcription Request</h2>
+        <TranscriptionRequest
+          hearing={hearing}
+          set={setHearing}
+          readOnly={disabled} />
+        <div className="cf-help-divider" />
+      </div>
+    }
+  </React.Fragment>
+);
 
 export default Sections;

--- a/client/app/hearingSchedule/components/DetailsSections.jsx
+++ b/client/app/hearingSchedule/components/DetailsSections.jsx
@@ -80,7 +80,7 @@ export const Overview = ({
 
 const Details = ({
   hearing: { judgeId, room, evidenceWindowWaived, notes, bvaPoc },
-  set, readOnly
+  set, readOnly, isLegacy
 }) => (
   <React.Fragment>
     <div {...rowThirds}>
@@ -104,16 +104,18 @@ const Details = ({
         readOnly={readOnly}
         onChange={(val) => set('bvaPoc', val)}
       />
-      <div>
-        <strong>Waive 90 Day Evidence Hold</strong>
-        <Checkbox
-          label="Yes, Waive 90 Day Evidence Hold"
-          name="evidenceWindowWaived"
-          disabled={readOnly}
-          value={evidenceWindowWaived || false}
-          onChange={(val) => set('evidenceWindowWaived', val)}
-        />
-      </div>
+      {!isLegacy &&
+        <div>
+          <strong>Waive 90 Day Evidence Hold</strong>
+          <Checkbox
+            label="Yes, Waive 90 Day Evidence Hold"
+            name="evidenceWindowWaived"
+            disabled={readOnly}
+            value={evidenceWindowWaived || false}
+            onChange={(val) => set('evidenceWindowWaived', val)}
+          />
+        </div>
+      }
     </div>
     <TextareaField
       name="Notes"
@@ -305,45 +307,44 @@ const TranscriptionRequest = ({
   </div>
 );
 
-export const LegacyWarning = () => (
-  <div {...css({
-    textAlign: 'center',
-    marginTop: '4rem'
-  })}>
-    <h1>This is a Legacy Case Hearing</h1>
-    <p>To view or edit details for this hearing access VACOLS</p>
-  </div>
-);
+const Sections = ({ transcription, hearing, disabled, setHearing, setTranscription }) => {
+  const isLegacy = hearing.docketName !== 'hearing';
 
-const Sections = ({ transcription, hearing, disabled, setHearing, setTranscription }) => (
-  <React.Fragment>
-    <Details
-      hearing={hearing}
-      set={setHearing}
-      readOnly={disabled} />
-    <div className="cf-help-divider" />
+  return (
+    <React.Fragment>
+      <Details
+        hearing={hearing}
+        set={setHearing}
+        readOnly={disabled}
+        isLegacy={isLegacy} />
+      <div className="cf-help-divider" />
 
-    <h2>Transcription Details</h2>
-    <TranscriptionDetails
-      transcription={transcription}
-      set={setTranscription}
-      readOnly={disabled} />
-    <div className="cf-help-divider" />
+      {!isLegacy &&
+        <div>
+          <h2>Transcription Details</h2>
+          <TranscriptionDetails
+            transcription={transcription}
+            set={setTranscription}
+            readOnly={disabled} />
+          <div className="cf-help-divider" />
 
-    <h2>Transcription Problem</h2>
-    <TranscriptionProblem
-      transcription={transcription}
-      set={setTranscription}
-      readOnly={disabled} />
-    <div className="cf-help-divider" />
+          <h2>Transcription Problem</h2>
+          <TranscriptionProblem
+            transcription={transcription}
+            set={setTranscription}
+            readOnly={disabled} />
+          <div className="cf-help-divider" />
 
-    <h2>Transcription Request</h2>
-    <TranscriptionRequest
-      hearing={hearing}
-      set={setHearing}
-      readOnly={disabled} />
-    <div className="cf-help-divider" />
-  </React.Fragment>
-);
+          <h2>Transcription Request</h2>
+          <TranscriptionRequest
+            hearing={hearing}
+            set={setHearing}
+            readOnly={disabled} />
+          <div className="cf-help-divider" />
+        </div>
+      }
+    </React.Fragment>
+  );
+};
 
 export default Sections;

--- a/spec/feature/hearing_schedule/hearing_details_spec.rb
+++ b/spec/feature/hearing_schedule/hearing_details_spec.rb
@@ -5,6 +5,11 @@ require "rails_helper"
 RSpec.feature "Hearing Schedule Daily Docket" do
   let(:user) { create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"]) }
 
+  before do
+    create(:staff, sdept: "HRG", sactive: "A", snamef: "ABC", snamel: "EFG")
+    create(:staff, svlj: "J", sactive: "A", snamef: "HIJ", snamel: "LMNO")
+  end
+
   context "Hearing details is not editable for a non-hearings management user" do
     let!(:current_user) { User.authenticate!(user: user) }
     let!(:hearing) { create(:hearing, :with_tasks) }
@@ -21,11 +26,6 @@ RSpec.feature "Hearing Schedule Daily Docket" do
       User.authenticate!(user: user)
     end
     let!(:hearing) { create(:hearing, :with_tasks) }
-
-    before do
-      create(:staff, sdept: "HRG", sactive: "A", snamef: "ABC", snamel: "EFG")
-      create(:staff, svlj: "J", sactive: "A", snamef: "HIJ", snamel: "LMNO")
-    end
 
     scenario "User can update fields", skip: "Test is flakey" do
       visit "hearings/" + hearing.external_id.to_s + "/details"
@@ -70,6 +70,20 @@ RSpec.feature "Hearing Schedule Daily Docket" do
       expect(page).to have_field("hearingRoomDropdown", disabled: false)
       expect(page).to have_field("Notes", disabled: false)
       expect(page).to have_no_selector("label", text: "Yes, Waive 90 Day Evidence Hold")
+    end
+
+    scenario "User can select judge, hearing room, hearing coordinator, and add notes" do
+      visit "hearings/" + legacy_hearing.external_id.to_s + "/details"
+
+      click_dropdown(name: "judgeDropdown", index: 0, wait: 30)
+      click_dropdown(name: "hearingCoordinatorDropdown", index: 0, wait: 30)
+      click_dropdown(name: "hearingRoomDropdown", index: 0, wait: 30)
+
+      fill_in "Notes", with: generate_words(10)
+
+      click_button("Save")
+
+      expect(page).to have_content("Hearing Successfully Updated")
     end
 
     scenario "User can not edit transcription" do

--- a/spec/feature/hearing_schedule/hearing_details_spec.rb
+++ b/spec/feature/hearing_schedule/hearing_details_spec.rb
@@ -62,9 +62,29 @@ RSpec.feature "Hearing Schedule Daily Docket" do
     end
     let!(:legacy_hearing) { create(:legacy_hearing) }
 
-    scenario "User can update nothing" do
+    scenario "User can edit Judge" do
       visit "hearings/" + legacy_hearing.external_id.to_s + "/details"
-      expect(page).to have_content("This is a Legacy Case Hearing")
+
+      expect(page).to have_field("judgeDropdown", disabled: false)
+      expect(page).to have_field("hearingCoordinatorDropdown", disabled: false)
+      expect(page).to have_field("hearingRoomDropdown", disabled: false)
+      expect(page).to have_field("Notes", disabled: false)
+      expect(page).to have_no_selector("label", text: "Yes, Waive 90 Day Evidence Hold")
+    end
+
+    scenario "User can not edit transcription" do
+      visit "hearings/" + legacy_hearing.external_id.to_s + "/details"
+
+      expect(page).to have_no_field("taskNumber")
+      expect(page).to have_no_field("transcriber")
+      expect(page).to have_no_field("sentToTranscriberDate")
+      expect(page).to have_no_field("expectedReturnDate")
+      expect(page).to have_no_field("uploadedToVbmsDate")
+      expect(page).to have_no_field("problemType")
+      expect(page).to have_no_field("problemNoticeSentDate")
+      expect(page).to have_no_field("requestedRemedy")
+      expect(page).to have_no_field("copySentDate")
+      expect(page).to have_no_field("copyRequested")
     end
   end
 end

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -152,7 +152,7 @@ describe HearingDay do
         end
 
         it "only tries to update the room and the judge, because that's all that changed in the hearing day" do
-          expected_legacy_params = { room: "5", judge_id: judge.vacols_attorney_id.to_s }
+          expected_legacy_params = { room: "5", judge_id: judge.id }
           expect_any_instance_of(LegacyHearing).to receive(:update!).with(**expected_legacy_params)
           expected_ama_params = { room: "5", judge_id: judge.id }
           expect_any_instance_of(Hearing).to receive(:update!).with(**expected_ama_params)


### PR DESCRIPTION
Resolves #10403

### Description

Removes the legacy warning on the hearing details page, and makes the judge, room, and hearing coordinator editable on the page. Also changes the mapper to map the Caseflow user attorney id to the judge id.

Also removes `vacols_attributes` from the legacy hearings model because it is unused.

### Acceptance Criteria
- [x]  Users can edit an individual hearing's judge from the hearing details page for a legacy hearing