### PR TITLE
Add error handling to UpdateCachedAppealsAttributesJob

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -16,7 +16,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     cache_ama_appeals
     cache_legacy_appeals
 
-    record_runtime(start_time)s
+    record_runtime(start_time)
   rescue StandardError => error
     log_error(start_time, error)
   end

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -2,7 +2,9 @@
 
 BATCH_SIZE = 1000
 
-class UpdateCachedAppealsAttributesJob < ApplicationJob
+class UpdateCachedAppealsAttributesJob < CaseflowJob
+  # For time_ago_in_words()
+  include ActionView::Helpers::DateHelper
   queue_as :low_priority
 
   APP_NAME = "caseflow_job"

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -16,8 +16,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     cache_ama_appeals
     cache_legacy_appeals
 
-    record_runtime(start_time)
-
+    record_runtime(start_time)s
   rescue StandardError => error
     log_error(start_time, error)
   end

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -15,6 +15,9 @@ class UpdateCachedAppealsAttributesJob < ApplicationJob
     cache_legacy_appeals
 
     record_runtime(start_time)
+
+  rescue StandardError => error
+    log_error(start_time, error)
   end
 
   def cache_ama_appeals
@@ -57,7 +60,7 @@ class UpdateCachedAppealsAttributesJob < ApplicationJob
   end
 
   def cache_legacy_appeal_vacols_data(legacy_appeals)
-    legacy_appeals.pluck(:vacols_id).in_groups_of(BATCH_SIZE).each do |vacols_ids|
+    legacy_appeals.pluck(:vacols_id).in_groups_of(BATCH_SIZE, false).each do |vacols_ids|
       values_to_cache = VACOLS::Folder.where(ticknum: vacols_ids).pluck(:ticknum, :tinum).map do |vacols_folder|
         { vacols_id: vacols_folder[0], docket_number: vacols_folder[1] }
       end
@@ -89,5 +92,17 @@ class UpdateCachedAppealsAttributesJob < ApplicationJob
       metric_name: "runtime",
       metric_value: job_duration_seconds
     )
+  end
+
+  def log_error(start_time, err)
+    duration = time_ago_in_words(start_time)
+    msg = "UpdateCachedAppealsAttributesJob failed after running for #{duration}. Fatal error: #{err.message}"
+
+    Rails.logger.info(msg)
+    Rails.logger.info(err.backtrace.join("\n"))
+
+    slack_service.send_notification(msg)
+
+    record_runtime(start_time)
   end
 end

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -66,7 +66,6 @@ describe UpdateCachedAppealsAttributesJob do
     end
 
     it "sends a message to Slack that includes the error" do
-
       slack_msg = ""
       allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
 


### PR DESCRIPTION
Additionally, this PR adds the `false` flag to the array method `in_groups_of`, which is used for batching the appeals in groups of 1000, the maximum batch size for VACOLS db. The lack of this flag may have been causing errors, previously. 