### PR TITLE
Automatically populate VLJ support staff correspondence docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
+gem "caracal"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "8dde00d67b7c629e4b871f8dcb3617bfe989b3db"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "dddc821c2335c7de234a5454e4b4874e3f658420"
 gem "dogstatsd-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,10 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
+    caracal (1.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.1)
+      tilt (>= 1.4)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     claide (1.0.2)
@@ -548,6 +552,7 @@ DEPENDENCIES
   byebug
   capybara
   capybara-screenshot
+  caracal
   caseflow!
   connect_vbms!
   danger (~> 5.10)

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CorrespondenceController < ApplicationController
+
+  def example
+    task = Task.find(params[:id])
+
+    document = ::Caracal::Document.new
+    document.h1('Example document')
+    document.p(format("Appeal for Veteran %s requires additional attention.", task.appeal.veteran_full_name))
+
+    send_data(
+      document.render.string,
+      filename: "attention_needed.docx"
+    )
+  end  
+end

--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
 class CorrespondenceController < ApplicationController
-
   def example
     task = Task.find(params[:id])
 
     document = ::Caracal::Document.new
-    document.h1('Example document')
+    document.h1("Example document")
     document.p(format("Appeal for Veteran %s requires additional attention.", task.appeal.veteran_full_name))
 
     send_data(
       document.render.string,
       filename: "attention_needed.docx"
     )
-  end  
+  end
 end

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -60,6 +60,7 @@ class ColocatedTask < Task
     available_actions_with_conditions([
                                         Constants.TASK_ACTIONS.PLACE_HOLD.to_h,
                                         Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.to_h,
+                                        Constants.TASK_ACTIONS.PREPARE_CORRESPONDENCE.to_h,
                                         Constants.TASK_ACTIONS.CANCEL_TASK.to_h
                                       ])
   end

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -47,6 +47,7 @@ import PostponeHearingTaskModal from './PostponeHearingTaskModal';
 import ChangeTaskTypeModal from './ChangeTaskTypeModal';
 import StartHoldModal from './components/StartHoldModal';
 import EndHoldModal from './components/EndHoldModal';
+import CorrespondencePickerModal from './components/CorrespondencePickerModal';
 
 import CaseListView from './CaseListView';
 import CaseDetailsView from './CaseDetailsView';
@@ -232,6 +233,8 @@ class QueueApp extends React.PureComponent {
 
   routedEndHoldModal = (props) => <EndHoldModal {...props.match.params} />;
 
+  routedCorrespondencePickerModal = (props) => <CorrespondencePickerModal {...props.match.params} />;
+
   queueName = () => this.props.userRole === USER_ROLE_TYPES.attorney ? 'Your Queue' : 'Review Cases';
 
   propsForQueueLoadingScreen = () => {
@@ -347,6 +350,9 @@ class QueueApp extends React.PureComponent {
           <Route
             path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.END_TIMED_HOLD.value}`}
             render={this.routedEndHoldModal} />
+          <Route
+            path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.PREPARE_CORRESPONDENCE.value}`}
+            render={this.routedCorrespondencePickerModal} />
           <PageRoute
             exact
             path="/queue/appeals/:appealId"

--- a/client/app/queue/components/CorrespondencePickerModal.jsx
+++ b/client/app/queue/components/CorrespondencePickerModal.jsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import QueueFlowModal from './QueueFlowModal';
+import { requestSave } from '../uiReducer/uiActions';
+import { taskById } from '../selectors';
+import { withRouter } from 'react-router-dom';
+
+class CorrespondencePickerModal extends React.Component {
+  render = () => <QueueFlowModal
+    title="Download pre-filled correspondence"
+    pathAfterSubmit={`/queue/appeals/${this.props.appealId}`}
+    button="Done" 
+    submit={() => Promise.resolve()}
+  >
+    <p>Download Word document with relevant information about appeal already populated.</p>
+    <ul>
+      <li><a href={`/correspondence/${this.props.task.taskId}/example`}>Example document</a></li>
+    </ul>
+  </QueueFlowModal>;
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  task: taskById(state, { taskId: ownProps.taskId })
+});
+
+const mapDispatchToProps = (dispatch) => bindActionCreators({
+  requestSave
+}, dispatch);
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CorrespondencePickerModal));

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -20,6 +20,7 @@
     "MARK_NO_SHOW_HEARING_COMPLETE": { "label": "Mark task complete: Release case for review", "value": "modal/mark_task_complete", "func": "complete_data" },
     "PLACE_HOLD": { "label": "Place hold", "value": "place_hold" },
     "PLACE_TIMED_HOLD": { "label": "Put task on hold", "value": "modal/place_timed_hold" },
+    "PREPARE_CORRESPONDENCE": { "label": "Prepare correspondence", "value": "modal/prepare_correspondence" },
     "END_TIMED_HOLD": { "label": "End hold early", "value": "modal/end_hold" },
     "REASSIGN_TO_PERSON": { "label": "Re-assign to person", "value": "modal/reassign_to_person", "func": "assign_to_user_data" },
     "RESCHEDULE_HEARING": { "label": "Mark as complete: Reschedule hearing", "value": "modal/cancel_task", "func": "assign_to_hearing_schedule_team_data" },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,10 @@ Rails.application.routes.draw do
     resources :tag, only: [:create, :destroy]
   end
 
+  resources(:correspondence) do
+    get(:example, on: :member)
+  end
+
   namespace :reader do
     get 'appeal/veteran-id', to: "appeal#find_appeals_by_veteran_id",
       constraints: lambda{ |req| req.env["HTTP_VETERAN_ID"] =~ /[a-zA-Z0-9]{2,12}/ }


### PR DESCRIPTION
VLJ support staff regularly request the ability to automatically populate fields for documents they prepare. This is a proof of concept of a first step in that direction.

![magic-text-vlj-support](https://user-images.githubusercontent.com/32683958/58125169-f6cb0580-7bdd-11e9-9405-32eaa8e3787a.gif)