### PR TITLE
Add AppealReporter

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -7,6 +7,7 @@
 
 class Appeal < DecisionReview
   include Taskable
+  include DecisionDocumentable
 
   has_many :appeal_views, as: :appeal
   has_many :claims_folder_searches, as: :appeal

--- a/app/models/concerns/decision_documentable.rb
+++ b/app/models/concerns/decision_documentable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DecisionDocumentable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def has_zero_decision_documents
+      left_joins(:decision_documents).where(decision_documents: { id: nil })
+    end
+  end
+end

--- a/app/models/concerns/taskable.rb
+++ b/app/models/concerns/taskable.rb
@@ -3,6 +3,14 @@
 module Taskable
   extend ActiveSupport::Concern
 
+  class_methods do
+    def has_active_tasks
+      belongs_to_appeal_type = "belongs_to_#{name.underscore}".to_sym
+      where.not(id: Task.select(:appeal_id).send(belongs_to_appeal_type).inactive).
+        where.not(id: Task.select(:appeal_id).send(belongs_to_appeal_type).cancelled_root_task)
+    end
+  end
+
   def assigned_attorney
     tasks.includes(:assigned_to).detect { |t| t.is_a?(AttorneyTask) }.try(:assigned_to)
   end

--- a/app/models/concerns/taskable.rb
+++ b/app/models/concerns/taskable.rb
@@ -18,4 +18,8 @@ module Taskable
   def assigned_judge
     tasks.includes(:assigned_to).detect { |t| t.is_a?(JudgeTask) }.try(:assigned_to)
   end
+
+  def all_tasks_on_hold?
+    tasks.select(&:on_hold?).size == tasks.size
+  end
 end

--- a/app/models/concerns/taskable.rb
+++ b/app/models/concerns/taskable.rb
@@ -6,8 +6,8 @@ module Taskable
   class_methods do
     def has_active_tasks
       belongs_to_appeal_type = "belongs_to_#{name.underscore}".to_sym
-      where.not(id: Task.select(:appeal_id).send(belongs_to_appeal_type).inactive).
-        where.not(id: Task.select(:appeal_id).send(belongs_to_appeal_type).cancelled_root_task)
+      where.not(id: Task.select(:appeal_id).send(belongs_to_appeal_type).inactive)
+        .where.not(id: Task.select(:appeal_id).send(belongs_to_appeal_type).cancelled_root_task)
     end
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -12,6 +12,7 @@ class LegacyAppeal < ApplicationRecord
   include CachedAttributes
   include AddressMapper
   include Taskable
+  include DecisionDocumentable
 
   belongs_to :appeal_series
   has_many :dispatch_tasks, foreign_key: :appeal_id, class_name: "Dispatch::Task"

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -44,6 +44,10 @@ class Task < ApplicationRecord
                                  )
                                }
 
+  scope :belongs_to_appeal, -> { where(appeal_type: "Appeal") }
+  scope :belongs_to_legacy_appeal, -> { where(appeal_type: "LegacyAppeal") }
+  scope :cancelled_root_task, -> { where(type: "RootTask", status: Constants.TASK_STATUSES.cancelled) }
+
   def available_actions(_user)
     []
   end

--- a/app/services/appeal_reporter.rb
+++ b/app/services/appeal_reporter.rb
@@ -1,21 +1,29 @@
 # frozen_string_literal: true
 
 class AppealReporter
-
   def stuck
-    stuck = []
-    # AMA appeal must have 1 or more tasks
-    open_appeals.find_in_batches do |appeals|
-      stuck << appeals.select(&:all_tasks_on_hold?)
-    end
-    # legacy appeal may legitimally have zero tasks
-    open_legacy_appeals.find_in_batches do |appeals|
-      stuck << appeals.select { |appeal| appeal.tasks.count > 0 && appeal.all_tasks_on_hold? }
-    end
-    stuck.flatten
+    [stuck_appeals, stuck_legacy_appeals].flatten
   end
 
   private
+
+  def stuck_appeals
+    # AMA appeal must have 1 or more tasks
+    stuck = []
+    open_appeals.find_in_batches do |appeals|
+      stuck << appeals.select(&:all_tasks_on_hold?)
+    end
+    stuck
+  end
+
+  def stuck_legacy_appeals
+    # legacy appeal may legitimally have zero tasks
+    stuck = []
+    open_legacy_appeals.find_in_batches do |appeals|
+      stuck << appeals.select { |appeal| appeal.tasks.count > 0 && appeal.all_tasks_on_hold? }
+    end
+    stuck
+  end
 
   def open_appeals
     Appeal.has_zero_decision_documents.has_active_tasks

--- a/app/services/appeal_reporter.rb
+++ b/app/services/appeal_reporter.rb
@@ -10,7 +10,7 @@ class AppealReporter
     end
     # legacy appeal may legitimally have zero tasks
     open_legacy_appeals.find_in_batches do |appeals|
-      stuck << appeals.select { |appeal| appeal.tasks.count > 0 && all_tasks_on_hold? }
+      stuck << appeals.select { |appeal| appeal.tasks.count > 0 && appeal.all_tasks_on_hold? }
     end
     stuck.flatten
   end

--- a/app/services/appeal_reporter.rb
+++ b/app/services/appeal_reporter.rb
@@ -4,11 +4,13 @@ class AppealReporter
 
   def stuck
     stuck = []
+    # AMA appeal must have 1 or more tasks
     open_appeals.find_in_batches do |appeals|
-      stuck << appeals
+      stuck << appeals.select(&:all_tasks_on_hold?)
     end
+    # legacy appeal may legitimally have zero tasks
     open_legacy_appeals.find_in_batches do |appeals|
-      stuck << appeals
+      stuck << appeals.select { |appeal| appeal.tasks.count > 0 && all_tasks_on_hold? }
     end
     stuck.flatten
   end

--- a/app/services/appeal_reporter.rb
+++ b/app/services/appeal_reporter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AppealReporter
+
+  def stuck
+    stuck = []
+    open_appeals.find_in_batches do |appeals|
+      stuck << appeals
+    end
+    open_legacy_appeals.find_in_batches do |appeals|
+      stuck << appeals
+    end
+    stuck.flatten
+  end
+
+  private
+
+  def open_appeals
+    Appeal.has_zero_decision_documents.has_active_tasks
+  end
+
+  def open_legacy_appeals
+    LegacyAppeal.has_zero_decision_documents.has_active_tasks
+  end
+end

--- a/spec/services/appeal_reporter_spec.rb
+++ b/spec/services/appeal_reporter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe AppealReporter do
+  let!(:appeal_with_zero_tasks) { create(:appeal) }
+  let!(:appeal_with_tasks) { create(:appeal, :with_tasks) }
+  let!(:legacy_appeal_with_zero_tasks) { create(:legacy_appeal, vacols_case: create(:case)) }
+  let!(:legacy_appeal_with_tasks) { create(:task, type: "RootTask").appeal }
+  let!(:appeal_with_all_tasks_on_hold) do
+    appeal = create(:appeal, :with_tasks)
+    schedule_hearing_task = create(:schedule_hearing_task, appeal: appeal)
+    schedule_hearing_task.parent.update!(parent: appeal.root_task)
+    appeal.root_task.descendants.each(&:on_hold!)
+    appeal
+  end
+
+  describe "#stuck" do
+    subject { described_class.new.stuck }
+
+    it "returns array of appeals that look stuck" do
+      expect(subject).to match_array([appeal_with_zero_tasks, appeal_with_all_tasks_on_hold])
+    end
+  end
+end


### PR DESCRIPTION


example generated SQL:

```sql
SELECT "appeals".* 
FROM   "appeals" 
       LEFT OUTER JOIN "decision_documents" 
                    ON "decision_documents"."appeal_id" = "appeals"."id" 
                       AND "decision_documents"."appeal_type" = "appeal" 
WHERE  "decision_documents"."id" IS NULL 
       AND ( "appeals"."id" NOT IN (SELECT "tasks"."appeal_id" 
                                    FROM   "tasks" 
                                    WHERE  "tasks"."appeal_type" = "Appeal" 
                                           AND "tasks"."status" IN ( 
                                               'completed', 'cancelled' 
                                                                   )) ) 
       AND ( "appeals"."id" NOT IN (SELECT "tasks"."appeal_id" 
                                    FROM   "tasks" 
                                    WHERE  "tasks"."appeal_type" = "Appeal" 
                                           AND "tasks"."type" = "RootTask" 
                                           AND "tasks"."status" = "cancelled") )
```