### PR TITLE
Cache BGS veteran info to prevent duplicate API calls

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -7,10 +7,10 @@ class ExternalApi::BGSService
   include PowerOfAttorneyMapper
   include AddressMapper
 
-  attr_accessor :client
+  attr_reader :client
 
-  def initialize
-    @client = init_client
+  def initialize(client: init_client)
+    @client = client
 
     # These instance variables are used for caching their
     # respective requests
@@ -58,10 +58,12 @@ class ExternalApi::BGSService
     DBService.release_db_connections
 
     @veteran_info[vbms_id] ||=
-      MetricsService.record("BGS: fetch veteran info for vbms id: #{vbms_id}",
-                            service: :bgs,
-                            name: "veteran.find_by_file_number") do
-        client.veteran.find_by_file_number(vbms_id)
+      Rails.cache.fetch(fetch_veteran_info_cache_key(vbms_id), expires_in: 24.hours) do
+        MetricsService.record("BGS: fetch veteran info for vbms id: #{vbms_id}",
+                              service: :bgs,
+                              name: "veteran.find_by_file_number") do
+          client.veteran.find_by_file_number(vbms_id)
+        end
       end
   end
 
@@ -172,7 +174,10 @@ class ExternalApi::BGSService
 
   # This method checks to see if the current user has access to this case
   # in BGS. Cases in BGS are assigned a "sensitivity level" which may be
-  # higher than that of the current employee
+  # higher than that of the current employee.
+  #
+  # We cache at 2 levels: the boolean check per user, and the veteran record itself.
+  # The veteran record is so that subsequent calls to fetch_veteran_info can read from cache.
   def can_access?(vbms_id)
     Rails.cache.fetch(can_access_cache_key(current_user, vbms_id), expires_in: 24.hours) do
       DBService.release_db_connections
@@ -180,7 +185,11 @@ class ExternalApi::BGSService
       MetricsService.record("BGS: can_access? (find_by_file_number): #{vbms_id}",
                             service: :bgs,
                             name: "can_access?") do
-        client.can_access?(vbms_id, true)
+        record = client.veteran.find_by_file_number(vbms_id)
+        Rails.cache.write(fetch_veteran_info_cache_key(vbms_id), record, expires_in: 24.hours)
+        true
+      rescue BGS::ShareError
+        false
       end
     end
   end
@@ -199,6 +208,10 @@ class ExternalApi::BGSService
 
   def bust_can_access_cache(user, vbms_id)
     Rails.cache.delete(can_access_cache_key(user, vbms_id))
+  end
+
+  def bust_fetch_veteran_info_cache(vbms_id)
+    Rails.cache.delete(fetch_veteran_info_cache_key(vbms_id))
   end
 
   def fetch_ratings_in_range(participant_id:, start_date:, end_date:)
@@ -301,6 +314,10 @@ class ExternalApi::BGSService
 
   def can_access_cache_key(user, vbms_id)
     "bgs_can_access_#{user.css_id}_#{user.station_id}_#{vbms_id}"
+  end
+
+  def fetch_veteran_info_cache_key(vbms_id)
+    "bgs_veteran_info_#{vbms_id}"
   end
 
   def init_client

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -186,6 +186,9 @@ class ExternalApi::BGSService
                             service: :bgs,
                             name: "can_access?") do
         record = client.veteran.find_by_file_number(vbms_id)
+        # local memo cache for this object
+        @veteran_info[vbms_id] ||= record
+        # persist cache for other objects
         Rails.cache.write(fetch_veteran_info_cache_key(vbms_id), record, expires_in: 24.hours)
         true
       rescue BGS::ShareError

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -58,7 +58,7 @@ class ExternalApi::BGSService
     DBService.release_db_connections
 
     @veteran_info[vbms_id] ||=
-      Rails.cache.fetch(fetch_veteran_info_cache_key(vbms_id), expires_in: 24.hours) do
+      Rails.cache.fetch(fetch_veteran_info_cache_key(vbms_id), expires_in: 10.minutes) do
         MetricsService.record("BGS: fetch veteran info for vbms id: #{vbms_id}",
                               service: :bgs,
                               name: "veteran.find_by_file_number") do

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -189,7 +189,7 @@ class ExternalApi::BGSService
         # local memo cache for this object
         @veteran_info[vbms_id] ||= record
         # persist cache for other objects
-        Rails.cache.write(fetch_veteran_info_cache_key(vbms_id), record, expires_in: 24.hours)
+        Rails.cache.write(fetch_veteran_info_cache_key(vbms_id), record, expires_in: 10.minutes)
         true
       rescue BGS::ShareError
         false

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -7,6 +7,7 @@ describe ExternalApi::BGSService do
   let(:veteran_record) { { name: "foo", ssn: "123" } }
   let(:user) { build(:user) }
   let(:vbms_id) { "55554444" }
+  let(:cache_key) { "bgs_veteran_info_#{vbms_id}" }
 
   before do
     RequestStore[:current_user] = user
@@ -26,6 +27,7 @@ describe ExternalApi::BGSService do
 
         expect(bgs_veteran_service).to have_received(:find_by_file_number).once
         expect(vet_record).to eq(veteran_record)
+        expect(Rails.cache.exist?(cache_key)).to be_truthy
       end
     end
 
@@ -39,6 +41,7 @@ describe ExternalApi::BGSService do
 
         expect(bgs_veteran_service).to have_received(:find_by_file_number).once
         expect(vet_record).to eq(veteran_record)
+        expect(Rails.cache.exist?(cache_key)).to be_truthy
       end
     end
   end

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe ExternalApi::BGSService do
+  let(:bgs_veteran_service) { double("veteran") }
+  let(:bgs_client) { double("BGS::Services") }
+  let(:bgs) { ExternalApi::BGSService.new(client: bgs_client) }
+  let(:veteran_record) { { name: "foo", ssn: "123" } }
+  let(:user) { build(:user) }
+  let(:vbms_id) { "55554444" }
+
+  before do
+    RequestStore[:current_user] = user
+    allow(bgs).to receive(:fetch_veteran_info).and_call_original
+    allow(bgs_client).to receive(:veteran).and_return(bgs_veteran_service)
+    allow(bgs_veteran_service).to receive(:find_by_file_number) { veteran_record }
+  end
+
+  after do
+    bgs.bust_fetch_veteran_info_cache(vbms_id)
+  end
+
+  describe "#fetch_veteran_info" do
+    context "when called without previous .can_access?" do
+      it "reads from BGS" do
+        vet_record = bgs.fetch_veteran_info(vbms_id)
+
+        expect(bgs_veteran_service).to have_received(:find_by_file_number).once
+        expect(vet_record).to eq(veteran_record)
+      end
+    end
+
+    context "when .can_access? is called first" do
+      before do
+        bgs.can_access?(vbms_id)
+      end
+
+      it "reads from cache" do
+        vet_record = bgs.fetch_veteran_info(vbms_id)
+
+        expect(bgs_veteran_service).to have_received(:find_by_file_number).once
+        expect(vet_record).to eq(veteran_record)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently a `Veteran` record call to `stale_attributes?` will generate 2 identical BGS API calls to fetch the veteran info: one via `can_access?` and one via `fetch_veteran_info`.

This PR caches the first response so that there is only 1 call per BGSService object.

Furthermore, the response is cached in Redis so that other `Veteran` objects can take advantage of the local cache. Note that `can_access?` should always check per-user so it ignores the Redis cache of the Veteran record in lieu of a sensitivity check.