### PR TITLE
Allow withdrawn appeals to be distributed

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -624,6 +624,10 @@ class Appeal < DecisionReview
     %w[supplemental_claim cavc]
   end
 
+  def cancel_active_tasks
+    AppealActiveTaskCancellation.new(self).call
+  end
+
   private
 
   def most_recently_assigned_to_label(tasks)

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -199,6 +199,10 @@ class ClaimReview < DecisionReview
     epe.request_issues
   end
 
+  def cancel_active_tasks
+    ClaimReviewActiveTaskCancellation.new(self).call
+  end
+
   private
 
   def incomplete_tasks?

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -184,10 +184,6 @@ class DecisionReview < ApplicationRecord
     # no-op
   end
 
-  def cancel_active_tasks
-    tasks.each(&:cancel_task_and_child_subtasks)
-  end
-
   def contestable_issues
     return contestable_issues_from_decision_issues unless can_contest_rating_issues?
 

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -12,7 +12,8 @@ class RequestIssuesUpdate < ApplicationRecord
   attr_writer :request_issues_data
   attr_reader :error_code
 
-  delegate :veteran, to: :review
+  delegate :veteran, :cancel_active_tasks, to: :review
+  delegate :withdrawn_issues, to: :withdrawal
 
   def perform!
     return false unless validate_before_perform
@@ -25,7 +26,6 @@ class RequestIssuesUpdate < ApplicationRecord
       process_withdrawn_issues!
       process_edited_issues!
       review.mark_rating_request_issues_to_reassociate!
-
       update!(
         before_request_issue_ids: before_issues.map(&:id),
         after_request_issue_ids: after_issues.map(&:id),
@@ -82,20 +82,12 @@ class RequestIssuesUpdate < ApplicationRecord
     removed_issues + withdrawn_issues
   end
 
-  def persisted_issues
-    after_issues - withdrawn_issues
-  end
-
   def before_issues
     @before_issues ||= before_request_issue_ids ? fetch_before_issues : calculate_before_issues
   end
 
   def after_issues
     @after_issues ||= after_request_issue_ids ? fetch_after_issues : calculate_after_issues
-  end
-
-  def withdrawn_issues
-    @withdrawn_issues ||= withdrawn_request_issue_ids ? fetch_withdrawn_issues : calculate_withdrawn_issues
   end
 
   def edited_issues
@@ -122,22 +114,10 @@ class RequestIssuesUpdate < ApplicationRecord
     end
   end
 
-  def calculate_withdrawn_issues
-    withdrawn_issue_data.map do |issue_data|
-      review.find_or_build_request_issue_from_intake_data(issue_data)
-    end
-  end
-
   def calculate_edited_issues
     edited_issue_data.map do |issue_data|
       review.find_or_build_request_issue_from_intake_data(issue_data)
     end
-  end
-
-  def withdrawn_issue_data
-    return [] unless @request_issues_data
-
-    @request_issues_data.select { |ri| !ri[:withdrawal_date].nil? && ri[:request_issue_id] }
   end
 
   def edited_issue_data
@@ -174,10 +154,6 @@ class RequestIssuesUpdate < ApplicationRecord
     RequestIssue.where(id: after_request_issue_ids)
   end
 
-  def fetch_withdrawn_issues
-    RequestIssue.where(id: withdrawn_request_issue_ids)
-  end
-
   def fetch_edited_issues
     RequestIssue.where(id: edited_request_issue_ids)
   end
@@ -187,10 +163,15 @@ class RequestIssuesUpdate < ApplicationRecord
   end
 
   def process_withdrawn_issues!
-    return if withdrawn_issues.empty?
+    withdrawal.call
+  end
 
-    withdrawal_date = withdrawn_issue_data.first[:withdrawal_date]
-    withdrawn_issues.each { |ri| ri.withdraw!(withdrawal_date) }
+  def withdrawal
+    @withdrawal ||= RequestIssueWithdrawal.new(
+      user: user,
+      review: review,
+      request_issues_data: @request_issues_data
+    )
   end
 
   def process_edited_issues!
@@ -205,9 +186,5 @@ class RequestIssuesUpdate < ApplicationRecord
 
   def process_removed_issues!
     removed_issues.each(&:remove!)
-  end
-
-  def cancel_active_tasks
-    persisted_issues.empty? && review.cancel_active_tasks
   end
 end

--- a/app/policies/withdrawn_decision_review_policy.rb
+++ b/app/policies/withdrawn_decision_review_policy.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class WithdrawnDecisionReviewPolicy
+  delegate :request_issues, to: :decision_review
+
+  def initialize(decision_review)
+    @decision_review = decision_review
+  end
+
+  def satisfied?
+    no_active_request_issues? && at_least_one_withdrawn_issue?
+  end
+
+  private
+
+  attr_reader :decision_review
+
+  def no_active_request_issues?
+    request_issues.active.empty?
+  end
+
+  def at_least_one_withdrawn_issue?
+    request_issues.withdrawn.any?
+  end
+end

--- a/app/services/appeal_active_task_cancellation.rb
+++ b/app/services/appeal_active_task_cancellation.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+class AppealActiveTaskCancellation
+  delegate :request_issues, :tasks, to: :appeal
+
+  def initialize(appeal)
+    @appeal = appeal
+  end
+
+  def call
+    if WithdrawnDecisionReviewPolicy.new(appeal).satisfied?
+      # Withdrawn appeals must be included in the automatic distribution pool.
+      # For an appeal to be considered ready for distribution, it must have an
+      # assigned DistributionTask. In order for the appeal to progress after
+      # distribution, its RootTask and TrackVeteranTask cannot be cancelled.
+      cancel_active_tasks_except_those_needed_for_distribution
+      assign_distribution_task
+    elsif no_active_request_issues?
+      cancel_active_tasks
+    end
+  end
+
+  private
+
+  attr_reader :appeal
+
+  def cancel_active_tasks_except_those_needed_for_distribution
+    all_tasks_except_those_needed_for_distribution.each(&:cancel_task_and_child_subtasks)
+  end
+
+  def assign_distribution_task
+    tasks.find_by(type: "DistributionTask").update!(status: "assigned")
+  end
+
+  def all_tasks_except_those_needed_for_distribution
+    tasks.where.not(type: tasks_needed_for_distribution)
+  end
+
+  def tasks_needed_for_distribution
+    %w[TrackVeteranTask RootTask]
+  end
+
+  def no_active_request_issues?
+    request_issues.active.empty?
+  end
+
+  def cancel_active_tasks
+    tasks.each(&:cancel_task_and_child_subtasks)
+  end
+end

--- a/app/services/claim_review_active_task_cancellation.rb
+++ b/app/services/claim_review_active_task_cancellation.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class ClaimReviewActiveTaskCancellation
+  def initialize(review)
+    @review = review
+  end
+
+  def call
+    review.tasks.each(&:cancel_task_and_child_subtasks) if no_active_request_issues?
+  end
+
+  private
+
+  attr_reader :review
+
+  def no_active_request_issues?
+    review.request_issues.active.empty?
+  end
+end

--- a/app/workflows/request_issue_withdrawal.rb
+++ b/app/workflows/request_issue_withdrawal.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class RequestIssueWithdrawal
+  def initialize(user:, review:, request_issues_data:)
+    @user = user
+    @review = review
+    @request_issues_data = request_issues_data
+  end
+
+  def call
+    return if withdrawn_issues.empty?
+
+    withdrawal_date = withdrawn_issue_data.first[:withdrawal_date]
+    withdrawn_issues.each { |ri| ri.withdraw!(withdrawal_date) }
+  end
+
+  def withdrawn_issues
+    @withdrawn_issues ||= calculate_withdrawn_issues
+  end
+
+  private
+
+  attr_reader :user, :review, :request_issues_data
+
+  def calculate_withdrawn_issues
+    withdrawn_issue_data.map do |issue_data|
+      review.find_or_build_request_issue_from_intake_data(issue_data)
+    end
+  end
+
+  def withdrawn_issue_data
+    return [] unless request_issues_data
+
+    request_issues_data.select { |ri| !ri[:withdrawal_date].nil? && ri[:request_issue_id] }
+  end
+end

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -1335,6 +1335,7 @@ feature "Higher Level Review Edit issues" do
         click_edit_submit_and_confirm
 
         expect(page).to have_content(Constants.INTAKE_FORM_NAMES.higher_level_review)
+        sleep 1
         expect(completed_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
         expect(in_progress_task.reload.status).to eq(Constants.TASK_STATUSES.in_progress)
       end

--- a/spec/workflows/appeal_withdrawal_spec.rb
+++ b/spec/workflows/appeal_withdrawal_spec.rb
@@ -1,0 +1,248 @@
+# frozen_string_literal: true
+
+describe "Withdrawing an appeal" do
+  context "appeal has one request issue and it is withdrawn" do
+    it "allows it to be distributed" do
+      add_blocking_mail_task_to_appeal
+      withdraw_all_request_issues
+
+      tasks = appeal.tasks.reload
+
+      expect(all_blocking_mail_tasks(tasks).pluck(:status).uniq).to eq ["cancelled"]
+      expect(distribution_task(tasks).status).to eq "assigned"
+      expect(track_veteran_task(tasks).status).to eq "in_progress"
+      expect(appeal.root_task.status).to eq "on_hold"
+    end
+  end
+
+  context "appeal has multiple open request issues and only one is withdrawn" do
+    it "does not mark it for distribution, and does not cancel active tasks" do
+      withdraw_only_one_request_issue
+
+      tasks = appeal_with_many_request_issues.tasks.reload
+
+      expect(distribution_task(tasks).status).to eq "on_hold"
+      expect(track_veteran_task(tasks).status).to eq "in_progress"
+      expect(appeal_with_many_request_issues.root_task.status).to eq "on_hold"
+    end
+  end
+
+  context "all eligible request issues are withdrawn, and remaining ones are ineligible" do
+    it "allows it to be distributed" do
+      withdraw_all_eligible_request_issues
+
+      appeal = appeal_with_ineligible_request_issues
+      tasks = appeal.tasks.reload
+
+      expect(distribution_task(tasks).status).to eq "assigned"
+      expect(track_veteran_task(tasks).status).to eq "in_progress"
+      expect(appeal.root_task.status).to eq "on_hold"
+    end
+  end
+
+  context "appeal has withdrawn request issues and the remaining are all closed" do
+    it "allows it to be distributed" do
+      withdraw_request_issue_and_leave_other_one_closed
+
+      appeal = appeal_with_closed_request_issues
+      tasks = appeal.tasks.reload
+
+      expect(distribution_task(tasks).status).to eq "assigned"
+      expect(track_veteran_task(tasks).status).to eq "in_progress"
+      expect(appeal.root_task.status).to eq "on_hold"
+    end
+  end
+
+  context "appeal only has ineligible request issues after removing other ones" do
+    it "cancels all active tasks" do
+      remove_all_eligible_request_issues
+
+      appeal = appeal_with_ineligible_request_issues
+      tasks = appeal.tasks.reload
+
+      expect(tasks.pluck(:status).uniq).to eq ["cancelled"]
+    end
+  end
+
+  def add_blocking_mail_task_to_appeal
+    OrganizationsUser.add_user_to_organization(user, MailTeam.singleton)
+    CongressionalInterestMailTask.create_from_params(
+      {
+        appeal: appeal,
+        parent_id: appeal.root_task.id
+      }, user
+    )
+  end
+
+  def withdraw_all_request_issues
+    request_issues_data = [
+      { request_issue_id: appeal.request_issues.last.id, withdrawal_date: Time.zone.now }
+    ]
+
+    RequestIssuesUpdate.new(
+      user: user,
+      review: appeal,
+      request_issues_data: request_issues_data
+    ).perform!
+  end
+
+  def withdraw_only_one_request_issue
+    request_issues_data = [
+      { request_issue_id: appeal_with_many_request_issues.request_issues.last.id, withdrawal_date: Time.zone.now },
+      { request_issue_id: appeal_with_many_request_issues.request_issues.first.id }
+    ]
+
+    RequestIssuesUpdate.new(
+      user: user,
+      review: appeal_with_many_request_issues,
+      request_issues_data: request_issues_data
+    ).perform!
+  end
+
+  def withdraw_all_eligible_request_issues
+    appeal = appeal_with_ineligible_request_issues
+    ineligible_request_issue = appeal.request_issues.where.not(ineligible_reason: nil).first
+    eligible_request_issue = appeal.request_issues.where(ineligible_reason: nil).first
+    request_issues_data = [
+      { request_issue_id: ineligible_request_issue.id },
+      { request_issue_id: eligible_request_issue.id, withdrawal_date: Time.zone.now }
+    ]
+
+    RequestIssuesUpdate.new(
+      user: user,
+      review: appeal,
+      request_issues_data: request_issues_data
+    ).perform!
+  end
+
+  def remove_all_eligible_request_issues
+    appeal = appeal_with_ineligible_request_issues
+    ineligible_request_issue = appeal.request_issues.where.not(ineligible_reason: nil).first
+    eligible_request_issue = appeal.request_issues.where(ineligible_reason: nil).first
+    request_issues_data = [
+      { request_issue_id: ineligible_request_issue.id },
+    ]
+
+    RequestIssuesUpdate.new(
+      user: user,
+      review: appeal,
+      request_issues_data: request_issues_data
+    ).perform!
+  end
+
+  def withdraw_request_issue_and_leave_other_one_closed
+    appeal = appeal_with_closed_request_issues
+    closed_request_issue = appeal.request_issues.where.not(closed_at: nil).first
+    eligible_request_issue = appeal.request_issues.where(closed_at: nil).first
+    request_issues_data = [
+      { request_issue_id: eligible_request_issue.id, withdrawal_date: Time.zone.now }
+    ]
+
+    RequestIssuesUpdate.new(
+      user: user,
+      review: appeal,
+      request_issues_data: request_issues_data
+    ).perform!
+  end
+
+  def distribution_task(tasks)
+    tasks.find_by(type: "DistributionTask")
+  end
+
+  def track_veteran_task(tasks)
+    tasks.find_by(type: "TrackVeteranTask")
+  end
+
+  def all_blocking_mail_tasks(tasks)
+    tasks.where(type: "CongressionalInterestMailTask")
+  end
+
+  def appeal
+    @appeal ||= begin
+      appeal = create(
+        :appeal,
+        :with_tasks,
+        docket_type: "direct_review",
+        request_issues: build_list(:request_issue, 1, contested_issue_description: "Knee pain")
+      )
+      create_distribution_and_track_veteran_tasks(appeal)
+      appeal
+    end
+  end
+
+  def appeal_with_many_request_issues
+    @appeal_with_many_request_issues ||= begin
+      appeal = create(
+        :appeal,
+        :with_tasks,
+        docket_type: "direct_review",
+      )
+      appeal.request_issues = build_list(
+        :request_issue, 2, contested_issue_description: "Knee pain", decision_review: appeal
+      )
+      appeal.save!
+      create_distribution_and_track_veteran_tasks(appeal)
+      appeal
+    end
+  end
+
+  def appeal_with_ineligible_request_issues
+    @appeal_with_ineligible_request_issues ||= begin
+      appeal = create(
+        :appeal,
+        :with_tasks,
+        docket_type: "direct_review",
+      )
+      eligible_request_issue = create(
+        :request_issue,
+        contested_issue_description: "Knee pain",
+        decision_review: appeal
+      )
+      ineligible_request_issue = create(
+        :request_issue,
+        contested_issue_description: "Back pain",
+        ineligible_reason: "untimely",
+        decision_review: appeal
+      )
+      appeal.request_issues = [eligible_request_issue, ineligible_request_issue]
+      appeal.save!
+      create_distribution_and_track_veteran_tasks(appeal)
+      appeal
+    end
+  end
+
+  def appeal_with_closed_request_issues
+    @appeal_with_closed_request_issues ||= begin
+      appeal = create(
+        :appeal,
+        :with_tasks,
+        docket_type: "direct_review",
+      )
+      eligible_request_issue = create(
+        :request_issue,
+        contested_issue_description: "Knee pain",
+        decision_review: appeal
+      )
+      closed_request_issue = create(
+        :request_issue,
+        contested_issue_description: "Back pain",
+        closed_status: :decided,
+        closed_at: Time.zone.now,
+        decision_review: appeal
+      )
+      appeal.request_issues = [eligible_request_issue, closed_request_issue]
+      appeal.save!
+      create_distribution_and_track_veteran_tasks(appeal)
+      appeal
+    end
+  end
+
+  def create_distribution_and_track_veteran_tasks(appeal)
+    create(:distribution_task, appeal: appeal)
+    create(:track_veteran_task, appeal: appeal)
+  end
+
+  def user
+    @user ||= create(:user)
+  end
+end


### PR DESCRIPTION
**Why**: Judges need to provide a decision for withdrawn appeals.
The definition of a withdrawn appeal is one where all request issues
have been withdrawn, even if they are ineligible or closed for other
reasons.

Previously, withdrawing all request issues would cancel all of the
appeal's active tasks. However, in order to allow the appeal to be
distributed, we cannot cancel its `RootTask` or `TrackVeteranTask`,
and we need to set its `DistributionTask`'s status to `assigned`.

If an appeal has a mixture of withdrawn and ineligible request issues,
or a mixture of withdrawn and closed request issues, then we should
cancel all active tasks

Resolves #10973
