### PR TITLE
Refactor BvaDispatchTask#outcode

### DIFF
--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -23,54 +23,10 @@ class BvaDispatchTask < GenericTask
 
     def outcode(appeal, params, user)
       if appeal.is_a?(Appeal)
-        tasks = where(appeal: appeal, assigned_to: user)
-        throw_error_if_no_tasks_or_if_task_is_completed(appeal, tasks, user)
-        task = tasks[0]
+        AmaAppealDispatch.new(appeal: appeal, user: user, params: params).call
+      elsif appeal.is_a?(LegacyAppeal)
+        LegacyAppealDispatch.new(appeal: appeal, params: params).call
       end
-
-      params[:appeal_id] = appeal.id
-      params[:appeal_type] = appeal.class.name
-      create_decision_document!(params)
-
-      if appeal.is_a?(Appeal)
-        task.update!(status: Constants.TASK_STATUSES.completed)
-        task.root_task.update!(status: Constants.TASK_STATUSES.completed)
-        appeal.request_issues.each(&:close_decided_issue!)
-      end
-    rescue ActiveRecord::RecordInvalid => error
-      if error.message.match?(/^Validation failed:/)
-        raise(Caseflow::Error::OutcodeValidationFailure, message: error.message)
-      end
-
-      raise error
-    end
-
-    private
-
-    def create_decision_document!(params)
-      DecisionDocument.create!(params).tap do |decision_document|
-        delay = if decision_document.decision_date.future?
-                  decision_document.decision_date + DecisionDocument::PROCESS_DELAY_VBMS_OFFSET_HOURS.hours
-                else
-                  0
-                end
-
-        decision_document.submit_for_processing!(delay: delay)
-
-        unless decision_document.processed? || decision_document.decision_date.future?
-          ProcessDecisionDocumentJob.perform_later(decision_document.id)
-        end
-      end
-    end
-
-    def throw_error_if_no_tasks_or_if_task_is_completed(appeal, tasks, user)
-      if tasks.count != 1
-        fail Caseflow::Error::BvaDispatchTaskCountMismatch, appeal_id: appeal.id, user_id: user.id, tasks: tasks
-      end
-
-      task = tasks[0]
-
-      fail(Caseflow::Error::BvaDispatchDoubleOutcode, appeal_id: appeal.id, task_id: task.id) if task.completed?
     end
   end
 end

--- a/app/workflows/ama_appeal_dispatch.rb
+++ b/app/workflows/ama_appeal_dispatch.rb
@@ -10,7 +10,7 @@ class AmaAppealDispatch
   def call
     throw_error_if_no_tasks_or_if_task_is_completed
 
-    create_decision_document!(params)
+    create_decision_document_and_submit_for_processing!(params)
     complete_dispatch_task!
     complete_dispatch_root_task!
     close_request_issues_as_decided!
@@ -50,20 +50,8 @@ class AmaAppealDispatch
     end
   end
 
-  def create_decision_document!(params)
-    DecisionDocument.create!(params).tap do |decision_document|
-      delay = if decision_document.decision_date.future?
-                decision_document.decision_date + DecisionDocument::PROCESS_DELAY_VBMS_OFFSET_HOURS.hours
-              else
-                0
-              end
-
-      decision_document.submit_for_processing!(delay: delay)
-
-      unless decision_document.processed? || decision_document.decision_date.future?
-        ProcessDecisionDocumentJob.perform_later(decision_document.id)
-      end
-    end
+  def create_decision_document_and_submit_for_processing!(params)
+    DecisionDocument.create!(params).tap(&:submit_for_processing!)
   end
 
   def complete_dispatch_task!

--- a/app/workflows/ama_appeal_dispatch.rb
+++ b/app/workflows/ama_appeal_dispatch.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class AmaAppealDispatch
+  def initialize(appeal:, params:, user:)
+    @appeal = appeal
+    @params = params.merge(appeal_id: appeal.id, appeal_type: "Appeal")
+    @user = user
+  end
+
+  def call
+    throw_error_if_no_tasks_or_if_task_is_completed
+
+    create_decision_document!(params)
+    complete_dispatch_task!
+    complete_dispatch_root_task!
+    close_request_issues_as_decided!
+  rescue ActiveRecord::RecordInvalid => error
+    if error.message.match?(/^Validation failed:/)
+      raise(Caseflow::Error::OutcodeValidationFailure, message: error.message)
+    end
+
+    raise error
+  end
+
+  private
+
+  attr_reader :appeal, :params, :user
+
+  def dispatch_tasks
+    @dispatch_tasks ||= BvaDispatchTask.where(appeal: appeal, assigned_to: user)
+  end
+
+  def dispatch_task
+    @dispatch_task ||= dispatch_tasks[0]
+  end
+
+  def throw_error_if_no_tasks_or_if_task_is_completed
+    if dispatch_tasks.size != 1
+      fail(
+        Caseflow::Error::BvaDispatchTaskCountMismatch,
+        appeal_id: appeal.id, user_id: user.id, tasks: dispatch_tasks
+      )
+    end
+
+    if dispatch_task.completed?
+      fail(
+        Caseflow::Error::BvaDispatchDoubleOutcode,
+        appeal_id: appeal.id, task_id: dispatch_task.id
+      )
+    end
+  end
+
+  def create_decision_document!(params)
+    DecisionDocument.create!(params).tap do |decision_document|
+      delay = if decision_document.decision_date.future?
+                decision_document.decision_date + DecisionDocument::PROCESS_DELAY_VBMS_OFFSET_HOURS.hours
+              else
+                0
+              end
+
+      decision_document.submit_for_processing!(delay: delay)
+
+      unless decision_document.processed? || decision_document.decision_date.future?
+        ProcessDecisionDocumentJob.perform_later(decision_document.id)
+      end
+    end
+  end
+
+  def complete_dispatch_task!
+    dispatch_task.update!(status: Constants.TASK_STATUSES.completed)
+  end
+
+  def complete_dispatch_root_task!
+    dispatch_task.root_task.update!(status: Constants.TASK_STATUSES.completed)
+  end
+
+  def close_request_issues_as_decided!
+    appeal.request_issues.each(&:close_decided_issue!)
+  end
+end

--- a/app/workflows/legacy_appeal_dispatch.rb
+++ b/app/workflows/legacy_appeal_dispatch.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class LegacyAppealDispatch
+  def initialize(appeal:, params:)
+    @appeal = appeal
+    @params = params.merge(appeal_id: appeal.id, appeal_type: "LegacyAppeal")
+  end
+
+  def call
+    create_decision_document!(params)
+  rescue ActiveRecord::RecordInvalid => error
+    if error.message.match?(/^Validation failed:/)
+      raise(Caseflow::Error::OutcodeValidationFailure, message: error.message)
+    end
+
+    raise error
+  end
+
+  private
+
+  attr_reader :appeal, :params
+
+  def create_decision_document!(params)
+    DecisionDocument.create!(params).tap do |decision_document|
+      delay = if decision_document.decision_date.future?
+                decision_document.decision_date + DecisionDocument::PROCESS_DELAY_VBMS_OFFSET_HOURS.hours
+              else
+                0
+              end
+
+      decision_document.submit_for_processing!(delay: delay)
+
+      unless decision_document.processed? || decision_document.decision_date.future?
+        ProcessDecisionDocumentJob.perform_later(decision_document.id)
+      end
+    end
+  end
+end

--- a/spec/workflows/legacy_appeal_dispatch_spec.rb
+++ b/spec/workflows/legacy_appeal_dispatch_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe LegacyAppealDispatch do
+  describe "#call" do
+    context "invalid or missing citation number" do
+      it "raises OutcodeValidationFailure" do
+        legacy_appeal = create(:legacy_appeal, vacols_case: create(:case))
+
+        params = {
+          appeal_id: legacy_appeal.id,
+        }
+
+        dispatch = LegacyAppealDispatch.new(appeal: legacy_appeal, params: params)
+
+        expect { dispatch.call }.to raise_error do |e|
+           expect(e.class).to eq Caseflow::Error::OutcodeValidationFailure
+           expect(e.message).to eq "Validation failed: Citation number is invalid"
+        end
+      end
+    end
+
+    context "missing decision_date" do
+      it "raises ActiveRecord::NotNullViolation" do
+        legacy_appeal = create(:legacy_appeal, vacols_case: create(:case))
+
+        params = {
+          appeal_id: legacy_appeal.id,
+          citation_number: "A18123456"
+        }
+
+        dispatch = LegacyAppealDispatch.new(appeal: legacy_appeal, params: params)
+
+        expect { dispatch.call }.to raise_error ActiveRecord::NotNullViolation
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**: Issue #10480 requires us to implement a new feature that only
applies to AMA appeals. The current code is not structured in such a
way that makes adding the feature easy. Keeping the existing code
would increase the complexity of the `outcode` method and reduce
readability.

In order to make adding the new feature easy without adding complexity,
we must first perform this preparatory refactoring.

The `outcode` method contains the "Switch Statements" code
smell which performs different actions based on the appeal's class.
The refactoring recipe we will use to remove this code smell is
"Replace conditional with polymorphism". We will adhere to the
"Tell, Don't Ask principle" and create separate classes for dispatching
AMA appeals and Legacy Appeals.

By extracting separate classes, we can also move the temporary `task`
and `tasks` variables into reusable methods. This recipe is known as
"Replace Temp with Query".

I also replaced actions such as `task.update!(status: "completed")`
with more descriptive method names like `complete_dispatch_task!`.

Note that we still have a conditional based on class in `outcode`. The
way to eliminate that conditional would be to have an `outcode` or
`bva_dispatch` method defined in the `Appeal` and `LegacyAppeal`
models that then call `AmaAppealDispatch` and `LegacyAppealDispatch`
respectively. Because those models are already too big, adding more
code would result in a Code Climate error. Since we don't anticipate
having more appeal types in the near future, I think this conditional
is fine for now.

References:
https://martinfowler.com/articles/preparatory-refactoring-example.html
https://refactoring.guru/smells/switch-statements
https://refactoring.guru/replace-conditional-with-polymorphism
https://refactoring.guru/replace-temp-with-query
