### PR TITLE
Increase efolder doc count cache to 4 hours

### DIFF
--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -4,7 +4,7 @@ require "json"
 
 class ExternalApi::EfolderService
   def self.document_count(file_number, user)
-    Rails.cache.fetch("Efolder-document-count-#{file_number}", expires_in: 1.hour) do
+    Rails.cache.fetch("Efolder-document-count-#{file_number}", expires_in: 4.hours) do
       headers = { "FILE-NUMBER" => file_number }
       response = send_efolder_request("/api/v2/document_counts", user, headers)
       response_body = JSON.parse(response.body)


### PR DESCRIPTION
The controller endpoint that hits this method continues to be one of the most cumulatively time consuming endpoints in the app.