### PR TITLE
aws_env in author name is sufficient

### DIFF
--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -34,7 +34,7 @@ class SlackService
       channel: channel,
       attachments: [
         {
-          title: "#{title} (#{aws_env})",
+          title: title,
           color: "#ccc",
           text: msg
         }


### PR DESCRIPTION
fixes this:

<img width="308" alt="Screen Shot 2019-07-26 at 9 03 51 AM" src="https://user-images.githubusercontent.com/1205061/61957197-50f09a00-af84-11e9-9a30-e60fe5597df8.png">
