### PR TITLE
Docket Row Key Fix

### DIFF
--- a/client/app/hearingSchedule/components/DailyDocketRows.jsx
+++ b/client/app/hearingSchedule/components/DailyDocketRows.jsx
@@ -62,7 +62,7 @@ export default class DailyDocketHearingRows extends React.Component {
     return <div {...rowsMargin}>
       <Header user={user} />
       <div>{hearings.map((hearing, index) => (
-        <div {...docketRowStyle} key={`docket-row-${index}`} className={user.userRoleHearingPrep ? 'judge-view' : ''}>
+        <div {...docketRowStyle} key={hearing.externalId} className={user.userRoleHearingPrep ? 'judge-view' : ''}>
           <DailyDocketRow hearingId={hearing.externalId}
             index={index}
             readOnly={readOnly}


### PR DESCRIPTION
2 issues 

1. DailyDocketRows were keyed in React based on the index of the hearing
2. When a hearing is `Canceled` or `Postponed` it is shifted to the bottom of the page, changing the hearing's index. 

The result was all user interactions after a disposition was updated to `Canceled` or `Postponed`  were bound to the wrong React element.