### PR TITLE
Drop reader users table

### DIFF
--- a/db/migrate/20190617164845_drop_reader_user_table.rb
+++ b/db/migrate/20190617164845_drop_reader_user_table.rb
@@ -1,0 +1,5 @@
+class DropReaderUserTable < ActiveRecord::Migration[5.1]
+  def change
+    drop_table :reader_users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190603150958) do
+ActiveRecord::Schema.define(version: 20190617164845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -760,13 +760,6 @@ ActiveRecord::Schema.define(version: 20190603150958) do
     t.index ["veteran_file_number"], name: "index_ramp_refilings_on_veteran_file_number"
   end
 
-  create_table "reader_users", id: :serial, force: :cascade do |t|
-    t.datetime "documents_fetched_at"
-    t.integer "user_id", null: false
-    t.index ["documents_fetched_at"], name: "index_reader_users_on_documents_fetched_at"
-    t.index ["user_id"], name: "index_reader_users_on_user_id", unique: true
-  end
-
   create_table "record_synced_by_jobs", force: :cascade do |t|
     t.string "error"
     t.datetime "processed_at"
@@ -1086,7 +1079,6 @@ ActiveRecord::Schema.define(version: 20190603150958) do
   add_foreign_key "organizations_users", "users"
   add_foreign_key "ramp_closed_appeals", "ramp_elections"
   add_foreign_key "ramp_election_rollbacks", "users"
-  add_foreign_key "reader_users", "users"
   add_foreign_key "request_issues_updates", "users"
   add_foreign_key "schedule_periods", "users"
   add_foreign_key "user_quotas", "users"


### PR DESCRIPTION
Drop `reader_users` table in follow up to this PR: https://github.com/department-of-veterans-affairs/caseflow/pull/11099

*Schema Changes Only*

* [x] #appeals-schema notified with summary and link to this PR
