### PR TITLE
Allow JudgeAssignTasks to keep changing types for another month

### DIFF
--- a/app/models/tasks/judge_assign_task.rb
+++ b/app/models/tasks/judge_assign_task.rb
@@ -12,11 +12,9 @@ class JudgeAssignTask < JudgeTask
     update!(type: JudgeDecisionReviewTask.name)
 
     # Tell sentry so we know this is still happening. Remove this in a month
-    msg = [
-      "Still changing JudgeAssignTask type to JudgeDecisionReviewTask.",
-      "See: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295487938"
-    ]
-    Raven.capture_message(msg, extra: { application: "tasks" }) if Time.zone.now > Time.zone.local(2019, 8, 1)
+    msg = "Still changing JudgeAssignTask type to JudgeDecisionReviewTask."\
+          "See: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295487938"
+    Raven.capture_message(msg, extra: { application: "tasks" }) if Time.zone.now > Time.zone.local(2019, 9, 1)
   end
 
   def label

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -220,13 +220,13 @@ describe JudgeTask, :all_dbs do
         )
       end
 
-      before { Timecop.freeze(Time.zone.local(2019, 8, 2)) }
+      before { Timecop.freeze(Time.zone.local(2019, 9, 2)) }
 
       it "changes the judge task type to decision review and sends an error to sentry" do
         expect(judge_task.type).to eq(JudgeAssignTask.name)
         expect(Raven).to receive(:capture_message).with(
-          ["Still changing JudgeAssignTask type to JudgeDecisionReviewTask.",
-           "See: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295487938"],
+          "Still changing JudgeAssignTask type to JudgeDecisionReviewTask."\
+           "See: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295487938",
           extra: { application: "tasks" }
         )
         subject


### PR DESCRIPTION
Related to this comment: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295849637

There are [still 68 tasks in this state](https://caseflow-looker.va.gov/sql/9vbvbc9qznxsth) so we need to extend the deadline another month.

No live data was left in a bad state despite the fact that `Raven.capture_message()` was erroring when passed an array instead of a string.

https://caseflow-looker.va.gov/sql/djdsw5zz3kgp5q
```sql
select count(*)
from tasks atty_tasks
join tasks judge_tasks
  on judge_tasks.id = atty_tasks.parent_id
where atty_tasks.type = 'AttorneyTask'
  and atty_tasks.status in ('completed', 'cancelled')
  and judge_tasks.type = 'JudgeAssignTask'
  and judge_tasks.status not in ('completed', 'cancelled');

# 0
```