### PR TITLE
Add VeteranAttributeCacher

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -17,6 +17,7 @@ detectors:
       - AsyncableJobsReporter
       - HearingSerializerBase
       - DataIntegrityChecksJob
+      - VeteranAttributeCacher
   InstanceVariableAssumption:
     exclude:
       - Appeal

--- a/app/services/veteran_attribute_cacher.rb
+++ b/app/services/veteran_attribute_cacher.rb
@@ -6,12 +6,16 @@ class VeteranAttributeCacher
   end
 
   def call
-    Veteran.where(ssn: nil).or(Veteran.where(first_name: nil)).find_each(batch_size: limit) do |v|
-      v.update_cached_attributes! if v.stale_attributes?
+    potentially_stale_records.find_each(batch_size: limit) do |veteran|
+      veteran.update_cached_attributes! if veteran.stale_attributes?
     end
   end
 
   private
 
   attr_reader :limit
+
+  def potentially_stale_records
+    Veteran.where(ssn: nil).or(Veteran.where(first_name: nil))
+  end
 end

--- a/app/services/veteran_attribute_cacher.rb
+++ b/app/services/veteran_attribute_cacher.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class VeteranAttributeCacher
+  def initialize(limit: 100)
+    @limit = limit
+  end
+
+  def call
+    Veteran.where(ssn: nil).or(Veteran.where(first_name: nil)).find_each(batch_size: limit) do |v|
+      v.update_cached_attributes! if v.stale_attributes?
+    end
+  end
+
+  private
+
+  attr_reader :limit
+end

--- a/spec/services/veteran_attribute_cacher_spec.rb
+++ b/spec/services/veteran_attribute_cacher_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe VeteranAttributeCacher do
+  context "local Veteran records exist with nil SSN or first_name" do
+    let(:veteran_file_number_one) { "11111111" }
+    let(:veteran_file_number_two) { "22222222" }
+    let(:veteran_with_nil_ssn) do
+      veteran_one.tap do |v|
+        v.ssn = nil
+        v.save!
+      end
+    end
+    let(:veteran_with_nil_name) do
+      veteran_two.tap do |v|
+        v.first_name = nil
+        v.save!
+      end
+    end
+    let(:veteran_one) do
+      Generators::Veteran.build(
+        file_number: veteran_file_number_one
+      )
+    end
+    let(:veteran_two) do
+      Generators::Veteran.build(
+        file_number: veteran_file_number_two
+      )
+    end
+
+    it "caches attributes locally" do
+      expect(veteran_with_nil_ssn[:ssn]).to be_nil # must use hash accessor to avoid bgs lookup
+      expect(veteran_with_nil_name.first_name).to be_nil
+
+      described_class.new.call
+
+      expect(veteran_with_nil_ssn.reload[:ssn]).to_not be_nil
+      expect(veteran_with_nil_name.reload.first_name).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
For backfilling our cached Veteran attributes. Can be called via console or we can add a job to do this more regularly if necessary.
