### PR TITLE
Segregate UI tests from non-UI tests

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -9,7 +9,7 @@ namespace :spec do
     ![".", ".."].include?(file) && File.directory?(File.join("./spec/feature", file))
   end
 
-  spec_names = [*feature_spec_folders, 'unit', 'other'].flat_map { |n| [n, "#{n}_no_ui"] }
+  spec_names = [*feature_spec_folders, "unit", "other"].flat_map { |n| [n, "#{n}_no_ui"] }
 
   # Tasks for setting up the environment and running the tests without
   # immediately printing output to the screen. This prevents output from overrunning
@@ -59,7 +59,7 @@ namespace :spec do
   make_rake_task = proc do |name:, desc:, pattern:, exclude_pattern:|
     [
       { name_suffix: nil, extra_rspec_opts: nil },
-      { name_suffix: '_no_ui', extra_rspec_opts: "--tag ~ui_test" }
+      { name_suffix: "_no_ui", extra_rspec_opts: "--tag ~ui_test" }
     ].each do |name_suffix:, extra_rspec_opts:|
       desc "#{desc}#{extra_rspec_opts ? " (#{extra_rspec_opts})" : ''}"
       RSpec::Core::RakeTask.new("#{name}#{name_suffix}".to_sym) do |t|
@@ -83,7 +83,7 @@ namespace :spec do
       pattern: "spec/feature/*_spec.rb",
       exclude_pattern: nil
     }
-  ].each &make_rake_task
+  ].each(&make_rake_task)
 
   feature_spec_folders.each do |folder|
     make_rake_task[

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-feature "Asyncable Jobs index" do
+feature "Asyncable Jobs index", ui_test: true do
   before do
     Timecop.freeze(Time.zone.now)
   end

--- a/spec/feature/certification/cancel_certification_spec.rb
+++ b/spec/feature/certification/cancel_certification_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.feature "Cancel certification" do
+RSpec.feature "Cancel certification", ui_test: true do
   let!(:current_user) { User.authenticate! }
 
   let(:appeal) do

--- a/spec/feature/certification/certification_stats_spec.rb
+++ b/spec/feature/certification/certification_stats_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.feature "Certification Stats Dashboard" do
+RSpec.feature "Certification Stats Dashboard", ui_test: true do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 55, 0, rand(1000)))
 

--- a/spec/feature/certification/save_certification_spec.rb
+++ b/spec/feature/certification/save_certification_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Save Certification" do
+RSpec.feature "Save Certification", ui_test: true do
   before do
     Form8.pdf_service = FakePdfService
     Timecop.freeze(Time.utc(2017, 2, 2, 20, 59, 0))

--- a/spec/feature/certification/start_certification_spec.rb
+++ b/spec/feature/certification/start_certification_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.feature "Start Certification" do
+RSpec.feature "Start Certification", ui_test: true do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end

--- a/spec/feature/dispatch/dispatch_stats_spec.rb
+++ b/spec/feature/dispatch/dispatch_stats_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Dispatch Stats Dashboard" do
+RSpec.feature "Dispatch Stats Dashboard", ui_test: true do
   before do
     Timecop.freeze(Time.utc(2015, 1, 1, 17, 55, 0, rand(1000)))
   end

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Establish Claim - ARC Dispatch" do
+RSpec.feature "Establish Claim - ARC Dispatch", ui_test: true do
   before do
     Timecop.freeze(pre_ramp_start_date)
 

--- a/spec/feature/dropdown_spec.rb
+++ b/spec/feature/dropdown_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Dropdown" do
+RSpec.feature "Dropdown", ui_test: true do
   let!(:current_user) { User.authenticate! }
   let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
 

--- a/spec/feature/hearings/add_hearing_day_spec.rb
+++ b/spec/feature/hearings/add_hearing_day_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Add a Hearing Day" do
+RSpec.feature "Add a Hearing Day", ui_test: true do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)

--- a/spec/feature/hearings/build_schedule_spec.rb
+++ b/spec/feature/hearings/build_schedule_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Build Hearing Schedule" do
+RSpec.feature "Build Hearing Schedule", ui_test: true do
   context "Build RO Hearing Schedule" do
     let!(:current_user) do
       User.authenticate!(roles: ["Build HearSched"])

--- a/spec/feature/hearings/change_hearing_disposition_spec.rb
+++ b/spec/feature/hearings/change_hearing_disposition_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Change hearing disposition" do
+RSpec.feature "Change hearing disposition", ui_test: true do
   let(:current_full_name) { "Leonela Harbold" }
   let(:hearing_admin_user) { FactoryBot.create(:user, full_name: current_full_name, station_id: 101) }
   let(:hearing_day) { FactoryBot.create(:hearing_day) }

--- a/spec/feature/hearings/daily_docket_spec.rb
+++ b/spec/feature/hearings/daily_docket_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Hearing Schedule Daily Docket" do
+RSpec.feature "Hearing Schedule Daily Docket", ui_test: true do
   let!(:actcode) { create(:actcode, actckey: "B", actcdtc: "30", actadusr: "SBARTELL", acspare1: "59") }
 
   context "Daily docket with one legacy hearing" do

--- a/spec/feature/hearings/edit_hearing_day_spec.rb
+++ b/spec/feature/hearings/edit_hearing_day_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Edit a Hearing Day" do
+RSpec.feature "Edit a Hearing Day", ui_test: true do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Hearing Schedule Daily Docket" do
+RSpec.feature "Hearing Schedule Daily Docket", ui_test: true do
   let(:user) { create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"]) }
 
   before do

--- a/spec/feature/hearings/hearing_worksheet_spec.rb
+++ b/spec/feature/hearings/hearing_worksheet_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Hearing prep" do
+RSpec.feature "Hearing prep", ui_test: true do
   context "Hearing worksheet" do
     let!(:current_user) { User.authenticate!(roles: ["Hearing Prep"]) }
     let!(:legacy_hearing) { create(:legacy_hearing, user: current_user) }

--- a/spec/feature/hearings/list_schedule_spec.rb
+++ b/spec/feature/hearings/list_schedule_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "List Schedule" do
+RSpec.feature "List Schedule", ui_test: true do
   context "Correct buttons are displayed based on permissions" do
     let!(:hearing) { create(:hearing) }
 

--- a/spec/feature/hearings/postpone_hearing_spec.rb
+++ b/spec/feature/hearings/postpone_hearing_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Postpone hearing" do
+RSpec.feature "Postpone hearing", ui_test: true do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)

--- a/spec/feature/hearings/remove_hearing_day_spec.rb
+++ b/spec/feature/hearings/remove_hearing_day_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Remove a Hearing Day" do
+RSpec.feature "Remove a Hearing Day", ui_test: true do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)

--- a/spec/feature/hearings/schedule_veteran_spec.rb
+++ b/spec/feature/hearings/schedule_veteran_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Schedule Veteran For A Hearing" do
+RSpec.feature "Schedule Veteran For A Hearing", ui_test: true do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     User.authenticate!(user: user)

--- a/spec/feature/help_spec.rb
+++ b/spec/feature/help_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Help" do
+RSpec.feature "Help", ui_test: true do
   let!(:current_user) { User.authenticate! }
   scenario "user goes to the help page" do
     User.authenticate!

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Intake Add Issues Page" do
+feature "Intake Add Issues Page", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Appeal Edit issues" do
+feature "Appeal Edit issues", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "support/intake_helpers"
 
-feature "Appeal Intake" do
+feature "Appeal Intake", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Intake Confirmation Page" do
+feature "Intake Confirmation Page", ui_test: true do
   include IntakeHelpers
 
   before { setup_intake_flags }

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Higher Level Review Edit issues" do
+feature "Higher Level Review Edit issues", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "support/intake_helpers"
 
-feature "Higher-Level Review" do
+feature "Higher-Level Review", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/intake_edit_confirmation_spec.rb
+++ b/spec/feature/intake/intake_edit_confirmation_spec.rb
@@ -3,7 +3,7 @@
 require "support/intake_helpers"
 require "byebug"
 
-feature "Intake Edit Confirmation" do
+feature "Intake Edit Confirmation", ui_test: true do
   include IntakeHelpers
 
   before { setup_intake_flags }

--- a/spec/feature/intake/intake_manager_spec.rb
+++ b/spec/feature/intake/intake_manager_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Intake Manager Page" do
+RSpec.feature "Intake Manager Page", ui_test: true do
   before do
     Timecop.freeze(post_ramp_start_date)
   end

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -1,9 +1,10 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
 require "support/intake_helpers"
 
-feature "Intake" do
+feature "Intake", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/intake_stats_spec.rb
+++ b/spec/feature/intake/intake_stats_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Intake Stats Dashboard" do
+RSpec.feature "Intake Stats Dashboard", ui_test: true do
   before do
     Timecop.freeze(Time.utc(2020, 1, 7, 17, 55, 0, rand(1000)))
   end

--- a/spec/feature/intake/nonrating_request_issue_modal_spec.rb
+++ b/spec/feature/intake/nonrating_request_issue_modal_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Nonrating Request Issue Modal" do
+feature "Nonrating Request Issue Modal", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/ramp_election_spec.rb
+++ b/spec/feature/intake/ramp_election_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "RAMP Election Intake" do
+feature "RAMP Election Intake", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/ramp_refiling_spec.rb
+++ b/spec/feature/intake/ramp_refiling_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "support/intake_helpers"
 
-RSpec.feature "RAMP Refiling Intake" do
+RSpec.feature "RAMP Refiling Intake", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Intake Review Page" do
+feature "Intake Review Page", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Supplemental Claim Edit issues" do
+feature "Supplemental Claim Edit issues", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "support/intake_helpers"
 
-feature "Supplemental Claim Intake" do
+feature "Supplemental Claim Intake", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/time_zone_spec.rb
+++ b/spec/feature/intake/time_zone_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Appeal time zone" do
+feature "Appeal time zone", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/intake/veteran_name_caching_spec.rb
+++ b/spec/feature/intake/veteran_name_caching_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/intake_helpers"
 
-feature "Higher-Level Review" do
+feature "Higher-Level Review", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/log_in_as_user_spec.rb
+++ b/spec/feature/log_in_as_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Log in as User" do
+RSpec.feature "Log in as User", ui_test: true do
   before do
     User.create(station_id: "283", css_id: "ANNE MERICA")
     User.authenticate!

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Login" do
+RSpec.feature "Login", ui_test: true do
   let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
 
   before do

--- a/spec/feature/non_comp/board_grants_spec.rb
+++ b/spec/feature/non_comp/board_grants_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "NonComp Board Grant Task Page" do
+feature "NonComp Board Grant Task Page", ui_test: true do
   before do
     FeatureToggle.enable!(:decision_reviews)
     Timecop.freeze(post_ama_start_date)

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "support/intake_helpers"
 
-feature "NonComp Dispositions Task Page" do
+feature "NonComp Dispositions Task Page", ui_test: true do
   include IntakeHelpers
 
   before do

--- a/spec/feature/non_comp/record_requests_spec.rb
+++ b/spec/feature/non_comp/record_requests_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "NonComp Record Request Page" do
+feature "NonComp Record Request Page", ui_test: true do
   before do
     FeatureToggle.enable!(:decision_reviews)
     Timecop.freeze(post_ama_start_date)

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-feature "NonComp Reviews Queue" do
+feature "NonComp Reviews Queue", ui_test: true do
   before do
     FeatureToggle.enable!(:decision_reviews)
   end

--- a/spec/feature/out_of_service_spec.rb
+++ b/spec/feature/out_of_service_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Out of Service" do
+RSpec.feature "Out of Service", ui_test: true do
   context "Across all apps" do
     before do
       User.authenticate!(css_id: "BVAAABSHIRE", roles: ["Admin Intake"])

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "AmaQueue" do
+RSpec.feature "AmaQueue", ui_test: true do
   def valid_document_id
     "12345-12345678"
   end

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Attorney checkout flow" do
+RSpec.feature "Attorney checkout flow", ui_test: true do
   let(:attorney_user) { FactoryBot.create(:default_user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
 

--- a/spec/feature/queue/attorney_queue_spec.rb
+++ b/spec/feature/queue/attorney_queue_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Attorney queue" do
+RSpec.feature "Attorney queue", ui_test: true do
   let(:judge) { FactoryBot.create(:user) }
   let!(:vacols_judge) { FactoryBot.create(:staff, :judge_role, user: judge) }
 

--- a/spec/feature/queue/case_assignment_spec.rb
+++ b/spec/feature/queue/case_assignment_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Case Assignment flows" do
+RSpec.feature "Case Assignment flows", ui_test: true do
   let(:attorney_user) { FactoryBot.create(:user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
 

--- a/spec/feature/queue/case_details/update_document_id_spec.rb
+++ b/spec/feature/queue/case_details/update_document_id_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Updating Document ID" do
+feature "Updating Document ID", ui_test: true do
   context "AMA case review" do
     it "only allows assigner and assignee to edit document ID and validates ID format" do
       attorney = create_ama_case_review

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Case details" do
+RSpec.feature "Case details", ui_test: true do
   before do
     Timecop.freeze(Time.utc(2020, 1, 1, 19, 0, 0))
   end

--- a/spec/feature/queue/colocated_checkout_flow_spec.rb
+++ b/spec/feature/queue/colocated_checkout_flow_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Colocated checkout flows" do
+RSpec.feature "Colocated checkout flows", ui_test: true do
   let(:attorney_user) { FactoryBot.create(:default_user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
   let(:colocated_user) { FactoryBot.create(:user) }

--- a/spec/feature/queue/colocated_task_queue_spec.rb
+++ b/spec/feature/queue/colocated_task_queue_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.feature "ColocatedTask" do
+RSpec.feature "ColocatedTask", ui_test: true do
   let(:vlj_support_staff) { FactoryBot.create(:user) }
 
   before { OrganizationsUser.add_user_to_organization(vlj_support_staff, Colocated.singleton) }

--- a/spec/feature/queue/delete_request_issues_spec.rb
+++ b/spec/feature/queue/delete_request_issues_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "correcting issues" do
+feature "correcting issues", ui_test: true do
   before { FeatureToggle.enable!(:ama_decision_issues) }
   after { FeatureToggle.disable!(:ama_decision_issues) }
 

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Hearings tasks workflows" do
+RSpec.feature "Hearings tasks workflows", ui_test: true do
   let(:user) { FactoryBot.create(:user) }
 
   before do

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Judge assignment to attorney and judge" do
+RSpec.feature "Judge assignment to attorney and judge", ui_test: true do
   let(:judge_one) { Judge.new(FactoryBot.create(:user, full_name: "Billie Daniel")) }
   let(:judge_two) { Judge.new(FactoryBot.create(:user, full_name: "Joe Shmoe")) }
   let!(:vacols_user_one) { FactoryBot.create(:staff, :judge_role, user: judge_one.user) }

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Judge checkout flow" do
+RSpec.feature "Judge checkout flow", ui_test: true do
   let(:attorney_user) { FactoryBot.create(:default_user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
 

--- a/spec/feature/queue/mail_task_spec.rb
+++ b/spec/feature/queue/mail_task_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "mail_task"
 
-RSpec.feature "MailTasks" do
+RSpec.feature "MailTasks", ui_test: true do
   let(:user) { FactoryBot.create(:user) }
 
   before do

--- a/spec/feature/queue/privacy_team_spec.rb
+++ b/spec/feature/queue/privacy_team_spec.rb
@@ -1,6 +1,7 @@
+# coding: utf-8
 # frozen_string_literal: true
 
-RSpec.feature "Privacy team tasks and queue" do
+RSpec.feature "Privacy team tasks and queue", ui_test: true do
   describe "Assigning ColocatedTask to Privacy team" do
     let(:attorney) { FactoryBot.create(:user) }
 

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Quality Review worflow" do
+RSpec.feature "Quality Review worflow", ui_test: true do
   let(:valid_document_id) { "12345-12345678" }
 
   let(:veteran_first_name) { "Marissa" }

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Search" do
+RSpec.feature "Search", ui_test: true do
   let(:attorney_user) { FactoryBot.create(:user) }
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -1,8 +1,9 @@
+# coding: utf-8
 # frozen_string_literal: true
 
 require "rails_helper"
 
-RSpec.feature "Task queue" do
+RSpec.feature "Task queue", ui_test: true do
   context "attorney user with assigned tasks" do
 
     let(:attorney_user) { FactoryBot.create(:user) }

--- a/spec/feature/queue/team_management_spec.rb
+++ b/spec/feature/queue/team_management_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Team management page" do
+RSpec.feature "Team management page", ui_test: true do
   let(:user) { FactoryBot.create(:user) }
 
   before do

--- a/spec/feature/queue/transcription_team_spec.rb
+++ b/spec/feature/queue/transcription_team_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "TranscriptionTeam" do
+RSpec.feature "TranscriptionTeam", ui_test: true do
   let(:transcription_team_member) { FactoryBot.create(:user) }
   let(:veteran) { FactoryBot.create(:veteran, first_name: "Maisie", last_name: "Varesko", file_number: 201_905_061) }
   let(:appeal) { FactoryBot.create(:appeal, veteran_file_number: veteran.file_number) }

--- a/spec/feature/queue/user_organization_spec.rb
+++ b/spec/feature/queue/user_organization_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "User organization" do
+RSpec.feature "User organization", ui_test: true do
   let(:role) { "org_role" }
   let!(:user) { User.authenticate!(user: create(:user, roles: [role])) }
   let!(:organization) { create(:organization, name: "Test organization", url: "test", role: role) }

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -81,7 +81,7 @@ def add_comment(text)
   click_on "Save"
 end
 
-RSpec.feature "Reader" do
+RSpec.feature "Reader", ui_test: true do
   before do
     Fakes::Initializer.load!
 

--- a/spec/feature/send_feedback_spec.rb
+++ b/spec/feature/send_feedback_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Send feedback" do
+RSpec.feature "Send feedback", ui_test: true do
   let!(:current_user) { User.authenticate! }
   let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
 

--- a/spec/feature/styleguide_spec.rb
+++ b/spec/feature/styleguide_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Style Guide" do
+RSpec.feature "Style Guide", ui_test: true do
   # :nocov:
   # The default Capybara driver would timeout on CircleCI pretty heavily.
   # The headless driver gets us the same result, but much faster

--- a/spec/feature/switch_apps_spec.rb
+++ b/spec/feature/switch_apps_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "SwitchApps" do
+RSpec.feature "SwitchApps", ui_test: true do
   context "A user with just Queue access" do
     let!(:user) do
       User.authenticate!(user: create(:user, roles: ["Reader"]))

--- a/spec/feature/switch_user_spec.rb
+++ b/spec/feature/switch_user_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Test Users for Demo" do
+RSpec.feature "Test Users for Demo", ui_test: true do
   before do
     # Switch user only works in demo
     ENV["DEPLOY_ENV"] = "development"

--- a/spec/models/tasks/hearing_admin_action_foreign_veteran_case_task_spec.rb
+++ b/spec/models/tasks/hearing_admin_action_foreign_veteran_case_task_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature HearingAdminActionForeignVeteranCaseTask do
     end
   end
 
-  context "UI tests" do
+  context "UI tests", ui_test: true do
     before do
       OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)
 

--- a/spec/models/tasks/hearing_admin_action_verify_address_task_spec.rb
+++ b/spec/models/tasks/hearing_admin_action_verify_address_task_spec.rb
@@ -88,7 +88,7 @@ RSpec.feature HearingAdminActionVerifyAddressTask do
     end
   end
 
-  describe "UI tests" do
+  describe "UI tests", ui_test: true do
     let(:instructions_text) { "This is why I want to cancel the task!" }
     
     context "with a hearing admin member" do


### PR DESCRIPTION
### Description

UI tests are now tagged with `ui_test: true`

example; ignore all UI tests:
```
bundle exec rspec --tag ~ui_test
```

example; only run UI tests:
```
bundle exec rspec --tag ui_test
```

Also, `lib/tasks/spec.rake` updated to give the option to ignore tests

examples:
```
bin/rake spec:unit # run all unit tests
bin/rake spec:unit_no_ui # run all unit tests except those which test the UI
bin/rake spec:queue_no_ui
```

### Acceptance Criteria

- calling rspec with or without `ui_test` tag runs correctly
- new rake tasks (*_no_ui) run correctly
