### PR TITLE
Ignore sentry alerts for a month, tag GH tix with sentry-alert

### DIFF
--- a/docs/bat-team.md
+++ b/docs/bat-team.md
@@ -40,10 +40,10 @@ come from the production Caseflow system.
 When a new Sentry alert appears in Slack, it should be investigated asap. If you cannot investigate it immediately,
 emoji tag it with the :bat: emoji.
 
-If a Github ticket already exists for the underlying issue, the Sentry alert should be ignored for a week.
+If a Github ticket already exists for the underlying issue, the Sentry alert should be ignored for a month.
 
 If a Github ticket does not yet exist, create a Github ticket, with a link to the Sentry incident
-in the ticket description.
+in the ticket description. Add the `sentry-alert` label to the new ticket, and any appropriate product-specific labels.
 
 The key evaluation is whether this incident reflects an immediate production issue,
 particularly affecting data integrity, or whether it can be picked up during normal sprint planning.
@@ -52,5 +52,5 @@ and consult with them about next steps. If it's an outage of some kind, we shoul
 The Bat Team should do just enough investigation to determine further action.
 
 Mark the Sentry alert in Slack with the green checkmark emoji when it has been triaged, and you can ignore the alert
-in Sentry for a week.
+in Sentry for a month.
 


### PR DESCRIPTION
Update 🦇 team docs with latest protocols.