### PR TITLE
Reassign EPE user on intake edit

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -563,6 +563,10 @@ class Appeal < DecisionReview
     true
   end
 
+  def processed_in_vbms?
+    false
+  end
+
   def first_distributed_to_judge_date
     judge_tasks = tasks.select { |t| t.is_a?(JudgeTask) }
     return unless judge_tasks.any?

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -55,7 +55,7 @@ class RequestIssuesUpdate < ApplicationRecord
 
     # re-assign user to whomever edited the Claim.
     # this works around issue when original user is no longer authorized for VBMS.
-    review.end_product_establishments.each { |epe| epe.user = user }
+    review.end_product_establishments.each { |epe| epe.user = user } if review.processed_in_vbms?
 
     review.establish!
 

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -53,7 +53,7 @@ class RequestIssuesUpdate < ApplicationRecord
   def establish!
     attempted!
 
-    # re-assign user temporarily to whomever edited the Claim.
+    # re-assign user to whomever edited the Claim.
     # this works around issue when original user is no longer authorized for VBMS.
     review.end_product_establishments.each { |epe| epe.user = user }
 

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -53,6 +53,10 @@ class RequestIssuesUpdate < ApplicationRecord
   def establish!
     attempted!
 
+    # re-assign user temporarily to whomever edited the Claim.
+    # this works around issue when original user is no longer authorized for VBMS.
+    review.end_product_establishments.each { |epe| epe.user = user }
+
     review.establish!
 
     potential_end_products_to_remove = []

--- a/spec/factories/end_product_establishment.rb
+++ b/spec/factories/end_product_establishment.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     code { "030HLRR" }
     modifier { "030" }
     payee_code { EndProduct::DEFAULT_PAYEE_CODE }
+    user { create(:user) }
 
     trait :cleared do
       synced_status { "CLR" }

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -280,9 +280,7 @@ feature "Appeal Edit issues" do
         click_intake_add_issue
         add_intake_rating_issue("Back pain")
         add_intake_rating_issue("ankylosis of hip") # eligible issue
-
-        safe_click("#button-submit-update")
-        safe_click ".confirm"
+        click_edit_submit_and_confirm
 
         expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
 
@@ -311,8 +309,7 @@ feature "Appeal Edit issues" do
         visit "appeals/#{appeal.uuid}/edit/"
         click_remove_intake_issue_by_text("Back pain")
         click_remove_issue_confirmation
-        safe_click("#button-submit-update")
-        safe_click ".confirm"
+        click_edit_submit_and_confirm
 
         expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
         expect(li_optin.reload.rollback_processed_at).to_not be_nil

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -603,6 +603,12 @@ describe RequestIssuesUpdate do
       expect(riu.withdrawn_request_issue_ids).to be_nil
       expect(subject).to be_truthy
     end
+
+    it "should re-assign EPE user to RequestIssuesUpdate user" do
+      expect(review.end_product_establishments.map(&:user)).to_not include(riu.user)
+      subject
+      expect(review.end_product_establishments.map(&:user).uniq).to eq([riu.user])
+    end
   end
 
   context "async logic scopes" do


### PR DESCRIPTION
connects #10747 

A Decision Review can be edited long after the original user who created it no longer has permission in VBMS. Re-assign the EndProductEstablishments to the user who performs the edit so that permissions align with whomever is actually making the change.