### PR TITLE
Ensure automatically created children of tasks receives same properties as factory created parents

### DIFF
--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.in_progress)
+        task.children.update_all(status: Constants.TASK_STATUSES.in_progress)
       end
     end
 
@@ -28,6 +29,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.on_hold)
+        task.children.update_all(status: Constants.TASK_STATUSES.on_hold)
       end
     end
 
@@ -38,6 +40,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.on_hold)
+        task.children.update_all(status: Constants.TASK_STATUSES.on_hold)
       end
     end
 
@@ -49,6 +52,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.completed)
+        task.children.update_all(status: Constants.TASK_STATUSES.completed)
       end
     end
 
@@ -59,6 +63,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.completed, closed_at: 3.weeks.ago)
+        task.children.update_all(status: Constants.TASK_STATUSES.completed, closed_at: 3.weeks.ago)
       end
     end
 
@@ -67,6 +72,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.cancelled)
+        task.children.update_all(status: Constants.TASK_STATUSES.cancelled)
       end
     end
 
@@ -85,6 +91,7 @@ FactoryBot.define do
 
       after(:create) do |task|
         task.update(status: Constants.TASK_STATUSES.on_hold)
+        task.children.update_all(status: Constants.TASK_STATUSES.on_hold)
       end
     end
 


### PR DESCRIPTION
Fixes some seed data. 

For instance, if a ColocatedTask were created with the trait `:on_hold`, the automatically created child would receive the parent's properties of `placed_on_hold_at` and `on_hold_duration`, but not a status of `on_hold` leaving `assigned` tasks in a user's On hold tab rather than assigned tab.

This is how our factories worked until we started [ensuring that tasks are created with an `assigned` status](https://github.com/department-of-veterans-affairs/caseflow/commit/8029d293c0820fd03b3c845b70302568044b47a2#diff-7797506992be54b6a7cf19b039400132R19).