### PR TITLE
Case distribution

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -94,6 +94,6 @@ class DistributionsController < ApplicationController
   end
 
   def pending_distribution
-    Distribution.pending_for_judge(current_user).first
+    Distribution.pending_for_judge(current_user)
   end
 end

--- a/app/jobs/start_distribution_job.rb
+++ b/app/jobs/start_distribution_job.rb
@@ -9,6 +9,7 @@ class StartDistributionJob < ApplicationJob
     distribution.distribute!
   rescue StandardError => error
     handle_error(error)
+    # do not re-raise, since we only want to run once.
   end
 
   private

--- a/app/jobs/start_distribution_job.rb
+++ b/app/jobs/start_distribution_job.rb
@@ -8,13 +8,14 @@ class StartDistributionJob < ApplicationJob
     RequestStore.store[:current_user] = user if user
     distribution.distribute!
   rescue StandardError => error
-    Rails.logger.info "StartDistributionJob failed: #{error.message}"
-    Rails.logger.info error.backtrace.join("\n")
+    handle_error(error)
   end
 
-  # :nocov:
-  def max_attempts
-    1
+  private
+
+  def handle_error(error)
+    Rails.logger.info "StartDistributionJob failed: #{error.message}"
+    Rails.logger.info error.backtrace.join("\n")
+    Raven.capture_exception(error)
   end
-  # :nocov:
 end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -28,8 +28,8 @@ class Distribution < ApplicationRecord
     end
 
     multi_transaction do
-      # this might take awhile due to VACOLS, so set our timeout to 2 minutes (in milliseconds).
-      ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 120000"
+      # this might take awhile due to VACOLS, so set our timeout to 3 minutes (in milliseconds).
+      ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 180000"
 
       update!(status: "started")
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -27,9 +27,9 @@ class Distribution < ApplicationRecord
       return unless valid?(context: :create)
     end
 
-    transaction do
-      # this might take awhile due to VACOLS, so set our timeout to 5 minutes.
-      ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 300000"
+    multi_transaction do
+      # this might take awhile due to VACOLS, so set our timeout to 2 minutes (in milliseconds).
+      ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 120000"
 
       update!(status: "started")
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -20,6 +20,12 @@ class Distribution < ApplicationRecord
   CASES_PER_ATTORNEY = 3
   ALTERNATIVE_BATCH_SIZE = 15
 
+  class << self
+    def pending_for_judge(judge)
+      find_by(status: %w[pending started], judge: judge)
+    end
+  end
+
   def distribute!
     return unless %w[pending error].include? status
 
@@ -40,10 +46,6 @@ class Distribution < ApplicationRecord
   rescue StandardError => error
     update!(status: "error")
     raise error
-  end
-
-  def self.pending_for_judge(judge)
-    where(status: %w[pending started], judge: judge)
   end
 
   private
@@ -69,7 +71,7 @@ class Distribution < ApplicationRecord
   end
 
   def validate_judge_has_no_pending_distributions
-    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge).any?
+    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge)
   end
 
   def judge_tasks

--- a/spec/factories/distribution.rb
+++ b/spec/factories/distribution.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :distribution do
-    judge { create(:user) }
+    association :judge, factory: :user
   end
 end

--- a/spec/factories/distribution.rb
+++ b/spec/factories/distribution.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :distribution do
+    judge { create(:user) }
+  end
+end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -30,26 +30,6 @@ describe Distribution, :all_dbs do
     FeatureToggle.disable!(:test_facols)
   end
 
-  context "#valid?" do
-    subject { Distribution.new(judge: judge).valid? }
-
-    context "existing Distribution record with status pending" do
-      let!(:existing_distribution) { create(:distribution, judge: judge) }
-
-      it "prevents new Distribution record" do
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "existing Distribution record with status started" do
-      let!(:existing_distribution) { create(:distribution, judge: judge, status: :started) }
-
-      it "prevents new Distribution record" do
-        expect(subject).to be_falsey
-      end
-    end
-  end
-
   context "#distribute!" do
     subject { Distribution.create!(judge: judge) }
 
@@ -209,16 +189,6 @@ describe Distribution, :all_dbs do
       expect(subject.distributed_cases.where(docket: Constants.AMA_DOCKETS.evidence_submission).count).to eq(2)
     end
 
-    # context "when the judge is only recieves hearing cases" do
-    #   it "correctly distributes cases to the judge" do
-    #     subject.distribute!
-    #     expect(subject.valid?).to eq(true)
-    #     expect(subject.statistics["batch_size"]).to eq(10)
-    #     expect(subject.distributed_cases.count).to eq(7)
-    #     expect(subject.distributed_cases.where(genpop: false).count).to eq(7)
-    #   end
-    # end
-
     context "when the job errors" do
       it "marks the distribution as error" do
         allow_any_instance_of(LegacyDocket).to receive(:distribute_nonpriority_appeals).and_raise(StandardError)
@@ -248,6 +218,22 @@ describe Distribution, :all_dbs do
     subject { Distribution.create(judge: user) }
 
     let(:user) { judge }
+
+    context "existing Distribution record with status pending" do
+      let!(:existing_distribution) { create(:distribution, judge: judge) }
+
+      it "prevents new Distribution record" do
+        expect { subject }.to raise_error("Foo")
+      end
+    end
+
+    context "existing Distribution record with status started" do
+      let!(:existing_distribution) { create(:distribution, judge: judge, status: :started) }
+
+      it "prevents new Distribution record" do
+        expect { subject }.to raise_error("Foo")
+      end
+    end
 
     context "when the user is not a judge in VACOLS" do
       let(:user) { create(:user) }

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -211,9 +211,10 @@ describe Distribution, :all_dbs do
 
     context "when the job errors" do
       it "marks the distribution as error" do
-        allow_any_instance_of(LegacyDocket).to receive(:distribute_priority_appeals).and_raise(StandardError)
+        allow_any_instance_of(LegacyDocket).to receive(:distribute_nonpriority_appeals).and_raise(StandardError)
         expect { subject.distribute! }.to raise_error(StandardError)
         expect(subject.status).to eq("error")
+        expect(subject.distributed_cases.count).to eq(0)
       end
     end
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -223,7 +223,8 @@ describe Distribution, :all_dbs do
       let!(:existing_distribution) { create(:distribution, judge: judge) }
 
       it "prevents new Distribution record" do
-        expect { subject }.to raise_error("Foo")
+        expect(subject.errors.details).to have_key(:judge)
+        expect(subject.errors.details[:judge]).to include(error: :pending_distribution)
       end
     end
 
@@ -231,7 +232,8 @@ describe Distribution, :all_dbs do
       let!(:existing_distribution) { create(:distribution, judge: judge, status: :started) }
 
       it "prevents new Distribution record" do
-        expect { subject }.to raise_error("Foo")
+        expect(subject.errors.details).to have_key(:judge)
+        expect(subject.errors.details[:judge]).to include(error: :pending_distribution)
       end
     end
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -30,18 +30,28 @@ describe Distribution, :all_dbs do
     FeatureToggle.disable!(:test_facols)
   end
 
-  # We use StartDistributionJob.perform_now in the test environment.
-  #
-  # context "StartDistributionJob" do
-  #   ActiveJob::Base.queue_adapter = :test
+  context "#valid?" do
+    subject { Distribution.new(judge: judge).valid? }
 
-  #   it "enqueues a job" do
-  #     expect { Distribution.create(judge: judge) }.to have_enqueued_job(StartDistributionJob)
-  #   end
-  # end
+    context "existing Distribution record with status pending" do
+      let!(:existing_distribution) { create(:distribution, judge: judge) }
+
+      it "prevents new Distribution record" do
+        expect(subject).to be_falsey
+      end
+    end
+
+    context "existing Distribution record with status started" do
+      let!(:existing_distribution) { create(:distribution, judge: judge, status: :started) }
+
+      it "prevents new Distribution record" do
+        expect(subject).to be_falsey
+      end
+    end
+  end
 
   context "#distribute!" do
-    subject { Distribution.create(judge: judge) }
+    subject { Distribution.create!(judge: judge) }
 
     let(:legacy_priority_count) { 14 }
 


### PR DESCRIPTION
connects #11713 

**Why**
Errors were logged but only to the Rails logs and not to Sentry. This hid the fact that we have ongoing problems. This first step is to log the full exceptions to Sentry to begin seeing patterns.

Also refactors slightly and adds more tests.