### PR TITLE
Refactor BulkAssignModal

### DIFF
--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 
+import BulkAssignModal from './components/BulkAssignModal';
 import TabWindow from '../components/TabWindow';
 import TaskTable, { docketNumberColumn } from './components/TaskTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
@@ -146,6 +147,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 
 const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
+  { organizationName === 'Hearing Admin' && <BulkAssignModal tasks={tasks} /> }
   <TaskTable
     customColumns={[docketNumberColumn(tasks, false)]}
     includeHearingBadge
@@ -156,7 +158,6 @@ const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <Re
     includeDaysWaiting
     includeReaderLink
     includeNewDocsIcon
-    organizationName={organizationName}
     tasks={tasks}
   />
 </React.Fragment>;

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -1,4 +1,6 @@
-import * as React from 'react';
+import React from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
@@ -7,6 +9,8 @@ import ApiUtil from '../../util/ApiUtil';
 import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import Dropdown from '../../components/Dropdown';
+
+import { bulkAssignTasks } from '../QueueActions';
 
 const BULK_ASSIGN_ISSUE_COUNT = [5, 10, 20, 30, 40, 50];
 
@@ -28,15 +32,9 @@ class BulkAssignModal extends React.PureComponent {
   }
 
   componentDidMount() {
-    let fetchedUsers;
-
-    if (this.props.organizationUrl) {
-      ApiUtil.get(`/organizations/${this.props.organizationUrl}/users.json`).then((resp) => {
-        fetchedUsers = resp.body.organization_users.data;
-
-        this.setState({ users: fetchedUsers });
-      });
-    }
+    ApiUtil.get('/organizations/hearing-admin/users.json').then((resp) => {
+      this.setState({ users: resp.body.organization_users.data });
+    });
   }
 
   handleModalToggle = () => {
@@ -71,7 +69,7 @@ class BulkAssignModal extends React.PureComponent {
     this.setState({ showErrors: true });
 
     if (this.generateErrors().length === 0) {
-      this.props.assignTasks(this.state.modal);
+      this.props.bulkAssignTasks(this.state.modal);
       this.handleModalToggle();
     }
   }
@@ -206,9 +204,8 @@ class BulkAssignModal extends React.PureComponent {
   }
 
   render() {
-    const isBulkAssignEnabled = this.props.enableBulkAssign && this.props.organizationUrl;
-    // const bulkAssignButton = <Button classNames={['bulk-assign-button']} onClick={this.handleModalToggle}>
-    //   Assign Tasks</Button>;
+    const bulkAssignButton = <Button classNames={['bulk-assign-button']} onClick={this.handleModalToggle}>
+      Assign Tasks</Button>;
     const confirmButton = <Button classNames={['usa-button-secondary']} onClick={this.bulkAssignTasks}>
       Assign</Button>;
     const cancelButton = <Button linkStyling onClick={this.handleModalToggle}>Cancel</Button>;
@@ -228,20 +225,23 @@ class BulkAssignModal extends React.PureComponent {
 
     return (
       <div>
-        {isBulkAssignEnabled && this.state.showModal && modal}
+        { this.state.showModal && modal }
         {/* hide the button until the backend work is complete: */}
-        {/* {isBulkAssignEnabled && bulkAssignButton} */}
+        { false && bulkAssignButton }
       </div>
     );
   }
 }
 
 BulkAssignModal.propTypes = {
-  enableBulkAssign: PropTypes.bool,
   tasks: PropTypes.array.isRequired,
-  organizationUrl: PropTypes.string,
-  assignTasks: PropTypes.func.isRequired,
   issueCountOptions: PropTypes.array
 };
 
-export default BulkAssignModal;
+const mapDispatchToProps = (dispatch) => (
+  bindActionCreators({ bulkAssignTasks }, dispatch)
+);
+
+export default (connect(() => {
+  return null;
+}, mapDispatchToProps)(BulkAssignModal));

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -14,7 +14,6 @@ import { bindActionCreators } from 'redux';
 
 import QueueTable from '../QueueTable';
 import Checkbox from '../../components/Checkbox';
-import BulkAssignModal from './BulkAssignModal';
 import DocketTypeBadge from '../../components/DocketTypeBadge';
 import HearingBadge from './HearingBadge';
 import OnHoldLabel, { numDaysOnHold } from './OnHoldLabel';
@@ -22,7 +21,7 @@ import ReaderLink from '../ReaderLink';
 import CaseDetailsLink from '../CaseDetailsLink';
 import ContinuousProgressBar from '../../components/ContinuousProgressBar';
 
-import { setSelectionOfTaskOfUser, bulkAssignTasks } from '../QueueActions';
+import { setSelectionOfTaskOfUser } from '../QueueActions';
 import { renderAppealType, taskHasCompletedHold, actionNameOfTask } from '../utils';
 import { DateString } from '../../util/DateUtil';
 import {
@@ -34,7 +33,6 @@ import {
 } from '../constants';
 import COPY from '../../../COPY.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
-import ORGANIZATION_NAMES from '../../../constants/ORGANIZATION_NAMES.json';
 
 const hasDASRecord = (task, requireDasRecord) => {
   return (task.appeal.isLegacyAppeal && requireDasRecord) ? Boolean(task.taskId) : true;
@@ -358,28 +356,15 @@ export class TaskTableUnconnected extends React.PureComponent {
     return _.findIndex(this.getQueueColumns(), (column) => column.getSortValue);
   }
 
-  render = () => {
-    const { tasks } = this.props;
-
-    return (
-      <div>
-        <BulkAssignModal
-          enableBulkAssign={this.props.organizationName === 'Hearing Admin'}
-          organizationUrl={ORGANIZATION_NAMES[this.props.organizationName]}
-          tasks={tasks}
-          assignTasks={this.props.bulkAssignTasks} />
-        <QueueTable
-          columns={this.getQueueColumns}
-          rowObjects={tasks}
-          getKeyForRow={this.props.getKeyForRow || this.getKeyForRow}
-          defaultSort={{ sortColIdx: this.getDefaultSortableColumn() }}
-          alternateColumnNames={COLUMN_NAMES}
-          enablePagination
-          rowClassNames={(task) =>
-            this.taskHasDASRecord(task) || !this.props.requireDasRecord ? null : 'usa-input-error'} />
-      </div>
-    );
-  }
+  render = () => <QueueTable
+    columns={this.getQueueColumns}
+    rowObjects={this.props.tasks}
+    getKeyForRow={this.props.getKeyForRow || this.getKeyForRow}
+    defaultSort={{ sortColIdx: this.getDefaultSortableColumn() }}
+    alternateColumnNames={COLUMN_NAMES}
+    enablePagination
+    rowClassNames={(task) =>
+      this.taskHasDASRecord(task) || !this.props.requireDasRecord ? null : 'usa-input-error'} />;
 }
 
 const mapStateToProps = (state) => ({
@@ -390,10 +375,7 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => (
-  bindActionCreators({
-    setSelectionOfTaskOfUser,
-    bulkAssignTasks
-  }, dispatch)
+  bindActionCreators({ setSelectionOfTaskOfUser }, dispatch)
 );
 
 export default (connect(mapStateToProps, mapDispatchToProps)(TaskTableUnconnected));

--- a/client/constants/ORGANIZATION_NAMES.json
+++ b/client/constants/ORGANIZATION_NAMES.json
@@ -1,4 +1,0 @@
-{
-  "Hearing Admin": "hearing-admin",
-  "Hearing Management": "hearing-management"
-}


### PR DESCRIPTION
In preparation for building queues from static configurations (#10620) and ultimately enabling pagination this PR moves where the `BulkAssignModal` component is called out of the `TaskTable` component so that component can be more easily built from a static configuration.