### PR TITLE
Quiet warnings and deprecation notices

### DIFF
--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -85,13 +85,9 @@ describe Document do
 
   context ".content_url" do
     context "EFolderService is ExternalApi::EfolderService" do
-      OldEFolderService = EFolderService
-
       before do
-        EFolderService = ExternalApi::EfolderService
+        stub_const("EFolderService", ExternalApi::EfolderService)
       end
-
-      after { EFolderService = OldEFolderService }
 
       context "application is reader" do
         before do
@@ -109,7 +105,7 @@ describe Document do
 
       context "application is not reader" do
         before do
-          RequestStore.store[:application] = Faker::Cat.name
+          RequestStore.store[:application] = Faker::Creature::Cat.name
         end
 
         it "returns the URL for the document in VBMS" do
@@ -122,7 +118,7 @@ describe Document do
     context "EFolderService is Fakes::VBMSService" do
       context "application is not reader" do
         before do
-          RequestStore.store[:application] = Faker::Cat.name
+          RequestStore.store[:application] = Faker::Creature::Cat.name
         end
 
         it "returns the URL for the document in VBMS" do

--- a/spec/services/external_api/va_dot_gov_service_spec.rb
+++ b/spec/services/external_api/va_dot_gov_service_spec.rb
@@ -2,6 +2,10 @@
 
 describe ExternalApi::VADotGovService do
   describe "#get_facility_data" do
+    before do
+      stub_const("VADotGovService", Fakes::VADotGovService)
+    end
+
     it "returns facility data" do
       results = VADotGovService.get_facility_data(ids: %w[vha_539 vha_757 vha_539])
 


### PR DESCRIPTION
connects #4910 

The proper way to stub a constant is with `stub_const` (h/t @monfresh).