### PR TITLE
Add test to confirm ColocatedTasks charge to correct VACOLS user

### DIFF
--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -493,7 +493,7 @@ describe ColocatedTask do
       colocated_task.reassign(reassign_params, reassigner)
     end
 
-    it "charges the case to the original assigner in VACOLS", focus: true do
+    it "charges the case to the original assigner in VACOLS" do
       # Complete the re-assigned task.
       org_task.children.open.first.update!(status: Constants.TASK_STATUSES.completed)
 

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -460,4 +460,45 @@ describe ColocatedTask do
       end
     end
   end
+
+  describe "Reassigned ColocatedTask for LegacyAppeal" do
+    let(:initial_assigner) { FactoryBot.create(:user) }
+    let!(:initial_assigner_staff) { FactoryBot.create(:staff, :attorney_role, sdomainid: initial_assigner.css_id) }
+    let(:reassigner) { FactoryBot.create(:user) }
+    let!(:reassigner_staff) { FactoryBot.create(:staff, sdomainid: reassigner.css_id) }
+
+    let(:appeal) do
+      FactoryBot.create(
+        :legacy_appeal,
+        vacols_case: FactoryBot.create(:case, bfcurloc: LegacyAppeal::LOCATION_CODES[:caseflow])
+      )
+    end
+
+    let(:org_task) do
+      FactoryBot.create(
+        :colocated_task,
+        appeal: appeal,
+        action: :retired_vlj,
+        assigned_by: initial_assigner,
+        assigned_to: Colocated.singleton
+      ).becomes(ColocatedTask)
+    end
+    let(:colocated_task) { org_task.children.first }
+
+    before do
+      reassign_params = {
+        assigned_to_type: User.name,
+        assigned_to_id: Colocated.singleton.next_assignee.id
+      }
+      colocated_task.reassign(reassign_params, reassigner)
+    end
+
+    it "charges the case to the original assigner in VACOLS", focus: true do
+      # Complete the re-assigned task.
+      org_task.children.open.first.update!(status: Constants.TASK_STATUSES.completed)
+
+      # Our AssociatedVacolsModels hold on to their VACOLS properties aggressively. Re-fetch the object to avoid that.
+      expect(LegacyAppeal.find(appeal.id).location_code).to eq(initial_assigner.vacols_uniq_id)
+    end
+  end
 end


### PR DESCRIPTION
Adds test to confirm that fix released in #10853 fixed the bug causing [`ColocatedTask`s to be charged to someone other than the assigning attorney](https://dsva.slack.com/archives/CHX8FMP28/p1560874152224100) when they were completed if the `ColocatedTask` was reassigned from one member of the VLJ support staff to another.

We can confirm that #10853 fixed this bug by commenting out the [`appeal.location_code == LegacyAppeal::LOCATION_CODES[:caseflow] ` line](https://github.com/department-of-veterans-affairs/caseflow/pull/10853/files#diff-8b82658bb308177c50466acc7dd20d8dR123) that was added in that PR and seeing this test fail.