### PR TITLE
whenever needing pushing facols as latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             POSTGRES_DB: caseflow_certification_test
 
       # This is our homespun VACOLS container. An oracle db with some special sauce.
-      - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:20190508 
+      - image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:latest 
 
       # This is the circleci provided Redis container.
       - image: circleci/redis:4.0.10

--- a/local/vacols/build_push.sh
+++ b/local/vacols/build_push.sh
@@ -64,7 +64,7 @@ build(){
   fi
 
   # Build Docker
-  echo -e "\tCreating Caseflow App Docker Image"
+  echo -e "\tCreating FACOLS App Docker Image"
   echo "--------"
   echo ""
 
@@ -77,12 +77,12 @@ build(){
     rm -rf $build_facols_dir
     docker_build="SUCCESS"
     echo ""
-    echo "Building Caseflow Docker App: ${bold}${docker_build}${normal}"
+    echo "Building FACOLS Docker App: ${bold}${docker_build}${normal}"
     return 0
   else
     docker_build="FAILED"
     echo ""
-    echo "Building Caseflow Docker App: ${bold}${docker_build}${normal}"
+    echo "Building FACOLS Docker App: ${bold}${docker_build}${normal}"
     echo "Please check above if there were execution errors."
     return 1
   fi
@@ -92,10 +92,10 @@ push(){
   eval $(aws ecr get-login --no-include-email --region us-gov-west-1)
   docker tag vacols_db:latest vacols_db:${today}
   docker tag vacols_db:${today} 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:${today}
+  docker tag vacols_db:latest 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:latest
   if docker push 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:${today} ; then
+    docker push 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:latest
     echo "${bold}Success. ${normal}The latest docker image has been pushed."
-    echo "${bold}REMEMBER TO CHANGE THE CIRCLE CI CONFIG to use this image.${normal}"
-    echo -e "\t008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:${today}"
   else
     echo "${bold}Failed to Upload. ${normal}Probably you don't have permissions to do this. Ask the DevOps Team please"
   fi


### PR DESCRIPTION
Per request in https://github.com/department-of-veterans-affairs/appeals-deployment/pull/2132#discussion_r300041543 I have changed to use CircleCi image to `facols:latest` and also altered the code to push it as well.

I have already pushed this manually with the image that I had locally
```
# docker tag 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:20190508 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:latest
# eval $(aws ecr get-login --no-include-email --region us-gov-west-1)
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
# docker push 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols:latest
The push refers to repository [008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/facols]
b1c97fcea9e0: Layer already exists
6a73aba6dbc6: Layer already exists
a5b4628abdf7: Layer already exists
6c5f3101c127: Layer already exists
a4412d05af73: Layer already exists
f558a802043c: Layer already exists
b0c95e788af0: Layer already exists
88e627ded19b: Layer already exists
c4a7cf6a6169: Layer already exists
latest: digest: sha256:4fffd36db7d81e6631653154a4b729a6cd0a6fa6786f20cd55213faa344ea895 size: 2211
```