### PR TITLE
Filter out inactive request issues from decision review task check

### DIFF
--- a/app/models/tasks/decision_review_task.rb
+++ b/app/models/tasks/decision_review_task.rb
@@ -47,7 +47,7 @@ class DecisionReviewTask < GenericTask
   end
 
   def validate_decision_issue_per_request_issue(decision_issue_params)
-    appeal.request_issues.map(&:id).sort == decision_issue_params.map do |decision_issue_param|
+    appeal.request_issues.active.map(&:id).sort == decision_issue_params.map do |decision_issue_param|
       decision_issue_param[:request_issue_id].to_i
     end.sort
   end

--- a/spec/models/tasks/decision_review_task_spec.rb
+++ b/spec/models/tasks/decision_review_task_spec.rb
@@ -34,7 +34,8 @@ describe DecisionReviewTask do
       [
         create(:request_issue, :rating, decision_review: hlr, benefit_type: benefit_type),
         create(:request_issue, :rating, decision_review: hlr, benefit_type: benefit_type),
-        create(:request_issue, :nonrating, decision_review: hlr, benefit_type: benefit_type)
+        create(:request_issue, :nonrating, decision_review: hlr, benefit_type: benefit_type),
+        create(:request_issue, :removed, decision_review: hlr, benefit_type: benefit_type)
       ]
     end
     let(:decision_date) { "01/01/2019" }


### PR DESCRIPTION
Resolves #11302 

The validity check for completing a decision review task was not taking the "closed" status of the Appeal's request issues into account.
