### PR TITLE
No @here for normal job report

### DIFF
--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -28,7 +28,6 @@ class PrepareEstablishClaimTasksJob < ApplicationJob
     msg = "PrepareEstablishClaimTasksJob successfully ran: #{count[:success]} tasks " \
           "prepared and #{count[:fail]} tasks failed"
     Rails.logger.info msg
-    msg += "\n<!here>" if count[:fail] > 0
     SlackService.new(url: url).send_notification(msg)
   end
 


### PR DESCRIPTION
The slack @-here was added for the async jobs report and that is no longer part of this job.