### PR TITLE
Print task trees

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,8 @@ gem "stringex", require: false
 gem "strong_migrations"
 # execjs runtime
 gem "therubyracer", platforms: :ruby
+# print trees
+gem "tty-tree"
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", ">= 1.3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,6 +502,7 @@ GEM
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
+    tty-tree (0.3.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.20)
@@ -604,6 +605,7 @@ DEPENDENCIES
   strong_migrations
   therubyracer
   timecop
+  tty-tree
   tzinfo-data
   uglifier (>= 1.3.0)
   webdrivers

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -39,6 +39,16 @@ class Appeal < DecisionReview
   UUID_REGEX = /^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/.freeze
   STATE_CODES_REQUIRING_TRANSLATION_TASK = %w[VI VQ PR PH RP PI].freeze
 
+  def structure_render(*atts)
+    TTY::Tree.new(structure(*atts)).render
+  end
+
+  def structure(*atts)
+    leaf_name = "#{self.class.name} #{id}"
+    parentless_tasks = tasks.where(parent_id: nil).order(:id)
+    { "#{leaf_name}": parentless_tasks.map { |task| task.structure(*atts) } }
+  end
+
   def document_fetcher
     @document_fetcher ||= DocumentFetcher.new(
       appeal: self, use_efolder: true

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -7,6 +7,7 @@
 
 class Appeal < DecisionReview
   include Taskable
+  include PrintsTaskTree
 
   has_many :appeal_views, as: :appeal
   has_many :claims_folder_searches, as: :appeal
@@ -38,16 +39,6 @@ class Appeal < DecisionReview
 
   UUID_REGEX = /^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/.freeze
   STATE_CODES_REQUIRING_TRANSLATION_TASK = %w[VI VQ PR PH RP PI].freeze
-
-  def structure_render(*atts)
-    TTY::Tree.new(structure(*atts)).render
-  end
-
-  def structure(*atts)
-    leaf_name = "#{self.class.name} #{id}"
-    parentless_tasks = tasks.where(parent_id: nil).order(:id)
-    { "#{leaf_name}": parentless_tasks.map { |task| task.structure(*atts) } }
-  end
 
   def document_fetcher
     @document_fetcher ||= DocumentFetcher.new(

--- a/app/models/concerns/prints_task_tree.rb
+++ b/app/models/concerns/prints_task_tree.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module PrintsTaskTree
+  extend ActiveSupport::Concern
+
+  def structure_render(*atts)
+    TTY::Tree.new(structure(*atts)).render
+  end
+
+  def structure(*atts)
+    leaf_name = "#{self.class.name} #{task_tree_attributes(*atts)}"
+    { "#{leaf_name}": task_tree_children.map { |child| child.structure(*atts) } }
+  end
+
+  private
+
+  def task_tree_children
+    return children.order(:id) if is_a? Task
+
+    tasks.where(parent_id: nil).order(:id)
+  end
+
+  def task_tree_attributes(*atts)
+    return attributes_to_s(*atts) if is_a? Task
+
+    id.to_s
+  end
+
+  def attributes_to_s(*atts)
+    atts_list = []
+    atts.each do |att|
+      value = attributes[att.to_s]
+      value = "(#{att})" if value.blank?
+      atts_list << value
+    end
+    atts_list.flatten.compact.join(", ")
+  end
+end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -90,6 +90,16 @@ class LegacyAppeal < ApplicationRecord
     self.class.repository.aod(vacols_id)
   end
 
+  def structure_render(*atts)
+    TTY::Tree.new(structure(*atts)).render
+  end
+
+  def structure(*atts)
+    leaf_name = "#{self.class.name} #{id}"
+    parentless_tasks = tasks.where(parent_id: nil).order(:id)
+    { "#{leaf_name}": parentless_tasks.map { |task| task.structure(*atts) } }
+  end
+
   def advanced_on_docket
     aod
   end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -12,6 +12,7 @@ class LegacyAppeal < ApplicationRecord
   include CachedAttributes
   include AddressMapper
   include Taskable
+  include PrintsTaskTree
 
   belongs_to :appeal_series
   has_many :dispatch_tasks, foreign_key: :appeal_id, class_name: "Dispatch::Task"
@@ -88,16 +89,6 @@ class LegacyAppeal < ApplicationRecord
 
   cache_attribute :aod do
     self.class.repository.aod(vacols_id)
-  end
-
-  def structure_render(*atts)
-    TTY::Tree.new(structure(*atts)).render
-  end
-
-  def structure(*atts)
-    leaf_name = "#{self.class.name} #{id}"
-    parentless_tasks = tasks.where(parent_id: nil).order(:id)
-    { "#{leaf_name}": parentless_tasks.map { |task| task.structure(*atts) } }
   end
 
   def advanced_on_docket

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -49,11 +49,8 @@ class Task < ApplicationRecord
                                  )
                                }
 
-  def structure(base = false, *args)
-    statuses = []
-    args.each { |arg| statuses << attributes[arg.to_s] }
-    p_statuses = statuses.any? ? " (#{statuses.flatten.compact.join(', ')})" : ""
-    leaf_name = "#{self.class.name}#{p_statuses}"
+  def structure(base = false, *atts)
+    leaf_name = "#{self.class.name} #{attributes_to_s(*atts)}"
     if children.count.zero?
       if base || parent.nil?
         { "#{leaf_name}": [] }
@@ -61,7 +58,7 @@ class Task < ApplicationRecord
         leaf_name
       end
     else
-      { "#{leaf_name}": children.map { |child| child.structure(false, *args) } }
+      { "#{leaf_name}": children.map { |child| child.structure(false, *atts) } }
     end
   end
 
@@ -410,6 +407,16 @@ class Task < ApplicationRecord
   end
 
   private
+
+  def attributes_to_s(*atts)
+    atts_list = []
+    atts.each do |att|
+      value = attributes[att.to_s]
+      value = "(#{att})" if value.blank?
+      atts_list << value
+    end
+    atts_list.flatten.compact.join(", ")
+  end
 
   def create_and_auto_assign_child_task(options = {})
     dup.tap do |child_task|

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -49,17 +49,9 @@ class Task < ApplicationRecord
                                  )
                                }
 
-  def structure(base = false, *atts)
+  def structure(*atts)
     leaf_name = "#{self.class.name} #{attributes_to_s(*atts)}"
-    if children.count.zero?
-      if base || parent.nil?
-        { "#{leaf_name}": [] }
-      else
-        leaf_name
-      end
-    else
-      { "#{leaf_name}": children.map { |child| child.structure(false, *atts) } }
-    end
+    { "#{leaf_name}": children.map { |child| child.structure(*atts) } }
   end
 
   def available_actions(_user)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,8 @@
 class Task < ApplicationRecord
   acts_as_tree
 
+  include PrintsTaskTree
+
   belongs_to :assigned_to, polymorphic: true
   belongs_to :assigned_by, class_name: "User"
   belongs_to :appeal, polymorphic: true
@@ -48,15 +50,6 @@ class Task < ApplicationRecord
                                    type: DecisionReviewTask.descendants.map(&:name) + ["DecisionReviewTask"]
                                  )
                                }
-
-  def structure_render(*atts)
-    TTY::Tree.new(structure(*atts)).render
-  end
-
-  def structure(*atts)
-    leaf_name = "#{self.class.name} #{attributes_to_s(*atts)}"
-    { "#{leaf_name}": children.map { |child| child.structure(*atts) } }
-  end
 
   def available_actions(_user)
     []
@@ -403,16 +396,6 @@ class Task < ApplicationRecord
   end
 
   private
-
-  def attributes_to_s(*atts)
-    atts_list = []
-    atts.each do |att|
-      value = attributes[att.to_s]
-      value = "(#{att})" if value.blank?
-      atts_list << value
-    end
-    atts_list.flatten.compact.join(", ")
-  end
 
   def create_and_auto_assign_child_task(options = {})
     dup.tap do |child_task|

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -49,6 +49,22 @@ class Task < ApplicationRecord
                                  )
                                }
 
+  def structure(base = false, *args)
+    statuses = []
+    args.each { |arg| statuses << attributes[arg.to_s] }
+    p_statuses = statuses.any? ? " (#{statuses.join(', ')})" : ""
+    leaf_name = "#{self.class.name}#{p_statuses}"
+    if children.count.zero?
+      if base || parent.nil?
+        { "#{leaf_name}": [] }
+      else
+        leaf_name
+      end
+    else
+      { "#{leaf_name}": children.map { |child| child.structure(false, *args) } }
+    end
+  end
+
   def available_actions(_user)
     []
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -52,7 +52,7 @@ class Task < ApplicationRecord
   def structure(base = false, *args)
     statuses = []
     args.each { |arg| statuses << attributes[arg.to_s] }
-    p_statuses = statuses.any? ? " (#{statuses.join(', ')})" : ""
+    p_statuses = statuses.any? ? " (#{statuses.flatten.compact.join(', ')})" : ""
     leaf_name = "#{self.class.name}#{p_statuses}"
     if children.count.zero?
       if base || parent.nil?

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -49,6 +49,10 @@ class Task < ApplicationRecord
                                  )
                                }
 
+  def structure_render(*atts)
+    TTY::Tree.new(structure(*atts)).render
+  end
+
   def structure(*atts)
     leaf_name = "#{self.class.name} #{attributes_to_s(*atts)}"
     { "#{leaf_name}": children.map { |child| child.structure(*atts) } }

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -12,6 +12,17 @@ describe Appeal do
     Timecop.freeze(Time.utc(2019, 1, 1, 12, 0, 0))
   end
 
+  context "#tasks_structure" do
+    let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+
+    subject { appeal.structure(:id) }
+
+    it "returns the task structure" do
+      expect_any_instance_of(RootTask).to receive(:structure).with(:id)
+      expect(subject.key?(:"Appeal #{appeal.id}")).to be_truthy
+    end
+  end
+
   context "active appeals" do
     let!(:active_appeal) { create(:appeal, :with_tasks) }
     let!(:inactive_appeal) { create(:appeal, :outcoded) }

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -12,14 +12,16 @@ describe Appeal do
     Timecop.freeze(Time.utc(2019, 1, 1, 12, 0, 0))
   end
 
-  context "#tasks_structure" do
-    let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+  context "includes PrintsTaskTree concern" do
+    context "#structure" do
+      let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
 
-    subject { appeal.structure(:id) }
+      subject { appeal.structure(:id) }
 
-    it "returns the task structure" do
-      expect_any_instance_of(RootTask).to receive(:structure).with(:id)
-      expect(subject.key?(:"Appeal #{appeal.id}")).to be_truthy
+      it "returns the task structure" do
+        expect_any_instance_of(RootTask).to receive(:structure).with(:id)
+        expect(subject.key?(:"Appeal #{appeal.id}")).to be_truthy
+      end
     end
   end
 

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -13,25 +13,27 @@ describe LegacyAppeal do
     create(:legacy_appeal, vacols_case: vacols_case)
   end
 
-  context "#tasks_structure" do
-    let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
-    let(:vacols_case) { create(:case, bfcorlid: "123456789S") }
+  context "includes PrintsTaskTree concern" do
+    context "#structure" do
+      let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+      let(:vacols_case) { create(:case, bfcorlid: "123456789S") }
 
-    subject { appeal.structure(:id) }
+      subject { appeal.structure(:id) }
 
-    it "returns the task structure" do
-      expect_any_instance_of(RootTask).to receive(:structure).with(:id)
-      expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
-    end
-
-    context "the appeal has more than one parentless task" do
-      let!(:colocated_task) { FactoryBot.create(:colocated_task, appeal: appeal, parent: nil) }
-
-      it "returns all parentless tasks" do
+      it "returns the task structure" do
         expect_any_instance_of(RootTask).to receive(:structure).with(:id)
-        expect_any_instance_of(ColocatedTask).to receive(:structure).with(:id)
         expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
-        expect(subject[:"LegacyAppeal #{appeal.id}"].count).to eq 2
+      end
+
+      context "the appeal has more than one parentless task" do
+        let!(:colocated_task) { FactoryBot.create(:colocated_task, appeal: appeal, parent: nil) }
+
+        it "returns all parentless tasks" do
+          expect_any_instance_of(RootTask).to receive(:structure).with(:id)
+          expect_any_instance_of(ColocatedTask).to receive(:structure).with(:id)
+          expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
+          expect(subject[:"LegacyAppeal #{appeal.id}"].count).to eq 2
+        end
       end
     end
   end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -13,6 +13,29 @@ describe LegacyAppeal do
     create(:legacy_appeal, vacols_case: vacols_case)
   end
 
+  context "#tasks_structure" do
+    let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+    let(:vacols_case) { create(:case, bfcorlid: "123456789S") }
+
+    subject { appeal.structure(:id) }
+
+    it "returns the task structure" do
+      expect_any_instance_of(RootTask).to receive(:structure).with(:id)
+      expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
+    end
+
+    context "the appeal has more than one parentless task" do
+      let!(:colocated_task) { FactoryBot.create(:colocated_task, appeal: appeal, parent: nil) }
+
+      it "returns all parentless tasks" do
+        expect_any_instance_of(RootTask).to receive(:structure).with(:id)
+        expect_any_instance_of(ColocatedTask).to receive(:structure).with(:id)
+        expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
+        expect(subject[:"LegacyAppeal #{appeal.id}"].count).to eq 2
+      end
+    end
+  end
+
   context "#eligible_for_soc_opt_in? and #matchable_to_request_issue?" do
     let(:soc_eligible_date) { receipt_date - 60.days }
     let(:nod_eligible_date) { receipt_date - 372.days }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,36 +1,38 @@
 # frozen_string_literal: true
 
 describe Task do
-  describe ".structure" do
-    let(:root_task) { FactoryBot.create(:root_task, :on_hold) }
-    let!(:bva_task) { FactoryBot.create(:bva_dispatch_task, :in_progress, parent: root_task) }
-    let(:judge_task) { FactoryBot.create(:ama_judge_task, :completed, parent: root_task) }
-    let!(:attorney_task) { FactoryBot.create(:ama_attorney_task, :completed, parent: judge_task) }
+  context "includes PrintsTaskTree concern" do
+    describe ".structure" do
+      let(:root_task) { FactoryBot.create(:root_task, :on_hold) }
+      let!(:bva_task) { FactoryBot.create(:bva_dispatch_task, :in_progress, parent: root_task) }
+      let(:judge_task) { FactoryBot.create(:ama_judge_task, :completed, parent: root_task) }
+      let!(:attorney_task) { FactoryBot.create(:ama_attorney_task, :completed, parent: judge_task) }
 
-    subject { root_task.structure(:id, :status) }
+      subject { root_task.structure(:id, :status) }
 
-    it "outputs the task structure" do
-      root_key = "#{root_task.class.name} #{root_task.id}, #{root_task.status}".to_sym
-      judge_key = "#{judge_task.class.name} #{judge_task.id}, #{judge_task.status}".to_sym
-      bva_key = "#{bva_task.class.name} #{bva_task.id}, #{bva_task.status}".to_sym
-      attorney_key = "#{attorney_task.class.name} #{attorney_task.id}, #{attorney_task.status}".to_sym
+      it "outputs the task structure" do
+        root_key = "#{root_task.class.name} #{root_task.id}, #{root_task.status}".to_sym
+        judge_key = "#{judge_task.class.name} #{judge_task.id}, #{judge_task.status}".to_sym
+        bva_key = "#{bva_task.class.name} #{bva_task.id}, #{bva_task.status}".to_sym
+        attorney_key = "#{attorney_task.class.name} #{attorney_task.id}, #{attorney_task.status}".to_sym
 
-      expect(subject.key?(root_key)).to be_truthy
-      expect(subject[root_key].count).to eq 2
-      judge_task_found = false
-      bva_task_found = false
-      subject[root_key].each do |child_task|
-        if child_task.key? judge_key
-          judge_task_found = true
-          expect(child_task[judge_key].count).to eq 1
-          expect(child_task[judge_key].first.key?(attorney_key)).to be_truthy
-          expect(child_task[judge_key].first[attorney_key]).to eq []
-        elsif child_task.key? bva_key
-          bva_task_found = true
+        expect(subject.key?(root_key)).to be_truthy
+        expect(subject[root_key].count).to eq 2
+        judge_task_found = false
+        bva_task_found = false
+        subject[root_key].each do |child_task|
+          if child_task.key? judge_key
+            judge_task_found = true
+            expect(child_task[judge_key].count).to eq 1
+            expect(child_task[judge_key].first.key?(attorney_key)).to be_truthy
+            expect(child_task[judge_key].first[attorney_key]).to eq []
+          elsif child_task.key? bva_key
+            bva_task_found = true
+          end
         end
+        expect(judge_task_found).to be_truthy
+        expect(bva_task_found).to be_truthy
       end
-      expect(judge_task_found).to be_truthy
-      expect(bva_task_found).to be_truthy
     end
   end
 


### PR DESCRIPTION
### Description
Make it possible to print task trees from the rails console.

```
> puts RootTask.last.structure_render(:id, :status, :closed_at)

RootTask 220, on_hold, (closed_at)
├── BvaDispatchTask 226, on_hold, (closed_at)
│   └── BvaDispatchTask 227, assigned, (closed_at)
├── JudgeAssignTask 224, completed, 2019-06-14 22:35:44 UTC
│   └── AttorneyTask 225, completed, 2019-06-14 22:35:44 UTC
└── DistributionTask 221, on_hold, (closed_at)
    └── HearingTask 222, on_hold, (closed_at)
        └── ScheduleHearingTask 223, assigned, (closed_at)
```

```
> puts LegacyAppeal.first.structure_render(:id, :status, :created_at)

LegacyAppeal 1
├── RootTask 347, assigned, 2019-06-14 22:35:49 UTC
└── ColocatedTask 348, on_hold, 2019-06-14 22:35:49 UTC
    └── ColocatedTask 349, on_hold, 2019-06-14 22:35:49 UTC
```