### PR TITLE
Rename tracking task COPY.json variables

### DIFF
--- a/app/models/queue_tabs/tracking_tasks_tab.rb
+++ b/app/models/queue_tabs/tracking_tasks_tab.rb
@@ -2,7 +2,7 @@
 
 class TrackingTasksTab < QueueTab
   def label
-    COPY::ALL_CASES_QUEUE_TABLE_TAB_TITLE
+    COPY::TRACKING_TASKS_TAB_TITLE
   end
 
   def name
@@ -10,7 +10,7 @@ class TrackingTasksTab < QueueTab
   end
 
   def description
-    COPY::ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION
+    COPY::TRACKING_TASKS_TAB_DESCRIPTION
   end
 
   def columns

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -129,8 +129,8 @@
   "ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to a member of the %s team.",
   "ORGANIZATIONAL_QUEUE_EMPTY_STATE_MESSAGE": "This queue is empty. You can ",
 
-  "ALL_CASES_QUEUE_TABLE_TAB_TITLE": "All cases",
-  "ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION": "All AMA cases represented by %s that have been active at the Board of Veterans' Appeals in the past 2 weeks.",
+  "TRACKING_TASKS_TAB_TITLE": "All cases",
+  "TRACKING_TASKS_TAB_DESCRIPTION": "All AMA cases represented by %s that have been active at the Board of Veterans' Appeals in the past 2 weeks.",
 
   "JUDGE_CASE_REVIEW_TABLE_TITLE": "Review %s Cases",
   "JUDGE_ASSIGN_DROPDOWN_LINK_LABEL": "Assign team cases",

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -241,8 +241,8 @@ RSpec.feature "Task queue" do
       end
 
       step("All cases tab") do
-        find("button", text: format(COPY::ALL_CASES_QUEUE_TABLE_TAB_TITLE, assigned_count)).click
-        expect(page).to have_content(format(COPY::ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, vso.name))
+        find("button", text: format(COPY::TRACKING_TASKS_TAB_TITLE, assigned_count)).click
+        expect(page).to have_content(format(COPY::TRACKING_TASKS_TAB_DESCRIPTION, vso.name))
         expect(find("tbody").find_all("tr").length).to eq(tracking_task_count)
       end
     end
@@ -264,11 +264,11 @@ RSpec.feature "Task queue" do
 
     it "displays tracking tasks in single table" do
       step("does not show tabs since field VSOs only have 1 tab") do
-        expect(page).to_not have_content(COPY::ALL_CASES_QUEUE_TABLE_TAB_TITLE)
+        expect(page).to_not have_content(COPY::TRACKING_TASKS_TAB_TITLE)
       end
 
       step("shows tab description and correct number of tasks") do
-        expect(page).to have_content(format(COPY::ALL_CASES_QUEUE_TABLE_TAB_DESCRIPTION, vso.name))
+        expect(page).to have_content(format(COPY::TRACKING_TASKS_TAB_DESCRIPTION, vso.name))
         expect(find("tbody").find_all("tr").length).to eq(tracking_task_count)
       end
     end
@@ -453,7 +453,7 @@ RSpec.feature "Task queue" do
     end
 
     it "does not show all cases tab for non-VSO organization" do
-      expect(page).to_not have_content(COPY::ALL_CASES_QUEUE_TABLE_TAB_TITLE)
+      expect(page).to_not have_content(COPY::TRACKING_TASKS_TAB_TITLE)
     end
 
     it "shows the right number of cases in each tab" do


### PR DESCRIPTION
Aligns variable names used in constants and copy to refer to the tracking task as [suggested in this comment](https://github.com/department-of-veterans-affairs/caseflow/pull/11321/files#r302067276) on PR #11321.