### PR TITLE
Build OrganizationQueue view from static configuration.

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -7,6 +7,11 @@ class Organizations::TasksController < OrganizationsController
   def index
     tasks = GenericQueue.new(user: organization).tasks
 
+    # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
+    if organization.url == "hearings-management"
+      tasks = tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
+    end
+
     render json: {
       organization_name: organization.name,
       tasks: json_tasks(tasks),

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -31,6 +31,10 @@ class Task < ApplicationRecord
     Constants.TASK_STATUSES.cancelled.to_sym => Constants.TASK_STATUSES.cancelled
   }
 
+  # This suppresses a warning about the :open scope overwriting the Kernel#open method
+  # https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-open
+  class << self; undef_method :open; end
+
   scope :active, -> { where(status: active_statuses) }
 
   scope :open, -> { where(status: open_statuses) }

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -39,7 +39,7 @@ const includeTrackingTasksTab = (organizationIsVso) => organizationIsVso;
 
 const allowBulkAssign = (organizationName) => (organizationName === 'Hearing Management');
 
-const showRegionalOfficeInQueue = (organizationName) => 
+const showRegionalOfficeInQueue = (organizationName) =>
   (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin');
 
 class OrganizationQueue extends React.PureComponent {
@@ -48,12 +48,13 @@ class OrganizationQueue extends React.PureComponent {
   }
 
   columnsFromConfig = (columnDefs) => {
-    //
+
   }
 
   tabsFromConfig = (config) => {
     return config.tabs.map((tabConfig) => {
-      return <React.Fragment>
+      return
+      <React.Fragment>
         <p className="cf-margin-top-0">{description}</p>
         { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
         <TaskTable
@@ -81,6 +82,7 @@ class OrganizationQueue extends React.PureComponent {
   queueConfig = () => {
     return {
       table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
+
       active_tab: 0, // TODO: This needs to respond to whether we have the tracking tasks tab or not.
       tabs: [
         // Tracking tasks tab.

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -54,32 +54,35 @@ class OrganizationQueue extends React.PureComponent {
     return {
       table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
       organizations: this.props.organizations,
-      active_tab: this.props.organizationIsVso ? 1 : 0, // TODO: This needs to respond to whether we have the tracking tasks tab or not. then it should be 1 -- this is if if () {
-      organizationName: this.props.organizationName,
+      active_tab: this.props.organizationIsVso ? 1 : 0, // tracking tasks tab?
+      // organizationName: this.props.organizationName,
       tabs: [
         {
-          tabTitle: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          tasks: this.props.unassignedTasks,
+          tabTitle: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, // pick
+          tabType: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,  // one
           label: sprintf(
               COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
-          tasks: this.props.unassignedTasks,
-          organizationName: this.props.organizationName,
-          userRole: this.props.userRole,
-          showRegionalOffice: showRegionalOfficeInQueue(this.props.organizationName),
-          allow_bulk_assign: allowBulkAssign(this.props.organizationName),
-          tabType: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
           description:
             sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
               this.props.organizationName),
+          organizationName: this.props.organizationName,
+          userRole: this.props.userRole,
+
+          allow_bulk_assign: allowBulkAssign(this.props.organizationName),
+
           columns: _.compact([
               "hearingBadgeColumn",
               "detailsColumn",
               "taskColumn",
               showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
               "typeColumn",
-              "docketNumberColumn"
-              // "daysWaitingColumn",
-              // "readerLinkColumn"
-            ])
+              "docketNumberColumn",
+              "daysWaitingColumn",
+              "readerLinkColumn"
+            ]),
+
+        // showRegionalOffice: showRegionalOfficeInQueue(this.props.organizationName),
 
         },
 
@@ -121,6 +124,7 @@ class OrganizationQueue extends React.PureComponent {
   }
 
   // accepts column string, calls proper column objection creation function, returns it.
+  // ONLY WORKS FOR UNASSIGNED TAB RIGHT NOW
   createColumnObject = (column) => {
     console.log("-------------");
     console.dir(this.props.unassignedTasks);
@@ -131,8 +135,9 @@ class OrganizationQueue extends React.PureComponent {
       taskColumn: taskColumn(this.props.unassignedTasks),
       regionalOfficeColumn: regionalOfficeColumn(this.props.unassignedTasks),
       typeColumn: typeColumn(this.props.unassignedTasks, false),
-      docketNumberColumn: docketNumberColumn(this.props.unassignedTasks, false)
-
+      docketNumberColumn: docketNumberColumn(this.props.unassignedTasks, false),
+      daysWaitingColumn: daysWaitingColumn(false),
+      readerLinkColumn: readerLinkColumn(false, true)
     };
 
     return functionForColumn[column];

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
@@ -33,9 +34,46 @@ const alertStyling = css({
   marginBottom: '1.5em'
 });
 
+// TODO: Is this worth it just because it is a handy alias?
+const includeTrackingTasksTab = (organizationIsVso) => organizationIsVso;
+
+const allowBulkAssign = (organizationName) => (organizationName === 'Hearing Management');
+
+const showRegionalOfficeInQueue = (organizationName) => 
+  (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin');
+
 class OrganizationQueue extends React.PureComponent {
   componentDidMount = () => {
     this.props.clearCaseSelectSearch();
+  }
+
+  queueConfig = () => {
+    return {
+      table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
+      active_tab: 0, // TODO: This needs to respond to whether we have the tracking tasks tab or not.
+      tabs: [
+        // Tracking tasks tab.
+        // Unassigned tasks tab.
+        {
+          name: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          description: sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, this.props.organizationName),
+          // Compact to account for the maybe absent regional office column
+          columns: _.compact([
+            "hearingBadgeColumn",
+            "detailsColumn",
+            "taskColumn",
+            showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
+            "typeColumn",
+            "docketNumberColumn",
+            "daysWaitingColumn",
+            "readerLinkColumn"
+          ]),
+          allow_bulk_assign: allowBulkAssign(this.props.organizationName)
+        },
+        // Assigned tasks tab.
+        // Completed tasks tab.
+      ]
+    };
   }
 
   render = () => {

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -91,51 +91,18 @@ class OrganizationQueue extends React.PureComponent {
 
 
 
-
-
-      // [
-        // tracking tasks tab
-        // {
-        //   name: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
-        //   description: sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, this.props.organizationName),
-        //   // Compact to account for the maybe absent regional office column
-        //   label: sprintf(
-        //     COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
-        //   columns: _.compact([
-        //     "hearingBadgeColumn",
-        //     "detailsColumn",
-        //     "taskColumn",
-        //     showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
-        //     "typeColumn",
-        //     "docketNumberColumn",
-        //     "daysWaitingColumn",
-        //     "readerLinkColumn"
-        //   ]),
-        //   allow_bulk_assign: allowBulkAssign(this.props.organizationName),
-        //   tasks: this.props.unassignedTasks,
-        // }
-
-        // unassigned tasks tab
-
-        //
-      // ]
-
     };
   }
 
   // accepts column string, calls proper column objection creation function, returns it.
-  // ONLY WORKS FOR UNASSIGNED TAB RIGHT NOW
-  createColumnObject = (column) => {
-    console.log("-------------");
-    console.dir(this.props.unassignedTasks);
-    console.log(column);
+  createColumnObject = (column, config) => {
     const functionForColumn = {
-      hearingBadgeColumn: hearingBadgeColumn(this.props.unassignedTasks),
-      detailsColumn: detailsColumn(this.props.unassignedTasks, false, this.props.userRole),
-      taskColumn: taskColumn(this.props.unassignedTasks),
-      regionalOfficeColumn: regionalOfficeColumn(this.props.unassignedTasks),
-      typeColumn: typeColumn(this.props.unassignedTasks, false),
-      docketNumberColumn: docketNumberColumn(this.props.unassignedTasks, false),
+      hearingBadgeColumn: hearingBadgeColumn(config.tasks),
+      detailsColumn: detailsColumn(config.tasks, false, config.userRole),
+      taskColumn: taskColumn(config.tasks),
+      regionalOfficeColumn: regionalOfficeColumn(config.tasks),
+      typeColumn: typeColumn(config.tasks, false),
+      docketNumberColumn: docketNumberColumn(config.tasks, false),
       daysWaitingColumn: daysWaitingColumn(false),
       readerLinkColumn: readerLinkColumn(false, true)
     };
@@ -143,27 +110,10 @@ class OrganizationQueue extends React.PureComponent {
     return functionForColumn[column];
   }
 
-  //
-  // columns = [
-  //   hearingBadgeColumn(tasks),
-  //   detailsColumn(tasks, false,
-  //   userRole),
-  //   taskColumn(tasks),
-  //   regionalOfficeColumn(tasks),
-  //   typeColumn(tasks, false),
-  //   docketNumberColumn(tasks, false),
-  //   daysWaitingColumn(false),
-  //   readerLinkColumn(false, true)];
-
-  // call all those pure column functions you made and
-  // return them in an array that can be passed
-  columnsFromConfig = (columnConfig) => {
-    const customColumns = columnConfig.map((column) => {
-      return this.createColumnObject(column);
-    })
-
-    console.log(customColumns);
-    return customColumns
+  columnsFromConfig = (tabConfig) => {
+    return tabConfig.columns.map((column) => {
+      return this.createColumnObject(column, tabConfig);
+    });
   }
 
 
@@ -194,11 +144,11 @@ class OrganizationQueue extends React.PureComponent {
   taskTableTabFactory = (tabConfig) => {
     // let tab;
 
-    let { columns, tasks, label, description } = tabConfig;
+    let { tasks, label, description } = tabConfig;
 
     // feeds an array of strings identifying which columnFunctions to call.
     // returns an array of column objects
-    const cols = this.columnsFromConfig(columns);
+    const cols = this.columnsFromConfig(tabConfig);
 
     return {
       label: label,
@@ -241,66 +191,17 @@ class OrganizationQueue extends React.PureComponent {
 
 // THE BIG KAHUNA
   makeQueueComponents = (config) => {
-
-    // should return an array of React.Fragments that
-    // contain TaskTableWithUserColumnTab
-    const tabs = this.tabsFromConfig(config);
-
     return <div>
       <h1 {...fullWidth}>{config.table_title}</h1>
       <QueueOrganizationDropdown organizations={config.organizations} />
 
       <TabWindow
         name="tasks-organization-queue"
-        tabs={tabs}
+        tabs={this.tabsFromConfig(config)}
         defaultPage={config.active_tab}
       />
     </div>;
   }
-
-  // <div>
-  //   <h1 {...fullWidth}>{sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName)}</h1>
-  //   <QueueOrganizationDropdown organizations={this.props.organizations} />
-  //   <TabWindow
-  //     name="tasks-organization-queue"
-  //     tabs={tabs}
-  //     defaultPage={focusedTab}
-  //   />
-  // </div>
-
-
-  // <QueueOrganizationDropdown organizations={this.props.organizations} />
-  // <TabWindow
-  //   name="tasks-organization-queue"
-  //   tabs={tabs}
-  //   defaultPage={config.active_tab}
-  // />
-
-
-  //
-  // tabs: [
-  //   // Tracking tasks tab.
-  //   // Unassigned tasks tab.
-  //   // {
-  //   //   name: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
-  //   //   description: sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, this.props.organizationName),
-  //   //   // Compact to account for the maybe absent regional office column
-  //   //   columns: _.compact([
-  //   //     "hearingBadgeColumn",
-  //   //     "detailsColumn",
-  //   //     "taskColumn",
-  //   //     showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
-  //   //     "typeColumn",
-  //   //     "docketNumberColumn",
-  //   //     "daysWaitingColumn",
-  //   //     "readerLinkColumn"
-  //   //   ]),
-  //   //   allow_bulk_assign: allowBulkAssign(this.props.organizationName),
-  //   //   tasks: this.props.unassignedTasks
-  //   // },
-  //   // Assigned tasks tab.
-  //   // Completed tasks tab.
-  // ]
 
   render = () => {
     const { success, tasksAssignedByBulk } = this.props;

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -31,15 +31,12 @@ const alertStyling = css({
   marginBottom: '1.5em'
 });
 
-// TODO: Is this worth it just because it is a handy alias? Yes
 const includeTrackingTasksTab = (organizationIsVso) => organizationIsVso;
 
 const allowBulkAssign = (organizationName) => (organizationName === 'Hearing Management');
 
 const showRegionalOfficeInQueue = (organizationName) =>
   (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin');
-
-
 
 
 class OrganizationQueue extends React.PureComponent {
@@ -51,9 +48,9 @@ class OrganizationQueue extends React.PureComponent {
     const config = {
       table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
       organizations: this.props.organizations,
-      active_tab: includeTrackingTasksTab(this.props.organizationIsVso) ? 1 : 0, // tracking tasks tab?
-      // organizationName: this.props.organizationName,
+      active_tab: includeTrackingTasksTab(this.props.organizationIsVso) ? 1 : 0,
       tabs: [
+        // Unassigned Tasks Tab
         {
           tasks: this.props.unassignedTasks,
           label: sprintf(
@@ -77,7 +74,7 @@ class OrganizationQueue extends React.PureComponent {
               "readerLinkColumn"
             ]),
         },
-
+        // Assigned Tasks tab
         {
           tasks: this.props.assignedTasks,
           label: sprintf(
@@ -98,6 +95,7 @@ class OrganizationQueue extends React.PureComponent {
               "daysWaitingColumn"
           ])
         },
+        // Completed Tasks tab
         {
           tasks: this.props.completedTasks,
           label: COPY.QUEUE_PAGE_COMPLETE_TAB_TITLE,
@@ -119,6 +117,7 @@ class OrganizationQueue extends React.PureComponent {
       ]
     };
 
+    // Tracking Task tab - when organization is a VSO
     if (includeTrackingTasksTab(this.props.organizationIsVso)) {
       config.tabs.unshift({
         tasks: this.props.trackingTasks,
@@ -137,25 +136,6 @@ class OrganizationQueue extends React.PureComponent {
     return config;
   }
 
-      // {
-      //   label: COPY.ALL_CASES_QUEUE_TABLE_TAB_TITLE,
-      //   page: <React.Fragment>
-      //     <p className="cf-margin-top-0">
-      //       {sprintf(COPY.ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, this.props.organizationName)}
-      //     </p>
-      //     <TaskTable
-      //       customColumns={[
-      //         detailsColumn(this.props.trackingTasks, false, this.props.userRole),
-      //         issueCountColumn(false),
-      //         typeColumn(this.props.trackingTasks, false),
-      //         docketNumberColumn(this.props.trackingTasks, false)
-      //       ]}
-      //       tasks={this.props.trackingTasks}
-      //     />
-      //   </React.Fragment>
-      // }
-      
-  // accepts column string, calls proper column objection creation function, returns it.
   createColumnObject = (column, config) => {
     const functionForColumn = {
       hearingBadgeColumn: hearingBadgeColumn(config.tasks),
@@ -181,12 +161,8 @@ class OrganizationQueue extends React.PureComponent {
   }
 
   taskTableTabFactory = (tabConfig) => {
-    // let tab;
+    const { tasks, label, description } = tabConfig;
 
-    let { tasks, label, description } = tabConfig;
-
-    // feeds an array of strings identifying which columnFunctions to call.
-    // returns an array of column objects
     const cols = this.columnsFromConfig(tabConfig);
 
     return {
@@ -207,7 +183,6 @@ class OrganizationQueue extends React.PureComponent {
     });
   }
 
-// THE BIG KAHUNA
   makeQueueComponents = (config) => {
     return <div>
       <h1 {...fullWidth}>{config.table_title}</h1>
@@ -223,32 +198,6 @@ class OrganizationQueue extends React.PureComponent {
 
   render = () => {
     const { success, tasksAssignedByBulk } = this.props;
-
-    // Focus on the first tab in the list of tabs unless we have an "all cases" view, in which case the first tab will
-    // be the "all cases" tab. In that case focus on the second tab which will be the first tab with workable tasks.
-    // let focusedTab = 0;
-
-    // if (this.props.organizationIsVso) {
-    //   focusedTab = 1;
-    //   tabs.unshift({
-    //     label: COPY.ALL_CASES_QUEUE_TABLE_TAB_TITLE,
-    //     page: <React.Fragment>
-    //       <p className="cf-margin-top-0">
-    //         {sprintf(COPY.ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, this.props.organizationName)}
-    //       </p>
-    //       <TaskTable
-    //         customColumns={[
-    //           detailsColumn(this.props.trackingTasks, false, this.props.userRole),
-    //           issueCountColumn(false),
-    //           typeColumn(this.props.trackingTasks, false),
-    //           docketNumberColumn(this.props.trackingTasks, false)
-    //         ]}
-    //         tasks={this.props.trackingTasks}
-    //       />
-    //     </React.Fragment>
-    //   });
-    // }
-
     const body = this.makeQueueComponents(this.queueConfig());
 
     return <AppSegment filledBackground styling={containerStyles}>

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -59,8 +59,6 @@ class OrganizationQueue extends React.PureComponent {
       tabs: [
         {
           tasks: this.props.unassignedTasks,
-          tabTitle: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, // pick
-          tabType: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,  // one
           label: sprintf(
               COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
           description:
@@ -81,16 +79,46 @@ class OrganizationQueue extends React.PureComponent {
               "daysWaitingColumn",
               "readerLinkColumn"
             ]),
-
-        // showRegionalOffice: showRegionalOfficeInQueue(this.props.organizationName),
-
         },
 
+        {
+          tasks: this.props.assignedTasks,
+          label: sprintf(
+              COPY.QUEUE_PAGE_ASSIGNED_TAB_TITLE, this.props.assignedTasks.length),
+          description:
+            sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION,
+              this.props.organizationName),
+          organizationName: this.props.organizationName,
+          userRole: this.props.userRole,
+          columns: _.compact([
+              "hearingBadgeColumn",
+              "detailsColumn",
+              "taskColumn",
+              showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
+              "typeColumn",
+              "assignedToColumn",
+              "docketNumberColumn",
+              "daysWaitingColumn"
+          ])
+        },
+        {
+          tasks: this.props.completedTasks,
+          label: COPY.QUEUE_PAGE_COMPLETE_TAB_TITLE,
+          description: sprintf(COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION,
+            this.props.organizationName),
+          userRole: this.props.userRole,
+          columns: _.compact([
+              "hearingBadgeColumn",
+              "detailsColumn",
+              "taskColumn",
+              showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
+              "typeColumn",
+              "assignedToColumn",
+              "docketNumberColumn",
+              "daysWaitingColumn"
+          ])
+        }
       ]
-
-
-
-
     };
   }
 
@@ -102,6 +130,7 @@ class OrganizationQueue extends React.PureComponent {
       taskColumn: taskColumn(config.tasks),
       regionalOfficeColumn: regionalOfficeColumn(config.tasks),
       typeColumn: typeColumn(config.tasks, false),
+      "assignedToColumn": assignedToColumn(config.tasks),
       docketNumberColumn: docketNumberColumn(config.tasks, false),
       daysWaitingColumn: daysWaitingColumn(false),
       readerLinkColumn: readerLinkColumn(false, true)
@@ -110,36 +139,12 @@ class OrganizationQueue extends React.PureComponent {
     return functionForColumn[column];
   }
 
+
   columnsFromConfig = (tabConfig) => {
     return tabConfig.columns.map((column) => {
       return this.createColumnObject(column, tabConfig);
     });
   }
-
-
-
-  // const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => {
-  //   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-  //     userRole), taskColumn(tasks), typeColumn(tasks, false),
-  //   docketNumberColumn(tasks, false), daysWaitingColumn(false),
-  //   readerLinkColumn(false, true)];
-  //
-  //   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
-  //     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-  //       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
-  //     typeColumn(tasks, false), docketNumberColumn(tasks, false),
-  //     daysWaitingColumn(false), readerLinkColumn(false, true)];
-  //   }
-  //
-  //   return (<React.Fragment>
-  //     <p className="cf-margin-top-0">{description}</p>
-  //     { organizationName === 'Hearing Management' && <BulkAssignButton /> }
-  //     <TaskTable
-  //       customColumns={columns}
-  //       tasks={tasks}
-  //     />
-  //   </React.Fragment>);
-  // };
 
   taskTableTabFactory = (tabConfig) => {
     // let tab;
@@ -161,27 +166,6 @@ class OrganizationQueue extends React.PureComponent {
         </React.Fragment>
     }
   }
-
-    // switch (config.TabType) {
-    //   case COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE:
-    //     tab = {
-    //       label: sprintf(
-    //         COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, config.tasks.length),
-    //       page:
-    //       <UnassignedTaskTableTab
-    //         organizationName={config.organizationName}
-    //         description={
-    //           sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-    //             config.organizationName)}
-    //         tasks={config.tasks}
-    //       />
-    //     }
-    //     break;
-    //   default:
-    //     continue;
-    //
-    // return tab;
-  // }
 
   tabsFromConfig = (config) => {
     return config.tabs.map((tabConfig) => {
@@ -321,47 +305,56 @@ const mapDispatchToProps = (dispatch) => ({
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrganizationQueue);
 
-const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => {
-  let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-    userRole), taskColumn(tasks), typeColumn(tasks, false),
-  docketNumberColumn(tasks, false), daysWaitingColumn(false),
-  readerLinkColumn(false, true)];
 
-  if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
-    columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-      userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
-    typeColumn(tasks, false), docketNumberColumn(tasks, false),
-    daysWaitingColumn(false), readerLinkColumn(false, true)];
-  }
 
-  return (<React.Fragment>
-    <p className="cf-margin-top-0">{description}</p>
-    { organizationName === 'Hearing Management' && <BulkAssignButton /> }
-    <TaskTable
-      customColumns={columns}
-      tasks={tasks}
-    />
-  </React.Fragment>);
-};
 
-const TaskTableWithUserColumnTab = ({ description, tasks, organizationName, userRole }) => {
-  let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-    userRole), taskColumn(tasks), typeColumn(tasks, false),
-  assignedToColumn(tasks), docketNumberColumn(tasks, false),
-  daysWaitingColumn(false)];
 
-  if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
-    columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-      userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
-    typeColumn(tasks, false), assignedToColumn(tasks),
-    docketNumberColumn(tasks, false), daysWaitingColumn(false)];
-  }
 
-  return <React.Fragment>
-    <p className="cf-margin-top-0">{description}</p>
-    <TaskTable
-      customColumns={columns}
-      tasks={tasks}
-    />
-  </React.Fragment>;
-};
+
+
+
+//
+// const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => {
+//   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+//     userRole), taskColumn(tasks), typeColumn(tasks, false),
+//   docketNumberColumn(tasks, false), daysWaitingColumn(false),
+//   readerLinkColumn(false, true)];
+//
+//   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
+//     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+//       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
+//     typeColumn(tasks, false), docketNumberColumn(tasks, false),
+//     daysWaitingColumn(false), readerLinkColumn(false, true)];
+//   }
+//
+//   return (<React.Fragment>
+//     <p className="cf-margin-top-0">{description}</p>
+//     { organizationName === 'Hearing Management' && <BulkAssignButton /> }
+//     <TaskTable
+//       customColumns={columns}
+//       tasks={tasks}
+//     />
+//   </React.Fragment>);
+// };
+//
+// const TaskTableWithUserColumnTab = ({ description, tasks, organizationName, userRole }) => {
+//   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+//     userRole), taskColumn(tasks), typeColumn(tasks, false),
+//   assignedToColumn(tasks), docketNumberColumn(tasks, false),
+//   daysWaitingColumn(false)];
+//
+//   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
+//     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+//       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
+//     typeColumn(tasks, false), assignedToColumn(tasks),
+//     docketNumberColumn(tasks, false), daysWaitingColumn(false)];
+//   }
+//
+//   return <React.Fragment>
+//     <p className="cf-margin-top-0">{description}</p>
+//     <TaskTable
+//       customColumns={columns}
+//       tasks={tasks}
+//     />
+//   </React.Fragment>;
+// };

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -67,6 +67,9 @@ class OrganizationQueue extends React.PureComponent {
           showRegionalOffice: showRegionalOfficeInQueue(this.props.organizationName),
           allow_bulk_assign: allowBulkAssign(this.props.organizationName),
           tabType: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          description:
+            sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
+              this.props.organizationName),
           columns: _.compact([
               "hearingBadgeColumn",
               "detailsColumn",
@@ -183,19 +186,19 @@ class OrganizationQueue extends React.PureComponent {
   //   </React.Fragment>);
   // };
 
-  taskTableTabFactory = (tabConfig, config) => {
+  taskTableTabFactory = (tabConfig) => {
     // let tab;
 
-    let { columns, tasks } = tabConfig;
+    let { columns, tasks, label, description } = tabConfig;
 
     // feeds an array of strings identifying which columnFunctions to call.
     // returns an array of column objects
     const cols = this.columnsFromConfig(columns);
 
     return {
-      label: 'lolol',
+      label: label,
       page: <React.Fragment>
-        <p className="cf-margin-top-0">{config.description}</p>
+        <p className="cf-margin-top-0">{description}</p>
         <TaskTable
           customColumns={cols}
           tasks={tasks}

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -38,7 +38,6 @@ const allowBulkAssign = (organizationName) => (organizationName === 'Hearing Man
 const showRegionalOfficeInQueue = (organizationName) =>
   (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin');
 
-
 class OrganizationQueue extends React.PureComponent {
   componentDidMount = () => {
     this.props.clearCaseSelectSearch();
@@ -54,45 +53,43 @@ class OrganizationQueue extends React.PureComponent {
         {
           tasks: this.props.unassignedTasks,
           label: sprintf(
-              COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
+            COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
           description:
             sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
               this.props.organizationName),
           organizationName: this.props.organizationName,
           userRole: this.props.userRole,
-
           allow_bulk_assign: allowBulkAssign(this.props.organizationName),
-
           columns: _.compact([
-              "hearingBadgeColumn",
-              "detailsColumn",
-              "taskColumn",
-              showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
-              "typeColumn",
-              "docketNumberColumn",
-              "daysWaitingColumn",
-              "readerLinkColumn"
-            ]),
+            'hearingBadgeColumn',
+            'detailsColumn',
+            'taskColumn',
+            showRegionalOfficeInQueue(this.props.organizationName) ? 'regionalOfficeColumn' : null,
+            'typeColumn',
+            'docketNumberColumn',
+            'daysWaitingColumn',
+            'readerLinkColumn'
+          ])
         },
         // Assigned Tasks tab
         {
           tasks: this.props.assignedTasks,
           label: sprintf(
-              COPY.QUEUE_PAGE_ASSIGNED_TAB_TITLE, this.props.assignedTasks.length),
+            COPY.QUEUE_PAGE_ASSIGNED_TAB_TITLE, this.props.assignedTasks.length),
           description:
             sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION,
               this.props.organizationName),
           organizationName: this.props.organizationName,
           userRole: this.props.userRole,
           columns: _.compact([
-              "hearingBadgeColumn",
-              "detailsColumn",
-              "taskColumn",
-              showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
-              "typeColumn",
-              "assignedToColumn",
-              "docketNumberColumn",
-              "daysWaitingColumn"
+            'hearingBadgeColumn',
+            'detailsColumn',
+            'taskColumn',
+            showRegionalOfficeInQueue(this.props.organizationName) ? 'regionalOfficeColumn' : null,
+            'typeColumn',
+            'assignedToColumn',
+            'docketNumberColumn',
+            'daysWaitingColumn'
           ])
         },
         // Completed Tasks tab
@@ -104,14 +101,14 @@ class OrganizationQueue extends React.PureComponent {
           organizationName: this.props.organizationName,
           userRole: this.props.userRole,
           columns: _.compact([
-              "hearingBadgeColumn",
-              "detailsColumn",
-              "taskColumn",
-              showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
-              "typeColumn",
-              "assignedToColumn",
-              "docketNumberColumn",
-              "daysWaitingColumn"
+            'hearingBadgeColumn',
+            'detailsColumn',
+            'taskColumn',
+            showRegionalOfficeInQueue(this.props.organizationName) ? 'regionalOfficeColumn' : null,
+            'typeColumn',
+            'assignedToColumn',
+            'docketNumberColumn',
+            'daysWaitingColumn'
           ])
         }
       ]
@@ -131,7 +128,7 @@ class OrganizationQueue extends React.PureComponent {
           'docketNumberColumn'
         ]
       });
-    };
+    }
 
     return config;
   }
@@ -143,7 +140,7 @@ class OrganizationQueue extends React.PureComponent {
       taskColumn: taskColumn(config.tasks),
       regionalOfficeColumn: regionalOfficeColumn(config.tasks),
       typeColumn: typeColumn(config.tasks, false),
-      "assignedToColumn": assignedToColumn(config.tasks),
+      assignedToColumn: assignedToColumn(config.tasks),
       docketNumberColumn: docketNumberColumn(config.tasks, false),
       daysWaitingColumn: daysWaitingColumn(false),
       readerLinkColumn: readerLinkColumn(false, true),
@@ -152,7 +149,6 @@ class OrganizationQueue extends React.PureComponent {
 
     return functionForColumn[column];
   }
-
 
   columnsFromConfig = (tabConfig) => {
     return tabConfig.columns.map((column) => {
@@ -166,20 +162,21 @@ class OrganizationQueue extends React.PureComponent {
     const cols = this.columnsFromConfig(tabConfig);
 
     return {
-      label: label,
+      label,
       page: <React.Fragment>
         <p className="cf-margin-top-0">{description}</p>
+        { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
         <TaskTable
           customColumns={cols}
           tasks={tasks}
         />
-        </React.Fragment>
-    }
+      </React.Fragment>
+    };
   }
 
   tabsFromConfig = (config) => {
     return config.tabs.map((tabConfig) => {
-      return this.taskTableTabFactory(tabConfig, config)
+      return this.taskTableTabFactory(tabConfig, config);
     });
   }
 

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -47,6 +47,37 @@ class OrganizationQueue extends React.PureComponent {
     this.props.clearCaseSelectSearch();
   }
 
+  columnsFromConfig = (columnDefs) => {
+    //
+  }
+
+  tabsFromConfig = (config) => {
+    return config.tabs.map((tabConfig) => {
+      return <React.Fragment>
+        <p className="cf-margin-top-0">{description}</p>
+        { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
+        <TaskTable
+          customColumns={this.columnsFromConfig(tabConfig.columns)}
+          tasks={tabConfig.tasks}
+        />
+      </React.Fragment>;
+    });
+  }
+
+  componentsFromConfig = (config) => {
+    const tabs = this.tabsFromConfig(config);
+
+    return <div>
+      <h1 {...fullWidth}>{config.table_title}</h1>
+      <QueueOrganizationDropdown organizations={this.props.organizations} />
+      <TabWindow
+        name="tasks-organization-queue"
+        tabs={tabs}
+        defaultPage={config.active_tab}
+      />
+    </div>;
+  }
+
   queueConfig = () => {
     return {
       table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
@@ -68,7 +99,8 @@ class OrganizationQueue extends React.PureComponent {
             "daysWaitingColumn",
             "readerLinkColumn"
           ]),
-          allow_bulk_assign: allowBulkAssign(this.props.organizationName)
+          allow_bulk_assign: allowBulkAssign(this.props.organizationName),
+          tasks: this.props.unassignedTasks
         },
         // Assigned tasks tab.
         // Completed tasks tab.
@@ -139,6 +171,8 @@ class OrganizationQueue extends React.PureComponent {
         </React.Fragment>
       });
     }
+
+    // const body = this.componentsFromConfig(this.queueConfig());
 
     return <AppSegment filledBackground styling={containerStyles}>
       {success && <Alert type="success" title={success.title} message={success.detail} />}

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -45,145 +45,16 @@ const showRegionalOfficeInQueue = (organizationName) =>
 
 
 
-
-
 class OrganizationQueue extends React.PureComponent {
   componentDidMount = () => {
     this.props.clearCaseSelectSearch();
   }
 
-  // columnsFromConfig = (columnStrings, organizationName) => {
-  //   // UNASSIGNED
-  //
-  //   // const requestedColumns = config.column;
-  //
-  //   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-  //     userRole), taskColumn(tasks), typeColumn(tasks, false),
-  //   docketNumberColumn(tasks, false), daysWaitingColumn(false),
-  //   readerLinkColumn(false, true)];
-  //
-  //   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
-  //     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-  //       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
-  //     typeColumn(tasks, false), docketNumberColumn(tasks, false),
-  //     daysWaitingColumn(false), readerLinkColumn(false, true)];
-  //   }
-  //
-  //   return columns;
-  // }
-
-
-  // call all those pure column functions you made and
-  // return them in an array that can be passed
-  columnsFromConfig = (config) => {
-
-  }
-
-
-
-  // const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => {
-  //   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-  //     userRole), taskColumn(tasks), typeColumn(tasks, false),
-  //   docketNumberColumn(tasks, false), daysWaitingColumn(false),
-  //   readerLinkColumn(false, true)];
-  //
-  //   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
-  //     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-  //       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
-  //     typeColumn(tasks, false), docketNumberColumn(tasks, false),
-  //     daysWaitingColumn(false), readerLinkColumn(false, true)];
-  //   }
-  //
-  //   return (<React.Fragment>
-  //     <p className="cf-margin-top-0">{description}</p>
-  //     { organizationName === 'Hearing Management' && <BulkAssignButton /> }
-  //     <TaskTable
-  //       customColumns={columns}
-  //       tasks={tasks}
-  //     />
-  //   </React.Fragment>);
-  // };
-
-  taskTableTabFactory = (config) => {
-    // let tab;
-
-    let { columns, tasks } = config;
-
-    const customColumns = this.columnsFromConfig(config);
-
-    return <React.Fragment>
-      <p className="cf-margin-top-0">{config.description}</p>
-      <TaskTable
-        customColumns={customColumns}
-        tasks={config.tasks}
-      />
-    </React.Fragment>;
-
-    // switch (config.TabType) {
-    //   case COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE:
-    //     tab = {
-    //       label: sprintf(
-    //         COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, config.tasks.length),
-    //       page:
-    //       <UnassignedTaskTableTab
-    //         organizationName={config.organizationName}
-    //         description={
-    //           sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-    //             config.organizationName)}
-    //         tasks={config.tasks}
-    //       />
-    //     }
-    //     break;
-    //   default:
-    //     continue;
-    //
-    // return tab;
-  }
-
-  tabsFromConfig = (config) => {
-    return config.tabs.map((tabConfig) => {
-      return this.taskTableTabFactory(tabConfig)
-    });
-  }
-
-// THE BIG KAHUNA
-  makeQueueComponents = (config) => {
-
-    // should return an array of React.Fragments that
-    // contain TaskTableWithUserColumnTab
-    const tabs = this.tabsFromConfig(config);
-
-    return <div>
-      <h1 {...fullWidth}>{config.table_title}</h1>
-      <QueueOrganizationDropdown organizations={config.organizations} />
-
-      <TabWindow
-        name="tasks-organization-queue"
-        tabs={tabs}
-        defaultPage={config.active_tab}
-      />
-    </div>;
-  }
-
-  // <TabWindow
-  //   name="tasks-organization-queue"
-  //   tabs={tabs}
-  //   defaultPage={config.active_tab}
-  // />
-
-  // <QueueOrganizationDropdown organizations={this.props.organizations} />
-  // <TabWindow
-  //   name="tasks-organization-queue"
-  //   tabs={tabs}
-  //   defaultPage={config.active_tab}
-  // />
-
   queueConfig = () => {
     return {
       table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
       organizations: this.props.organizations,
-
-      active_tab: 0, // TODO: This needs to respond to whether we have the tracking tasks tab or not.
+      active_tab: this.props.organizationIsVso ? 1 : 0, // TODO: This needs to respond to whether we have the tracking tasks tab or not. then it should be 1 -- this is if if () {
       organizationName: this.props.organizationName,
       tabs: [
         {
@@ -202,17 +73,13 @@ class OrganizationQueue extends React.PureComponent {
               "taskColumn",
               showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
               "typeColumn",
-              "docketNumberColumn",
-              "daysWaitingColumn",
-              "readerLinkColumn"
+              "docketNumberColumn"
+              // "daysWaitingColumn",
+              // "readerLinkColumn"
             ])
 
         },
 
-
-        {
-          tabType:
-        }
       ]
 
 
@@ -250,29 +117,182 @@ class OrganizationQueue extends React.PureComponent {
     };
   }
 
-  tabs: [
-    // Tracking tasks tab.
-    // Unassigned tasks tab.
-    // {
-    //   name: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
-    //   description: sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, this.props.organizationName),
-    //   // Compact to account for the maybe absent regional office column
-    //   columns: _.compact([
-    //     "hearingBadgeColumn",
-    //     "detailsColumn",
-    //     "taskColumn",
-    //     showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
-    //     "typeColumn",
-    //     "docketNumberColumn",
-    //     "daysWaitingColumn",
-    //     "readerLinkColumn"
-    //   ]),
-    //   allow_bulk_assign: allowBulkAssign(this.props.organizationName),
-    //   tasks: this.props.unassignedTasks
-    // },
-    // Assigned tasks tab.
-    // Completed tasks tab.
-  ]
+  // accepts column string, calls proper column objection creation function, returns it.
+  createColumnObject = (column) => {
+    console.log("-------------");
+    console.dir(this.props.unassignedTasks);
+    console.log(column);
+    const functionForColumn = {
+      hearingBadgeColumn: hearingBadgeColumn(this.props.unassignedTasks),
+      detailsColumn: detailsColumn(this.props.unassignedTasks, false, this.props.userRole),
+      taskColumn: taskColumn(this.props.unassignedTasks),
+      regionalOfficeColumn: regionalOfficeColumn(this.props.unassignedTasks),
+      typeColumn: typeColumn(this.props.unassignedTasks, false),
+      docketNumberColumn: docketNumberColumn(this.props.unassignedTasks, false)
+
+    };
+
+    return functionForColumn[column];
+  }
+
+  //
+  // columns = [
+  //   hearingBadgeColumn(tasks),
+  //   detailsColumn(tasks, false,
+  //   userRole),
+  //   taskColumn(tasks),
+  //   regionalOfficeColumn(tasks),
+  //   typeColumn(tasks, false),
+  //   docketNumberColumn(tasks, false),
+  //   daysWaitingColumn(false),
+  //   readerLinkColumn(false, true)];
+
+  // call all those pure column functions you made and
+  // return them in an array that can be passed
+  columnsFromConfig = (columnConfig) => {
+    const customColumns = columnConfig.map((column) => {
+      return this.createColumnObject(column);
+    })
+
+    console.log(customColumns);
+    return customColumns
+  }
+
+
+
+  // const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => {
+  //   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+  //     userRole), taskColumn(tasks), typeColumn(tasks, false),
+  //   docketNumberColumn(tasks, false), daysWaitingColumn(false),
+  //   readerLinkColumn(false, true)];
+  //
+  //   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
+  //     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+  //       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
+  //     typeColumn(tasks, false), docketNumberColumn(tasks, false),
+  //     daysWaitingColumn(false), readerLinkColumn(false, true)];
+  //   }
+  //
+  //   return (<React.Fragment>
+  //     <p className="cf-margin-top-0">{description}</p>
+  //     { organizationName === 'Hearing Management' && <BulkAssignButton /> }
+  //     <TaskTable
+  //       customColumns={columns}
+  //       tasks={tasks}
+  //     />
+  //   </React.Fragment>);
+  // };
+
+  taskTableTabFactory = (tabConfig, config) => {
+    // let tab;
+
+    let { columns, tasks } = tabConfig;
+
+    // feeds an array of strings identifying which columnFunctions to call.
+    // returns an array of column objects
+    const cols = this.columnsFromConfig(columns);
+
+    return {
+      label: 'lolol',
+      page: <React.Fragment>
+        <p className="cf-margin-top-0">{config.description}</p>
+        <TaskTable
+          customColumns={cols}
+          tasks={tasks}
+        />
+        </React.Fragment>
+    }
+  }
+
+    // switch (config.TabType) {
+    //   case COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE:
+    //     tab = {
+    //       label: sprintf(
+    //         COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, config.tasks.length),
+    //       page:
+    //       <UnassignedTaskTableTab
+    //         organizationName={config.organizationName}
+    //         description={
+    //           sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
+    //             config.organizationName)}
+    //         tasks={config.tasks}
+    //       />
+    //     }
+    //     break;
+    //   default:
+    //     continue;
+    //
+    // return tab;
+  // }
+
+  tabsFromConfig = (config) => {
+    return config.tabs.map((tabConfig) => {
+      return this.taskTableTabFactory(tabConfig, config)
+    });
+  }
+
+// THE BIG KAHUNA
+  makeQueueComponents = (config) => {
+
+    // should return an array of React.Fragments that
+    // contain TaskTableWithUserColumnTab
+    const tabs = this.tabsFromConfig(config);
+
+    return <div>
+      <h1 {...fullWidth}>{config.table_title}</h1>
+      <QueueOrganizationDropdown organizations={config.organizations} />
+
+      <TabWindow
+        name="tasks-organization-queue"
+        tabs={tabs}
+        defaultPage={config.active_tab}
+      />
+    </div>;
+  }
+
+  // <div>
+  //   <h1 {...fullWidth}>{sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName)}</h1>
+  //   <QueueOrganizationDropdown organizations={this.props.organizations} />
+  //   <TabWindow
+  //     name="tasks-organization-queue"
+  //     tabs={tabs}
+  //     defaultPage={focusedTab}
+  //   />
+  // </div>
+
+
+  // <QueueOrganizationDropdown organizations={this.props.organizations} />
+  // <TabWindow
+  //   name="tasks-organization-queue"
+  //   tabs={tabs}
+  //   defaultPage={config.active_tab}
+  // />
+
+
+  //
+  // tabs: [
+  //   // Tracking tasks tab.
+  //   // Unassigned tasks tab.
+  //   // {
+  //   //   name: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+  //   //   description: sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, this.props.organizationName),
+  //   //   // Compact to account for the maybe absent regional office column
+  //   //   columns: _.compact([
+  //   //     "hearingBadgeColumn",
+  //   //     "detailsColumn",
+  //   //     "taskColumn",
+  //   //     showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
+  //   //     "typeColumn",
+  //   //     "docketNumberColumn",
+  //   //     "daysWaitingColumn",
+  //   //     "readerLinkColumn"
+  //   //   ]),
+  //   //   allow_bulk_assign: allowBulkAssign(this.props.organizationName),
+  //   //   tasks: this.props.unassignedTasks
+  //   // },
+  //   // Assigned tasks tab.
+  //   // Completed tasks tab.
+  // ]
 
   render = () => {
     const { success, tasksAssignedByBulk } = this.props;

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -72,19 +72,46 @@ class OrganizationQueue extends React.PureComponent {
     return columns;
   }
 
+  tabFactory = (config) => {
+    let tab;
+
+    switch (config.TabType) {
+      case COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE:
+        tab = {
+          label: sprintf(
+            COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, config.tasks.length),
+          page: <UnassignedTaskTableTab
+            organizationName={config.organizationName}
+            description={
+              sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
+                config.organizationName)}
+            tasks={config.tasks}
+          />
+        }
+        break;
+      default:
+        continue;
+
+    return tab;
+  }
+
   tabsFromConfig = (config) => {
     return config.tabs.map((tabConfig) => {
-      return {
-        label: sprintf(
-          COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
-        page: <UnassignedTaskTableTab
-          organizationName={this.props.organizationName}
-          description={
-            sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-              this.props.organizationName)}
-          tasks={this.props.unassignedTasks}
-        />
-      };
+      return tabFactory(tabConfig)
+
+      // return {
+      //   label: sprintf(
+      //     COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
+      //   page: <UnassignedTaskTableTab
+      //     organizationName={this.props.organizationName}
+      //     description={
+      //       sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
+      //         this.props.organizationName)}
+      //     tasks={this.props.unassignedTasks}
+      //   />
+      // };
+
+
       // <React.Fragment>
       //   <p className="cf-margin-top-0">{description}</p>
       //   { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
@@ -176,6 +203,9 @@ class OrganizationQueue extends React.PureComponent {
       organizationName: this.props.organizationName,
       tabs: [
         {
+          tabType:COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          tasks: this.props.unassignedTasks,
+          organizationName: this.props.organizationName
           // label: sprintf(
           //   COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
           // page: <UnassignedTaskTableTab

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -52,121 +52,105 @@ class OrganizationQueue extends React.PureComponent {
     this.props.clearCaseSelectSearch();
   }
 
-  columnsFromConfig = (columnStrings, organizationName) => {
-    // UNASSIGNED
+  // columnsFromConfig = (columnStrings, organizationName) => {
+  //   // UNASSIGNED
+  //
+  //   // const requestedColumns = config.column;
+  //
+  //   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+  //     userRole), taskColumn(tasks), typeColumn(tasks, false),
+  //   docketNumberColumn(tasks, false), daysWaitingColumn(false),
+  //   readerLinkColumn(false, true)];
+  //
+  //   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
+  //     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+  //       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
+  //     typeColumn(tasks, false), docketNumberColumn(tasks, false),
+  //     daysWaitingColumn(false), readerLinkColumn(false, true)];
+  //   }
+  //
+  //   return columns;
+  // }
 
-    // const requestedColumns = config.column;
 
-    let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-      userRole), taskColumn(tasks), typeColumn(tasks, false),
-    docketNumberColumn(tasks, false), daysWaitingColumn(false),
-    readerLinkColumn(false, true)];
+  // call all those pure column functions you made and
+  // return them in an array that can be passed
+  columnsFromConfig = (config) => {
 
-    if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
-      columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
-        userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
-      typeColumn(tasks, false), docketNumberColumn(tasks, false),
-      daysWaitingColumn(false), readerLinkColumn(false, true)];
-    }
-
-    return columns;
   }
 
-  tabFactory = (config) => {
-    let tab;
 
-    switch (config.TabType) {
-      case COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE:
-        tab = {
-          label: sprintf(
-            COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, config.tasks.length),
-          page: <UnassignedTaskTableTab
-            organizationName={config.organizationName}
-            description={
-              sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-                config.organizationName)}
-            tasks={config.tasks}
-          />
-        }
-        break;
-      default:
-        continue;
 
-    return tab;
+  // const UnassignedTaskTableTab = ({ description, tasks, organizationName, userRole }) => {
+  //   let columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+  //     userRole), taskColumn(tasks), typeColumn(tasks, false),
+  //   docketNumberColumn(tasks, false), daysWaitingColumn(false),
+  //   readerLinkColumn(false, true)];
+  //
+  //   if (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin') {
+  //     columns = [hearingBadgeColumn(tasks), detailsColumn(tasks, false,
+  //       userRole), taskColumn(tasks), regionalOfficeColumn(tasks),
+  //     typeColumn(tasks, false), docketNumberColumn(tasks, false),
+  //     daysWaitingColumn(false), readerLinkColumn(false, true)];
+  //   }
+  //
+  //   return (<React.Fragment>
+  //     <p className="cf-margin-top-0">{description}</p>
+  //     { organizationName === 'Hearing Management' && <BulkAssignButton /> }
+  //     <TaskTable
+  //       customColumns={columns}
+  //       tasks={tasks}
+  //     />
+  //   </React.Fragment>);
+  // };
+
+  taskTableTabFactory = (config) => {
+    // let tab;
+
+    let { columns, tasks } = config;
+
+    const customColumns = this.columnsFromConfig(config);
+
+    return <React.Fragment>
+      <p className="cf-margin-top-0">{config.description}</p>
+      <TaskTable
+        customColumns={customColumns}
+        tasks={config.tasks}
+      />
+    </React.Fragment>;
+
+    // switch (config.TabType) {
+    //   case COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE:
+    //     tab = {
+    //       label: sprintf(
+    //         COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, config.tasks.length),
+    //       page:
+    //       <UnassignedTaskTableTab
+    //         organizationName={config.organizationName}
+    //         description={
+    //           sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
+    //             config.organizationName)}
+    //         tasks={config.tasks}
+    //       />
+    //     }
+    //     break;
+    //   default:
+    //     continue;
+    //
+    // return tab;
   }
 
   tabsFromConfig = (config) => {
     return config.tabs.map((tabConfig) => {
-      return tabFactory(tabConfig)
-
-      // return {
-      //   label: sprintf(
-      //     COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
-      //   page: <UnassignedTaskTableTab
-      //     organizationName={this.props.organizationName}
-      //     description={
-      //       sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-      //         this.props.organizationName)}
-      //     tasks={this.props.unassignedTasks}
-      //   />
-      // };
-
-
-      // <React.Fragment>
-      //   <p className="cf-margin-top-0">{description}</p>
-      //   { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
-      //   <TaskTable
-      //     customColumns={this.columnsFromConfig(tabConfig.columns, config.organizationName)}
-      //     tasks={tabConfig.tasks}
-      //   />
-      // </React.Fragment>;
+      return this.taskTableTabFactory(tabConfig)
     });
-
-
-    // const tabs = [
-    //   {
-    //     label: sprintf(
-    //       COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
-    //     page: <UnassignedTaskTableTab
-    //       organizationName={this.props.organizationName}
-    //       description={
-    //         sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-    //           this.props.organizationName)}
-    //       tasks={this.props.unassignedTasks}
-    //     />
-    //   },
-
-
-      // {
-      //   label: sprintf(
-      //     COPY.QUEUE_PAGE_ASSIGNED_TAB_TITLE, this.props.assignedTasks.length),
-      //   page: <TaskTableWithUserColumnTab
-      //     organizationName={this.props.organizationName}
-      //     description={
-      //       sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION,
-      //         this.props.organizationName)}
-      //     tasks={this.props.assignedTasks}
-      //     userRole={this.props.userRole}
-      //   />
-      // },
-      // {
-      //   label: COPY.QUEUE_PAGE_COMPLETE_TAB_TITLE,
-      //   page: <TaskTableWithUserColumnTab
-      //     organizationName={this.props.organizationName}
-      //     description={
-      //       sprintf(COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION,
-      //         this.props.organizationName)}
-      //     tasks={this.props.completedTasks}
-      //     userRole={this.props.userRole}
-      //   />
-      // }
-    // ];
-
-    // return tabs;
   }
 
 // THE BIG KAHUNA
-  componentsFromConfig = (config) => {
+  makeQueueComponents = (config) => {
+
+    // should return an array of React.Fragments that
+    // contain TaskTableWithUserColumnTab
     const tabs = this.tabsFromConfig(config);
 
     return <div>
@@ -203,18 +187,31 @@ class OrganizationQueue extends React.PureComponent {
       organizationName: this.props.organizationName,
       tabs: [
         {
-          tabType:COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          tabTitle: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          label: sprintf(
+              COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
           tasks: this.props.unassignedTasks,
-          organizationName: this.props.organizationName
-          // label: sprintf(
-          //   COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE, this.props.unassignedTasks.length),
-          // page: <UnassignedTaskTableTab
-          //   organizationName={this.props.organizationName}
-          //   description={
-          //     sprintf(COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION,
-          //       this.props.organizationName)}
-          //   tasks={this.props.unassignedTasks}
-          // />
+          organizationName: this.props.organizationName,
+          userRole: this.props.userRole,
+          showRegionalOffice: showRegionalOfficeInQueue(this.props.organizationName),
+          allow_bulk_assign: allowBulkAssign(this.props.organizationName),
+          tabType: COPY.ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE,
+          columns: _.compact([
+              "hearingBadgeColumn",
+              "detailsColumn",
+              "taskColumn",
+              showRegionalOfficeInQueue(this.props.organizationName) ? "regionalOfficeColumn" : null,
+              "typeColumn",
+              "docketNumberColumn",
+              "daysWaitingColumn",
+              "readerLinkColumn"
+            ])
+
+        },
+
+
+        {
+          tabType:
         }
       ]
 
@@ -341,7 +338,7 @@ class OrganizationQueue extends React.PureComponent {
       });
     }
 
-    const body = this.componentsFromConfig(this.queueConfig());
+    const body = this.makeQueueComponents(this.queueConfig());
 
     return <AppSegment filledBackground styling={containerStyles}>
       {success && <Alert type="success" title={success.title} message={success.detail} />}

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -47,7 +47,7 @@ class OrganizationQueue extends React.PureComponent {
     const config = {
       table_title: sprintf(COPY.ORGANIZATION_QUEUE_TABLE_TITLE, this.props.organizationName),
       organizations: this.props.organizations,
-      active_tab: includeTrackingTasksTab(this.props.organizationIsVso) ? 1 : 0,
+      active_tab_index: includeTrackingTasksTab(this.props.organizationIsVso) ? 1 : 0,
       tabs: [
         // Unassigned Tasks Tab
         {
@@ -188,7 +188,7 @@ class OrganizationQueue extends React.PureComponent {
       <TabWindow
         name="tasks-organization-queue"
         tabs={this.tabsFromConfig(config)}
-        defaultPage={config.active_tab}
+        defaultPage={config.active_tab_index}
       />
     </div>;
   }

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -158,7 +158,6 @@ RSpec.feature "Case details" do
         scenario "worksheet and details links are not visible" do
           visit vso.path
           click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
-
           expect(page).to have_current_path("/queue/appeals/#{appeal.vacols_id}")
           scroll_to("#hearings-section")
           expect(page).to_not have_content(COPY::CASE_DETAILS_HEARING_WORKSHEET_LINK_COPY)
@@ -1029,7 +1028,6 @@ RSpec.feature "Case details" do
           it "displays a loading failed message on the case details page" do
             visit(queue_home_path)
             click_on("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")
-            
             expect(page).to have_content(COPY::ACCESS_DENIED_TITLE)
             expect(page).to have_current_path(case_details_page_path)
           end

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Quality Review worflow" do
+RSpec.feature "Quality Review workflow" do
   let(:judge_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Javitz") }
   let!(:judge_staff) { FactoryBot.create(:staff, :judge_role, user: judge_user) }
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -266,11 +266,11 @@ RSpec.feature "Task queue" do
     before do
       OrganizationsUser.add_user_to_organization(mail_user, mail_team)
       OrganizationsUser.add_user_to_organization(mail_user, lit_support_team)
-      OrganizationsUser.add_user_to_organization(pulac_user, PulacCerullo.singleton) 
+      OrganizationsUser.add_user_to_organization(pulac_user, PulacCerullo.singleton)
       User.authenticate!(user: mail_user)
     end
 
-    def validate_pulac_cerullo_tasks_created(task_type, label) 
+    def validate_pulac_cerullo_tasks_created(task_type, label)
       visit "/queue/appeals/#{appeal.uuid}"
       find("button", text: COPY::TASK_SNAPSHOT_ADD_NEW_TASK_LABEL).click
 
@@ -288,7 +288,6 @@ RSpec.feature "Task queue" do
       click_dropdown(text: Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.label)
       click_button(text: "Submit")
 
-      
       mail_task = root_task.reload.children[0]
       expect(mail_task.class).to eq(eval(task_type))
       expect(mail_task.assigned_to).to eq(MailTeam.singleton)


### PR DESCRIPTION
Resolves #10620 

### Description
This PR includes code for building the `/organizations/<team>` view from a configuration object. This PR was taken to prepare for building OrganizationQueues from a backend configuration object. 

### Testing Plan
Since this is purely a refactor that seeks to change nothing about functionality, test coverage is already adequate.
