### PR TITLE
Only sending modified fields to backend from hearing worksheet

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -71,10 +71,6 @@ class HearingsController < HearingsApplicationController
 
   private
 
-  def check_hearing_prep_out_of_service
-    render "out_of_service", layout: "application" if Rails.cache.read("hearing_prep_out_of_service")
-  end
-
   def hearing
     @hearing ||= Hearing.find_hearing_by_uuid_or_vacols_id(hearing_external_id)
   end

--- a/client/app/hearings/actions/hearingWorksheetActions.js
+++ b/client/app/hearings/actions/hearingWorksheetActions.js
@@ -83,7 +83,14 @@ export const saveWorksheet = (worksheet) => (dispatch) => {
   dispatch(toggleWorksheetSaving(true));
   dispatch(setWorksheetSaveFailedStatus(false));
 
-  ApiUtil.patch(`/hearings/${worksheet.external_id}`, { data: { hearing: worksheet } }).
+  const formattedHearing = {
+    military_service: worksheet.military_service,
+    summary: worksheet.summary,
+    witness: worksheet.witness,
+    representative_name: worksheet.representative_name
+  };
+
+  ApiUtil.patch(`/hearings/${worksheet.external_id}`, { data: { hearing: formattedHearing } }).
     then(() => {
       dispatch({ type: ACTIONS.SET_WORKSHEET_EDITED_FLAG_TO_FALSE });
     },

--- a/spec/feature/hearings/hearing_worksheet_spec.rb
+++ b/spec/feature/hearings/hearing_worksheet_spec.rb
@@ -137,8 +137,7 @@ RSpec.feature "Hearing prep", :all_dbs do
         expect(page).to have_content("This is a witness")
         expect(page).to have_content("These are the notes being taken here")
         expect(page).to have_content("This is military service")
-        # Temporarily commented out until we fix issue #10621
-        # expect(page).to have_field("Hearing Prepped", checked: true, visible: false)
+        expect(page).to have_field("Hearing Prepped", checked: true, visible: false)
       end
 
       scenario "Can save preliminary impressions for ama hearings" do


### PR DESCRIPTION
Resolves #10621

### Description
The hearing worksheet has 3 backend/frontend integrations. The prepped field was being written to from two integrations and we were overwriting ourselves. I've updated the integrations so that 'prepped' can only be written from the header.