### PR TITLE
Execute build script from anywhere

### DIFF
--- a/lib/tasks/local/build.rake
+++ b/lib/tasks/local/build.rake
@@ -4,8 +4,7 @@ namespace :local do
   desc "build local development environment"
   task :build do
     puts "Building docker services from configuration"
-    system("cd local/vacols/ && ./build_push.sh local") || abort
-    system("cd ../../")
+    system("./local/vacols/build_push.sh local") || abort
 
     puts "Starting docker containers in the background"
     system("docker-compose up -d") || abort


### PR DESCRIPTION
Allows this script to be run from any directory instead of just its parent directory. Tested on a Mac using Bash but it should be portable.