### PR TITLE
only re-use modifiers for CLR EPs

### DIFF
--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -191,6 +191,14 @@ class EndProduct
     !INACTIVE_STATUSES.include?(status_type_code)
   end
 
+  def cleared?
+    status_type_code == "CLR"
+  end
+
+  def canceled?
+    status_type_code == "CAN"
+  end
+
   def contentions
     @contentions ||= claim_id ? VBMSService.fetch_contentions(claim_id: claim_id) : nil
   end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -451,7 +451,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def taken_modifiers
-    @taken_modifiers ||= veteran.end_products.select(&:active?).map(&:modifier)
+    @taken_modifiers ||= veteran.end_products.select(&:cleared?).map(&:modifier)
   end
 
   def find_open_modifier

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -451,7 +451,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def taken_modifiers
-    @taken_modifiers ||= veteran.end_products.select(&:cleared?).map(&:modifier)
+    @taken_modifiers ||= veteran.end_products.select(&:canceled?).map(&:modifier)
   end
 
   def find_open_modifier

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -451,7 +451,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def taken_modifiers
-    @taken_modifiers ||= veteran.end_products.select(&:canceled?).map(&:modifier)
+    @taken_modifiers ||= veteran.end_products.reject(&:cleared?).map(&:modifier)
   end
 
   def find_open_modifier

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -130,11 +130,11 @@ describe EndProductEstablishment do
       end
     end
 
-    context "when eps with a valid modifier already exist" do
+    context "when eps with a valid modifier already exists" do
       let!(:past_created_ep) do
         Generators::EndProduct.build(
           veteran_file_number: veteran_file_number,
-          bgs_attrs: { end_product_type_code: "030", status_type_code: "CAN" }
+          bgs_attrs: { end_product_type_code: "030", status_type_code: "PEND" }
         )
       end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -130,11 +130,11 @@ describe EndProductEstablishment do
       end
     end
 
-    context "when eps with a valid modifiers already exist" do
+    context "when eps with a valid modifier already exist" do
       let!(:past_created_ep) do
         Generators::EndProduct.build(
           veteran_file_number: veteran_file_number,
-          bgs_attrs: { end_product_type_code: "030" }
+          bgs_attrs: { end_product_type_code: "030", status_type_code: "CAN" }
         )
       end
 
@@ -202,7 +202,7 @@ describe EndProductEstablishment do
         %w[030 031 032].each do |modifier|
           Generators::EndProduct.build(
             veteran_file_number: veteran_file_number,
-            bgs_attrs: { end_product_type_code: modifier }
+            bgs_attrs: { end_product_type_code: modifier, status_type_code: "CAN" }
           )
         end
       end
@@ -212,12 +212,12 @@ describe EndProductEstablishment do
       end
     end
 
-    context "when existing EP has status CLR or CAN" do
+    context "when existing EP has status CLR" do
       before do
         %w[030 031 032].each do |modifier|
           Generators::EndProduct.build(
             veteran_file_number: veteran_file_number,
-            bgs_attrs: { end_product_type_code: modifier, status_type_code: %w[CLR CAN].sample }
+            bgs_attrs: { end_product_type_code: modifier, status_type_code: "CLR" }
           )
         end
       end
@@ -227,6 +227,21 @@ describe EndProductEstablishment do
         expect(Fakes::VBMSService).to have_received(:establish_claim!).with(
           hash_including(veteran_hash: veteran.reload.to_vbms_hash)
         )
+      end
+    end
+
+    context "when existing EP has status CAN" do
+      before do
+        %w[030 031 032].each do |modifier|
+          Generators::EndProduct.build(
+            veteran_file_number: veteran_file_number,
+            bgs_attrs: { end_product_type_code: modifier, status_type_code: "CAN" }
+          )
+        end
+      end
+
+      it "considers those EP modifiers as closed" do
+        expect { subject }.to raise_error(EndProductEstablishment::NoAvailableModifiers)
       end
     end
 


### PR DESCRIPTION
connects #11043 

There is some confusion right now about whether BGS should be allowing the re-use of canceled EP modifiers. We know they have in the past, but currently they are not being recycled.

This PR limits the pool of valid modifiers to just cleared EPs.