### PR TITLE
Add sorting feature to Days On Hold column in `/organizations/<organization` queue view.

### DIFF
--- a/app/models/task_pager.rb
+++ b/app/models/task_pager.rb
@@ -34,12 +34,13 @@ class TaskPager
       tasks.order(closed_at: sort_order)
     when Constants.QUEUE_CONFIG.TASK_TYPE_COLUMN
       tasks.order(type: sort_order, action: sort_order, created_at: sort_order)
-    when Constants.QUEUE_CONFIG.DAYS_ON_HOLD_COLUMN
+    when Constants.QUEUE_CONFIG.TASK_HOLD_LENGTH_COLUMN
       tasks.order(placed_on_hold_at: sort_order)
     # Columns not yet supported:
     #
     # APPEAL_TYPE_COLUMN
     # CASE_DETAILS_LINK_COLUMN
+    # DAYS_ON_HOLD_COLUMN
     # DOCUMENT_COUNT_READER_LINK_COLUMN
     # DOCKET_NUMBER_COLUMN
     # HEARING_BADGE_COLUMN
@@ -47,7 +48,6 @@ class TaskPager
     # REGIONAL_OFFICE_COLUMN
     # TASK_ASSIGNEE_COLUMN
     # TASK_ASSIGNER_COLUMN
-    # TASK_HOLD_LENGTH_COLUMN
     #
     else
       tasks.order(created_at: sort_order)

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -237,7 +237,7 @@ export const daysOnHoldColumn = (requireDasRecord) => {
           diff(task.placedOnHoldAt, 'days')} />
       </React.Fragment>;
     },
-    backendCanSort: false,
+    backendCanSort: true,
     getSortValue: (task) => numDaysOnHold(task)
   };
 };

--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -205,7 +205,7 @@ describe TaskPager, :all_dbs do
     end
 
     context "when sorting by days on hold" do
-      let(:sort_by) { Constants.QUEUE_CONFIG.DAYS_ON_HOLD_COLUMN }
+      let(:sort_by) { Constants.QUEUE_CONFIG.TASK_HOLD_LENGTH_COLUMN }
 
       before do
         created_tasks.each do |task|


### PR DESCRIPTION
Resolves #11317 

### Description
This corrects back-end sorting capabilities for the `caseDaysOnHoldColumn` used in `TaskTable`s and also turns on the usage thereof by flipping the `backendCanSort` flag on for that column.

We previously thought we had enabled the capabilities, but upon toggling the flag discovered that alas, we had not. Yay for feature flags!

### Testing Plan
`bundle exec rspec spec/models/task_pager_spec.rb`
