### PR TITLE
Display readable titles for ColocatedTasks in case timeline

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -60,6 +60,10 @@ class ColocatedTask < Task
     action || self.class.label
   end
 
+  def timeline_title
+    "#{label} completed"
+  end
+
   def available_actions(user)
     if assigned_to == user
       base_actions = [


### PR DESCRIPTION
Makes the title that appears in the case timeline match the label for the `ColocatedTask`.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/61149597-850d8a80-a4af-11e9-8664-204440b7f989.png) | ![image](https://user-images.githubusercontent.com/32683958/61149479-42e44900-a4af-11e9-9498-b8f890977185.png)
