### PR TITLE
Custom VACOLS attribute type for ASCII column

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,11 @@ You'll need to install the libraries required to connect to the VACOLS Oracle da
 You probably have to create an Oracle account to download these.
 
 Add this to your env to squash oracle errors on startup:
-`export NLS_LANG=AMERICAN_AMERICA.US7ASCII`
+`export NLS_LANG=AMERICAN_AMERICA.UTF8`
+
+NOTE that VACOLS actually only supports ASCII7 encoding but our code will manage the encoding transliteration.
+We tell the OracleEnhanced Ruby library it is UTF8 via the environment variable so that it does not
+"conveniently" convert encodings for us, and then only ever write ASCII to the database.
 
 (May need to have your user own the oracle /opt directory?)
 

--- a/README.md
+++ b/README.md
@@ -221,13 +221,6 @@ You'll need to install the libraries required to connect to the VACOLS Oracle da
 
 You probably have to create an Oracle account to download these.
 
-Add this to your env to squash oracle errors on startup:
-`export NLS_LANG=AMERICAN_AMERICA.UTF8`
-
-NOTE that VACOLS actually only supports ASCII7 encoding but our code will manage the encoding transliteration.
-We tell the OracleEnhanced Ruby library it is UTF8 via the environment variable so that it does not
-"conveniently" convert encodings for us, and then only ever write ASCII to the database.
-
 (May need to have your user own the oracle /opt directory?)
 
 **Windows**
@@ -338,7 +331,7 @@ Add these to your `.bash_profile`:
 export POSTGRES_HOST=localhost
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=postgres
-export NLS_LANG=AMERICAN_AMERICA.US7ASCII
+export NLS_LANG=AMERICAN_AMERICA.UTF8
 ```
 
 The last env var silences one of the Oracle warnings on startup.

--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "stringex/unidecoder"
-require "stringex/core_ext"
+require "helpers/ascii_converter"
 
 class QueueMapper
   COLUMN_NAMES = {
@@ -123,11 +122,11 @@ class QueueMapper
   end
 
   def truncate_notes_at_350_characters_and_convert_to_ascii
-    renamed_attributes[COLUMN_NAMES[:note]] = note[0..349].to_ascii if note
+    renamed_attributes[COLUMN_NAMES[:note]] = AsciiConverter.new(string: note).convert[0..349] if note
   end
 
   def truncate_comment_at_600_characters_and_convert_to_ascii
-    renamed_attributes[COLUMN_NAMES[:comment]] = comment[0..599].to_ascii if comment
+    renamed_attributes[COLUMN_NAMES[:comment]] = AsciiConverter.new(string: comment).convert[0..599] if comment
   end
 
   def add_modification_timestamp

--- a/app/mappers/queue_mapper.rb
+++ b/app/mappers/queue_mapper.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "helpers/ascii_converter"
-
 class QueueMapper
   COLUMN_NAMES = {
     case_id: :defolder,
@@ -86,8 +84,7 @@ class QueueMapper
     convert_quality_to_vacols_code
     convert_one_touch_initiative_to_vacols_code
     convert_deficiencies_to_vacols_code
-    truncate_notes_at_350_characters_and_convert_to_ascii
-    truncate_comment_at_600_characters_and_convert_to_ascii
+    assign_note_and_comment
     add_modification_timestamp
   end
 
@@ -121,12 +118,9 @@ class QueueMapper
     end
   end
 
-  def truncate_notes_at_350_characters_and_convert_to_ascii
-    renamed_attributes[COLUMN_NAMES[:note]] = AsciiConverter.new(string: note).convert[0..349] if note
-  end
-
-  def truncate_comment_at_600_characters_and_convert_to_ascii
-    renamed_attributes[COLUMN_NAMES[:comment]] = AsciiConverter.new(string: comment).convert[0..599] if comment
+  def assign_note_and_comment
+    renamed_attributes[COLUMN_NAMES[:note]] = note if note
+    renamed_attributes[COLUMN_NAMES[:comment]] = comment if comment
   end
 
   def add_modification_timestamp

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -6,7 +6,7 @@ class VACOLS::CaseHearing < VACOLS::Record
   self.sequence_name = "hearsched_pkseq"
 
   attribute :hearing_date, :datetime
-  attribute :notes1, AsciiString.new
+  attribute :notes1, :ascii_string
   validates :hearing_type, :hearing_date, :room, presence: true, on: :create
 
   has_one :staff, foreign_key: :sattyid, primary_key: :board_member

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -6,6 +6,7 @@ class VACOLS::CaseHearing < VACOLS::Record
   self.sequence_name = "hearsched_pkseq"
 
   attribute :hearing_date, :datetime
+  attribute :notes1, AsciiString.new
   validates :hearing_type, :hearing_date, :room, presence: true, on: :create
 
   has_one :staff, foreign_key: :sattyid, primary_key: :board_member

--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -7,7 +7,7 @@ class VACOLS::CaseIssue < VACOLS::Record
 
   class IssueError < StandardError; end
 
-  attribute :issdesc, AsciiString.new
+  attribute :issdesc, :ascii_string
 
   validates :isskey, :issseq, :issprog, :isscode, :issaduser, :issadtime, presence: true, on: :create
 

--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -7,6 +7,8 @@ class VACOLS::CaseIssue < VACOLS::Record
 
   class IssueError < StandardError; end
 
+  attribute :issdesc, AsciiString.new
+
   validates :isskey, :issseq, :issprog, :isscode, :issaduser, :issadtime, presence: true, on: :create
 
   # :nocov:

--- a/app/models/vacols/decass.rb
+++ b/app/models/vacols/decass.rb
@@ -5,6 +5,9 @@ class VACOLS::Decass < VACOLS::Record
   self.table_name = "decass"
   self.primary_key = "defolder"
 
+  attribute :deatcom, :ascii_string, limit: 350
+  attribute :debmcom, :ascii_string, limit: 600
+
   validates :defolder, :deatty, :deteam, :deadusr, :deadtim, presence: true, on: :create
 
   class DecassError < StandardError; end

--- a/app/models/vacols/record.rb
+++ b/app/models/vacols/record.rb
@@ -30,4 +30,13 @@ class VACOLS::Record < ApplicationRecord
     slogid = RequestStore.store[:current_user].vacols_uniq_id
     slogid.nil? ? "" : slogid.upcase
   end
+
+  # AsciiString attribute type not applied to update_all() class method
+  # so must override and do encoding fixes here.
+  def self.sanitize_sql_hash_for_assignment(attrs, table)
+    attrs.each do |attr, value|
+      attrs[attr] = AsciiConverter.new(string: value.to_s).convert
+    end
+    super
+  end
 end

--- a/app/models/vacols/representative.rb
+++ b/app/models/vacols/representative.rb
@@ -7,12 +7,12 @@ class VACOLS::Representative < VACOLS::Record
   self.table_name = "rep"
   self.primary_key = "repkey"
 
-  attribute :repaddr1, AsciiString.new(limit: 50)
-  attribute :repaddr2, AsciiString.new(limit: 50)
-  attribute :repcity, AsciiString.new(limit: 20)
-  attribute :replast, AsciiString.new(limit: 40)
-  attribute :repfirst, AsciiString.new(limit: 24)
-  attribute :repmi, AsciiString.new(limit: 4)
+  attribute :repaddr1, :ascii_string, limit: 50
+  attribute :repaddr2, :ascii_string, limit: 50
+  attribute :repcity, :ascii_string, limit: 20
+  attribute :replast, :ascii_string, limit: 40
+  attribute :repfirst, :ascii_string, limit: 24
+  attribute :repmi, :ascii_string, limit: 4
 
   class RepError < StandardError; end
   class InvalidRepTypeError < RepError; end
@@ -122,6 +122,9 @@ class VACOLS::Representative < VACOLS::Record
       .where("extract(month from repaddtime) = ?", repaddtime.month)
       .where("extract(day   from repaddtime) = ?", repaddtime.day)
       .update_all(rep_attrs)
+  rescue => err
+    binding.pry
+    fail err
   end
 
   def self.create_rep!(bfkey, rep_attrs)

--- a/app/models/vacols/representative.rb
+++ b/app/models/vacols/representative.rb
@@ -122,9 +122,6 @@ class VACOLS::Representative < VACOLS::Record
       .where("extract(month from repaddtime) = ?", repaddtime.month)
       .where("extract(day   from repaddtime) = ?", repaddtime.day)
       .update_all(rep_attrs)
-  rescue => err
-    binding.pry
-    fail err
   end
 
   def self.create_rep!(bfkey, rep_attrs)

--- a/app/models/vacols/representative.rb
+++ b/app/models/vacols/representative.rb
@@ -7,6 +7,13 @@ class VACOLS::Representative < VACOLS::Record
   self.table_name = "rep"
   self.primary_key = "repkey"
 
+  attribute :repaddr1, AsciiString.new(limit: 50)
+  attribute :repaddr2, AsciiString.new(limit: 50)
+  attribute :repcity, AsciiString.new(limit: 20)
+  attribute :replast, AsciiString.new(limit: 40)
+  attribute :repfirst, AsciiString.new(limit: 24)
+  attribute :repmi, AsciiString.new(limit: 4)
+
   class RepError < StandardError; end
   class InvalidRepTypeError < RepError; end
 
@@ -87,16 +94,16 @@ class VACOLS::Representative < VACOLS::Record
     }
     unless name.empty?
       attrs = attrs.merge(
-        repfirst: name[:first_name][0, 24],
-        repmi: name[:middle_initial][0, 4],
-        replast: name[:last_name][0, 40]
+        repfirst: name[:first_name],
+        repmi: name[:middle_initial],
+        replast: name[:last_name]
       )
     end
     unless address.empty?
       attrs = attrs.merge(
-        repaddr1: address[:address_one][0, 50],
-        repaddr2: address[:address_two][0, 50],
-        repcity: address[:city][0, 20],
+        repaddr1: address[:address_one],
+        repaddr2: address[:address_two],
+        repcity: address[:city],
         repst: address[:state][0, 4],
         repzip: address[:zip][0, 10]
       )

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,4 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["NLS_LANG"] = "AMERICAN_AMERICA.UTF8"
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup'

--- a/config/initializers/activerecord_types.rb
+++ b/config/initializers/activerecord_types.rb
@@ -1,12 +1,15 @@
+# frozen_string_literal: true
+
 # Custom column types, particularly for VACOLS
 
 require "helpers/ascii_converter"
 
 class AsciiString < ActiveRecord::Type::Text
   private
+
   def cast_value(value)
     ascii_value = AsciiConverter.new(string: value.to_s).convert
-    limit ? ascii_value[0, limit-1] : ascii_value
+    limit ? ascii_value[0, (limit - 1)] : ascii_value
   end
 end
 

--- a/config/initializers/activerecord_types.rb
+++ b/config/initializers/activerecord_types.rb
@@ -4,7 +4,9 @@ require "stringex/unidecoder"
 require "stringex/core_ext"
 
 class AsciiString < ActiveRecord::Type::String
-  def cast(value)
+  private
+
+  def cast_value(value)
     limit ? value.to_s.to_ascii[0, limit-1] : value.to_s.to_ascii
   end
 end

--- a/config/initializers/activerecord_types.rb
+++ b/config/initializers/activerecord_types.rb
@@ -1,13 +1,12 @@
 # Custom column types, particularly for VACOLS
 
-require "stringex/unidecoder"
-require "stringex/core_ext"
+require "helpers/ascii_converter"
 
-class AsciiString < ActiveRecord::Type::String
+class AsciiString < ActiveRecord::Type::Text
   private
-
   def cast_value(value)
-    limit ? value.to_s.to_ascii[0, limit-1] : value.to_s.to_ascii
+    ascii_value = AsciiConverter.new(string: value.to_s).convert
+    limit ? ascii_value[0, limit-1] : ascii_value
   end
 end
 

--- a/config/initializers/activerecord_types.rb
+++ b/config/initializers/activerecord_types.rb
@@ -9,7 +9,7 @@ class AsciiString < ActiveRecord::Type::Text
 
   def cast_value(value)
     ascii_value = AsciiConverter.new(string: value.to_s).convert
-    limit ? ascii_value[0, (limit - 1)] : ascii_value
+    limit ? ascii_value[0, limit] : ascii_value
   end
 end
 

--- a/config/initializers/activerecord_types.rb
+++ b/config/initializers/activerecord_types.rb
@@ -1,0 +1,12 @@
+# Custom column types, particularly for VACOLS
+
+require "stringex/unidecoder"
+require "stringex/core_ext"
+
+class AsciiString < ActiveRecord::Type::String
+  def cast(value)
+    limit ? value.to_s.to_ascii[0, limit-1] : value.to_s.to_ascii
+  end
+end
+
+ActiveRecord::Type.register(:ascii_string, AsciiString)

--- a/lib/helpers/ascii_converter.rb
+++ b/lib/helpers/ascii_converter.rb
@@ -11,7 +11,9 @@ class AsciiConverter
   def convert
     return str if ascii?
 
-    return str.encode("UTF-8", "Windows-1252").to_ascii if cp1252?
+    return str.to_ascii if utf8?
+
+    return str.encode("UTF-8", "Windows-1252").to_ascii if !utf8? && cp1252?
 
     str.to_ascii
   end
@@ -19,6 +21,10 @@ class AsciiConverter
   private
 
   attr_reader :str
+
+  def utf8?
+    str.valid_encoding? && str.encoding == Encoding::UTF_8
+  end
 
   def ascii?
     str.bytes.none? { |byte| byte > 127 }

--- a/lib/helpers/ascii_converter.rb
+++ b/lib/helpers/ascii_converter.rb
@@ -1,0 +1,26 @@
+require "stringex/unidecoder"
+require "stringex/core_ext"
+
+class AsciiConverter
+  def initialize(string:)
+    @str = string
+  end
+
+  def convert
+    return str if ascii?
+    return str.encode("UTF-8", "Windows-1252").to_ascii if cp1252?
+    return str.to_ascii
+  end
+
+  private
+
+  attr_reader :str
+
+  def ascii?
+    !str.bytes.any? { |byte| byte > 127 }
+  end
+
+  def cp1252?
+    (str.bytes & Array(128..159)).any?
+  end
+end

--- a/lib/helpers/ascii_converter.rb
+++ b/lib/helpers/ascii_converter.rb
@@ -9,7 +9,7 @@ class AsciiConverter
   end
 
   def convert
-    return str if ascii?
+    return str if str.ascii_only?
 
     return str.to_ascii if utf8?
 
@@ -24,10 +24,6 @@ class AsciiConverter
 
   def utf8?
     str.valid_encoding? && str.encoding == Encoding::UTF_8
-  end
-
-  def ascii?
-    str.bytes.none? { |byte| byte > 127 }
   end
 
   def cp1252?

--- a/lib/helpers/ascii_converter.rb
+++ b/lib/helpers/ascii_converter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "stringex/unidecoder"
 require "stringex/core_ext"
 
@@ -8,8 +10,10 @@ class AsciiConverter
 
   def convert
     return str if ascii?
+
     return str.encode("UTF-8", "Windows-1252").to_ascii if cp1252?
-    return str.to_ascii
+
+    str.to_ascii
   end
 
   private
@@ -17,7 +21,7 @@ class AsciiConverter
   attr_reader :str
 
   def ascii?
-    !str.bytes.any? { |byte| byte > 127 }
+    str.bytes.none? { |byte| byte > 127 }
   end
 
   def cp1252?

--- a/spec/helpers/ascii_converter_spec.rb
+++ b/spec/helpers/ascii_converter_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe AsciiConverter do
+  describe "#convert" do
+    subject { described_class.new(string: string).convert }
+
+    context "string contains Windows 1252 codepoint" do
+      let(:string) { "O\x92Reilly" }
+
+      it "returns ASCII" do
+        expect(subject).to eq("O'Reilly")
+      end
+    end
+  end
+end

--- a/spec/mappers/queue_mapper_spec.rb
+++ b/spec/mappers/queue_mapper_spec.rb
@@ -80,36 +80,6 @@ describe QueueMapper do
       end
     end
 
-    context "when optional note is too long (more than 350 characters)" do
-      let(:info) do
-        { work_product: "OMO - IME",
-          overtime: true,
-          note: "a" * 351,
-          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
-          document_id: "123456789.1234",
-          modifying_user: "TESTSLOGID" }
-      end
-
-      it "only uses the first 350 characters" do
-        expect(subject[:deatcom]).to eq "a" * 350
-      end
-    end
-
-    context "when note contains non-ASCII characters that make the length greater than 350" do
-      let(:info) do
-        { work_product: "OMO - IME",
-          overtime: true,
-          note: ("a" * 341) + "Véteran’s issue",
-          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
-          document_id: "123456789.1234",
-          modifying_user: "TESTSLOGID" }
-      end
-
-      it "only keeps the first 350 characters and converts them to ASCII" do
-        expect(subject[:deatcom]).to eq(("a" * 341) + "Veteran's")
-      end
-    end
-
     context "when optional note is missing" do
       let(:info) do
         { work_product: "OMO - IME",
@@ -121,22 +91,6 @@ describe QueueMapper do
 
       it "does not contain the deatcom key" do
         expect(subject.keys).to_not include :deatcom
-      end
-    end
-
-    context "when comment contains non-ASCII characters that make the length greater than 600" do
-      let(:info) do
-        { work_product: "OMO - IME",
-          overtime: true,
-          note: "test",
-          comment: ("a" * 575) + "“pleadings” and ‘motions” and",
-          reassigned_to_judge_date: VacolsHelper.local_date_with_utc_timezone,
-          document_id: "M1234567.1234",
-          modifying_user: "TESTSLOGID" }
-      end
-
-      it "only keeps the first 600 characters and converts them to ASCII" do
-        expect(subject[:debmcom]).to eq(("a" * 575) + "\"pleadings\" and 'motions\"")
       end
     end
 

--- a/spec/models/vacols/representative_spec.rb
+++ b/spec/models/vacols/representative_spec.rb
@@ -71,7 +71,15 @@ describe VACOLS::Representative, :all_dbs do
 
   context "when name or address contains non-ASCII characters" do
     let(:name_hash) { { first_name: "Søren", middle_initial: "A", last_name: "Skarsgård" } }
-    let(:address_hash) { { address_one: "123 Walnut Aveñue", address_two: "«456»", city: "San Juañ", state: "OH", zip: "12222" } }
+    let(:address_hash) do
+      {
+        address_one: "123 Walnut Aveñue",
+        address_two: "«456»",
+        city: "San Juañ",
+        state: "OH",
+        zip: "12222"
+      }
+    end
     let(:bfkey) { "99999XYZ" }
 
     subject do

--- a/spec/models/vacols/representative_spec.rb
+++ b/spec/models/vacols/representative_spec.rb
@@ -117,5 +117,16 @@ describe VACOLS::Representative, :all_dbs do
         expect(rep.repcity).to eq("San Juan")
       end
     end
+
+    context "name contains invalid UTF-8 codepoint from bad Windows 1252 conversion" do
+      let(:bfkey) { appeal.vacols_id }
+      let(:name_hash) { { first_name: "Søren", middle_initial: "A", last_name: "O\x92Reilly" } }
+
+      it "corrects codepoint before transliterating to ASCII" do
+        subject
+
+        expect(rep.replast).to eq("O'Reilly")
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #8643 
Resolves #10748 

### Description
VACOLS is configured for ASCII7 encoding only, and we keep trying to send it codepoints that are valid UTF-8 but not valid ASCII.
