### PR TITLE
Hide distance text if AHL distance is nil

### DIFF
--- a/client/app/hearings/components/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/AssignHearingsTabs.jsx
@@ -182,10 +182,14 @@ export default class AssignHearingsTabs extends React.Component {
 
     const { city, state, distance } = location;
 
-    return <span>
-      <div>{`${city}, ${state} ${getFacilityType(location)}`}</div>
-      <div>{`Distance: ${distance} miles away`}</div>
-    </span>;
+    return (
+      <span>
+        <div>{`${city}, ${state} ${getFacilityType(location)}`}</div>
+        {!_.isNil(distance) &&
+          <div>{`Distance: ${distance} miles away`}</div>
+        }
+      </span>
+    );
   }
 
   filterAppeals = (appeals, tab) => {


### PR DESCRIPTION
Resolves #11003

### Description

  * Hide distance text if AHL distance is nil

<img width="792" alt="Screen Shot 2019-07-29 at 4 39 11 PM" src="https://user-images.githubusercontent.com/1298274/62080958-a72d3980-b21f-11e9-83c0-1d96eb0399f7.png">