### PR TITLE
Enable passing of ids to fixes:activate_stalled_hearing_tasks rake task

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -5,34 +5,48 @@ namespace :fixes do
 
   # usage:
   # Activate all stalled HearingTasks by setting their ScheduleHearingTask child status to assigned
-  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[0, false]
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[0,false]
   # Activate only the first stalled HearingTask
-  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[1, false]
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[1,false]
+  # Activate only the HearingTasks with the passed ids
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[0,false,12,13,14]
   # Perform a dry run
-  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[]
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks
+  # Perform a dry run on the HearingTasks with the passed ids
+  #   $ bundle exec rake fixes:activate_stalled_hearing_tasks[0,12,13,14]
   desc "re-activate stalled HearingTasks"
   task :activate_stalled_hearing_tasks, [:limit, :dry_run] => :environment do |_, args|
     Rails.logger.tagged("rake fixes:activate_stalled_hearing_tasks") do
       Rails.logger.info("Invoked with: #{args.to_a.join(', ')}")
     end
+    extras = args.extras
 
     limit = args.limit&.to_i
 
     limited = (limit &.> 0)
 
     dry_run = args.dry_run&.to_s&.strip&.upcase != "FALSE"
+    if dry_run && args.dry_run.to_i > 0
+      extras.unshift(args.dry_run)
+    end
 
     if dry_run
       puts "*** DRY RUN"
-      puts "*** pass 'false' as the third argument to execute"
+      puts "*** pass 'false' as the second argument to execute"
     end
+
+    hearing_tasks = if extras.any?
+                      HearingTask.find(extras)
+                    else
+                      HearingTask.open.order(:id)
+                    end
 
     # find HearingTasks that
     # - are open
     # - are the only HearingTask on their appeal
     # - have no active descendants
     # - have a single child which is an on_hold ScheduleHearingTask with no open descendants
-    target_tasks = HearingTask.open.order(:id).select do |task|
+    target_tasks = hearing_tasks.select do |task|
       task.appeal.tasks.where(type: HearingTask.name).count == 1 &&
         task.descendants.map(&:active?).exclude?(true) &&
         task.children.count == 1 &&


### PR DESCRIPTION
Connects #11070 

### Description
Enables passing of ids to the `fixes:activate_stalled_hearing_tasks` rake task, so that we can fix just a few tasks before we run the script to fix every task. The `limit` parameter does something similar, but still examines every `HearingTask` in the database to determine whether it's stalled or not.