### PR TITLE
TaskTimer should clean up its errors when processed successfully

### DIFF
--- a/app/jobs/task_timer_job.rb
+++ b/app/jobs/task_timer_job.rb
@@ -22,6 +22,7 @@ class TaskTimerJob < CaseflowJob
 
       task_timer.attempted!
       task_timer.task.when_timer_ends
+      task_timer.clear_error!
       task_timer.processed!
     end
   rescue StandardError => error


### PR DESCRIPTION
aligns with how other jobs behave.