### PR TITLE
Set application for IDT controllers to trigger BGS AOD lookup

### DIFF
--- a/app/controllers/idt/api/v1/base_controller.rb
+++ b/app/controllers/idt/api/v1/base_controller.rb
@@ -3,6 +3,7 @@
 class Idt::Api::V1::BaseController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :validate_token
+  before_action :set_application
 
   # :nocov:
   rescue_from StandardError do |error|


### PR DESCRIPTION
see #11014 

It appears that this method was never being called in the IDT controller space and so `RequestStore[:application]` was never being set.