### PR TITLE
When canceling Claim Review establishment, also close request issues

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -220,6 +220,13 @@ class ClaimReview < DecisionReview
     ) || new_end_product_establishment(issue)
   end
 
+  def cancel_establishment!
+    transaction do
+      canceled!
+      request_issues.each { |reqi| reqi.close!(status: :end_product_canceled) }
+    end
+  end
+
   private
 
   def cleared_end_products

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -105,6 +105,33 @@ describe ClaimReview, :postgres do
     )
   end
 
+  describe "#cancel_establishment!" do
+    let(:claim_review) do
+      create(
+        :higher_level_review,
+        receipt_date: receipt_date,
+        establishment_attempted_at: (ClaimReview.processing_retry_interval_hours - 1).hours.ago,
+        establishment_error: "oops!"
+      )
+    end
+
+    subject { claim_review.cancel_establishment! }
+
+    it "sets async canceled_at and closes all request_issues" do
+      request_issue = rating_request_issue.tap(&:save!)
+
+      expect(request_issue).to_not be_closed
+
+      subject
+
+      claim_review.reload
+
+      expect(claim_review).to be_canceled
+      expect(claim_review.establishment_error).to eq("oops!")
+      expect(request_issue.reload).to be_closed
+    end
+  end
+
   let(:vbms_error) do
     VBMS::HTTPError.new("500", "More EPs more problems")
   end


### PR DESCRIPTION
connects #10087
connects #11632

### Description
When we need to manually cancel an irrevocably stuck async claim review, use this method to properly clean up.