### PR TITLE
Inject docket number column into TaskTable instance in OrganizationQueue.

### DIFF
--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -5,7 +5,7 @@ import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 
 import TabWindow from '../components/TabWindow';
-import TaskTable from './components/TaskTable';
+import TaskTable, { DocketNumberColumn } from './components/TaskTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
@@ -147,12 +147,12 @@ export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
   <TaskTable
+    customColumns={[DocketNumberColumn(tasks, false)]}
     includeHearingBadge
     includeDetailsLink
     includeTask
     includeRegionalOffice={organizationName === 'Hearing Management' || organizationName === 'Hearing Admin'}
     includeType
-    includeDocketNumber
     includeDaysWaiting
     includeReaderLink
     includeNewDocsIcon
@@ -161,8 +161,11 @@ const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <Re
   />
 </React.Fragment>;
 
+    // includeDocketNumber
+
 const TaskTableWithUserColumnTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
+
   <TaskTable
     includeHearingBadge
     includeDetailsLink

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -5,7 +5,7 @@ import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 
 import TabWindow from '../components/TabWindow';
-import TaskTable, { DocketNumberColumn } from './components/TaskTable';
+import TaskTable, { docketNumberColumn } from './components/TaskTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
@@ -85,7 +85,7 @@ class OrganizationQueue extends React.PureComponent {
             {sprintf(COPY.ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, this.props.organizationName)}
           </p>
           <TaskTable
-            customColumns={[DocketNumberColumn(tasks, false)]}
+            customColumns={[docketNumberColumn(this.props.trackingTasks, false)]}
             includeDetailsLink
             includeIssueCount
             includeType
@@ -147,7 +147,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
   <TaskTable
-    customColumns={[DocketNumberColumn(tasks, false)]}
+    customColumns={[docketNumberColumn(tasks, false)]}
     includeHearingBadge
     includeDetailsLink
     includeTask
@@ -165,7 +165,7 @@ const TaskTableWithUserColumnTab = ({ description, tasks, organizationName }) =>
   <p className="cf-margin-top-0">{description}</p>
 
   <TaskTable
-    customColumns={[DocketNumberColumn(tasks, false)]}
+    customColumns={[docketNumberColumn(tasks, false)]}
     includeHearingBadge
     includeDetailsLink
     includeTask

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -85,10 +85,10 @@ class OrganizationQueue extends React.PureComponent {
             {sprintf(COPY.ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, this.props.organizationName)}
           </p>
           <TaskTable
+            customColumns={[DocketNumberColumn(tasks, false)]}
             includeDetailsLink
             includeIssueCount
             includeType
-            includeDocketNumber
             tasks={this.props.trackingTasks}
           />
         </React.Fragment>
@@ -161,19 +161,17 @@ const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <Re
   />
 </React.Fragment>;
 
-    // includeDocketNumber
-
 const TaskTableWithUserColumnTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
 
   <TaskTable
+    customColumns={[DocketNumberColumn(tasks, false)]}
     includeHearingBadge
     includeDetailsLink
     includeTask
     includeRegionalOffice={organizationName === 'Hearing Management' || organizationName === 'Hearing Admin'}
     includeType
     includeAssignedTo
-    includeDocketNumber
     includeDaysWaiting
     tasks={tasks}
   />

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -37,7 +37,7 @@ import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTION
 import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
-  return (task.appeal.isLegacyAppeal && requireDasRecord) ? task.taskId : true;
+  return (task.appeal.isLegacyAppeal && requireDasRecord) ? Boolean(task.taskId) : true;
 };
 
 const collapseColumn = (requireDasRecord) => (task) => hasDASRecord(task, requireDasRecord) ? 1 : 0;

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -92,11 +92,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   taskHasDASRecord = (task) => {
-    if (task.appeal.isLegacyAppeal && this.props.requireDasRecord) {
-      return task.taskId;
-    }
-
-    return true;
+    return hasDASRecord(task, this.props.requireDasRecord);
   }
 
   collapseColumnIfNoDASRecord = (task) => this.taskHasDASRecord(task) ? 1 : 0

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -38,7 +38,7 @@ import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
   if (task.appeal.isLegacyAppeal && requireDasRecord) {
-    return task.taskId;
+    return !!task.taskId;
   }
 
   return true;
@@ -69,7 +69,7 @@ export const docketNumberColumn = (tasks, requireDasRecord) => {
     },
     span: collapseColumn(requireDasRecord),
     getSortValue: (task) => {
-      if (!taskHasDASRecord(task, requireDasRecord)) {
+      if (!hasDASRecord(task, requireDasRecord)) {
         return null;
       }
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -38,14 +38,16 @@ import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
   if (task.appeal.isLegacyAppeal && requireDasRecord) {
-    return Boolean(task.taskId);
+    // return Boolean(task.taskId);
+    return task.taskId;
   }
 
   return true;
 };
 
-const collapseColumn = (requireDasRecord) =>
+const collapseColumn = (requireDasRecord) => {
   (task) => hasDASRecord(task, requireDasRecord) ? 1 : 0;
+}
 
 export const docketNumberColumn = (tasks, requireDasRecord) => {
   return {
@@ -210,7 +212,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDocketNumberColumn = () => {
-    docketNumberColumn(this.props.tasks, this.props.requireDasRecord);
+    return docketNumberColumn(this.props.tasks, this.props.requireDasRecord);
   }
 
   caseIssueCountColumn = () => {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -36,48 +36,47 @@ import COPY from '../../../COPY.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
-
 const taskHasDASRecord = (task, requireDasRecord) => {
   if (task.appeal.isLegacyAppeal && requireDasRecord) {
     return task.taskId;
   }
 
   return true;
-}
+};
 
 const collapseColumnIfNoDASRecord = (requireDasRecord) =>
   (task) => taskHasDASRecord(task, requireDasRecord) ? 1 : 0;
 
-export const DocketNumberColumn = (tasks, requireDasRecord) => {
-   return {
-     header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
-     enableFilter: true,
-     tableData: tasks,
-     columnName: 'appeal.docketName',
-     customFilterLabels: DOCKET_NAME_FILTERS,
-     anyFiltersAreSet: true,
-     label: 'Filter by docket name',
-     valueName: 'docketName',
-     valueFunction: (task) => {
-       if (!taskHasDASRecord(task, requireDasRecord)) {
-         return null;
-       }
+export const docketNumberColumn = (tasks, requireDasRecord) => {
+  return {
+    header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
+    enableFilter: true,
+    tableData: tasks,
+    columnName: 'appeal.docketName',
+    customFilterLabels: DOCKET_NAME_FILTERS,
+    anyFiltersAreSet: true,
+    label: 'Filter by docket name',
+    valueName: 'docketName',
+    valueFunction: (task) => {
+      if (!taskHasDASRecord(task, requireDasRecord)) {
+        return null;
+      }
 
-       return <React.Fragment>
-         <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
-         <span>{task.appeal.docketNumber}</span>
-       </React.Fragment>;
-     },
-     span: collapseColumnIfNoDASRecord(requireDasRecord),
-     getSortValue: (task) => {
-       if (!taskHasDASRecord(task, requireDasRecord)) {
-         return null;
-       }
+      return <React.Fragment>
+        <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
+        <span>{task.appeal.docketNumber}</span>
+      </React.Fragment>;
+    },
+    span: collapseColumnIfNoDASRecord(requireDasRecord),
+    getSortValue: (task) => {
+      if (!taskHasDASRecord(task, requireDasRecord)) {
+        return null;
+      }
 
-       return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
-     }
-   }
- }
+      return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
+    }
+  };
+};
 
 export class TaskTableUnconnected extends React.PureComponent {
   getKeyForRow = (rowNumber, object) => object.uniqueId

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -37,17 +37,10 @@ import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTION
 import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
-  if (task.appeal.isLegacyAppeal && requireDasRecord) {
-    // return Boolean(task.taskId);
-    return task.taskId;
-  }
-
-  return true;
+  return (task.appeal.isLegacyAppeal && requireDasRecord) ? task.taskId : true;
 };
 
-const collapseColumn = (requireDasRecord) => {
-  (task) => hasDASRecord(task, requireDasRecord) ? 1 : 0;
-}
+const collapseColumn = (requireDasRecord) => (task) => hasDASRecord(task, requireDasRecord) ? 1 : 0;
 
 export const docketNumberColumn = (tasks, requireDasRecord) => {
   return {
@@ -212,7 +205,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDocketNumberColumn = () => {
-    return this.props.includeDocketNumber ? docketNumberColumn(this.props.tasks, this.props.requireDasRecord): null;
+    return this.props.includeDocketNumber ? docketNumberColumn(this.props.tasks, this.props.requireDasRecord) : null;
   }
 
   caseIssueCountColumn = () => {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -212,7 +212,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDocketNumberColumn = () => {
-    return docketNumberColumn(this.props.tasks, this.props.requireDasRecord);
+    return this.props.includeDocketNumber ? docketNumberColumn(this.props.tasks, this.props.requireDasRecord): null;
   }
 
   caseIssueCountColumn = () => {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -38,7 +38,7 @@ import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
   if (task.appeal.isLegacyAppeal && requireDasRecord) {
-    return !!task.taskId;
+    return Boolean(task.taskId);
   }
 
   return true;

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -175,37 +175,6 @@ export class TaskTableUnconnected extends React.PureComponent {
     } : null;
   }
 
-  caseDocketNumberColumn = () => {
-    return this.props.includeDocketNumber ? {
-      header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
-      enableFilter: true,
-      tableData: this.props.tasks,
-      columnName: 'appeal.docketName',
-      customFilterLabels: DOCKET_NAME_FILTERS,
-      anyFiltersAreSet: true,
-      label: 'Filter by docket name',
-      valueName: 'docketName',
-      valueFunction: (task) => {
-        if (!this.taskHasDASRecord(task)) {
-          return null;
-        }
-
-        return <React.Fragment>
-          <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
-          <span>{task.appeal.docketNumber}</span>
-        </React.Fragment>;
-      },
-      span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => {
-        if (!this.taskHasDASRecord(task)) {
-          return null;
-        }
-
-        return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
-      }
-    } : null;
-  }
-
   caseTypeColumn = () => {
     return this.props.includeType ? {
       header: COPY.CASE_LIST_TABLE_APPEAL_TYPE_COLUMN_TITLE,
@@ -241,6 +210,37 @@ export class TaskTableUnconnected extends React.PureComponent {
       label: 'Filter by assignee',
       valueFunction: (task) => task.assignedTo.name,
       getSortValue: (task) => task.assignedTo.name
+    } : null;
+  }
+
+  caseDocketNumberColumn = () => {
+    return this.props.includeDocketNumber ? {
+      header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
+      enableFilter: true,
+      tableData: this.props.tasks,
+      columnName: 'appeal.docketName',
+      customFilterLabels: DOCKET_NAME_FILTERS,
+      anyFiltersAreSet: true,
+      label: 'Filter by docket name',
+      valueName: 'docketName',
+      valueFunction: (task) => {
+        if (!this.taskHasDASRecord(task)) {
+          return null;
+        }
+
+        return <React.Fragment>
+          <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
+          <span>{task.appeal.docketNumber}</span>
+        </React.Fragment>;
+      },
+      span: this.collapseColumnIfNoDASRecord,
+      getSortValue: (task) => {
+        if (!this.taskHasDASRecord(task)) {
+          return null;
+        }
+
+        return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
+      }
     } : null;
   }
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -36,6 +36,49 @@ import COPY from '../../../COPY.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
+
+const taskHasDASRecord = (task, requireDasRecord) => {
+  if (task.appeal.isLegacyAppeal && requireDasRecord) {
+    return task.taskId;
+  }
+
+  return true;
+}
+
+const collapseColumnIfNoDASRecord = (requireDasRecord) =>
+  (task) => taskHasDASRecord(task, requireDasRecord) ? 1 : 0;
+
+export const DocketNumberColumn = (tasks, requireDasRecord) => {
+   return {
+     header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
+     enableFilter: true,
+     tableData: tasks,
+     columnName: 'appeal.docketName',
+     customFilterLabels: DOCKET_NAME_FILTERS,
+     anyFiltersAreSet: true,
+     label: 'Filter by docket name',
+     valueName: 'docketName',
+     valueFunction: (task) => {
+       if (!taskHasDASRecord(task, requireDasRecord)) {
+         return null;
+       }
+
+       return <React.Fragment>
+         <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
+         <span>{task.appeal.docketNumber}</span>
+       </React.Fragment>;
+     },
+     span: collapseColumnIfNoDASRecord(requireDasRecord),
+     getSortValue: (task) => {
+       if (!taskHasDASRecord(task, requireDasRecord)) {
+         return null;
+       }
+
+       return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
+     }
+   }
+ }
+
 export class TaskTableUnconnected extends React.PureComponent {
   getKeyForRow = (rowNumber, object) => object.uniqueId
 
@@ -133,6 +176,37 @@ export class TaskTableUnconnected extends React.PureComponent {
     } : null;
   }
 
+  caseDocketNumberColumn = () => {
+    return this.props.includeDocketNumber ? {
+      header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
+      enableFilter: true,
+      tableData: this.props.tasks,
+      columnName: 'appeal.docketName',
+      customFilterLabels: DOCKET_NAME_FILTERS,
+      anyFiltersAreSet: true,
+      label: 'Filter by docket name',
+      valueName: 'docketName',
+      valueFunction: (task) => {
+        if (!this.taskHasDASRecord(task)) {
+          return null;
+        }
+
+        return <React.Fragment>
+          <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
+          <span>{task.appeal.docketNumber}</span>
+        </React.Fragment>;
+      },
+      span: this.collapseColumnIfNoDASRecord,
+      getSortValue: (task) => {
+        if (!this.taskHasDASRecord(task)) {
+          return null;
+        }
+
+        return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
+      }
+    } : null;
+  }
+
   caseTypeColumn = () => {
     return this.props.includeType ? {
       header: COPY.CASE_LIST_TABLE_APPEAL_TYPE_COLUMN_TITLE,
@@ -168,37 +242,6 @@ export class TaskTableUnconnected extends React.PureComponent {
       label: 'Filter by assignee',
       valueFunction: (task) => task.assignedTo.name,
       getSortValue: (task) => task.assignedTo.name
-    } : null;
-  }
-
-  caseDocketNumberColumn = () => {
-    return this.props.includeDocketNumber ? {
-      header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
-      enableFilter: true,
-      tableData: this.props.tasks,
-      columnName: 'appeal.docketName',
-      customFilterLabels: DOCKET_NAME_FILTERS,
-      anyFiltersAreSet: true,
-      label: 'Filter by docket name',
-      valueName: 'docketName',
-      valueFunction: (task) => {
-        if (!this.taskHasDASRecord(task)) {
-          return null;
-        }
-
-        return <React.Fragment>
-          <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
-          <span>{task.appeal.docketNumber}</span>
-        </React.Fragment>;
-      },
-      span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => {
-        if (!this.taskHasDASRecord(task)) {
-          return null;
-        }
-
-        return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
-      }
     } : null;
   }
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -38,7 +38,7 @@ import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
   if (task.appeal.isLegacyAppeal && requireDasRecord) {
-    return !!task.taskId;
+    return task.taskId;
   }
 
   return true;

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -36,16 +36,16 @@ import COPY from '../../../COPY.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
-const taskHasDASRecord = (task, requireDasRecord) => {
+const hasDASRecord = (task, requireDasRecord) => {
   if (task.appeal.isLegacyAppeal && requireDasRecord) {
-    return task.taskId;
+    return !!task.taskId;
   }
 
   return true;
 };
 
-const collapseColumnIfNoDASRecord = (requireDasRecord) =>
-  (task) => taskHasDASRecord(task, requireDasRecord) ? 1 : 0;
+const collapseColumn = (requireDasRecord) =>
+  (task) => hasDASRecord(task, requireDasRecord) ? 1 : 0;
 
 export const docketNumberColumn = (tasks, requireDasRecord) => {
   return {
@@ -58,7 +58,7 @@ export const docketNumberColumn = (tasks, requireDasRecord) => {
     label: 'Filter by docket name',
     valueName: 'docketName',
     valueFunction: (task) => {
-      if (!taskHasDASRecord(task, requireDasRecord)) {
+      if (!hasDASRecord(task, requireDasRecord)) {
         return null;
       }
 
@@ -67,7 +67,7 @@ export const docketNumberColumn = (tasks, requireDasRecord) => {
         <span>{task.appeal.docketNumber}</span>
       </React.Fragment>;
     },
-    span: collapseColumnIfNoDASRecord(requireDasRecord),
+    span: collapseColumn(requireDasRecord),
     getSortValue: (task) => {
       if (!taskHasDASRecord(task, requireDasRecord)) {
         return null;
@@ -214,34 +214,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDocketNumberColumn = () => {
-    return this.props.includeDocketNumber ? {
-      header: COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
-      enableFilter: true,
-      tableData: this.props.tasks,
-      columnName: 'appeal.docketName',
-      customFilterLabels: DOCKET_NAME_FILTERS,
-      anyFiltersAreSet: true,
-      label: 'Filter by docket name',
-      valueName: 'docketName',
-      valueFunction: (task) => {
-        if (!this.taskHasDASRecord(task)) {
-          return null;
-        }
-
-        return <React.Fragment>
-          <DocketTypeBadge name={task.appeal.docketName} number={task.appeal.docketNumber} />
-          <span>{task.appeal.docketNumber}</span>
-        </React.Fragment>;
-      },
-      span: this.collapseColumnIfNoDASRecord,
-      getSortValue: (task) => {
-        if (!this.taskHasDASRecord(task)) {
-          return null;
-        }
-
-        return `${task.appeal.docketName || ''} ${task.appeal.docketNumber}`;
-      }
-    } : null;
+    docketNumberColumn(this.props.tasks, this.props.requireDasRecord);
   }
 
   caseIssueCountColumn = () => {


### PR DESCRIPTION
Partially resolves #10619, which calls for injecting columns into `TaskTable` instances via a `customColumns` array, as opposed to setting properties.  

In order to tackle this more granularly, we have elected to do this one column at a time. This is the first PR in this series of work and represents the injection of the docket number column.
