### PR TITLE
When creating a task, status should be assigned - send Sentry alert for now

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -473,8 +473,8 @@ class Task < ApplicationRecord
     if status != Constants.TASK_STATUSES.assigned
       # Send this to Sentry for now to find cases where we create
       # tasks with statuses other than assigned
-      fail Caseflow::Error::InvalidStatusOnTaskCreate, task_type: type
-      # Raven.capture_exception(Caseflow::Error::InvalidStatusOnTaskCreate.new)
+      # fail Caseflow::Error::InvalidStatusOnTaskCreate, task_type: type
+      Raven.capture_exception(Caseflow::Error::InvalidStatusOnTaskCreate.new)
     end
 
     true

--- a/app/workflows/ihp_tasks_factory.rb
+++ b/app/workflows/ihp_tasks_factory.rb
@@ -6,6 +6,8 @@ class IhpTasksFactory
   end
 
   def create_ihp_tasks!
+    return unless @parent
+
     appeal = @parent.appeal
     appeal.representatives.select { |org| org.should_write_ihp?(appeal) }.map do |vso_organization|
       # For some RAMP appeals, this method may run twice.

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -66,6 +66,14 @@ module Caseflow::Error
     end
   end
 
+  class InvalidStatusOnTaskCreate < SerializableError
+    def initialize(args)
+      @task_type = args[:task_type]
+      @code = args[:code] || 400
+      @message = args[:message] || "Task status has to be 'assigned' on create for #{@task_type}"
+    end
+  end
+
   class InvalidParentTask < SerializableError
     def initialize(args)
       @task_type = args[:task_type]

--- a/spec/controllers/decision_reviews_controller_spec.rb
+++ b/spec/controllers/decision_reviews_controller_spec.rb
@@ -114,7 +114,7 @@ describe DecisionReviewsController, type: :controller do
 
     context "with board grant effectuation task" do
       let(:task) do
-        create(:board_grant_effectuation_task, status: "in_progress", assigned_to: non_comp_org)
+        create(:board_grant_effectuation_task, :in_progress, assigned_to: non_comp_org)
       end
 
       it "marks task as completed" do
@@ -138,7 +138,7 @@ describe DecisionReviewsController, type: :controller do
     end
 
     context "with decision review task" do
-      let(:task) { create(:higher_level_review_task, status: "in_progress", assigned_to: non_comp_org) }
+      let(:task) { create(:higher_level_review_task, :in_progress, assigned_to: non_comp_org) }
 
       let!(:request_issues) do
         [

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe TasksController, type: :controller do
 
       let!(:task1) { create(:colocated_task, assigned_by: user, assigned_to: Colocated.singleton) }
       let!(:task2) { create(:colocated_task, assigned_by: user, assigned_to: Colocated.singleton) }
-      let!(:task3) { create(:colocated_task, assigned_by: user, status: Constants.TASK_STATUSES.completed) }
+      let!(:task3) { create(:colocated_task, :completed, assigned_by: user) }
 
       let!(:task11) { create(:ama_attorney_task, assigned_to: user) }
       let!(:task12) { create(:ama_attorney_task, :in_progress, assigned_to: user) }
       let!(:task13) { create(:ama_attorney_task, :completed, assigned_to: user) }
-      let!(:task16) { create(:ama_attorney_task, :completed, assigned_to: user, closed_at: 3.weeks.ago) }
+      let!(:task16) { create(:ama_attorney_task, :completed_in_the_past, assigned_to: user) }
       let!(:task14) { create(:ama_attorney_task, :on_hold, assigned_to: user) }
 
       it "should process the request successfully" do
@@ -78,11 +78,11 @@ RSpec.describe TasksController, type: :controller do
       let!(:task4) do
         create(:colocated_task, assigned_to: user, appeal: create(:legacy_appeal, vacols_case: create(:case, :aod)))
       end
-      let!(:task5) { create(:colocated_task, assigned_to: user, status: Constants.TASK_STATUSES.in_progress) }
+      let!(:task5) { create(:colocated_task, :in_progress, assigned_to: user) }
       let!(:task_ama_colocated_aod) do
         create(:ama_colocated_task, assigned_to: user, appeal: create(:appeal, :advanced_on_docket_due_to_age))
       end
-      let!(:task6) { create(:colocated_task, assigned_to: user, status: Constants.TASK_STATUSES.completed) }
+      let!(:task6) { create(:colocated_task, :completed, assigned_to: user) }
       let!(:task7) { create(:colocated_task) }
 
       it "should process the request succesfully" do
@@ -117,7 +117,7 @@ RSpec.describe TasksController, type: :controller do
       let!(:task9) { create(:ama_judge_task, :in_progress, assigned_to: user, assigned_by: user) }
       let!(:task10) { create(:ama_judge_task, :completed, assigned_to: user, assigned_by: user) }
       let!(:task15) do
-        create(:ama_judge_task, :completed, assigned_to: user, assigned_by: user, closed_at: 3.weeks.ago)
+        create(:ama_judge_task, :completed_in_the_past, assigned_to: user, assigned_by: user)
       end
 
       it "should process the request succesfully" do
@@ -883,9 +883,11 @@ RSpec.describe TasksController, type: :controller do
     subject { post(:request_hearing_disposition_change, params: params) }
 
     context "when the task is a no show hearing task with a HearingTask ancestor" do
-      let(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
-      let(:disposition_task) { FactoryBot.create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal) }
-      let!(:task) { FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal) }
+      let(:hearing_task) { create(:hearing_task, parent: root_task, appeal: appeal) }
+      let(:disposition_task) do
+        create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal)
+      end
+      let!(:task) { create(:no_show_hearing_task, parent: disposition_task, appeal: appeal) }
       let(:params) do
         {
           id: task.id,
@@ -916,7 +918,7 @@ RSpec.describe TasksController, type: :controller do
         FactoryBot.create(:hearing, appeal: appeal, hearing_day: hearing_day, disposition: past_hearing_disposition)
       end
       let(:hearing_task) do
-        FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal, status: Constants.TASK_STATUSES.completed)
+        FactoryBot.create(:hearing_task, :completed, parent: root_task, appeal: appeal)
       end
       let!(:association) { FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task) }
       let!(:hearing_task_2) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -21,7 +21,9 @@ FactoryBot.define do
 
     trait :with_tasks do
       after(:create) do |hearing, _evaluator|
-        create(:hearing_task_association, hearing: hearing, hearing_task: create(:hearing_task, appeal: hearing.appeal))
+        create(:hearing_task_association,
+          hearing: hearing,
+          hearing_task: create(:hearing_task, appeal: hearing.appeal))
         create(:assign_hearing_disposition_task,
                parent: hearing.hearing_task_association.hearing_task,
                appeal: hearing.appeal)

--- a/spec/factories/legacy_hearing.rb
+++ b/spec/factories/legacy_hearing.rb
@@ -43,8 +43,16 @@ FactoryBot.define do
 
     trait :with_tasks do
       after(:create) do |hearing, _evaluator|
-        create(:hearing_task_association, hearing: hearing, hearing_task: create(:hearing_task, appeal: hearing.appeal))
-        create(:assign_hearing_disposition_task, parent: hearing.hearing_task_association.hearing_task, appeal: hearing.appeal)
+        create(
+          :hearing_task_association,
+          hearing: hearing,
+          hearing_task: create(:hearing_task, appeal: hearing.appeal)
+        )
+        create(
+          :assign_hearing_disposition_task,
+          parent: hearing.hearing_task_association.hearing_task,
+          appeal: hearing.appeal
+        )
       end
     end
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -9,31 +9,65 @@ FactoryBot.define do
     action { nil }
     type { Task.name }
 
+    trait :assigned do
+      status { Constants.TASK_STATUSES.assigned }
+    end
+
     trait :in_progress do
-      status { Constants.TASK_STATUSES.in_progress }
       started_at { rand(1..10).days.ago }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.in_progress)
+      end
     end
 
     trait :on_hold do
-      status { Constants.TASK_STATUSES.on_hold }
       started_at { rand(20..30).days.ago }
       placed_on_hold_at { rand(1..10).days.ago }
       on_hold_duration { [30, 60, 90].sample }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.on_hold)
+      end
     end
 
     trait :completed_hold do
-      status { Constants.TASK_STATUSES.on_hold }
       started_at { rand(25..30).days.ago }
       placed_on_hold_at { rand(15..25).days.ago }
       on_hold_duration { 10 }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.on_hold)
+      end
     end
 
     trait :completed do
-      status { Constants.TASK_STATUSES.completed }
       started_at { rand(20..30).days.ago }
       placed_on_hold_at { rand(1..10).days.ago }
       on_hold_duration { [30, 60, 90].sample }
       closed_at { Time.zone.now }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.completed)
+      end
+    end
+
+    trait :completed_in_the_past do
+      started_at { rand(20..30).weeks.ago }
+      placed_on_hold_at { rand(4..10).weeks.ago }
+      on_hold_duration { [30, 60, 90].sample }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.completed, closed_at: 3.weeks.ago)
+      end
+    end
+
+    trait :cancelled do
+      closed_at { Time.zone.now }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.cancelled)
+      end
     end
 
     factory :root_task, class: RootTask do
@@ -48,7 +82,10 @@ FactoryBot.define do
       appeal { create(:appeal) }
       assigned_by { nil }
       assigned_to { Bva.singleton }
-      status { Constants.TASK_STATUSES.on_hold }
+
+      after(:create) do |task|
+        task.update(status: Constants.TASK_STATUSES.on_hold)
+      end
     end
 
     factory :generic_task, class: GenericTask do

--- a/spec/feature/hearings/daily_docket_spec.rb
+++ b/spec/feature/hearings/daily_docket_spec.rb
@@ -109,12 +109,13 @@ RSpec.feature "Hearing Schedule Daily Docket" do
     end
     let!(:disposition_task) do
       create(:assign_hearing_disposition_task,
+             :completed,
              parent: hearing_task_association.hearing_task,
-             appeal: hearing.appeal,
-             status: Constants.TASK_STATUSES.completed)
+             appeal: hearing.appeal)
     end
 
     scenario "User cannot update disposition" do
+      hearing_task_association.hearing_task.update(status: :in_progress)
       visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
       expect(find(".dropdown-#{hearing.external_id}-disposition")).to have_css(".is-disabled")
     end

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -667,6 +667,14 @@ feature "Appeal Edit issues" do
              closed_at: last_week)
     end
 
+    let!(:cancelled_task) do
+      create(:appeal_task,
+             :cancelled,
+             appeal: appeal,
+             assigned_to: non_comp_org,
+             closed_at: Time.zone.now)
+    end
+
     context "when review has multiple active tasks" do
       let!(:in_progress_task) do
         create(:appeal_task,
@@ -731,14 +739,6 @@ feature "Appeal Edit issues" do
       end
 
       context "when appeal task is cancelled" do
-        let!(:task) do
-          create(:appeal_task,
-                 status: Constants.TASK_STATUSES.cancelled,
-                 appeal: appeal,
-                 assigned_to: non_comp_org,
-                 closed_at: Time.zone.now)
-        end
-
         scenario "show timestamp when all request issues are cancelled" do
           visit "appeals/#{appeal.uuid}/edit"
           # remove all request issues
@@ -753,8 +753,8 @@ feature "Appeal Edit issues" do
           visit "appeals/#{appeal.uuid}/edit"
           expect(page).not_to have_content(existing_request_issues.first.description)
           expect(page).not_to have_content(existing_request_issues.second.description)
-          expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
-          expect(task.closed_at).to eq(Time.zone.now)
+          expect(cancelled_task.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(cancelled_task.closed_at).to eq(Time.zone.now)
         end
       end
     end

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -25,6 +25,21 @@ feature "NonComp Reviews Queue" do
     let(:today) { Time.zone.now }
     let(:last_week) { Time.zone.now - 7.days }
 
+    let!(:completed_tasks) do
+      [
+        create(:higher_level_review_task,
+               :completed,
+               appeal: hlr_a,
+               assigned_to: non_comp_org,
+               closed_at: last_week),
+        create(:higher_level_review_task,
+               :completed,
+               appeal: hlr_b,
+               assigned_to: non_comp_org,
+               closed_at: today)
+      ]
+    end
+
     let!(:in_progress_tasks) do
       [
         create(:higher_level_review_task,
@@ -42,21 +57,6 @@ feature "NonComp Reviews Queue" do
                appeal: appeal,
                assigned_to: non_comp_org,
                assigned_at: 1.day.ago)
-      ]
-    end
-
-    let!(:completed_tasks) do
-      [
-        create(:higher_level_review_task,
-               :completed,
-               appeal: hlr_a,
-               assigned_to: non_comp_org,
-               closed_at: last_week),
-        create(:higher_level_review_task,
-               :completed,
-               appeal: hlr_b,
-               assigned_to: non_comp_org,
-               closed_at: today)
       ]
     end
 

--- a/spec/feature/queue/attorney_queue_spec.rb
+++ b/spec/feature/queue/attorney_queue_spec.rb
@@ -36,11 +36,11 @@ RSpec.feature "Attorney queue" do
       let(:attorney_task) do
         FactoryBot.create(
           :ama_attorney_task,
+          :on_hold,
           appeal: appeal,
           assigned_by: judge,
           assigned_to: attorney,
-          parent: judge_task,
-          status: Constants.TASK_STATUSES.on_hold
+          parent: judge_task
         )
       end
       let!(:colocated_task) do

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -531,7 +531,7 @@ RSpec.feature "Case details" do
       let!(:pulac_cerullo) do
         FactoryBot.create(
           :pulac_cerullo_task,
-          status: Constants.TASK_STATUSES.completed,
+          :completed,
           instructions: ["completed"],
           closed_at: 45.days.ago,
           appeal: appeal
@@ -624,7 +624,6 @@ RSpec.feature "Case details" do
       let!(:assigned_task) do
         FactoryBot.create(
           :colocated_task,
-          status: Constants.TASK_STATUSES.assigned,
           assigned_to: colocated_user,
           assigned_by: attorney_user
         )
@@ -843,14 +842,19 @@ RSpec.feature "Case details" do
   describe "Show multiple tasks" do
     let(:appeal) { create(:appeal) }
     let!(:root_task) do
-      create(:root_task, appeal: appeal, assigned_to: judge_user,
-                         status: Constants.TASK_STATUSES.assigned)
+      create(:root_task, appeal: appeal, assigned_to: judge_user)
     end
     let(:instructions_text) { "note #1" }
     let!(:task) do
-      create(:task, appeal: appeal, status: Constants.TASK_STATUSES.in_progress,
-                    assigned_by: judge_user, assigned_to: attorney_user, type: GenericTask,
-                    parent_id: root_task.id, started_at: rand(1..10).days.ago, instructions: [instructions_text])
+      create(:task,
+             :in_progress,
+             appeal: appeal,
+             assigned_by: judge_user,
+             assigned_to: attorney_user,
+             type: GenericTask,
+             parent_id: root_task.id,
+             started_at: rand(1..10).days.ago,
+             instructions: [instructions_text])
     end
 
     context "single task" do
@@ -874,14 +878,14 @@ RSpec.feature "Case details" do
     end
     context "multiple tasks" do
       let!(:task2) do
-        create(:task, appeal: appeal, status: Constants.TASK_STATUSES.in_progress,
-                      assigned_by: judge_user, assigned_to: attorney_user, type: AttorneyTask,
-                      parent_id: task.id, started_at: rand(1..20).days.ago)
+        create(:task, :in_progress, appeal: appeal,
+                                    assigned_by: judge_user, assigned_to: attorney_user, type: AttorneyTask,
+                                    parent_id: task.id, started_at: rand(1..20).days.ago)
       end
       let!(:task3) do
-        create(:task, appeal: appeal, status: Constants.TASK_STATUSES.in_progress,
-                      assigned_by: judge_user, assigned_to: attorney_user, type: AttorneyTask,
-                      parent_id: task.id, started_at: rand(1..20).days.ago, assigned_at: 15.days.ago)
+        create(:task, :in_progress, appeal: appeal,
+                                    assigned_by: judge_user, assigned_to: attorney_user, type: AttorneyTask,
+                                    parent_id: task.id, started_at: rand(1..20).days.ago, assigned_at: 15.days.ago)
       end
       it "two tasks are displayed in the TaskSnapshot" do
         visit "/queue/appeals/#{appeal.uuid}"
@@ -912,13 +916,12 @@ RSpec.feature "Case details" do
 
     context "one task" do
       let!(:root_task) do
-        create(:root_task, appeal: legacy_appeal, assigned_to: judge_user,
-                           status: Constants.TASK_STATUSES.assigned)
+        create(:root_task, appeal: legacy_appeal, assigned_to: judge_user)
       end
       let!(:legacy_task) do
-        create(:task, appeal: legacy_appeal, status: Constants.TASK_STATUSES.in_progress,
-                      assigned_by: judge_user, assigned_to: attorney_user, type: GenericTask,
-                      parent_id: root_task.id, started_at: rand(1..10).days.ago)
+        create(:task, :in_progress, appeal: legacy_appeal,
+                                    assigned_by: judge_user, assigned_to: attorney_user, type: GenericTask,
+                                    parent_id: root_task.id, started_at: rand(1..10).days.ago)
       end
 
       it "is displayed in the TaskSnapshot" do
@@ -981,9 +984,9 @@ RSpec.feature "Case details" do
       let!(:tracking_task) do
         FactoryBot.create(
           :track_veteran_task,
+          :completed,
           appeal: appeal,
-          parent: root_task,
-          status: Constants.TASK_STATUSES.completed
+          parent: root_task
         )
       end
 

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.feature "Hearings tasks workflows" do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   before do
     OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)
@@ -11,18 +11,21 @@ RSpec.feature "Hearings tasks workflows" do
   end
 
   describe "Postponing a NoShowHearingTask" do
-    let(:veteran) { FactoryBot.create(:veteran, first_name: "Semka", last_name: "Venturini", file_number: 800_888_002) }
-    let(:appeal) { FactoryBot.create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number) }
+    let(:veteran) { create(:veteran, first_name: "Semka", last_name: "Venturini", file_number: 800_888_002) }
+    let(:appeal) { create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number) }
     let(:veteran_link_text) { "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})" }
-    let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
-    let(:distribution_task) { FactoryBot.create(:distribution_task, appeal: appeal, parent: root_task) }
-    let(:parent_hearing_task) { FactoryBot.create(:hearing_task, parent: distribution_task, appeal: appeal) }
-    let!(:completed_scheduling_task) do
-      FactoryBot.create(:schedule_hearing_task, :completed, parent: parent_hearing_task, appeal: appeal)
+    let(:root_task) { create(:root_task, appeal: appeal) }
+    let(:distribution_task) { create(:distribution_task, appeal: appeal, parent: root_task) }
+    let(:parent_hearing_task) { create(:hearing_task, parent: distribution_task, appeal: appeal) }
+    let(:disposition_task) do
+      create(:assign_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal)
     end
-    let(:disposition_task) { FactoryBot.create(:assign_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal) }
     let!(:no_show_hearing_task) do
-      FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal)
+      create(:no_show_hearing_task, parent: disposition_task, appeal: appeal)
+    end
+
+    let!(:completed_scheduling_task) do
+      create(:schedule_hearing_task, :completed, parent: parent_hearing_task, appeal: appeal)
     end
 
     it "closes current branch of task tree and starts a new one" do
@@ -104,25 +107,28 @@ RSpec.feature "Hearings tasks workflows" do
       expect(task.reload.status).to eq(Constants.TASK_STATUSES.completed)
     end
 
-    let(:appeal) { FactoryBot.create(:appeal, :hearing_docket) }
-    let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
-    let(:distribution_task) { FactoryBot.create(:distribution_task, appeal: appeal, parent: root_task) }
-    let(:parent_hearing_task) { FactoryBot.create(:hearing_task, parent: hearing_task_parent, appeal: appeal) }
-    let!(:completed_scheduling_task) do
-      FactoryBot.create(:schedule_hearing_task, :completed, parent: parent_hearing_task, appeal: appeal)
+    let(:appeal) { create(:appeal, :hearing_docket) }
+    let(:root_task) { create(:root_task, appeal: appeal) }
+    let(:distribution_task) { create(:distribution_task, appeal: appeal, parent: root_task) }
+    let(:parent_hearing_task) { create(:hearing_task, parent: hearing_task_parent, appeal: appeal) }
+    let(:disposition_task) do
+      create(:assign_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal)
     end
-    let(:disposition_task) { FactoryBot.create(:assign_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal) }
     let!(:no_show_hearing_task) do
-      FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal)
+      create(:no_show_hearing_task, parent: disposition_task, appeal: appeal)
+    end
+
+    let!(:completed_scheduling_task) do
+      create(:schedule_hearing_task, :completed, parent: parent_hearing_task, appeal: appeal)
     end
 
     context "when the appeal is a LegacyAppeal" do
-      let(:appeal) { FactoryBot.create(:legacy_appeal, vacols_case: FactoryBot.create(:case)) }
+      let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
       let(:hearing_task_parent) { root_task }
 
       context "when the appellant is represented by a VSO" do
         before do
-          FactoryBot.create(:vso)
+          create(:vso)
           allow_any_instance_of(LegacyAppeal).to receive(:representatives) { Representative.all }
         end
 

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -30,19 +30,19 @@ RSpec.feature "Quality Review workflow" do
     let!(:judge_task) do
       FactoryBot.create(
         :ama_judge_decision_review_task,
+        :completed,
         appeal: appeal,
         parent: root_task,
-        assigned_to: judge_user,
-        status: :completed
+        assigned_to: judge_user
       )
     end
     let!(:attorney_task) do
       FactoryBot.create(
         :ama_attorney_task,
+        :completed,
         appeal: appeal,
         parent: judge_task,
-        assigned_to: attorney_user,
-        status: :completed
+        assigned_to: attorney_user
       )
     end
     let!(:qr_task) do
@@ -113,7 +113,8 @@ RSpec.feature "Quality Review workflow" do
 
         visit "/queue"
 
-        click_on veteran_full_name
+        judge_qa_review_task = JudgeQualityReviewTask.first
+        find("#veteran-name-for-task-#{judge_qa_review_task.id}").click
 
         find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL, match: :first).click
 
@@ -172,7 +173,8 @@ RSpec.feature "Quality Review workflow" do
 
         visit "/queue"
 
-        click_on veteran_full_name
+        judge_qa_review_task = JudgeQualityReviewTask.first
+        find("#veteran-name-for-task-#{judge_qa_review_task.id}").click
 
         find("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL, match: :first).click
         expect(page).to have_content(qr_instructions)
@@ -219,7 +221,7 @@ RSpec.feature "Quality Review workflow" do
     let(:hold_length) { 30 }
 
     let!(:judge_task) do
-      FactoryBot.create(:ama_judge_task, appeal: appeal, parent: root_task, assigned_to: judge_user, status: :completed)
+      FactoryBot.create(:ama_judge_task, :completed, appeal: appeal, parent: root_task, assigned_to: judge_user)
     end
     let!(:qr_org_task) { QualityReviewTask.create_from_root_task(root_task) }
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -892,15 +892,17 @@ RSpec.feature "Task queue" do
   end
 
   describe "a task with a child TimedHoldTask" do
-    let(:user) { FactoryBot.create(:user) }
-    let(:veteran) { FactoryBot.create(:veteran, first_name: "Julita", last_name: "Van Sant", file_number: 201_905_061) }
-    let(:appeal) { FactoryBot.create(:appeal, veteran_file_number: veteran.file_number) }
+    let(:user) { create(:user) }
+    let(:veteran) { create(:veteran, first_name: "Julita", last_name: "Van Sant", file_number: 201_905_061) }
+    let(:appeal) { create(:appeal, veteran_file_number: veteran.file_number) }
     let(:veteran_link_text) { "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})" }
-    let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
-    let!(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
-    let!(:disposition_task) { FactoryBot.create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal) }
+    let!(:root_task) { create(:root_task, appeal: appeal) }
+    let!(:hearing_task) { create(:hearing_task, parent: root_task, appeal: appeal) }
+    let!(:disposition_task) do
+      create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal)
+    end
     let!(:transcription_task) do
-      FactoryBot.create(:transcription_task, parent: disposition_task, appeal: appeal, assigned_to: user)
+      create(:transcription_task, parent: disposition_task, appeal: appeal, assigned_to: user)
     end
     let(:days_on_hold) { 18 }
     let!(:timed_hold_task) do

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -77,11 +77,12 @@ describe FetchHearingLocationsForVeteransJob do
         let!(:appeal_2) { create(:appeal, veteran_file_number: "222222222") }
         let!(:task_3) { create(:schedule_hearing_task, appeal: appeal_2) }
         let!(:completed_admin_action) do
-          HearingAdminActionVerifyAddressTask.create!(
+          create(
+            :hearing_admin_action_verify_address_task,
+            :completed,
             appeal: appeal_2,
             assigned_to: HearingsManagement.singleton,
-            parent: task_3,
-            status: "completed"
+            parent: task_3
           )
         end
         # should not be returned
@@ -90,14 +91,15 @@ describe FetchHearingLocationsForVeteransJob do
           (0..2).each do |number|
             create(:veteran, file_number: "23456781#{number}")
             app = create(:appeal, veteran_file_number: "23456781#{number}")
-            create(:schedule_hearing_task, appeal: app, status: "completed")
+            create(:schedule_hearing_task, :completed, appeal: app)
           end
 
           # task with Address admin action
           create(:veteran, file_number: "234567815")
           app_2 = create(:appeal, veteran_file_number: "234567815")
           tsk = create(:schedule_hearing_task, appeal: app_2)
-          HearingAdminActionVerifyAddressTask.create!(
+          create(
+            :hearing_admin_action_verify_address_task,
             appeal: app_2,
             assigned_to: HearingsManagement.singleton,
             parent: tsk
@@ -107,7 +109,8 @@ describe FetchHearingLocationsForVeteransJob do
           create(:veteran, file_number: "234567816")
           app_3 = create(:appeal, veteran_file_number: "234567816")
           tsk_2 = create(:schedule_hearing_task, appeal: app_3)
-          HearingAdminActionForeignVeteranCaseTask.create!(
+          create(
+            :hearing_admin_action_verify_address_task,
             appeal: app_3,
             assigned_to: HearingsManagement.singleton,
             parent: tsk_2

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -14,7 +14,7 @@ describe Appeal do
 
   context "includes PrintsTaskTree concern" do
     context "#structure" do
-      let!(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+      let!(:root_task) { create(:root_task, appeal: appeal) }
 
       subject { appeal.structure(:id) }
 
@@ -580,7 +580,7 @@ describe Appeal do
       let(:appeal) { create(:appeal) }
 
       before do
-        create(:root_task, appeal: appeal, status: :completed)
+        create(:root_task, :completed, appeal: appeal)
       end
 
       it "returns Post-decision" do
@@ -599,7 +599,7 @@ describe Appeal do
       let(:appeal) { create(:appeal) }
 
       before do
-        create(:root_task, appeal: appeal, status: :in_progress)
+        create(:root_task, :in_progress, appeal: appeal)
       end
 
       it "returns Case storage" do
@@ -609,10 +609,10 @@ describe Appeal do
 
     context "if there are TrackVeteranTasks" do
       let!(:appeal) { create(:appeal) }
-      let!(:root_task) { create(:root_task, appeal: appeal, status: :in_progress) }
+      let!(:root_task) { create(:root_task, :in_progress, appeal: appeal) }
 
       before do
-        create(:track_veteran_task, appeal: appeal, status: :in_progress)
+        create(:track_veteran_task, :in_progress, appeal: appeal)
       end
 
       it "does not include TrackVeteranTasks in its determinations" do
@@ -636,7 +636,7 @@ describe Appeal do
         create(:generic_task, assigned_to: user, appeal: appeal_user, parent: user_root_task)
 
         on_hold_root = create(:root_task, appeal: appeal_on_hold, updated_at: today - 1)
-        create(:generic_task, status: :on_hold, appeal: appeal_on_hold, parent: on_hold_root, updated_at: today + 1)
+        create(:generic_task, :on_hold, appeal: appeal_on_hold, parent: on_hold_root, updated_at: today + 1)
       end
 
       it "if the most recent assignee is an organization it returns the organization name" do
@@ -879,8 +879,7 @@ describe Appeal do
     let!(:hearings_user) { create(:hearings_coordinator) }
     let!(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date + 1 }
     let(:appeal) { create(:appeal, receipt_date: receipt_date) }
-    let(:root_task_status) { "in_progress" }
-    let!(:appeal_root_task) { create(:root_task, appeal: appeal, status: root_task_status) }
+    let!(:appeal_root_task) { create(:root_task, :in_progress, appeal: appeal) }
 
     context "appeal not assigned" do
       it "is on docket" do
@@ -891,9 +890,8 @@ describe Appeal do
     end
 
     context "hearing to be scheduled" do
-      let(:schedule_hearing_status) { "in_progress" }
       let!(:schedule_hearing_task) do
-        create(:schedule_hearing_task, appeal: appeal, assigned_to: hearings_user, status: schedule_hearing_status)
+        create(:schedule_hearing_task, :in_progress, appeal: appeal, assigned_to: hearings_user)
       end
 
       it "is waiting for hearing to be scheduled" do
@@ -932,17 +930,17 @@ describe Appeal do
       let!(:schedule_hearing_task) do
         FactoryBot.create(
           :schedule_hearing_task,
+          :completed,
           parent: hearing_task,
-          appeal: appeal,
-          status: Constants.TASK_STATUSES.completed
+          appeal: appeal
         )
       end
       let!(:disposition_task) do
         FactoryBot.create(
           :assign_hearing_disposition_task,
+          :in_progress,
           parent: hearing_task,
-          appeal: appeal,
-          status: Constants.TASK_STATUSES.in_progress
+          appeal: appeal
         )
       end
 
@@ -956,19 +954,15 @@ describe Appeal do
     end
 
     context "in an evidence submission window" do
-      let(:schedule_hearing_status) { "completed" }
       let!(:schedule_hearing_task) do
-        create(:schedule_hearing_task, appeal: appeal, assigned_to: hearings_user, status: schedule_hearing_status)
+        create(:schedule_hearing_task, :completed, appeal: appeal, assigned_to: hearings_user)
       end
-      let(:evidence_hold_task_status) { "in_progress" }
       let!(:evidence_submission_task) do
-        EvidenceSubmissionWindowTask.create!(appeal: appeal,
-                                             status: evidence_hold_task_status, assigned_to: Bva.singleton)
+        create(:evidence_submission_window_task, :in_progress, appeal: appeal, assigned_to: Bva.singleton)
       end
-      let(:judge_review_task_status) { "in_progress" }
       let!(:judge_review_task) do
-        create(:ama_judge_decision_review_task,
-               assigned_to: judge, appeal: appeal, status: judge_review_task_status)
+        create(:ama_judge_decision_review_task, :in_progress,
+               assigned_to: judge, appeal: appeal)
       end
 
       it "is in evidentiary period " do
@@ -979,19 +973,16 @@ describe Appeal do
     end
 
     context "assigned to judge" do
-      let(:schedule_hearing_status) { "completed" }
       let!(:schedule_hearing_task) do
-        create(:schedule_hearing_task, appeal: appeal, assigned_to: hearings_user, status: schedule_hearing_status)
+        create(:schedule_hearing_task, :completed, appeal: appeal, assigned_to: hearings_user)
       end
-      let(:evidence_hold_task_status) { "completed" }
       let!(:evidence_submission_task) do
-        EvidenceSubmissionWindowTask.create!(appeal: appeal,
-                                             status: evidence_hold_task_status, assigned_to: Bva.singleton)
+        create(:evidence_submission_window_task, :completed, appeal: appeal,
+                                                             assigned_to: Bva.singleton)
       end
-      let(:judge_review_task_status) { "in_progress" }
       let!(:judge_review_task) do
-        create(:ama_judge_decision_review_task,
-               assigned_to: judge, appeal: appeal, status: judge_review_task_status)
+        create(:ama_judge_decision_review_task, :in_progress,
+               assigned_to: judge, appeal: appeal)
       end
 
       it "waiting for a decision" do
@@ -1002,12 +993,11 @@ describe Appeal do
     end
 
     context "have a decision with no remands or effectuation, no decision document" do
-      let(:judge_review_task_status) { "completed" }
+      let!(:appeal_root_task) { create(:root_task, :completed, appeal: appeal) }
       let!(:judge_review_task) do
-        create(:ama_judge_decision_review_task,
-               assigned_to: judge, appeal: appeal, status: judge_review_task_status)
+        create(:ama_judge_decision_review_task, :completed,
+               assigned_to: judge, appeal: appeal)
       end
-      let(:root_task_status) { "completed" }
       let!(:not_remanded_decision_issue) do
         create(:decision_issue,
                decision_review: appeal, disposition: "allowed")
@@ -1032,11 +1022,10 @@ describe Appeal do
     end
 
     context "has an effectuation" do
-      let(:root_task_status) { "completed" }
-      let(:judge_review_task_status) { "completed" }
+      let!(:appeal_root_task) { create(:root_task, :completed, appeal: appeal) }
       let!(:judge_review_task) do
-        create(:ama_judge_decision_review_task,
-               assigned_to: judge, appeal: appeal, status: judge_review_task_status)
+        create(:ama_judge_decision_review_task, :completed,
+               assigned_to: judge, appeal: appeal)
       end
       let!(:not_remanded_decision_issue) do
         create(:decision_issue,
@@ -1058,11 +1047,10 @@ describe Appeal do
     end
 
     context "has an active remand" do
-      let(:root_task_status) { "completed" }
-      let(:judge_review_task_status) { "completed" }
+      let!(:appeal_root_task) { create(:root_task, :completed, appeal: appeal) }
       let!(:judge_review_task) do
-        create(:ama_judge_decision_review_task,
-               assigned_to: judge, appeal: appeal, status: judge_review_task_status)
+        create(:ama_judge_decision_review_task, :completed,
+               assigned_to: judge, appeal: appeal)
       end
       let!(:not_remanded_decision_issue) { create(:decision_issue, decision_review: appeal) }
       let!(:remanded_decision_issue) do
@@ -1084,11 +1072,10 @@ describe Appeal do
     end
 
     context "has multiple remands" do
-      let(:root_task_status) { "completed" }
-      let(:judge_review_task_status) { "completed" }
+      let!(:appeal_root_task) { create(:root_task, :completed, appeal: appeal) }
       let!(:judge_review_task) do
-        create(:ama_judge_decision_review_task,
-               assigned_to: judge, appeal: appeal, status: judge_review_task_status)
+        create(:ama_judge_decision_review_task, :completed,
+               assigned_to: judge, appeal: appeal)
       end
       let!(:not_remanded_decision_issue) do
         create(:decision_issue,
@@ -1183,12 +1170,12 @@ describe Appeal do
     let(:judge) { create(:user) }
     let(:judge_task_created_date) { receipt_date + 10 }
     let!(:judge_review_task) do
-      create(:ama_judge_decision_review_task,
-             assigned_to: judge, appeal: appeal, created_at: judge_task_created_date, status: "completed")
+      create(:ama_judge_decision_review_task, :completed,
+             assigned_to: judge, appeal: appeal, created_at: judge_task_created_date)
     end
     let!(:judge_quality_review_task) do
-      create(:ama_judge_quality_review_task,
-             assigned_to: judge, appeal: appeal, created_at: judge_task_created_date + 2.days, status: "completed")
+      create(:ama_judge_quality_review_task, :completed,
+             assigned_to: judge, appeal: appeal, created_at: judge_task_created_date + 2.days)
     end
 
     context "decision, no remand and an effectuation" do
@@ -1505,7 +1492,7 @@ describe Appeal do
 
     context "has an open evidence submission task" do
       let!(:evidence_submission_task) do
-        EvidenceSubmissionWindowTask.create!(appeal: appeal, status: "in_progress", assigned_to: Bva.singleton)
+        create(:evidence_submission_window_task, :in_progress, appeal: appeal, assigned_to: Bva.singleton)
       end
 
       it "has an evidentiary_period alert" do
@@ -1516,8 +1503,7 @@ describe Appeal do
     end
 
     context "has a scheduled hearing" do
-      let(:root_task_status) { "in_progress" }
-      let!(:appeal_root_task) { create(:root_task, appeal: appeal, status: root_task_status) }
+      let!(:appeal_root_task) { create(:root_task, :in_progress, appeal: appeal) }
       let!(:hearing_task) { FactoryBot.create(:hearing_task, parent: appeal_root_task, appeal: appeal) }
       let(:hearing_scheduled_for) { Time.zone.today + 15.days }
       let!(:hearing_day) do
@@ -1546,17 +1532,17 @@ describe Appeal do
       let!(:schedule_hearing_task) do
         FactoryBot.create(
           :schedule_hearing_task,
+          :completed,
           parent: hearing_task,
-          appeal: appeal,
-          status: Constants.TASK_STATUSES.completed
+          appeal: appeal
         )
       end
       let!(:disposition_task) do
         FactoryBot.create(
           :assign_hearing_disposition_task,
+          :in_progress,
           parent: hearing_task,
-          appeal: appeal,
-          status: Constants.TASK_STATUSES.in_progress
+          appeal: appeal
         )
       end
 

--- a/spec/models/hearing_task_association_spec.rb
+++ b/spec/models/hearing_task_association_spec.rb
@@ -5,10 +5,10 @@ require "rails_helper"
 describe HearingTaskAssociation do
   describe "uniqueness validation" do
     let(:hearing) { nil }
-    let(:status) { Constants.TASK_STATUSES.in_progress }
-    let(:hearing_task) { FactoryBot.create(:hearing_task, appeal: hearing&.appeal, status: status) }
+    let(:trait) { :in_progress }
+    let(:hearing_task) { FactoryBot.create(:hearing_task, trait, appeal: hearing&.appeal) }
     let(:hearing_task_2) do
-      FactoryBot.create(:hearing_task, appeal: hearing&.appeal, status: Constants.TASK_STATUSES.assigned)
+      FactoryBot.create(:hearing_task, trait, appeal: hearing&.appeal)
     end
     let!(:hearing_task_association) do
       FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task)
@@ -30,7 +30,7 @@ describe HearingTaskAssociation do
       end
 
       context "there is a duplicate hearing task but it's closed" do
-        let(:status) { Constants.TASK_STATUSES.cancelled }
+        let(:trait) { :cancelled }
 
         it "allows creation of a duplicate" do
           before_count = HearingTaskAssociation.count
@@ -50,7 +50,7 @@ describe HearingTaskAssociation do
       end
 
       context "there is a duplicate hearing task but it's closed" do
-        let(:status) { Constants.TASK_STATUSES.cancelled }
+        let(:trait) { :cancelled }
 
         it "allows creation of a duplicate" do
           before_count = HearingTaskAssociation.count

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2367,7 +2367,7 @@ describe LegacyAppeal do
 
           before do
             on_hold_root = create(:root_task, appeal: appeal, updated_at: pre_ama - 1)
-            create(:generic_task, status: :on_hold, appeal: appeal, parent: on_hold_root, updated_at: pre_ama + 1)
+            create(:generic_task, :on_hold, appeal: appeal, parent: on_hold_root, updated_at: pre_ama + 1)
           end
 
           it "it returns something" do

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -56,7 +56,9 @@ describe LegacyHearing do
 
     context "when the hearing has an open disposition task" do
       let!(:hearing_task_association) { create(:hearing_task_association, hearing: hearing) }
-      let!(:disposition_task) { create(:assign_hearing_disposition_task, parent: hearing_task_association.hearing_task) }
+      let!(:disposition_task) do
+        create(:assign_hearing_disposition_task, parent: hearing_task_association.hearing_task)
+      end
 
       it { is_expected.to eq(true) }
     end
@@ -65,8 +67,12 @@ describe LegacyHearing do
       let!(:hearing_task_association) { create(:hearing_task_association, hearing: hearing) }
       let!(:disposition_task) do
         create(:assign_hearing_disposition_task,
-               parent: hearing_task_association.hearing_task,
-               status: Constants.TASK_STATUSES.cancelled)
+               :cancelled,
+               parent: hearing_task_association.hearing_task)
+      end
+
+      before do
+        hearing_task_association.hearing_task.update(status: :in_progress)
       end
 
       it { is_expected.to eq(false) }
@@ -74,7 +80,9 @@ describe LegacyHearing do
 
     context "when the hearing has a disposition task with children" do
       let!(:hearing_task_association) { create(:hearing_task_association, hearing: hearing) }
-      let!(:disposition_task) { create(:assign_hearing_disposition_task, parent: hearing_task_association.hearing_task) }
+      let!(:disposition_task) do
+        create(:assign_hearing_disposition_task, parent: hearing_task_association.hearing_task)
+      end
       let!(:transcription_task) { create(:transcription_task, parent: disposition_task) }
 
       it { is_expected.to eq(false) }

--- a/spec/models/queues/attorney_queue_spec.rb
+++ b/spec/models/queues/attorney_queue_spec.rb
@@ -34,7 +34,7 @@ describe AttorneyQueue do
         end
       end
       let!(:action5) do
-        create(:colocated_task, assigned_by: user, status: "in_progress", assigned_to: Colocated.singleton)
+        create(:colocated_task, :in_progress, assigned_by: user, assigned_to: Colocated.singleton)
       end
 
       it "should return the list" do

--- a/spec/models/queues/generic_queue_spec.rb
+++ b/spec/models/queues/generic_queue_spec.rb
@@ -13,7 +13,6 @@ describe GenericQueue do
         :on_hold,
         assigned_by: atty,
         assigned_to: user,
-        placed_on_hold_at: 15.days.ago,
         on_hold_duration: 3
       )
     end
@@ -23,6 +22,7 @@ describe GenericQueue do
 
     context "when some on hold tasks have expired" do
       it "should set the status of the expired task to in_progress" do
+        on_hold_task.update(placed_on_hold_at: 15.days.ago)
         tasks = GenericQueue.new(user: user).tasks
         expect(tasks.size).to eq(task_count + 1)
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -13,10 +13,10 @@ describe Task do
       subject { root_task.structure(:id, :status) }
 
       it "outputs the task structure" do
-        root_key = "#{root_task.class.name} #{root_task.id}, #{root_task.status}".to_sym
-        judge_key = "#{judge_task.class.name} #{judge_task.id}, #{judge_task.status}".to_sym
-        bva_key = "#{bva_task.class.name} #{bva_task.id}, #{bva_task.status}".to_sym
-        attorney_key = "#{attorney_task.class.name} #{attorney_task.id}, #{attorney_task.status}".to_sym
+        root_key = "#{root_task.type} #{root_task.id}, #{root_task.status}".to_sym
+        judge_key = "#{judge_task.type} #{judge_task.id}, #{judge_task.status}".to_sym
+        bva_key = "#{bva_task.type} #{bva_task.id}, #{bva_task.status}".to_sym
+        attorney_key = "#{attorney_task.type} #{attorney_task.id}, #{attorney_task.status}".to_sym
 
         expect(subject.key?(root_key)).to be_truthy
         expect(subject[root_key].count).to eq 2
@@ -47,6 +47,7 @@ describe Task do
     context "when on_hold task is assigned to a person" do
       context "when task has no child tasks" do
         let(:child) { nil }
+
         it "should not change the task's status" do
           status_before = task.status
           subject
@@ -56,6 +57,7 @@ describe Task do
 
       context "when task has 1 incomplete child task" do
         let(:child) { FactoryBot.create(:task, :in_progress, type: Task.name, parent_id: task.id) }
+
         it "should not change the task's status" do
           status_before = task.status
           subject
@@ -65,6 +67,7 @@ describe Task do
 
       context "when task has 1 complete child task" do
         let(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent_id: task.id) }
+
         it "should change task's status to assigned" do
           status_before = task.status
           subject
@@ -91,6 +94,7 @@ describe Task do
           FactoryBot.create_list(:task, 2, :in_progress, type: Task.name, parent_id: task.id)
         end
         let(:child) { incomplete_children.last }
+
         it "should not change the task's status" do
           status_before = task.status
           subject
@@ -101,6 +105,7 @@ describe Task do
       context "when task has only complete child tasks" do
         let(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
         let(:child) { completed_children.last }
+
         it "should change task's status to assigned" do
           status_before = task.status
           subject
@@ -116,25 +121,30 @@ describe Task do
 
       context "when task has no child tasks" do
         let(:child) { nil }
+
         it "should not update any attribute of the task" do
-          expect_any_instance_of(Task).to_not receive(:update!)
+          task_status = task.status
           subject
+          expect(task.reload.status).to eq task_status
         end
       end
 
       context "when task has 1 incomplete child task" do
         let(:child) { FactoryBot.create(:task, :in_progress, type: Task.name, parent_id: task.id) }
+
         it "should not update any attribute of the task" do
-          expect_any_instance_of(Task).to_not receive(:update!)
+          task_status = task.status
           subject
+          expect(task.reload.status).to eq task_status
         end
       end
 
       context "when task has 1 complete child task" do
         let(:child) { FactoryBot.create(:task, :completed, type: Task.name, parent_id: task.id) }
+
         it "should update the task" do
-          expect_any_instance_of(Task).to receive(:update!)
           subject
+          expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
         end
       end
 
@@ -156,18 +166,21 @@ describe Task do
           FactoryBot.create_list(:task, 2, :in_progress, type: Task.name, parent_id: task.id)
         end
         let(:child) { incomplete_children.last }
+
         it "should not update any attribute of the task" do
-          expect_any_instance_of(Task).to_not receive(:update!)
+          task_status = task.status
           subject
+          expect(task.reload.status).to eq task_status
         end
       end
 
       context "when task has only complete child tasks" do
         let(:completed_children) { FactoryBot.create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
         let(:child) { completed_children.last }
+
         it "should update the task" do
-          expect_any_instance_of(Task).to receive(:update!)
           subject
+          expect(task.status).to eq(Constants.TASK_STATUSES.completed)
         end
       end
 
@@ -388,14 +401,22 @@ describe Task do
       end
 
       context "a new child task is added" do
-        let(:root_task) { FactoryBot.create(:root_task) }
+        let(:root_task) { create(:root_task) }
         let(:hearing_task) do
-          FactoryBot.create(
-            :hearing_task, parent: root_task, appeal: root_task.appeal, assigned_to: HearingsManagement.singleton
+          create(
+            :hearing_task,
+            parent: root_task,
+            appeal: root_task.appeal,
+            assigned_to: HearingsManagement.singleton
           )
         end
         let(:task) do
-          FactoryBot.create(:assign_hearing_disposition_task, parent: hearing_task, appeal: root_task.appeal, assigned_to: user)
+          create(
+            :assign_hearing_disposition_task,
+            parent: hearing_task,
+            appeal: root_task.appeal,
+            assigned_to: user
+          )
         end
 
         subject do
@@ -450,12 +471,12 @@ describe Task do
   end
 
   describe ".open?" do
-    let(:status) { nil }
-    let(:task) { FactoryBot.create(:generic_task, status: status) }
+    let(:trait) { nil }
+    let(:task) { FactoryBot.create(:generic_task, trait) }
     subject { task.open? }
 
     context "when status is assigned" do
-      let(:status) { Constants.TASK_STATUSES.assigned }
+      let(:trait) { :assigned }
 
       it "is open" do
         expect(subject).to eq(true)
@@ -463,7 +484,7 @@ describe Task do
     end
 
     context "when status is in_progress" do
-      let(:status) { Constants.TASK_STATUSES.in_progress }
+      let(:trait) { :in_progress }
 
       it "is open" do
         expect(subject).to eq(true)
@@ -471,7 +492,7 @@ describe Task do
     end
 
     context "when status is on_hold" do
-      let(:status) { Constants.TASK_STATUSES.on_hold }
+      let(:trait) { :on_hold }
 
       it "is open" do
         expect(subject).to eq(true)
@@ -479,7 +500,7 @@ describe Task do
     end
 
     context "when status is completed" do
-      let(:status) { Constants.TASK_STATUSES.completed }
+      let(:trait) { :completed }
 
       it "is not open" do
         expect(subject).to eq(false)
@@ -487,7 +508,7 @@ describe Task do
     end
 
     context "when status is cancelled" do
-      let(:status) { Constants.TASK_STATUSES.cancelled }
+      let(:trait) { :cancelled }
 
       it "is not open" do
         expect(subject).to eq(false)
@@ -499,7 +520,7 @@ describe Task do
     let(:user) { create(:user) }
 
     context "when task status is on_hold" do
-      let(:task) { create(:generic_task, status: "on_hold") }
+      let(:task) { create(:generic_task, :on_hold) }
 
       it "returns false" do
         expect(task.actions_available?(user)).to eq(false)
@@ -511,7 +532,7 @@ describe Task do
     let(:user) { create(:user) }
 
     context "when task status is completed" do
-      let(:task) { create(:generic_task, status: "completed") }
+      let(:task) { create(:generic_task, :completed) }
 
       it "returns false" do
         expect(task.actions_allowable?(user)).to eq(false)
@@ -772,9 +793,10 @@ describe Task do
     end
 
     context "when a task has completed an old-style hold" do
-      let(:task) { FactoryBot.create(:task, :on_hold, placed_on_hold_at: 200.days.ago) }
+      let(:task) { FactoryBot.create(:task, :on_hold) }
 
       it "recognizes that the old style hold has expired" do
+        task.update(placed_on_hold_at: 200.days.ago)
         expect(subject).to eq(true)
       end
     end

--- a/spec/models/task_timer_spec.rb
+++ b/spec/models/task_timer_spec.rb
@@ -23,7 +23,7 @@ describe TaskTimer do
   end
 
   describe "requires_processing" do
-    let(:task) { FactoryBot.create(:generic_task, status: task_status) }
+    let(:task) { FactoryBot.create(:generic_task, trait) }
     let!(:task_timer) { TaskTimer.create!(task: task).tap(&:submit_for_processing!) }
 
     before do
@@ -33,14 +33,14 @@ describe TaskTimer do
     subject { TaskTimer.requires_processing }
 
     context "when the related task is closed" do
-      let(:task_status) { Constants.TASK_STATUSES.cancelled }
+      let(:trait) { :cancelled }
       it "returns no task timers" do
         expect(subject.length).to eq(0)
       end
     end
 
     context "when the related task is active" do
-      let(:task_status) { Constants.TASK_STATUSES.in_progress }
+      let(:trait) { :in_progress }
       it "returns the correct task timer" do
         processable_task_timers = subject
         expect(processable_task_timers.length).to eq(1)

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -250,20 +250,22 @@ describe AssignHearingDispositionTask do
         hearing_task: hearing_task
       )
     end
-    let!(:schedule_hearing_task) do
-      FactoryBot.create(
-        :schedule_hearing_task,
-        parent: hearing_task,
-        appeal: appeal,
-        status: Constants.TASK_STATUSES.completed
-      )
-    end
+
     let!(:disposition_task) do
       FactoryBot.create(
         :assign_hearing_disposition_task,
+        :in_progress,
         parent: hearing_task,
-        appeal: appeal,
-        status: Constants.TASK_STATUSES.in_progress
+        appeal: appeal
+      )
+    end
+
+    let!(:schedule_hearing_task) do
+      FactoryBot.create(
+        :schedule_hearing_task,
+        :completed,
+        parent: hearing_task,
+        appeal: appeal
       )
     end
 

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -16,8 +16,7 @@ describe AttorneyTask do
         assigned_to: attorney,
         assigned_by: judge,
         appeal: appeal,
-        parent: parent,
-        status: Constants.TASK_STATUSES.assigned
+        parent: parent
       )
     end
 
@@ -35,13 +34,12 @@ describe AttorneyTask do
 
     context "there is a completed sibling task" do
       before do
-        AttorneyTask.create!(
-          assigned_to: attorney,
-          assigned_by: judge,
-          appeal: appeal,
-          parent: parent,
-          status: Constants.TASK_STATUSES.completed
-        )
+        create(:ama_attorney_task,
+               :completed,
+               assigned_to: attorney,
+               assigned_by: judge,
+               appeal: appeal,
+               parent: parent)
       end
 
       it "is valid" do
@@ -51,12 +49,12 @@ describe AttorneyTask do
 
     context "there is an uncompleted sibling task" do
       before do
-        AttorneyTask.create!(
+        create(
+          :ama_attorney_task,
           assigned_to: attorney,
           assigned_by: judge,
           appeal: appeal,
-          parent: parent,
-          status: Constants.TASK_STATUSES.assigned
+          parent: parent
         )
       end
 

--- a/spec/models/tasks/board_grant_effectuation_task_spec.rb
+++ b/spec/models/tasks/board_grant_effectuation_task_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 describe BoardGrantEffectuationTask do
-  let(:task_status) { "assigned" }
-  let(:task) { create(:board_grant_effectuation_task, status: task_status) }
+  let(:trait) { :assigned }
+  let(:task) { create(:board_grant_effectuation_task, trait) }
 
   context "#label" do
     subject { task.label }
@@ -26,7 +26,7 @@ describe BoardGrantEffectuationTask do
     end
 
     context "completed task" do
-      let(:task_status) { "completed" }
+      let(:trait) { :completed }
 
       it "cannot be completed again" do
         expect(subject).to eq false

--- a/spec/models/tasks/decision_review_task_spec.rb
+++ b/spec/models/tasks/decision_review_task_spec.rb
@@ -30,7 +30,7 @@ describe DecisionReviewTask do
         benefit_type: benefit_type
       )
     end
-    let(:task_status) { "assigned" }
+    let(:trait) { :assigned }
     let!(:request_issues) do
       [
         create(:request_issue, :rating, decision_review: hlr, benefit_type: benefit_type),
@@ -62,7 +62,7 @@ describe DecisionReviewTask do
         }
       ]
     end
-    let(:task) { create(:higher_level_review_task, appeal: hlr, status: task_status) }
+    let(:task) { create(:higher_level_review_task, trait, appeal: hlr) }
     subject { task.complete_with_payload!(decision_issue_params, decision_date) }
 
     context "assigned task" do
@@ -96,7 +96,7 @@ describe DecisionReviewTask do
     end
 
     context "completed task" do
-      let(:task_status) { "completed" }
+      let(:trait) { :completed }
 
       it "cannot be completed again" do
         expect(subject).to eq false

--- a/spec/models/tasks/distribution_task_spec.rb
+++ b/spec/models/tasks/distribution_task_spec.rb
@@ -13,10 +13,11 @@ describe DistributionTask do
     end
 
     let(:distribution_task) do
-      DistributionTask.create!(
+      create(
+        :distribution_task,
+        :on_hold,
         appeal: create(:appeal),
-        assigned_to: Bva.singleton,
-        status: "on_hold"
+        assigned_to: Bva.singleton
       )
     end
 

--- a/spec/models/tasks/evidence_submission_window_task_spec.rb
+++ b/spec/models/tasks/evidence_submission_window_task_spec.rb
@@ -94,9 +94,9 @@ describe EvidenceSubmissionWindowTask do
       let!(:parent) do
         FactoryBot.create(
           :assign_hearing_disposition_task,
+          :in_progress,
           parent: hearing_task,
-          appeal: appeal,
-          status: Constants.TASK_STATUSES.in_progress
+          appeal: appeal
         )
       end
       let!(:task) do

--- a/spec/models/tasks/hearing_task_spec.rb
+++ b/spec/models/tasks/hearing_task_spec.rb
@@ -11,9 +11,9 @@ describe HearingTask do
     let!(:disposition_task) do
       FactoryBot.create(
         :assign_hearing_disposition_task,
+        :in_progress,
         parent: hearing_task,
-        appeal: appeal,
-        status: Constants.TASK_STATUSES.in_progress
+        appeal: appeal
       )
     end
     let!(:transcription_task) { create(:transcription_task, parent: disposition_task, appeal: appeal) }
@@ -41,13 +41,13 @@ describe HearingTask do
     let(:root_task) { FactoryBot.create(:root_task) }
     let(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: root_task.appeal) }
     let(:disposition_task_type) { :assign_hearing_disposition_task }
-    let(:disposition_task_status) { Constants.TASK_STATUSES.assigned }
+    let(:trait) { :assigned }
     let!(:disposition_task) do
       FactoryBot.create(
         disposition_task_type,
+        trait,
         parent: hearing_task,
-        appeal: root_task.appeal,
-        status: disposition_task_status
+        appeal: root_task.appeal
       )
     end
 
@@ -58,7 +58,7 @@ describe HearingTask do
     end
 
     context "the disposition task is not active" do
-      let(:disposition_task_status) { Constants.TASK_STATUSES.cancelled }
+      let(:trait) { :cancelled }
 
       it "returns nil" do
         expect(subject).to be_nil

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -166,9 +166,9 @@ describe JudgeTask do
     let!(:child) do
       FactoryBot.create(
         :ama_attorney_task,
+        :completed,
         assigned_to: attorney,
         assigned_by: judge,
-        status: Constants.TASK_STATUSES.completed,
         parent: parent
       )
     end

--- a/spec/models/tasks/mail_task_spec.rb
+++ b/spec/models/tasks/mail_task_spec.rb
@@ -85,7 +85,7 @@ describe MailTask do
 
     context "when the task's appeal has a closed HearingTask" do
       before do
-        FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal, status: Constants.TASK_STATUSES.completed)
+        FactoryBot.create(:hearing_task, :completed, parent: root_task, appeal: appeal)
       end
 
       it "indicates there there is not a pending_hearing_task" do

--- a/spec/models/tasks/no_show_hearing_task_spec.rb
+++ b/spec/models/tasks/no_show_hearing_task_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 describe NoShowHearingTask do
-  let(:appeal) { FactoryBot.create(:appeal, :hearing_docket) }
-  let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
-  let(:distribution_task) { FactoryBot.create(:distribution_task, appeal: appeal, parent: root_task) }
-  let(:hearing_task) { FactoryBot.create(:hearing_task, parent: distribution_task, appeal: appeal) }
+  let(:appeal) { create(:appeal, :hearing_docket) }
+  let(:root_task) { create(:root_task, appeal: appeal) }
+  let(:distribution_task) { create(:distribution_task, appeal: appeal, parent: root_task) }
+  let(:hearing_task) { create(:hearing_task, parent: distribution_task, appeal: appeal) }
+  let!(:disposition_task) { create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal) }
+  let(:no_show_hearing_task) { create(:no_show_hearing_task, parent: disposition_task, appeal: appeal) }
   let!(:completed_scheduling_task) do
-    FactoryBot.create(:schedule_hearing_task, :completed, parent: hearing_task, appeal: appeal)
+    create(:schedule_hearing_task, :completed, parent: hearing_task, appeal: appeal)
   end
-  let(:disposition_task) { FactoryBot.create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal) }
-  let(:no_show_hearing_task) { FactoryBot.create(:no_show_hearing_task, parent: disposition_task, appeal: appeal) }
 
   context "create a new NoShowHearingTask" do
     let(:task_params) { { appeal: appeal, parent: disposition_task } }

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -79,18 +79,18 @@ describe RootTask do
         subject { RootTask.create!(appeal: appeal) }
 
         before do
-          FactoryBot.create(:root_task, appeal: appeal, status: root_task_status)
+          FactoryBot.create(:root_task, trait, appeal: appeal)
         end
 
         context "when existing RootTask is active" do
-          let(:root_task_status) { Constants.TASK_STATUSES.on_hold }
+          let(:trait) { :on_hold }
           it "will raise an error" do
             expect { subject }.to raise_error(Caseflow::Error::DuplicateOrgTask)
           end
         end
 
         context "when existing RootTask is inactive" do
-          let(:root_task_status) { Constants.TASK_STATUSES.completed }
+          let(:trait) { :completed }
           it "will raise an error" do
             expect { subject }.to raise_error(Caseflow::Error::DuplicateOrgTask)
           end

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -187,20 +187,22 @@ describe ScheduleHearingTask do
   end
 
   describe "#create_change_hearing_disposition_task" do
-    let(:appeal) { FactoryBot.create(:appeal) }
-    let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+    let(:appeal) { create(:appeal) }
+    let(:root_task) { create(:root_task, appeal: appeal) }
     let(:past_hearing_disposition) { Constants.HEARING_DISPOSITION_TYPES.postponed }
-    let(:hearing) { FactoryBot.create(:hearing, appeal: appeal, disposition: past_hearing_disposition) }
-    let(:hearing_task) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
-    let!(:disposition_task) { FactoryBot.create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal) }
-    let!(:association) { FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task) }
-    let!(:hearing_task_2) { FactoryBot.create(:hearing_task, parent: root_task, appeal: appeal) }
-    let!(:task) { FactoryBot.create(:schedule_hearing_task, parent: hearing_task_2, appeal: appeal) }
+    let(:hearing) { create(:hearing, appeal: appeal, disposition: past_hearing_disposition) }
+    let(:hearing_task) { create(:hearing_task, parent: root_task, appeal: appeal) }
+    let!(:disposition_task) do
+      create(:assign_hearing_disposition_task, parent: hearing_task, appeal: appeal)
+    end
+    let!(:association) { create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task) }
+    let!(:hearing_task_2) { create(:hearing_task, parent: root_task, appeal: appeal) }
+    let!(:task) { create(:schedule_hearing_task, parent: hearing_task_2, appeal: appeal) }
     let(:instructions) { "These are my detailed instructions for a schedule hearing task." }
 
     before do
       [hearing_task, disposition_task].each { |task| task&.update!(status: Constants.TASK_STATUSES.completed) }
-      FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task_2)
+      create(:hearing_task_association, hearing: hearing, hearing_task: hearing_task_2)
     end
 
     subject { task.create_change_hearing_disposition_task(instructions) }

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -62,10 +62,10 @@ describe TimedHoldTask do
 
       context "when there are closed sibling TimedHoldTasks" do
         let!(:cancelled_sibling) do
-          FactoryBot.create(:timed_hold_task, **args.merge(status: Constants.TASK_STATUSES.cancelled))
+          FactoryBot.create(:timed_hold_task, :cancelled, **args)
         end
         let!(:completed_sibling) do
-          FactoryBot.create(:timed_hold_task, **args.merge(status: Constants.TASK_STATUSES.completed))
+          FactoryBot.create(:timed_hold_task, :completed, **args)
         end
 
         it "does not change the status of the closed sibling tasks" do
@@ -140,12 +140,12 @@ describe TimedHoldTask do
   end
 
   describe ".when_timer_ends" do
-    let(:task) { FactoryBot.create(:timed_hold_task, status: status) }
+    let(:task) { FactoryBot.create(:timed_hold_task, trait) }
 
     subject { task.when_timer_ends }
 
     context "when the task is active" do
-      let(:status) { Constants.TASK_STATUSES.in_progress }
+      let(:trait) { :in_progress }
 
       context "when the TimedHoldTask does not have a parent task" do
         it "changes task status to completed" do
@@ -155,8 +155,8 @@ describe TimedHoldTask do
       end
 
       context "when the TimedHoldTask has a parent task assigned to an organization" do
-        let(:parent_task) { FactoryBot.create(:generic_task, status: Constants.TASK_STATUSES.on_hold) }
-        let(:task) { FactoryBot.create(:timed_hold_task, status: status, parent: parent_task) }
+        let(:parent_task) { FactoryBot.create(:generic_task, :on_hold) }
+        let(:task) { FactoryBot.create(:timed_hold_task, trait, parent: parent_task) }
         it "sets the parent task status to assigned" do
           subject
           expect(parent_task.status).to eq(Constants.TASK_STATUSES.assigned)
@@ -165,7 +165,7 @@ describe TimedHoldTask do
     end
 
     context "when the task has already been completed" do
-      let(:status) { Constants.TASK_STATUSES.completed }
+      let(:trait) { :completed }
 
       it "does not update the status of the task" do
         expect(task).to_not receive(:update!)
@@ -174,7 +174,7 @@ describe TimedHoldTask do
     end
 
     context "when the task has been cancelled" do
-      let(:status) { Constants.TASK_STATUSES.cancelled }
+      let(:trait) { :cancelled }
 
       it "does not change the status of the task" do
         expect(task).to_not receive(:update!)

--- a/spec/policies/appeal_request_issues_policy_spec.rb
+++ b/spec/policies/appeal_request_issues_policy_spec.rb
@@ -12,8 +12,7 @@ describe AppealRequestIssuesPolicy do
         create(:task,
                type: "AttorneyTask",
                appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.assigned)
+               assigned_to: user)
 
         expect(subject).to be true
       end
@@ -24,8 +23,7 @@ describe AppealRequestIssuesPolicy do
         create(:task,
                type: "AttorneyTask",
                appeal: appeal,
-               assigned_to: build_stubbed(:user),
-               status: Constants.TASK_STATUSES.assigned)
+               assigned_to: build_stubbed(:user))
 
         expect(subject).to be false
       end
@@ -34,10 +32,10 @@ describe AppealRequestIssuesPolicy do
     context "when appeal has in-progress judge task assigned to user" do
       it "returns true" do
         create(:task,
+               :in_progress,
                type: "JudgeDecisionReviewTask",
                appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.in_progress)
+               assigned_to: user)
 
         expect(subject).to be true
       end
@@ -46,10 +44,10 @@ describe AppealRequestIssuesPolicy do
     context "when appeal has completed attorney task assigned to user" do
       it "returns false" do
         create(:task,
+               :completed,
                type: "AttorneyTask",
                appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.completed)
+               assigned_to: user)
 
         expect(subject).to be false
       end
@@ -60,8 +58,7 @@ describe AppealRequestIssuesPolicy do
         create(:task,
                type: "ColocatedTask",
                appeal: appeal,
-               assigned_to: user,
-               status: Constants.TASK_STATUSES.assigned)
+               assigned_to: user)
 
         expect(subject).to be false
       end
@@ -76,8 +73,7 @@ describe AppealRequestIssuesPolicy do
         create(:task,
                type: "ColocatedTask",
                appeal: appeal,
-               assigned_to: build_stubbed(:user),
-               status: Constants.TASK_STATUSES.assigned)
+               assigned_to: build_stubbed(:user))
 
         expect(subject).to be true
       end
@@ -92,8 +88,7 @@ describe AppealRequestIssuesPolicy do
         create(:task,
                type: "AttorneyTask",
                appeal: appeal,
-               assigned_to: build_stubbed(:user),
-               status: Constants.TASK_STATUSES.assigned)
+               assigned_to: build_stubbed(:user))
 
         expect(subject).to be false
       end

--- a/spec/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query_spec.rb
+++ b/spec/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query_spec.rb
@@ -7,8 +7,8 @@ describe AppealsWithNoTasksOrAllTasksOnHoldQuery do
   let!(:appeal_with_tasks) { create(:appeal, :with_post_intake_tasks) }
   let!(:appeal_with_all_tasks_on_hold) do
     appeal = create(:appeal, :with_post_intake_tasks)
-    schedule_hearing_task = create(:schedule_hearing_task, appeal: appeal)
-    schedule_hearing_task.parent.update!(parent: appeal.root_task)
+    hearing_task = create(:hearing_task, appeal: appeal, parent: appeal.root_task)
+    schedule_hearing_task = create(:schedule_hearing_task, appeal: appeal, parent: hearing_task)
     appeal.root_task.descendants.each(&:on_hold!)
     appeal
   end

--- a/spec/requests/api/docs/v3/docs_controller_spec.rb
+++ b/spec/requests/api/docs/v3/docs_controller_spec.rb
@@ -1,23 +1,25 @@
+# frozen_string_literal: true
+
 describe Api::Docs::V3::DocsController, type: :request do
-  describe '#decision_reviews' do
-    it 'should successfully return openapi spec' do
-      get '/api/docs/v3/decision_reviews'
+  describe "#decision_reviews" do
+    it "should successfully return openapi spec" do
+      get "/api/docs/v3/decision_reviews"
       expect(response).to have_http_status(200)
       json = JSON.parse(response.body)
-      expect(json["openapi"]).to eq('3.0.0')
+      expect(json["openapi"]).to eq("3.0.0")
     end
-    describe '/higher_level_review documentation' do
+    describe "/higher_level_review documentation" do
       before(:each) do
-        get '/api/docs/v3/decision_reviews'
+        get "/api/docs/v3/decision_reviews"
       end
       let(:hlr_doc) do
         json = JSON.parse(response.body)
-        json['paths']['/higher_level_reviews']
+        json["paths"]["/higher_level_reviews"]
       end
-      it 'should have POST' do
-        expect(hlr_doc).to include('post')
+      it "should have POST" do
+        expect(hlr_doc).to include("post")
       end
-      # TODO when doc is real, verify some other stuff about it
+      # TODO: when doc is real, verify some other stuff about it
     end
   end
 end

--- a/spec/support/fake_decision_review.rb
+++ b/spec/support/fake_decision_review.rb
@@ -2,5 +2,6 @@
 
 class FakeDecisionReview
   def active_request_issues; end
+
   def withdrawn_request_issues; end
 end

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -26,8 +26,8 @@ describe BulkTaskAssignment do
     # Even it is the oldest task, it should skip it becasue it is on hold
     let!(:no_show_hearing_task4) do
       FactoryBot.create(:no_show_hearing_task,
+                        :on_hold,
                         assigned_to: organization,
-                        status: :on_hold,
                         created_at: 6.days.ago)
     end
 


### PR DESCRIPTION
This is the first PR to enforce initial status for Task creation. We will first send all offenses to Sentry instead of throwing an error so not to block work. 