### PR TITLE
Use Right Prop Name for onChange on Hearing Day Nav

### DIFF
--- a/client/app/hearings/components/AssignHearings.jsx
+++ b/client/app/hearings/components/AssignHearings.jsx
@@ -82,7 +82,7 @@ export default class AssignHearings extends React.Component {
         {<UpcomingHearingDaysNav
           upcomingHearingDays={upcomingHearingDays}
           selectedHearingDay={selectedHearingDay}
-          onSelectedHearingDayChangeFactory={onSelectedHearingDayChange} />
+          onSelectedHearingDayChange={onSelectedHearingDayChange} />
         }
         {appealsReadyForHearing &&
           <AssignHearingsTabs


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2473869/59060745-c044ea00-886f-11e9-8228-1ad1ae7a2f0b.png)

Left side hearing day nav was inactive for users. 