### PR TITLE
Remove SSN presence validation

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -16,7 +16,7 @@ class Veteran < ApplicationRecord
                     :military_postal_type_code, :military_post_office_type_code,
                     :service, :date_of_birth, :date_of_death
 
-  validates :ssn, :first_name, :last_name, presence: true, on: :bgs
+  validates :first_name, :last_name, presence: true, on: :bgs
   validates :address_line1, :address_line2, :address_line3, length: { maximum: 20 }, on: :bgs
   with_options if: :alive? do
     validates :address_line1, :country, presence: true, on: :bgs

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -79,7 +79,7 @@ feature "Intake Add Issues Page" do
         add_intake_rating_issue("Left knee granted")
         expect(page).to have_content("The Veteran's profile has missing or invalid information")
         expect(page).to have_content(
-          "the corporate database, then retry establishing the EP in Caseflow: ssn, country."
+          "the corporate database, then retry establishing the EP in Caseflow: country."
         )
         expect(page).to have_content("This Veteran's address is too long. Please edit it in VBMS or SHARE")
         expect(page).to have_button("Establish appeal", disabled: true)

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -389,7 +389,7 @@ feature "Appeal Edit issues" do
       expect(page).to have_content("The Veteran's profile has missing or invalid information")
       expect(page).to have_content("Please fill in the following field(s) in the Veteran's profile in VBMS or")
       expect(page).to have_content(
-        "the corporate database, then retry establishing the EP in Caseflow: ssn, country"
+        "the corporate database, then retry establishing the EP in Caseflow: country"
       )
       expect(page).to have_content("This Veteran's address is too long. Please edit it in VBMS or SHARE")
       expect(page).to have_button("Save", disabled: true)

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -213,7 +213,7 @@ feature "Intake" do
         expect(page).to have_current_path("/intake/search")
         expect(page).to have_content("Please fill in the following field(s) in the Veteran's profile in VBMS or")
         expect(page).to have_content(
-          "the corporate database, then retry establishing the EP in Caseflow: ssn, country."
+          "the corporate database, then retry establishing the EP in Caseflow: country."
         )
         expect(page).to have_content("This Veteran's address is too long. Please edit it in VBMS or SHARE")
       end

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -323,7 +323,7 @@ def check_invalid_veteran_alert_on_review_page(form_type)
   expect(page).to have_content("The Veteran's profile has missing or invalid information")
   expect(page).to have_content("Please fill in the following field(s) in the Veteran's profile in VBMS or")
   expect(page).to have_content(
-    "the corporate database, then retry establishing the EP in Caseflow: ssn, country."
+    "the corporate database, then retry establishing the EP in Caseflow: country."
   )
   expect(page).to have_content("This Veteran's address is too long. Please edit it in VBMS or SHARE")
   expect(page).to have_button("Continue to next step", disabled: true)

--- a/spec/models/higher_level_review_spec.rb
+++ b/spec/models/higher_level_review_spec.rb
@@ -51,6 +51,7 @@ describe HigherLevelReview do
         let(:benefit_type) { "compensation" }
 
         it "adds an error" do
+          veteran.update(first_name: nil)
           expect(subject).to eq false
           expect(higher_level_review.errors[:veteran]).to include("veteran_not_valid")
         end

--- a/spec/models/supplemental_claim_spec.rb
+++ b/spec/models/supplemental_claim_spec.rb
@@ -49,12 +49,11 @@ describe SupplementalClaim do
         end
 
         context "invalid Veteran" do
-          let(:ssn) { nil }
-
           context "processed in VBMS" do
             let(:benefit_type) { "compensation" }
 
             it "adds an error" do
+              veteran.update(first_name: nil)
               expect(subject).to eq false
               expect(supplemental_claim.errors[:veteran]).to include("veteran_not_valid")
             end


### PR DESCRIPTION
**Why**: Some veterans legitimately do not have an SSN, and we don't
want to prevent Intake from proceeding due to a missing SSN.

Resolves #11257
