### PR TITLE
Specify which class uses the "task" association

### DIFF
--- a/app/models/claim_establishment.rb
+++ b/app/models/claim_establishment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ClaimEstablishment < ApplicationRecord
-  belongs_to :task
+  belongs_to :task, class_name: "Dispatch::Task"
 
   enum decision_type: {
     full_grant: 1,


### PR DESCRIPTION
Since this class was first created, we have a new `tasks` table/model that confused things.