### PR TITLE
wrap distribution in a transaction with 5-minute timeout

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -37,7 +37,6 @@ class Distribution < ApplicationRecord
 
       update!(status: "completed", completed_at: Time.zone.now, statistics: ama_statistics)
     end
-
   rescue StandardError => error
     update!(status: "error")
     raise error

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -31,15 +31,16 @@ class Distribution < ApplicationRecord
       # this might take awhile due to VACOLS, so set our timeout to 5 minutes.
       ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 300000"
 
-      update(status: "started")
+      update!(status: "started")
 
       ama_distribution
 
-      update(status: "completed", completed_at: Time.zone.now, statistics: ama_statistics)
-    rescue StandardError => error
-      update(status: "error")
-      raise error
+      update!(status: "completed", completed_at: Time.zone.now, statistics: ama_statistics)
     end
+
+  rescue StandardError => error
+    update!(status: "error")
+    raise error
   end
 
   def self.pending_for_judge(judge)

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -27,14 +27,19 @@ class Distribution < ApplicationRecord
       return unless valid?(context: :create)
     end
 
-    update(status: "started")
+    transaction do
+      # this might take awhile due to VACOLS, so set our timeout to 5 minutes.
+      ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 300000"
 
-    ama_distribution
+      update(status: "started")
 
-    update(status: "completed", completed_at: Time.zone.now, statistics: ama_statistics)
-  rescue StandardError => error
-    update(status: "error")
-    raise error
+      ama_distribution
+
+      update(status: "completed", completed_at: Time.zone.now, statistics: ama_statistics)
+    rescue StandardError => error
+      update(status: "error")
+      raise error
+    end
   end
 
   def self.pending_for_judge(judge)


### PR DESCRIPTION
see https://dsva.slack.com/archives/CHX8FMP28/p1563279965388200

VACOLS is taking longer than 30 seconds total to finish and our psql statement timeout gives up after that amount of time.
