### PR TITLE
Update auto case distribution specs

### DIFF
--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -238,18 +238,8 @@ RSpec.feature "Judge assignment to attorney and judge" do
         .to receive(:nonpriority_decisions_per_year)
         .and_return(1000)
 
-      allow_any_instance_of(HearingRequestDocket)
-        .to receive(:age_of_n_oldest_priority_appeals)
-        .and_return([])
-
-      allow_any_instance_of(HearingRequestDocket)
-        .to receive(:distribute_appeals)
-        .and_return([])
-
       allow_any_instance_of(LegacyDocket).to receive(:weight).and_return(101.4)
       allow_any_instance_of(DirectReviewDocket).to receive(:weight).and_return(10)
-      allow_any_instance_of(EvidenceSubmissionDocket).to receive(:weight).and_return(95)
-      allow_any_instance_of(HearingRequestDocket).to receive(:weight).and_return(7)
     end
 
     it "displays an error if the distribution request is invalid" do

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -40,9 +40,9 @@ describe Distribution do
   context "#distribute!" do
     subject { Distribution.create(judge: judge) }
 
-    let(:legacy_priority_count) { 15 }
+    let(:legacy_priority_count) { 14 }
 
-    let!(:priority_cases) do
+    let!(:legacy_priority_cases) do
       (1..legacy_priority_count).map do |i|
         create(:case,
                :aod,
@@ -55,7 +55,7 @@ describe Distribution do
       end
     end
 
-    let!(:nonpriority_cases) do
+    let!(:legacy_nonpriority_cases) do
       (15..100).map do |i|
         create(:case,
                bfd19: 1.year.ago,
@@ -68,7 +68,7 @@ describe Distribution do
     end
 
     let!(:same_judge_priority_hearings) do
-      priority_cases[0..1].map do |appeal|
+      legacy_priority_cases[0..1].map do |appeal|
         create(:case_hearing,
                :disposition_held,
                folder_nr: appeal.bfkey,
@@ -78,7 +78,7 @@ describe Distribution do
     end
 
     let!(:same_judge_nonpriority_hearings) do
-      nonpriority_cases[29..33].map do |appeal|
+      legacy_nonpriority_cases[29..33].map do |appeal|
         create(:case_hearing,
                :disposition_held,
                folder_nr: appeal.bfkey,
@@ -88,7 +88,7 @@ describe Distribution do
     end
 
     let!(:other_judge_hearings) do
-      nonpriority_cases[2..27].map do |appeal|
+      legacy_nonpriority_cases[2..27].map do |appeal|
         create(:case_hearing,
                :disposition_held,
                folder_nr: appeal.bfkey,
@@ -135,8 +135,6 @@ describe Distribution do
       appeal
     end
 
-    let(:legacy_priority_count) { 14 }
-
     let!(:other_direct_review_cases) do
       (0...20).map do
         create(:appeal,
@@ -171,7 +169,7 @@ describe Distribution do
       expect(subject.completed_at).to eq(Time.zone.now)
       expect(subject.statistics["batch_size"]).to eq(15)
       expect(subject.statistics["total_batch_size"]).to eq(45)
-      expect(subject.statistics["priority_count"]).to eq(15)
+      expect(subject.statistics["priority_count"]).to eq(legacy_priority_count + 1)
       expect(subject.statistics["legacy_proportion"]).to eq(0.4)
       expect(subject.statistics["direct_review_proportion"]).to eq(0.2)
       expect(subject.statistics["evidence_submission_proportion"]).to eq(0.2)
@@ -183,6 +181,10 @@ describe Distribution do
       expect(subject.distributed_cases.first.docket).to eq("legacy")
       expect(subject.distributed_cases.first.ready_at).to eq(2.days.ago.beginning_of_day)
       expect(subject.distributed_cases.where(priority: true).count).to eq(5)
+      expect(subject.distributed_cases.where(genpop: true).count).to eq(5)
+      expect(subject.distributed_cases.where(priority: true, genpop: false).count).to eq(2)
+      expect(subject.distributed_cases.where(priority: false, genpop_query: "not_genpop").count).to eq(0)
+      expect(subject.distributed_cases.where(priority: false, genpop_query: "any").map(&:docket_index).max).to eq(30)
       expect(subject.distributed_cases.where(priority: true, docket: "direct_review").count).to eq(1)
       expect(subject.distributed_cases.where(docket: "legacy").count).to be >= 8
       expect(subject.distributed_cases.where(docket: "direct_review").count).to be >= 3


### PR DESCRIPTION
**Why**: A recent change in #10895 inadvertently removed some
distribution expectations. I also removed some unnecessary setup
steps in the judge assignment feature spec.
