### PR TITLE
Include "Assign team cases" dropdown for all vacols judges

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -247,11 +247,10 @@ class User < ApplicationRecord
 
   def selectable_organizations
     orgs = organizations.select(&:selectable_in_queue?)
-    judge_team = JudgeTeam.for_judge(self)
 
-    if judge_team
+    if judge_in_vacols?
       orgs << {
-        id: judge_team.id,
+        id: (JudgeTeam.for_judge(self) || JudgeTeam.create_for_judge(self)).id,
         name: "Assign",
         url: format("queue/%s/assign", id)
       }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -250,7 +250,6 @@ class User < ApplicationRecord
 
     if judge_in_vacols?
       orgs << {
-        id: (JudgeTeam.for_judge(self) || JudgeTeam.create_for_judge(self)).id,
         name: "Assign",
         url: format("queue/%s/assign", id)
       }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -248,7 +248,7 @@ class User < ApplicationRecord
   def selectable_organizations
     orgs = organizations.select(&:selectable_in_queue?)
 
-    if judge_in_vacols?
+    if JudgeTeam.for_judge(self) || judge_in_vacols?
       orgs << {
         name: "Assign",
         url: format("queue/%s/assign", id)

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -4,7 +4,7 @@
     userId: current_user.id,
     userRole: (current_user.vacols_roles.first || "").capitalize,
     userCssId: current_user.css_id,
-    organizations: current_user.selectable_organizations.map {|o| o.slice(:id, :name, :url)},
+    organizations: current_user.selectable_organizations.map {|o| o.slice(:name, :url)},
     userIsVsoEmployee: current_user.vso_employee?,
     canEditAod: AodTeam.singleton.user_has_access?(current_user),
     caseSearchHomePage: case_search_home_page,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -250,6 +250,7 @@ describe User, :all_dbs do
 
   context "#selectable_organizations" do
     let(:user) { create(:user) }
+    let!(:staff) { create(:staff, :attorney_role, user: user) }
 
     subject { user.selectable_organizations }
 
@@ -265,7 +266,7 @@ describe User, :all_dbs do
     end
 
     context "when user is a judge in vacols" do
-      before { expect_any_instance_of(User).to receive(:judge_in_vacols?).and_return(true) }
+      let!(:staff) { create(:staff, :attorney_judge_role, user: user) }
 
       context "but has no judge team" do
         it "creates a judge team and and includes it in the selectable organizations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -255,52 +255,19 @@ describe User, :all_dbs do
     subject { user.selectable_organizations }
 
     context "when user is not a judge in vacols" do
-      before do
-        OrganizationsUser.add_user_to_organization(user, JudgeTeam.create_for_judge(create(:user)))
-      end
-
-      it "does not create a judge team and the team is not in the selectable organizations" do
+      it "assign cases is not returned" do
         is_expected.to be_empty
-        expect(user.organizations.first.is_a?(JudgeTeam)).to eq true
       end
     end
 
     context "when user is a judge in vacols" do
       let!(:staff) { create(:staff, :attorney_judge_role, user: user) }
 
-      context "but has no judge team" do
-        it "creates a judge team and and includes it in the selectable organizations" do
-          expect(JudgeTeam.for_judge(user)).to eq nil
-
-          subject
-
-          team = JudgeTeam.for_judge(user.reload)
-          is_expected.to include(
-            id: team.id,
-            name: "Assign",
-            url: format("queue/%<id>s/assign", id: user.id)
-          )
-          expect(user.organizations).to include team
-        end
-      end
-
-      context "but has a judge team" do
-        let!(:team) { JudgeTeam.create_for_judge(user) }
-
-        it "includes it in the selectable organizations but does not create a new judge team" do
-          expect(JudgeTeam.for_judge(user.reload)).to eq team
-          judge_team_count = JudgeTeam.count
-
-          subject
-
-          expect(JudgeTeam.count).to eq judge_team_count
-          is_expected.to include(
-            id: team.id,
-            name: "Assign",
-            url: format("queue/%<id>s/assign", id: user.id)
-          )
-          expect(user.organizations).to include team
-        end
+      it "assign cases is returned" do
+        is_expected.to include(
+          name: "Assign",
+          url: format("queue/%<id>s/assign", id: user.id)
+        )
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -254,7 +254,7 @@ describe User, :all_dbs do
 
     subject { user.selectable_organizations }
 
-    context "when user is not a judge in vacols" do
+    context "when user is not a judge in vacols and does not have a judge team" do
       it "assign cases is not returned" do
         is_expected.to be_empty
       end
@@ -262,6 +262,17 @@ describe User, :all_dbs do
 
     context "when user is a judge in vacols" do
       let!(:staff) { create(:staff, :attorney_judge_role, user: user) }
+
+      it "assign cases is returned" do
+        is_expected.to include(
+          name: "Assign",
+          url: format("queue/%<id>s/assign", id: user.id)
+        )
+      end
+    end
+
+    context "when user has a judge team" do
+      before { JudgeTeam.create_for_judge(user) }
 
       it "assign cases is returned" do
         is_expected.to include(


### PR DESCRIPTION
Resolves #11570

### Description
Displays the "Assign cases" dropdown for any user with a judge vacols role.

|Before|After|
|---|---|
|<img width="950" alt="Screen Shot 2019-08-08 at 3 13 16 PM" src="https://user-images.githubusercontent.com/45575454/62731640-a26f3f00-b9f0-11e9-9a86-70d91c502332.png">|<img width="954" alt="Screen Shot 2019-08-08 at 3 21 29 PM" src="https://user-images.githubusercontent.com/45575454/62731643-a69b5c80-b9f0-11e9-8c38-2ebd538599e6.png">|



### Acceptance Criteria
- [ ] Acting judges are presented with a dropdown menu on their queue table view to visit the assign cases page

### Testing Plan
1. Pick a user that is not a judge in VACOLS (I'll be using BVADREINGER!)
```ruby
> User.find_by(css_id: "BVADREINGER").judge_in_vacols?
=> false
```
2. Visit their queue and confirm there is no "Assign team cases" option if they have a "Switch views" dropdown
3. Give this user an "Acting judge" role in vacols
```ruby
> FactoryBot.create(:staff, :attorney_judge_role, user: User.find_by(css_id: "BVADREINGER"))
> User.find_by(css_id: "BVADREINGER").judge_in_vacols?
=> true
```
4. Visit the user's queue again, ensure they have a "Switch views" dropdown with an "Assign team cases" option, and ensure clicking this takes you to their judge "Assign cases" view