### PR TITLE
Add not null db constraint to tasks.assigned_to_id

### DIFF
--- a/db/migrate/20190530185719_add_not_null_task_assigned_to.rb
+++ b/db/migrate/20190530185719_add_not_null_task_assigned_to.rb
@@ -1,0 +1,5 @@
+class AddNotNullTaskAssignedTo < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null(:tasks, :assigned_to_id, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -947,7 +947,7 @@ ActiveRecord::Schema.define(version: 20190603150958) do
     t.string "appeal_type", null: false
     t.datetime "assigned_at"
     t.integer "assigned_by_id"
-    t.integer "assigned_to_id"
+    t.integer "assigned_to_id", null: false
     t.string "assigned_to_type", null: false
     t.datetime "closed_at"
     t.datetime "created_at", null: false

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -561,7 +561,7 @@ describe Task do
   end
 
   describe ".create_and_auto_assign_child_task" do
-    subject { Task.create!(assigned_to: org, appeal: FactoryBot.create(:appeal), type: Task.name) }
+    subject { create(:task, assigned_to: org, appeal: create(:appeal)) }
 
     context "when the task is assigned to an organization that automatically assigns tasks to its members" do
       class AutoAssignOrg < Organization
@@ -572,8 +572,8 @@ describe Task do
         end
       end
 
-      let(:user) { FactoryBot.create(:user) }
-      let(:org) { AutoAssignOrg.create(assignee: user) }
+      let(:user) { create(:user) }
+      let(:org) { AutoAssignOrg.create!(url: 'autoassign', name: 'AutoAssign', assignee: user) }
 
       it "should create a child task when a task assigned to the organization is created" do
         expect(subject.children.length).to eq(1)


### PR DESCRIPTION
connects #10937 

`assigned_to_type` was already not null.

*Schema Changes Only*

* [x] #appeals-schema notified with summary and link to this PR
