### PR TITLE
Close EP400 request issues

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -378,7 +378,7 @@ class EndProductEstablishment < ApplicationRecord
 
   def close_request_issues_with_no_decision!
     return unless status_cleared?
-    return unless result.claim_type_code.include?("400")
+    return unless result.claim_type_code =~ /^400/
 
     request_issues.each { |ri| RequestIssueClosure.new(ri).with_no_decision! }
   end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -201,7 +201,7 @@ class EndProductEstablishment < ApplicationRecord
       )
       sync_source!
       close_request_issues_if_canceled!
-      close_request_issues_if_converted_to_ep400!
+      close_request_issues_with_no_decision!
     end
   rescue EstablishedEndProductNotFound, AppealRepository::AppealNotValidToReopen => error
     raise error
@@ -376,7 +376,7 @@ class EndProductEstablishment < ApplicationRecord
     request_issues.all.find_each(&:close_after_end_product_canceled!)
   end
 
-  def close_request_issues_if_converted_to_ep400!
+  def close_request_issues_with_no_decision!
     return unless status_cleared?
     return unless result.claim_type_code.include?("400")
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -662,10 +662,11 @@ describe EndProductEstablishment do
     context "when a matching end product has been established" do
       let(:reference_id) { matching_ep.claim_id }
       let(:status_type_code) { "CLR" }
+      let(:claim_type_code) { "030HLRR" }
       let!(:matching_ep) do
         Generators::EndProduct.build(
           veteran_file_number: veteran_file_number,
-          bgs_attrs: { status_type_code: status_type_code }
+          bgs_attrs: { status_type_code: status_type_code, claim_type_code: claim_type_code }
         )
       end
 
@@ -741,6 +742,19 @@ describe EndProductEstablishment do
           it "does not fail" do
             subject
           end
+        end
+      end
+
+      context "when the end product has been cleared and no decision issues are expected" do
+        let(:status_type_code) { "CLR" }
+        let(:claim_type_code) { "400RA" }
+
+        it "closes request issues with no_decision" do
+          subject
+
+          expect(end_product_establishment.reload.synced_status).to eq("CLR")
+          expect(request_issues.first.reload.closed_at).to eq(Time.zone.now)
+          expect(request_issues.first.closed_status).to eq("no_decision")
         end
       end
 


### PR DESCRIPTION
We have confirmation from AMO that if an end product gets its claim type changed to an EP400, that we can close the request issues with no_decision.  Currently we are doing this manually case-by-case, so that the request issues can be intaken again on a new decision review.
https://dsva.slack.com/archives/CFBLH2LR4/p1561396691147800

I have started looking into doing this for EPs that are already cleared. Since we don't store the claim_type_code if it gets changed, it will be good to prevent new incoming ones so that we don't have to search for new ones, which requires fetching the EPE result from BGS and takes some time.

Note, we do establish sometimes establish 400 claims from Caseflow as well, but those do not have any request issues.