### PR TITLE
Avoid serializing tasks 2x unless feature use_task_pages_api

### DIFF
--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -38,6 +38,7 @@ class QueueConfig
   end
 
   def serialized_tasks_for_user(tasks, user)
+    return [] unless FeatureToggle.enabled?(:use_task_pages_api)
     return [] if tasks.empty?
 
     primed_tasks = AppealRepository.eager_load_legacy_appeals_for_tasks(tasks)

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -79,6 +79,9 @@ describe QueueConfig do
         end
 
         context "when the organization has tasks assigned to it" do
+          before { FeatureToggle.enable!(:use_task_pages_api) }
+          after { FeatureToggle.disable!(:use_task_pages_api) }
+
           let!(:unassigned_tasks) { FactoryBot.create_list(:generic_task, 4, assigned_to: organization) }
           let!(:on_hold_tasks) { FactoryBot.create_list(:generic_task, 2, :on_hold, assigned_to: organization) }
           let!(:completed_tasks) { FactoryBot.create_list(:generic_task, 7, :completed, assigned_to: organization) }
@@ -131,6 +134,9 @@ describe QueueConfig do
         end
 
         context "when the VSO has tracking tasks assigned to it" do
+          before { FeatureToggle.enable!(:use_task_pages_api) }
+          after { FeatureToggle.disable!(:use_task_pages_api) }
+
           let!(:tracking_tasks) { FactoryBot.create_list(:track_veteran_task, 5, assigned_to: organization) }
 
           it "returns the tasks in the tracking tasks tabs" do


### PR DESCRIPTION
adds the `:use_task_pages_api` feature toggle and turns off task serialization in `queue_config` for now.