### PR TITLE
Testing for TaskTimerJob success by emitting gauge to DataDog.

### DIFF
--- a/spec/jobs/task_timer_job_spec.rb
+++ b/spec/jobs/task_timer_job_spec.rb
@@ -98,4 +98,15 @@ describe TaskTimerJob, :postgres do
     TaskTimerJob.new.process(timer)
     expect(timer.reload.processed_at).to eq(nil)
   end
+
+  it "records the jobs runtime with Datadog" do
+    expect(DataDogService).to receive(:emit_gauge).with(
+      app_name: "caseflow_job",
+      metric_group: TaskTimerJob.name.underscore,
+      metric_name: "runtime",
+      metric_value: anything
+    )
+
+    TaskTimerJob.perform_now
+  end
 end


### PR DESCRIPTION
Completes #11442 

### Description
Adds some DataDog reporting to the TaskTimerJob so we can see runtime, success, or any issues.