### PR TITLE
Re-enable table filter names for org queues

### DIFF
--- a/client/app/components/FilterSummary.jsx
+++ b/client/app/components/FilterSummary.jsx
@@ -62,8 +62,7 @@ const FilterSummary = ({ filteredByList, clearFilteredByList }) => {
 
 FilterSummary.propTypes = {
   filteredByList: PropTypes.object.isRequired,
-  clearFilteredByList: PropTypes.func.isRequired,
-  alternateColumnNames: PropTypes.object
+  clearFilteredByList: PropTypes.func.isRequired
 };
 
 export default FilterSummary;

--- a/client/app/components/FilterSummary.jsx
+++ b/client/app/components/FilterSummary.jsx
@@ -1,8 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
+import COPY from '../../COPY.json';
 
-const FilterSummary = ({ filteredByList, alternateColumnNames, clearFilteredByList }) => {
+const ALTERNATE_COLUMN_NAMES = {
+  'appeal.caseType': 'Case Type',
+  'appeal.docketName': COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
+  'assignedTo.name': COPY.CASE_LIST_TABLE_APPEAL_LOCATION_COLUMN_TITLE,
+  'closestRegionalOffice.location_hash.city': 'Regional Office',
+  label: 'Task(s)'
+};
+
+const FilterSummary = ({ filteredByList, clearFilteredByList }) => {
   let filterSummary = null;
   let filterListContent = [];
   const clearAllFiltersLink = <button
@@ -16,7 +25,8 @@ const FilterSummary = ({ filteredByList, alternateColumnNames, clearFilteredByLi
       // as there could still bea key in the filteredByList object pointing to an empty array.
       if (filteredByList[filter].length > 0) {
         const filterContent = (<span
-          key={filter}> {alternateColumnNames ? alternateColumnNames[filter] : filter} ({filteredByList[filter].length})
+          key={filter}> {ALTERNATE_COLUMN_NAMES[filter] ? ALTERNATE_COLUMN_NAMES[filter] : filter} (
+          {filteredByList[filter].length})
         </span>);
 
         filterListContent = filterListContent.concat(filterContent);

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -21,10 +21,7 @@ import {
 } from './selectors';
 import { tasksWithAppealsFromRawTasks } from './utils';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
-import {
-  COLUMN_NAMES,
-  fullWidth
-} from './constants';
+import { fullWidth } from './constants';
 import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
 
 const containerStyles = css({
@@ -112,7 +109,6 @@ class OrganizationQueue extends React.PureComponent {
           numberOfPages={tabConfig.task_page_count}
           totalTaskCount={tabConfig.total_task_count}
           taskPagesApiEndpoint={tabConfig.task_page_endpoint_base_path}
-          alternateColumnNames={COLUMN_NAMES}
           enablePagination
         />
       </React.Fragment>

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -21,7 +21,10 @@ import {
 } from './selectors';
 import { tasksWithAppealsFromRawTasks } from './utils';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
-import { fullWidth } from './constants';
+import {
+  COLUMN_NAMES,
+  fullWidth
+} from './constants';
 import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
 
 const containerStyles = css({
@@ -109,6 +112,7 @@ class OrganizationQueue extends React.PureComponent {
           numberOfPages={tabConfig.task_page_count}
           totalTaskCount={tabConfig.total_task_count}
           taskPagesApiEndpoint={tabConfig.task_page_endpoint_base_path}
+          alternateColumnNames={COLUMN_NAMES}
           enablePagination
         />
       </React.Fragment>

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -428,7 +428,6 @@ export default class QueueTable extends React.PureComponent {
     }}>
       <FilterSummary
         filteredByList={this.state.filteredByList}
-        alternateColumnNames={this.props.alternateColumnNames}
         clearFilteredByList={(newList) => this.updateFilteredByList(newList)} />
       { paginationElements }
       { body }
@@ -460,7 +459,6 @@ QueueTable.propTypes = {
   userReadableColumnNames: PropTypes.object,
   useTaskPagesApi: PropTypes.bool,
   taskPagesApiEndpoint: PropTypes.string,
-  alternateColumnNames: PropTypes.object,
   enablePagination: PropTypes.bool,
   casesPerPage: PropTypes.number
 };

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -28,7 +28,6 @@ import {
   CATEGORIES,
   redText,
   LEGACY_APPEAL_TYPES,
-  COLUMN_NAMES,
   DOCKET_NAME_FILTERS
 } from '../constants';
 import COPY from '../../../COPY.json';
@@ -403,7 +402,6 @@ export class TaskTableUnconnected extends React.PureComponent {
     rowObjects={this.props.tasks}
     getKeyForRow={this.props.getKeyForRow || this.getKeyForRow}
     defaultSort={{ sortColIdx: this.getDefaultSortableColumn() }}
-    alternateColumnNames={COLUMN_NAMES}
     enablePagination
     rowClassNames={(task) =>
       this.taskHasDASRecord(task) || !this.props.requireDasRecord ? null : 'usa-input-error'} />;

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -1,3 +1,4 @@
+
 /* eslint-disable max-lines */
 import { css } from 'glamor';
 import _ from 'lodash';
@@ -167,14 +168,6 @@ export const PAGE_TITLES = {
 
 export const CUSTOM_HOLD_DURATION_TEXT = 'Custom';
 export const COLOCATED_HOLD_DURATIONS = [15, 30, 45, 60, 90, 120, CUSTOM_HOLD_DURATION_TEXT];
-
-export const COLUMN_NAMES = {
-  'appeal.caseType': 'Case Type',
-  'appeal.docketName': COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
-  'assignedTo.name': COPY.CASE_LIST_TABLE_APPEAL_LOCATION_COLUMN_TITLE,
-  'closestRegionalOffice.location_hash.city': 'Regional Office',
-  label: 'Task(s)'
-};
 
 export const DOCKET_NAME_FILTERS = {
   direct_review: 'Direct Review',

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -170,7 +170,8 @@ export const COLOCATED_HOLD_DURATIONS = [15, 30, 45, 60, 90, 120, CUSTOM_HOLD_DU
 
 export const COLUMN_NAMES = {
   'appeal.caseType': 'Case Type',
-  'appeal.docketName': 'Docket Number',
+  'appeal.docketName': COPY.CASE_LIST_TABLE_DOCKET_NUMBER_COLUMN_TITLE,
+  'assignedTo.name': COPY.CASE_LIST_TABLE_APPEAL_LOCATION_COLUMN_TITLE,
   'closestRegionalOffice.location_hash.city': 'Regional Office',
   label: 'Task(s)'
 };


### PR DESCRIPTION
The move from using the `TaskTable` component to using the `QueueTable` component in PR #11213 left behind our friendly names that we display when we are filtering columns in that table. This PR adds those back in.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/60345648-7db29100-9987-11e9-9a93-054caecbb2b9.png) | ![image](https://user-images.githubusercontent.com/32683958/60345655-8014eb00-9987-11e9-9498-90e8980c592a.png)

There is probably a longer-term fix here to just use the column's `header` attribute [as defined in `TaskTable`](https://github.com/department-of-veterans-affairs/caseflow/blob/0083faa2ce9995302ce2d7717753b6cc26f121ce/client/app/queue/components/TaskTable.jsx#L43), but a quick glance at the code makes it appear as if that will be a fairly involved change.