### PR TITLE
Organization clean_url means voc_rehab -> voc-rehab

### DIFF
--- a/app/models/concerns/has_business_line.rb
+++ b/app/models/concerns/has_business_line.rb
@@ -5,9 +5,7 @@ module HasBusinessLine
 
   def business_line
     business_line_name = Constants::BENEFIT_TYPES[benefit_type]
-    @business_line ||= BusinessLine.find_or_create_by(name: business_line_name) do |org|
-      org.url = benefit_type
-    end
+    @business_line ||= BusinessLine.find_or_create_by(name: business_line_name) { |org| org.url = benefit_type }
   end
 
   def processed_in_vbms?

--- a/app/models/concerns/has_business_line.rb
+++ b/app/models/concerns/has_business_line.rb
@@ -5,7 +5,9 @@ module HasBusinessLine
 
   def business_line
     business_line_name = Constants::BENEFIT_TYPES[benefit_type]
-    @business_line ||= BusinessLine.find_or_create_by(url: benefit_type, name: business_line_name)
+    @business_line ||= BusinessLine.find_or_create_by(name: business_line_name) do |org|
+      org.url = benefit_type
+    end
   end
 
   def processed_in_vbms?


### PR DESCRIPTION
**Why**

E.g. previously we did a `find` using the `url` "voc_rehab". Finding zero results, we tried to create it using "voc-rehab" because the `clean_url` before_save hook in Organization model altered the string. That means we would try to insert a duplicate organization.

This change assumes every BusinessLine type Organization has a unique name and that is sufficient for the initial `find`.