### PR TITLE
Tables without pagination enabled were still filtering by default pag…

### DIFF
--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -263,12 +263,16 @@ export default class QueueTable extends React.PureComponent {
     const casesPerPage = this.props.casesPerPage || DEFAULT_CASES_PER_PAGE;
     const paginatedData = [];
 
-    for (let i = 0; i < tableData.length; i += casesPerPage) {
-      paginatedData.push(tableData.slice(i, i + casesPerPage));
+    if (this.props.enablePagination) {
+      for (let i = 0; i < tableData.length; i += casesPerPage) {
+        paginatedData.push(tableData.slice(i, i + casesPerPage));
+      }
+    } else {
+      paginatedData.push(tableData);
     }
 
     return paginatedData;
-  }
+  };
 
   setColumnSortOrder = (colName) => this.setState(
     { sortColName: colName,


### PR DESCRIPTION
Hearing schedule users are only seeing 15 hearing days. This is because of a bug in the QueueTable component. When pagination is not enabled, the component still filters the only page to 15 rows. This PR fixes that bug.