### PR TITLE
Fix imprecise on hold calculation

### DIFF
--- a/app/models/tasks/timed_hold_task.rb
+++ b/app/models/tasks/timed_hold_task.rb
@@ -39,7 +39,15 @@ class TimedHoldTask < GenericTask
 
   # Inspect the end time for related task timer.
   def timer_end_time
-    task_timers.first&.submitted_at
+    # Asyncable subtracts processing_retry_interval_hours from the initial delay before inserting the value into the
+    # submitted_at field. Since we expect to always instantiate TimedHoldTasks with a delay we need to take into account
+    # to know when the timer will complete.
+    #
+    # https://github.com/department-of-veterans-affairs/
+    #   caseflow/blob/1f7480d8ee155ede9a57a3128c43033908bd2c80/app/models/concerns/asyncable.rb#L125
+    #
+    # If we allow TimedHoldTasks to be submitted without delay this will need to change.
+    task_timers.first ? task_timers.first.submitted_at + TaskTimer.processing_retry_interval_hours.hours : nil
   end
 
   def timer_start_time

--- a/spec/controllers/tasks/place_hold_controller_spec.rb
+++ b/spec/controllers/tasks/place_hold_controller_spec.rb
@@ -29,10 +29,7 @@ RSpec.describe Tasks::PlaceHoldController, type: :controller do
         expect(timed_hold_task).to be_a(TimedHoldTask)
         expect(timed_hold_task.instructions).to eq([instructions])
         expect(timed_hold_task.assigned_by).to eq(user)
-
-        task_timer = timed_hold_task.task_timers.first
-        expect(task_timer).to be_a(TaskTimer)
-        expect(task_timer.submitted_at.to_date).to eq((Time.zone.now + days_on_hold.days).to_date)
+        expect(timed_hold_task.timer_end_time.to_date).to eq((Time.zone.now + days_on_hold.days).to_date)
       end
     end
 

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -185,7 +185,9 @@ describe TimedHoldTask do
 
     describe ".timer_end_time" do
       it "returns the expected end time" do
-        expect(task.reload.timer_end_time).to eq task.task_timers.first.submitted_at
+        expect(task.reload.timer_end_time).to eq(
+          task.task_timers.first.submitted_at + TaskTimer.processing_retry_interval_hours.hours
+        )
       end
     end
 


### PR DESCRIPTION
Fixes tests that fail 3 hours or fewer before midnight every night (see [related slack conversation](https://dsva.slack.com/archives/C2ZAMLK88/p1557989197421100)). Also, takes into account `Asyncable`'s intervals when calculating timed holds.