### PR TITLE
Fix judge checkout for acting judges

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -369,6 +369,8 @@
   "DECISION_ISSUE_CONFIRM_DELETE_WITH_CONNECTED_ISSUES": " Deleting this decision will also remove it from other issues you've added it to.",
   "DECISION_ISSUE_CONFIRM_DELETE": "Are you sure you want to delete this decision?",
 
+  "EVALUATE_DECISION_PAGE_TITLE": "Evaluate Decision",
+
   "TEAM_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow team management",
   "TEAM_MANAGEMENT_PAGE_HEADER": "Caseflow Team Management",
   "TEAM_MANAGEMENT_ID_COLUMN_HEADING": "ID",

--- a/client/app/queue/EvaluateDecisionView.jsx
+++ b/client/app/queue/EvaluateDecisionView.jsx
@@ -28,7 +28,7 @@ import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
 import {
   marginBottom, marginTop,
   paddingLeft, fullWidth,
-  redText, PAGE_TITLES,
+  redText,
   VACOLS_DISPOSITIONS,
   ISSUE_DISPOSITIONS,
   JUDGE_CASE_REVIEW_COMMENT_MAX_LENGTH
@@ -66,8 +66,6 @@ class EvaluateDecisionView extends React.PureComponent {
   componentDidMount = () => this.setState(
     _.pick(this.props.taskOptions, _.keys(this.state))
   );
-
-  getPageName = () => PAGE_TITLES.EVALUATE;
 
   qualityIsDeficient = () => ['needs_improvements', 'does_not_meet_expectations'].includes(this.state.quality);
 
@@ -131,7 +129,6 @@ class EvaluateDecisionView extends React.PureComponent {
       appeal,
       checkoutFlow,
       decision,
-      userRole,
       appealId
     } = this.props;
 
@@ -143,7 +140,7 @@ class EvaluateDecisionView extends React.PureComponent {
       successMsg = sprintf(COPY.JUDGE_CHECKOUT_OMO_SUCCESS_MESSAGE_TITLE, appeal.veteranFullName);
     }
     const issuesToPass = appeal.isLegacyAppeal ? appeal.issues : appeal.decisionIssues;
-    const payload = buildCaseReviewPayload(checkoutFlow, decision, userRole, issuesToPass, {
+    const payload = buildCaseReviewPayload(checkoutFlow, decision, false, issuesToPass, {
       location: loc,
       attorney_id: appeal.isLegacyAppeal ? task.assignedBy.pgId : appeal.assignedAttorney.id,
       isLegacyAppeal: appeal.isLegacyAppeal,
@@ -215,7 +212,7 @@ class EvaluateDecisionView extends React.PureComponent {
         taskType="Dispatch"
         redirectUrl={window.location.pathname} />
       <h1 {...css(fullWidth, marginBottom(2), marginTop(2))}>
-        {this.getPageName()}
+        {COPY.EVALUATE_DECISION_PAGE_TITLE}
       </h1>
       {error && <Alert title={error.title} type="error" styling={css(marginTop(0), marginBottom(1))}>
         {error.detail}
@@ -341,7 +338,6 @@ const mapStateToProps = (state, ownProps) => {
     taskOptions: state.queue.stagedChanges.taskDecision.opts,
     task: taskById(state, { taskId: ownProps.taskId }),
     decision: state.queue.stagedChanges.taskDecision,
-    userRole: state.ui.userRole,
     error: state.ui.messages.error
   };
 };

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -88,7 +88,7 @@ class SelectDispositionsView extends React.PureComponent {
 
     if (remandedIssues) {
       nextStep = 'remands';
-    } else if (userRole === USER_ROLE_TYPES.judge) {
+    } else if (userRole === USER_ROLE_TYPES.judge || checkoutFlow === 'dispatch_decision') {
       nextStep = 'evaluate';
     } else {
       nextStep = 'submit';

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -22,11 +22,9 @@ import {
 } from './QueueActions';
 import { hideSuccessMessage } from './uiReducer/uiActions';
 import {
-  PAGE_TITLES,
   VACOLS_DISPOSITIONS,
   ISSUE_DISPOSITIONS
 } from './constants';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
 
 import BENEFIT_TYPES from '../../constants/BENEFIT_TYPES.json';
 import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json';
@@ -63,20 +61,19 @@ class SelectDispositionsView extends React.PureComponent {
     };
   }
 
+  decisionReviewCheckoutFlow = () => this.props.checkoutFlow === 'dispatch_decision';
+
   componentDidMount = () => {
-    if (this.props.userRole === USER_ROLE_TYPES.attorney) {
+    if (!this.decisionReviewCheckoutFlow()) {
       this.props.setDecisionOptions({ work_product: 'Decision' });
     }
   }
-
-  getPageName = () => PAGE_TITLES.DISPOSITIONS[this.props.userRole.toUpperCase()];
 
   getNextStepUrl = () => {
     const {
       appealId,
       taskId,
       checkoutFlow,
-      userRole,
       appeal: { decisionIssues }
     } = this.props;
 
@@ -88,7 +85,7 @@ class SelectDispositionsView extends React.PureComponent {
 
     if (remandedIssues) {
       nextStep = 'remands';
-    } else if (userRole === USER_ROLE_TYPES.judge || checkoutFlow === 'dispatch_decision') {
+    } else if (this.decisionReviewCheckoutFlow()) {
       nextStep = 'evaluate';
     } else {
       nextStep = 'submit';
@@ -437,15 +434,13 @@ class SelectDispositionsView extends React.PureComponent {
 
 SelectDispositionsView.propTypes = {
   appealId: PropTypes.string.isRequired,
-  checkoutFlow: PropTypes.string.isRequired,
-  userRole: PropTypes.string.isRequired
+  checkoutFlow: PropTypes.string.isRequired
 };
 
 const mapStateToProps = (state, ownProps) => ({
   appeal: state.queue.stagedChanges.appeals[ownProps.appealId],
   success: state.ui.messages.success,
-  highlight: state.ui.highlightFormItems,
-  ..._.pick(state.ui, 'userRole')
+  highlight: state.ui.highlightFormItems
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/app/queue/SubmitDecisionView.jsx
+++ b/client/app/queue/SubmitDecisionView.jsx
@@ -121,13 +121,11 @@ class SubmitDecisionView extends React.PureComponent {
       },
       checkoutFlow,
       decision,
-      userRole,
       judges
     } = this.props;
 
     const issuesToPass = isLegacyAppeal ? issues : decisionIssues;
-    const payload = buildCaseReviewPayload(checkoutFlow, decision,
-      userRole, issuesToPass, { isLegacyAppeal });
+    const payload = buildCaseReviewPayload(checkoutFlow, decision, true, issuesToPass, { isLegacyAppeal });
 
     const fields = {
       type: checkoutFlow === DECISION_TYPES.DRAFT_DECISION ?
@@ -275,7 +273,6 @@ const mapStateToProps = (state, ownProps) => {
     },
     ui: {
       highlightFormItems,
-      userRole,
       messages: {
         error
       }
@@ -288,7 +285,6 @@ const mapStateToProps = (state, ownProps) => {
     task: taskById(state, { taskId: ownProps.taskId }),
     decision,
     error,
-    userRole,
     highlightFormItems
   };
 };

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -93,8 +93,7 @@ export const paddingLeft = (padding) => css({ paddingLeft: `${padding}rem` });
 export const CATEGORIES = {
   CASE_DETAIL: 'Appeal Details',
   QUEUE_TABLE: 'Queue Table',
-  QUEUE_TASK: 'Queue Task',
-  EVALUATE_DECISION: 'Evaluate Decision'
+  QUEUE_TASK: 'Queue Task'
 };
 
 export const TASK_ACTIONS = {
@@ -162,8 +161,7 @@ export const PAGE_TITLES = {
   REMANDS: {
     JUDGE: 'Review Remand Reasons',
     ATTORNEY: 'Select Remand Reasons'
-  },
-  EVALUATE: 'Evaluate Decision'
+  }
 };
 
 export const CUSTOM_HOLD_DURATION_TEXT = 'Custom';

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -14,7 +14,6 @@ import ISSUE_INFO from '../../constants/ISSUE_INFO.json';
 import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json';
 import UNDECIDED_VACOLS_DISPOSITIONS_BY_ID from '../../constants/UNDECIDED_VACOLS_DISPOSITIONS_BY_ID.json';
 import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
 import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
 import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMATION.json';
 import CO_LOCATED_ADMIN_ACTIONS from '../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
@@ -412,13 +411,14 @@ export const getIssueDiagnosticCodeLabel = (code) => {
   return `${code} - ${readableLabel.staff_description}`;
 };
 
+// Build case review payloads for attorney decision draft submissions as well as judge decision evaluations.
 export const buildCaseReviewPayload = (
-  checkoutFlow, decision, userRole, issues, args = {}
+  checkoutFlow, decision, draftDecisionSubmission, issues, args = {}
 ) => {
   const payload = {
     data: {
       tasks: {
-        type: `${userRole}CaseReview`,
+        type: draftDecisionSubmission ? 'AttorneyCaseReview' : 'JudgeCaseReview',
         ...decision.opts
       }
     }
@@ -430,7 +430,7 @@ export const buildCaseReviewPayload = (
     delete args.isLegacyAppeal;
   }
 
-  if (userRole === USER_ROLE_TYPES.attorney) {
+  if (draftDecisionSubmission) {
     _.extend(payload.data.tasks, { document_type: checkoutFlow });
   } else {
     args.factors_not_considered = _.keys(args.factors_not_considered);

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -7,7 +7,14 @@ RSpec.feature "Judge checkout flow" do
   let!(:vacols_atty) { FactoryBot.create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
 
   let(:judge_user) { FactoryBot.create(:user, station_id: User::BOARD_STATION_ID, full_name: "Aaron Judge") }
-  let!(:vacols_judge) { FactoryBot.create(:staff, :judge_role, sdomainid: judge_user.css_id) }
+  let!(:vacols_judge) { FactoryBot.create(:staff, vacols_role_trait, sdomainid: judge_user.css_id) }
+  let(:vacols_role_trait) { :judge_role }
+
+  before do
+    # When a judge completes judge checkout we create either a QR or dispatch task. Make sure we have somebody in
+    # the BVA dispatch team so that the creation of that task (which round robin assigns org tasks) does not fail.
+    OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
+  end
 
   context "given a valid ama appeal with single issue" do
     let!(:appeal) do
@@ -47,10 +54,6 @@ RSpec.feature "Judge checkout flow" do
     before do
       child_task.update!(status: Constants.TASK_STATUSES.completed)
       User.authenticate!(user: judge_user)
-
-      # When a judge completes judge checkout we create either a QR or dispatch task. Make sure we have somebody in
-      # the BVA dispatch team so that the creation of that task (which round robin assigns org tasks) does not fail.
-      OrganizationsUser.add_user_to_organization(FactoryBot.create(:user), BvaDispatch.singleton)
     end
 
     scenario "starts dispatch checkout flow" do
@@ -218,6 +221,70 @@ RSpec.feature "Judge checkout flow" do
         decass = VACOLS::Decass.find_by(defolder: appeal.vacols_id, deadtim: Time.zone.today)
         expect(decass.decomp).to eq(VacolsHelper.local_date_with_utc_timezone)
         expect(decass.deoq).to eq("3")
+      end
+    end
+  end
+
+  context "when an acting judge is checking out an AMA appeal" do
+    let(:vacols_role_trait) { :attorney_judge_role }
+
+    let(:appeal) do
+      FactoryBot.create(
+        :appeal,
+        number_of_claimants: 1,
+        request_issues: FactoryBot.build_list(:request_issue, 1)
+      )
+    end
+    let!(:decision_issue) do
+      FactoryBot.create(:decision_issue, decision_review: appeal, request_issues: appeal.request_issues)
+    end
+
+    let(:root_task) { FactoryBot.create(:root_task, appeal: appeal) }
+    let(:judge_review_task) do
+      FactoryBot.create(
+        :ama_judge_decision_review_task,
+        appeal: appeal,
+        parent: root_task,
+        assigned_to: judge_user
+      )
+    end
+    let!(:attorney_task) do
+      FactoryBot.create(
+        :ama_attorney_task,
+        appeal: appeal,
+        parent: judge_review_task,
+        assigned_to: attorney_user
+      )
+    end
+
+    before do
+      attorney_task.update!(status: Constants.TASK_STATUSES.completed)
+      User.authenticate!(user: judge_user)
+    end
+
+    it "allows the acting judge to complete judge checkout" do
+      step("Navigate from case details to decision issues by way of actions dropdown") do
+        visit("/queue/appeals/#{appeal.external_id}")
+        click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.label)
+        expect(page).to have_content(COPY::DECISION_ISSUE_PAGE_TITLE)
+      end
+
+      step("Navigate to evaluation page from decision issues page") do
+        click_on("Continue")
+        expect(page).to have_content(COPY::EVALUATE_DECISION_PAGE_TITLE)
+      end
+
+      step("Fill out evaluation page") do
+        find("label", text: Constants.JUDGE_CASE_REVIEW_OPTIONS.COMPLEXITY.medium).click
+        find("label", text: "3 - #{Constants.JUDGE_CASE_REVIEW_OPTIONS.QUALITY.meets_expectations}").click
+        click_on("Continue")
+      end
+
+      step("Verify that draft decision evaluation completed successfully") do
+        expect(page).to have_content(COPY::JUDGE_CHECKOUT_DISPATCH_SUCCESS_MESSAGE_TITLE % appeal.veteran_full_name)
+        case_review = JudgeCaseReview.find_by(task_id: judge_review_task.id)
+        expect(case_review.attorney).to eq(attorney_user)
+        expect(case_review.judge).to eq(judge_user)
       end
     end
   end


### PR DESCRIPTION
Fixes issue raised in the bat-team slack channel: https://dsva.slack.com/archives/CHX8FMP28/p1564420254107500

Queue uses the [current user's first VACOLS role](https://github.com/department-of-veterans-affairs/caseflow/blob/901def2e8b7136015db38935d4a9b8bec916b2bc/app/views/queue/index.html.erb#L5) as their role on the front-end. If [somebody is identified in VACOLS](https://github.com/department-of-veterans-affairs/caseflow/blob/901def2e8b7136015db38935d4a9b8bec916b2bc/app/repositories/user_repository.rb#L87) as both an acting judge and an attorney, Caseflow will list their VACOLS roles as both attorney and judge with attorney first. Since the attorney VACOLS role is listed first the front-end believes the current user is an attorney.

This PR removes judge checkout's reliance on user role to determine navigation and the package the front-end passes to the back-end.