### PR TITLE
[WIP] Move task action definitions out of code

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -86,12 +86,18 @@ class Task < ApplicationRecord
   end
 
   # A wrapper around actions_allowable that also disallows doing actions to on_hold tasks.
+  # Could be replaced by adding the following rule to the top of a given task class' ACTION_SETS:
+  # {
+  #    conditions: [:on_hold],
+  #    actions: []
+  # }
   def actions_available?(user)
     return false if status == Constants.TASK_STATUSES.on_hold && !on_timed_hold?
 
     actions_allowable?(user)
   end
 
+  # Is this function worth it?
   def actions_allowable?(user)
     return false if !active?
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -229,9 +229,7 @@ class Task < ApplicationRecord
   end
 
   def task_is_assigned_to_user_within_organization?(user)
-    parent&.assigned_to.is_a?(Organization) &&
-      assigned_to.is_a?(User) &&
-      parent.assigned_to.user_has_access?(user)
+    TaskCondition.assigned_to_user_within_organization(self, user)
   end
 
   def can_be_updated_by_user?(user)

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -20,11 +20,7 @@ class AttorneyTask < Task
       actions: [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]
     },
     {
-      conditions: [:not_assigned_to_me],
-      actions: []
-    },
-    {
-      conditions: [:ama_appeal, :on_timed_hold],
+      conditions: [:assigned_to_me, :ama_appeal, :on_timed_hold],
       actions: [
         Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h,
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
@@ -32,7 +28,7 @@ class AttorneyTask < Task
       ]
     },
     {
-      conditions: [:ama_appeal],
+      conditions: [:assigned_to_me, :ama_appeal],
       actions: [
         Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h,
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
@@ -40,7 +36,7 @@ class AttorneyTask < Task
       ]
     },
     {
-      conditions: [:on_timed_hold],
+      conditions: [:assigned_to_me, :on_timed_hold],
       actions: [
         Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h,
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
@@ -48,12 +44,16 @@ class AttorneyTask < Task
       ]
     },
     {
-      conditions: [],
+      conditions: [:assigned_to_me],
       actions: [
         Constants.TASK_ACTIONS.REVIEW_LEGACY_DECISION.to_h,
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
         Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.to_h
       ]
+    },
+    {
+      conditions: [],
+      actions: []
     }
   ].freeze
 

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -14,8 +14,27 @@ class AttorneyTask < Task
   validate :assigned_to_role_is_valid
   validate :child_attorney_tasks_are_completed, on: :create
 
+  ACTION_SETS = [
+    {
+      conditions: [],
+      actions: []
+    },
+    {
+      conditions: [],
+      actions: []
+    },
+    {
+      conditions: [],
+      actions: []
+    },
+    {
+      conditions: [],
+      actions: []
+    }
+  ]
+
   def available_actions(user)
-    if parent.is_a?(JudgeTask) && parent.assigned_to == user
+    if TaskCondition::parent_is_a_judge_task(self, user) && TaskCondition::parent_assigned_to_me(self, user)
       return [Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h]
     end
 

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -58,9 +58,7 @@ class AttorneyTask < Task
   ].freeze
 
   def available_actions(user)
-    ACTION_SETS.each do |set|
-      break set[:actions] if set[:conditions].map { |condition| TaskCondition.send(condition, self, user) }.all?(true)
-    end
+    TaskCondition.actions_for_active_set(ACTION_SETS, self, user)
   end
 
   def timeline_title

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -42,18 +42,34 @@ class AttorneyTask < Task
       return []
     end
 
+    if TaskCondition.ama_appeal(self, user) && TaskCondition.on_timed_hold(self, user)
+      return [
+        Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h,
+        Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+        Constants.TASK_ACTIONS.END_TIMED_HOLD.to_h
+      ]
+    end
+
     if TaskCondition.ama_appeal(self, user)
       return [
         Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h,
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
-        appropriate_timed_hold_task_action
+        Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.to_h
+      ]
+    end
+
+    if TaskCondition.on_timed_hold(self, user)
+      return [
+        Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h,
+        Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+        Constants.TASK_ACTIONS.END_TIMED_HOLD.to_h
       ]
     end
 
     [
       Constants.TASK_ACTIONS.REVIEW_LEGACY_DECISION.to_h,
       Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
-      appropriate_timed_hold_task_action
+      Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.to_h
     ]
   end
 

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -75,7 +75,7 @@ class ColocatedTask < Task
     # core_actions.unshift(Constants.TASK_ACTIONS.CHANGE_TASK_TYPE.to_h)
 
     if action == "translation" && appeal.is_a?(Appeal)
-      return ama_translation_actions(core_actions)
+      return core_actions | [Constants.TASK_ACTIONS.SEND_TO_TRANSLATION.to_h]
     end
 
     core_actions
@@ -86,11 +86,6 @@ class ColocatedTask < Task
   end
 
   private
-
-  def ama_translation_actions(core_actions)
-    core_actions.push(Constants.TASK_ACTIONS.SEND_TO_TRANSLATION.to_h)
-    core_actions
-  end
 
   def legacy_translation_or_hearing_actions(actions)
     return legacy_schedule_hearing_actions(actions) if action == "schedule_hearing"

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -34,7 +34,6 @@ class GenericTask < Task
       conditions: [:assigned_to_user_within_organization],
       actions: [Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h]
     },
-
     {
       conditions: [:assigned_to_organization_user_belongs_to],
       actions: [

--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -124,7 +124,7 @@ end
 class ClearAndUnmistakeableErrorMailTask < MailTask
   def available_actions(user)
     if LitigationSupport.singleton.user_has_access?(user)
-      return super.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
+      return super | [Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h]
     end
 
     super
@@ -308,7 +308,7 @@ end
 class ReconsiderationMotionMailTask < MailTask
   def available_actions(user)
     if LitigationSupport.singleton.user_has_access?(user)
-      return super.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
+      return super | [Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h]
     end
 
     super
@@ -336,7 +336,7 @@ end
 class VacateMotionMailTask < MailTask
   def available_actions(user)
     if LitigationSupport.singleton.user_has_access?(user)
-      return super.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
+      return super | [Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h]
     end
 
     super

--- a/app/services/task_condition.rb
+++ b/app/services/task_condition.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+# TODO: Transform these into where statements so we can run them proactively.
 module TaskCondition
   def self.ama_appeal(task, _user)
-    task&.appeal&.is_a?(Appeal)
+    # Task.where(type: task.type).where(appeal_type: Appeal.name).include?(task)
+    task.appeal&.is_a?(Appeal)
   end
 
   def self.assigned_to_me(task, user)
-    task&.assigned_to &.== user
+    # TODO: How do we handle proactive calculation when it depends on current user?
+    task.assigned_to &.== user
   end
 
   def self.judge_task(task, _user)
@@ -14,18 +17,22 @@ module TaskCondition
   end
 
   def self.legacy_appeal(task, _user)
-    task&.appeal&.is_a?(LegacyAppeal)
+    task.appeal&.is_a?(LegacyAppeal)
   end
 
   def self.not_assigned_to_me(task, user)
-    task&.assigned_to &.!= user
+    task.assigned_to &.!= user
+  end
+
+  def self.on_timed_hold(task, _user)
+    task.on_timed_hold?
   end
 
   def self.parent_assigned_to_me(task, user)
-    assigned_to_me(task&.parent, user)
+    assigned_to_me(task.parent, user)
   end
 
   def self.parent_is_a_judge_task(task, user)
-    judge_task(task&.parent, user)
+    judge_task(task.parent, user)
   end
 end

--- a/app/services/task_condition.rb
+++ b/app/services/task_condition.rb
@@ -4,11 +4,11 @@
 # - Task.where(type: task.type).where(appeal_type: Appeal.name).include?(task)
 # - How do we handle proactive calculation when it depends on current user?
 module TaskCondition
-  def actions_for_active_set(sets, task, user)
+  def self.actions_for_active_set(sets, task, user)
     sets.each { |set| break set[:actions] if TaskCondition.condition_checker(set[:conditions], task, user) }
   end
 
-  def condition_checker(conditions, task, user)
+  def self.condition_checker(conditions, task, user)
     conditions.map { |condition| TaskCondition.send(condition, task, user) }.all?(true)
   end
 

--- a/app/services/task_condition.rb
+++ b/app/services/task_condition.rb
@@ -1,19 +1,31 @@
 # frozen_string_literal: true
 
 module TaskCondition
+  def self.ama_appeal(task, _user)
+    task&.appeal&.is_a?(Appeal)
+  end
+
   def self.assigned_to_me(task, user)
     task&.assigned_to &.== user
+  end
+
+  def self.judge_task(task, _user)
+    task.is_a?(JudgeTask)
+  end
+
+  def self.legacy_appeal(task, _user)
+    task&.appeal&.is_a?(LegacyAppeal)
+  end
+
+  def self.not_assigned_to_me(task, user)
+    task&.assigned_to &.!= user
   end
 
   def self.parent_assigned_to_me(task, user)
     assigned_to_me(task&.parent, user)
   end
 
-  def self.is_a_judge_task(task, _user)
-    task.is_a?(JudgeTask)
-  end
-
   def self.parent_is_a_judge_task(task, user)
-    is_a_judge_task(task&.parent, user)
+    judge_task(task&.parent, user)
   end
 end

--- a/app/services/task_condition.rb
+++ b/app/services/task_condition.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module TaskCondition
+  def self.assigned_to_me(task, user)
+    task&.assigned_to &.== user
+  end
+
+  def self.parent_assigned_to_me(task, user)
+    assigned_to_me(task&.parent, user)
+  end
+
+  def self.is_a_judge_task(task, _user)
+    task.is_a?(JudgeTask)
+  end
+
+  def self.parent_is_a_judge_task(task, user)
+    is_a_judge_task(task&.parent, user)
+  end
+end

--- a/app/services/task_condition.rb
+++ b/app/services/task_condition.rb
@@ -2,6 +2,16 @@
 
 # TODO: Transform these into where statements so we can run them proactively.
 module TaskCondition
+  def actions_for_active_set(sets, task, user)
+    sets.each { |set| break set[:actions] if TaskCondition.condition_checker(set[:conditions], task, user) }
+  end
+
+  def condition_checker(conditions, task, user)
+    conditions.map { |condition| TaskCondition.send(condition, task, user) }.all?(true)
+  end
+
+  # private
+
   def self.ama_appeal(task, _user)
     # Task.where(type: task.type).where(appeal_type: Appeal.name).include?(task)
     task.appeal&.is_a?(Appeal)


### PR DESCRIPTION
Work in progress of a first step for how we can move definition of task actions and their conditions out of code and into self-service configurations.

### Benefits:
* Self-service.
* Immediate changes in production.
* Offload decision on business rules to those most familiar with business process.
* Reduces testing burden on developers.