### PR TITLE
add error responses to the Higher-Level Review spec

### DIFF
--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -138,7 +138,291 @@ paths:
         '202':
           description: Created
         '400':
-          description: Invalid Request
+          description: |-
+            400 response
+          content:
+            application/vnd.api+json:
+              examples:
+                malformed_request:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "400",
+                        "title":  "Malformed request",
+                        "code":  "malformed_request"
+                      }
+                    ]
+                  }
+        '401':
+          description: |-
+            401 response
+          content:
+            application/vnd.api+json:
+              examples:
+                unauthenticated:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "401",
+                        "title":  "Unauthenticated",
+                        "code":  "unauthenticated"
+                      }
+                    ]
+                  }
+        '403':
+          description: |-
+            403 response
+          content:
+            application/vnd.api+json:
+              examples:
+                veteran_not_accessible:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "403",
+                        "title":  "Veteran File inaccessible",
+                        "code":  "veteran_not_accessible"
+                      }
+                    ]
+                  }
+        '404':
+          description: |-
+            404 response
+          content:
+            application/vnd.api+json:
+              examples:
+                veteran_not_found:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "404",
+                        "title":  "Veteran File not found",
+                        "code":  "veteran_not_found"
+                      }
+                    ]
+                  }
+                isssue_not_found:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "404",
+                        "title":  "Issue not found",
+                        "code":  "isssue_not_found"
+                      }
+                    ]
+                  }
+                claimant_not_found:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "404",
+                        "title":  "Claimant not found",
+                        "code":  "claimant_not_found"
+                      }
+                    ]
+                  }
+        '409':
+          description: |-
+            409 response
+          content:
+            application/vnd.api+json:
+              examples:
+                duplicate_intake_in_progress:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "409",
+                        "title":  "Intake in progress",
+                        "code":  "duplicate_intake_in_progress"
+                      }
+                    ]
+                  }
+        '422':
+          description: |-
+            422 response
+          content:
+            application/vnd.api+json:
+              examples:
+                payee_code_required:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Claimant payee code may not be blank",
+                        "code":  "payee_code_required"
+                      }
+                    ]
+                  }
+                claimant_required:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Claimant participant id may not be blank",
+                        "code":  "claimant_required"
+                      }
+                    ]
+                  }
+                claimant_address_required:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Claimant address required",
+                        "code":  "claimant_address_required"
+                      }
+                    ]
+                  }
+                benefit_type_requires_payee_code:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Benefit type requires payee code",
+                        "code":  "benefit_type_requires_payee_code"
+                      }
+                    ]
+                  }
+                duplicate_of_rating_issue_in_active_review:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Duplicate rating issue",
+                        "code":  "duplicate_of_rating_issue_in_active_review"
+                      }
+                    ]
+                  }
+                invalid_file_number:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Invalid Veteran File number",
+                        "code":  "invalid_file_number"
+                      }
+                    ]
+                  }
+                claimant_ineligible:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Claimant Ineligible (not on original Benefit Claim or no POA)",
+                        "code":  "claimant_ineligible"
+                      }
+                    ]
+                  }
+                untimely:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because it has a prior decision date that’s older than 1 year",
+                        "code":  "untimely"
+                      }
+                    ]
+                  }
+                before_ama:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because it has a prior decision date before February 19, 2019",
+                        "code":  "before_ama"
+                      }
+                    ]
+                  }
+                higher_level_review_to_higher_level_review:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because it was last processed as a Higher-Level Review and this can't be done twice in a row",
+                        "code":  "higher_level_review_to_higher_level_review"
+                      }
+                    ]
+                  }
+                appeal_to_appeal:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because it was last processed as a Board Appeal and this can't be done twice in a row",
+                        "code":  "appeal_to_appeal"
+                      }
+                    ]
+                  }
+                appeal_to_higher_level_review:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because it was last processed as a Board Appeal which can't be followed by a Higher-Level Review",
+                        "code":  "appeal_to_higher_level_review"
+                      }
+                    ]
+                  }
+                legacy_issue_not_withdrawn:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because the same issue is under review as a Legacy Appeal but the claimant didn’t choose to withdraw their issue from the legacy system",
+                        "code":  "legacy_issue_not_withdrawn"
+                      }
+                    ]
+                  }
+                legacy_appeal_not_eligible:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Issue is ineligible because the same issue is under review as a Legacy Appeal and that appeal is outside the window of eligibility",
+                        "code":  "legacy_appeal_not_eligible"
+                      }
+                    ]
+                  }
+                veteran_has_multiple_phone_numbers:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Veteran has multiple phone numbers",
+                        "code":  "veteran_has_multiple_phone_numbers"
+                      }
+                    ]
+                  }
+                veteran_not_valid:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Veteran not valid",
+                        "code":  "veteran_not_valid"
+                      }
+                    ]
+                  }
+                reserved_veteran_file_number:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Reserved veteran file number",
+                        "code":  "reserved_veteran_file_number"
+                      }
+                    ]
+                  }
+                unknown_error:
+                  value: {
+                    "errors": [
+                      {
+                        "status": "422",
+                        "title":  "Unknown error",
+                        "code":  "unknown_error"
+                      }
+                    ]
+                  }
         '500':
           description: Failed
 components:


### PR DESCRIPTION
Resolves:
https://app.zenhub.com/workspaces/developervagov-5ac272fff41bfa50c0e46c48/issues/department-of-veterans-affairs/vets-contrib/2561

### Description
Enumerate all of the possible error responses for the Higher Level Review endpoint (Lighthouse) by adding example to openapi spec

### Acceptance Criteria
- [ ] HLR error responses are adequately documented

### Testing Plan
- [ ] `decision_reviews.yaml` renders correctly in editor.swagger.io
