### PR TITLE
add migrations to add created by and updated by ids to hearings and l…

### DIFF
--- a/db/migrate/20190711191432_add_created_by_id_and_updated_by_id_to_hearings.rb
+++ b/db/migrate/20190711191432_add_created_by_id_and_updated_by_id_to_hearings.rb
@@ -1,0 +1,23 @@
+class AddCreatedByIdAndUpdatedByIdToHearings < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference(
+      :hearings,
+      :created_by,
+      foreign_key: { to_table: :users },
+      comment: "The ID of the user who created the Hearing",
+      index: false
+    )
+    add_reference(
+      :hearings,
+      :updated_by,
+      foreign_key: { to_table: :users },
+      comment: "The ID of the user who most recently updated the Hearing",
+      index: false
+    )
+
+    add_index :hearings, :created_by_id, algorithm: :concurrently
+    add_index :hearings, :updated_by_id, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20190711194030_add_created_by_id_and_updated_by_id_to_legacy_hearings.rb
+++ b/db/migrate/20190711194030_add_created_by_id_and_updated_by_id_to_legacy_hearings.rb
@@ -1,0 +1,23 @@
+class AddCreatedByIdAndUpdatedByIdToLegacyHearings < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference(
+      :legacy_hearings,
+      :created_by,
+      foreign_key: { to_table: :users },
+      comment: "The ID of the user who created the Legacy Hearing",
+      index: false
+    )
+    add_reference(
+      :legacy_hearings,
+      :updated_by,
+      foreign_key: { to_table: :users },
+      comment: "The ID of the user who most recently updated the Legacy Hearing",
+      index: false
+    )
+
+    add_index :legacy_hearings, :created_by_id, algorithm: :concurrently
+    add_index :legacy_hearings, :updated_by_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711181657) do
+ActiveRecord::Schema.define(version: 20190711194030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -545,6 +545,7 @@ ActiveRecord::Schema.define(version: 20190711181657) do
     t.integer "appeal_id", null: false
     t.string "bva_poc"
     t.datetime "created_at", comment: "Automatic timestamp when row was created."
+    t.bigint "created_by_id", comment: "The ID of the user who created the Hearing"
     t.string "disposition"
     t.boolean "evidence_window_waived"
     t.integer "hearing_day_id", null: false
@@ -559,8 +560,11 @@ ActiveRecord::Schema.define(version: 20190711181657) do
     t.boolean "transcript_requested"
     t.date "transcript_sent_date"
     t.datetime "updated_at", comment: "Timestamp when record was last updated."
+    t.bigint "updated_by_id", comment: "The ID of the user who most recently updated the Hearing"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.string "witness"
+    t.index ["created_by_id"], name: "index_hearings_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_hearings_on_updated_by_id"
     t.index ["uuid"], name: "index_hearings_on_uuid"
   end
 
@@ -657,13 +661,17 @@ ActiveRecord::Schema.define(version: 20190711181657) do
   create_table "legacy_hearings", force: :cascade do |t|
     t.integer "appeal_id"
     t.datetime "created_at", comment: "Automatic timestamp when row was created."
+    t.bigint "created_by_id", comment: "The ID of the user who created the Legacy Hearing"
     t.string "military_service"
     t.boolean "prepped"
     t.text "summary"
     t.datetime "updated_at", comment: "Timestamp when record was last updated."
+    t.bigint "updated_by_id", comment: "The ID of the user who most recently updated the Legacy Hearing"
     t.integer "user_id"
     t.string "vacols_id", null: false
     t.string "witness"
+    t.index ["created_by_id"], name: "index_legacy_hearings_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_legacy_hearings_on_updated_by_id"
     t.index ["user_id"], name: "index_legacy_hearings_on_user_id"
     t.index ["vacols_id"], name: "index_legacy_hearings_on_vacols_id", unique: true
   end
@@ -1088,9 +1096,13 @@ ActiveRecord::Schema.define(version: 20190711181657) do
   add_foreign_key "document_views", "users"
   add_foreign_key "end_product_establishments", "users"
   add_foreign_key "hearing_views", "users"
+  add_foreign_key "hearings", "users", column: "created_by_id"
+  add_foreign_key "hearings", "users", column: "updated_by_id"
   add_foreign_key "intakes", "users"
   add_foreign_key "legacy_appeals", "appeal_series"
   add_foreign_key "legacy_hearings", "users"
+  add_foreign_key "legacy_hearings", "users", column: "created_by_id"
+  add_foreign_key "legacy_hearings", "users", column: "updated_by_id"
   add_foreign_key "organizations_users", "users"
   add_foreign_key "ramp_closed_appeals", "ramp_elections"
   add_foreign_key "ramp_election_rollbacks", "users"


### PR DESCRIPTION
Adds schema changes for #11351

Will follow up with a PR to modify these fields when changes get made

### Description

Adds `created_by_id` and `updated_by_id` columns to the `hearings` and `legacy_hearings` tables.

*Schema Changes Only*

* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
