### PR TITLE
Make shared examples name for Verify Address Task unique

### DIFF
--- a/spec/controllers/hearings/worksheets_controller_spec.rb
+++ b/spec/controllers/hearings/worksheets_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hearings::WorksheetsController, type: :controller, focus: true do
+RSpec.describe Hearings::WorksheetsController, type: :controller do
   let!(:user) { User.authenticate!(roles: ["Hearing Prep"]) }
   let(:legacy_hearing) { create(:legacy_hearing) }
   let(:hearing) { create(:hearing, :with_tasks) }

--- a/spec/controllers/hearings/worksheets_controller_spec.rb
+++ b/spec/controllers/hearings/worksheets_controller_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Hearings::WorksheetsController, type: :controller do
+RSpec.describe Hearings::WorksheetsController, type: :controller, focus: true do
   let!(:user) { User.authenticate!(roles: ["Hearing Prep"]) }
   let(:legacy_hearing) { create(:legacy_hearing) }
   let(:hearing) { create(:hearing, :with_tasks) }

--- a/spec/feature/hearings/hearing_admin_action_verify_address_task_spec.rb
+++ b/spec/feature/hearings/hearing_admin_action_verify_address_task_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "Address Verify Task for Appeal" do
+RSpec.shared_examples "Address Verify Task Frontend Workflow" do
   let!(:user) { create(:hearings_coordinator) }
   let(:root_task) { create(:root_task, appeal: appeal) }
   let(:distribution_task) { create(:distribution_task, appeal: appeal, parent: root_task) }
@@ -96,7 +96,7 @@ RSpec.feature HearingAdminActionVerifyAddressTask do
     let!(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
     let!(:appeal_id) { appeal.vacols_id }
 
-    include_examples "Address Verify Task for Appeal"
+    include_examples "Address Verify Task Frontend Workflow"
   end
 
   describe "Address Verify Workflow with AMA Appeal" do
@@ -104,6 +104,6 @@ RSpec.feature HearingAdminActionVerifyAddressTask do
     let!(:appeal) { create(:appeal, :hearing_docket, veteran: veteran) }
     let!(:appeal_id) { appeal.uuid }
 
-    include_examples "Address Verify Task for Appeal"
+    include_examples "Address Verify Task Frontend Workflow"
   end
 end


### PR DESCRIPTION
Resolves a warning I was seeing when running the test suite:

```
/home/ftseng/Documents/Code/caseflow/spec/models/concerns/timeable_task_spec.rb:4: warning: previous definition of NOW was here
WARNING: Shared example group 'Address Verify Task for Appeal' has been previously defined at:
  /home/ftseng/Documents/Code/caseflow/spec/feature/hearings/hearing_admin_action_verify_address_task_spec.rb:5
...and you are now defining it at:
  /home/ftseng/Documents/Code/caseflow/spec/models/tasks/hearing_admin_action_verify_address_task_spec.rb:5
The new definition will overwrite the original one.
```

### Description

  - Make the shared example name for the address verify spec unique