### PR TITLE
User objects stringify to the CSS id

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,8 @@ class User < ApplicationRecord
 
   before_create :normalize_css_id
 
+  delegate :to_s, to: :css_id
+
   def username
     css_id
   end


### PR DESCRIPTION
WIP

I noticed that `hearing_days` table has a `created_by` and `updated_by` that in db/seeds is not being saved correctly. I think ultimately that should be a `created_by_id` that points at `users.id`. But this might be a shortterm fix.