### PR TITLE
Add exception class to rescue

### DIFF
--- a/app/models/establish_claim.rb
+++ b/app/models/establish_claim.rb
@@ -164,7 +164,7 @@ class EstablishClaim < Dispatch::Task
 
     begin
       appeal.decisions.each(&:fetch_and_cache_document_from_vbms)
-    rescue VBMS::ClientError, VBMSError => error
+    rescue VBMS::ClientError, VBMSError, Caseflow::Error::VBMS => error
       Rails.logger.info "Failed EstablishClaim (id = #{id}), Error: #{error}"
       return :failed
     end


### PR DESCRIPTION
```
[1] pry(main)> e = VBMSError::DocumentTooBig.new('foo')
=> #<VBMSError::DocumentTooBig: foo>
[2] pry(main)> e.is_a?(VBMSError)
=> false
[3] pry(main)> e.is_a?(VBMS::ClientError)
=> false
[4] pry(main)> e.is_a?(Caseflow::Error::VBMS)
=> true
```

connects #10938 