### PR TITLE
Create report for catching untracked LegacyAppeals

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::JobsController < Api::ApplicationController
     "task_timer_job" => TaskTimerJob,
     "fetch_hearing_locations_for_veterans_job" => FetchHearingLocationsForVeteransJob,
     "update_appellant_representation_job" => UpdateAppellantRepresentationJob,
+    "untracked_legacy_appeals_report_job" => UntrackedLegacyAppealsReportJob,
     "hearing_disposition_change_job" => HearingDispositionChangeJob,
     "warm_bgs_participant_caches_job" => WarmBgsParticipantCachesJob
   }.freeze

--- a/app/jobs/untracked_legacy_appeals_report_job.rb
+++ b/app/jobs/untracked_legacy_appeals_report_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UntrackedLegacyAppealsReportJob < CaseflowJob
+  queue_as :low_priority
+  application_attr :queue
+
+  def perform
+    send_report(legacy_appeal_ids_without_active_tasks)
+  end
+
+  def legacy_appeal_ids_without_active_tasks
+    vacols_ids = VACOLS::Case.where(bfcurloc: LegacyAppeal::LOCATION_CODES[:caseflow]).pluck(:bfkey)
+    legacy_appeals_charged_to_caseflow_ids = LegacyAppeal.where(vacols_id: vacols_ids).pluck(:id)
+    legacy_appeal_with_active_tasks_ids = Task.where.not(
+      type: [RootTask.name, TrackVeteranTask.name]
+    ).where(appeal_type: LegacyAppeal.name, appeal_id: legacy_appeals_charged_to_caseflow_ids).pluck(:appeal_id).uniq
+
+    legacy_appeals_charged_to_caseflow_ids.sort - legacy_appeal_with_active_tasks_ids.sort
+  end
+
+  def send_report(appeal_ids)
+    return if appeal_ids.empty?
+
+    msg = "Found #{appeal_ids.count} legacy appeals charged to CASEFLOW in VACOLS with no active Caseflow tasks.\n"
+    msg += "LegacyAppeal.where(id: #{appeal_ids.sort})"
+
+    Rails.logger.info(msg)
+    slack_service.send_notification(msg)
+  end
+end

--- a/app/jobs/untracked_legacy_appeals_report_job.rb
+++ b/app/jobs/untracked_legacy_appeals_report_job.rb
@@ -22,6 +22,8 @@ class UntrackedLegacyAppealsReportJob < CaseflowJob
     return if appeal_ids.empty?
 
     msg = "Found #{appeal_ids.count} legacy appeals charged to CASEFLOW in VACOLS with no active Caseflow tasks.\n"
+    msg += "These appeals will not progress unless location is manually corrected in VACOLS or an applicable Caseflow "
+    msg += "task is manually created. Research and fix these appeals accordingly.\n"
     msg += "LegacyAppeal.where(id: #{appeal_ids.sort})"
 
     Rails.logger.info(msg)

--- a/spec/jobs/untracked_legacy_appeals_report_job_spec.rb
+++ b/spec/jobs/untracked_legacy_appeals_report_job_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe UntrackedLegacyAppealsReportJob do
+  context "when there are LegacyAppeals charged to CASEFLOW in VACOLS without active Caseflow tasks" do
+    let(:untracked_legacy_appeals) do
+      Array.new(3) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+    end
+    let(:tracked_legacy_appeals) do
+      Array.new(4) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+    end
+
+    before do
+      # Set the VACOLS location code to CASEFLOW for all legacy appeals.
+      [untracked_legacy_appeals, tracked_legacy_appeals].flatten.each do |appeal|
+        VACOLS::Case.find_by(bfkey: appeal.vacols_id).update!(bfcurloc: LegacyAppeal::LOCATION_CODES[:caseflow])
+      end
+
+      # Only create tasks for tracked legacy appeals.
+      tracked_legacy_appeals.each do |appeal|
+        FactoryBot.create(:generic_task, assigned_to: FactoryBot.create(:user), appeal: appeal)
+      end
+    end
+
+    describe ".legacy_appeal_ids_without_active_tasks" do
+      subject { UntrackedLegacyAppealsReportJob.new.legacy_appeal_ids_without_active_tasks }
+
+      it "returns the appeal IDs of the untracked_legacy_appeals" do
+        expect(subject).to match_array(untracked_legacy_appeals.pluck(:id))
+      end
+    end
+
+    describe ".perform" do
+      subject { UntrackedLegacyAppealsReportJob.new.perform_now }
+
+      it "sends a message that includes the IDs of the untracked legacy appeals to Slack" do
+        slack_msg = ""
+        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, msg| slack_msg = msg }
+
+        subject
+        expect(slack_msg).to match(/#{untracked_legacy_appeals.pluck(:id).sort}/)
+      end
+    end
+  end
+
+  context "when all LegacyAppeals charged to CASEFLOW in VACOLS have active Caseflow tasks" do
+    let(:tracked_legacy_appeals) do
+      Array.new(5) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+    end
+
+    before do
+      tracked_legacy_appeals.each do |appeal|
+        VACOLS::Case.find_by(bfkey: appeal.vacols_id).update!(bfcurloc: LegacyAppeal::LOCATION_CODES[:caseflow])
+        FactoryBot.create(:generic_task, assigned_to: FactoryBot.create(:user), appeal: appeal)
+      end
+    end
+
+    describe ".legacy_appeal_ids_without_active_tasks" do
+      subject { UntrackedLegacyAppealsReportJob.new.legacy_appeal_ids_without_active_tasks }
+
+      it "returns an empty array since all legacy appeals are tracked" do
+        expect(subject).to eq([])
+      end
+    end
+
+    describe ".perform" do
+      subject { UntrackedLegacyAppealsReportJob.new.perform_now }
+
+      it "does not send a message to Slack" do
+        slack_msg = ""
+        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, msg| slack_msg = msg }
+
+        subject
+        expect(slack_msg).to eq("")
+      end
+    end
+  end
+
+  describe ".send_report" do
+    subject { UntrackedLegacyAppealsReportJob.new.send_report(array_ids) }
+
+    context "when an empty array is passed to " do
+      let(:array_ids) { [] }
+
+      it "does not send a message to slack" do
+        slack_msg = ""
+        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, msg| slack_msg = msg }
+
+        subject
+        expect(slack_msg).to eq("")
+      end
+    end
+
+    context "when an array with elements is passed to " do
+      let(:array_ids) { [1989, 143, 44] }
+
+      it "the IDs are sorted and a message is sent to slack" do
+        slack_msg = ""
+        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, msg| slack_msg = msg }
+
+        subject
+        expect(slack_msg).to match(/#{array_ids.sort}/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects #11183. This PR adds a job that sends a report to Slack when it runs if there are `LegacyAppeal`s without active Caseflow tasks charged to the "CASEFLOW" location in VACOLS. A follow-on PR will be created in the appeals-deployment repo after this is merged to run this report daily.