### PR TITLE
Rename Hearing Management to Hearings Management as it is in plural i…

### DIFF
--- a/app/models/organizations/hearings_management.rb
+++ b/app/models/organizations/hearings_management.rb
@@ -6,6 +6,6 @@ class HearingsManagement < Organization
   end
 
   def self.singleton
-    HearingsManagement.first || HearingsManagement.create(name: "Hearing Management", url: "hearing-management")
+    HearingsManagement.first || HearingsManagement.create(name: "Hearings Management", url: "hearings-management")
   end
 end

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -88,7 +88,7 @@ export default (connect(mapStateToProps, mapDispatchToProps)(ColocatedTaskListVi
 const NewTasksTab = connect(
   (state) => ({
     tasks: newTasksByAssigneeCssIdSelector(state),
-    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearing Management')
+    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearings Management')
   }))(
   (props) => {
     return <React.Fragment>
@@ -110,7 +110,7 @@ const NewTasksTab = connect(
 const OnHoldTasksTab = connect(
   (state) => ({
     tasks: onHoldTasksByAssigneeCssIdSelector(state),
-    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearing Management')
+    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearings Management')
   }))(
   (props) => {
     return <React.Fragment>
@@ -134,7 +134,7 @@ const OnHoldTasksTab = connect(
 const CompleteTasksTab = connect(
   (state) => ({
     tasks: completeTasksByAssigneeCssIdSelector(state),
-    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearing Management')
+    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearings Management')
   }))(
   (props) => {
     return <React.Fragment>

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -33,10 +33,10 @@ const alertStyling = css({
 
 const includeTrackingTasksTab = (organizationIsVso) => organizationIsVso;
 
-const allowBulkAssign = (organizationName) => (organizationName === 'Hearing Management');
+const allowBulkAssign = (organizationName) => (organizationName === 'Hearings Management');
 
 const showRegionalOfficeInQueue = (organizationName) =>
-  (organizationName === 'Hearing Management' || organizationName === 'Hearing Admin');
+  (organizationName === 'Hearings Management' || organizationName === 'Hearing Admin');
 
 class OrganizationQueue extends React.PureComponent {
   componentDidMount = () => {

--- a/spec/factories/organization.rb
+++ b/spec/factories/organization.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
 
     factory :hearings_management do
       type { "HearingsManagement" }
-      name { "Hearing Management" }
+      name { "Hearings Management" }
     end
   end
 end

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature "Hearings tasks workflows" do
             FactoryBot.create(:no_show_hearing_task)
           end
           success_msg = "You have bulk assigned 4 No Show Hearing Task task(s)"
-          visit("/organizations/hearing-management")
+          visit("/organizations/hearings-management")
           click_button(text: "Assign Tasks")
           fill_in_and_submit_bulk_assign_modal
           expect(page).to have_content(success_msg)


### PR DESCRIPTION
…n production DB

### Description
In production DB, Hearing Management organization is hard coded in a plural format. I think it was manually created through the rails console. However, in the code we reference singular name in a few places. This is a quick fix to fix bulk assignment button. 

TODO:
1. Rename Hearings Management to Hearing Management
2. Move organization names to the constants file

