### PR TITLE
Unable to cest EP| decision date 2/15/19

### DIFF
--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -206,7 +206,7 @@ const formatRatingRequestIssues = (state) => {
       return {
         request_issue_id: issue.id,
         rating_issue_reference_id: issue.ratingIssueReferenceId,
-        decision_date: issue.decisionDate,
+        decision_date: formatDateStringForApi(issue.decisionDate),
         decision_text: issue.description,
         rating_issue_profile_date: issue.ratingIssueProfileDate,
         rating_issue_diagnostic_code: issue.ratingIssueDiagnosticCode,

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -206,7 +206,7 @@ const formatRatingRequestIssues = (state) => {
       return {
         request_issue_id: issue.id,
         rating_issue_reference_id: issue.ratingIssueReferenceId,
-        decision_date: formatDateStringForApi(issue.decisionDate),
+        decision_date: issue.decisionDate,
         decision_text: issue.description,
         rating_issue_profile_date: issue.ratingIssueProfileDate,
         rating_issue_diagnostic_code: issue.ratingIssueDiagnosticCode,

--- a/client/constants/INELIGIBLE_REQUEST_ISSUES.json
+++ b/client/constants/INELIGIBLE_REQUEST_ISSUES.json
@@ -1,7 +1,7 @@
 {
   "duplicate_of_rating_issue_in_active_review": "is ineligible because it's already under review as a {review_title}",
   "untimely": "is ineligible because it has a prior decision date that’s older than 1 year",
-  "before_ama": "is ineligible because it has a prior decision date before February 14, 2019",
+  "before_ama": "is ineligible because it has a prior decision date before February 19, 2019",
   "higher_level_review_to_higher_level_review": "is ineligible because it was last processed as a Higher-Level Review and this can't be done twice in a row",
   "appeal_to_appeal": "is ineligible because it was last processed as a Board Appeal and this can't be done twice in a row.",
   "appeal_to_higher_level_review": "is ineligible because it was last processed as a Board Appeal which can't be followed by a Higher-Level Review.",


### PR DESCRIPTION
Connects  https://github.com/department-of-veterans-affairs/appeals-support/issues/5277

Intake was supposed to Launch on `February 14, 2019`  but because of the government shut down it was Launched on `February 19, 2019`. 
Unfortunately I was not able to  find the specific issue that user was adding but I will ask Raven to reach out and retry this issue once this is merged.