### PR TITLE
If BGS returns nil for POA use empty hash in IDT response

### DIFF
--- a/app/controllers/idt/api/v1/veterans_controller.rb
+++ b/app/controllers/idt/api/v1/veterans_controller.rb
@@ -34,7 +34,11 @@ class Idt::Api::V1::VeteransController < Idt::Api::V1::BaseController
 
     return {} unless poa
 
-    poa.merge(bgs.find_address_by_participant_id(poa[:participant_id]))
+    poa_address = bgs.find_address_by_participant_id(poa[:participant_id])
+
+    return poa.reject { |key| key == :participant_id } unless poa_address
+
+    poa.merge(poa_address)
   end
 
   def json_veteran_details

--- a/app/controllers/idt/api/v1/veterans_controller.rb
+++ b/app/controllers/idt/api/v1/veterans_controller.rb
@@ -26,10 +26,15 @@ class Idt::Api::V1::VeteransController < Idt::Api::V1::BaseController
   end
 
   def poa
-    @poa ||= begin
-      poa = bgs.fetch_poa_by_file_number(veteran[:file_number])
-      poa.merge(bgs.find_address_by_participant_id(poa[:participant_id]))
-    end
+    @poa ||= fetch_poa_with_address
+  end
+
+  def fetch_poa_with_address
+    poa = bgs.fetch_poa_by_file_number(veteran[:file_number])
+
+    return {} unless poa
+
+    poa.merge(bgs.find_address_by_participant_id(poa[:participant_id]))
   end
 
   def json_veteran_details

--- a/app/controllers/idt/api/v1/veterans_controller.rb
+++ b/app/controllers/idt/api/v1/veterans_controller.rb
@@ -36,7 +36,7 @@ class Idt::Api::V1::VeteransController < Idt::Api::V1::BaseController
 
     poa_address = bgs.find_address_by_participant_id(poa[:participant_id])
 
-    return poa.reject { |key| key == :participant_id } unless poa_address
+    return poa unless poa_address
 
     poa.merge(poa_address)
   end

--- a/spec/controllers/idt/api/veterans_controller_spec.rb
+++ b/spec/controllers/idt/api/veterans_controller_spec.rb
@@ -86,7 +86,11 @@ RSpec.describe Idt::Api::V1::VeteransController, type: :controller do
 
           response_body = JSON.parse(response.body)
 
-          expect(response_body["poa"]).to eq("representative_type" => "Attorney", "representative_name" => "Clarence Darrow")
+          expect(response_body["poa"]).to eq(
+            "representative_type" => "Attorney",
+            "representative_name" => "Clarence Darrow",
+            "participant_id" => power_of_attorney.bgs_participant_id
+          )
         end
       end
 

--- a/spec/controllers/idt/api/veterans_controller_spec.rb
+++ b/spec/controllers/idt/api/veterans_controller_spec.rb
@@ -75,6 +75,21 @@ RSpec.describe Idt::Api::V1::VeteransController, type: :controller do
         end
       end
 
+      context "POA has no address" do
+        before do
+          allow_any_instance_of(Fakes::BGSService).to receive(:find_address_by_participant_id).and_return(nil)
+          request.headers["FILENUMBER"] = file_number
+        end
+
+        it "returns just the POA name" do
+          get :details
+
+          response_body = JSON.parse(response.body)
+
+          expect(response_body["poa"]).to eq("representative_type" => "Attorney", "representative_name" => "Clarence Darrow")
+        end
+      end
+
       context "and a veteran's file number as a string" do
         before do
           request.headers["FILENUMBER"] = file_number

--- a/spec/controllers/idt/api/veterans_controller_spec.rb
+++ b/spec/controllers/idt/api/veterans_controller_spec.rb
@@ -58,6 +58,23 @@ RSpec.describe Idt::Api::V1::VeteransController, type: :controller do
         request.headers["TOKEN"] = token
       end
 
+      context "POA is nil" do
+        before do
+          request.headers["FILENUMBER"] = file_number
+          allow_any_instance_of(Fakes::BGSService).to receive(:fetch_poa_by_file_number).and_return(nil)
+        end
+
+        it "returns empty hash" do
+          get :details
+
+          expect(response.status).to eq 200
+
+          response_body = JSON.parse(response.body)
+
+          expect(response_body["poa"]).to eq({})
+        end
+      end
+
       context "and a veteran's file number as a string" do
         before do
           request.headers["FILENUMBER"] = file_number


### PR DESCRIPTION
connects #11078 

Fixes 500 error when IDT tries to fetch a non-existent POA.