### PR TITLE
Add migration to add timestamps to hearings table

### DIFF
--- a/db/migrate/20190711152558_add_created_at_and_updated_at_to_hearings.rb
+++ b/db/migrate/20190711152558_add_created_at_and_updated_at_to_hearings.rb
@@ -1,5 +1,6 @@
 class AddCreatedAtAndUpdatedAtToHearings < ActiveRecord::Migration[5.1]
   def change
-    add_timestamps :hearings, null: true
+    add_column :hearings, :created_at, :datetime, null: true, comment: "Automatic timestamp when row was created."
+    add_column :hearings, :updated_at, :datetime, null: true, comment: "Timestamp when record was last updated."
   end
 end

--- a/db/migrate/20190711152558_add_created_at_and_updated_at_to_hearings.rb
+++ b/db/migrate/20190711152558_add_created_at_and_updated_at_to_hearings.rb
@@ -1,0 +1,5 @@
+class AddCreatedAtAndUpdatedAtToHearings < ActiveRecord::Migration[5.1]
+  def change
+    add_timestamps :hearings, null: true
+  end
+end

--- a/db/migrate/20190711181657_add_created_at_and_updated_at_to_legacy_hearings.rb
+++ b/db/migrate/20190711181657_add_created_at_and_updated_at_to_legacy_hearings.rb
@@ -1,5 +1,6 @@
 class AddCreatedAtAndUpdatedAtToLegacyHearings < ActiveRecord::Migration[5.1]
   def change
-    add_timestamps :legacy_hearings, null: true
+    add_column :legacy_hearings, :created_at, :datetime, null: true, comment: "Automatic timestamp when row was created."
+    add_column :legacy_hearings, :updated_at, :datetime, null: true, comment: "Timestamp when record was last updated."
   end
 end

--- a/db/migrate/20190711181657_add_created_at_and_updated_at_to_legacy_hearings.rb
+++ b/db/migrate/20190711181657_add_created_at_and_updated_at_to_legacy_hearings.rb
@@ -1,0 +1,5 @@
+class AddCreatedAtAndUpdatedAtToLegacyHearings < ActiveRecord::Migration[5.1]
+  def change
+    add_timestamps :legacy_hearings, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711152558) do
+ActiveRecord::Schema.define(version: 20190711181657) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -656,9 +656,11 @@ ActiveRecord::Schema.define(version: 20190711152558) do
 
   create_table "legacy_hearings", force: :cascade do |t|
     t.integer "appeal_id"
+    t.datetime "created_at"
     t.string "military_service"
     t.boolean "prepped"
     t.text "summary"
+    t.datetime "updated_at"
     t.integer "user_id"
     t.string "vacols_id", null: false
     t.string "witness"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190705172439) do
+ActiveRecord::Schema.define(version: 20190711152558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -544,6 +544,7 @@ ActiveRecord::Schema.define(version: 20190705172439) do
   create_table "hearings", force: :cascade do |t|
     t.integer "appeal_id", null: false
     t.string "bva_poc"
+    t.datetime "created_at"
     t.string "disposition"
     t.boolean "evidence_window_waived"
     t.integer "hearing_day_id", null: false
@@ -557,6 +558,7 @@ ActiveRecord::Schema.define(version: 20190705172439) do
     t.text "summary"
     t.boolean "transcript_requested"
     t.date "transcript_sent_date"
+    t.datetime "updated_at"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.string "witness"
     t.index ["uuid"], name: "index_hearings_on_uuid"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -544,7 +544,7 @@ ActiveRecord::Schema.define(version: 20190711181657) do
   create_table "hearings", force: :cascade do |t|
     t.integer "appeal_id", null: false
     t.string "bva_poc"
-    t.datetime "created_at"
+    t.datetime "created_at", comment: "Automatic timestamp when row was created."
     t.string "disposition"
     t.boolean "evidence_window_waived"
     t.integer "hearing_day_id", null: false
@@ -558,7 +558,7 @@ ActiveRecord::Schema.define(version: 20190711181657) do
     t.text "summary"
     t.boolean "transcript_requested"
     t.date "transcript_sent_date"
-    t.datetime "updated_at"
+    t.datetime "updated_at", comment: "Timestamp when record was last updated."
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.string "witness"
     t.index ["uuid"], name: "index_hearings_on_uuid"
@@ -656,11 +656,11 @@ ActiveRecord::Schema.define(version: 20190711181657) do
 
   create_table "legacy_hearings", force: :cascade do |t|
     t.integer "appeal_id"
-    t.datetime "created_at"
+    t.datetime "created_at", comment: "Automatic timestamp when row was created."
     t.string "military_service"
     t.boolean "prepped"
     t.text "summary"
-    t.datetime "updated_at"
+    t.datetime "updated_at", comment: "Timestamp when record was last updated."
     t.integer "user_id"
     t.string "vacols_id", null: false
     t.string "witness"


### PR DESCRIPTION
Resolves #11382

### Description

  * Add `created_at` and `updated_at` columns to hearings and legacy hearings

*Schema Changes Only*

* [x] Column comments updated.
  - ~~I can add, but these are autogenerated and convention, so I think N/A~~ Added!
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
  - Didn't see any meaningful change
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
  - N/A for this PR
* [x] #appeals-schema notified with summary and link to this PR
