### PR TITLE
Only find RO by RO facility locator id

### DIFF
--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -119,7 +119,7 @@ class RegionalOffice
 
     def find_ro_by_facility_id(facility_id)
       CITIES.detect do |regional_office_id, val|
-        if val[:facility_locator_id] == facility_id || val[:alternate_locations]&.include?(facility_id)
+        if val[:facility_locator_id] == facility_id
           break regional_office_id
         end
       end

--- a/spec/models/regional_office_spec.rb
+++ b/spec/models/regional_office_spec.rb
@@ -81,11 +81,9 @@ describe RegionalOffice do
 
   context ".find_ro_by_facility_id" do
     let(:ro_facility_id) { "vba_377" }
-    let(:ahl_facility_id) { "vba_405" }
 
-    it "returns RO ids for either RO or AHL facility ids" do
+    it "returns RO ids from facility locator id" do
       expect(RegionalOffice.find_ro_by_facility_id(ro_facility_id)).to eq "RO77"
-      expect(RegionalOffice.find_ro_by_facility_id(ahl_facility_id)).to eq "RO05"
     end
   end
 end


### PR DESCRIPTION
resolves test failure where RO facility id is included as an `alternate_location` facility id.

We won't actually ever need to find an RO by AHL facility locator id.