### PR TITLE
exclude all open ScheduleHearingTasks from 57 pickup

### DIFF
--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -320,9 +320,8 @@ class AppealRepository
   end
 
   def self.vacols_ids_with_schedule_tasks
-    ScheduleHearingTask.where(appeal_type: LegacyAppeal.name)
+    ScheduleHearingTask.open.where(appeal_type: LegacyAppeal.name)
       .joins("LEFT JOIN legacy_appeals ON appeal_id = legacy_appeals.id")
-      .where("status <> ? AND type = ?", Constants.TASK_STATUSES.completed.to_sym, ScheduleHearingTask.name)
       .select("legacy_appeals.vacols_id").pluck(:vacols_id).uniq
   end
 


### PR DESCRIPTION
resolves #11308

`AppealRepository.create_schedule_hearing_tasks` creates ScheduleHearingTasks for all VACOLS cases in location 57, but previously excluded appeals without `completed` ScheduleHearingTasks which would include `cancelled` tasks. 

This PR updates task creation to only [exclude cases](https://github.com/department-of-veterans-affairs/caseflow/blob/0e8e2a88000d599d36d880b21518602b00f8446e/app/services/appeal_repository.rb#L340) with *open* ScheduleHearingTasks