### PR TITLE
Temporary fix for db/seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -91,6 +91,7 @@ class SeedDB
       decision_review: appeal
     )
 
+    FeatureToggle.enable!(:ama_acd_tasks)
     InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
 
     # Completing the evidence submission task will mark the appeal ready for distribution
@@ -130,27 +131,27 @@ class SeedDB
   end
 
   def create_no_show_hearings_tasks
-    5.times do 
+    5.times do
       appeal = FactoryBot.create(
-        :appeal, 
-        :hearing_docket, 
-        closest_regional_office: ["RO17", "RO19", "RO31"].sample
+        :appeal,
+        :hearing_docket,
+        closest_regional_office: %w[RO17 RO19 RO31].sample
       )
       root_task = FactoryBot.create(:root_task, appeal: appeal)
       distribution_task = FactoryBot.create(
-        :distribution_task, 
-        appeal: appeal, 
+        :distribution_task,
+        appeal: appeal,
         parent: root_task
       )
       parent_hearing_task = FactoryBot.create(
-        :hearing_task, 
-        parent: distribution_task, 
+        :hearing_task,
+        parent: distribution_task,
         appeal: appeal
       )
       FactoryBot.create(
-        :schedule_hearing_task, 
-        :completed, 
-        parent: parent_hearing_task, 
+        :schedule_hearing_task,
+        :completed,
+        parent: parent_hearing_task,
         appeal: appeal
       )
       disposition_task = FactoryBot.create(:disposition_task, parent: parent_hearing_task, appeal: appeal)
@@ -536,18 +537,14 @@ class SeedDB
 
     vet.save
 
-    appeal = FactoryBot.create(
+    FeatureToggle.enable!(:ama_acd_tasks)
+    FactoryBot.create(
       :appeal,
       :with_tasks,
       number_of_claimants: 1,
       closest_regional_office: ro_key,
       veteran_file_number: vet.file_number,
       docket_type: "hearing"
-    )
-
-    ScheduleHearingTask.create!(
-      appeal: appeal,
-      parent: HearingTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
     )
   end
 
@@ -890,9 +887,7 @@ class SeedDB
       first_name: Faker::Name.first_name,
       last_name: Faker::Name.last_name
     )
-     # participant_id: Faker::Number.number(9).to_s,
 
-    description = "Service connection for pain disorder is granted with an evaluation of 70\% effective May 1 2011"
     notes = "Pain disorder with 100\% evaluation per examination"
 
     appeal = FactoryBot.create(
@@ -947,8 +942,7 @@ class SeedDB
     atty_task.update!(status: Constants.TASK_STATUSES.completed)
     judge_task.update!(status: Constants.TASK_STATUSES.completed)
 
-    bva_dispatch_org_task = BvaDispatchTask.create_from_root_task(root_task)
-
+    BvaDispatchTask.create_from_root_task(root_task)
   end
 
   def create_tasks
@@ -1101,7 +1095,6 @@ class SeedDB
     description = "Service connection for pain disorder is granted with an evaluation of 70\% effective May 1 2011"
     notes = "Pain disorder with 100\% evaluation per examination"
 
-    FeatureToggle.enable!(:ama_acd_tasks)
     FeatureToggle.enable!(:ama_auto_case_distribution)
 
     @ama_appeals << FactoryBot.create(


### PR DESCRIPTION
Allows us to run `bundle exec rake db:seed` in our local development environments again. This will be removed when we get rid of the `ama_acd_tasks` feature flag.