### PR TITLE
Check for tabs before accessing them

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaimDecision.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimDecision.jsx
@@ -174,7 +174,7 @@ export class EstablishClaimDecision extends React.Component {
               tabs={tabs}
               onChange={this.onTabSelected} />
           </div>}
-          {!this.hasMultipleDecisions() && tabs[0].page}
+          {!this.hasMultipleDecisions() && tabs.length > 0 && tabs[0].page}
 
           <div className="usa-width-one-half">
             <TextField


### PR DESCRIPTION
See https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/5630/

JS error trying to access `tabs[0].page` when `tabs[0]` is undefined.
