### PR TITLE
Resolve db seeding bug

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -915,8 +915,8 @@ class SeedDB
     atty = FactoryBot.create(:user, station_id: 101)
     atty.update!(full_name: attorney_name) if attorney_name
     FactoryBot.create(:staff, :attorney_role, user: atty)
-    atty_task_params = [{ appeal: appeal, parent_id: judge_task.id, assigned_to: atty, assigned_by: judge }]
-    atty_task = AttorneyTask.create_many_from_params(atty_task_params, judge).first
+    atty_task_params = { appeal: appeal, parent_id: judge_task.id, assigned_to: atty, assigned_by: judge }
+    atty_task = AttorneyTask.create!(atty_task_params)
 
     atty_task.update!(status: Constants.TASK_STATUSES.completed)
     judge_task.update!(status: Constants.TASK_STATUSES.completed)


### PR DESCRIPTION
When using create_many_from_params for tasks, verify_user_can_create is run, which builds an action hash, calling all task action functions. For the new REASSIGN_TO_JUDGE, this calls User.find_by_css_id_or_create_with_default_station_id, which populated the user table with vacols users. This was creating a user with the css_id or CSS_ID13. At that point, FactoryBot had sequenced users with css_ids up to CSS_ID12, so when it tried to create a user with CSS_ID13, the css_id unique constraint failed.