### PR TITLE
11440 Search by Docket Number

### DIFF
--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -23,6 +23,25 @@ class AppealFinder
     )
   end
 
+  def find_appeals_by_docket_number(docket_number)
+    return [] if docket_number.empty?
+
+    # Take the first six digits as date, remaining as ID
+    parsed = docket_number.split("-")
+
+    # If we can't parse a valid date from search, return no results
+    begin
+      receipt_date = Date.strptime(parsed[0], "%y%m%d")
+
+      id = parsed[1]
+      appeals = Appeal.where(id: id, receipt_date: receipt_date)
+
+      return appeals
+    rescue ArgumentError => e
+      return []
+    end
+  end
+
   class << self
     def find_appeals_with_file_numbers(file_numbers)
       return [] if file_numbers.empty?

--- a/app/workflows/case_search_results_base.rb
+++ b/app/workflows/case_search_results_base.rb
@@ -20,13 +20,18 @@ class CaseSearchResultsBase
       extra: error_status_or_search_results
     )
   end
-
+  
   protected
 
   attr_reader :status, :user
 
   def current_user_is_vso_employee?
     user.vso_employee?
+  end
+
+  # Child classes will likely override this
+  def veterans
+    []
   end
 
   def veterans_user_can_access

--- a/app/workflows/case_search_results_for_docket_number.rb
+++ b/app/workflows/case_search_results_for_docket_number.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class CaseSearchResultsForDocketNumber < ::CaseSearchResultsBase
+  validate :docket_number_presence
+  validate :veterans_exist, if: :current_user_is_vso_employee?
+
+  def initialize(docket_number:, user:)
+    super(user: user)
+    @docket_number = docket_number.to_s if docket_number
+  end
+
+  protected
+
+  def appeals
+    @appeals = AppealFinder.new(user: user).find_appeals_by_docket_number(docket_number)
+    return @appeals
+  end
+
+  def claim_reviews
+    veteran_file_numbers = veterans_user_can_access.map(&:file_number)
+
+    ClaimReview.find_all_visible_by_file_number(*veteran_file_numbers)
+  end
+
+  private
+
+  attr_reader :docket_number
+
+  def docket_number_presence
+    return if docket_number
+
+    errors.add(:workflow, missing_docket_number_error)
+    @status = :bad_request
+  end
+
+  def missing_docket_number_error
+    {
+      "title": "Docket number missing",
+      "detail": "HTTP_CASE_SEARCH request header must include docket number"
+    }
+  end
+
+  def veterans_exist
+    return unless veterans_user_can_access.empty?
+
+    errors.add(:workflow, not_found_error)
+    @status = :not_found
+  end
+
+  def not_found_error
+    {
+      "title": "Docket ID not found",
+      "detail": "Could not find a case matching the docket number"
+    }
+  end
+
+  def veterans
+    # Determine vet that corresponds to docket number so we can validate user can access
+    @file_numbers_for_appeals ||= appeals.map(&:veteran_file_number).uniq
+    @veterans ||= VeteranFinder.find_or_create_all(@file_numbers_for_appeals)
+  end
+end

--- a/app/workflows/case_search_results_for_veteran_file_number.rb
+++ b/app/workflows/case_search_results_for_veteran_file_number.rb
@@ -6,7 +6,10 @@ class CaseSearchResultsForVeteranFileNumber < ::CaseSearchResultsBase
 
   def initialize(file_number_or_ssn:, user:)
     super(user: user)
-    @file_number_or_ssn = file_number_or_ssn.to_s if file_number_or_ssn
+    # Ensure we have a string made of solely numeric characters
+    file_number_or_ssn = file_number_or_ssn.to_s.gsub(/\D/, "")
+
+    @file_number_or_ssn = file_number_or_ssn if file_number_or_ssn
   end
 
   protected

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1,9 +1,9 @@
 {
   "CASE_SEARCH_HOME_PAGE_HEADING": "Veteran Case Search",
-  "CASE_SEARCH_INPUT_PLACEHOLDER": "Enter a Veteran ID or SSN",
-  "CASE_SEARCH_INPUT_INSTRUCTION": "Please enter a valid claims file number or SSN to search for all available cases.",
+  "CASE_SEARCH_INPUT_PLACEHOLDER": "Enter a Veteran ID, SSN, or docket number",
+  "CASE_SEARCH_INPUT_INSTRUCTION": "Please enter a valid claims file number, SSN, or docket number to search for all available cases.",
   "CASE_SEARCH_ERROR_EMPTY_SEARCH_TERM": "Cannot search for no text",
-  "CASE_SEARCH_ERROR_INVALID_ID_HEADING": "Invalid Veteran ID “%s”",
+  "CASE_SEARCH_ERROR_INVALID_ID_HEADING": "Invalid search parameter “%s”",
   "CASE_SEARCH_ERROR_NO_CASES_FOUND_HEADING": "No cases found for “%s”",
   "CASE_SEARCH_ERROR_UNKNOWN_ERROR_HEADING": "Server encountered an error searching for “%s”",
   "CASE_SEARCH_ERROR_UNKNOWN_ERROR_MESSAGE": "Please retry your search and contact support if errors persist.",

--- a/client/app/queue/CaseListSearch.jsx
+++ b/client/app/queue/CaseListSearch.jsx
@@ -8,7 +8,7 @@ import COPY from '../../COPY.json';
 
 import {
   clearCaseListSearch,
-  fetchAppealsUsingVeteranId,
+  appealsSearch,
   setCaseListSearch
 } from './CaseList/CaseListActions';
 
@@ -21,7 +21,7 @@ class CaseListSearch extends React.PureComponent {
   onSubmitSearch = (searchQuery) => {
     /* eslint-disable no-empty-function */
     // Error cases already handled inside the promise itself.
-    this.props.fetchAppealsUsingVeteranId(searchQuery).then((veteranIds) => {
+    this.props.appealsSearch(searchQuery).then((veteranIds) => {
       const caseListPath = `/search?veteran_ids=${veteranIds.join(',')}`;
 
       if (this.props.location.pathname === '/schedule') {
@@ -66,7 +66,7 @@ CaseListSearch.defaultProps = {
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   clearCaseListSearch,
-  fetchAppealsUsingVeteranId,
+  appealsSearch,
   setCaseListSearch
 }, dispatch);
 


### PR DESCRIPTION
Resolves #11440 

### Description
Added support for searching for cases by docket number in addition to existing veteran SSN or file number. This includes making both frontend and backend code more generic, supporting both kinds of searches via the existing /appeals endpoint.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

