### PR TITLE
Sort Records to sync ASC

### DIFF
--- a/app/models/record_synced_by_job.rb
+++ b/app/models/record_synced_by_job.rb
@@ -5,6 +5,6 @@ class RecordSyncedByJob < ApplicationRecord
 
   def self.next_records_to_process(records, limit)
     records.includes(:record_synced_by_job)
-      .order("record_synced_by_jobs.processed_at ASC").limit(limit)
+      .order("record_synced_by_jobs.processed_at ASC NULLS FIRST").limit(limit)
   end
 end

--- a/app/models/record_synced_by_job.rb
+++ b/app/models/record_synced_by_job.rb
@@ -5,6 +5,6 @@ class RecordSyncedByJob < ApplicationRecord
 
   def self.next_records_to_process(records, limit)
     records.includes(:record_synced_by_job)
-      .order("record_synced_by_jobs.processed_at DESC").limit(limit)
+      .order("record_synced_by_jobs.processed_at ASC").limit(limit)
   end
 end

--- a/spec/models/record_synced_by_job_spec.rb
+++ b/spec/models/record_synced_by_job_spec.rb
@@ -13,7 +13,7 @@ describe RecordSyncedByJob do
     end
 
     let!(:old_record_synced_by_job) do
-      RecordSyncedByJob.create!(record: recent_appeal_with_sync, processed_at: 2.days.ago)
+      RecordSyncedByJob.create!(record: old_appeal_with_sync, processed_at: 2.days.ago)
     end
 
     context "when the limit is 1" do


### PR DESCRIPTION
`UpdateAppellantRepresentationJob` updates the `processed_at` date to current time. We should pull the oldest 1000 records rather than the newest 1000 in order to process all appeals.