### PR TITLE
Replace canceled with cancelled, repo wide

### DIFF
--- a/app/controllers/dispatch/establish_claims_controller.rb
+++ b/app/controllers/dispatch/establish_claims_controller.rb
@@ -8,7 +8,7 @@ class Dispatch::EstablishClaimsController < Dispatch::TasksController
   before_action :verify_manager_access, only: [
     :unprepared_tasks,
     :update_employee_count,
-    :canceled_tasks,
+    :cancelled_tasks,
     :work_assignments
   ]
   skip_before_action :verify_admin_access, only: [:index]
@@ -21,7 +21,7 @@ class Dispatch::EstablishClaimsController < Dispatch::TasksController
   def show
     start_task!
 
-    return render "canceled" if task.canceled?
+    return render "cancelled" if task.cancelled?
     return render "assigned_existing_ep" if task.assigned_existing_ep?
     return render "complete" if task.completed?
 
@@ -97,8 +97,8 @@ class Dispatch::EstablishClaimsController < Dispatch::TasksController
     end
   end
 
-  def canceled_tasks
-    @canceled_tasks = EstablishClaim.past_weeks(5).canceled.newest_first
+  def cancelled_tasks
+    @cancelled_tasks = EstablishClaim.past_weeks(5).cancelled.newest_first
   end
 
   private

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -55,22 +55,22 @@ module Asyncable
       :error
     end
 
-    def canceled_at_column
-      :canceled_at
+    def cancelled_at_column
+      :cancelled_at
     end
 
     def unexpired
       where(arel_table[last_submitted_at_column].gt(requires_processing_until))
     end
 
-    def canceled
-      where.not(canceled_at_column => nil)
+    def cancelled
+      where.not(cancelled_at_column => nil)
     end
 
     def processable
       where(arel_table[last_submitted_at_column].lteq(Time.zone.now))
         .where(processed_at_column => nil)
-        .where(canceled_at_column => nil)
+        .where(cancelled_at_column => nil)
     end
 
     def never_attempted
@@ -84,7 +84,7 @@ module Asyncable
     end
 
     def attemptable
-      previously_attempted_ready_for_retry.or(never_attempted).where(canceled_at_column => nil)
+      previously_attempted_ready_for_retry.or(never_attempted).where(cancelled_at_column => nil)
     end
 
     def order_by_oldest_submitted
@@ -112,7 +112,7 @@ module Asyncable
       processable
         .or(with_error)
         .or(attempted_without_being_submitted)
-        .where(canceled_at_column => nil)
+        .where(cancelled_at_column => nil)
         .order_by_oldest_submitted
     end
   end
@@ -141,8 +141,8 @@ module Asyncable
     update!(self.class.attempted_at_column => Time.zone.now)
   end
 
-  def canceled!
-    update!(self.class.canceled_at_column => Time.zone.now)
+  def cancelled!
+    update!(self.class.cancelled_at_column => Time.zone.now)
   end
 
   # There are sometimes cases where no processing required, and we can mark submitted and processed all in one
@@ -169,8 +169,8 @@ module Asyncable
     !!self[self.class.submitted_at_column]
   end
 
-  def canceled?
-    !!self[self.class.canceled_at_column]
+  def cancelled?
+    !!self[self.class.cancelled_at_column]
   end
 
   def expired_without_processing?
@@ -207,7 +207,7 @@ module Asyncable
       self.class.last_submitted_at_column => Time.zone.now,
       self.class.processed_at_column => nil,
       self.class.attempted_at_column => nil,
-      self.class.canceled_at_column => nil,
+      self.class.cancelled_at_column => nil,
       self.class.error_column => nil
     )
   end

--- a/app/models/concerns/decision_syncable.rb
+++ b/app/models/concerns/decision_syncable.rb
@@ -24,8 +24,8 @@ module DecisionSyncable
       :decision_sync_error
     end
 
-    def canceled_at_column
-      :decision_sync_canceled_at
+    def cancelled_at_column
+      :decision_sync_cancelled_at
     end
   end
 end

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -46,8 +46,8 @@ class DecisionReview < ApplicationRecord
       :establishment_last_submitted_at
     end
 
-    def canceled_at_column
-      :establishment_canceled_at
+    def cancelled_at_column
+      :establishment_cancelled_at
     end
 
     def review_title

--- a/app/models/dispatch/task.rb
+++ b/app/models/dispatch/task.rb
@@ -15,7 +15,7 @@ class Dispatch::Task < ApplicationRecord
 
   enum completion_status: {
     routed_to_arc: 0,
-    canceled: 1,
+    cancelled: 1,
     expired: 2,
     routed_to_ro: 3,
     assigned_existing_ep: 4,
@@ -170,7 +170,7 @@ class Dispatch::Task < ApplicationRecord
   def cancel!(feedback = nil)
     assign_attributes(comment: feedback)
 
-    complete!(status: :canceled)
+    complete!(status: :cancelled)
   end
 
   def progress_status

--- a/app/models/dispatch_stats.rb
+++ b/app/models/dispatch_stats.rb
@@ -59,16 +59,16 @@ class DispatchStats < Caseflow::Stats
       EstablishClaim.where(completed_at: range).for_partial_grant_or_remand.count
     end,
 
-    establish_claim_canceled: lambda do |range|
-      EstablishClaim.where(completed_at: range).canceled.count
+    establish_claim_cancelled: lambda do |range|
+      EstablishClaim.where(completed_at: range).cancelled.count
     end,
 
-    establish_claim_canceled_full_grant: lambda do |range|
-      EstablishClaim.where(completed_at: range).canceled.for_full_grant.count
+    establish_claim_cancelled_full_grant: lambda do |range|
+      EstablishClaim.where(completed_at: range).cancelled.for_full_grant.count
     end,
 
-    establish_claim_canceled_partial_grant_remand: lambda do |range|
-      EstablishClaim.where(completed_at: range).canceled.for_partial_grant_or_remand.count
+    establish_claim_cancelled_partial_grant_remand: lambda do |range|
+      EstablishClaim.where(completed_at: range).cancelled.for_partial_grant_or_remand.count
     end,
 
     establish_claim_completed_success: lambda do |range|

--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -206,7 +206,7 @@ class EndProduct
     status_type_code == "CLR"
   end
 
-  def canceled?
+  def cancelled?
     status_type_code == "CAN"
   end
 

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -196,7 +196,7 @@ class EndProductEstablishment < ApplicationRecord
         last_synced_at: Time.zone.now
       )
       sync_source!
-      close_request_issues_if_canceled!
+      close_request_issues_if_cancelled!
       close_request_issues_with_no_decision!
     end
   rescue EstablishedEndProductNotFound, AppealRepository::AppealNotValidToReopen => error
@@ -218,7 +218,7 @@ class EndProductEstablishment < ApplicationRecord
     }
   end
 
-  def status_canceled?
+  def status_cancelled?
     synced_status == CANCELED_STATUS
   end
 
@@ -359,17 +359,17 @@ class EndProductEstablishment < ApplicationRecord
 
   def cancel!
     transaction do
-      # delete end product in bgs & set sync status to canceled
+      # delete end product in bgs & set sync status to cancelled
       BGSService.new.cancel_end_product(veteran_file_number, code, modifier)
       update!(synced_status: CANCELED_STATUS)
-      close_request_issues_if_canceled!
+      close_request_issues_if_cancelled!
     end
   end
 
-  def close_request_issues_if_canceled!
-    return unless status_canceled?
+  def close_request_issues_if_cancelled!
+    return unless status_cancelled?
 
-    request_issues.all.find_each(&:close_after_end_product_canceled!)
+    request_issues.all.find_each(&:close_after_end_product_cancelled!)
   end
 
   def close_request_issues_with_no_decision!

--- a/app/models/establish_claim.rb
+++ b/app/models/establish_claim.rb
@@ -49,7 +49,7 @@ class EstablishClaim < Dispatch::Task
       include: [:user, appeal: {
         include: [
           :pending_eps,
-          :non_canceled_end_products_within_30_days,
+          :non_cancelled_end_products_within_30_days,
           decisions: { methods: :received_at }
         ],
         methods: [

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -11,7 +11,7 @@ class Intake < ApplicationRecord
 
   enum completion_status: {
     success: "success",
-    canceled: "canceled",
+    cancelled: "cancelled",
     error: "error",
     expired: "expired"
   }
@@ -150,7 +150,7 @@ class Intake < ApplicationRecord
         cancel_reason: reason,
         cancel_other: other
       )
-      complete_with_status!(:canceled)
+      complete_with_status!(:cancelled)
     end
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -678,7 +678,7 @@ class LegacyAppeal < ApplicationRecord
     end_products.select(&:dispatch_conflict?)
   end
 
-  def non_canceled_end_products_within_30_days
+  def non_cancelled_end_products_within_30_days
     end_products.select { |ep| ep.potential_match?(self) }
   end
 

--- a/app/models/ramp_closed_appeal.rb
+++ b/app/models/ramp_closed_appeal.rb
@@ -38,9 +38,9 @@ class RampClosedAppeal < ApplicationRecord
     # If the ramp election was already rolled back, it can't be reclosed, so skip
     return unless ramp_election.established?
 
-    # If the end product was canceled, don't re-close the VACOLS appeal.
+    # If the end product was cancelled, don't re-close the VACOLS appeal.
     # Instead rollback the RAMP election data from Caseflow
-    return ramp_election.rollback! if ramp_election.end_product_establishment.status_canceled?
+    return ramp_election.rollback! if ramp_election.end_product_establishment.status_cancelled?
 
     fail NoReclosingBvaDecidedAppeals if appeal.decided_by_bva?
 

--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -62,7 +62,7 @@ class RampElection < RampReview
   def on_sync(end_product_establishment)
     recreate_issues_from_contentions!(end_product_establishment)
 
-    if FeatureToggle.enabled?(:automatic_ramp_rollback) && end_product_establishment.status_canceled?
+    if FeatureToggle.enabled?(:automatic_ramp_rollback) && end_product_establishment.status_cancelled?
       rollback_ramp_review
     end
   end

--- a/app/models/ramp_election_rollback.rb
+++ b/app/models/ramp_election_rollback.rb
@@ -12,7 +12,7 @@ class RampElectionRollback < ApplicationRecord
   belongs_to :ramp_election
 
   validates :user, :ramp_election, :reason, presence: true
-  validate  :validate_canceled_end_product
+  validate  :validate_cancelled_end_product
 
   before_create :reopen_vacols_appeals!, :rollback_ramp_election
 
@@ -43,11 +43,11 @@ class RampElectionRollback < ApplicationRecord
   end
 
   # We currently don't cancel the associated ramp election EP, we
-  # require that it was canceled manually beforehand
-  def validate_canceled_end_product
+  # require that it was cancelled manually beforehand
+  def validate_cancelled_end_product
     establishment = EndProductEstablishment.find_by(source: ramp_election)
-    unless establishment&.status_canceled?
-      errors.add(:ramp_election, "end_product_not_canceled")
+    unless establishment&.status_cancelled?
+      errors.add(:ramp_election, "end_product_not_cancelled")
     end
   end
 end

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -40,7 +40,7 @@ class RequestIssue < ApplicationRecord
   enum closed_status: {
     decided: "decided",
     removed: "removed",
-    end_product_canceled: "end_product_canceled",
+    end_product_cancelled: "end_product_cancelled",
     withdrawn: "withdrawn",
     dismissed_death: "dismissed_death",
     dismissed_matter_of_law: "dismissed_matter_of_law",
@@ -416,10 +416,10 @@ class RequestIssue < ApplicationRecord
     close!(status: :decided)
   end
 
-  def close_after_end_product_canceled!
-    return unless end_product_establishment&.reload&.status_canceled?
+  def close_after_end_product_cancelled!
+    return unless end_product_establishment&.reload&.status_cancelled?
 
-    close!(status: :end_product_canceled) do
+    close!(status: :end_product_cancelled) do
       legacy_issue_optin&.flag_for_rollback!
     end
   end
@@ -440,7 +440,7 @@ class RequestIssue < ApplicationRecord
       decision_issues.each(&:soft_delete_on_removed_request_issue)
       # Removing a request issue also deletes the associated request_decision_issue
       request_decision_issues.update_all(deleted_at: Time.zone.now)
-      canceled! if submitted_not_processed?
+      cancelled! if submitted_not_processed?
     end
   end
 

--- a/app/models/request_issue_closure.rb
+++ b/app/models/request_issue_closure.rb
@@ -6,14 +6,14 @@ class RequestIssueClosure
   end
 
   delegate :closed_at, :end_product_establishment, :contention_reference_id,
-           :legacy_issue_optin, :contention_disposition, :canceled!, :close!, to: :request_issue
+           :legacy_issue_optin, :contention_disposition, :cancelled!, :close!, to: :request_issue
 
   def with_no_decision!
     return unless end_product_establishment&.status_cleared?
     return if contention_disposition
 
     close!(status: :no_decision) do
-      canceled!
+      cancelled!
       legacy_issue_optin&.flag_for_rollback!
     end
   end

--- a/app/views/dispatch/establish_claims/canceled_tasks.html.erb
+++ b/app/views/dispatch/establish_claims/canceled_tasks.html.erb
@@ -3,7 +3,7 @@
 
 <% content_for :full_page_content do %>
 	<%= react_component("EstablishClaimContainer", props: {
-	canceledTasks: @canceled_tasks.map(&:to_hash),
+	cancelledTasks: @cancelled_tasks.map(&:to_hash),
 	page: "CanceledTasksIndex",
 	userDisplayName: current_user.display_name,
 	dropdownUrls: dropdown_urls,

--- a/app/views/dispatch_stats/show.html.erb
+++ b/app/views/dispatch_stats/show.html.erb
@@ -183,28 +183,28 @@
     <div class="cf-stats-section -missing">
       <h3>Establish Claim Tasks Canceled <span class="data-date"></span></h3>
 
-      <div class="cf-stat-panel data-chart" data-key="establish_claim_canceled">
+      <div class="cf-stat-panel data-chart" data-key="establish_claim_cancelled">
         <h4 class="cf-stat-title">
           All
         </h4>
-        <div class="cf-stat-figure data-value" data-key="establish_claim_canceled">
-          <%= @stats[0].values[:establish_claim_canceled] %>
+        <div class="cf-stat-figure data-value" data-key="establish_claim_cancelled">
+          <%= @stats[0].values[:establish_claim_cancelled] %>
         </div>
       </div>
-      <div class="cf-stat-panel data-chart" data-key="establish_claim_canceled_full_grant">
+      <div class="cf-stat-panel data-chart" data-key="establish_claim_cancelled_full_grant">
         <h4 class="cf-stat-title">
           Full Grants
         </h4>
-        <div class="cf-stat-figure data-value" data-key="establish_claim_canceled_full_grant">
-          <%= @stats[0].values[:establish_claim_canceled_full_grant] %>
+        <div class="cf-stat-figure data-value" data-key="establish_claim_cancelled_full_grant">
+          <%= @stats[0].values[:establish_claim_cancelled_full_grant] %>
         </div>
       </div>
-      <div class="cf-stat-panel data-chart" data-key="establish_claim_canceled_partial_grant_remand">
+      <div class="cf-stat-panel data-chart" data-key="establish_claim_cancelled_partial_grant_remand">
         <h4 class="cf-stat-title">
           Partial Grants & Remands
         </h4>
-        <div class="cf-stat-figure data-value" data-key="establish_claim_canceled_partial_grant_remand">
-          <%= @stats[0].values[:establish_claim_canceled_partial_grant_remand] %>
+        <div class="cf-stat-figure data-value" data-key="establish_claim_cancelled_partial_grant_remand">
+          <%= @stats[0].values[:establish_claim_cancelled_partial_grant_remand] %>
         </div>
       </div>
     </div>

--- a/client/app/containers/EstablishClaimPage/CanceledTasksIndex.jsx
+++ b/client/app/containers/EstablishClaimPage/CanceledTasksIndex.jsx
@@ -9,7 +9,7 @@ export default class CanceledTasksIndex extends React.Component {
   render() {
 
     let {
-      canceledTasks
+      cancelledTasks
     } = this.props;
 
     let tableColumns = [
@@ -53,7 +53,7 @@ export default class CanceledTasksIndex extends React.Component {
       <div className="usa-width-one-whole">
         <Table
           columns={tableColumns}
-          rowObjects={canceledTasks}
+          rowObjects={cancelledTasks}
           summary={`Canceled EPs: ${dateRange()}`} />
       </div>
     </div>;
@@ -61,5 +61,5 @@ export default class CanceledTasksIndex extends React.Component {
 }
 
 CanceledTasksIndex.propTypes = {
-  canceledTasks: PropTypes.arrayOf(PropTypes.object)
+  cancelledTasks: PropTypes.arrayOf(PropTypes.object)
 };

--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -263,8 +263,8 @@ export default class EstablishClaim extends React.Component {
   }
 
   shouldShowAssociatePage() {
-    return this.props.task.appeal.non_canceled_end_products_within_30_days &&
-      this.props.task.appeal.non_canceled_end_products_within_30_days.length > 0;
+    return this.props.task.appeal.non_cancelled_end_products_within_30_days &&
+      this.props.task.appeal.non_cancelled_end_products_within_30_days.length > 0;
   }
 
   isAssociatePage() {
@@ -490,7 +490,7 @@ export default class EstablishClaim extends React.Component {
           { this.isAssociatePage() &&
           <AssociatePage
             loading={this.state.loading}
-            endProducts={this.props.task.appeal.non_canceled_end_products_within_30_days}
+            endProducts={this.props.task.appeal.non_cancelled_end_products_within_30_days}
             history={this.history}
             task={this.props.task}
             decisionType={decisionType}

--- a/client/app/intake/pages/decisionReviewEditCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewEditCompleted.jsx
@@ -72,7 +72,7 @@ const getEndProductUpdate = ({
 
   if (epBefore && !epAfter) {
     return <Fragment>
-      <strong>A {claimReviewName} {epType} EP is being canceled.</strong>
+      <strong>A {claimReviewName} {epType} EP is being cancelled.</strong>
       <p>All contentions on this EP were removed</p>
     </Fragment>;
   } else if (epBefore && epAfter && epChanged) {

--- a/client/app/intake/pages/review.jsx
+++ b/client/app/intake/pages/review.jsx
@@ -71,7 +71,7 @@ class ReviewNextButton extends React.PureComponent {
       formType
     } = this.props;
 
-    // selected form might be null or empty if the review has been canceled
+    // selected form might be null or empty if the review has been cancelled
     // in that case, just use null as data types since page will be redirected
     const selectedForm = _.find(FORM_TYPES, { key: formType });
     const intakeData = selectedForm ? intakeForms[selectedForm.key] : null;

--- a/client/app/intakeManager/FlaggedForReview.jsx
+++ b/client/app/intakeManager/FlaggedForReview.jsx
@@ -57,7 +57,7 @@ export default class FlaggedForReview extends Component {
           <h1>Claims for manager review</h1>
           <p>
           This list shows claims that did not result in an End Product (EP)
-          because the user canceled midway through processing, or did not finish
+          because the user cancelled midway through processing, or did not finish
           establishing the claim after receiving an alert message. After an EP is
           successfully established, you can <a href="" className="cf-action-refresh">refresh</a> the
           page to update this list.

--- a/client/app/manageEstablishClaim/ManageEstablishClaim.jsx
+++ b/client/app/manageEstablishClaim/ManageEstablishClaim.jsx
@@ -141,8 +141,8 @@ class ManageEstablishClaim extends React.Component {
 
             <h2>ARC Reports</h2>
             <p>
-              <a href="/dispatch/canceled" target="_blank">
-                View canceled tasks <i className="fa fa-external-link" aria-hidden="true"></i>
+              <a href="/dispatch/cancelled" target="_blank">
+                View cancelled tasks <i className="fa fa-external-link" aria-hidden="true"></i>
               </a>
             </p>
             <p>

--- a/client/test/karma/containers/EstablishClaim-test.js
+++ b/client/test/karma/containers/EstablishClaim-test.js
@@ -24,7 +24,7 @@ describe('EstablishClaim', () => {
           decisions: [{
             label: null
           }],
-          non_canceled_end_products_within_30_days: [],
+          non_cancelled_end_products_within_30_days: [],
           pending_eps: [],
           station_key: '397',
           regional_office_key: 'RO11'
@@ -166,7 +166,7 @@ describe('EstablishClaim', () => {
           decisions: [{
             label: null
           }],
-          non_canceled_end_products_within_30_days: [],
+          non_cancelled_end_products_within_30_days: [],
           pending_eps: []
         },
         user: 'a'

--- a/client/test/node/containers/EstablishClaim-test.js
+++ b/client/test/node/containers/EstablishClaim-test.js
@@ -23,7 +23,7 @@ describe('EstablishClaim', () => {
           decisions: [{
             label: null
           }],
-          non_canceled_end_products_within_30_days: [],
+          non_cancelled_end_products_within_30_days: [],
           pending_eps: [],
           station_key: '397',
           regional_office_key: 'RO11'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
     get "/", to: redirect("/dispatch/establish-claim")
     get 'missing-decision', to: 'establish_claims#unprepared_tasks'
     get 'admin', to: 'establish_claims#admin'
-    get 'canceled', to: 'establish_claims#canceled_tasks'
+    get 'cancelled', to: 'establish_claims#cancelled_tasks'
     get 'work-assignments', to: 'establish_claims#work_assignments'
     patch 'employee-count/:count', to: 'establish_claims#update_employee_count'
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.string "docket_type", comment: "The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
     t.datetime "established_at", comment: "Timestamp for when the appeal has successfully been intaken into Caseflow by the user."
     t.datetime "establishment_attempted_at", comment: "Timestamp for when the appeal's establishment was last attempted."
-    t.datetime "establishment_canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "establishment_cancelled_at", comment: "Timestamp when job was abandoned"
     t.string "establishment_error", comment: "The error message if attempting to establish the appeal resulted in an error. This gets cleared once the establishment is successful."
     t.datetime "establishment_last_submitted_at", comment: "Timestamp for when the the job is eligible to run (can be reset to restart the job)."
     t.datetime "establishment_processed_at", comment: "Timestamp for when the establishment has succeeded in processing."
@@ -140,7 +140,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.string "contention_reference_id", comment: "The ID of the contention created in VBMS. Indicates successful creation of the contention. If the EP has been rated, this contention could have been connected to a rating issue. That connection is used to map the rating issue back to the decision issue."
     t.bigint "decision_document_id", comment: "The ID of the decision document which triggered this effectuation."
     t.datetime "decision_sync_attempted_at", comment: "When the EP is cleared, an asyncronous job attempts to map the resulting rating issue back to the decision issue. Timestamp representing the time the job was last attempted."
-    t.datetime "decision_sync_canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "decision_sync_cancelled_at", comment: "Timestamp when job was abandoned"
     t.string "decision_sync_error", comment: "Async job processing last error message. See description for decision_sync_attempted_at for the decision sync job description."
     t.datetime "decision_sync_last_submitted_at", comment: "Timestamp for when the the job is eligible to run (can be reset to restart the job)."
     t.datetime "decision_sync_processed_at", comment: "Async job processing completed timestamp. See description for decision_sync_attempted_at for the decision sync job description."
@@ -240,7 +240,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.bigint "appeal_id", null: false
     t.string "appeal_type"
     t.datetime "attempted_at"
-    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "cancelled_at", comment: "Timestamp when job was abandoned"
     t.string "citation_number", null: false
     t.datetime "created_at", null: false
     t.date "decision_date", null: false
@@ -368,7 +368,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.string "development_item_reference_id", comment: "When a Veteran requests an informal conference with their higher level review, a tracked item is created. This stores the ID of the of the tracked item, it is also used to indicate the success of creating the tracked item."
     t.string "doc_reference_id", comment: "When a Veteran requests an informal conference, a claimant letter is generated. This stores the document ID of the claimant letter, and is also used to track the success of creating the claimant letter."
     t.datetime "established_at", comment: "Timestamp for when the end product was established."
-    t.datetime "last_synced_at", comment: "The time that the status of the end product was last synced with BGS. The end product is synced until it is canceled or cleared, meaning it is no longer active."
+    t.datetime "last_synced_at", comment: "The time that the status of the end product was last synced with BGS. The end product is synced until it is cancelled or cleared, meaning it is no longer active."
     t.boolean "limited_poa_access", comment: "Indicates whether the limited Power of Attorney has access to view documents"
     t.string "limited_poa_code", comment: "The limited Power of Attorney code, which indicates whether the claim has a POA specifically for this claim, which can be different than the Veteran's POA"
     t.string "modifier", comment: "The end product modifier. For higher level reviews, the modifiers range from 030-039. For supplemental claims, they range from 040-049. The same modifier cannot be used twice for an active end product per Veteran. Once an end product is no longer active, the modifier can be used again."
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.bigint "source_id", null: false, comment: "The ID of the source that resulted in this end product establishment."
     t.string "source_type", null: false, comment: "The type of source that resulted in this end product establishment."
     t.string "station", comment: "The station ID of the end product's station."
-    t.string "synced_status", comment: "The status of the end product, which is synced by a job. Once and end product is cleared (CLR) or canceled (CAN) the status is final and the end product will not continue being synced."
+    t.string "synced_status", comment: "The status of the end product, which is synced by a job. Once and end product is cleared (CLR) or cancelled (CAN) the status is final and the end product will not continue being synced."
     t.integer "user_id", comment: "The ID of the user who performed the decision review intake."
     t.string "veteran_file_number", null: false, comment: "The file number of the Veteran submitted when establishing the end product."
     t.index ["source_type", "source_id"], name: "index_end_product_establishments_on_source_type_and_source_id"
@@ -565,7 +565,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
   create_table "higher_level_reviews", force: :cascade, comment: "Intake data for Higher Level Reviews." do |t|
     t.string "benefit_type", comment: "The benefit type selected by the Veteran on their form, also known as a Line of Business."
     t.datetime "establishment_attempted_at", comment: "Timestamp for the most recent attempt at establishing a claim."
-    t.datetime "establishment_canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "establishment_cancelled_at", comment: "Timestamp when job was abandoned"
     t.string "establishment_error", comment: "The error captured for the most recent attempt at establishing a claim if it failed.  This is removed once establishing the claim succeeds."
     t.datetime "establishment_last_submitted_at", comment: "Timestamp for the latest attempt at establishing the End Products for the Decision Review."
     t.datetime "establishment_processed_at", comment: "Timestamp for when the End Product Establishments for the Decision Review successfully finished processing."
@@ -582,11 +582,11 @@ ActiveRecord::Schema.define(version: 20190702171142) do
   end
 
   create_table "intakes", id: :serial, force: :cascade, comment: "Represents the intake of an form or request made by a veteran." do |t|
-    t.string "cancel_other", comment: "Notes added if a user canceled an intake for any reason other than the stock set of options."
-    t.string "cancel_reason", comment: "The reason the intake was canceled. Could have been manually canceled by a user, or automatic."
+    t.string "cancel_other", comment: "Notes added if a user cancelled an intake for any reason other than the stock set of options."
+    t.string "cancel_reason", comment: "The reason the intake was cancelled. Could have been manually cancelled by a user, or automatic."
     t.datetime "completed_at", comment: "Timestamp for when the intake was completed, whether it was successful or not."
     t.datetime "completion_started_at", comment: "Timestamp for when the user submitted the intake to be completed."
-    t.string "completion_status", comment: "Indicates whether the intake was successful, or was closed by being canceled, expired, or due to an error."
+    t.string "completion_status", comment: "Indicates whether the intake was successful, or was closed by being cancelled, expired, or due to an error."
     t.integer "detail_id", comment: "The ID of the record created as a result of the intake."
     t.string "detail_type", comment: "The type of the record created as a result of the intake."
     t.string "error_code", comment: "If the intake was unsuccessful due to a set of known errors, the error code is stored here. An error is also stored here for RAMP elections that are connected to an active end product, even though the intake is a success."
@@ -721,10 +721,10 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.string "vacols_id", null: false, comment: "The VACOLS BFKEY of the legacy appeal that has been closed and opted into RAMP."
   end
 
-  create_table "ramp_election_rollbacks", force: :cascade, comment: "If a RAMP election needs to get rolled back, for example if the EP is canceled, it is tracked here. Also any VACOLS issues that were closed in the legacy system and opted into RAMP are re-opened in the legacy system." do |t|
+  create_table "ramp_election_rollbacks", force: :cascade, comment: "If a RAMP election needs to get rolled back, for example if the EP is cancelled, it is tracked here. Also any VACOLS issues that were closed in the legacy system and opted into RAMP are re-opened in the legacy system." do |t|
     t.datetime "created_at", null: false, comment: "Timestamp for when the rollback was created."
     t.bigint "ramp_election_id", comment: "The ID of the RAMP Election being rolled back."
-    t.string "reason", comment: "The reason for rolling back the RAMP Election. Rollbacks happen automatically for canceled RAMP Election End Products, but can also happen for other reason such as by request."
+    t.string "reason", comment: "The reason for rolling back the RAMP Election. Rollbacks happen automatically for cancelled RAMP Election End Products, but can also happen for other reason such as by request."
     t.string "reopened_vacols_ids", comment: "The IDs of any legacy appeals which were reopened as a result of rolling back the RAMP Election, corresponding to the VACOLS BFKEY.", array: true
     t.datetime "updated_at", null: false, comment: "Timestamp for when the rollback was last updated."
     t.bigint "user_id", comment: "The user who created the RAMP Election rollback, typically a system user."
@@ -792,7 +792,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
   create_table "request_issues", force: :cascade, comment: "Each Request Issue represents the Veteran's response to a Rating Issue. Request Issues come in three flavors: rating, nonrating, and unidentified. They are attached to a Decision Review and (for those that track contentions) an End Product Establishment. A Request Issue can contest a rating issue, a decision issue, or a nonrating issue without a decision issue." do |t|
     t.string "benefit_type", null: false, comment: "The Line of Business the issue is connected with."
     t.datetime "closed_at", comment: "Timestamp when the request issue was closed. The reason it was closed is in closed_status."
-    t.string "closed_status", comment: "Indicates whether the request issue is closed, for example if it was removed from a Decision Review, the associated End Product got canceled, the Decision Review was withdrawn."
+    t.string "closed_status", comment: "Indicates whether the request issue is closed, for example if it was removed from a Decision Review, the associated End Product got cancelled, the Decision Review was withdrawn."
     t.integer "contention_reference_id", comment: "The ID of the contention created on the End Product for this request issue. This is populated after the contention is created in VBMS."
     t.datetime "contention_removed_at", comment: "When a request issue is removed from a Decision Review during an edit, if it has a contention in VBMS that is also removed. This field indicates when the contention has successfully been removed in VBMS."
     t.datetime "contention_updated_at", comment: "Timestamp indicating when a contention was successfully updated in VBMS."
@@ -806,7 +806,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.bigint "decision_review_id", comment: "ID of the decision review that this request issue belongs to"
     t.string "decision_review_type", comment: "Class name of the decision review that this request issue belongs to"
     t.datetime "decision_sync_attempted_at", comment: "Async job processing last attempted timestamp"
-    t.datetime "decision_sync_canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "decision_sync_cancelled_at", comment: "Timestamp when job was abandoned"
     t.string "decision_sync_error", comment: "Async job processing last error message"
     t.datetime "decision_sync_last_submitted_at", comment: "Async job processing most recent start timestamp"
     t.datetime "decision_sync_processed_at", comment: "Async job processing completed timestamp"
@@ -840,7 +840,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.integer "after_request_issue_ids", null: false, comment: "An array of the active request issue IDs after a user has finished editing a decision review. Used with before_request_issue_ids to determine appropriate actions (such as which contentions need to be added).", array: true
     t.datetime "attempted_at", comment: "Timestamp for when the request issue update processing was last attempted."
     t.integer "before_request_issue_ids", null: false, comment: "An array of the active request issue IDs previously on the decision review before this editing session. Used with after_request_issue_ids to determine appropriate actions (such as which contentions need to be removed).", array: true
-    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "cancelled_at", comment: "Timestamp when job was abandoned"
     t.integer "edited_request_issue_ids", comment: "An array of the request issue IDs that were edited during this request issues update", array: true
     t.string "error", comment: "The error message if the last attempt at processing the request issues update was not successful."
     t.datetime "last_submitted_at", comment: "Timestamp for when the processing for the request issues update was last submitted. Used to determine how long to continue retrying the processing job. Can be reset to allow for additional retries."
@@ -902,7 +902,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
     t.bigint "decision_review_remanded_id", comment: "If an Appeal or Higher Level Review decision is remanded, including Duty to Assist errors, it automatically generates a new Supplemental Claim.  If this Supplemental Claim was generated, then the ID of the original Decision Review with the remanded decision is stored here."
     t.string "decision_review_remanded_type", comment: "The type of the Decision Review remanded if applicable, used with decision_review_remanded_id to as a composite key to identify the remanded Decision Review."
     t.datetime "establishment_attempted_at", comment: "Timestamp for the most recent attempt at establishing a claim."
-    t.datetime "establishment_canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "establishment_cancelled_at", comment: "Timestamp when job was abandoned"
     t.string "establishment_error", comment: "The error captured for the most recent attempt at establishing a claim if it failed.  This is removed once establishing the claim succeeds."
     t.datetime "establishment_last_submitted_at", comment: "Timestamp for the latest attempt at establishing the End Products for the Decision Review."
     t.datetime "establishment_processed_at", comment: "Timestamp for when the End Product Establishments for the Decision Review successfully finished processing."
@@ -926,7 +926,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
 
   create_table "task_timers", force: :cascade, comment: "Task timers allow tasks to be run asynchronously after some future date, like EvidenceSubmissionWindowTask." do |t|
     t.datetime "attempted_at", comment: "Async timestamp for most recent attempt to run."
-    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "cancelled_at", comment: "Timestamp when job was abandoned"
     t.datetime "created_at", null: false, comment: "Automatic timestamp for record creation."
     t.string "error", comment: "Async any error message from most recent failed attempt to run."
     t.datetime "last_submitted_at", comment: "Async timestamp for most recent job start."
@@ -1010,7 +1010,7 @@ ActiveRecord::Schema.define(version: 20190702171142) do
   create_table "vbms_uploaded_documents", force: :cascade do |t|
     t.bigint "appeal_id", null: false
     t.datetime "attempted_at"
-    t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
+    t.datetime "cancelled_at", comment: "Timestamp when job was abandoned"
     t.datetime "created_at", null: false
     t.string "document_type", null: false
     t.string "error"

--- a/spec/factories/end_product_establishment.rb
+++ b/spec/factories/end_product_establishment.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
       synced_status { "CLR" }
     end
 
-    trait :canceled do
+    trait :cancelled do
       synced_status { "CAN" }
     end
 

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -236,8 +236,8 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       end
     end
 
-    scenario "View canceled EPs page" do
-      reason = "Cuz it's canceled"
+    scenario "View cancelled EPs page" do
+      reason = "Cuz it's cancelled"
 
       create(:establish_claim,
              user: create(:user, full_name: "Cance L. Smith"),
@@ -247,9 +247,9 @@ RSpec.feature "Establish Claim - ARC Dispatch" do
       end
 
       visit "/dispatch/work-assignments"
-      click_on "View canceled tasks"
+      click_on "View cancelled tasks"
 
-      # should see the canceled tasks
+      # should see the cancelled tasks
       page.within_window windows.last do
         expect(page).to be_titled("Canceled EPs")
         expect(page).to have_content("Canceled EPs")

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -103,7 +103,7 @@ feature "Appeal Intake" do
     visit "/intake"
     expect(page).to have_content("Something went wrong")
     intake.reload
-    expect(intake.completion_status).to eq("canceled")
+    expect(intake.completion_status).to eq("cancelled")
     visit "/intake"
     expect(page).to_not have_content("Something went wrong")
     expect(page).to have_content("Which form are you processing?")
@@ -735,7 +735,7 @@ feature "Appeal Intake" do
     intake.reload
     expect(intake.completed_at).to eq(Time.zone.now)
     expect(intake.cancel_reason).to eq("other")
-    expect(intake).to be_canceled
+    expect(intake).to be_cancelled
   end
 
   scenario "adding nonrating issue with non-comp benefit type" do

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1284,7 +1284,7 @@ feature "Higher-Level Review" do
       intake.reload
       expect(intake.completed_at).to eq(Time.zone.now)
       expect(intake.cancel_reason).to eq("other")
-      expect(intake).to be_canceled
+      expect(intake).to be_cancelled
     end
 
     context "with active legacy appeal" do

--- a/spec/feature/intake/intake_edit_confirmation_spec.rb
+++ b/spec/feature/intake/intake_edit_confirmation_spec.rb
@@ -59,7 +59,7 @@ feature "Intake Edit Confirmation" do
             expect(page).to have_content("A #{decision_review.class.review_title} Nonrating EP is being established")
           end
 
-          it "shows when an EP is being canceled" do
+          it "shows when an EP is being cancelled" do
             visit edit_path
             # first add a nonrating issue so we can remove the rating issue & EP
             click_intake_add_issue
@@ -70,7 +70,7 @@ feature "Intake Edit Confirmation" do
             click_edit_submit
 
             expect(page).to have_current_path("/#{edit_path}/confirmation")
-            expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being canceled")
+            expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being cancelled")
           end
 
           it "shows when an EP is being updated" do
@@ -114,7 +114,7 @@ feature "Intake Edit Confirmation" do
           click_edit_submit
 
           expect(page).to have_current_path("/#{edit_path}/confirmation")
-          expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being canceled")
+          expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being cancelled")
           expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
         end
       end

--- a/spec/feature/intake/intake_manager_spec.rb
+++ b/spec/feature/intake/intake_manager_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Intake Manager Page" do
       RampElectionIntake.create!(
         veteran_file_number: "1100",
         completed_at: 5.minutes.ago,
-        completion_status: :canceled,
+        completion_status: :cancelled,
         user: current_user
       )
 
@@ -51,7 +51,7 @@ RSpec.feature "Intake Manager Page" do
       RampElectionIntake.create!(
         veteran_file_number: "1114",
         completed_at: 4.hours.ago,
-        completion_status: :canceled,
+        completion_status: :cancelled,
         cancel_reason: :duplicate_ep,
         user: current_user
       )
@@ -59,9 +59,9 @@ RSpec.feature "Intake Manager Page" do
       RampElectionIntake.create!(
         veteran_file_number: "1118",
         completed_at: 8.hours.ago,
-        completion_status: :canceled,
+        completion_status: :cancelled,
         cancel_reason: :other,
-        cancel_other: "I am canceled just because",
+        cancel_other: "I am cancelled just because",
         user: current_user
       )
 
@@ -83,7 +83,7 @@ RSpec.feature "Intake Manager Page" do
       expect(find("#table-row-2")).to have_content("Error: sensitivity")
 
       expect(find("#table-row-1")).to have_content("Canceled: duplicate EP created outside Caseflow")
-      expect(find("#table-row-0")).to have_content("Canceled: I am canceled just because")
+      expect(find("#table-row-0")).to have_content("Canceled: I am cancelled just because")
 
       expect(page).not_to have_selector("#table-row-5")
     end

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -268,7 +268,7 @@ feature "Intake" do
       expect(intake.completed_at).to eq(Time.zone.now)
       expect(intake.cancel_reason).to eq("other")
       expect(intake.cancel_other).to eq("blue!")
-      expect(intake).to be_canceled
+      expect(intake).to be_cancelled
     end
 
     context "BGS error" do
@@ -292,7 +292,7 @@ feature "Intake" do
         expect(page).to have_content("Error: bgs error. Intake has been cancelled, please retry.")
 
         # verify that current intake has been cancelled
-        expect(Intake.find_by(completion_status: "canceled", veteran_file_number: "12341234")).to_not be_nil
+        expect(Intake.find_by(completion_status: "cancelled", veteran_file_number: "12341234")).to_not be_nil
 
         # verify user can proceed with new intake
         visit "/intake"

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -841,7 +841,7 @@ feature "Supplemental Claim Intake" do
       intake.reload
       expect(intake.completed_at).to eq(Time.zone.now)
       expect(intake.cancel_reason).to eq("other")
-      expect(intake).to be_canceled
+      expect(intake).to be_cancelled
     end
 
     context "with active legacy appeal" do

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -546,7 +546,7 @@ RSpec.feature "Task queue" do
         expect(vacols_case.reload.bfcurloc).to eq LegacyAppeal::LOCATION_CODES[:caseflow]
       end
 
-      it "the case should be returned in the attorneys queue when canceled" do
+      it "the case should be returned in the attorneys queue when cancelled" do
         visit("/queue/appeals/#{appeal.external_id}")
         find(".Select-control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
         expect(page).to have_content(Constants.TASK_ACTIONS.CANCEL_TASK.label)
@@ -936,7 +936,7 @@ RSpec.feature "Task queue" do
         expect(page).to have_content("No active tasks")
       end
 
-      step "verify that the associated TimedHoldTask has been canceled" do
+      step "verify that the associated TimedHoldTask has been cancelled" do
         expect(timed_hold_task.reload.open?).to be_falsey
       end
     end

--- a/spec/jobs/sync_reviews_job_spec.rb
+++ b/spec/jobs/sync_reviews_job_spec.rb
@@ -45,9 +45,9 @@ describe SyncReviewsJob do
       )
     end
 
-    context "when there are canceled or cleared end product establishments" do
-      let!(:end_product_establishment_canceled) do
-        create(:end_product_establishment, :canceled, established_at: 4.days.ago)
+    context "when there are cancelled or cleared end product establishments" do
+      let!(:end_product_establishment_cancelled) do
+        create(:end_product_establishment, :cancelled, established_at: 4.days.ago)
       end
 
       let!(:end_product_establishment_cleared) do
@@ -55,7 +55,7 @@ describe SyncReviewsJob do
       end
 
       it "does not sync them" do
-        expect(EndProductSyncJob).to_not receive(:perform_later).with(end_product_establishment_canceled.id)
+        expect(EndProductSyncJob).to_not receive(:perform_later).with(end_product_establishment_cancelled.id)
         expect(EndProductSyncJob).to_not receive(:perform_later).with(end_product_establishment_cleared.id)
 
         SyncReviewsJob.perform_now("limit" => 2)

--- a/spec/models/appeal_intake_spec.rb
+++ b/spec/models/appeal_intake_spec.rb
@@ -64,7 +64,7 @@ describe AppealIntake do
     it "cancels and deletes the Appeal record created" do
       subject
 
-      expect(intake.reload).to be_canceled
+      expect(intake.reload).to be_cancelled
       expect { detail.reload }.to raise_error ActiveRecord::RecordNotFound
       expect(intake).to have_attributes(
         cancel_reason: "system_error",

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -132,11 +132,11 @@ describe ClaimReview do
       )
     end
 
-    let!(:claim_review_canceled) do
+    let!(:claim_review_cancelled) do
       create(
         :higher_level_review,
         receipt_date: receipt_date,
-        establishment_canceled_at: 2.days.ago
+        establishment_cancelled_at: 2.days.ago
       )
     end
 
@@ -146,9 +146,9 @@ describe ClaimReview do
       end
     end
 
-    context ".canceled" do
-      it "only returns canceled jobs" do
-        expect(HigherLevelReview.canceled).to eq([claim_review_canceled])
+    context ".cancelled" do
+      it "only returns cancelled jobs" do
+        expect(HigherLevelReview.cancelled).to eq([claim_review_cancelled])
       end
     end
 
@@ -163,7 +163,7 @@ describe ClaimReview do
     context ".attemptable" do
       it "matches reviews that could be attempted" do
         expect(HigherLevelReview.attemptable).not_to include(claim_review_recently_attempted)
-        expect(HigherLevelReview.attemptable).not_to include(claim_review_canceled)
+        expect(HigherLevelReview.attemptable).not_to include(claim_review_cancelled)
       end
     end
 
@@ -419,10 +419,10 @@ describe ClaimReview do
       end
     end
 
-    context "when there is a canceled end product establishment" do
-      let!(:canceled_epe) do
+    context "when there is a cancelled end product establishment" do
+      let!(:cancelled_epe) do
         create(:end_product_establishment,
-               :canceled,
+               :cancelled,
                code: rating_request_issue.end_product_code,
                source: claim_review,
                veteran_file_number: claim_review.veteran.file_number)
@@ -430,7 +430,7 @@ describe ClaimReview do
 
       let(:issues) { [non_rating_request_issue, rating_request_issue] }
 
-      it "does not attempt to re-use the canceled EPE" do
+      it "does not attempt to re-use the cancelled EPE" do
         subject
 
         expect(claim_review.reload.end_product_establishments.count).to eq(3)

--- a/spec/models/dispatch/task_spec.rb
+++ b/spec/models/dispatch/task_spec.rb
@@ -86,7 +86,7 @@ describe Dispatch::Task do
     subject { Dispatch::Task.completed_success }
 
     let!(:successful_task) { FakeTask.create!(completion_status: :routed_to_arc) }
-    let!(:canceled_task) { FakeTask.create!(completion_status: :canceled) }
+    let!(:cancelled_task) { FakeTask.create!(completion_status: :cancelled) }
 
     it "returns only the successfully completed task" do
       is_expected.to eq [successful_task]
@@ -293,7 +293,7 @@ describe Dispatch::Task do
       is_expected.to be_truthy
 
       expect(task.reload).to be_completed
-      expect(task).to be_canceled
+      expect(task).to be_cancelled
       expect(task.reload.comment).to eq("feedbackz")
     end
   end

--- a/spec/models/dispatch_stats_spec.rb
+++ b/spec/models/dispatch_stats_spec.rb
@@ -77,16 +77,16 @@ describe DispatchStats do
       expect(prev_weekly_stats[:establish_claim_started]).to eq(1)
     end
 
-    it "calculates and saves all canceled dispatch_stats" do
+    it "calculates and saves all cancelled dispatch_stats" do
       Generators::EstablishClaim.create(completed_at: 30.minutes.ago, completion_status: 1)
 
       DispatchStats.calculate_all!
 
-      expect(monthly_stats[:establish_claim_canceled]).to eq(1)
-      expect(weekly_stats[:establish_claim_canceled]).to eq(1)
-      expect(daily_stats[:establish_claim_canceled]).to eq(1)
-      expect(hourly_stats[:establish_claim_canceled]).to eq(1)
-      expect(prev_weekly_stats[:establish_claim_canceled]).to eq(0)
+      expect(monthly_stats[:establish_claim_cancelled]).to eq(1)
+      expect(weekly_stats[:establish_claim_cancelled]).to eq(1)
+      expect(daily_stats[:establish_claim_cancelled]).to eq(1)
+      expect(hourly_stats[:establish_claim_cancelled]).to eq(1)
+      expect(prev_weekly_stats[:establish_claim_cancelled]).to eq(0)
     end
 
     it "filters remands and partial grants from full grants" do

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -832,14 +832,14 @@ describe EndProductEstablishment do
         end
       end
 
-      context "when the end product is canceled" do
+      context "when the end product is cancelled" do
         let(:status_type_code) { "CAN" }
 
         it "closes request issues" do
           subject
           expect(end_product_establishment.reload.synced_status).to eq("CAN")
           expect(request_issues.first.reload.closed_at).to eq(Time.zone.now)
-          expect(request_issues.first.closed_status).to eq("end_product_canceled")
+          expect(request_issues.first.closed_status).to eq("end_product_cancelled")
         end
       end
 
@@ -892,10 +892,10 @@ describe EndProductEstablishment do
     end
   end
 
-  context "#status_canceled?" do
-    subject { end_product_establishment.status_canceled? }
+  context "#status_cancelled?" do
+    subject { end_product_establishment.status_cancelled? }
 
-    context "returns true if canceled" do
+    context "returns true if cancelled" do
       let(:synced_status) { "CAN" }
 
       it { is_expected.to eq(true) }

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -35,10 +35,10 @@ describe HigherLevelReviewIntake do
       )
     end
 
-    let!(:canceled_epe) do
+    let!(:cancelled_epe) do
       create(
         :end_product_establishment,
-        :canceled,
+        :cancelled,
         veteran_file_number: veteran_file_number,
         established_at: Time.zone.yesterday
       )
@@ -89,7 +89,7 @@ describe HigherLevelReviewIntake do
     it "cancels and deletes the Higher-Level Review record created" do
       subject
 
-      expect(intake.reload).to be_canceled
+      expect(intake.reload).to be_cancelled
       expect { detail.reload }.to raise_error ActiveRecord::RecordNotFound
       expect(intake).to have_attributes(
         cancel_reason: "system_error",

--- a/spec/models/intake_spec.rb
+++ b/spec/models/intake_spec.rb
@@ -174,14 +174,14 @@ describe Intake do
       )
     end
 
-    let!(:canceled_intake) do
+    let!(:cancelled_intake) do
       Intake.create!(
         veteran_file_number: veteran_file_number,
         detail: detail,
         user: user,
         started_at: 10.minutes.ago,
         completed_at: 5.minutes.ago,
-        completion_status: :canceled,
+        completion_status: :cancelled,
         cancel_reason: :duplicate_ep
       )
     end
@@ -249,7 +249,7 @@ describe Intake do
         user: user,
         started_at: 10.minutes.ago,
         completed_at: 5.minutes.ago,
-        completion_status: :canceled,
+        completion_status: :cancelled,
         cancel_reason: :duplicate_ep
       )
 
@@ -274,15 +274,15 @@ describe Intake do
         user: user,
         started_at: 10.minutes.ago,
         completed_at: 5.minutes.ago,
-        completion_status: :canceled,
+        completion_status: :cancelled,
         cancel_reason: :other,
         cancel_other: "I get established manually"
       )
     end
 
-    it "returns included intakes (canceled, actionable errors that have not yet been resolved)" do
+    it "returns included intakes (cancelled, actionable errors that have not yet been resolved)" do
       expect(subject).to_not include(completed_intake)
-      expect(subject).to include(canceled_intake)
+      expect(subject).to include(cancelled_intake)
       expect(subject).to include(
         intake_not_accessible,
         intake_not_valid
@@ -327,14 +327,14 @@ describe Intake do
         veteran_file_number: veteran_file_number,
         detail_type: "SupplementalClaim",
         completed_at: 3.days.ago,
-        completion_status: "canceled"
+        completion_status: "cancelled"
       )
       Intake.create!(
         user: user,
         veteran_file_number: veteran_file_number,
         detail_type: "HigherLevelReview",
         completed_at: 3.days.ago,
-        completion_status: "canceled"
+        completion_status: "cancelled"
       )
       Intake.create!(
         user: user,
@@ -367,11 +367,11 @@ describe Intake do
 
   context "#complete_with_status!" do
     it "saves intake with proper tagging" do
-      intake.complete_with_status!(:canceled)
+      intake.complete_with_status!(:cancelled)
       intake.reload
 
       expect(intake.completed_at).to eq(Time.zone.now)
-      expect(intake).to be_canceled
+      expect(intake).to be_cancelled
     end
   end
 

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -1457,9 +1457,9 @@ describe LegacyAppeal do
     end
   end
 
-  context "#non_canceled_end_products_within_30_days" do
+  context "#non_cancelled_end_products_within_30_days" do
     let!(:vacols_case) { create(:case_with_decision, bfddec: 1.day.ago) }
-    let(:result) { appeal.non_canceled_end_products_within_30_days }
+    let(:result) { appeal.non_cancelled_end_products_within_30_days }
 
     let!(:twenty_day_old_pending_ep) do
       Generators::EndProduct.build(

--- a/spec/models/ramp_closed_appeal_spec.rb
+++ b/spec/models/ramp_closed_appeal_spec.rb
@@ -54,7 +54,7 @@ describe RampClosedAppeal do
   context "#reclose!" do
     subject { ramp_closed_appeal.reclose! }
 
-    context "when end product was canceled" do
+    context "when end product was cancelled" do
       let!(:current_end_product) do
         end_product.tap do |_ep|
           create(
@@ -132,7 +132,7 @@ describe RampClosedAppeal do
 
     let(:veteran) { Generators::Veteran.build(file_number: "23232323", participant_id: "323232") }
 
-    let(:ramp_election_canceled_ep) do
+    let(:ramp_election_cancelled_ep) do
       create(:ramp_election,
              veteran_file_number: veteran.file_number,
              option_selected: :higher_level_review,
@@ -140,17 +140,17 @@ describe RampClosedAppeal do
              established_at: 2.days.ago)
     end
 
-    let!(:ramp_closed_appeals_canceled_ep) do
+    let!(:ramp_closed_appeals_cancelled_ep) do
       [
         RampClosedAppeal.create!(
           vacols_id: "CANCELED1",
           nod_date: 2.years.ago,
-          ramp_election: ramp_election_canceled_ep
+          ramp_election: ramp_election_cancelled_ep
         ),
         RampClosedAppeal.create!(
           vacols_id: "CANCELED2",
           nod_date: 1.year.ago,
-          ramp_election: ramp_election_canceled_ep
+          ramp_election: ramp_election_cancelled_ep
         )
       ]
     end
@@ -165,7 +165,7 @@ describe RampClosedAppeal do
                     ])
       create(
         :end_product_establishment,
-        source: ramp_election_canceled_ep,
+        source: ramp_election_cancelled_ep,
         veteran_file_number: veteran.file_number,
         last_synced_at: 2.days.ago,
         synced_status: "CAN"
@@ -174,8 +174,8 @@ describe RampClosedAppeal do
 
     it "finds reopened appeals based off of ramp closed appeals" do
       expect(subject.count).to eq 3
-      expect(subject).to include ramp_closed_appeals_canceled_ep.first
-      expect(subject).to include ramp_closed_appeals_canceled_ep.last
+      expect(subject).to include ramp_closed_appeals_cancelled_ep.first
+      expect(subject).to include ramp_closed_appeals_cancelled_ep.last
     end
   end
 end

--- a/spec/models/ramp_election_intake_spec.rb
+++ b/spec/models/ramp_election_intake_spec.rb
@@ -37,7 +37,7 @@ describe RampElectionIntake do
   end
 
   context "#cancel!" do
-    subject { intake.cancel!(reason: "other", other: "Spelling canceled and cancellation is fun") }
+    subject { intake.cancel!(reason: "other", other: "Spelling cancelled and cancellation is fun") }
 
     let(:detail) do
       create(:ramp_election,
@@ -59,10 +59,10 @@ describe RampElectionIntake do
     it "cancels and clears detail values" do
       subject
 
-      expect(intake.reload).to be_canceled
+      expect(intake.reload).to be_cancelled
       expect(intake).to have_attributes(
         cancel_reason: "other",
-        cancel_other: "Spelling canceled and cancellation is fun"
+        cancel_other: "Spelling cancelled and cancellation is fun"
       )
       expect(detail.reload).to have_attributes(
         option_selected: nil,
@@ -76,7 +76,7 @@ describe RampElectionIntake do
 
       it "returns and does nothing" do
         expect(intake).to_not be_persisted
-        expect(intake).to_not be_canceled
+        expect(intake).to_not be_cancelled
         expect(intake).to have_attributes(
           cancel_reason: nil,
           cancel_other: nil
@@ -93,7 +93,7 @@ describe RampElectionIntake do
 
       it "returns and does nothing" do
         expect(intake).to_not be_persisted
-        expect(intake).to_not be_canceled
+        expect(intake).to_not be_cancelled
         expect(intake).to have_attributes(
           cancel_reason: nil,
           cancel_other: nil
@@ -298,11 +298,11 @@ describe RampElectionIntake do
         end
       end
 
-      context "a new Intake for an existing canceled RAMP election" do
+      context "a new Intake for an existing cancelled RAMP election" do
         let(:status_type_code) { "CAN" }
         let(:preexisting_ep_receive_date) { detail.receipt_date.to_date.to_formatted_s(:short_date) }
 
-        it "does not attempt to re-use the existing canceled EP" do
+        it "does not attempt to re-use the existing cancelled EP" do
           expect(veteran_end_products.count).to eq 2
           expect(veteran_end_products.map(&:claim_id)).to include(preexisting_ep.claim_id)
 

--- a/spec/models/ramp_election_rollback_spec.rb
+++ b/spec/models/ramp_election_rollback_spec.rb
@@ -78,7 +78,7 @@ describe RampElectionRollback do
       it { is_expected.to be false }
     end
 
-    context "when end product isn't canceled" do
+    context "when end product isn't cancelled" do
       let(:ep_status) { "PEND" }
 
       it { is_expected.to be false }

--- a/spec/models/ramp_election_spec.rb
+++ b/spec/models/ramp_election_spec.rb
@@ -52,7 +52,7 @@ describe RampElection do
 
       after { FeatureToggle.disable!(:automatic_ramp_rollback) }
 
-      context "when status is canceled" do
+      context "when status is cancelled" do
         it "rolls back the ramp election" do
           subject
           expect(RampElectionRollback.find_by(
@@ -63,7 +63,7 @@ describe RampElection do
         end
       end
 
-      context "when status is not canceled" do
+      context "when status is not cancelled" do
         let(:synced_status) { "CLR" }
 
         it "rolls back the ramp election" do

--- a/spec/models/ramp_refiling_intake_spec.rb
+++ b/spec/models/ramp_refiling_intake_spec.rb
@@ -505,7 +505,7 @@ describe RampRefilingIntake do
     it "cancels and deletes the refiling record created" do
       subject
 
-      expect(intake.reload).to be_canceled
+      expect(intake.reload).to be_cancelled
       expect { detail.reload }.to raise_error ActiveRecord::RecordNotFound
       expect(intake).to have_attributes(
         cancel_reason: "system_error",
@@ -519,7 +519,7 @@ describe RampRefilingIntake do
 
       it "returns and does nothing" do
         expect(intake).to_not be_persisted
-        expect(intake).to_not be_canceled
+        expect(intake).to_not be_cancelled
         expect(intake).to have_attributes(
           cancel_reason: nil,
           cancel_other: nil
@@ -532,7 +532,7 @@ describe RampRefilingIntake do
 
       it "returns and does nothing" do
         expect(intake).to_not be_persisted
-        expect(intake).to_not be_canceled
+        expect(intake).to_not be_cancelled
         expect(intake).to have_attributes(
           cancel_reason: nil,
           cancel_other: nil

--- a/spec/models/request_issue_closure_spec.rb
+++ b/spec/models/request_issue_closure_spec.rb
@@ -28,7 +28,7 @@ describe RequestIssueClosure do
 
         expect(request_issue.closed_status).to eq("no_decision")
         expect(request_issue.closed_at).to be_within(1.second).of Time.zone.now
-        expect(request_issue.decision_sync_canceled_at).to be_within(1.second).of Time.zone.now
+        expect(request_issue.decision_sync_cancelled_at).to be_within(1.second).of Time.zone.now
       end
 
       context "request issue is already closed" do

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -303,7 +303,7 @@ describe RequestIssue do
 
       it "cancels the decision sync job" do
         subject
-        expect(request_issue1.decision_sync_canceled_at).to eq Time.zone.now
+        expect(request_issue1.decision_sync_cancelled_at).to eq Time.zone.now
       end
     end
   end
@@ -1272,14 +1272,14 @@ describe RequestIssue do
     end
   end
 
-  context "#close_after_end_product_canceled!" do
-    subject { rating_request_issue.close_after_end_product_canceled! }
-    let(:end_product_establishment) { create(:end_product_establishment, :canceled) }
+  context "#close_after_end_product_cancelled!" do
+    subject { rating_request_issue.close_after_end_product_cancelled! }
+    let(:end_product_establishment) { create(:end_product_establishment, :cancelled) }
 
     it "closes the request issue" do
       subject
       expect(rating_request_issue.closed_at).to eq(Time.zone.now)
-      expect(rating_request_issue.closed_status).to eq("end_product_canceled")
+      expect(rating_request_issue.closed_status).to eq("end_product_cancelled")
     end
 
     context "if the request issue is already closed" do

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -366,7 +366,7 @@ describe RequestIssuesUpdate do
 
           expect(review.request_issues.first.rating_issue_associated_at).to eq(Time.zone.now)
 
-          # ep should not be canceled because 1 rating request issue still exists
+          # ep should not be cancelled because 1 rating request issue still exists
           rating_end_product_establishment.reload
           expect(rating_end_product_establishment.synced_status).to eq(nil)
         end
@@ -394,7 +394,7 @@ describe RequestIssuesUpdate do
           review.request_issues.reload
           expect(subject).to be_truthy
 
-          # expect end product to be canceled
+          # expect end product to be cancelled
           found_nonrating_ep = EndProductEstablishment.find_by(
             id: nonrating_end_product_establishment.id,
             synced_status: "CAN"
@@ -503,7 +503,7 @@ describe RequestIssuesUpdate do
 
           expect(review.request_issues.first.rating_issue_associated_at).to eq(Time.zone.now)
 
-          # ep should not be canceled because 1 rating request issue still exists
+          # ep should not be cancelled because 1 rating request issue still exists
           expect(rating_end_product_establishment.reload.synced_status).to eq(nil)
         end
 

--- a/spec/models/supplemental_claim_intake_spec.rb
+++ b/spec/models/supplemental_claim_intake_spec.rb
@@ -55,7 +55,7 @@ describe SupplementalClaimIntake do
     it "cancels and deletes the supplemental claim record created" do
       subject
 
-      expect(intake.reload).to be_canceled
+      expect(intake.reload).to be_cancelled
       expect { detail.reload }.to raise_error ActiveRecord::RecordNotFound
       expect(intake).to have_attributes(
         cancel_reason: "system_error",

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -269,7 +269,7 @@ describe AssignHearingDispositionTask do
       subject { disposition_task.cancel! }
 
       context "the appeal is an AMA appeal" do
-        context "the task's hearing's disposition is canceled" do
+        context "the task's hearing's disposition is cancelled" do
           let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.cancelled }
 
           it "cancels the disposition task and its parent hearing task" do
@@ -319,7 +319,7 @@ describe AssignHearingDispositionTask do
           end
         end
 
-        context "the task's hearing's disposition is not canceled" do
+        context "the task's hearing's disposition is not cancelled" do
           let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.postponed }
 
           it "raises an error" do

--- a/spec/services/asyncable_jobs_spec.rb
+++ b/spec/services/asyncable_jobs_spec.rb
@@ -38,11 +38,11 @@ describe AsyncableJobs do
            establishment_error: "bad problem")
   end
 
-  let!(:sc_canceled) do
+  let!(:sc_cancelled) do
     create(:supplemental_claim,
            veteran_file_number: veteran.file_number,
            establishment_error: "bad problem",
-           establishment_canceled_at: 2.days.ago)
+           establishment_cancelled_at: 2.days.ago)
   end
 
   describe "#jobs" do
@@ -54,7 +54,7 @@ describe AsyncableJobs do
       expect(subject.jobs).to include(sc_not_submitted)
       expect(subject.jobs).to include(sc_not_attempted_expired)
       expect(subject.jobs).to include(sc_not_attempted)
-      expect(subject.jobs).to_not include(sc_canceled)
+      expect(subject.jobs).to_not include(sc_cancelled)
     end
 
     it "sorts by the submited_at column, descending order" do


### PR DESCRIPTION
Ran "git grep -l 'canceled' | xargs sed -i 's/canceled/cancelled/g'"

(backed out any changes to the `db/migrations` dir)

Resolves one existential crisis in our codebase.
