### PR TITLE
Make doccount temporarily the empty string

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -35,7 +35,7 @@ class AppealsController < ApplicationController
   end
 
   def document_count
-    render json: { document_count: "Temporarily unavailable" }
+    render json: { document_count: "" } # TODO: fix document count performance
   rescue Caseflow::Error::EfolderAccessForbidden => error
     render(error.serialize_response)
   rescue StandardError => error

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -35,7 +35,7 @@ class AppealsController < ApplicationController
   end
 
   def document_count
-    render json: { document_count: "" } # TODO: fix document count performance
+    render json: { document_count: "" }
   rescue Caseflow::Error::EfolderAccessForbidden => error
     render(error.serialize_response)
   rescue StandardError => error

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -182,10 +182,11 @@ RSpec.describe AppealsController, type: :controller do
       end
       let(:appeal) { create(:appeal, veteran_file_number: file_number) }
 
-      it "should return document count", skip: "temp disabled for doccount test" do
+      it "should return document count" do
         get :document_count, params: { appeal_id: appeal.uuid }
 
         response_body = JSON.parse(response.body)
+        pending "temp disabled for doccount test"
         expect(response_body["document_count"]).to eq 2
       end
     end


### PR DESCRIPTION
Should generate HTML anchor link text like "View docs" with no count.