### PR TITLE
Refactor TaskTable includeDetailsLink into pure detailsColumn function.

### DIFF
--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -5,7 +5,7 @@ import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 
 import TabWindow from '../components/TabWindow';
-import TaskTable, { docketNumberColumn, hearingBadgeColumn } from './components/TaskTable';
+import TaskTable, { docketNumberColumn, hearingBadgeColumn, detailsColumn } from './components/TaskTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
@@ -58,6 +58,7 @@ class OrganizationQueue extends React.PureComponent {
             sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION,
               this.props.organizationName)}
           tasks={this.props.assignedTasks}
+          userRole={this.props.userRole}
         />
       },
       {
@@ -68,6 +69,7 @@ class OrganizationQueue extends React.PureComponent {
             sprintf(COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION,
               this.props.organizationName)}
           tasks={this.props.completedTasks}
+          userRole={this.props.userRole}
         />
       }
     ];
@@ -85,8 +87,10 @@ class OrganizationQueue extends React.PureComponent {
             {sprintf(COPY.ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, this.props.organizationName)}
           </p>
           <TaskTable
-            customColumns={[docketNumberColumn(this.props.trackingTasks, false)]}
-            includeDetailsLink
+            customColumns={[
+              docketNumberColumn(this.props.trackingTasks, false),
+              detailsColumn(this.props.trackingTasks, false, this.props.userRole)
+            ]}
             includeIssueCount
             includeType
             tasks={this.props.trackingTasks}
@@ -125,6 +129,7 @@ const mapStateToProps = (state) => {
 
   return {
     success,
+    userRole: state.ui.userRole
     organizationName: state.ui.activeOrganization.name,
     organizationIsVso: state.ui.activeOrganization.isVso,
     organizations: state.ui.organizations,
@@ -132,7 +137,7 @@ const mapStateToProps = (state) => {
     unassignedTasks: getUnassignedOrganizationalTasks(state),
     assignedTasks: getAssignedOrganizationalTasks(state),
     completedTasks: getCompletedOrganizationalTasks(state),
-    trackingTasks: trackingTasksForOrganization(state)
+    trackingTasks: trackingTasksForOrganization(state),
   };
 };
 
@@ -144,11 +149,14 @@ const mapDispatchToProps = (dispatch) => ({
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 
-const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <React.Fragment>
+const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
   <TaskTable
-    customColumns={[docketNumberColumn(tasks, false), hearingBadgeColumn(tasks)]}
-    includeDetailsLink
+    customColumns={[
+      docketNumberColumn(tasks, false),
+      hearingBadgeColumn(tasks),
+      detailsColumn(tasks, false, userRole)
+    ]}
     includeTask
     includeRegionalOffice={organizationName === 'Hearing Management' || organizationName === 'Hearing Admin'}
     includeType
@@ -160,12 +168,11 @@ const UnassignedTaskTableTab = ({ description, tasks, organizationName }) => <Re
   />
 </React.Fragment>;
 
-const TaskTableWithUserColumnTab = ({ description, tasks, organizationName }) => <React.Fragment>
+const TaskTableWithUserColumnTab = ({ description, tasks, organizationName, userRole }) => <React.Fragment>
   <p className="cf-margin-top-0">{description}</p>
 
   <TaskTable
-    customColumns={[docketNumberColumn(tasks, false), hearingBadgeColumn(tasks)]}
-    includeDetailsLink
+    customColumns={[docketNumberColumn(tasks, false), hearingBadgeColumn(tasks), detailsColumn(tasks, false, userRole)]}
     includeTask
     includeRegionalOffice={organizationName === 'Hearing Management' || organizationName === 'Hearing Admin'}
     includeType

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -129,7 +129,7 @@ const mapStateToProps = (state) => {
 
   return {
     success,
-    userRole: state.ui.userRole
+    userRole: state.ui.userRole,
     organizationName: state.ui.activeOrganization.name,
     organizationIsVso: state.ui.activeOrganization.isVso,
     organizations: state.ui.organizations,
@@ -137,7 +137,7 @@ const mapStateToProps = (state) => {
     unassignedTasks: getUnassignedOrganizationalTasks(state),
     assignedTasks: getAssignedOrganizationalTasks(state),
     completedTasks: getCompletedOrganizationalTasks(state),
-    trackingTasks: trackingTasksForOrganization(state),
+    trackingTasks: trackingTasksForOrganization(state)
   };
 };
 

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -73,11 +73,19 @@ export const docketNumberColumn = (tasks, requireDasRecord) => {
   };
 };
 
+<<<<<<< HEAD
 export const hearingBadgeColumn = () => {
   return {
     header: '',
     valueFunction: (task) => <HearingBadge task={task} />
   };
+=======
+export const hearingBadgeColumn = (tasks) => {
+  return {
+    header: '',
+    valueFunction: (task) => <HearingBadge task={task} />
+  }
+>>>>>>> Refactor TaskTable includeHearingBadge class method into pure method that can be used to inject a hearing badge into task tables.
 };
 
 export class TaskTableUnconnected extends React.PureComponent {
@@ -100,7 +108,11 @@ export class TaskTableUnconnected extends React.PureComponent {
   collapseColumnIfNoDASRecord = (task) => this.taskHasDASRecord(task) ? 1 : 0
 
   caseHearingColumn = () => {
+<<<<<<< HEAD
     return this.props.includeHearingBadge ? hearingBadgeColumn() : null;
+=======
+    return this.props.includeHearingBadge ? hearingBadgeColumn(this.props.tasks): null;
+>>>>>>> Refactor TaskTable includeHearingBadge class method into pure method that can be used to inject a hearing badge into task tables.
   }
 
   caseSelectColumn = () => {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -94,8 +94,8 @@ export const detailsColumn = (tasks, requireDasRecord, userRole) => {
 
       return `${_.last(vetName)} ${vetName[0]}`;
     }
-  }
-}
+  };
+};
 
 export class TaskTableUnconnected extends React.PureComponent {
   getKeyForRow = (rowNumber, object) => object.uniqueId
@@ -136,7 +136,9 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDetailsColumn = () => {
-    return this.props.includeDetailsLink ? detailsColumn(this.props.tasks, this.props.requireDasRecord, this.props.userRole) : null;
+    return this.props.includeDetailsLink ?
+      detailsColumn(this.props.tasks, this.props.requireDasRecord, this.props.userRole) :
+      null;
   }
 
   caseTaskColumn = () => {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -80,6 +80,23 @@ export const hearingBadgeColumn = () => {
   };
 };
 
+export const detailsColumn = (tasks, requireDasRecord, userRole) => {
+  return {
+    header: COPY.CASE_LIST_TABLE_VETERAN_NAME_COLUMN_TITLE,
+    valueFunction: (task) => <CaseDetailsLink
+      task={task}
+      appeal={task.appeal}
+      userRole={userRole}
+      disabled={!hasDASRecord(task, requireDasRecord)} />,
+    getSortValue: (task) => {
+      const vetName = task.appeal.veteranFullName.split(' ');
+      // only take last, first names. ignore middle names/initials
+
+      return `${_.last(vetName)} ${vetName[0]}`;
+    }
+  }
+}
+
 export class TaskTableUnconnected extends React.PureComponent {
   getKeyForRow = (rowNumber, object) => object.uniqueId
 
@@ -119,20 +136,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDetailsColumn = () => {
-    return this.props.includeDetailsLink ? {
-      header: COPY.CASE_LIST_TABLE_VETERAN_NAME_COLUMN_TITLE,
-      valueFunction: (task) => <CaseDetailsLink
-        task={task}
-        appeal={task.appeal}
-        userRole={this.props.userRole}
-        disabled={!this.taskHasDASRecord(task)} />,
-      getSortValue: (task) => {
-        const vetName = task.appeal.veteranFullName.split(' ');
-        // only take last, first names. ignore middle names/initials
-
-        return `${_.last(vetName)} ${vetName[0]}`;
-      }
-    } : null;
+    return this.props.includeDetailsLink ? detailsColumn(this.props.tasks, this.props.requireDasRecord, this.props.userRole) : null;
   }
 
   caseTaskColumn = () => {

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -73,19 +73,11 @@ export const docketNumberColumn = (tasks, requireDasRecord) => {
   };
 };
 
-<<<<<<< HEAD
 export const hearingBadgeColumn = () => {
   return {
     header: '',
     valueFunction: (task) => <HearingBadge task={task} />
   };
-=======
-export const hearingBadgeColumn = (tasks) => {
-  return {
-    header: '',
-    valueFunction: (task) => <HearingBadge task={task} />
-  }
->>>>>>> Refactor TaskTable includeHearingBadge class method into pure method that can be used to inject a hearing badge into task tables.
 };
 
 export class TaskTableUnconnected extends React.PureComponent {
@@ -108,11 +100,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   collapseColumnIfNoDASRecord = (task) => this.taskHasDASRecord(task) ? 1 : 0
 
   caseHearingColumn = () => {
-<<<<<<< HEAD
     return this.props.includeHearingBadge ? hearingBadgeColumn() : null;
-=======
-    return this.props.includeHearingBadge ? hearingBadgeColumn(this.props.tasks): null;
->>>>>>> Refactor TaskTable includeHearingBadge class method into pure method that can be used to inject a hearing badge into task tables.
   }
 
   caseSelectColumn = () => {


### PR DESCRIPTION
Connects #10619 

OrganizationQueue component then imports detailsColumn and injects into TaskTable via the customColumns property. The information regarding user role, as used in this column, has been moved to the OrganizationQueue component's props.