### PR TITLE
Compare Appeal's Closest Regional Office to Determine if Dropdown Should Be Dynamic

### DIFF
--- a/client/app/hearings/components/dailyDocket/DailyDocketRowInputs.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRowInputs.jsx
@@ -11,7 +11,6 @@ import { AppealHearingLocationsDropdown } from '../../../components/DataDropdown
 import HearingTime from '../modalForms/HearingTime';
 import { pencilSymbol } from '../../../components/RenderFunctions';
 
-import { regionalOfficeCity } from '../../../queue/utils';
 import { DISPOSITION_OPTIONS } from '../../constants';
 
 const staticSpacing = css({ marginTop: '5px' });
@@ -203,7 +202,7 @@ export const NotesField = ({ hearing, update, readOnly }) => {
 };
 
 export const HearingLocationDropdown = ({ hearing, readOnly, regionalOffice, update }) => {
-  const roIsDifferent = regionalOffice !== regionalOfficeCity(hearing);
+  const roIsDifferent = regionalOffice !== hearing.closestRegionalOffice;
   let staticHearingLocations = _.isEmpty(hearing.availableHearingLocations) ?
     [hearing.location] : _.values(hearing.availableHearingLocations);
 

--- a/client/app/hearings/components/modalForms/AssignHearingForm.jsx
+++ b/client/app/hearings/components/modalForms/AssignHearingForm.jsx
@@ -4,7 +4,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import ApiUtil from '../../../util/ApiUtil';
-import { regionalOfficeCity } from '../../../queue/utils';
 
 import {
   RegionalOfficeDropdown,
@@ -80,6 +79,7 @@ class AssignHearingForm extends React.Component {
     const { appeal, values, initialRegionalOffice, initialHearingDate } = this.props;
     const { regionalOffice, hearingLocation, hearingDay, scheduledTimeString } = values;
     const availableHearingLocations = _.orderBy(appeal.availableHearingLocations || [], ['distance'], ['asc']);
+    const dynamic = regionalOffice !== appeal.closestRegionalOffice || _.isEmpty(appeal.availableHearingLocations);
 
     return (
       <div>
@@ -94,8 +94,7 @@ class AssignHearingForm extends React.Component {
             key={`hearingLocation__${regionalOffice}`}
             regionalOffice={regionalOffice}
             appealId={appeal.externalId}
-            dynamic={regionalOffice !== regionalOfficeCity(appeal) ||
-              _.isEmpty(appeal.availableHearingLocations)}
+            dynamic={dynamic}
             staticHearingLocations={availableHearingLocations}
             value={hearingLocation}
             onChange={(value) => this.onChange({ hearingLocation: value })}

--- a/client/app/queue/components/PostponeHearingModal.jsx
+++ b/client/app/queue/components/PostponeHearingModal.jsx
@@ -13,7 +13,7 @@ import {
   requestPatch, showErrorMessage
 } from '../uiReducer/uiActions';
 import QueueFlowModal from './QueueFlowModal';
-import { taskActionData, prepareAppealForStore, regionalOfficeCity } from '../utils';
+import { taskActionData, prepareAppealForStore } from '../utils';
 import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
 
 import RadioField from '../../components/RadioField';
@@ -207,7 +207,7 @@ class PostponeHearingModal extends React.Component {
 
         {afterDispositionUpdateAction === ACTIONS.RESCHEDULE &&
         <AssignHearingForm
-          initialRegionalOffice={regionalOfficeCity(appeal)}
+          initialRegionalOffice={appeal.closestRegionalOffice}
           showErrorMessages={showErrorMessages}
           appeal={appeal}
         />


### PR DESCRIPTION
We should use persisted `available_hearing_locations` for an appeal whenever possible. Check to see if regional office matches to determine is dropdown should be dynamic. 