### PR TITLE
Fix N+1 query in Organizations::TasksController

### DIFF
--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -38,6 +38,8 @@ class QueueConfig
   end
 
   def serialized_tasks_for_user(tasks, user)
+    return [] if tasks.empty?
+
     primed_tasks = AppealRepository.eager_load_legacy_appeals_for_tasks(tasks)
 
     organization.ama_task_serializer.new(

--- a/app/models/queues/generic_queue.rb
+++ b/app/models/queues/generic_queue.rb
@@ -46,7 +46,8 @@ class GenericQueue
       { appeal: [:available_hearing_locations, :claimants] },
       :assigned_by,
       :assigned_to,
-      :children
+      :children,
+      :parent
     ]
   end
 end

--- a/app/models/task_pager.rb
+++ b/app/models/task_pager.rb
@@ -64,24 +64,37 @@ class TaskPager
   private
 
   def tracking_tasks
-    TrackVeteranTask.active.where(assigned_to: assignee)
+    TrackVeteranTask.includes(*task_includes).active.where(assigned_to: assignee)
   end
 
   def unassigned_tasks
-    Task.visible_in_queue_table_view.where(assigned_to: assignee).active
+    Task.includes(*task_includes)
+      .visible_in_queue_table_view.where(assigned_to: assignee).active
   end
 
   def assigned_tasks
-    Task.visible_in_queue_table_view.where(assigned_to: assignee).on_hold
+    Task.includes(*task_includes)
+      .visible_in_queue_table_view.where(assigned_to: assignee).on_hold
   end
 
   def recently_completed_tasks
-    Task.visible_in_queue_table_view.where(assigned_to: assignee).recently_closed
+    Task.includes(*task_includes)
+      .visible_in_queue_table_view.where(assigned_to: assignee).recently_closed
   end
 
   def assignee_is_user_or_organization
     unless assignee.is_a?(User) || assignee.is_a?(Organization)
       errors.add(:assignee, COPY::TASK_PAGE_INVALID_ASSIGNEE_MESSAGE)
     end
+  end
+
+  def task_includes
+    [
+      { appeal: [:available_hearing_locations, :claimants] },
+      :assigned_by,
+      :assigned_to,
+      :children,
+      :parent
+    ]
   end
 end


### PR DESCRIPTION
We had previously optimized the task queries generated by
`GenericQueue`. We need to do the same in `QueueConfig` since they get
serialized the same way.

This saves about 200 DB calls locally. To test, disable the
authorization-related `before_actions` in `OrganizationsController`
and `Organizations::TasksController`. Then while the app is running,
run this command:
```
curl http://localhost:3000/organizations/bva/tasks
```
