### PR TITLE
Remove unused function argument

### DIFF
--- a/app/models/tasks/address_change_mail_task.rb
+++ b/app/models/tasks/address_change_mail_task.rb
@@ -5,7 +5,7 @@ class AddressChangeMailTask < MailTask
     COPY::ADDRESS_CHANGE_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(parent, _params)
+  def self.default_assignee(parent)
     fail Caseflow::Error::MailRoutingError unless case_active?(parent)
 
     return HearingAdmin.singleton if pending_hearing_task?(parent)

--- a/app/models/tasks/aod_motion_mail_task.rb
+++ b/app/models/tasks/aod_motion_mail_task.rb
@@ -5,7 +5,7 @@ class AodMotionMailTask < MailTask
     COPY::AOD_MOTION_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     AodTeam.singleton
   end
 end

--- a/app/models/tasks/appeal_withdrawal_mail_task.rb
+++ b/app/models/tasks/appeal_withdrawal_mail_task.rb
@@ -5,7 +5,7 @@ class AppealWithdrawalMailTask < MailTask
     COPY::APPEAL_WITHDRAWAL_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     Colocated.singleton
   end
 end

--- a/app/models/tasks/clear_and_unmistakeable_error_mail_task.rb
+++ b/app/models/tasks/clear_and_unmistakeable_error_mail_task.rb
@@ -13,7 +13,7 @@ class ClearAndUnmistakeableErrorMailTask < MailTask
     COPY::CLEAR_AND_UNMISTAKABLE_ERROR_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/congressional_interest_mail_task.rb
+++ b/app/models/tasks/congressional_interest_mail_task.rb
@@ -9,7 +9,7 @@ class CongressionalInterestMailTask < MailTask
     COPY::CONGRESSIONAL_INTEREST_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/controlled_correspondence_mail_task.rb
+++ b/app/models/tasks/controlled_correspondence_mail_task.rb
@@ -5,7 +5,7 @@ class ControlledCorrespondenceMailTask < MailTask
     COPY::CONTROLLED_CORRESPONDENCE_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/death_certificate_mail_task.rb
+++ b/app/models/tasks/death_certificate_mail_task.rb
@@ -5,7 +5,7 @@ class DeathCertificateMailTask < MailTask
     COPY::DEATH_CERTIFICATE_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     Colocated.singleton
   end
 end

--- a/app/models/tasks/evidence_or_argument_mail_task.rb
+++ b/app/models/tasks/evidence_or_argument_mail_task.rb
@@ -5,7 +5,7 @@ class EvidenceOrArgumentMailTask < MailTask
     COPY::EVIDENCE_OR_ARGUMENT_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(parent, _params)
+  def self.default_assignee(parent)
     fail Caseflow::Error::MailRoutingError unless case_active?(parent)
 
     return HearingAdmin.singleton if pending_hearing_task?(parent)

--- a/app/models/tasks/extension_request_mail_task.rb
+++ b/app/models/tasks/extension_request_mail_task.rb
@@ -9,7 +9,7 @@ class ExtensionRequestMailTask < MailTask
     COPY::EXTENSION_REQUEST_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(parent, _params)
+  def self.default_assignee(parent)
     fail Caseflow::Error::MailRoutingError unless case_active?(parent)
 
     Colocated.singleton

--- a/app/models/tasks/foia_request_mail_task.rb
+++ b/app/models/tasks/foia_request_mail_task.rb
@@ -9,7 +9,7 @@ class FoiaRequestMailTask < MailTask
     COPY::FOIA_REQUEST_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     PrivacyTeam.singleton
   end
 end

--- a/app/models/tasks/hearing_related_mail_task.rb
+++ b/app/models/tasks/hearing_related_mail_task.rb
@@ -9,7 +9,7 @@ class HearingRelatedMailTask < MailTask
     COPY::HEARING_RELATED_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(parent, _params)
+  def self.default_assignee(parent)
     fail Caseflow::Error::MailRoutingError unless case_active?(parent)
 
     return HearingAdmin.singleton if pending_hearing_task?(parent)

--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -52,7 +52,7 @@ class MailTask < GenericTask
       if [:assigned_to_type, :assigned_to_id].all? { |key| params.key?(key) }
         super
       else
-        default_assignee(parent, params)
+        default_assignee(parent)
       end
     end
 

--- a/app/models/tasks/other_motion_mail_task.rb
+++ b/app/models/tasks/other_motion_mail_task.rb
@@ -5,7 +5,7 @@ class OtherMotionMailTask < MailTask
     COPY::OTHER_MOTION_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/power_of_attorney_related_mail_task.rb
+++ b/app/models/tasks/power_of_attorney_related_mail_task.rb
@@ -9,7 +9,7 @@ class PowerOfAttorneyRelatedMailTask < MailTask
     COPY::POWER_OF_ATTORNEY_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(parent, _params)
+  def self.default_assignee(parent)
     fail Caseflow::Error::MailRoutingError unless case_active?(parent)
 
     return HearingAdmin.singleton if pending_hearing_task?(parent)

--- a/app/models/tasks/privacy_act_request_mail_task.rb
+++ b/app/models/tasks/privacy_act_request_mail_task.rb
@@ -9,7 +9,7 @@ class PrivacyActRequestMailTask < MailTask
     COPY::PRIVACY_ACT_REQUEST_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     PrivacyTeam.singleton
   end
 end

--- a/app/models/tasks/privacy_complaint_mail_task.rb
+++ b/app/models/tasks/privacy_complaint_mail_task.rb
@@ -9,7 +9,7 @@ class PrivacyComplaintMailTask < MailTask
     COPY::PRIVACY_COMPLAINT_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     PrivacyTeam.singleton
   end
 end

--- a/app/models/tasks/reconsideration_motion_mail_task.rb
+++ b/app/models/tasks/reconsideration_motion_mail_task.rb
@@ -13,7 +13,7 @@ class ReconsiderationMotionMailTask < MailTask
     COPY::RECONSIDERATION_MOTION_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/returned_undeliverable_correspondence_mail_task.rb
+++ b/app/models/tasks/returned_undeliverable_correspondence_mail_task.rb
@@ -5,7 +5,7 @@ class ReturnedUndeliverableCorrespondenceMailTask < MailTask
     COPY::RETURNED_CORRESPONDENCE_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(parent, _params)
+  def self.default_assignee(parent)
     return BvaDispatch.singleton if !case_active?(parent)
     return HearingAdmin.singleton if pending_hearing_task?(parent)
     return most_recent_active_task_assignee(parent) if most_recent_active_task_assignee(parent)

--- a/app/models/tasks/status_inquiry_mail_task.rb
+++ b/app/models/tasks/status_inquiry_mail_task.rb
@@ -5,7 +5,7 @@ class StatusInquiryMailTask < MailTask
     COPY::STATUS_INQUIRY_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/vacate_motion_mail_task.rb
+++ b/app/models/tasks/vacate_motion_mail_task.rb
@@ -13,7 +13,7 @@ class VacateMotionMailTask < MailTask
     COPY::VACATE_MOTION_MAIL_TASK_LABEL
   end
 
-  def self.default_assignee(_parent, _params)
+  def self.default_assignee(_parent)
     LitigationSupport.singleton
   end
 end


### PR DESCRIPTION
Removes unused `params` argument from `MailTask.default_assignee`. [Link to the comment](https://github.com/department-of-veterans-affairs/caseflow/pull/10926#discussion_r291202985) where this was noticed during code review.