### PR TITLE
Only add the decision task to the task list once, not on every render

### DIFF
--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -88,6 +88,14 @@ class TaskRows extends React.PureComponent {
   constructor(props) {
     super(props);
 
+    const mappedDecisionDateObj = this.mapDecisionDateToSortableObject(this.props.appeal);
+
+    if (this.props.appeal.decisionDate) {
+      this.props.taskList.push(mappedDecisionDateObj);
+    } else {
+      this.props.taskList.unshift(mappedDecisionDateObj);
+    }
+
     this.state = {
       taskInstructionsIsVisible: { }
     };
@@ -325,18 +333,9 @@ class TaskRows extends React.PureComponent {
       timeline
     } = this.props;
 
-    const taskListToSort = taskList;
-    const mappedDecisionDateObj = this.mapDecisionDateToSortableObject(appeal);
-
-    if (appeal.decisionDate) {
-      taskListToSort.push(mappedDecisionDateObj);
-    } else {
-      taskListToSort.unshift(mappedDecisionDateObj);
-    }
-
     return <React.Fragment key={appeal.externalId}>
 
-      { sortTaskList(taskListToSort, appeal).map((task, index) => {
+      { sortTaskList(taskList, appeal).map((task, index) => {
         const templateConfig = {
           task,
           index,


### PR DESCRIPTION
Resolves the bug below.

![Untitled](https://user-images.githubusercontent.com/45575454/60280121-55b42680-98d0-11e9-9aa1-ab162cc0f4b2.gif)

This is due to [adding a dispatch pending task](https://github.com/department-of-veterans-affairs/caseflow/blob/3d9d2b7e66d547b0839fc07dbf4796e03a061183/client/app/queue/components/TaskRows.jsx#L332) every time the case timeline component rerenders. As [`taskListToSort` is a reference to `props.taskList`](https://github.com/department-of-veterans-affairs/caseflow/blob/3d9d2b7e66d547b0839fc07dbf4796e03a061183/client/app/queue/components/TaskRows.jsx#L328), rather than a copy, `.push()` or `.unshift()` will modify the original `taskList`. This cannot be fixed with a copy as [other functions](https://github.com/department-of-veterans-affairs/caseflow/blob/3d9d2b7e66d547b0839fc07dbf4796e03a061183/client/app/queue/components/TaskRows.jsx#L248) need to know the correct index and length of the tasks array with the dispatch placeholder task.

### Description
Add case timeline decision date objects when the component is created, not every time it is rendered.
