### PR TITLE
use css_id for created_by and updated_by when creating HearingDays in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -152,7 +152,9 @@ class SeedDB
         parent: parent_hearing_task,
         appeal: appeal
       )
-      disposition_task = FactoryBot.create(:assign_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal)
+      disposition_task = FactoryBot.create(
+        :assign_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal
+      )
       FactoryBot.create(
         [:no_show_hearing_task, :evidence_submission_window_task].sample,
         parent: disposition_task,
@@ -163,7 +165,11 @@ class SeedDB
 
   def create_change_hearing_disposition_task
     hearings_member = User.find_or_create_by(css_id: "BVATWARNER", station_id: 101)
-    hearing_day = FactoryBot.create(:hearing_day, created_by: hearings_member, updated_by: hearings_member)
+    hearing_day = FactoryBot.create(
+      :hearing_day,
+      created_by: hearings_member.css_id,
+      updated_by: hearings_member.css_id
+    )
     veteran = FactoryBot.create(:veteran, first_name: "Abellona", last_name: "Valtas", file_number: 123_456_789)
     appeal = FactoryBot.create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number)
     root_task = FactoryBot.create(:root_task, appeal: appeal)
@@ -507,8 +513,8 @@ class SeedDB
           judge: User.find_by_css_id("BVAAABSHIRE"),
           request_type: (ro_key == "C") ? "C" : "V",
           scheduled_for: Time.zone.today + (index * 11).days,
-          created_by: user,
-          updated_by: user
+          created_by: user.css_id,
+          updated_by: user.css_id
         )
 
         case index
@@ -636,7 +642,7 @@ class SeedDB
     # Newer style, tasks created through the Factory trait
     [
       { number_of_claimants: nil, veteran_file_number: "963360019", docket_type: dr, request_issue_count: 2 },
-      { number_of_claimants: 1, veteran_file_number: "604969679", docket_type: dr, request_issue_count: 1 },
+      { number_of_claimants: 1, veteran_file_number: "604969679", docket_type: dr, request_issue_count: 1 }
     ].each do |params|
       FactoryBot.create(
         :appeal,
@@ -1017,7 +1023,7 @@ class SeedDB
     judge = User.find_by(css_id: "BVAAABSHIRE")
 
     # At Judge Assignment
-    #evidence submission docket
+    # evidence submission docket
     create_task_at_judge_assignment(@ama_appeals[0], judge, 35.days.ago)
     create_task_at_judge_assignment(@ama_appeals[1], judge)
 
@@ -1192,8 +1198,8 @@ class SeedDB
       request_type: "V",
       scheduled_for: 5.days.from_now,
       room: "001",
-      created_by: user,
-      updated_by: user
+      created_by: user.css_id,
+      updated_by: user.css_id
     )
   end
 


### PR DESCRIPTION
`HearingDays` created in seeds were improperly setting `created_by` and `updated_by` to `User` objects instead of `css_id`s. Also fixed some minor linting errors.
