### PR TITLE
Move pagination URL parameters into shared constants

### DIFF
--- a/app/controllers/organizations/task_pages_controller.rb
+++ b/app/controllers/organizations/task_pages_controller.rb
@@ -23,8 +23,8 @@ class Organizations::TaskPagesController < OrganizationsController
   def index
     tasks = TaskPager.new(
       assignee: organization,
-      tab_name: params[:tab],
-      page: params[:page]
+      tab_name: params[Constants.QUEUE_CONFIG.TAB_NAME_REQUEST_PARAM.to_sym],
+      page: params[Constants.QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM.to_sym]
     ).paged_tasks
 
     render json: {

--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -48,12 +48,14 @@ class QueueConfig
     # Otherwise avoid the overhead of the additional database requests.
     tasks = use_task_pages_api?(user) ? serialized_tasks_for_user(task_pager.paged_tasks, user) : []
 
+    endpoint = "#{organization.path}/task_pages?#{Constants.QUEUE_CONFIG.TAB_NAME_REQUEST_PARAM}=#{tab[:name]}"
+
     tab.merge(
       label: format(tab[:label], task_pager.total_task_count),
       tasks: tasks,
       task_page_count: task_pager.task_page_count,
       total_task_count: task_pager.total_task_count,
-      task_page_endpoint_base_path: "#{organization.path}/task_pages?tab=#{tab[:name]}"
+      task_page_endpoint_base_path: endpoint
     )
   end
 

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -13,6 +13,7 @@
   "ISSUE_COUNT_COLUMN": "issueCountColumn",
   "REGIONAL_OFFICE_COLUMN": "regionalOfficeColumn",
   "TASK_ASSIGNEE_COLUMN": "assignedToColumn",
+  "TASK_TYPE_COLUMN": "taskColumn",
 
   "TAB_NAME_REQUEST_PARAM": "tab",
   "PAGE_NUMBER_REQUEST_PARAM": "page"

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -13,5 +13,7 @@
   "ISSUE_COUNT_COLUMN": "issueCountColumn",
   "REGIONAL_OFFICE_COLUMN": "regionalOfficeColumn",
   "TASK_ASSIGNEE_COLUMN": "assignedToColumn",
-  "TASK_TYPE_COLUMN": "taskColumn"
+
+  "TAB_NAME_REQUEST_PARAM": "tab",
+  "PAGE_NUMBER_REQUEST_PARAM": "page"
 }


### PR DESCRIPTION
Connects #11054. Reduces the size of changes that will come with the follow-on PR that introduces the first instance of sorting pagination requests (#11247).