### PR TITLE
Use created_at to determine 'days waiting' value

### DIFF
--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -319,7 +319,7 @@ export class TaskTableUnconnected extends React.PureComponent {
         }
 
         const daysWaiting = moment().startOf('day').
-          diff(moment(task.assignedOn), 'days');
+          diff(moment(task.createdAt), 'days');
 
         return <React.Fragment>
           {daysWaiting} {pluralize('day', daysWaiting)}
@@ -328,7 +328,7 @@ export class TaskTableUnconnected extends React.PureComponent {
       span: this.collapseColumnIfNoDASRecord,
       backendCanSort: true,
       getSortValue: (task) => moment().startOf('day').
-        diff(moment(task.assignedOn), 'days')
+        diff(moment(task.createdAt), 'days')
     } : null;
   }
 

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -158,6 +158,7 @@ export const prepareLegacyTasksForStore = (tasks) => {
       appealType: task.attributes.appeal_type,
       externalAppealId: task.attributes.external_appeal_id,
       assignedOn: task.attributes.assigned_on,
+      createdAt: task.attributes.assigned_on,
       closedAt: null,
       assignedTo: {
         cssId: task.attributes.assigned_to.css_id,

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :task do
     assigned_at { rand(30..35).days.ago }
+    created_at { assigned_at }
     assigned_by { create(:user) }
     assigned_to { create(:user) }
     appeal { create(:legacy_appeal, vacols_case: create(:case)) }


### PR DESCRIPTION
This change makes it so the "days waiting" value in attorney queues does not reset to zero when a previously "on hold" case returns to them for action. Related slack discussion: https://dsva.slack.com/archives/C6E41RE92/p1562784114188800

![image](https://user-images.githubusercontent.com/32683958/61003688-85cce200-a332-11e9-9818-bbbc1538b6fb.png)

@laurjpeterson can you confirm that this is the correct behaviour?