### PR TITLE
Route errors from HearingDispositionChangeJob to hearings channel

### DIFF
--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -6,6 +6,7 @@ class HearingDispositionChangeJob < CaseflowJob
   # For time_ago_in_words()
   include ActionView::Helpers::DateHelper
   queue_as :low_priority
+  application_attr :hearing_schedule
 
   def perform
     start_time = Time.zone.now


### PR DESCRIPTION
Resolves #11020 

This PR adds application attribute to HearingDispositionChangeJob which in turn allows our sentry-to-slack lambda to route alert to the right place. Fore more details see: 
https://github.com/department-of-veterans-affairs/appeals-deployment/blob/master/ansible/roles/caseflow-jobs/files/sentry-to-slack/index.js