### PR TITLE
suppress the "overwriting existing method" warning

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -31,6 +31,10 @@ class Task < ApplicationRecord
     Constants.TASK_STATUSES.cancelled.to_sym => Constants.TASK_STATUSES.cancelled
   }
 
+  # This suppresses a warning about the :open scope overwriting the Kernel#open method
+  # https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-open
+  class << self; undef_method :open; end
+
   scope :active, -> { where(status: active_statuses) }
 
   scope :open, -> { where(status: open_statuses) }


### PR DESCRIPTION
### Description
Suppresses the warning:
```
Creating scope :open. Overwriting existing method Task.open.
```
...displayed on load by caseflow because the `Task.open` scope overwrites the Ruby kernal's [`open` method](https://ruby-doc.org/core-2.6.3/Kernel.html#method-i-open), which is available on every Ruby object.