### PR TITLE
Allow VLJ support staff to reassign tasks assigned to themselves

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -54,6 +54,7 @@ class ColocatedTask < Task
       return available_actions_with_conditions([
                                                  Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
                                                  Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.to_h,
+                                                 Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h,
                                                  Constants.TASK_ACTIONS.CANCEL_TASK.to_h
                                                ])
     end

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -51,12 +51,15 @@ class ColocatedTask < Task
 
   def available_actions(user)
     if assigned_to == user
-      return available_actions_with_conditions([
-                                                 Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-                                                 Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.to_h,
-                                                 Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h,
-                                                 Constants.TASK_ACTIONS.CANCEL_TASK.to_h
-                                               ])
+      base_actions = [
+        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
+        Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.to_h,
+        Constants.TASK_ACTIONS.CANCEL_TASK.to_h
+      ]
+
+      base_actions.push(Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h) if Colocated.singleton.user_is_admin?(user)
+
+      return available_actions_with_conditions(base_actions)
     end
 
     if task_is_assigned_to_user_within_organization?(user) && Colocated.singleton.admins.include?(user)


### PR DESCRIPTION
Currently, VLJ support admins can only re-assign `ColocatedTask`s from one member of the VLJ support staff to another if the task is not assigned to the admin who is trying to do the re-assigning. This ticket grants the admin the option to re-assign the task even if it is assigned to them.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/60276493-b8ee8a80-98c9-11e9-8afd-24adb347a028.png) | ![image](https://user-images.githubusercontent.com/32683958/60276201-2c43cc80-98c9-11e9-9934-89add307c472.png)
