### PR TITLE
Speed Up Schedule Hearing Task Serialization

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -112,7 +112,7 @@ class TasksController < ApplicationController
     ro = HearingDayMapper.validate_regional_office(params[:ro])
     tasks = ScheduleHearingTask.tasks_for_ro(ro)
     AppealRepository.eager_load_legacy_appeals_for_tasks(tasks)
-    params = { user: current_user, role: user_role }
+    params = { user: current_user, role: user_role, include_previous_task: false }
 
     render json: AmaAndLegacyTaskSerializer.new(
       tasks: tasks, params: params, ama_serializer: WorkQueue::RegionalOfficeTaskSerializer

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -100,6 +100,8 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :previous_task do |object|
+    return {} if params[:include_previous_task] == false
+
     {
       assigned_at: object.previous_task.try(:assigned_at)
     }

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -19,7 +19,6 @@ class ScheduleHearingTask < GenericTask
       ).includes(
         :assigned_to, :assigned_by,
         appeal: [:available_hearing_locations],
-        hearing_task_association: [:hearing],
         attorney_case_reviews: [:attorney]
       )
 

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -16,11 +16,7 @@ class ScheduleHearingTask < GenericTask
         "status = ? OR status = ?",
         Constants.TASK_STATUSES.assigned.to_sym,
         Constants.TASK_STATUSES.in_progress.to_sym
-      ).includes(
-        :assigned_to, :assigned_by,
-        appeal: [:available_hearing_locations],
-        attorney_case_reviews: [:attorney]
-      )
+      ).includes(:assigned_to, :assigned_by, appeal: [:available_hearing_locations], attorney_case_reviews: [:attorney])
 
       appeal_tasks = incomplete_tasks.joins(
         "INNER JOIN appeals ON appeals.id = appeal_id AND tasks.appeal_type = 'Appeal'"

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -16,7 +16,12 @@ class ScheduleHearingTask < GenericTask
         "status = ? OR status = ?",
         Constants.TASK_STATUSES.assigned.to_sym,
         Constants.TASK_STATUSES.in_progress.to_sym
-      ).includes(:assigned_to, :assigned_by, appeal: [:available_hearing_locations], attorney_case_reviews: [:attorney])
+      ).includes(
+        :assigned_to, :assigned_by,
+        appeal: [:available_hearing_locations],
+        hearing_task_association: [:hearing],
+        attorney_case_reviews: [:attorney]
+      )
 
       appeal_tasks = incomplete_tasks.joins(
         "INNER JOIN appeals ON appeals.id = appeal_id AND tasks.appeal_type = 'Appeal'"


### PR DESCRIPTION
Potentially Resolves https://github.com/department-of-veterans-affairs/appeals-support/issues/5310

New Relic shows that an additional queries to the task table adds the most time to this process
<img width="850" alt="Screenshot 2019-06-18 12 20 45" src="https://user-images.githubusercontent.com/2473869/59703383-c0c27680-91c7-11e9-85b1-14c9c4de9277.png">

This PR is a temporary workaround that makes `previous_task` attribute option
