### PR TITLE
Add RequestIssue.contention method

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -146,6 +146,8 @@ class EndProductEstablishment < ApplicationRecord
     cached ? cached_result : fetched_result
   end
 
+  alias end_product result
+
   delegate :contentions, to: :cached_result
 
   def limited_poa_on_established_claim

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -525,6 +525,10 @@ class RequestIssue < ApplicationRecord
     end
   end
 
+  def contention
+    end_product_establishment.end_product.contentions.find { |c| c.id.to_s == contention_reference_id.to_s }
+  end
+
   private
 
   def limited_poa

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -526,7 +526,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def contention
-    end_product_establishment.contention_for(self)
+    end_product_establishment.contention_for_object(self)
   end
 
   private

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -526,7 +526,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def contention
-    end_product_establishment.end_product.contentions.find { |c| c.id.to_s == contention_reference_id.to_s }
+    end_product_establishment.contention_for(self)
   end
 
   private

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -124,6 +124,21 @@ describe RequestIssue do
     end
   end
 
+  context "#contention" do
+    let(:end_product_establishment) { create(:end_product_establishment, :active) }
+    let!(:contention) do
+      Generators::Contention.build(
+        id: contention_reference_id,
+        claim_id: end_product_establishment.reference_id,
+        disposition: "allowed"
+      )
+    end
+
+    it "returns matching contention" do
+      expect(rating_request_issue.contention.id.to_s).to eq(contention_reference_id.to_s)
+    end
+  end
+
   context "#guess_benefit_type" do
     context "issue is unidentified" do
       it "returns 'unidentified'" do


### PR DESCRIPTION
This small change is in anticipation of more advanced error checking when a request issue is edited. We'll want to fetch the contention and make sure it exists before modifying the request issue.

see #11348 