### PR TITLE
hardcode limit on tasks returned by /organizations/tasks endpoint

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -19,7 +19,8 @@ class Organizations::TasksController < OrganizationsController
   def tasks
     # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
     if organization.url == "hearings-management"
-      GenericQueue.new(user: organization, limit: 1000).tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
+      GenericQueue.new(user: organization, limit: 1000).tasks
+        .select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
     else
       GenericQueue.new(user: organization, limit: 400).tasks
     end

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -19,7 +19,8 @@ class Organizations::TasksController < OrganizationsController
   def tasks
     # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
     if organization.url == "hearings-management"
-      GenericQueue.new(user: organization, limit: 500).tasks.select { |task| task.appeal.aod }
+      GenericQueue.new(user: organization, limit: 500).tasks
+        .select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
     else
       GenericQueue.new(user: organization, limit: 400).tasks
     end

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -19,7 +19,7 @@ class Organizations::TasksController < OrganizationsController
   def tasks
     # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
     if organization.url == "hearings-management"
-      GenericQueue.new(user: organization, limit: 1000).tasks
+      GenericQueue.new(user: organization, limit: 500).tasks
         .select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
     else
       GenericQueue.new(user: organization, limit: 400).tasks

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -17,6 +17,7 @@ class Organizations::TasksController < OrganizationsController
   private
 
   def tasks
+    # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
     if organization.url == "hearings-management"
       GenericQueue.new(user: organization, limit: 1000).tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
     else

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -19,8 +19,7 @@ class Organizations::TasksController < OrganizationsController
   def tasks
     # Temporarily limit hearings-management tasks to AOD tasks, because currently no tasks are loading
     if organization.url == "hearings-management"
-      GenericQueue.new(user: organization, limit: 500).tasks
-        .select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
+      GenericQueue.new(user: organization, limit: 500).tasks.select { |task| task.appeal.aod }
     else
       GenericQueue.new(user: organization, limit: 400).tasks
     end

--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -18,9 +18,9 @@ class Organizations::TasksController < OrganizationsController
 
   def tasks
     if organization.url == "hearings-management"
-      GenericQueue.new(user: organization).tasks(1000).select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
+      GenericQueue.new(user: organization, limit: 1000).tasks.select { |task| task.appeal.is_a?(Appeal) || task.appeal.aod }
     else
-      GenericQueue.new(user: organization).tasks(400)
+      GenericQueue.new(user: organization, limit: 400).tasks
     end
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -207,6 +207,8 @@ class Appeal < DecisionReview
     claimants.any? { |claimant| claimant.advanced_on_docket(receipt_date) }
   end
 
+  alias aod advanced_on_docket
+
   delegate :first_name,
            :last_name,
            :name_suffix,


### PR DESCRIPTION
until server-side pagination is complete, hardcode a limit on the number of tasks returned.