### PR TITLE
Be more permissible with bulk assign modal URL

### DIFF
--- a/client/app/queue/components/BulkAssignButton.jsx
+++ b/client/app/queue/components/BulkAssignButton.jsx
@@ -3,7 +3,14 @@ import { withRouter } from 'react-router-dom';
 import Button from '../../components/Button';
 
 class BulkAssignButton extends React.PureComponent {
-  changeRoute = () => this.props.history.push(`${this.props.location.pathname}/modal/bulk_assign_tasks`);
+  changeRoute = () => {
+    let baseUrl = this.props.location.pathname;
+
+    // Remove the trailing slash if it exists so we navigate to the correct URl.
+    baseUrl = baseUrl.slice(-1) === '/' ? baseUrl.slice(0, -1) : baseUrl;
+
+    this.props.history.push(`${baseUrl}/modal/bulk_assign_tasks`);
+  }
 
   render = () => <Button classNames={['bulk-assign-button']} onClick={this.changeRoute}>Assign Tasks</Button>;
 }


### PR DESCRIPTION
Allows us to pull up the bulk assign modal if the URL is either `...organizations/hearings-management/` or `...organizations/hearings-management`. Previously the modal would only show in the latter case.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/32683958/61301523-0d42a700-a7b2-11e9-9e55-05309939a15a.gif) | ![after](https://user-images.githubusercontent.com/32683958/61301526-0f0c6a80-a7b2-11e9-93ef-f6f9139a6349.gif)
