### PR TITLE
Add decision issues back to case details

### DIFF
--- a/client/app/queue/components/CaseDetailsIssueList.jsx
+++ b/client/app/queue/components/CaseDetailsIssueList.jsx
@@ -27,11 +27,11 @@ const headingStyling = css({
 export default function CaseDetailsIssueList(props) {
   if (!props.isLegacyAppeal) {
     return <AmaIssueList
-        requestIssues={props.issues}
-        decisionIssues={props.decisionIssues}>
-        <DecisionIssues
-          decisionIssues={props.decisionIssues} />
-      </AmaIssueList>;
+      requestIssues={props.issues}
+      decisionIssues={props.decisionIssues}>
+      <DecisionIssues
+        decisionIssues={props.decisionIssues} />
+    </AmaIssueList>;
   }
 
   return <React.Fragment>

--- a/client/app/queue/components/CaseDetailsIssueList.jsx
+++ b/client/app/queue/components/CaseDetailsIssueList.jsx
@@ -6,6 +6,7 @@ import AmaIssueList from '../../components/AmaIssueList';
 import ISSUE_INFO from '../../../constants/ISSUE_INFO.json';
 import CaseDetailsDescriptionList from './CaseDetailsDescriptionList';
 import { dispositionLabelForDescription } from './LegacyIssueListItem';
+import DecisionIssues from '../components/DecisionIssues';
 
 const singleIssueContainerStyling = css({
   display: 'inline-block',
@@ -26,8 +27,11 @@ const headingStyling = css({
 export default function CaseDetailsIssueList(props) {
   if (!props.isLegacyAppeal) {
     return <AmaIssueList
-      requestIssues={props.issues}
-      decisionIssues={props.decisionIssues} />;
+        requestIssues={props.issues}
+        decisionIssues={props.decisionIssues}>
+        <DecisionIssues
+          decisionIssues={props.decisionIssues} />
+      </AmaIssueList>;
   }
 
   return <React.Fragment>

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -43,8 +43,8 @@ RSpec.feature "Attorney checkout flow" do
     let(:decision_issue_text) { "This is a test decision issue" }
     let(:updated_decision_issue_text) { "This is updated text" }
 
-    let(:other_issue_tex) { "This is a second issue" }
-    let(:allowed_issue_tex) { "This is an allowed issue" }
+    let(:other_issue_text) { "This is a second issue" }
+    let(:allowed_issue_text) { "This is an allowed issue" }
 
     let(:decision_issue_disposition) { "Remanded" }
     let(:benefit_type) { "Education" }
@@ -112,7 +112,7 @@ RSpec.feature "Attorney checkout flow" do
       all("button", text: "+ Add decision", count: 2)[0].click
       expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
 
-      fill_in "Text Box", with: other_issue_tex
+      fill_in "Text Box", with: other_issue_text
 
       find(".Select-control", text: "Select disposition").click
       find("div", class: "Select-option", text: decision_issue_disposition).click
@@ -126,7 +126,7 @@ RSpec.feature "Attorney checkout flow" do
       all("button", text: "+ Add decision", count: 2)[0].click
       expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
 
-      fill_in "Text Box", with: allowed_issue_tex
+      fill_in "Text Box", with: allowed_issue_text
 
       find(".Select-control", text: "Select disposition").click
       find("div", class: "Select-option", text: "Allowed").click
@@ -154,7 +154,7 @@ RSpec.feature "Attorney checkout flow" do
       all("button", text: "+ Add decision", count: 2)[0].click
       expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
 
-      fill_in "Text Box", with: allowed_issue_tex
+      fill_in "Text Box", with: allowed_issue_text
 
       find(".Select-control", text: "Select disposition").click
       find("div", class: "Select-option", text: "Allowed").click
@@ -192,7 +192,7 @@ RSpec.feature "Attorney checkout flow" do
       expect(page).to have_content(decision_issue_text)
       expect(page).to have_content(decision_issue_disposition)
 
-      expect(page).to have_content(other_issue_tex)
+      expect(page).to have_content(other_issue_text)
 
       click_on "Continue"
 
@@ -249,7 +249,13 @@ RSpec.feature "Attorney checkout flow" do
 
       click_on "(#{appeal.veteran_file_number})"
 
+      # ensure decision issues show up on case details page
       expect(page).to have_content "Correct issues"
+      expect(page).to have_content(decision_issue_text)
+      expect(page).to have_content(other_issue_text)
+      expect(page).to have_content(allowed_issue_text)
+      expect(page).to have_content("Added to 2 issues", count: 2)
+
       click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.label)
 
       expect(page).to have_content("Added to 2 issues", count: 2)


### PR DESCRIPTION
### Description
Decision issues were accidentally removed from case details by this PR https://github.com/department-of-veterans-affairs/caseflow/pull/10284/files.

I think the mocks provided to Annie were missing decision issues as en example so she thought case details doesn't display those. 

That's how it looks now

![image](https://user-images.githubusercontent.com/3811786/59040746-5a436d00-8845-11e9-88b7-fe51b041a925.png)



