### PR TITLE
do not sync record on every veteran_ssn call

### DIFF
--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -163,7 +163,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def veteran_ssn
-    @veteran_ssn ||= Veteran.find_or_create_by_file_number(veteran_file_number, sync_name: true).ssn
+    veteran.ssn
   end
 
   def mark_rating_request_issues_to_reassociate!

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -163,7 +163,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def veteran_ssn
-    veteran.ssn
+    veteran&.ssn
   end
 
   def mark_rating_request_issues_to_reassociate!


### PR DESCRIPTION
basically reverting back to `veteran.ssn` pattern because we are trying to avoid BGS calls. Instead we'll do a one-time backfill of ssn and rely on Intake to populate that field going forward.
