### PR TITLE
remove module prefix to fix issue with module reloading

### DIFF
--- a/lib/fakes/va_dot_gov_service.rb
+++ b/lib/fakes/va_dot_gov_service.rb
@@ -2,7 +2,7 @@
 
 class Fakes::VADotGovService < ExternalApi::VADotGovService
   def self.send_va_dot_gov_request(endpoint:, query: {}, **_args)
-    if endpoint == ExternalApi::VADotGovService::FACILITIES_ENDPOINT
+    if endpoint == VADotGovService::FACILITIES_ENDPOINT
       facilities = query[:ids].split(",").map do |id|
         data = fake_facilities_data[:data][0]
         data["id"] = id
@@ -20,7 +20,7 @@ class Fakes::VADotGovService < ExternalApi::VADotGovService
       fake_facilities[:data] = facilities
       fake_facilities[:meta][:distances] = distances
       HTTPI::Response.new 200, {}, fake_facilities.to_json
-    elsif endpoint == ExternalApi::VADotGovService::ADDRESS_VALIDATION_ENDPOINT
+    elsif endpoint == VADotGovService::ADDRESS_VALIDATION_ENDPOINT
       HTTPI::Response.new 200, {}, fake_address_data.to_json
     end
   end


### PR DESCRIPTION
Resolves #10805

### Description

When reloading `Fakes::VADotGovService` on the Rails server after a change to `app/services/va_dot_gov_address_validator.rb`, Rails was getting caught trying to resolve `ExternalApi`, and throwing an error. This fix removes the `ExternalApi` prefix, so that Rails can find the `VADotGovService`. 