### PR TITLE
Hide reader link from VSO org queues

### DIFF
--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -92,7 +92,7 @@ class QueueConfig
         Constants.QUEUE_CONFIG.APPEAL_TYPE_COLUMN,
         Constants.QUEUE_CONFIG.DOCKET_NUMBER_COLUMN,
         Constants.QUEUE_CONFIG.DAYS_ON_HOLD_COLUMN,
-        Constants.QUEUE_CONFIG.DOCUMENT_COUNT_READER_LINK_COLUMN
+        organization.is_a?(Representative) ? nil : Constants.QUEUE_CONFIG.DOCUMENT_COUNT_READER_LINK_COLUMN
       ].compact,
       task_group: Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_GROUP,
       tasks: tasks,


### PR DESCRIPTION
Removes the reader link from VSO queues.

Somewhere along our transition to the queue config we started showing the reader link for VSO queues. This PR removes it again.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/60214428-767a6e80-9833-11e9-9f52-94bbf616e68a.png) | ![image](https://user-images.githubusercontent.com/32683958/60214566-be999100-9833-11e9-8513-0cec91986cca.png)
