### PR TITLE
Allow Case Review members to edit request issues

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -35,7 +35,7 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :can_edit_request_issues do |object, params|
-    params[:user]&.can_edit_request_issues?(object)
+    AppealRequestIssuesPolicy.new(user: params[:user], appeal: object).editable?
   end
 
   attribute(:hearings) { |object| hearings(object) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,14 +98,6 @@ class User < ApplicationRecord
     nil
   end
 
-  def can_edit_request_issues?(appeal)
-    Task.where(
-      appeal: appeal,
-      assigned_to: self,
-      status: [Constants.TASK_STATUSES.assigned, Constants.TASK_STATUSES.in_progress]
-    ).select { |t| t.is_a?(JudgeTask) || t.is_a?(AttorneyTask) }.any?
-  end
-
   def participant_id
     @participant_id ||= bgs.get_participant_id_for_user(self)
   end

--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AppealRequestIssuesPolicy
+  def initialize(user:, appeal:)
+    @user = user
+    @appeal = appeal
+  end
+
+  def editable?
+    return true if case_review_team_member?
+
+    appeal_has_in_progress_or_assigned_judge_or_attorney_tasks_assigned_to_user?
+  end
+
+  private
+
+  attr_reader :user, :appeal
+
+  def case_review_team_member?
+    BvaIntake.singleton.user_has_access?(user)
+  end
+
+  def appeal_has_in_progress_or_assigned_judge_or_attorney_tasks_assigned_to_user?
+    Task.where(
+      appeal: appeal,
+      assigned_to: user,
+      status: [Constants.TASK_STATUSES.assigned, Constants.TASK_STATUSES.in_progress]
+    ).select { |task| task.is_a?(JudgeTask) || task.is_a?(AttorneyTask) }.any?
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -344,45 +344,6 @@ describe User do
     end
   end
 
-  context "#can_edit_request_issues?" do
-    let(:appeal) { create(:appeal) }
-
-    subject { user.can_edit_request_issues?(appeal) }
-
-    context "when appeal has in-progress attorney task assigned to user" do
-      let!(:task) do
-        create(:task,
-               type: "AttorneyTask",
-               appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.assigned)
-      end
-      it { is_expected.to be true }
-    end
-
-    context "when appeal has in-progress judge task assigned to user" do
-      let!(:task) do
-        create(:task,
-               type: "JudgeDecisionReviewTask",
-               appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.in_progress)
-      end
-      it { is_expected.to be true }
-    end
-
-    context "when appeal has completed task assigned to user" do
-      let!(:task) do
-        create(:task,
-               type: "AttorneyTask",
-               appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.completed)
-      end
-      it { is_expected.to be false }
-    end
-  end
-
   context "#appeal_has_task_assigned_to_user?" do
     context "when legacy appeal" do
       let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }

--- a/spec/policies/appeal_request_issues_policy_spec.rb
+++ b/spec/policies/appeal_request_issues_policy_spec.rb
@@ -67,7 +67,8 @@ describe AppealRequestIssuesPolicy do
       end
     end
 
-    context "when user is a member of the Case Review team, regardless of the appeal's tasks" do
+    context "when user is a member of the Case Review team, and the appeal has not
+            been assigned to an attorney yet" do
       let(:user) { create(:user) }
 
       it "returns true" do
@@ -79,6 +80,22 @@ describe AppealRequestIssuesPolicy do
                status: Constants.TASK_STATUSES.assigned)
 
         expect(subject).to be true
+      end
+    end
+
+    context "when user is a member of the Case Review team, and the appeal has
+            already been assigned to an attorney" do
+      let(:user) { create(:user) }
+
+      it "returns false" do
+        OrganizationsUser.add_user_to_organization(user, BvaIntake.singleton)
+        create(:task,
+               type: "AttorneyTask",
+               appeal: appeal,
+               assigned_to: build_stubbed(:user),
+               status: Constants.TASK_STATUSES.assigned)
+
+        expect(subject).to be false
       end
     end
   end

--- a/spec/policies/appeal_request_issues_policy_spec.rb
+++ b/spec/policies/appeal_request_issues_policy_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+describe AppealRequestIssuesPolicy do
+  describe "#editable?" do
+    let(:appeal) { build_stubbed(:appeal) }
+    let(:user) { build_stubbed(:user) }
+
+    subject { AppealRequestIssuesPolicy.new(user: user, appeal: appeal).editable? }
+
+    context "when appeal has assigned attorney task assigned to user" do
+      it "returns true" do
+        create(:task,
+               type: "AttorneyTask",
+               appeal: appeal,
+               assigned_to: user,
+               status: Constants.TASK_STATUSES.assigned)
+
+        expect(subject).to be true
+      end
+    end
+
+    context "when appeal has assigned attorney task not assigned to user" do
+      it "returns false" do
+        create(:task,
+               type: "AttorneyTask",
+               appeal: appeal,
+               assigned_to: build_stubbed(:user),
+               status: Constants.TASK_STATUSES.assigned)
+
+        expect(subject).to be false
+      end
+    end
+
+    context "when appeal has in-progress judge task assigned to user" do
+      it "returns true" do
+        create(:task,
+               type: "JudgeDecisionReviewTask",
+               appeal: appeal,
+               assigned_to: user,
+               status: Constants.TASK_STATUSES.in_progress)
+
+        expect(subject).to be true
+      end
+    end
+
+    context "when appeal has completed attorney task assigned to user" do
+      it "returns false" do
+        create(:task,
+               type: "AttorneyTask",
+               appeal: appeal,
+               assigned_to: user,
+               status: Constants.TASK_STATUSES.completed)
+
+        expect(subject).to be false
+      end
+    end
+
+    context "when appeal has assigned task assigned to user that is neither a Judge or Attorney Task" do
+      it "return false" do
+        create(:task,
+               type: "ColocatedTask",
+               appeal: appeal,
+               assigned_to: user,
+               status: Constants.TASK_STATUSES.assigned)
+
+        expect(subject).to be false
+      end
+    end
+
+    context "when user is a member of the Case Review team, regardless of the appeal's tasks" do
+      let(:user) { create(:user) }
+
+      it "returns true" do
+        OrganizationsUser.add_user_to_organization(user, BvaIntake.singleton)
+        create(:task,
+               type: "ColocatedTask",
+               appeal: appeal,
+               assigned_to: build_stubbed(:user),
+               status: Constants.TASK_STATUSES.assigned)
+
+        expect(subject).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #11167

- Moved the logic for determining whether or not the user can edit
request issues from the User class to a policy class since this is
only used by the serializer.
- Added a conditional to check if the user is a member of the
Case Review team
- Added more tests to cover all scenarios

