### PR TITLE
Default to RO58 for Philippines addresses

### DIFF
--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -5,7 +5,7 @@ class VaDotGovAddressValidator
 
   STATUSES = {
     matched_available_hearing_locations: :matched_available_hearing_locations,
-    phillipines_exception: :defaulted_to_phillipines_RO58,
+    philippines_exception: :defaulted_to_philippines_RO58,
     created_admin_action: :created_admin_action
   }.freeze
 
@@ -185,8 +185,8 @@ class VaDotGovAddressValidator
   end
 
   def handle_error(error)
-    if VaDotGovAddressValidatorExceptions.check_for_phillipines_and_maybe_update(appeal, address)
-      return { status: STATUSES[:phillipines_exception] }
+    if VaDotGovAddressValidatorExceptions.check_for_philippines_and_maybe_update(appeal, address)
+      return { status: STATUSES[:philippines_exception] }
     end
 
     case error

--- a/app/services/va_dot_gov_address_validator_exceptions.rb
+++ b/app/services/va_dot_gov_address_validator_exceptions.rb
@@ -40,5 +40,16 @@ class VaDotGovAddressValidatorExceptions
     def facility_is_san_antonio_satellite_office?(facility_id)
       facility_id == "vha_671BY"
     end
+
+    def check_for_phillipines_and_maybe_update(appeal, address)
+      if "Phillipines".casecmp(address[:country]) == 0
+        appeal.update(closest_regional_office: "RO58")
+        facility = VADotGovService.get_facility_data(ids: ["vba_358"])
+        appeal.va_dot_gov_address_validator.create_available_hearing_location(facility: facility)
+        return true
+      end
+
+      false
+    end
   end
 end

--- a/app/services/va_dot_gov_address_validator_exceptions.rb
+++ b/app/services/va_dot_gov_address_validator_exceptions.rb
@@ -41,8 +41,8 @@ class VaDotGovAddressValidatorExceptions
       facility_id == "vha_671BY"
     end
 
-    def check_for_phillipines_and_maybe_update(appeal, address)
-      if "Phillipines".casecmp(address[:country]) == 0
+    def check_for_philippines_and_maybe_update(appeal, address)
+      if "Philippines".casecmp(address[:country]) == 0
         appeal.update(closest_regional_office: "RO58")
         facility = VADotGovService.get_facility_data(ids: ["vba_358"])
         appeal.va_dot_gov_address_validator.create_available_hearing_location(facility: facility)

--- a/app/services/va_dot_gov_address_validator_exceptions.rb
+++ b/app/services/va_dot_gov_address_validator_exceptions.rb
@@ -44,7 +44,7 @@ class VaDotGovAddressValidatorExceptions
     def check_for_philippines_and_maybe_update(appeal, address)
       if "Philippines".casecmp(address[:country]) == 0
         appeal.update(closest_regional_office: "RO58")
-        facility = VADotGovService.get_facility_data(ids: ["vba_358"])
+        facility = VADotGovService.get_facility_data(ids: ["vba_358"]).first
         appeal.va_dot_gov_address_validator.create_available_hearing_location(facility: facility)
         return true
       end


### PR DESCRIPTION
Resolves #9873 

- if an appellant's address is set to "Philippines", default `closest_regional_office` and `available_hearing_locations` to RO58 (Manila)

sample values for appellant country for cases that were previously set to Manila in VACOLS
```ruby
# appeal.id, appeal.appellant[:address][:country]
[288847, "PHILIPPINES"],
 [303963, "Philippines"],
 [166656, "Philippines"],
 [170445, "PHILIPPINES"],
 [28764, "Philippines"],
 [139804, "Philippines"],
 [141547, "PHILIPPINES"],
 [159066, "PHILS"],
 [161413, "Philippines"],
 [161552, "Philippines"],
 [124194, "PHILIPPINES"],
 [57113, "Philippines"],
 [90785, "PHILS"],
 [112293, "Philippines"],
 [118555, "PHILIPPINES"],
 [288619, "Philippines"],
 [323026, "PHILIPPINES"],
 [357942, "Philippines"],
 [359760, "PHILIPPINES"],
 [515346, "PHILIPPINES"],
 [379607, "Philippines"],
 [384451, "Philippines"],
 [626116, "Philippines"],
 [282933, "Philippines"],
 [711903, "PHILIPPINES"],
 [664782, "Philippines"]
```
