### PR TITLE
Removing unnecessary transaction to speed up pageload

### DIFF
--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -326,22 +326,19 @@ class LegacyHearing < ApplicationRecord
     end
 
     def assign_or_create_from_vacols_record(vacols_record, legacy_hearing: nil)
-      transaction do
-        hearing = legacy_hearing ||
-                  find_or_initialize_by(vacols_id: vacols_record.hearing_pkseq)
+      hearing = legacy_hearing || find_or_initialize_by(vacols_id: vacols_record.hearing_pkseq)
 
-        # update hearing if user is nil, it's likely when the record doesn't exist and is being created
-        # or if vacols record css is different from
-        # who it's assigned to in the db.
-        if user_nil_or_assigned_to_another_judge?(hearing.user, vacols_record.css_id)
-          hearing.update(
-            appeal: LegacyAppeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
-            user: User.find_by(css_id: vacols_record.css_id)
-          )
-        end
-
-        hearing
+      # update hearing if user is nil, it's likely when the record doesn't exist and is being created
+      # or if vacols record css is different from
+      # who it's assigned to in the db.
+      if user_nil_or_assigned_to_another_judge?(hearing.user, vacols_record.css_id)
+        hearing.update(
+          appeal: LegacyAppeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
+          user: User.find_by(css_id: vacols_record.css_id)
+        )
       end
+
+      hearing
     end
   end
 end


### PR DESCRIPTION
### Description
The VSO view is timing out. I believe it's partially because we start an unnecessary transaction in `LegacyHearing.assign_or_create_from_vacols_record`. This PR removes that transaction.