### PR TITLE
Fix flakey bulk assignment test

### DIFF
--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -9,7 +9,7 @@ import QueueFlowModal from './QueueFlowModal';
 import Dropdown from '../../components/Dropdown';
 import { regionalOfficeCity } from '../utils';
 import { getUnassignedOrganizationalTasks } from '../selectors';
-import { bulkAssignTasks, onReceiveQueue } from '../QueueActions';
+import { bulkAssignTasks } from '../QueueActions';
 import {
   setActiveOrganization
 } from '../uiReducer/uiActions';
@@ -239,7 +239,6 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => (
   bindActionCreators({ bulkAssignTasks,
-    onReceiveQueue,
     setActiveOrganization }, dispatch)
 );
 

--- a/spec/feature/queue/bulk_task_assignment_spec.rb
+++ b/spec/feature/queue/bulk_task_assignment_spec.rb
@@ -25,7 +25,6 @@ RSpec.feature "Bulk task assignment" do
       3.times do
         FactoryBot.create(:no_show_hearing_task)
       end
-      success_msg = "You have bulk assigned 3 No Show Hearing Task task(s)"
       visit("/organizations/hearings-management")
       click_button(text: "Assign Tasks")
       expect(page).to have_content("Bulk Assign Tasks")
@@ -37,9 +36,8 @@ RSpec.feature "Bulk task assignment" do
       expect(page).to_not have_content("Loading")
 
       fill_in_and_submit_bulk_assign_modal
-      expect(page).to have_content(success_msg)
-      expect(user.tasks.where(type: "NoShowHearingTask").size).to eq 3
       expect(page).to have_content("Assigned (3)")
+      expect(NoShowHearingTask.where(assigned_to: user).size).to eq 3
     end
 
 

--- a/spec/feature/queue/bulk_task_assignment_spec.rb
+++ b/spec/feature/queue/bulk_task_assignment_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Bulk task assignment" do
       submit.click
     end
 
-    it "is able to bulk assign tasks for the hearing management org", skip: "flake https://github.com/department-of-veterans-affairs/caseflow/issues/10516#issuecomment-504168657" do
+    it "is able to bulk assign tasks for the hearing management org" do
       3.times do
         FactoryBot.create(:no_show_hearing_task)
       end
@@ -38,6 +38,7 @@ RSpec.feature "Bulk task assignment" do
 
       fill_in_and_submit_bulk_assign_modal
       expect(page).to have_content(success_msg)
+      expect(user.tasks.where(type: "NoShowHearingTask").size).to eq 3
       expect(page).to have_content("Assigned (3)")
     end
 


### PR DESCRIPTION
Fixes a flakey test: https://circleci.com/gh/department-of-veterans-affairs/caseflow/69567
I think this test randomly fails because of the code to reload the entire page `window.location.reload();`: https://github.com/department-of-veterans-affairs/caseflow/blob/739506249373f151849124a430caf1223f13fa7c/client/app/queue/components/BulkAssignModal.jsx#L70. By the time Capybara makes it here, the page is reloaded and the message is already gone. Testing it locally, works fine. I think i will create a ticket to NOT reload the entire page on success instead reload the tasks only. 
