### PR TITLE
Upgrade caseflow-commons gem to 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "26d1bc1e6f45867a20d5e59c697ad3d1bdb70ebe"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "c7289957fef9c3548994d98c03a6cf5f0948fbe4"
 gem "dogstatsd-ruby"
 gem "fast_jsonapi"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 26d1bc1e6f45867a20d5e59c697ad3d1bdb70ebe
-  ref: 26d1bc1e6f45867a20d5e59c697ad3d1bdb70ebe
+  revision: ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa
+  ref: ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa
   specs:
-    caseflow (0.3.9)
+    caseflow (0.4.0)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails


### PR DESCRIPTION
No functional changes, just leveling at Ruby 2.5.3