### PR TITLE
Move ACD scopes from Appeal to Docket

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -29,60 +29,11 @@ class Appeal < DecisionReview
     validates_associated :claimants
   end
 
-  scope :join_aod_motions, lambda {
-    joins(claimants: :person)
-      .joins("LEFT OUTER JOIN advance_on_docket_motions on advance_on_docket_motions.person_id = people.id")
-  }
-
-  scope :all_priority, lambda {
-    join_aod_motions
-      .where("advance_on_docket_motions.created_at > appeals.established_at")
-      .where("advance_on_docket_motions.granted = ?", true)
-      .or(join_aod_motions
-        .where("people.date_of_birth <= ?", 75.years.ago))
-      .group("appeals.id")
-  }
-
-  # rubocop:disable Metrics/LineLength
-  scope :all_nonpriority, lambda {
-    join_aod_motions
-      .where("people.date_of_birth > ?", 75.years.ago)
-      .group("appeals.id")
-      .having("count(case when advance_on_docket_motions.granted and advance_on_docket_motions.created_at > appeals.established_at then 1 end) = ?", 0)
-  }
-  # rubocop:enable Metrics/LineLength
-
-  scope :ready_for_distribution, lambda {
-    joins(:tasks)
-      .group("appeals.id")
-      .having("count(case when tasks.type = ? and tasks.status = ? then 1 end) >= ?",
-              DistributionTask.name, Constants.TASK_STATUSES.assigned, 1)
-      .having("count(case when tasks.type in (?) and tasks.status not in (?) then 1 end) = ?",
-              MailTask.blocking_subclasses, Task.closed_statuses, 0)
-  }
-
-  scope :non_ihp, lambda {
-    joins(:tasks)
-      .group("appeals.id")
-      .having("count(case when tasks.type = ? then 1 end) = ?",
-              InformalHearingPresentationTask.name, 0)
-  }
-
   scope :active, lambda {
     joins(:tasks)
       .group("appeals.id")
       .having("count(case when tasks.type = ? and tasks.status not in (?) then 1 end) >= ?",
               RootTask.name, Task.closed_statuses, 1)
-  }
-
-  scope :ordered_by_distribution_ready_date, lambda {
-    joins(:tasks)
-      .group("appeals.id")
-      .order("max(case when tasks.type = 'DistributionTask' then tasks.assigned_at end)")
-  }
-
-  scope :priority_ordered_by_distribution_ready_date, lambda {
-    from(all_priority).ordered_by_distribution_ready_date
   }
 
   UUID_REGEX = /^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/.freeze
@@ -107,14 +58,6 @@ class Appeal < DecisionReview
     else
       LegacyAppeal.find_or_create_by_vacols_id(id)
     end
-  end
-
-  def self.nonpriority_decisions_per_year
-    appeal_ids = all_nonpriority
-      .joins(:decision_documents)
-      .where("decision_date > ?", 1.year.ago)
-      .select("appeals.id")
-    where(id: appeal_ids).count
   end
 
   def ui_hash

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -10,23 +10,22 @@ class Docket
   def appeals(priority: nil, ready: nil)
     fail "'ready for distribution' value cannot be false" if ready == false
 
-    scope = docket_appeals
+    scope = docket_appeals.active
     scope = scope.ready_for_distribution if ready == true
 
     if priority == true
-      scope = scope.all_priority
+      scope = scope.priority
       return scope.ordered_by_distribution_ready_date
     end
 
-    scope = scope.all_nonpriority if priority == false
+    scope = scope.nonpriority if priority == false
     scope.order("receipt_date")
   end
 
   def count(priority: nil, ready: nil)
     # The underlying scopes here all use `group_by` statements,
     # so we count using a subquery finding the relevant ids.
-    appeal_ids = appeals(priority: priority, ready: ready).select("appeals.id")
-    Appeal.where(id: appeal_ids).count
+    appeals(priority: priority, ready: ready).ids.size
   end
 
   def weight
@@ -55,10 +54,17 @@ class Docket
   end
   # rubocop:enable Lint/UnusedMethodArgument
 
+  def self.nonpriority_decisions_per_year
+    Appeal.extending(Scopes).nonpriority
+      .joins(:decision_documents)
+      .where("decision_date > ?", 1.year.ago)
+      .pluck(:id).size
+  end
+
   private
 
   def docket_appeals
-    Appeal.active.where(docket_type: docket_type)
+    Appeal.where(docket_type: docket_type).extending(Scopes)
   end
 
   def assign_judge_tasks_for_appeals(appeals, judge)
@@ -77,6 +83,53 @@ class Docket
       Rails.logger.info("Closing distribution task with task id #{task.id} to #{task.assigned_to.css_id}")
 
       task
+    end
+  end
+
+  module Scopes
+    def priority
+      join_aod_motions
+        .where("advance_on_docket_motions.created_at > appeals.established_at")
+        .where("advance_on_docket_motions.granted = ?", true)
+        .or(join_aod_motions
+          .where("people.date_of_birth <= ?", 75.years.ago))
+        .group("appeals.id")
+    end
+
+    # rubocop:disable Metrics/LineLength
+    def nonpriority
+      join_aod_motions
+        .where("people.date_of_birth > ?", 75.years.ago)
+        .group("appeals.id")
+        .having("count(case when advance_on_docket_motions.granted and advance_on_docket_motions.created_at > appeals.established_at then 1 end) = ?", 0)
+    end
+    # rubocop:enable Metrics/LineLength
+
+    def join_aod_motions
+      joins(claimants: :person)
+        .joins("LEFT OUTER JOIN advance_on_docket_motions on advance_on_docket_motions.person_id = people.id")
+    end
+
+    def ready_for_distribution
+      joins(:tasks)
+        .group("appeals.id")
+        .having("count(case when tasks.type = ? and tasks.status = ? then 1 end) >= ?",
+                DistributionTask.name, Constants.TASK_STATUSES.assigned, 1)
+        .having("count(case when tasks.type in (?) and tasks.status not in (?) then 1 end) = ?",
+                MailTask.blocking_subclasses, Task.closed_statuses, 0)
+    end
+
+    def ordered_by_distribution_ready_date
+      joins(:tasks)
+        .group("appeals.id")
+        .order("max(case when tasks.type = 'DistributionTask' then tasks.assigned_at end)")
+    end
+
+    def non_ihp
+      joins(:tasks)
+        .group("appeals.id")
+        .having("count(case when tasks.type = ? then 1 end) = ?",
+                InformalHearingPresentationTask.name, 0)
     end
   end
 end

--- a/app/models/docket_coordinator.rb
+++ b/app/models/docket_coordinator.rb
@@ -108,6 +108,6 @@ class DocketCoordinator
   end
 
   def nonpriority_decisions_per_year
-    @nonpriority_decisions_per_year ||= [LegacyAppeal, Appeal].map(&:nonpriority_decisions_per_year).reduce(0, :+)
+    @nonpriority_decisions_per_year ||= [LegacyAppeal, Docket].map(&:nonpriority_decisions_per_year).reduce(0, :+)
   end
 end

--- a/app/models/dockets/direct_review_docket.rb
+++ b/app/models/dockets/direct_review_docket.rb
@@ -48,13 +48,13 @@ class DirectReviewDocket < Docket
   private
 
   def all_nonpriority
-    Appeal.all_nonpriority.where(docket_type: docket_type)
+    docket_appeals.nonpriority
   end
 
   def nonpriority_nonihp_ready_appeals
     docket_appeals
       .ready_for_distribution
-      .all_nonpriority
+      .nonpriority
       .non_ihp
       .order("receipt_date")
   end

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -234,7 +234,7 @@ RSpec.feature "Judge assignment to attorney and judge" do
         .to receive(:nonpriority_receipts_per_year)
         .and_return(100)
 
-      allow(Appeal)
+      allow(Docket)
         .to receive(:nonpriority_decisions_per_year)
         .and_return(1000)
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -12,34 +12,6 @@ describe Appeal do
     Timecop.freeze(Time.utc(2019, 1, 1, 12, 0, 0))
   end
 
-  context "priority and non-priority appeals" do
-    let!(:aod_age_appeal) { create(:appeal, :advanced_on_docket_due_to_age) }
-    let!(:aod_motion_appeal) { create(:appeal, :advanced_on_docket_due_to_motion) }
-    let!(:denied_aod_motion_appeal) { create(:appeal, :denied_advance_on_docket) }
-    let!(:inapplicable_aod_motion_appeal) { create(:appeal, :inapplicable_aod_motion) }
-
-    context "#all_priority" do
-      subject { Appeal.all_priority }
-      it "returns aod appeals due to age and motion" do
-        expect(subject).to include aod_age_appeal
-        expect(subject).to include aod_motion_appeal
-        expect(subject).to_not include appeal
-        expect(subject).to_not include denied_aod_motion_appeal
-        expect(subject).to_not include inapplicable_aod_motion_appeal
-      end
-    end
-
-    context "#all_nonpriority" do
-      subject { Appeal.all_nonpriority }
-      it "returns non aod appeals" do
-        expect(subject).to include appeal
-        expect(subject).to_not include aod_motion_appeal
-        expect(subject).to include denied_aod_motion_appeal
-        expect(subject).to include inapplicable_aod_motion_appeal
-      end
-    end
-  end
-
   context "active appeals" do
     let!(:active_appeal) { create(:appeal, :with_tasks) }
     let!(:inactive_appeal) { create(:appeal, :outcoded) }
@@ -48,83 +20,6 @@ describe Appeal do
     it "returns only active appeals" do
       expect(subject).to include active_appeal
       expect(subject).to_not include inactive_appeal
-    end
-  end
-
-  context "ready appeals" do
-    let!(:direct_review_appeal) { create(:appeal, docket_type: "direct_review") }
-    let!(:hearing_appeal) { create(:appeal, docket_type: "hearing") }
-    let!(:evidence_submission_appeal) { create(:appeal, docket_type: "evidence_submission") }
-
-    subject { Appeal.ready_for_distribution }
-
-    it "returns appeals" do
-      [direct_review_appeal, evidence_submission_appeal, hearing_appeal].each do |appeal|
-        InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
-      end
-
-      expect(subject).to include direct_review_appeal
-      expect(subject).to_not include evidence_submission_appeal
-      expect(subject).to_not include hearing_appeal
-    end
-
-    context "if mail tasks exist" do
-      let(:blocking_mail_task_class) { CongressionalInterestMailTask }
-      let(:nonblocking_mail_task_class) { AodMotionMailTask }
-      let(:user) { FactoryBot.create(:user) }
-
-      before do
-        OrganizationsUser.add_user_to_organization(user, MailTeam.singleton)
-      end
-
-      let!(:blocked_appeal) do
-        appeal = create(:appeal, :with_tasks, docket_type: "direct_review")
-        blocking_mail_task_class.create_from_params({
-                                                      appeal: appeal,
-                                                      parent_id: appeal.root_task.id
-                                                    }, user)
-        appeal
-      end
-      let!(:nonblocked_appeal) do
-        appeal = create(:appeal, :with_tasks, docket_type: "direct_review")
-        nonblocking_mail_task_class.create_from_params({
-                                                         appeal: appeal,
-                                                         parent_id: appeal.root_task.id
-                                                       }, user)
-        appeal
-      end
-      let!(:nonblocked_appeal2) do
-        appeal = create(:appeal, :with_tasks, docket_type: "direct_review")
-        blocking_mail_task_class.create_from_params({
-                                                      appeal: appeal,
-                                                      parent_id: appeal.root_task.id
-                                                    }, user)
-        MailTask.find_by(appeal: appeal).update!(status: "completed")
-        appeal
-      end
-
-      it "does not return appeals with open blocking mail tasks" do
-        expect(subject).to_not include blocked_appeal
-      end
-      it "returns appeals with open nonblocking mail tasks" do
-        expect(subject).to include nonblocked_appeal
-      end
-      it "does not return appeals with completed blocking mail tasks " do
-        expect(subject).to include nonblocked_appeal2
-      end
-    end
-  end
-
-  context "ready appeals sorted by date" do
-    it "returns appeals with distribution tasks ordered by when they became ready for distribution" do
-      first_appeal = create(:appeal, :with_tasks)
-      first_appeal.tasks.each { |task| task.update!(assigned_at: 2.days.ago, type: "DistributionTask") }
-      second_appeal = create(:appeal, :with_tasks)
-      second_appeal.tasks.each { |task| task.update!(assigned_at: 5.days.ago, type: "DistributionTask") }
-
-      sorted_appeals = Appeal.ordered_by_distribution_ready_date
-
-      expect(sorted_appeals[0]).to eq second_appeal
     end
   end
 
@@ -920,31 +815,6 @@ describe Appeal do
         it "is at bva" do
           expect(subject).to eq("bva")
         end
-      end
-    end
-  end
-
-  context "#nonpriority_decisions_per_year" do
-    let!(:newer_decisions) do
-      (0...18).map do |num|
-        doc = create(:decision_document, decision_date: (num * 20).days.ago)
-        doc.appeal.update(docket_type: "direct_review")
-        doc.appeal
-      end
-    end
-    let!(:older_decisions) do
-      (0...2).map do |num|
-        doc = create(:decision_document, decision_date: (366 + (num * 20)).days.ago)
-        doc.appeal.update(docket_type: "direct_review")
-        doc.appeal
-      end
-    end
-
-    context "non-priority decision list" do
-      subject { Appeal.nonpriority_decisions_per_year }
-
-      it "returns decisions from the last year" do
-        expect(subject).to eq(18)
       end
     end
   end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -102,7 +102,7 @@ describe Distribution do
         .to receive(:nonpriority_receipts_per_year)
         .and_return(100)
 
-      allow(Appeal)
+      allow(Docket)
         .to receive(:nonpriority_decisions_per_year)
         .and_return(1000)
 

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -16,7 +16,7 @@ describe DocketCoordinator do
       .to receive(:nonpriority_receipts_per_year)
       .and_return(nonpriority_receipts_per_year)
 
-    allow(Appeal)
+    allow(Docket)
       .to receive(:nonpriority_decisions_per_year)
       .and_return(nonpriority_decisions_per_year)
   end

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+require_relative "../../app/models/tasks/mail_task"
+
 describe Docket do
   context "docket" do
     # nonpriority
@@ -16,6 +19,9 @@ describe Docket do
     let!(:aod_motion_appeal) do
       create(:appeal, :advanced_on_docket_due_to_motion, :with_tasks, docket_type: "direct_review")
     end
+
+    let!(:hearing_appeal) { create(:appeal, :with_tasks, docket_type: "hearing") }
+    let!(:evidence_submission_appeal) { create(:appeal, :with_tasks, docket_type: "evidence_submission") }
 
     context "appeals" do
       context "when no options given" do
@@ -48,6 +54,96 @@ describe Docket do
           expect(subject).to include inapplicable_aod_motion_appeal
           expect(subject).to_not include aod_age_appeal
           expect(subject).to_not include aod_motion_appeal
+        end
+      end
+
+      context "when only looking for appeals that are ready for distribution" do
+        subject { DirectReviewDocket.new.appeals(ready: true) }
+
+        it "only returns active appeals that meet both of these conditions:
+            it has at least one Distribution Task with status assigned
+            AND
+            it doesn't have any blocking Mail Tasks." do
+
+          expected_appeals = [
+            appeal,
+            denied_aod_motion_appeal,
+            inapplicable_aod_motion_appeal,
+            aod_age_appeal,
+            aod_motion_appeal
+          ]
+          expect(subject).to match_array(expected_appeals)
+        end
+      end
+
+      context "when looking for priority appeals" do
+        it "returns appeals with distribution tasks ordered by when they became ready for distribution" do
+          aod_age_appeal.tasks.find { |task| task.is_a?(DistributionTask) }.update!(assigned_at: 2.days.ago)
+          aod_motion_appeal.tasks.find { |task| task.is_a?(DistributionTask) }.update!(assigned_at: 5.days.ago)
+
+          sorted_appeals = DirectReviewDocket.new.appeals(priority: true, ready: true)
+
+          expect(sorted_appeals[0]).to eq aod_motion_appeal
+        end
+      end
+
+      context "appeal has mail tasks" do
+        subject { DirectReviewDocket.new.appeals(ready: true) }
+
+        let(:user) { FactoryBot.create(:user) }
+
+        before do
+          OrganizationsUser.add_user_to_organization(user, MailTeam.singleton)
+        end
+
+        context "nonblocking mail tasks" do
+          it "includes those appeals" do
+            nonblocking_appeal = create(:appeal, :with_tasks, docket_type: "direct_review")
+            AodMotionMailTask.create_from_params({
+                                                   appeal: nonblocking_appeal,
+                                                   parent_id: nonblocking_appeal.root_task.id
+                                                 }, user)
+
+            expect(subject).to include nonblocking_appeal
+          end
+        end
+
+        context "blocking mail tasks with status not completed or cancelled" do
+          it "excludes those appeals" do
+            blocking_appeal = create(:appeal, :with_tasks, docket_type: "direct_review")
+            CongressionalInterestMailTask.create_from_params({
+                                                               appeal: blocking_appeal,
+                                                               parent_id: blocking_appeal.root_task.id
+                                                             }, user)
+
+            expect(subject).to_not include blocking_appeal
+          end
+        end
+
+        context "blocking mail tasks with status completed or cancelled" do
+          it "includes those appeals" do
+            with_blocking_but_closed_tasks = create(:appeal, :with_tasks, docket_type: "direct_review")
+            FoiaRequestMailTask.create_from_params({
+                                                     appeal: with_blocking_but_closed_tasks,
+                                                     parent_id: with_blocking_but_closed_tasks.root_task.id
+                                                   }, user)
+            FoiaRequestMailTask.find_by(appeal: with_blocking_but_closed_tasks).update!(status: "completed")
+
+            expect(subject).to include with_blocking_but_closed_tasks
+          end
+        end
+
+        context "nonblocking mail tasks but closed Root Task" do
+          it "excludes those appeals" do
+            inactive_appeal = create(:appeal, :with_tasks, docket_type: "direct_review")
+            AodMotionMailTask.create_from_params({
+                                                   appeal: inactive_appeal,
+                                                   parent_id: inactive_appeal.root_task.id
+                                                 }, user)
+            inactive_appeal.root_task.update!(status: "completed")
+
+            expect(subject).to_not include inactive_appeal
+          end
         end
       end
     end
@@ -92,6 +188,39 @@ describe Docket do
           expect(tasks.first.class).to eq(DistributedCase)
           expect(distribution.distributed_cases.length).to eq(2)
           expect(judge_user.reload.tasks.map(&:appeal)).to include(aod_age_appeal)
+        end
+      end
+    end
+
+    describe ".nonpriority_decisions_per_year" do
+      let!(:newer_non_priority_decisions) do
+        2.times do
+          doc = create(:decision_document, decision_date: 20.days.ago)
+          doc.appeal.update(docket_type: "direct_review")
+          doc.appeal
+        end
+      end
+      let!(:older_non_priority_decision) do
+        doc = create(:decision_document, decision_date: 380.days.ago)
+        doc.appeal.update(docket_type: "direct_review")
+        doc.appeal
+      end
+      let!(:newer_priority_decision) do
+        appeal = create(:appeal, :advanced_on_docket_due_to_age, :with_tasks, docket_type: "direct_review")
+        create(:decision_document, decision_date: 20.days.ago, appeal: appeal)
+        appeal
+      end
+      let!(:older_priority_decision) do
+        appeal = create(:appeal, :advanced_on_docket_due_to_age, :with_tasks, docket_type: "direct_review")
+        create(:decision_document, decision_date: 380.days.ago, appeal: appeal)
+        appeal
+      end
+
+      context "non-priority decision list" do
+        subject { Docket.nonpriority_decisions_per_year }
+
+        it "returns nonpriority decisions from the last year" do
+          expect(subject).to eq(2)
         end
       end
     end

--- a/spec/models/dockets/hearing_request_docket_spec.rb
+++ b/spec/models/dockets/hearing_request_docket_spec.rb
@@ -205,6 +205,28 @@ describe HearingRequestDocket do
     end
   end
 
+  describe "#count" do
+    context "priority and readiness for distribution not specified" do
+      it "returns all hearing docket appeals" do
+        matching_all_conditions_except_priority_and_ready_for_distribution
+        non_priority_with_no_held_hearings
+        create_priority_distributable_hearing_appeal_not_tied_to_any_judge
+
+        expect(HearingRequestDocket.new.count).to eq 3
+      end
+    end
+
+    context "priority: true and ready: true" do
+      it "only returns hearing docket appeals that are priority and ready for distribution" do
+        matching_all_conditions_except_priority_and_ready_for_distribution
+        non_priority_with_no_held_hearings
+        create_priority_distributable_hearing_appeal_not_tied_to_any_judge
+
+        expect(HearingRequestDocket.new.count(priority: true, ready: true)).to eq 1
+      end
+    end
+  end
+
   private
 
   def create_appeals_that_should_not_be_returned_by_query


### PR DESCRIPTION
**Why**: These scopes only apply to automatic case distribution, and
some aren't used alone. For example, we would never call
`Appeal.ready_for_distribution` in the app because we check appeals
for each docket separately. `ready_for_distribution` is an additonal
scope applied to a base query that checks for active appeals with
a particular docket type. Therefore, it doesn't make sense to place
these scopes in the Appeal class and test them individually since
they aren't used that way.

For now, the logical place to put these scopes is in the Docket class.
Once we continue refactoring the ACD code, we might find a better
place.