### PR TITLE
Rename Quality Review test user

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -246,7 +246,7 @@ class SeedDB
   end
 
   def create_qr_user
-    qr_user = User.create!(station_id: 101, css_id: "QR_USER", full_name: "QR User")
+    qr_user = User.create!(station_id: 101, css_id: "QR_USER", full_name: "Quality Reviewer")
     OrganizationsUser.add_user_to_organization(qr_user, QualityReview.singleton)
 
     # Create QR tasks; one assigned just to the QR org and three assigned both to the org and a QR user.


### PR DESCRIPTION
I almost always search for the quality review test user in my local development environment by typing "quality re", remembering that the quality review test user does not have the entire title of the team in their name, deleting everything I've typed, and typing "QR" so I can select the correct user. This PR allows me to type what is natural and saves officemates from hearing me yell "uggghhh" once every three days.

![image](https://user-images.githubusercontent.com/32683958/57704411-d45e4880-762f-11e9-8779-6ac4f28f6e04.png)
