### PR TITLE
Fix bugs around bulk assignment UI and write more feature tests

### DIFF
--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -39,7 +39,7 @@ class BulkTaskAssignment
   def tasks_to_be_assigned
     @tasks_to_be_assigned ||= begin
       tasks = task_type.constantize
-        .open.where(assigned_to_id: organization.id)
+        .active.where(assigned_to_id: organization.id)
         .limit(task_count).order(:created_at)
       if regional_office
         tasks = tasks.joins(

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -134,19 +134,25 @@ class BulkAssignModal extends React.PureComponent {
   }
 
   filterTasksByRegionalOffice = (tasks) => {
+    let filteredTasks = tasks;
+
     if (this.state.modal.regionalOffice) {
-      tasks = tasks.filter((task) => {
+      filteredTasks = filteredTasks.filter((task) => {
         return regionalOfficeCity(task) === this.state.modal.regionalOffice;
       });
     }
-    return tasks;
+
+    return filteredTasks;
   }
 
   filterTasksByTaskType = (tasks) => {
+    let filteredTasks = tasks;
+
     if (this.state.modal.taskType) {
-      tasks = this.filterTasks('type', this.state.modal.taskType, tasks);
+      filteredTasks = this.filterTasks('type', this.state.modal.taskType, filteredTasks);
     }
-    return tasks
+
+    return filteredTasks;
   }
 
   generateUserOptions = () => {
@@ -161,7 +167,7 @@ class BulkAssignModal extends React.PureComponent {
   }
 
   generateRegionalOfficeOptions = () => {
-    let filteredTasks = this.filterTasksByTaskType(this.props.tasks);
+    const filteredTasks = this.filterTasksByTaskType(this.props.tasks);
 
     const options = _.uniq(filteredTasks.map((task) => {
       return regionalOfficeCity(task);
@@ -171,7 +177,7 @@ class BulkAssignModal extends React.PureComponent {
   }
 
   generateTaskTypeOptions = () => {
-    let filteredTasks = this.filterTasksByRegionalOffice(this.props.tasks);
+    const filteredTasks = this.filterTasksByRegionalOffice(this.props.tasks);
 
     const taskOptions = _.uniq(filteredTasks.map((task) => task.type)).map((task) => {
       return {
@@ -187,6 +193,7 @@ class BulkAssignModal extends React.PureComponent {
     const actualOptions = [];
     const issueCounts = BULK_ASSIGN_ISSUE_COUNT;
     let filteredTasks = this.filterTasksByRegionalOffice(this.props.tasks);
+
     filteredTasks = this.filterTasksByTaskType(filteredTasks);
 
     for (let i = 0; i < issueCounts.length; i++) {
@@ -197,12 +204,12 @@ class BulkAssignModal extends React.PureComponent {
         });
         break;
       }
-      if (filteredTasks.length === issueCounts[i]) { continue; }
-
-      actualOptions.push({
-        value: issueCounts[i],
-        displayText: issueCounts[i]
-      });
+      if (filteredTasks.length > issueCounts[i]) {
+        actualOptions.push({
+          value: issueCounts[i],
+          displayText: issueCounts[i]
+        });
+      }
     }
 
     return actualOptions;

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -197,7 +197,7 @@ class BulkAssignModal extends React.PureComponent {
         });
         break;
       }
-      if (filteredTasks.length == issueCounts[i]) { continue; }
+      if (filteredTasks.length === issueCounts[i]) { continue; }
 
       actualOptions.push({
         value: issueCounts[i],
@@ -208,7 +208,7 @@ class BulkAssignModal extends React.PureComponent {
     return actualOptions;
   }
 
-  generateDropdown = (label, fieldName, options, isRequired, defaultText) => <Dropdown
+  generateDropdown = (label, fieldName, options, isRequired) => <Dropdown
     name={label}
     options={options}
     value={this.state.modal[fieldName]}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -124,16 +124,16 @@ class SeedDB
     OrganizationsUser.add_user_to_organization(hearings_member, HearingsManagement.singleton)
     OrganizationsUser.add_user_to_organization(hearings_member, HearingAdmin.singleton)
 
-    create_no_show_hearings_tasks
+    create_different_hearings_tasks
     create_change_hearing_disposition_task
   end
 
-  def create_no_show_hearings_tasks
-    5.times do
+  def create_different_hearings_tasks
+    10.times do
       appeal = FactoryBot.create(
         :appeal,
         :hearing_docket,
-        closest_regional_office: %w[RO17 RO19 RO31].sample
+        closest_regional_office: ["RO17", "RO19", "RO31", nil].sample
       )
       root_task = FactoryBot.create(:root_task, appeal: appeal)
       distribution_task = FactoryBot.create(
@@ -153,7 +153,11 @@ class SeedDB
         appeal: appeal
       )
       disposition_task = FactoryBot.create(:disposition_task, parent: parent_hearing_task, appeal: appeal)
-      FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal)
+      FactoryBot.create(
+        [:no_show_hearing_task, :evidence_submission_window_task].sample,
+        parent: disposition_task,
+        appeal: appeal
+      )
     end
   end
 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -200,6 +200,13 @@ FactoryBot.define do
       parent { create(:disposition_task, appeal: appeal) }
     end
 
+    factory :evidence_submission_window_task, class: EvidenceSubmissionWindowTask do
+      type { EvidenceSubmissionWindowTask.name }
+      appeal { create(:appeal) }
+      assigned_to { HearingsManagement.singleton }
+      parent { create(:disposition_task, appeal: appeal) }
+    end
+
     factory :ama_attorney_task, class: AttorneyTask do
       type { AttorneyTask.name }
       appeal { create(:appeal) }

--- a/spec/feature/queue/bulk_task_assignment_spec.rb
+++ b/spec/feature/queue/bulk_task_assignment_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+RSpec.feature "Bulk task assignment" do
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)
+    User.authenticate!(user: user)
+  end
+
+  describe "bulk assign hearing tasks" do
+    def fill_in_and_submit_bulk_assign_modal
+      expect(page).to have_content("Bulk Assign Tasks")
+      options = find_all("option")
+      assign_to = options.find { |option| option.text =~ /#{user.full_name}/ }
+      assign_to.click
+      task_type = options.find { |option| option.text =~ /No Show Hearing Task/ }
+      task_type.click
+      number_of_tasks = options.find { |option| option.text =~ /3/ }
+      number_of_tasks.click
+      submit = all("button", text: "Assign Tasks")[0]
+      submit.click
+    end
+
+    it "is able to bulk assign tasks for the hearing management org" do
+      3.times do
+        FactoryBot.create(:no_show_hearing_task)
+      end
+      success_msg = "You have bulk assigned 3 No Show Hearing Task task(s)"
+      visit("/organizations/hearings-management")
+      click_button(text: "Assign Tasks")
+      fill_in_and_submit_bulk_assign_modal
+      expect(page).to have_content(success_msg)
+      expect(page).to have_content("Assigned (3)")
+    end
+
+    it "filters regional office by task types" do
+      # RO17 == St. Petersburg
+      # RO19 == Columbia
+      2.times do
+        FactoryBot.create(
+          :no_show_hearing_task,
+          appeal: create(:appeal, closest_regional_office: "RO17")
+        )
+      end
+
+      2.times do
+        FactoryBot.create(
+          :evidence_submission_window_task,
+          appeal: create(:appeal, closest_regional_office: "RO19")
+        )
+      end
+      visit("/organizations/hearings-management")
+      click_button(text: "Assign Tasks")
+      expect(page).to have_content("Bulk Assign Tasks")
+      options = find_all("option")
+      task_type = options.find { |option| option.text =~ /No Show/ }
+      task_type.click
+      options = find_all("option")
+      expect(options.map(&:text).include?("Columbia")).to eq false
+
+      task_type = options.find { |option| option.text =~ /Evidence/ }
+      task_type.click
+      options = find_all("option")
+      expect(options.map(&:text).include?("St. Petersburg")).to eq false
+    end
+
+    it "filters tasks by regional office and task type" do
+      4.times do
+        FactoryBot.create(
+          :no_show_hearing_task,
+          appeal: create(:appeal, closest_regional_office: "RO17")
+        )
+      end
+
+      2.times do
+        FactoryBot.create(
+          :evidence_submission_window_task,
+          appeal: create(:appeal, closest_regional_office: "RO19")
+        )
+      end
+
+      5.times do
+        FactoryBot.create(
+          :evidence_submission_window_task,
+          appeal: create(:appeal, closest_regional_office: "RO17")
+        )
+      end
+
+      visit("/organizations/hearings-management")
+      click_button(text: "Assign Tasks")
+      expect(page).to have_content("Bulk Assign Tasks")
+      options = find_all("option")
+      regional_office = options.find { |option| option.text =~ /St. Petersburg/ }
+      regional_office.click
+      task_type = options.find { |option| option.text =~ /No Show/ }
+      task_type.click
+
+      values = find_all("option").map(&:text)
+      expect(values.include?("4 (all available tasks)")).to eq true
+    end
+
+    it "filters task types by regional office" do
+      2.times do
+        FactoryBot.create(
+          :no_show_hearing_task,
+          appeal: create(:appeal, closest_regional_office: "RO17")
+        )
+      end
+
+      2.times do
+        FactoryBot.create(
+          :evidence_submission_window_task,
+          appeal: create(:appeal, closest_regional_office: "RO19")
+        )
+      end
+      visit("/organizations/hearings-management")
+      click_button(text: "Assign Tasks")
+      expect(page).to have_content("Bulk Assign Tasks")
+      options = find_all("option")
+      regional_office = options.find { |option| option.text =~ /Columbia/ }
+      regional_office.click
+      values = find_all("option").map(&:value)
+      expect(values.include?("NoShowHearingTask")).to eq false
+      expect(values.include?("EvidenceSubmissionWindowTask")).to eq true
+    end
+  end
+end

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -90,32 +90,6 @@ RSpec.feature "Hearings tasks workflows" do
           end
         end
       end
-
-      describe "Bulk assign hearing tasks" do
-        def fill_in_and_submit_bulk_assign_modal
-          options = find_all("option")
-          assign_to = options[2]
-          assign_to.click
-          task_type = options[8]
-          task_type.click
-          number_of_tasks = options[10]
-          number_of_tasks.click
-          submit = all("button", text: "Assign Tasks")[0]
-          submit.click
-        end
-
-        it "is able to bulk assign tasks for the hearing management org" do
-          3.times do
-            FactoryBot.create(:no_show_hearing_task)
-          end
-          success_msg = "You have bulk assigned 4 No Show Hearing Task task(s)"
-          visit("/organizations/hearings-management")
-          click_button(text: "Assign Tasks")
-          fill_in_and_submit_bulk_assign_modal
-          expect(page).to have_content(success_msg)
-          expect(page).to have_content("Assigned (4)")
-        end
-      end
     end
   end
 

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -23,6 +23,14 @@ describe BulkTaskAssignment do
                         created_at: 1.day.ago)
     end
 
+    # Even it is the oldest task, it should skip it becasue it is on hold
+    let!(:no_show_hearing_task4) do
+      FactoryBot.create(:no_show_hearing_task,
+                        assigned_to: organization,
+                        status: :on_hold,
+                        created_at: 6.day.ago)
+    end
+
     let(:assigned_to) { create(:user) }
     let(:assigned_by) { create(:user) }
 


### PR DESCRIPTION
Resolves #11106 

### Description
Fixes issues around Bulk Assignment modal:

1. If task type is selected, only display regional office list based on the task type selected.
1. Fix blank lines in the dropdown list for user and task type. Note: blank line is allowed in regional office list because it is optional
1. Do not allow to click assign tasks when required fields are missing
1. It appears, the number of tasks is not showing when there are a lot of tasks (more than a hard coded max value)
1. Do not reassign tasks that are already on hold

