### PR TITLE
Only show AOD tasks for hearings management, temporary

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -6,6 +6,7 @@ class Organizations::TasksController < OrganizationsController
 
   def index
     tasks = GenericQueue.new(user: organization).tasks
+    tasks = tasks.select{|t| t.appeal.is_a?(LegacyAppeal) && t.appeal.aod} if organization.is_a?(HearingsManagement)
 
     render json: {
       organization_name: organization.name,

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -8,7 +8,7 @@ class Organizations::TasksController < OrganizationsController
     tasks = GenericQueue.new(user: organization).tasks
 
     # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
-    tasks = tasks.select{|t| t.appeal.is_a?(LegacyAppeal) ? t.appeal.aod : true} if organization.id == "20"
+    tasks = tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod } if organization.id == "20"
 
     render json: {
       organization_name: organization.name,

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -6,7 +6,9 @@ class Organizations::TasksController < OrganizationsController
 
   def index
     tasks = GenericQueue.new(user: organization).tasks
-    tasks = tasks.select{|t| t.appeal.is_a?(LegacyAppeal) && t.appeal.aod} if organization.is_a?(HearingsManagement)
+
+    # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
+    tasks = tasks.select{|t| t.appeal.is_a?(LegacyAppeal) ? t.appeal.aod : true} if organization.id == "20"
 
     render json: {
       organization_name: organization.name,

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -8,7 +8,9 @@ class Organizations::TasksController < OrganizationsController
     tasks = GenericQueue.new(user: organization).tasks
 
     # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
-    tasks = tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod } if organization.id == "20"
+    if organization.url == "hearings-management"
+      tasks = tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
+    end
 
     render json: {
       organization_name: organization.name,

--- a/spec/feature/hearings/change_hearing_disposition_spec.rb
+++ b/spec/feature/hearings/change_hearing_disposition_spec.rb
@@ -98,6 +98,7 @@ RSpec.feature "Change hearing disposition" do
   scenario "change hearing disposition to cancelled" do
     step "visit the hearing admin organization queue and click on the veteran's name" do
       visit "/organizations/#{HearingAdmin.singleton.url}"
+
       expect(page).to have_content("Unassigned (1)")
       click_on veteran_link_text
     end

--- a/spec/feature/hearings/change_hearing_disposition_spec.rb
+++ b/spec/feature/hearings/change_hearing_disposition_spec.rb
@@ -98,7 +98,6 @@ RSpec.feature "Change hearing disposition" do
   scenario "change hearing disposition to cancelled" do
     step "visit the hearing admin organization queue and click on the veteran's name" do
       visit "/organizations/#{HearingAdmin.singleton.url}"
-
       expect(page).to have_content("Unassigned (1)")
       click_on veteran_link_text
     end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1029,7 +1029,7 @@ RSpec.feature "Case details" do
           it "displays a loading failed message on the case details page" do
             visit(queue_home_path)
             click_on("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")
-            
+
             expect(page).to have_content(COPY::ACCESS_DENIED_TITLE)
             expect(page).to have_current_path(case_details_page_path)
           end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -158,7 +158,6 @@ RSpec.feature "Case details" do
         scenario "worksheet and details links are not visible" do
           visit vso.path
           click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
-
           expect(page).to have_current_path("/queue/appeals/#{appeal.vacols_id}")
           scroll_to("#hearings-section")
           expect(page).to_not have_content(COPY::CASE_DETAILS_HEARING_WORKSHEET_LINK_COPY)
@@ -1029,7 +1028,6 @@ RSpec.feature "Case details" do
           it "displays a loading failed message on the case details page" do
             visit(queue_home_path)
             click_on("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")
-
             expect(page).to have_content(COPY::ACCESS_DENIED_TITLE)
             expect(page).to have_current_path(case_details_page_path)
           end

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.feature "Quality Review worflow" do
+RSpec.feature "Quality Review workflow" do
   let(:judge_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Javitz") }
   let!(:judge_staff) { FactoryBot.create(:staff, :judge_role, user: judge_user) }
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -288,7 +288,6 @@ RSpec.feature "Task queue" do
       click_dropdown(text: Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.label)
       click_button(text: "Submit")
 
-
       mail_task = root_task.reload.children[0]
       expect(mail_task.class).to eq(eval(task_type))
       expect(mail_task.assigned_to).to eq(MailTeam.singleton)

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -266,11 +266,11 @@ RSpec.feature "Task queue" do
     before do
       OrganizationsUser.add_user_to_organization(mail_user, mail_team)
       OrganizationsUser.add_user_to_organization(mail_user, lit_support_team)
-      OrganizationsUser.add_user_to_organization(pulac_user, PulacCerullo.singleton) 
+      OrganizationsUser.add_user_to_organization(pulac_user, PulacCerullo.singleton)
       User.authenticate!(user: mail_user)
     end
 
-    def validate_pulac_cerullo_tasks_created(task_type, label) 
+    def validate_pulac_cerullo_tasks_created(task_type, label)
       visit "/queue/appeals/#{appeal.uuid}"
       find("button", text: COPY::TASK_SNAPSHOT_ADD_NEW_TASK_LABEL).click
 
@@ -288,7 +288,7 @@ RSpec.feature "Task queue" do
       click_dropdown(text: Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.label)
       click_button(text: "Submit")
 
-      
+
       mail_task = root_task.reload.children[0]
       expect(mail_task.class).to eq(eval(task_type))
       expect(mail_task.assigned_to).to eq(MailTeam.singleton)


### PR DESCRIPTION
connects #10997

the Hearings Management tasks are not showing up due to there being too many.  With Pramal and Phillip's advise, this PR just shows the AOD tasks for hearings management as a temporary fix.

More ideas on fixes are in the ticket, we may want to decide if we can implement some of the medium term fixes quickly enough that we would want to wait on those instead. Those would include speeding up the data call, before pagination is implemented (long term fix).