### PR TITLE
Store POA at time of dispatch in Appeals table

### DIFF
--- a/app/workflows/ama_appeal_dispatch.rb
+++ b/app/workflows/ama_appeal_dispatch.rb
@@ -14,6 +14,7 @@ class AmaAppealDispatch
     complete_dispatch_task!
     complete_dispatch_root_task!
     close_request_issues_as_decided!
+    store_poa_participant_id
   rescue ActiveRecord::RecordInvalid => error
     if error.message.match?(/^Validation failed:/)
       raise(Caseflow::Error::OutcodeValidationFailure, message: error.message)
@@ -64,5 +65,9 @@ class AmaAppealDispatch
 
   def close_request_issues_as_decided!
     appeal.request_issues.each(&:close_decided_issue!)
+  end
+
+  def store_poa_participant_id
+    appeal.update!(poa_participant_id: appeal.power_of_attorney&.participant_id)
   end
 end

--- a/db/migrate/20190531152758_add_poa_participant_id_to_appeal.rb
+++ b/db/migrate/20190531152758_add_poa_participant_id_to_appeal.rb
@@ -1,0 +1,12 @@
+class AddPoaParticipantIdToAppeal < ActiveRecord::Migration[5.1]
+  def change
+    add_column(
+      :appeals,
+      :poa_participant_id,
+      :string,
+      comment: "Used to identify the power of attorney (POA) at the time the " \
+               "appeal was dispatched to BVA. Sometimes the POA changes in BGS " \
+               "after the fact, and BGS only returns the current representative."
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190529143622) do
+ActiveRecord::Schema.define(version: 20190531152758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 20190529143622) do
     t.datetime "establishment_processed_at", comment: "Timestamp for when the establishment has succeeded in processing."
     t.datetime "establishment_submitted_at", comment: "Timestamp for when the the intake was submitted for asynchronous processing."
     t.boolean "legacy_opt_in_approved", comment: "Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review."
+    t.string "poa_participant_id", comment: "Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
     t.date "receipt_date", comment: "Receipt date of the appeal form. Used to determine which issues are within the timeliness window to be appealed. Only issues decided prior to the receipt date will show up as contestable issues."
     t.date "target_decision_date", comment: "If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false, comment: "The universally unique identifier for the appeal, which can be used to navigate to appeals/appeal_uuid. This allows a single ID to determine an appeal whether it is a legacy appeal or an AMA appeal."

--- a/spec/workflows/ama_appeal_dispatch_spec.rb
+++ b/spec/workflows/ama_appeal_dispatch_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe AmaAppealDispatch do
+  describe "#call" do
+    it "stores current POA participant ID in the Appeals table" do
+      user = create(:user)
+      OrganizationsUser.add_user_to_organization(user, BvaDispatch.singleton)
+      appeal = create(:appeal, :advanced_on_docket_due_to_age)
+      root_task = create(:root_task, appeal: appeal)
+      BvaDispatchTask.create_from_root_task(root_task)
+      claimant = appeal.claimants.first
+      poa_participant_id = "1234567"
+
+      bgs_poa = instance_double(BgsPowerOfAttorney)
+      allow(BgsPowerOfAttorney).to receive(:new)
+        .with(claimant_participant_id: claimant.participant_id).and_return(bgs_poa)
+      allow(bgs_poa).to receive(:participant_id).and_return(poa_participant_id)
+
+      params = {
+        appeal_id: appeal.id,
+        appeal_type: "Appeal",
+        citation_number: "A18123456",
+        decision_date: Time.zone.now,
+        redacted_document_location: "C://Windows/User/BLOBLAW/Documents/Decision.docx"
+      }
+
+      AmaAppealDispatch.new(appeal: appeal, params: params, user: user).call
+
+      expect(appeal.reload.poa_participant_id).to eq poa_participant_id
+    end
+  end
+end


### PR DESCRIPTION
**Why**: To make it easier for the IDT folks to track cases based on
who was the POA when the appeal was decided. The problem is that the
representatives change after the fact, and BGS only returns the current
representative.

**How**: Add a new `poa_participant_id` column to the Appeals table and
add a new method to `AmaAppealDispatch` that stores the POA participant
ID.

Resolves #10480

*Schema Changes Only*

* [X] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [X] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
