### PR TITLE
randomize SSN in specs

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -303,7 +303,7 @@ class Veteran < ApplicationRecord
       before_create_veteran_by_file_number # Used to simulate race conditions
       veteran.tap do |v|
         v.update!(
-          participant_id: v.ptcpnt_id,
+          participant_id: v.ptcpnt_id || v.bgs_record[:participant_id],
           first_name: v.bgs_record[:first_name],
           last_name: v.bgs_record[:last_name],
           middle_name: v.bgs_record[:middle_name],

--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -3,7 +3,7 @@
 class VeteranFinder
   class << self
     def find_or_create_all(*file_numbers_or_ssns)
-      file_numbers_or_ssns.flat_map(&VeteranFinder.method(:find_or_create_by_file_number_or_ssn))
+      file_numbers_or_ssns.flat_map(&VeteranFinder.method(:find_or_create_by_file_number_or_ssn)).uniq
     end
 
     private

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -583,8 +583,14 @@ class Fakes::BGSService
   end
 
   def fetch_file_number_by_ssn(ssn)
-    # reverse is a hack to return something different than what is passed.
-    ssn_not_found ? nil : ssn.to_s.reverse
+    return if ssn_not_found
+
+    self.class.veteran_records.each do |file_number, rec|
+      if rec[:ssn].to_s == ssn.to_s
+        return file_number
+      end
+    end
+    nil # i.e. not found
   end
 
   def fetch_ratings_in_range(participant_id:, start_date:, end_date:)

--- a/lib/generators/veteran.rb
+++ b/lib/generators/veteran.rb
@@ -59,7 +59,7 @@ class Generators::Veteran
         return_message: "Records found.",
         salutation_name: nil,
         sensitive_level_of_record: "0",
-        ssn: "111223334",
+        ssn: Generators::Random.unique_ssn,
         state: "VA",
         suffix_name: "II",
         temporary_custodian_indicator: nil,

--- a/spec/controllers/idt/api/veterans_controller_spec.rb
+++ b/spec/controllers/idt/api/veterans_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Idt::Api::V1::VeteransController, type: :controller do
     context "when request header contains valid token" do
       let(:role) { :attorney_role }
       let(:file_number) { "111222333" }
-      let!(:ssn) { file_number.to_s.reverse } # our fakes do this
+      let!(:ssn) { "666660000" }
       let!(:veteran) { create(:veteran, file_number: file_number, ssn: ssn) }
       let!(:power_of_attorney) { PowerOfAttorney.new(file_number: file_number) }
       let!(:power_of_attorney_address) { power_of_attorney.bgs_representative_address }

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe IntakesController do
 
   describe "#create" do
     let(:file_number) { "123456788" }
-    let(:ssn) { file_number.to_s.reverse } # our fakes do this
-    let!(:veteran) { create(:veteran, file_number: file_number) }
+    let(:ssn) { "666660000" }
+    let!(:veteran) { create(:veteran, file_number: file_number, ssn: ssn) }
 
     it "should search by Veteran file number" do
       post :create, params: { file_number: file_number, form_type: "higher_level_review" }

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     name_suffix { "II" }
 
     transient do
-      ssn { "987654321" }
+      ssn { Generators::Random.unique_ssn }
 
       bgs_veteran_record do
         {
@@ -33,7 +33,12 @@ FactoryBot.define do
     after(:build) do |veteran, evaluator|
       Fakes::BGSService.veteran_records ||= {}
       Fakes::BGSService.veteran_records[veteran.file_number] =
-        evaluator.bgs_veteran_record.merge(file_number: veteran.file_number, participant_id: veteran.participant_id)
+        evaluator.bgs_veteran_record.merge(
+          file_number: veteran.file_number,
+          # both for compatability
+          ptcpnt_id: veteran.participant_id,
+          participant_id: veteran.participant_id
+        )
     end
   end
 end

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Search" do
         expect(page).to have_content(format(COPY::CASE_SEARCH_ERROR_INVALID_ID_HEADING, invalid_veteran_id))
       end
 
-      it "searching in search bar works" do
+      it "searching in search bar works", skip: "flake https://github.com/department-of-veterans-affairs/caseflow/issues/10516#issuecomment-504491971" do
         fill_in "searchBarEmptyList", with: appeal.sanitized_vbms_id
         click_on "Search"
 
@@ -320,7 +320,7 @@ RSpec.feature "Search" do
         vso_user = create(:user, :vso_role, css_id: "BVA_VSO")
         User.authenticate!(user: vso_user)
         visit "/search"
-        fill_in "searchBarEmptyList", with: "123456789"
+        fill_in "searchBarEmptyList", with: "666660000"
         click_on "Search"
 
         expect(page).to have_content("Could not find a Veteran matching the file number")

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -55,7 +55,7 @@ RSpec.feature "Search" do
 
       context "when a claim has a higher level review and/or supplemental claim" do
         context "and it has no appeals" do
-          let!(:veteran) { FactoryBot.create(:veteran) }
+          let!(:veteran) { create(:veteran) }
           let!(:higher_level_review) { create(:higher_level_review, veteran_file_number: veteran.file_number) }
 
           before do

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -494,6 +494,10 @@ RSpec.feature "Search" do
              :with_tasks)
     end
 
+    before do
+      caseflow_appeal.root_task.cancelled!
+    end
+
     def perform_search
       visit "/search"
       fill_in "searchBarEmptyList", with: caseflow_appeal.veteran_file_number
@@ -501,7 +505,6 @@ RSpec.feature "Search" do
     end
 
     scenario "withdraw entire review and show withdrawn on search page" do
-      caseflow_appeal.root_task.update(status: Constants.TASK_STATUSES.cancelled)
       perform_search
       expect(page).to have_content("Withdrawn")
     end

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -26,7 +26,7 @@ RSpec.feature "Search" do
         expect(page).to have_content(format(COPY::CASE_SEARCH_ERROR_INVALID_ID_HEADING, invalid_veteran_id))
       end
 
-      it "searching in search bar works", skip: "flake https://github.com/department-of-veterans-affairs/caseflow/issues/10516#issuecomment-504491971" do
+      it "searching in search bar works" do
         fill_in "searchBarEmptyList", with: appeal.sanitized_vbms_id
         click_on "Search"
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -508,8 +508,8 @@ describe Veteran do
 
   describe ".find_by_file_number_or_ssn" do
     let(:file_number) { "123456789" }
-    let(:ssn) { file_number.to_s.reverse } # our fakes do this
-    let!(:veteran) { create(:veteran, file_number: file_number) }
+    let(:ssn) { "666660000" }
+    let!(:veteran) { create(:veteran, file_number: file_number, ssn: ssn) }
 
     it "fetches based on file_number" do
       expect(described_class.find_by_file_number_or_ssn(file_number)).to eq(veteran)
@@ -564,10 +564,14 @@ describe Veteran do
 
   describe ".find_or_create_by_file_number_or_ssn" do
     let(:file_number) { "123456789" }
-    let(:ssn) { file_number.to_s.reverse } # our fakes do this
+    let(:ssn) { "666660000" }
+
+    before do
+      BGSService.veteran_records = {}
+    end
 
     context "veteran exists in Caseflow" do
-      let!(:veteran) { create(:veteran, file_number: file_number) }
+      let!(:veteran) { create(:veteran, file_number: file_number, ssn: ssn) }
 
       it "fetches based on file_number" do
         expect(described_class.find_or_create_by_file_number_or_ssn(file_number)).to eq(veteran)
@@ -591,7 +595,7 @@ describe Veteran do
     end
 
     context "does not exist in Caseflow" do
-      let!(:veteran) { create(:veteran, file_number: file_number) }
+      let!(:veteran) { create(:veteran, file_number: file_number, ssn: ssn) }
 
       before do
         veteran.destroy! # leaves it in BGS
@@ -613,7 +617,7 @@ describe Veteran do
     end
 
     context "exists in BGS with different name than in Caseflow" do
-      let!(:veteran) { create(:veteran, file_number: file_number) }
+      let!(:veteran) { create(:veteran, file_number: file_number, ssn: ssn) }
 
       before do
         Fakes::BGSService.veteran_records[veteran.file_number][:last_name] = "Changed"


### PR DESCRIPTION
Our specs were using a single SSN for all Veteran factory records. Now that we can reliably search by file number or SSN, this was causing unexpected collisions.

Also, the fake BGS `fetch_file_number_by_ssn` was not actually looking things up by SSN. Now it does.
