### PR TITLE
Do not re-parse VBMS errors in BGS wrapper

### DIFF
--- a/app/exceptions/bgs_sync_error.rb
+++ b/app/exceptions/bgs_sync_error.rb
@@ -16,6 +16,8 @@ class BGSSyncError < RuntimeError
 
   # rubocop:disable Metrics/MethodLength
   def self.from_bgs_error(error, epe)
+    return error if error.is_a?(Caseflow::Error::VBMS)
+
     error_message = if error.try(:body)
                       # https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/3124/
                       error.body.encode("UTF-8", invalid: :replace, undef: :replace, replace: "")


### PR DESCRIPTION
see https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/4933/events/333702/