### PR TITLE
Resolve OpenHearingsChecker private method error

### DIFF
--- a/app/services/open_hearing_tasks_without_active_descendants_checker.rb
+++ b/app/services/open_hearing_tasks_without_active_descendants_checker.rb
@@ -6,6 +6,10 @@ class OpenHearingTasksWithoutActiveDescendantsChecker < DataIntegrityChecker
     build_report(hearing_task_ids)
   end
 
+  def slack_channel
+    "#appeals-hearings"
+  end
+
   private
 
   def ids_of_open_hearing_tasks_without_active_descendants
@@ -21,9 +25,5 @@ class OpenHearingTasksWithoutActiveDescendantsChecker < DataIntegrityChecker
     add_to_report "Found #{count} open #{'HearingTask'.pluralize(count)} with no active descendant tasks."
     add_to_report "The #{'hearing'.pluralize(count)} may not progress without manual intervention."
     add_to_report "HearingTask.where(id: #{ids})"
-  end
-
-  def slack_channel
-    "#appeals-hearings"
   end
 end

--- a/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
+++ b/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
@@ -68,4 +68,10 @@ describe OpenHearingTasksWithoutActiveDescendantsChecker, :all_dbs do
       end
     end
   end
+
+  describe ".slack_channel", focus: true do
+    it "is available as a public method" do
+      expect { subject.slack_channel }.to_not raise_error
+    end
+  end
 end

--- a/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
+++ b/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
@@ -69,7 +69,7 @@ describe OpenHearingTasksWithoutActiveDescendantsChecker, :all_dbs do
     end
   end
 
-  describe ".slack_channel", focus: true do
+  describe ".slack_channel" do
     it "is available as a public method" do
       expect { subject.slack_channel }.to_not raise_error
     end


### PR DESCRIPTION
Resolves [the following issue we're seeing](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/5993/):

> NoMethodError app/jobs/data_integrity_checks_job.rb in send_to_slack
> private method `slack_channel' called for #<OpenHearingTasksWithoutActiveDescendantsChecker:0x00007f6f7c121720>