### PR TITLE
Fix Hearing Location on Hearing Details

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -15,6 +15,7 @@ detectors:
     exclude:
       - FetchDocumentsForReaderJob#fetch_for_appeal
       - AsyncableJobsReporter
+      - HearingSerializerBase
   InstanceVariableAssumption:
     exclude:
       - Appeal

--- a/.reek.yml
+++ b/.reek.yml
@@ -6,6 +6,9 @@ detectors:
     exclude:
       - BulkTaskAssignment
       - QueueConfig
+  DataClump:
+    exclude:
+      - HearingSerializerBase
   DuplicateMethodCall:
     enabled: false
   FeatureEnvy:

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -178,85 +178,14 @@ class Hearing < ApplicationRecord
   end
 
   def quick_to_hash(_current_user_id)
-    serializable_hash(
-      methods: [
-        :external_id,
-        :veteran_first_name,
-        :veteran_last_name,
-        :regional_office_key,
-        :regional_office_name,
-        :regional_office_timezone,
-        :readable_request_type,
-        :scheduled_for,
-        :scheduled_time_string,
-        :central_office_time_string,
-        :appeal_external_id,
-        :veteran_file_number,
-        :evidence_window_waived,
-        :bva_poc,
-        :room,
-        :transcription,
-        :docket_number,
-        :docket_name,
-        :current_issue_count,
-        :location,
-        :worksheet_issues,
-        :closest_regional_office,
-        :available_hearing_locations,
-        :disposition_editable,
-        :advance_on_docket_motion,
-        :claimant_id
-      ],
-      except: [:military_service]
-    )
+    HearingSerializer.quick(self).serializable_hash[:data][:attributes]
   end
 
   def to_hash(_current_user_id)
-    serializable_hash(
-      methods: [
-        :external_id,
-        :veteran_first_name,
-        :veteran_last_name,
-        :appellant_first_name,
-        :appellant_last_name,
-        :appellant_address_line_1,
-        :appellant_city,
-        :appellant_state,
-        :appellant_zip,
-        :regional_office_key,
-        :regional_office_name,
-        :regional_office_timezone,
-        :readable_request_type,
-        :scheduled_for,
-        :scheduled_time_string,
-        :central_office_time_string,
-        :veteran_age,
-        :veteran_gender,
-        :appeal_external_id,
-        :veteran_file_number,
-        :evidence_window_waived,
-        :bva_poc,
-        :room,
-        :transcription,
-        :docket_number,
-        :docket_name,
-        :military_service,
-        :current_issue_count,
-        :representative,
-        :location,
-        :worksheet_issues,
-        :closest_regional_office,
-        :available_hearing_locations,
-        :disposition_editable,
-        :advance_on_docket_motion,
-        :claimant_id
-      ]
-    )
+    HearingSerializer.default(self).serializable_hash[:data][:attributes]
   end
 
   def to_hash_for_worksheet(current_user_id)
-    serializable_hash(
-      methods: [:judge]
-    ).merge(to_hash(current_user_id))
+    HearingSerializer.worksheet(self).serializable_hash[:data][:attributes]
   end
 end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -185,7 +185,7 @@ class Hearing < ApplicationRecord
     ::HearingSerializer.default(self).serializable_hash[:data][:attributes]
   end
 
-  def to_hash_for_worksheet(current_user_id)
+  def to_hash_for_worksheet(_current_user_id)
     ::HearingSerializer.worksheet(self).serializable_hash[:data][:attributes]
   end
 end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -178,14 +178,14 @@ class Hearing < ApplicationRecord
   end
 
   def quick_to_hash(_current_user_id)
-    HearingSerializer.quick(self).serializable_hash[:data][:attributes]
+    ::HearingSerializer.quick(self).serializable_hash[:data][:attributes]
   end
 
   def to_hash(_current_user_id)
-    HearingSerializer.default(self).serializable_hash[:data][:attributes]
+    ::HearingSerializer.default(self).serializable_hash[:data][:attributes]
   end
 
   def to_hash_for_worksheet(current_user_id)
-    HearingSerializer.worksheet(self).serializable_hash[:data][:attributes]
+    ::HearingSerializer.worksheet(self).serializable_hash[:data][:attributes]
   end
 end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -67,6 +67,13 @@ class Hearing < ApplicationRecord
     end
   end
 
+  def readable_location
+    return "Washington, DC" if request_type == HearingDay::REQUEST_TYPES[:central]
+    return "#{location.city}, #{location.state}" if location
+
+    nil
+  end
+
   def readable_request_type
     HEARING_TYPES[request_type.to_sym]
   end

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -205,7 +205,7 @@ class LegacyHearing < ApplicationRecord
   end
 
   def to_hash(current_user_id)
-    LegacyHearingSerializer.default(
+    ::LegacyHearingSerializer.default(
       self,
       params: { current_user_id: current_user_id }
     ).serializable_hash[:data][:attributes]
@@ -226,7 +226,7 @@ class LegacyHearing < ApplicationRecord
   end
 
   def to_hash_for_worksheet(current_user_id)
-    LegacyHearingSerializer.worksheet(
+    ::LegacyHearingSerializer.worksheet(
       self,
       params: { current_user_id: current_user_id }
     ).serializable_hash[:data][:attributes]

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -204,63 +204,12 @@ class LegacyHearing < ApplicationRecord
     end
   end
 
-  # rubocop:disable Metrics/MethodLength
   def to_hash(current_user_id)
-    serializable_hash(
-      methods: [
-        :disposition_editable,
-        :scheduled_for,
-        :scheduled_time_string,
-        :central_office_time_string,
-        :readable_request_type,
-        :disposition,
-        :aod,
-        :transcript_requested,
-        :hold_open,
-        :notes,
-        :add_on,
-        :representative,
-        :representative_name,
-        :regional_office_key,
-        :hearing_day_id,
-        :regional_office_name,
-        :regional_office_timezone,
-        :venue,
-        :veteran_first_name,
-        :veteran_last_name,
-        :appellant_first_name,
-        :appellant_last_name,
-        :vbms_id,
-        :current_issue_count,
-        :prepped,
-        :docket_number,
-        :docket_name,
-        :appeal_type,
-        :appellant_address_line_1,
-        :appellant_address_line_2,
-        :appellant_city,
-        :appellant_country,
-        :appellant_state,
-        :appellant_zip,
-        :location,
-        :readable_location,
-        :appeal_external_id,
-        :external_id,
-        :veteran_file_number,
-        :closest_regional_office,
-        :available_hearing_locations,
-        :bva_poc,
-        :room,
-        :judge_id
-      ],
-      except: [:military_service, :vacols_id]
-    ).merge(
-      viewed_by_current_user: hearing_views.all.any? do |hearing_view|
-        hearing_view.user_id == current_user_id
-      end
-    )
+    LegacyHearingSerializer.default(
+      self,
+      params: { current_user_id: current_user_id }
+    ).serializable_hash[:data][:attributes]
   end
-  # rubocop:enable Metrics/MethodLength
 
   alias quick_to_hash to_hash
 
@@ -277,19 +226,10 @@ class LegacyHearing < ApplicationRecord
   end
 
   def to_hash_for_worksheet(current_user_id)
-    serializable_hash(
-      methods: [:appeal_id,
-                :judge,
-                :summary,
-                :appeals_ready_for_hearing,
-                :cached_number_of_documents,
-                :military_service]
-    ).merge(
-      to_hash(current_user_id)
-    ).merge(
-      veteran_gender: fetch_veteran_gender,
-      veteran_age: fetch_veteran_age
-    )
+    LegacyHearingSerializer.worksheet(
+      self,
+      params: { current_user_id: current_user_id }
+    ).serializable_hash[:data][:attributes]
   end
 
   def appeals_ready_for_hearing

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -186,7 +186,7 @@ class LegacyHearing < ApplicationRecord
 
   def readable_location
     if request_type == LegacyHearing::CO_HEARING
-      return "Washington DC"
+      return "Washington, DC"
     end
 
     regional_office_name

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -100,7 +100,9 @@ class LegacyHearing < ApplicationRecord
   end
 
   def regional_office_key
-    return (venue_key || appeal&.regional_office_key) if request_type == "T" || hearing_day.nil?
+    if request_type == HearingDay::REQUEST_TYPES[:travel] || hearing_day.nil?
+      return (venue_key || appeal&.regional_office_key)
+    end
 
     hearing_day&.regional_office
   end

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative 'hearing_serializer_base'
+
+class HearingSerializer
+  include FastJsonapi::ObjectSerializer
+  extend HearingSerializerBase
+
+  attribute :advance_on_docket_motion
+  attribute :appeal_external_id
+  attribute :appeal_id
+  attribute :appellant_address_line_1, if: for_full
+  attribute :appellant_city, if: for_full
+  attribute :appellant_first_name, if: for_full
+  attribute :appellant_last_name, if: for_full
+  attribute :appellant_state, if: for_full
+  attribute :appellant_zip, if: for_full
+  attribute :available_hearing_locations
+  attribute :bva_poc
+  attribute :central_office_time_string
+  attribute :claimant_id
+  attribute :closest_regional_office
+  attribute :current_issue_count
+  attribute :disposition
+  attribute :disposition_editable
+  attribute :docket_name
+  attribute :docket_number
+  attribute :evidence_window_waived
+  attribute :external_id
+  attribute :hearing_day_id
+  attribute :id
+  attribute :judge, if: for_worksheet
+  attribute :judge_id
+  attribute :location
+  attribute :military_service, if: for_full
+  attribute :notes
+  attribute :prepped
+  attribute :readable_location
+  attribute :readable_request_type
+  attribute :regional_office_key
+  attribute :regional_office_name
+  attribute :regional_office_timezone
+  attribute :representative, if: for_full
+  attribute :representative_name
+  attribute :room
+  attribute :scheduled_for
+  attribute :scheduled_time
+  attribute :scheduled_time_string
+  attribute :summary
+  attribute :transcript_requested
+  attribute :transcript_sent_date
+  attribute :transcription
+  attribute :uuid
+  attribute :veteran_age, if: for_full
+  attribute :veteran_file_number
+  attribute :veteran_first_name
+  attribute :veteran_gender, if: for_full
+  attribute :veteran_last_name
+  attribute :witness
+  attribute :worksheet_issues
+end

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -2,7 +2,7 @@
 
 class HearingSerializer
   include FastJsonapi::ObjectSerializer
-  extend HearingSerializerBase
+  include HearingSerializerBase
 
   attribute :advance_on_docket_motion
   attribute :appeal_external_id

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'hearing_serializer_base'
-
 class HearingSerializer
   include FastJsonapi::ObjectSerializer
   extend HearingSerializerBase

--- a/app/serializers/hearings/hearing_serializer_base.rb
+++ b/app/serializers/hearings/hearing_serializer_base.rb
@@ -2,30 +2,30 @@
 
 module HearingSerializerBase
   def default(object, **params)
-    self.new(object, **params)
+    new(object, **params)
   end
 
   def quick(object, **params)
     params[:params] ||= {}
     params[:params][:quick] = true
 
-    self.new(object, **params)
+    new(object, **params)
   end
 
   def worksheet(object, **params)
     params[:params] ||= {}
     params[:params][:worksheet] = true
 
-    self.new(object, **params)
+    new(object, **params)
   end
 
   protected
 
   def for_full
-    Proc.new { |_record, params| not params[:quick] }
+    proc { |_record, params| !params[:quick] }
   end
 
   def for_worksheet
-    Proc.new { |_record, params| params[:worksheet] }
+    proc { |_record, params| params[:worksheet] }
   end
 end

--- a/app/serializers/hearings/hearing_serializer_base.rb
+++ b/app/serializers/hearings/hearing_serializer_base.rb
@@ -1,31 +1,35 @@
 # frozen_string_literal: true
 
 module HearingSerializerBase
-  def default(object, **params)
-    new(object, **params)
-  end
+  extend ActiveSupport::Concern
 
-  def quick(object, **params)
-    params[:params] ||= {}
-    params[:params][:quick] = true
+  class_methods do 
+    def default(object, **params)
+      new(object, **params)
+    end
 
-    new(object, **params)
-  end
+    def quick(object, **params)
+      params[:params] ||= {}
+      params[:params][:quick] = true
 
-  def worksheet(object, **params)
-    params[:params] ||= {}
-    params[:params][:worksheet] = true
+      new(object, **params)
+    end
 
-    new(object, **params)
-  end
+    def worksheet(object, **params)
+      params[:params] ||= {}
+      params[:params][:worksheet] = true
 
-  protected
+      new(object, **params)
+    end
 
-  def for_full
-    proc { |_record, params| !params[:quick] }
-  end
+    protected
 
-  def for_worksheet
-    proc { |_record, params| params[:worksheet] }
+    def for_full
+      proc { |_record, params| !params[:quick] }
+    end
+
+    def for_worksheet
+      proc { |_record, params| params[:worksheet] }
+    end
   end
 end

--- a/app/serializers/hearings/hearing_serializer_base.rb
+++ b/app/serializers/hearings/hearing_serializer_base.rb
@@ -3,7 +3,7 @@
 module HearingSerializerBase
   extend ActiveSupport::Concern
 
-  class_methods do 
+  class_methods do
     def default(object, **params)
       new(object, **params)
     end

--- a/app/serializers/hearings/hearing_serializer_base.rb
+++ b/app/serializers/hearings/hearing_serializer_base.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module HearingSerializerBase
+  def default(object, **params)
+    self.new(object, **params)
+  end
+
+  def quick(object, **params)
+    params[:params] ||= {}
+    params[:params][:quick] = true
+
+    self.new(object, **params)
+  end
+
+  def worksheet(object, **params)
+    params[:params] ||= {}
+    params[:params][:worksheet] = true
+
+    self.new(object, **params)
+  end
+
+  protected
+
+  def for_full
+    Proc.new { |_record, params| not params[:quick] }
+  end
+
+  def for_worksheet
+    Proc.new { |_record, params| params[:worksheet] }
+  end
+end

--- a/app/serializers/hearings/legacy_hearing_serializer.rb
+++ b/app/serializers/hearings/legacy_hearing_serializer.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class LegacyHearingSerializer
+  include FastJsonapi::ObjectSerializer
+  extend HearingSerializerBase
+
+  attribute :add_on
+  attribute :aod
+  attribute :appeal_external_id
+  attribute :appeal_id
+  attribute :appeal_type
+  attribute :appeals_ready_for_hearing, if: for_worksheet
+  attribute :appellant_address_line_1
+  attribute :appellant_address_line_2
+  attribute :appellant_city
+  attribute :appellant_country
+  attribute :appellant_first_name
+  attribute :appellant_last_name
+  attribute :appellant_state
+  attribute :appellant_zip
+  attribute :available_hearing_locations
+  attribute :bva_poc
+  attribute :cached_number_of_documents, if: for_worksheet
+  attribute :central_office_time_string
+  attribute :closest_regional_office
+  attribute :current_issue_count
+  attribute :disposition
+  attribute :disposition_editable
+  attribute :docket_name
+  attribute :docket_number
+  attribute :external_id
+  attribute :hearing_day_id
+  attribute :hold_open
+  attribute :id
+  attribute :judge, if: for_worksheet
+  attribute :judge_id
+  attribute :location
+  attribute :military_service, if: for_worksheet
+  attribute :notes
+  attribute :prepped
+  attribute :readable_location
+  attribute :readable_request_type
+  attribute :regional_office_key
+  attribute :regional_office_name
+  attribute :regional_office_timezone
+  attribute :representative
+  attribute :representative_name
+  attribute :room
+  attribute :scheduled_for
+  attribute :scheduled_time_string
+  attribute :summary
+  attribute :transcript_requested
+  attribute :user_id
+  attribute :vacols_id, if: for_worksheet
+  attribute :vbms_id
+  attribute :venue
+  attribute :veteran_age, if: for_worksheet, &:fetch_veteran_age
+  attribute :veteran_file_number
+  attribute :veteran_first_name
+  attribute :veteran_gender, if: for_worksheet, &:fetch_veteran_gender
+  attribute :veteran_last_name
+  attribute :viewed_by_current_user do |hearing, params|
+    hearing.hearing_views.all.any? do |hearing_view|
+      hearing_view.user_id == params[:current_user_id]
+    end
+  end
+  attribute :witness
+end

--- a/app/serializers/hearings/legacy_hearing_serializer.rb
+++ b/app/serializers/hearings/legacy_hearing_serializer.rb
@@ -2,7 +2,7 @@
 
 class LegacyHearingSerializer
   include FastJsonapi::ObjectSerializer
-  extend HearingSerializerBase
+  include HearingSerializerBase
 
   attribute :add_on
   attribute :aod

--- a/client/app/hearings/components/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/AssignHearingsTabs.jsx
@@ -175,10 +175,6 @@ export default class AssignHearingsTabs extends React.Component {
 
   };
 
-  getHearingLocation = (hearing) => (
-    hearing.readableRequestType === 'Central' ? 'Washington, DC' : hearing.readableLocation
-  );
-
   formatSuggestedHearingLocation = (location) => {
     if (!location) {
       return '';
@@ -251,7 +247,7 @@ export default class AssignHearingsTabs extends React.Component {
         return true;
       }
 
-      const hearingLocation = this.getHearingLocation(hearing);
+      const hearingLocation = hearing.readableLocation;
 
       if (_.isEmpty(hearingLocation) && filteredBy === 'null') {
         return true;
@@ -271,7 +267,7 @@ export default class AssignHearingsTabs extends React.Component {
         isAdvancedOnDocket: hearing.aod
       }),
       docketNumber: this.getHearingDocketTag(hearing),
-      hearingLocation: this.getHearingLocation(hearing),
+      hearingLocation: hearing.readableLocation,
       time: this.getHearingTime(hearing.scheduledFor, hearing.regionalOfficeTimezone)
     }));
   };
@@ -287,7 +283,7 @@ export default class AssignHearingsTabs extends React.Component {
 
   getFilteredLocationsForUpcomingHearings = (data) => (
     data.map((row) => {
-      const location = this.getHearingLocation(row);
+      const location = row.readableLocation;
 
       return {
         displayText: location || '<<blank>>',

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ module CaseflowCertification
 
     config.eager_load_paths << Rails.root.join('lib')
     config.eager_load_paths += Dir[Rails.root.join('app', 'models', '{**}')]
+    config.eager_load_paths += Dir[Rails.root.join('app', 'serializers', '{**}')]
 
     config.exceptions_app = self.routes
 

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -295,7 +295,7 @@ describe HearingDay do
         expect(subject.size).to eq 1
         expect(subject[0]["hearings"].size).to eq 1
         expect(subject[0]["readable_request_type"]).to eq Hearing::HEARING_TYPES[:V]
-        expect(subject[0]["hearings"][0]["appeal_id"]).to eq appeal.id
+        expect(subject[0]["hearings"][0][:appeal_id]).to eq appeal.id
       end
     end
   end
@@ -344,8 +344,8 @@ describe HearingDay do
         expect(subject.size).to eq 1
         expect(subject[0]["hearings"].size).to eq 1
         expect(subject[0]["readable_request_type"]).to eq Hearing::HEARING_TYPES[:V]
-        expect(subject[0]["hearings"][0]["appeal_id"]).to eq appeal.id
-        expect(subject[0]["hearings"][0]["hearing_disp"]).to eq nil
+        expect(subject[0]["hearings"][0][:appeal_id]).to eq appeal.id
+        expect(subject[0]["hearings"][0][:hearing_disp]).to eq nil
       end
     end
 
@@ -380,13 +380,13 @@ describe HearingDay do
       it "returns hearings are mapped to days" do
         subject.sort_by! { |hearing_day| hearing_day["scheduled_for"]}
         expect(subject.size).to eq 3
-        expect(subject[0]["hearings"][0]["appeal_id"]).to eq ama_appeal.id
+        expect(subject[0]["hearings"][0][:appeal_id]).to eq ama_appeal.id
         expect(subject[1]["hearings"].size).to eq 2
         expect(subject[1]["readable_request_type"]).to eq Hearing::HEARING_TYPES[:V]
-        expect(subject[1]["hearings"][0]["appeal_id"]).to eq appeal.id
-        expect(subject[1]["hearings"][0]["hearing_disp"]).to eq nil
-        expect(subject[1]["hearings"][1]["appeal_id"]).to eq appeal_today.id
-        expect(subject[2]["hearings"][0]["appeal_id"]).to eq appeal_tomorrow.id
+        expect(subject[1]["hearings"][0][:appeal_id]).to eq appeal.id
+        expect(subject[1]["hearings"][0][:hearing_disp]).to eq nil
+        expect(subject[1]["hearings"][1][:appeal_id]).to eq appeal_today.id
+        expect(subject[2]["hearings"][0][:appeal_id]).to eq appeal_tomorrow.id
       end
     end
 
@@ -427,7 +427,7 @@ describe HearingDay do
         expect(subject.size).to eq 1
         expect(subject[0]["hearings"].size).to eq 1
         expect(subject[0]["readable_request_type"]).to eq Hearing::HEARING_TYPES[:C]
-        expect(subject[0]["hearings"][0]["appeal_id"]).to eq appeal.id
+        expect(subject[0]["hearings"][0][:appeal_id]).to eq appeal.id
       end
     end
   end


### PR DESCRIPTION
Resolves #10073 

### Description

- Refactors `to_hash` logic to serializers for Hearing and LegacyHearing.
- Implement and serialize `readableLocation` for Hearing. This was being used on the frontend, but didn't exist for non-legacy hearings.
