### PR TITLE
add created_by_id and updated_by_id to hearing day

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -137,7 +137,13 @@ class HearingDay < ApplicationRecord
 
   class << self
     def create_hearing_day(hearing_hash)
-      hearing_hash = hearing_hash.merge(created_by: current_user_css_id, updated_by: current_user_css_id)
+      current_user_id = RequestStore.store[:current_user].id
+      hearing_hash = hearing_hash.merge(
+        created_by: current_user_css_id,
+        updated_by: current_user_css_id,
+        created_by_id: current_user_id,
+        updated_by_id: current_user_id
+      )
       create(hearing_hash).to_hash
     end
 

--- a/db/migrate/20190716211829_add_created_and_updated_at_foreign_keys_to_hearing_days.rb
+++ b/db/migrate/20190716211829_add_created_and_updated_at_foreign_keys_to_hearing_days.rb
@@ -1,0 +1,11 @@
+class AddCreatedAndUpdatedAtForeignKeysToHearingDays < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :hearing_days, :created_by, foreign_key: {:to_table=>:users}, index: false, comment: "The ID of the user who created the Hearing Day"
+    add_index :hearing_days, :created_by_id, algorithm: :concurrently
+
+    add_reference :hearing_days, :updated_by, foreign_key: {:to_table=>:users}, index: false, comment: "The ID of the user who most recently updated the Hearing Day"
+    add_index :hearing_days, :updated_by_id, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190711194030) do
+ActiveRecord::Schema.define(version: 20190716211829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -480,6 +480,7 @@ ActiveRecord::Schema.define(version: 20190711194030) do
     t.string "bva_poc"
     t.datetime "created_at", null: false
     t.string "created_by", null: false
+    t.bigint "created_by_id", comment: "The ID of the user who created the Hearing Day"
     t.datetime "deleted_at"
     t.integer "judge_id"
     t.boolean "lock"
@@ -490,7 +491,10 @@ ActiveRecord::Schema.define(version: 20190711194030) do
     t.date "scheduled_for", null: false
     t.datetime "updated_at", null: false
     t.string "updated_by", null: false
+    t.bigint "updated_by_id", comment: "The ID of the user who most recently updated the Hearing Day"
+    t.index ["created_by_id"], name: "index_hearing_days_on_created_by_id"
     t.index ["deleted_at"], name: "index_hearing_days_on_deleted_at"
+    t.index ["updated_by_id"], name: "index_hearing_days_on_updated_by_id"
   end
 
   create_table "hearing_issue_notes", force: :cascade do |t|
@@ -1095,6 +1099,8 @@ ActiveRecord::Schema.define(version: 20190711194030) do
   add_foreign_key "dispatch_tasks", "users"
   add_foreign_key "document_views", "users"
   add_foreign_key "end_product_establishments", "users"
+  add_foreign_key "hearing_days", "users", column: "created_by_id"
+  add_foreign_key "hearing_days", "users", column: "updated_by_id"
   add_foreign_key "hearing_views", "users"
   add_foreign_key "hearings", "users", column: "created_by_id"
   add_foreign_key "hearings", "users", column: "updated_by_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -164,6 +164,7 @@ class SeedDB
   def create_change_hearing_disposition_task
     hearings_member = User.find_or_create_by(css_id: "BVATWARNER", station_id: 101)
     hearing_day = FactoryBot.create(:hearing_day, created_by: hearings_member, updated_by: hearings_member)
+    hearing_day.update!(created_by_id: hearings_member.id, updated_by_id: hearings_member.id)
     veteran = FactoryBot.create(:veteran, first_name: "Abellona", last_name: "Valtas", file_number: 123_456_789)
     appeal = FactoryBot.create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number)
     root_task = FactoryBot.create(:root_task, appeal: appeal)
@@ -510,6 +511,7 @@ class SeedDB
           created_by: user,
           updated_by: user
         )
+        day.update!(created_by_id: user.id, updated_by_id: user.id)
 
         case index
         when 1
@@ -1187,7 +1189,7 @@ class SeedDB
     )
 
     user = User.find_by(css_id: "BVATWARNER")
-    HearingDay.create(
+    day = HearingDay.create(
       regional_office: "RO17",
       request_type: "V",
       scheduled_for: 5.days.from_now,
@@ -1195,6 +1197,7 @@ class SeedDB
       created_by: user,
       updated_by: user
     )
+    day.update!(created_by_id: user.id, updated_by_id: user.id)
   end
 
   def create_intake_users

--- a/spec/factories/hearing_day.rb
+++ b/spec/factories/hearing_day.rb
@@ -2,10 +2,17 @@
 
 FactoryBot.define do
   factory :hearing_day do
+    transient do
+      creating_user { create(:user) }
+      updating_user { create(:user) }
+    end
+
     scheduled_for { Date.tomorrow }
     request_type { HearingDay::REQUEST_TYPES[:central] }
     room { "2" }
-    created_by { create(:user).css_id }
-    updated_by { create(:user).css_id }
+    created_by { creating_user.css_id }
+    updated_by { updating_user.css_id }
+    created_by_id { creating_user.id }
+    updated_by_id { updating_user.id }
   end
 end


### PR DESCRIPTION
### Description
Connects #11260. This is the first of several PRs that'll resolve that issue.

Adds `created_by_id` and `updated_by_id` columns as foreign keys to Users on the hearing day model, and sets their values when new `HearingDay`s are created. Future PRs will update existing hearing days, add the appropriate ActiveRecord associations, and  remove `created_by` and `updated_by`.

**This PR changes the Schema**

* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
