### PR TITLE
add stalled hearing task checker to job

### DIFF
--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -6,6 +6,7 @@ class DataIntegrityChecksJob < CaseflowJob
 
   CHECKERS = %w[
     ExpiredAsyncJobsChecker
+    OpenHearingTasksWithoutActiveDescendantsChecker
     UntrackedLegacyAppealsChecker
   ].freeze
 

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -4,14 +4,22 @@ require "rails_helper"
 
 describe DataIntegrityChecksJob do
   let(:expired_async_jobs_checker) { ExpiredAsyncJobsChecker.new }
+  let(:open_hearing_tasks_without_active_descendants_checker) { OpenHearingTasksWithoutActiveDescendantsChecker.new }
   let(:untracked_legacy_appeals_checker) { UntrackedLegacyAppealsChecker.new }
   let(:slack_service) { SlackService.new(url: "http://www.example.com") }
 
   before do
     allow(ExpiredAsyncJobsChecker).to receive(:new).and_return(expired_async_jobs_checker)
+    allow(OpenHearingTasksWithoutActiveDescendantsChecker).to receive(:new).and_return(
+      open_hearing_tasks_without_active_descendants_checker
+    )
     allow(UntrackedLegacyAppealsChecker).to receive(:new).and_return(untracked_legacy_appeals_checker)
     allow(SlackService).to receive(:new).and_return(slack_service)
-    [expired_async_jobs_checker, untracked_legacy_appeals_checker].each do |checker|
+    [
+      expired_async_jobs_checker,
+      open_hearing_tasks_without_active_descendants_checker,
+      untracked_legacy_appeals_checker
+    ].each do |checker|
       allow(checker).to receive(:call).and_call_original
       allow(checker).to receive(:report?).and_call_original
       allow(checker).to receive(:report).and_call_original
@@ -26,6 +34,10 @@ describe DataIntegrityChecksJob do
       expect(expired_async_jobs_checker).to have_received(:call).once
       expect(expired_async_jobs_checker).to have_received(:report?).once
       expect(expired_async_jobs_checker).to_not have_received(:report)
+
+      expect(open_hearing_tasks_without_active_descendants_checker).to have_received(:call).once
+      expect(open_hearing_tasks_without_active_descendants_checker).to have_received(:report?).once
+      expect(open_hearing_tasks_without_active_descendants_checker).to_not have_received(:report)
 
       expect(untracked_legacy_appeals_checker).to have_received(:call).once
       expect(untracked_legacy_appeals_checker).to have_received(:report?).once


### PR DESCRIPTION
Connects #11070

### Description
Adds the data integrity check merged in #11564 to the `DataIntegrityChecksJob` checkers list, so it will run.