### PR TITLE
Async jobs report no pagination

### DIFF
--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -26,7 +26,7 @@ class PrepareEstablishClaimTasksJob < ApplicationJob
   end
 
   def unfinished_jobs_report
-    jobs = AsyncableJobs.new.jobs.select(&:expired_without_processing?)
+    jobs = AsyncableJobs.new(page_size: 1000).jobs.select(&:expired_without_processing?)
     job_reporter = AsyncableJobsReporter.new(jobs: jobs)
     msg = "Expired Jobs: #{jobs.count} expired unfinished asyncable jobs exist in the queue.\n"
     msg += job_reporter.summarize

--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -26,7 +26,7 @@ class PrepareEstablishClaimTasksJob < ApplicationJob
   end
 
   def unfinished_jobs_report
-    jobs = AsyncableJobs.new(page_size: 1000).jobs.select(&:expired_without_processing?)
+    jobs = AsyncableJobs.new(page_size: -1).jobs.select(&:expired_without_processing?)
     job_reporter = AsyncableJobsReporter.new(jobs: jobs)
     msg = "Expired Jobs: #{jobs.count} expired unfinished asyncable jobs exist in the queue.\n"
     msg += job_reporter.summarize

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -31,7 +31,8 @@ class AsyncableJobs
     jobs = expired_jobs.flatten.sort_by(&:sort_by_last_submitted_at)
 
     return paginated_jobs(jobs) if page_size > 0
-    return jobs
+
+    jobs
   end
 
   def paginated_jobs(jobs)

--- a/app/services/asyncable_jobs.rb
+++ b/app/services/asyncable_jobs.rb
@@ -29,6 +29,12 @@ class AsyncableJobs
       expired_jobs << klass.potentially_stuck
     end
     jobs = expired_jobs.flatten.sort_by(&:sort_by_last_submitted_at)
+
+    return paginated_jobs(jobs) if page_size > 0
+    return jobs
+  end
+
+  def paginated_jobs(jobs)
     @total_jobs = jobs.length
     @total_pages = (total_jobs / page_size).to_i
     @total_pages += 1 if total_jobs % page_size

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -90,12 +90,24 @@ describe AsyncableJobs do
   end
 
   describe "#total_jobs" do
-    subject { described_class.new(page: 2, page_size: 4) }
+    context "page_size > 0" do
+      subject { described_class.new(page: 2, page_size: 4) }
 
-    it "paginates" do
-      expect(subject.jobs.length).to eq(2)
-      expect(subject.total_jobs).to eq(6)
-      expect(subject.total_pages).to eq(2)
+      it "paginates" do
+        expect(subject.jobs.length).to eq(2)
+        expect(subject.total_jobs).to eq(6)
+        expect(subject.total_pages).to eq(2)
+      end
+    end
+
+    context "page_size < 0" do
+      subject { described_class.new(page_size: -1) }
+
+      it "does not paginate" do
+        expect(subject.jobs.length).to eq(6)
+        expect(subject.total_jobs).to be_nil
+        expect(subject.total_pages).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
The nightly job was paginating by default, which meant we only ever saw max of 50 stuck async jobs.

Passing a value less than zero (e.g. "-1") will turn off pagination.