### PR TITLE
Revert naming of print route method to show_print

### DIFF
--- a/app/controllers/hearings/worksheets_controller.rb
+++ b/app/controllers/hearings/worksheets_controller.rb
@@ -30,7 +30,7 @@ class Hearings::WorksheetsController < HearingsController
     end
   end
 
-  def print
+  def show_print
     stylesheets = {
       override_stylesheet: "print/hearings_worksheet_overrides",
       print_stylesheet: "print/hearings_worksheet"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
   get 'hearings/schedule/build/upload', to: "hearings_application#build_schedule_index"
   get 'hearings/schedule/build/upload/:schedule_period_id', to: "hearings_application#build_schedule_index"
   get 'hearings/schedule/assign', to: "hearings_application#index"
-  get 'hearings/worksheet/print', to: "hearings/worksheets#print"
+  get 'hearings/worksheet/print', to: "hearings/worksheets#show_print"
   get 'hearings/:id/worksheet', to: "hearings/worksheets#show", as: 'hearing_worksheet'
   post 'hearings/hearing_day', to: "hearings/hearing_day#create"
   get 'hearings/schedule/:schedule_period_id/download', to: "hearings/schedule_periods#download"


### PR DESCRIPTION
### Description

Fixes an issue where users can't access their hearings worksheets because the verify action is looking for a method called `show_print`.