### PR TITLE
Grouping duplicated hearings

### DIFF
--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -115,6 +115,7 @@ class VACOLS::CaseHearing < VACOLS::Record
         .joins("left outer join folder on folder.ticknum = brieff.bfkey")
         .joins("left outer join corres on corres.stafkey = bfcorkey")
         .where(hearing_type: HEARING_TYPES)
+        .group(:hearing_pkseq)
     end
   end
 


### PR DESCRIPTION
Connects #10919 

### Description
We're joining VACOLS hearings to the VACOLS users table using a non-unique column. This is causing us to duplicate hearings. We'll need to figure out the correct way to join these tables, but in the meantime, this PR should silence the Sentry alerts.
