### PR TITLE
Stop cascading task closure at org boundary

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -5,6 +5,7 @@ detectors:
     enabled: false
   TooManyMethods:
     exclude:
+      - DispositionTask
       - RootTask
   InstanceVariableAssumption:
     exclude:

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -381,8 +381,8 @@ class Task < ApplicationRecord
   end
 
   def update_status_if_children_tasks_are_complete(child_task)
-    if children.any? && children.select(&:active?).empty? && on_hold?
-      if assigned_to.is_a?(Organization) && task_types_to_cascade_task_completion.include?(child_task.type)
+    if children.any? && children.active.empty? && on_hold?
+      if assigned_to.is_a?(Organization) && cascade_closure_from_child_task?(child_task)
         return update!(status: Constants.TASK_STATUSES.completed)
       end
 
@@ -390,8 +390,8 @@ class Task < ApplicationRecord
     end
   end
 
-  def task_types_to_cascade_task_completion
-    [type]
+  def cascade_closure_from_child_task?(child_task)
+    type == child_task&.type
   end
 
   def set_assigned_at

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -231,8 +231,8 @@ class Task < ApplicationRecord
     ["", ""]
   end
 
-  def when_child_task_completed
-    update_status_if_children_tasks_are_complete
+  def when_child_task_completed(child_task)
+    update_status_if_children_tasks_are_complete(child_task)
   end
 
   def task_is_assigned_to_user_within_organization?(user)
@@ -363,7 +363,7 @@ class Task < ApplicationRecord
   end
 
   def update_parent_status
-    parent.when_child_task_completed
+    parent.when_child_task_completed(self)
   end
 
   def update_children_status_after_closed; end
@@ -380,11 +380,18 @@ class Task < ApplicationRecord
     saved_change_to_attribute?(:placed_on_hold_at)
   end
 
-  def update_status_if_children_tasks_are_complete
-    if children.any? && children.select(&:active?).empty?
-      return update!(status: Constants.TASK_STATUSES.completed) if assigned_to.is_a?(Organization)
-      return update!(status: :assigned) if on_hold?
+  def update_status_if_children_tasks_are_complete(child_task)
+    if children.any? && children.select(&:active?).empty? && on_hold?
+      if assigned_to.is_a?(Organization) && task_types_to_cascade_task_completion.include?(child_task.type)
+        return update!(status: Constants.TASK_STATUSES.completed)
+      end
+
+      update!(status: Constants.TASK_STATUSES.assigned)
     end
+  end
+
+  def task_types_to_cascade_task_completion
+    [type]
   end
 
   def set_assigned_at

--- a/app/models/tasks/disposition_task.rb
+++ b/app/models/tasks/disposition_task.rb
@@ -113,6 +113,10 @@ class DispositionTask < GenericTask
     children.active.update_all(status: status)
   end
 
+  def cascade_closure_from_child_task?(_child_task)
+    true
+  end
+
   def update_hearing_and_self(params:, payload_values:)
     case payload_values[:disposition]
     when Constants.HEARING_DISPOSITION_TYPES.cancelled

--- a/app/models/tasks/distribution_task.rb
+++ b/app/models/tasks/distribution_task.rb
@@ -4,14 +4,6 @@
 # Task that signals that an appeal is ready for distribution to a judge, including for auto case distribution.
 
 class DistributionTask < GenericTask
-  # Prevent this task from being marked complete
-  # when a child task (e.g. evidence submission)
-  # is marked complete because distribution tasks are used
-  # to signal that cases are ready for assignment to judges.
-  def update_status_if_children_tasks_are_complete(_child_task)
-    ready_for_distribution! if children.any? && children.active.none?
-  end
-
   def ready_for_distribution!
     update!(status: :assigned, assigned_at: Time.zone.now)
   end

--- a/app/models/tasks/distribution_task.rb
+++ b/app/models/tasks/distribution_task.rb
@@ -8,7 +8,7 @@ class DistributionTask < GenericTask
   # when a child task (e.g. evidence submission)
   # is marked complete because distribution tasks are used
   # to signal that cases are ready for assignment to judges.
-  def update_status_if_children_tasks_are_complete
+  def update_status_if_children_tasks_are_complete(_child_task)
     ready_for_distribution! if children.any? && children.active.none?
   end
 

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -62,8 +62,8 @@ class HearingTask < GenericTask
 
   private
 
-  def task_types_to_cascade_task_completion
-    [type, NoShowHearingTask.name, DispositionTask.name]
+  def cascade_closure_from_child_task?(_child_task)
+    true
   end
 
   def set_assignee
@@ -71,7 +71,7 @@ class HearingTask < GenericTask
   end
 
   def update_status_if_children_tasks_are_complete(_child_task)
-    if children.select(&:active?).empty?
+    if children.active.empty?
       return update!(status: :cancelled) if children.select { |c| c.type == DispositionTask.name && c.cancelled? }.any?
     end
 

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -26,7 +26,7 @@ class HearingTask < GenericTask
     true
   end
 
-  def when_child_task_completed
+  def when_child_task_completed(child_task)
     super
 
     return unless appeal.tasks.active.where(type: HearingTask.name).empty?
@@ -62,11 +62,15 @@ class HearingTask < GenericTask
 
   private
 
+  def task_types_to_cascade_task_completion
+    [type, NoShowHearingTask.name, DispositionTask.name]
+  end
+
   def set_assignee
     self.assigned_to = Bva.singleton
   end
 
-  def update_status_if_children_tasks_are_complete
+  def update_status_if_children_tasks_are_complete(_child_task)
     if children.select(&:active?).empty?
       return update!(status: :cancelled) if children.select { |c| c.type == DispositionTask.name && c.cancelled? }.any?
     end

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -13,7 +13,7 @@ class RootTask < GenericTask
     self.assigned_to = Bva.singleton
   end
 
-  def when_child_task_completed; end
+  def when_child_task_completed(_child_task); end
 
   def update_children_status_after_closed
     children.active.where(type: TrackVeteranTask.name).update_all(status: Constants.TASK_STATUSES.completed)

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -63,11 +63,6 @@ class ScheduleHearingTask < GenericTask
     end
   end
 
-  # We only want to take this off hold, not actually complete it, like the inherited method does
-  def update_status_if_children_tasks_are_complete
-    update!(status: :assigned) if on_hold?
-  end
-
   def update_from_params(params, current_user)
     multi_transaction do
       verify_user_can_update!(current_user)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -101,6 +101,18 @@ describe Task do
         end
       end
 
+      context "when task is closed" do
+        let!(:task) { FactoryBot.create(:task, :on_hold, type: Task.name, assigned_to: organization) }
+        let!(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent: task) }
+
+        before { task.update!(status: Constants.TASK_STATUSES.completed) }
+
+        it "does not change the status of the task" do
+          subject
+          expect(task.status).to eq(Constants.TASK_STATUSES.completed)
+        end
+      end
+
       context "when task has some complete and some incomplete child tasks" do
         let!(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
         let(:incomplete_children) do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -36,6 +36,18 @@ describe Task do
         end
       end
 
+      context "when task is closed" do
+        let!(:task) { FactoryBot.create(:task, :on_hold, type: Task.name) }
+        let!(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent: task) }
+
+        before { task.update!(status: Constants.TASK_STATUSES.completed) }
+
+        it "does not change the status of the task" do
+          subject
+          expect(task.status).to eq(Constants.TASK_STATUSES.completed)
+        end
+      end
+
       context "when task has some complete and some incomplete child tasks" do
         let!(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
         let(:incomplete_children) do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -2,52 +2,59 @@
 
 describe Task do
   describe ".when_child_task_completed" do
+    let(:task) { FactoryBot.create(:task, :on_hold, type: Task.name) }
+    let(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent: task) }
+
+    subject { task.when_child_task_completed(child) }
+
     context "when on_hold task is assigned to a person" do
-      let(:task) { FactoryBot.create(:task, :on_hold, type: "Task") }
       context "when task has no child tasks" do
+        let(:child) { nil }
         it "should not change the task's status" do
           status_before = task.status
-          task.when_child_task_completed
+          subject
           expect(task.status).to eq(status_before)
         end
       end
 
       context "when task has 1 incomplete child task" do
-        before { FactoryBot.create(:task, :in_progress, type: "Task", parent_id: task.id) }
+        let(:child) { FactoryBot.create(:task, :in_progress, type: Task.name, parent_id: task.id) }
         it "should not change the task's status" do
           status_before = task.status
-          task.when_child_task_completed
+          subject
           expect(task.status).to eq(status_before)
         end
       end
 
       context "when task has 1 complete child task" do
-        before { FactoryBot.create(:task, :completed, type: "Task", parent_id: task.id) }
+        let(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent_id: task.id) }
         it "should change task's status to assigned" do
           status_before = task.status
-          task.when_child_task_completed
+          subject
           expect(task.status).to_not eq(status_before)
           expect(task.status).to eq("assigned")
         end
       end
 
       context "when task has some complete and some incomplete child tasks" do
-        before do
-          FactoryBot.create_list(:task, 3, :completed, type: "Task", parent_id: task.id)
-          FactoryBot.create_list(:task, 2, :in_progress, type: "Task", parent_id: task.id)
+        let!(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let(:incomplete_children) do
+          FactoryBot.create_list(:task, 2, :in_progress, type: Task.name, parent_id: task.id)
         end
+        let(:child) { incomplete_children.last }
         it "should not change the task's status" do
           status_before = task.status
-          task.when_child_task_completed
+          subject
           expect(task.status).to eq(status_before)
         end
       end
 
       context "when task has only complete child tasks" do
-        before { FactoryBot.create_list(:task, 4, :completed, type: "Task", parent_id: task.id) }
+        let(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let(:child) { completed_children.last }
         it "should change task's status to assigned" do
           status_before = task.status
-          task.when_child_task_completed
+          subject
           expect(task.status).to_not eq(status_before)
           expect(task.status).to eq("assigned")
         end
@@ -56,46 +63,58 @@ describe Task do
 
     context "when on_hold task is assigned to an organization" do
       let(:organization) { Organization.create!(name: "Other organization", url: "other") }
-      let(:task) { FactoryBot.create(:task, :on_hold, type: "Task", assigned_to: organization) }
+      let(:task) { FactoryBot.create(:task, :on_hold, type: Task.name, assigned_to: organization) }
+
       context "when task has no child tasks" do
+        let(:child) { nil }
         it "should not update any attribute of the task" do
           expect_any_instance_of(Task).to_not receive(:update!)
-          task.when_child_task_completed
+          subject
         end
       end
 
       context "when task has 1 incomplete child task" do
-        before { FactoryBot.create(:task, :in_progress, type: "Task", parent_id: task.id) }
+        let(:child) { FactoryBot.create(:task, :in_progress, type: Task.name, parent_id: task.id) }
         it "should not update any attribute of the task" do
           expect_any_instance_of(Task).to_not receive(:update!)
-          task.when_child_task_completed
+          subject
         end
       end
 
       context "when task has 1 complete child task" do
-        before { FactoryBot.create(:task, :completed, type: "Task", parent_id: task.id) }
+        let(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent_id: task.id) }
         it "should update the task" do
           expect_any_instance_of(Task).to receive(:update!)
-          task.when_child_task_completed
+          subject
         end
       end
 
       context "when task has some complete and some incomplete child tasks" do
-        before do
-          FactoryBot.create_list(:task, 3, :completed, type: "Task", parent_id: task.id)
-          FactoryBot.create_list(:task, 2, :in_progress, type: "Task", parent_id: task.id)
+        let!(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let(:incomplete_children) do
+          FactoryBot.create_list(:task, 2, :in_progress, type: Task.name, parent_id: task.id)
         end
+        let(:child) { incomplete_children.last }
         it "should not update any attribute of the task" do
           expect_any_instance_of(Task).to_not receive(:update!)
-          task.when_child_task_completed
+          subject
         end
       end
 
       context "when task has only complete child tasks" do
-        before { FactoryBot.create_list(:task, 4, :completed, type: "Task", parent_id: task.id) }
+        let(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let(:child) { completed_children.last }
         it "should update the task" do
           expect_any_instance_of(Task).to receive(:update!)
-          task.when_child_task_completed
+          subject
+        end
+      end
+
+      context "when child task has a different type than parent" do
+        let!(:child) { FactoryBot.create(:generic_task, :completed, parent_id: task.id) }
+        it "sets the status of the parent to assigned" do
+          subject
+          expect(task.reload.status).to eq(Constants.TASK_STATUSES.assigned)
         end
       end
     end
@@ -120,7 +139,7 @@ describe Task do
   end
 
   describe "#prepared_by_display_name" do
-    let(:task) { create(:task, type: "Task") }
+    let(:task) { create(:task, type: Task.name) }
 
     context "when there is no attorney_case_review" do
       it "should return nil" do
@@ -129,7 +148,7 @@ describe Task do
     end
 
     context "when there is an attorney_case_review" do
-      let!(:child) { create(:task, type: "Task", appeal: task.appeal, parent_id: task.id) }
+      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent_id: task.id) }
       let!(:attorney_case_reviews) do
         create(:attorney_case_review, task_id: child.id, attorney: create(:user, full_name: "Bob Smith"))
       end
@@ -162,7 +181,7 @@ describe Task do
   end
 
   describe "#latest_attorney_case_review" do
-    let(:task) { create(:task, type: "Task") }
+    let(:task) { create(:task, type: Task.name) }
 
     context "when there is no sub task" do
       it "should return nil" do
@@ -171,7 +190,7 @@ describe Task do
     end
 
     context "when there is a sub task" do
-      let!(:child) { create(:task, type: "Task", appeal: task.appeal, parent_id: task.id) }
+      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent_id: task.id) }
       let!(:attorney_case_reviews) do
         [
           create(:attorney_case_review, task_id: child.id, created_at: 1.day.ago),
@@ -478,8 +497,8 @@ describe Task do
     let!(:judge) { FactoryBot.create(:user) }
     let!(:attorney) { FactoryBot.create(:user) }
     let!(:appeal) { FactoryBot.create(:appeal) }
-    let!(:task) { FactoryBot.create(:task, type: "Task", appeal: appeal) }
-    let(:params) { { assigned_to: judge, appeal: task.appeal, parent_id: task.id, type: "Task" } }
+    let!(:task) { FactoryBot.create(:task, type: Task.name, appeal: appeal) }
+    let(:params) { { assigned_to: judge, appeal: task.appeal, parent_id: task.id, type: Task.name } }
 
     before do
       FactoryBot.create(:staff, :judge_role, sdomainid: judge.css_id)
@@ -533,7 +552,7 @@ describe Task do
     end
 
     context "the params are incomplete" do
-      let(:params) { { assigned_to: judge, appeal: nil, parent_id: task.id, type: "Task" } }
+      let(:params) { { assigned_to: judge, appeal: nil, parent_id: task.id, type: Task.name } }
 
       it "raises an error" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid, /Appeal can't be blank/)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -36,7 +36,7 @@ describe Task do
         end
       end
 
-      context "when task is closed" do
+      context "when task is already closed" do
         let!(:task) { FactoryBot.create(:task, :on_hold, type: Task.name) }
         let!(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent: task) }
 
@@ -101,7 +101,7 @@ describe Task do
         end
       end
 
-      context "when task is closed" do
+      context "when task is already closed" do
         let!(:task) { FactoryBot.create(:task, :on_hold, type: Task.name, assigned_to: organization) }
         let!(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent: task) }
 

--- a/spec/models/tasks/hearing_admin_action_task_spec.rb
+++ b/spec/models/tasks/hearing_admin_action_task_spec.rb
@@ -68,7 +68,6 @@ describe HearingAdminActionTask do
     end
 
     it "finds closest_ro for veteran" do
-      VADotGovService = Fakes::VADotGovService
       verify_address_task.update!(status: "completed")
 
       expect(Appeal.first.closest_regional_office).to eq "RO17"

--- a/spec/models/tasks/no_show_hearing_task_spec.rb
+++ b/spec/models/tasks/no_show_hearing_task_spec.rb
@@ -5,9 +5,13 @@ describe NoShowHearingTask do
   let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
   let(:distribution_task) { FactoryBot.create(:distribution_task, appeal: appeal, parent: root_task) }
   let(:hearing_task) { FactoryBot.create(:hearing_task, parent: distribution_task, appeal: appeal) }
+  let!(:completed_scheduling_task) do
+    FactoryBot.create(:schedule_hearing_task, :completed, parent: hearing_task, appeal: appeal)
+  end
+  let(:disposition_task) { FactoryBot.create(:disposition_task, parent: hearing_task, appeal: appeal) }
+  let(:no_show_hearing_task) { FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal) }
 
   context "create a new NoShowHearingTask" do
-    let!(:disposition_task) { FactoryBot.create(:disposition_task, parent: hearing_task, appeal: appeal) }
     let(:task_params) { { appeal: appeal, parent: disposition_task } }
 
     subject { NoShowHearingTask.create!(**task_params) }
@@ -43,14 +47,6 @@ describe NoShowHearingTask do
   end
 
   describe ".reschedule_hearing" do
-    let!(:completed_scheduling_task) do
-      FactoryBot.create(:schedule_hearing_task, :completed, parent: hearing_task, appeal: appeal)
-    end
-    let(:disposition_task) { FactoryBot.create(:disposition_task, parent: hearing_task, appeal: appeal) }
-    let(:no_show_hearing_task) do
-      FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal)
-    end
-
     context "when all operations succeed" do
       it "closes existing tasks and creates new HearingTask and ScheduleHearingTask" do
         expect { no_show_hearing_task.reschedule_hearing }.to_not raise_error
@@ -82,6 +78,22 @@ describe NoShowHearingTask do
 
         expect(distribution_task.reload.ready_for_distribution?).to eq(false)
       end
+    end
+  end
+
+  describe "completing a child HearingAdminActionTask" do
+    let!(:hearing_admin_action_task) do
+      HearingAdminActionVerifyPoaTask.create!(
+        appeal: appeal,
+        parent: no_show_hearing_task,
+        assigned_to: HearingsManagement.singleton
+      )
+    end
+
+    it "sets the status of the parent NoShowHearingTask to assigned" do
+      expect(no_show_hearing_task.status).to eq(Constants.TASK_STATUSES.on_hold)
+      hearing_admin_action_task.update!(status: Constants.TASK_STATUSES.completed)
+      expect(no_show_hearing_task.status).to eq(Constants.TASK_STATUSES.assigned)
     end
   end
 end

--- a/spec/models/tasks/quality_review_task_spec.rb
+++ b/spec/models/tasks/quality_review_task_spec.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 describe QualityReviewTask do
+  let(:root_task) { FactoryBot.create(:root_task) }
+  let(:qr_task) { QualityReviewTask.create_from_root_task(root_task) }
+
   before do
     OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
   end
 
   describe ".update!(status: Constants.TASK_STATUSES.completed)" do
-    let(:root_task) { FactoryBot.create(:root_task) }
-
     context "when QualityReviewTask is assigned to the QR organization" do
-      let!(:qr_task) { QualityReviewTask.create_from_root_task(root_task) }
-
       it "should create a task for BVA dispatch and close the current task" do
         expect(root_task.children.select { |t| t.type == BvaDispatchTask.name }.count).to eq(0)
         expect { qr_task.update!(status: Constants.TASK_STATUSES.completed) }.to_not raise_error
@@ -58,13 +57,21 @@ describe QualityReviewTask do
   end
 
   describe ".update!(status: Constants.TASK_STATUSES.cancelled)" do
-    let(:root_task) { FactoryBot.create(:root_task) }
-    let!(:qr_task) { QualityReviewTask.create_from_root_task(root_task) }
-
     it "should create a task for BVA dispatch" do
       qr_task.update!(status: Constants.TASK_STATUSES.cancelled)
       expect(qr_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
       expect(root_task.reload.children.select { |t| t.type == BvaDispatchTask.name }.count).to eq(1)
+    end
+  end
+
+  describe "completing a child GenericTask" do
+    let!(:generic_task_child) do
+      GenericTask.create!(appeal: qr_task.appeal, parent: qr_task, assigned_to: FactoryBot.create(:user))
+    end
+    it "sets the status of the parent QualityReviewTask to assigned" do
+      expect(qr_task.status).to eq(Constants.TASK_STATUSES.on_hold)
+      generic_task_child.update!(status: Constants.TASK_STATUSES.completed)
+      expect(qr_task.status).to eq(Constants.TASK_STATUSES.assigned)
     end
   end
 end

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -145,9 +145,20 @@ describe TimedHoldTask do
     context "when the task is active" do
       let(:status) { Constants.TASK_STATUSES.in_progress }
 
-      it "changes task status to completed" do
-        subject
-        expect(task.status).to eq(Constants.TASK_STATUSES.completed)
+      context "when the TimedHoldTask does not have a parent task" do
+        it "changes task status to completed" do
+          subject
+          expect(task.status).to eq(Constants.TASK_STATUSES.completed)
+        end
+      end
+
+      context "when the TimedHoldTask has a parent task assigned to an organization" do
+        let(:parent_task) { FactoryBot.create(:generic_task, status: Constants.TASK_STATUSES.on_hold) }
+        let(:task) { FactoryBot.create(:timed_hold_task, status: status, parent: parent_task) }
+        it "sets the parent task status to assigned" do
+          subject
+          expect(parent_task.status).to eq(Constants.TASK_STATUSES.assigned)
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #10324. Prevents [cascading task closures](https://github.com/department-of-veterans-affairs/caseflow/blob/3e0639a69202486a15e4b2b8bb763754c14b236e/app/models/task.rb#L22) from occurring when organizationally-assigned parent task is of a different type than the just-closed child task. Additionally, this PR prevents us from changing the status for organizationally-assigned tasks unless those tasks are "on hold".