### PR TITLE
Only update VACOLS location for ColocatedTasks when location is CASEFLOW

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -116,12 +116,11 @@ class ColocatedTask < Task
   end
 
   def update_location_in_vacols
-    all_colocated_tasks_for_legacy_appeal_complete = saved_change_to_status? &&
-                                                     !active? &&
-                                                     appeal_type == LegacyAppeal.name &&
-                                                     all_tasks_closed_for_appeal?
-
-    if all_colocated_tasks_for_legacy_appeal_complete
+    if saved_change_to_status? &&
+       !active? &&
+       all_tasks_closed_for_appeal? &&
+       appeal.is_a?(LegacyAppeal) &&
+       appeal.location_code == LegacyAppeal::LOCATION_CODES[:caseflow]
       AppealRepository.update_location!(appeal, location_based_on_action)
     end
   end


### PR DESCRIPTION
There are 49 dispatched legacy appeals with active `ColocatedTask`s in our system (see #8810). When those `ColocatedTask`s are completed they will change the VACOLS location code to the location of the creator of the `ColocatedTask`. This PR changes that behaviour so Caseflow only changes the location of a case in VACOLS if the current location of that case is "CASEFLOW".