### PR TITLE
Adding judge permissions to print daily docket page

### DIFF
--- a/app/controllers/hearing_schedule_controller.rb
+++ b/app/controllers/hearing_schedule_controller.rb
@@ -4,8 +4,8 @@ class HearingScheduleController < ApplicationController
   before_action :react_routed, :check_hearings_out_of_service
   before_action :verify_build_hearing_schedule_access, only: [:build_schedule_index]
   before_action :verify_hearings_or_reader_access, only: [:hearing_details_index]
-  before_action :verify_edit_hearing_schedule_access, except: [:hearing_details_index, :index, :show]
-  before_action :verify_view_hearing_schedule_access, only: [:index, :show]
+  before_action :verify_edit_hearing_schedule_access, except: [:hearing_details_index, :index, :show, :index_print]
+  before_action :verify_view_hearing_schedule_access, only: [:index, :show, :index_print]
 
   def set_application
     RequestStore.store[:application] = "hearings"

--- a/app/controllers/hearings/hearing_day_controller.rb
+++ b/app/controllers/hearings/hearing_day_controller.rb
@@ -2,7 +2,7 @@
 
 class Hearings::HearingDayController < HearingScheduleController
   before_action :verify_build_hearing_schedule_access, only: [:destroy, :create]
-  skip_before_action :deny_vso_access, only: [:index, :show]
+  skip_before_action :deny_vso_access, only: [:index, :show, :index_print]
 
   # show schedule days for date range provided
   def index


### PR DESCRIPTION
### Description
The support team received tickets from judges who weren't able to access the print daily docket page. This PR updates permissions such that judges are able to view the print page.

### To Test
1) Log in to Caseflow as a judge. 
2) Update the user's permission such that they only have "Hearing Prep". 
3) Navigate to the print page and ensure it loads correctly.
