### PR TITLE
Simplify TaskTimerJob specs

### DIFF
--- a/app/jobs/task_timer_job.rb
+++ b/app/jobs/task_timer_job.rb
@@ -27,13 +27,13 @@ class TaskTimerJob < CaseflowJob
     record_runtime(start_time)
   end
 
+  private
+
   def process(task_timer)
     # Calling ".with_lock" will block the current thread until
     # no other threads have a lock on the row, and will reload
     # the record after acquiring the lock.
     task_timer.with_lock do
-      return if task_timer.processed? || task_timer.canceled?
-
       task_timer.attempted!
       task_timer.task.when_timer_ends
       task_timer.clear_error!
@@ -48,15 +48,13 @@ class TaskTimerJob < CaseflowJob
 
   def cancel(task_timer)
     task_timer.with_lock do
-      return if task_timer.canceled? || task_timer.processed?
-
       task_timer.canceled!
     end
   rescue StandardError => error
     # Ensure errors are sent to Sentry, but don't block the job from continuing.
     # The next time the job runs, we'll process the unprocessed task timers again.
     task_timer.update_error!(error.inspect)
-    Raven.capture_exception(error)
+    capture_exception(error: error)
   end
 
   def record_runtime(start_time)


### PR DESCRIPTION
**Why**: The specs were calling what should be private methods directly.
If we want to treat the job spec as an integration spec, then we only
want to call `perform_now` and verify the result.

**How**:
- Make all methods below `perform` private
- Remove the use of Timecop and set the `last_submitted_at` column
instead to mimic the delayed submission for processing in TimeableTask.
- For each scenario we want to cover, set up the required DB attributes,
then call `perform_now` and verify the result.
