### PR TITLE
Automatic case distribution for Hearing Docket

### DIFF
--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -5,15 +5,23 @@ class HearingRequestDocket < Docket
     "hearing"
   end
 
-  # CMGTODO: should only return genpop appeals.
-  def age_of_n_oldest_priority_appeals(_num)
-    []
+  def age_of_n_oldest_priority_appeals(num)
+    relation = appeals(priority: true, ready: true).limit(num)
+
+    HearingRequestDistributionQuery.new(
+      base_relation: relation, genpop: "only_genpop"
+    ).call.map(&:ready_for_distribution_at)
   end
 
-  # CMGTODO
-  # rubocop:disable Lint/UnusedMethodArgument
-  def distribute_appeals(_distribution, priority: false, genpop: "any", limit: 1)
-    []
+  def distribute_appeals(distribution, priority: false, genpop: "any", limit: 1)
+    base_relation = appeals(priority: priority, ready: true).limit(limit)
+
+    appeals = HearingRequestDistributionQuery.new(
+      base_relation: base_relation, genpop: genpop, judge: distribution.judge
+    ).call
+
+    HearingRequestCaseDistributor.new(
+      appeals: appeals, genpop: genpop, distribution: distribution, priority: priority
+    ).call
   end
-  # rubocop:enable Lint/UnusedMethodArgument
 end

--- a/app/queries/hearing_request_distribution_query.rb
+++ b/app/queries/hearing_request_distribution_query.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+class HearingRequestDistributionQuery
+  def initialize(base_relation:, genpop:, judge: nil)
+    @base_relation = base_relation.extending(Scopes)
+    @genpop = genpop
+    @judge = judge
+  end
+
+  def call
+    return not_genpop_appeals if genpop == "not_genpop"
+
+    return only_genpop_appeals if genpop == "only_genpop"
+
+    # We are returning an array of arrays in order to process the
+    # "not_genpop_appeals" separately from the "only_genpop_appeals" in
+    # HearingRequestCaseDistributor in order to accurately populate the `genpop`
+    # field in the `DistributedCase`. The last step in the automatic case
+    # distribution process is to create `DistributedCase`s for the Distribution.
+    # For the Hearing Docket, a DistributedCase validates the presence of the
+    # genpop attribute. This is used for reporting purposes and so we can
+    # verify that the algorithm is correct. For example, if we found a
+    # DistributedCase with `genpop_query` set to "not_genpop", but its `genpop`
+    # field was set to `true`, that would indicate a bug.
+    [not_genpop_appeals, only_genpop_appeals] if genpop == "any"
+  end
+
+  private
+
+  attr_reader :base_relation, :genpop, :judge
+
+  def not_genpop_appeals
+    base_relation.most_recent_hearings.tied_to_distribution_judge(judge)
+  end
+
+  # We are combining two queries using an array because using `or` doesn't work
+  # due to incompatibilities between the two queries.
+  def only_genpop_appeals
+    no_hearings_or_no_held_hearings = with_no_hearings.or(with_no_held_hearings)
+    [most_recent_held_hearings_not_tied_to_any_active_judge, no_hearings_or_no_held_hearings].flatten
+  end
+
+  def most_recent_held_hearings_not_tied_to_any_active_judge
+    base_relation.most_recent_hearings.not_tied_to_any_active_judge
+  end
+
+  def with_no_hearings
+    base_relation.with_no_hearings
+  end
+
+  def with_no_held_hearings
+    base_relation.with_no_held_hearings
+  end
+
+  module Scopes
+    def most_recent_hearings
+      query = <<-SQL
+        INNER JOIN
+        (SELECT h.appeal_id, max(hd.scheduled_for) as latest_scheduled_for
+        FROM hearings h
+        JOIN hearing_days hd on h.hearing_day_id = hd.id
+        GROUP BY
+        h.appeal_id
+        ) as latest_date_by_appeal
+        ON appeals.id = latest_date_by_appeal.appeal_id
+        AND hearing_days.scheduled_for = latest_date_by_appeal.latest_scheduled_for
+      SQL
+
+      joins(query, hearings: :hearing_day)
+    end
+
+    def tied_to_distribution_judge(judge)
+      where(hearings: { disposition: "held", judge_id: judge.id })
+    end
+
+    def not_tied_to_any_active_judge
+      judge_css_ids = JudgeTeam.pluck(:name)
+      inactive_judges = User.where(css_id: judge_css_ids).where("last_login_at < ?", 60.days.ago).pluck(:id)
+      where(hearings: { disposition: "held", judge_id: inactive_judges.append(nil) })
+    end
+
+    def with_no_hearings
+      left_joins(:hearings).where(hearings: { id: nil })
+    end
+
+    def with_no_held_hearings
+      left_joins(:hearings).where.not(hearings: { disposition: "held" })
+    end
+  end
+end

--- a/app/workflows/create_judge_assign_tasks_for_appeals.rb
+++ b/app/workflows/create_judge_assign_tasks_for_appeals.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class CreateJudgeAssignTasksForAppeals
+  def initialize(appeals:, genpop:, judge:)
+    @appeals = appeals
+    @genpop = genpop
+    @judge = judge
+  end
+
+  def call
+    return [] if appeals.empty?
+
+    appeals.map do |appeal|
+      JudgeAssignTaskCreator.new(appeal: appeal, judge: judge, genpop: genpop).call
+    end
+  end
+
+  private
+
+  attr_reader :appeals, :genpop, :judge
+end

--- a/app/workflows/hearing_request_case_distributor.rb
+++ b/app/workflows/hearing_request_case_distributor.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class HearingRequestCaseDistributor
+  def initialize(appeals:, genpop:, distribution:, priority:)
+    @appeals = appeals
+    @genpop = genpop
+    @distribution = distribution
+    @priority = priority
+  end
+
+  def call
+    Distribution.transaction do
+      tasks = assign_judge_tasks_for_appeals
+
+      tasks.map do |task, genpop_value|
+        distribution.distributed_cases.create!(case_id: task.appeal.uuid,
+                                               docket: "hearing",
+                                               priority: priority,
+                                               ready_at: task.appeal.ready_for_distribution_at,
+                                               task: task,
+                                               genpop: genpop_value,
+                                               genpop_query: genpop)
+      end
+    end
+  end
+
+  private
+
+  attr_reader :appeals, :genpop, :distribution, :priority
+
+  def assign_judge_tasks_for_appeals
+    assign_judge_tasks_for_not_genpop_appeals.concat(assign_judge_tasks_for_only_genpop_appeals)
+  end
+
+  def assign_judge_tasks_for_not_genpop_appeals
+    CreateJudgeAssignTasksForAppeals.new(appeals: not_genpop_appeals, genpop: false, judge: distribution.judge).call
+  end
+
+  def assign_judge_tasks_for_only_genpop_appeals
+    CreateJudgeAssignTasksForAppeals.new(appeals: only_genpop_appeals, genpop: true, judge: distribution.judge).call
+  end
+
+  def not_genpop_appeals
+    return appeals if genpop == "not_genpop"
+
+    return appeals[0] if genpop == "any"
+
+    []
+  end
+
+  def only_genpop_appeals
+    return appeals if genpop == "only_genpop"
+
+    return appeals[1] if genpop == "any"
+
+    []
+  end
+end

--- a/app/workflows/judge_assign_task_creator.rb
+++ b/app/workflows/judge_assign_task_creator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class JudgeAssignTaskCreator
+  def initialize(appeal:, judge:, genpop:)
+    @appeal = appeal
+    @judge = judge
+    @genpop = genpop
+  end
+
+  def call
+    Rails.logger.info("Assigning judge task for appeal #{appeal.id}")
+    Rails.logger.info("Assigned judge task with task id #{task.id} to #{task.assigned_to.css_id}")
+    Rails.logger.info("Closing distribution task for appeal #{appeal.id}")
+
+    close_distribution_tasks_for_appeal
+
+    Rails.logger.info("Closed distribution task for appeal #{appeal.id}")
+
+    [task, genpop]
+  end
+
+  private
+
+  attr_reader :appeal, :judge, :genpop
+
+  def task
+    @task ||= JudgeAssignTask.create!(
+      appeal: appeal,
+      parent: appeal.root_task,
+      appeal_type: Appeal.name,
+      assigned_at: Time.zone.now,
+      assigned_to: judge,
+      action: "assign"
+    )
+  end
+
+  def close_distribution_tasks_for_appeal
+    appeal.tasks.where(type: DistributionTask.name).update(status: :completed)
+  end
+end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -77,6 +77,14 @@ FactoryBot.define do
       end
     end
 
+    trait :ready_for_distribution do
+      after(:create) do |appeal, _evaluator|
+        appeal.create_tasks_on_intake_success!
+        distribution_tasks = appeal.tasks.select { |task| task.is_a?(DistributionTask) }
+        distribution_tasks.each { |task| task.ready_for_distribution! }
+      end
+    end
+
     trait :outcoded do
       after(:create) do |appeal, _evaluator|
         appeal.create_tasks_on_intake_success!

--- a/spec/models/dockets/hearing_request_docket_spec.rb
+++ b/spec/models/dockets/hearing_request_docket_spec.rb
@@ -3,28 +3,385 @@
 describe HearingRequestDocket do
   before do
     FeatureToggle.enable!(:ama_auto_case_distribution)
+    FeatureToggle.enable!(:ama_acd_tasks)
   end
   after do
     FeatureToggle.disable!(:ama_auto_case_distribution)
+    FeatureToggle.disable!(:ama_acd_tasks)
   end
 
-  let(:judge_user) { create(:user) }
-  let!(:vacols_judge) { create(:staff, :judge_role, sdomainid: judge_user.css_id) }
-  let(:distribution) { Distribution.create!(judge: judge_user) }
-
   describe "#age_of_n_oldest_priority_appeals" do
+    let(:judge_user) { create(:user, last_login_at: Time.zone.now) }
+    let!(:vacols_judge) { create(:staff, :judge_role, sdomainid: judge_user.css_id) }
+
     subject { HearingRequestDocket.new.age_of_n_oldest_priority_appeals(10) }
 
-    it "should return a stubbed value" do
-      expect(subject).to eq([])
+    it "only returns priority, distributable, hearing docket appeals that match the following conditions:
+        where the most recent held hearing was not tied to an active judge
+        OR
+        appeals that have no hearings at all
+        appeals that have no hearings with disposition held" do
+      _another_inactive_judge = create(:user, last_login_at: 70.days.ago)
+      JudgeTeam.create_for_judge(_another_inactive_judge)
+      create_appeals_that_should_not_be_returned_by_query
+      # base conditions = priority, distributable, hearing docket
+      first_appeal = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_inactive_judge
+      second_appeal = matching_all_base_conditions_with_no_hearings
+      third_appeal = matching_all_base_conditions_with_no_held_hearings
+      fourth_appeal = matching_all_base_conditions_with_most_recent_hearing_tied_to_other_active_judge_but_not_held
+      # This one below should never happen, but is included for completeness
+      fifth_appeal = matching_all_base_conditions_with_most_recent_held_hearing_not_tied_to_any_judge
+
+      result = [first_appeal, second_appeal, third_appeal, fourth_appeal, fifth_appeal]
+        .map(&:ready_for_distribution_at).map(&:to_s)
+
+      # For some reason, in Circle CI, the datetimes are not matching exactly to the millisecond
+      expect(subject.map(&:to_s)).to match_array(result)
     end
   end
 
-  describe "#age_of_n_oldest_priority_appeals" do
-    subject { HearingRequestDocket.new.distribute_appeals(distribution) }
+  describe "#distribute_appeals" do
+    let(:distribution_judge) { create(:user, last_login_at: Time.zone.now) }
+    let!(:vacols_judge) { create(:staff, :judge_role, sdomainid: distribution_judge.css_id) }
+    let!(:distribution) { Distribution.create!(judge: distribution_judge) }
 
-    it "should return a stubbed value" do
-      expect(subject).to eq([])
+    context "nonpriority appeals and not_genpop" do
+      subject do
+        HearingRequestDocket.new.distribute_appeals(
+          distribution, priority: false, limit: 10, genpop: "not_genpop"
+        )
+      end
+
+      it "only distributes nonpriority, distributable, hearing docket cases
+          where the most recent held hearing is tied to the distribution judge" do
+        create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+        appeal = create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+
+        tasks = subject
+
+        expect(tasks.length).to eq(1)
+        expect(tasks.first.class).to eq(DistributedCase)
+        expect(tasks.first.genpop).to eq false
+        expect(tasks.first.genpop_query).to eq "not_genpop"
+        expect(distribution.distributed_cases.length).to eq(1)
+        expect(distribution_judge.reload.tasks.map(&:appeal)).to eq([appeal])
+      end
     end
+
+    context "priority appeals and not_genpop" do
+      subject do
+        HearingRequestDocket.new.distribute_appeals(
+          distribution, priority: true, limit: 10, genpop: "not_genpop"
+        )
+      end
+
+      it "only distributes priority, distributable, hearing docket cases
+          where the most recent held hearing is tied to the distribution judge" do
+        # appeals that should not be returned
+        create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+        create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+        matching_all_base_conditions_with_most_recent_hearing_tied_to_other_active_judge_but_not_held
+        matching_all_base_conditions_with_most_recent_hearing_tied_to_distribution_judge_but_not_held
+        matching_all_base_conditions_with_most_recent_held_hearing_not_tied_to_any_judge
+        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_other_active_judge
+
+        appeal = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+        another = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+
+        tasks = subject
+
+        expect(tasks.length).to eq(2)
+        expect(tasks.first.class).to eq(DistributedCase)
+        expect(tasks.first.genpop).to eq false
+        expect(tasks.first.genpop_query).to eq "not_genpop"
+        expect(distribution.distributed_cases.length).to eq(2)
+        expect(distribution_judge.reload.tasks.map(&:appeal)).to match_array([appeal, another])
+      end
+    end
+
+    context "priority appeals and genpop 'any'" do
+      subject do
+        HearingRequestDocket.new.distribute_appeals(
+          distribution, priority: true, limit: 10, genpop: "any"
+        )
+      end
+
+      it "only distributes priority, distributable, hearing docket cases
+          that are either genpop or not genpop" do
+        not_tied = create_priority_distributable_hearing_appeal_not_tied_to_any_judge
+        tied = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+        create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+        create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_active_judge
+
+        tasks = subject
+
+        expect(tasks.length).to eq(2)
+        expect(tasks.first.class).to eq(DistributedCase)
+        expect(tasks.first.genpop).to eq false
+        expect(tasks.first.genpop_query).to eq "any"
+        expect(tasks.second.genpop).to eq true
+        expect(tasks.second.genpop_query).to eq "any"
+        expect(distribution.distributed_cases.length).to eq(2)
+        expect(distribution_judge.reload.tasks.map(&:appeal)).to match_array([tied, not_tied])
+      end
+    end
+
+    context "nonpriority appeals and genpop 'any'" do
+      subject do
+        HearingRequestDocket.new.distribute_appeals(
+          distribution, priority: false, limit: 10, genpop: "any"
+        )
+      end
+
+      it "only distributes nonpriority, distributable, hearing docket cases
+          that are either genpop or not genpop" do
+        create_priority_distributable_hearing_appeal_not_tied_to_any_judge
+        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+        tied = create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+        not_tied = create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+        no_held_hearings = non_priority_with_no_held_hearings
+        no_hearings = non_priority_with_no_hearings
+        tasks = subject
+
+        expect(tasks.length).to eq(4)
+        expect(tasks.first.class).to eq(DistributedCase)
+        expect(tasks.first.genpop).to eq false
+        expect(tasks.first.genpop_query).to eq "any"
+        expect(tasks.second.genpop).to eq true
+        expect(tasks.second.genpop_query).to eq "any"
+        expect(distribution.distributed_cases.length).to eq(4)
+        expect(distribution_judge.reload.tasks.map(&:appeal))
+          .to match_array([tied, not_tied, no_held_hearings, no_hearings])
+      end
+    end
+
+    context "priority appeals and only_genpop" do
+      subject do
+        HearingRequestDocket.new.distribute_appeals(
+          distribution, priority: true, limit: 10, genpop: "only_genpop"
+        )
+      end
+
+      it "only distributes priority, distributable, hearing docket, genpop cases" do
+        appeal = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_inactive_judge
+        no_held_hearings = matching_all_base_conditions_with_no_held_hearings
+        no_hearings = matching_all_base_conditions_with_no_hearings
+
+        create_appeals_that_should_not_be_returned_by_query
+        create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+        create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+
+        tasks = subject
+
+        expect(tasks.length).to eq(3)
+        expect(tasks.first.class).to eq(DistributedCase)
+        expect(tasks.first.genpop).to eq true
+        expect(tasks.first.genpop_query).to eq "only_genpop"
+        expect(distribution.distributed_cases.length).to eq(3)
+        expect(distribution_judge.reload.tasks.map(&:appeal))
+          .to match_array([appeal, no_held_hearings, no_hearings])
+      end
+    end
+
+    context "nonpriority appeals and only_genpop" do
+      subject do
+        HearingRequestDocket.new.distribute_appeals(
+          distribution, priority: false, limit: 10, genpop: "only_genpop"
+        )
+      end
+
+      it "only distributes nonpriority, distributable, hearing docket, genpop cases" do
+        create_priority_distributable_hearing_appeal_not_tied_to_any_judge
+        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+        create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+
+        appeal = create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+        no_held_hearings = non_priority_with_no_held_hearings
+        no_hearings = non_priority_with_no_hearings
+
+        tasks = subject
+
+        expect(tasks.length).to eq(3)
+        expect(tasks.first.class).to eq(DistributedCase)
+        expect(tasks.map(&:genpop).uniq).to eq [true]
+        expect(tasks.map(&:genpop_query).uniq).to eq ["only_genpop"]
+        expect(distribution.distributed_cases.length).to eq(3)
+        expect(distribution_judge.reload.tasks.map(&:appeal))
+          .to match_array([appeal, no_held_hearings, no_hearings])
+      end
+    end
+  end
+
+  private
+
+  def create_appeals_that_should_not_be_returned_by_query
+    matching_all_conditions_except_not_tied_to_active_judge
+    matching_all_conditions_except_priority
+    matching_all_conditions_except_ready_for_distribution
+    matching_all_conditions_except_priority_and_ready_for_distribution
+    matching_only_priority_and_ready_for_distribution
+    matching_all_base_conditions_with_most_recent_held_hearing_tied_to_active_judge
+  end
+
+  def matching_all_base_conditions_with_no_hearings
+    create(:appeal, :advanced_on_docket_due_to_age, :ready_for_distribution, docket_type: "hearing")
+  end
+
+  def non_priority_with_no_hearings
+    create(:appeal, :denied_advance_on_docket, :ready_for_distribution, docket_type: "hearing")
+  end
+
+  def matching_all_base_conditions_with_no_held_hearings
+    appeal = create(:appeal, :advanced_on_docket_due_to_age, :ready_for_distribution, docket_type: "hearing")
+    create(:hearing, disposition: "no_show", appeal: appeal)
+    appeal
+  end
+
+  def non_priority_with_no_held_hearings
+    appeal = create(:appeal, :denied_advance_on_docket, :ready_for_distribution, docket_type: "hearing")
+    create(:hearing, disposition: "no_show", appeal: appeal)
+    appeal
+  end
+
+  def matching_all_conditions_except_not_tied_to_active_judge
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+    hearing = create(:hearing, disposition: "held", appeal: appeal)
+    hearing.update(judge: active_judge)
+  end
+
+  def matching_all_conditions_except_priority
+    appeal = create(:appeal, :denied_advance_on_docket, :ready_for_distribution, docket_type: "hearing")
+    create(:hearing, disposition: "held", appeal: appeal)
+    appeal = create(:appeal, :inapplicable_aod_motion, :ready_for_distribution, docket_type: "hearing")
+    create(:hearing, disposition: "held", appeal: appeal)
+    appeal = create(:appeal, :ready_for_distribution, docket_type: "hearing")
+    create(:hearing, disposition: "held", appeal: appeal)
+  end
+
+  def matching_all_conditions_except_ready_for_distribution
+    appeal = create(:appeal, :advanced_on_docket_due_to_age, :with_tasks, docket_type: "hearing")
+    create(:hearing, disposition: "held", appeal: appeal)
+  end
+
+  def matching_all_conditions_except_priority_and_ready_for_distribution
+    appeal = create(:appeal, :with_tasks, docket_type: "hearing")
+    create(:hearing, disposition: "held", appeal: appeal)
+  end
+
+  def matching_only_priority_and_ready_for_distribution
+    create(:appeal, :advanced_on_docket_due_to_age, :with_tasks, docket_type: "direct_review")
+  end
+
+  def matching_all_base_conditions_with_most_recent_held_hearing_tied_to_inactive_judge
+    inactive_judge = create(:user, last_login_at: 70.days.ago)
+    JudgeTeam.create_for_judge(inactive_judge)
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+    hearing = create(:hearing, disposition: "held", appeal: appeal, transcript_sent_date: 1.day.ago)
+    hearing.update(judge: inactive_judge)
+    appeal
+  end
+
+  def create_priority_distributable_hearing_appeal_not_tied_to_any_judge
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+    hearing = create(:hearing, disposition: "held", appeal: appeal)
+    appeal
+  end
+
+  def create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
+    appeal = create(:appeal, :ready_for_distribution, :denied_advance_on_docket, docket_type: "hearing")
+
+    most_recent = create(:hearing_day, scheduled_for: 1.day.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: most_recent)
+    hearing.update(judge: distribution_judge)
+
+    appeal
+  end
+
+  def create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
+    appeal = create(:appeal, :ready_for_distribution, :denied_advance_on_docket, docket_type: "hearing")
+    create(:hearing, disposition: "held", appeal: appeal)
+    appeal
+  end
+
+  def matching_all_base_conditions_with_most_recent_held_hearing_tied_to_active_judge
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+    most_recent = create(:hearing_day, scheduled_for: 1.day.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: most_recent)
+    hearing.update(judge: active_judge)
+
+    not_tied = create(:hearing_day, scheduled_for: 2.days.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: not_tied)
+    appeal
+  end
+
+  def matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+    most_recent = create(:hearing_day, scheduled_for: 1.day.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: most_recent)
+    hearing.update(judge: distribution_judge)
+
+    not_tied = create(:hearing_day, scheduled_for: 2.days.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: not_tied)
+    appeal
+  end
+
+  def matching_all_base_conditions_with_most_recent_held_hearing_not_tied_to_any_judge
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+    most_recent = create(:hearing_day, scheduled_for: 3.days.ago)
+    create(:hearing, disposition: "held", appeal: appeal, hearing_day: most_recent)
+
+    tied_hearing_day = create(:hearing_day, scheduled_for: 4.days.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: tied_hearing_day)
+    hearing.update(judge: active_judge)
+
+    appeal
+  end
+
+  def matching_all_base_conditions_with_most_recent_hearing_tied_to_other_active_judge_but_not_held
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+
+    most_recent = create(:hearing_day, scheduled_for: 1.day.ago)
+    hearing = create(:hearing, disposition: "cancelled", appeal: appeal, hearing_day: most_recent)
+    hearing.update(judge: active_judge)
+
+    older_hearing_day = create(:hearing_day, scheduled_for: 2.days.ago)
+    create(:hearing, disposition: "held", appeal: appeal, hearing_day: older_hearing_day)
+
+    appeal
+  end
+
+  def matching_all_base_conditions_with_most_recent_hearing_tied_to_distribution_judge_but_not_held
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+
+    most_recent = create(:hearing_day, scheduled_for: 1.day.ago)
+    hearing = create(:hearing, disposition: "cancelled", appeal: appeal, hearing_day: most_recent)
+    hearing.update(judge: distribution_judge)
+
+    older_hearing_day = create(:hearing_day, scheduled_for: 2.days.ago)
+    create(:hearing, disposition: "held", appeal: appeal, hearing_day: older_hearing_day)
+
+    appeal
+  end
+
+  def matching_all_base_conditions_with_most_recent_held_hearing_tied_to_other_active_judge
+    appeal = create(:appeal, :ready_for_distribution, :advanced_on_docket_due_to_motion, docket_type: "hearing")
+
+    most_recent_hearing_day = create(:hearing_day, scheduled_for: 1.day.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: most_recent_hearing_day)
+    hearing.update(judge: active_judge)
+
+    older_hearing_day = create(:hearing_day, scheduled_for: 2.days.ago)
+    hearing = create(:hearing, disposition: "held", appeal: appeal, hearing_day: older_hearing_day)
+    hearing.update(judge: distribution_judge)
+
+    appeal
+  end
+
+  def active_judge
+    active_judge = create(:user, last_login_at: Time.zone.now)
+    JudgeTeam.create_for_judge(active_judge)
+    active_judge
   end
 end


### PR DESCRIPTION
Resolves #9999

In order to support distribution of appeals in the Hearing docket, we
needed to define the `age_of_n_oldest_priority_appeals` and
`distribute_appeals` methods to adhere to the conditions that are
specific to Hearing appeals.

In `age_of_n_oldest_priority_appeals`, the first set of base conditions
that get applied are: priority, ready for distribution, and in the
hearing docket. These scopes (defined in the `Appeal` model) get
applied via the `Docket` class. An appeal is considered prioritized if
it is Advanced on the Docket. More details about priority status here:
https://github.com/department-of-veterans-affairs/caseflow/wiki/Automatic-Case-Distribution#priority

For appeals in the Hearing docket, we only want `genpop` appeals, which
are those that adhere to any of these conditions:
- with no hearings
- with hearings, but none that are held
- where the most recent held hearing was held by an inactive judge

This means that if an appeal has multiple hearings, one or more of
which have the `disposition` attribute set to `held`, we only want to
look at the most recent hearing. In order to determine the date the
hearing was held, we need to join on the `HearingDay` table and look
at the `scheduled_for` field.

More background info on `genpop` here:
https://github.com/department-of-veterans-affairs/caseflow/wiki/Automatic-Case-Distribution#genpop

For the `distribute_appeals` method, the base conditions are: ready for
distribution and in the hearing docket. Priority and genpop are passed
in via `AmaCaseDistribution#ama_distribution` because both priority and
nonpriority cases can be distributed, as well as "only genpop",
"not genpop", or "any" (which is a combination of the previous two).