### PR TITLE
add rake task that activates stalled hearing tasks

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+namespace :fixes do
+  class NoStalledHearingTasksFound < StandardError; end
+
+  # usage:
+  # Activate all stalled HearingTasks by setting their ScheduleHearingTask child status to assigned
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[0, false]
+  # Activate only the first stalled HearingTask
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[1, false]
+  # Perform a dry run
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[]
+  desc "re-activate stalled HearingTasks"
+  task :activate_stalled_hearing_tasks, [:limit, :dry_run] => :environment do |_, args|
+    Rails.logger.tagged("rake fixes:activate_stalled_hearing_tasks") do
+      Rails.logger.info("Invoked with: #{args.to_a.join(', ')}")
+    end
+
+    limit = args.limit&.to_i
+
+    limited = (limit &.> 0)
+
+    dry_run = args.dry_run&.to_s&.strip&.upcase != "FALSE"
+
+    if dry_run
+      puts "*** DRY RUN"
+      puts "*** pass 'false' as the third argument to execute"
+    end
+
+    # find HearingTasks that
+    # - are open
+    # - are the only HearingTask on their appeal
+    # - have no active descendants
+    # - have a single child which is an on_hold ScheduleHearingTask with no open descendants
+    target_tasks = HearingTask.open.order(:id).select do |task|
+      task.appeal.tasks.where(type: HearingTask.name).count == 1 &&
+        task.descendants.map(&:active?).exclude?(true) &&
+        task.children.count == 1 &&
+        task.children.first.type == ScheduleHearingTask.name &&
+        task.children.first.status == Constants.TASK_STATUSES.on_hold &&
+        (task.children.first.descendants - [task.children.first]).map(&:open?).exclude?(true)
+    end
+
+    target_tasks_found = target_tasks.count
+
+    if limited
+      target_tasks = target_tasks[0..limit - 1]
+    end
+
+    if target_tasks.count == 0
+      fail NoStalledHearingTasksFound, "No stalled HearingTasks were found."
+    end
+
+    change = dry_run ? "Would update" : "Updating"
+    message = "Found #{target_tasks_found} stalled HearingTasks. #{change} #{target_tasks.count} stalled " \
+      "HearingTasks with IDs #{target_tasks.map(&:id).sort}!"
+    puts message
+
+    if !dry_run
+      Rails.logger.tagged("rake fixes:activate_stalled_hearing_tasks") { Rails.logger.info(message) }
+      target_tasks.each { |task| task.children.first.update!(status: Constants.TASK_STATUSES.assigned) }
+    end
+  end
+end

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require "support/database_cleaner"
+require "support/vacols_database_cleaner"
+require "rails_helper"
+require "rake"
+
+describe "task rake fixes", :all_dbs do
+  before :all do
+    Rake.application = Rake::Application.new
+    Rake.application.rake_require "tasks/fixes"
+    Rake::Task.define_task :environment
+  end
+
+  describe "fixes:activate_stalled_hearing_tasks" do
+    subject do
+      Rake::Task["fixes:activate_stalled_hearing_tasks"].reenable
+      Rake::Task["fixes:activate_stalled_hearing_tasks"].invoke(*args)
+    end
+
+    context "there are appeals with stalled hearing tasks" do
+      # a legacy appeal
+      let(:appeal1) { create(:legacy_appeal, vacols_case: create(:case)) }
+      let(:root_task1) { create(:root_task, appeal: appeal1) }
+      let(:hearing_task1) { create(:hearing_task, appeal: appeal1, parent: root_task1) }
+      let!(:schedule_hearing_task1) { create(:schedule_hearing_task, appeal: appeal1, parent: hearing_task1) }
+      # a second legacy appeal
+      let(:appeal2) { create(:legacy_appeal, vacols_case: create(:case)) }
+      let(:root_task2) { create(:root_task, appeal: appeal2) }
+      let(:hearing_task2) { create(:hearing_task, appeal: appeal2, parent: root_task2) }
+      let!(:schedule_hearing_task2) { create(:schedule_hearing_task, appeal: appeal2, parent: hearing_task2) }
+      # an ama appeal
+      let(:appeal3) { create(:appeal) }
+      let(:root_task3) { create(:root_task, appeal: appeal3) }
+      let(:distribution_task3) { create(:distribution_task, appeal: appeal3, parent: root_task3) }
+      let(:hearing_task3) { create(:hearing_task, appeal: appeal3, parent: distribution_task3) }
+      let!(:schedule_hearing_task3) { create(:schedule_hearing_task, appeal: appeal3, parent: hearing_task3) }
+      let!(:track_veteran_task3) { create(:track_veteran_task, appeal: appeal3, parent: root_task3) }
+
+      let(:schedule_hearing_tasks) { [schedule_hearing_task1, schedule_hearing_task2, schedule_hearing_task3] }
+
+      before do
+        schedule_hearing_task1.update_columns(status: Constants.TASK_STATUSES.on_hold)
+        schedule_hearing_task2.update_columns(status: Constants.TASK_STATUSES.on_hold)
+        schedule_hearing_task3.update_columns(status: Constants.TASK_STATUSES.on_hold)
+      end
+
+      context "no dry run or limit variables are passed" do
+        let(:args) { [] }
+
+        it "only describes what changes will be made" do
+          ids = HearingTask.all.map(&:id).sort
+          expected_output = <<~OUTPUT
+            *** DRY RUN
+            *** pass 'false' as the third argument to execute
+            Found 3 stalled HearingTasks. Would update 3 stalled HearingTasks with IDs #{ids}!
+          OUTPUT
+          expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+          expect { subject }.to output(expected_output).to_stdout
+          # no changes have been made
+          schedule_hearing_tasks.each do |task|
+            expect(task.status).to eq Constants.TASK_STATUSES.on_hold
+          end
+        end
+      end
+
+      context "dry run is set to false" do
+        context "limit is set to zero" do
+          let(:args) { [0, "false"] }
+
+          it "makes the requested changes" do
+            ids = HearingTask.all.map(&:id).sort
+            expected_output = <<~OUTPUT
+              Found 3 stalled HearingTasks. Updating 3 stalled HearingTasks with IDs #{ids}!
+            OUTPUT
+            expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+            expect(Rails.logger).to receive(:info).with expected_output.chomp
+            expect { subject }.to output(expected_output).to_stdout
+            # changes have been made
+            schedule_hearing_tasks.each do |task|
+              expect(task.reload.status).to eq Constants.TASK_STATUSES.assigned
+            end
+          end
+
+          context "a HearingTask isn't open" do
+            before do
+              schedule_hearing_task1.update_columns(status: Constants.TASK_STATUSES.cancelled)
+              hearing_task1.update_columns(status: Constants.TASK_STATUSES.cancelled)
+            end
+
+            it "doesn't try to change the un-open HearingTask" do
+              ids = HearingTask.open.map(&:id).sort
+              expected_output = <<~OUTPUT
+                Found 2 stalled HearingTasks. Updating 2 stalled HearingTasks with IDs #{ids}!
+              OUTPUT
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect(Rails.logger).to receive(:info).with expected_output.chomp
+              expect { subject }.to output(expected_output).to_stdout
+              # changes have been made
+              HearingTask.open.each do |task|
+                expect(task.children.first.status).to eq Constants.TASK_STATUSES.assigned
+              end
+              expect(HearingTask.closed.count).to eq 1
+              expect(HearingTask.closed.first.children.first.status).to eq Constants.TASK_STATUSES.cancelled
+            end
+          end
+
+          context "there's another HearingTask on the same appeal as one of the stalled HearingTasks" do
+            let(:hearing_task2b) { create(:hearing_task, appeal: appeal2, parent: root_task2) }
+            let!(:schedule_hearing_task2b) { create(:schedule_hearing_task, appeal: appeal2, parent: hearing_task2b) }
+
+            it "doesn't try to change the open HearingTask on the same appeal" do
+              ids = [hearing_task1.id, hearing_task3.id]
+              expected_output = <<~OUTPUT
+                Found 2 stalled HearingTasks. Updating 2 stalled HearingTasks with IDs #{ids}!
+              OUTPUT
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect(Rails.logger).to receive(:info).with expected_output.chomp
+              expect { subject }.to output(expected_output).to_stdout
+              # only the first and third tasks have been changed
+              expect(schedule_hearing_task1.reload.status).to eq Constants.TASK_STATUSES.assigned
+              expect(schedule_hearing_task2.reload.status).to eq Constants.TASK_STATUSES.on_hold
+              expect(schedule_hearing_task3.reload.status).to eq Constants.TASK_STATUSES.assigned
+            end
+          end
+
+          context "a HearingTask has an active descendant" do
+            before do
+              schedule_hearing_task3.update_columns(status: Constants.TASK_STATUSES.in_progress)
+            end
+
+            it "doesn't try to change the open HearingTask with the active descendant" do
+              ids = [hearing_task1.id, hearing_task2.id]
+              expected_output = <<~OUTPUT
+                Found 2 stalled HearingTasks. Updating 2 stalled HearingTasks with IDs #{ids}!
+              OUTPUT
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect(Rails.logger).to receive(:info).with expected_output.chomp
+              expect { subject }.to output(expected_output).to_stdout
+              # only the first and second tasks have been changed
+              expect(schedule_hearing_task1.reload.status).to eq Constants.TASK_STATUSES.assigned
+              expect(schedule_hearing_task2.reload.status).to eq Constants.TASK_STATUSES.assigned
+              expect(schedule_hearing_task3.reload.status).to eq Constants.TASK_STATUSES.in_progress
+            end
+          end
+
+          context "a HearingTask has more than one child" do
+            let!(:disposition_task1) do
+              create(:assign_hearing_disposition_task, appeal: appeal1, parent: hearing_task1)
+            end
+
+            before do
+              disposition_task1.update_columns(status: Constants.TASK_STATUSES.cancelled)
+            end
+
+            it "doesn't try to change the open HearingTask with the active descendant" do
+              ids = [hearing_task2.id, hearing_task3.id]
+              expected_output = <<~OUTPUT
+                Found 2 stalled HearingTasks. Updating 2 stalled HearingTasks with IDs #{ids}!
+              OUTPUT
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect(Rails.logger).to receive(:info).with expected_output.chomp
+              expect { subject }.to output(expected_output).to_stdout
+              # only the second and third tasks have been changed
+              expect(schedule_hearing_task1.reload.status).to eq Constants.TASK_STATUSES.on_hold
+              expect(schedule_hearing_task2.reload.status).to eq Constants.TASK_STATUSES.assigned
+              expect(schedule_hearing_task3.reload.status).to eq Constants.TASK_STATUSES.assigned
+            end
+          end
+
+          context "a HearingTask's on_hold ScheduleHearingTask child has an active descendant" do
+            let!(:verify_address_task2) do
+              create(:hearing_admin_action_verify_address_task, appeal: appeal2, parent: schedule_hearing_task2)
+            end
+
+            it "doesn't try to change the open HearingTask with the active descendant" do
+              ids = [hearing_task1.id, hearing_task3.id]
+              expected_output = <<~OUTPUT
+                Found 2 stalled HearingTasks. Updating 2 stalled HearingTasks with IDs #{ids}!
+              OUTPUT
+              expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+              expect(Rails.logger).to receive(:info).with expected_output.chomp
+              expect { subject }.to output(expected_output).to_stdout
+              # only the first and third tasks have been changed
+              expect(schedule_hearing_task1.reload.status).to eq Constants.TASK_STATUSES.assigned
+              expect(schedule_hearing_task2.reload.status).to eq Constants.TASK_STATUSES.on_hold
+              expect(schedule_hearing_task3.reload.status).to eq Constants.TASK_STATUSES.assigned
+            end
+          end
+        end
+
+        context "limit is set to a positive integer" do
+          let(:args) { [2, "false"] }
+
+          it "makes the requested changes" do
+            ids = HearingTask.all.map(&:id).sort
+            expected_output = <<~OUTPUT
+              Found 3 stalled HearingTasks. Updating 2 stalled HearingTasks with IDs #{ids[0..1]}!
+            OUTPUT
+            expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+            expect(Rails.logger).to receive(:info).with expected_output.chomp
+            expect { subject }.to output(expected_output).to_stdout
+            # only the first two tasks have been changed
+            expect(schedule_hearing_task1.reload.status).to eq Constants.TASK_STATUSES.assigned
+            expect(schedule_hearing_task2.reload.status).to eq Constants.TASK_STATUSES.assigned
+            expect(schedule_hearing_task3.reload.status).to eq Constants.TASK_STATUSES.on_hold
+          end
+        end
+      end
+    end
+
+    context "there are no stalled hearing tasks" do
+      let(:args) { [0, "false"] }
+
+      it "tells the caller that there are no tasks to change" do
+        expected_output = "No stalled HearingTasks were found."
+        expect(Rails.logger).to receive(:info).with("Invoked with: #{args.join(', ')}")
+        expect { subject }.to raise_error(NoStalledHearingTasksFound).with_message(expected_output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects #11070 

### Description
A rake task that finds `HearingTask`s that
- are open,
- are the only `HearingTask` on their appeal,
- have no active descendants, and
- have a single child which is an `on_hold` `ScheduleHearingTask` with no open descendants

...and sets that `on_hold` `ScheduleHearingTask`'s status to `assigned`.

When the script is run manually in production, it should fix almost all of the currently stalled tasks.
