### PR TITLE
Hide view docs button in Case Details for RO and call center users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,9 +18,6 @@ class User < ApplicationRecord
   # Ephemeral values obtained from CSS on auth. Stored in user's session
   attr_writer :regional_office
 
-  FUNCTIONS = ["Establish Claim", "Manage Claim Establishment", "Certify Appeal",
-               "Reader", "Hearing Prep", "Mail Intake", "Admin Intake", "Case Details"].freeze
-
   # Because of the function character limit, we need to also alias some functions
   FUNCTION_ALIASES = {
     "Manage Claims Establishme" => ["Manage Claim Establishment"],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,10 @@ class User < ApplicationRecord
     can_any_of_these_roles?(["Build HearSched", "Edit HearSched", "RO ViewHearSched", "VSO", "Hearing Prep"])
   end
 
+  def can_view_hearing_schedule?
+    can?("RO ViewHearSched") && !can?("Build HearSched") && !can?("Edit HearSched")
+  end
+
   def administer_org_users?
     admin? || granted?("Admin Intake") || roles.include?("Admin Intake")
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,8 +71,20 @@ class User < ApplicationRecord
     can_any_of_these_roles?(["Build HearSched", "Edit HearSched", "RO ViewHearSched", "VSO", "Hearing Prep"])
   end
 
+  def can_assign_hearing_schedule?
+    can_any_of_these_roles?(["Edit HearSched", "Build HearSched"])
+  end
+
   def can_view_hearing_schedule?
     can?("RO ViewHearSched") && !can?("Build HearSched") && !can?("Edit HearSched")
+  end
+
+  def can_vso_hearing_schedule?
+    can?("VSO") && !can?("RO ViewHearSched") && !can?("Build HearSched") && !can?("Edit HearSched")
+  end
+
+  def in_hearing_or_transcription_organization?
+    HearingsManagement.singleton.users.include?(self) || TranscriptionTeam.singleton.users.include?(self)
   end
 
   def administer_org_users?

--- a/app/views/hearings/index.html.erb
+++ b/app/views/hearings/index.html.erb
@@ -16,13 +16,12 @@
   buildDate: build_date,
   userRoleAssign: current_user.can?('Edit HearSched') || current_user.can?('Build HearSched'),
   userRoleBuild: current_user.can?('Build HearSched'),
-  userRoleView: current_user.can?('RO ViewHearSched') &&
-      !current_user.can?('Build HearSched') && !current_user.can?('Edit HearSched'),
   userRoleVso: current_user.can?('VSO') && !current_user.can?('RO ViewHearSched') &&
       !current_user.can?('Build HearSched') && !current_user.can?('Edit HearSched'),
   userRoleHearingPrep: current_user.can?('Hearing Prep'),
   userInHearingsOrganization: (HearingsManagement.singleton.users.include?(current_user) ||
       TranscriptionTeam.singleton.users.include?(current_user)),
+  userCanViewHearingSchedule: current_user.can_view_hearing_schedule?,
   userId: current_user.id,
   userCssId: current_user.css_id
 }) %>

--- a/app/views/hearings/index.html.erb
+++ b/app/views/hearings/index.html.erb
@@ -14,14 +14,12 @@
   applicationUrls: application_urls,
   feedbackUrl: feedback_url,
   buildDate: build_date,
-  userRoleAssign: current_user.can?('Edit HearSched') || current_user.can?('Build HearSched'),
-  userRoleBuild: current_user.can?('Build HearSched'),
-  userRoleVso: current_user.can?('VSO') && !current_user.can?('RO ViewHearSched') &&
-      !current_user.can?('Build HearSched') && !current_user.can?('Edit HearSched'),
-  userRoleHearingPrep: current_user.can?('Hearing Prep'),
-  userInHearingsOrganization: (HearingsManagement.singleton.users.include?(current_user) ||
-      TranscriptionTeam.singleton.users.include?(current_user)),
+  userCanAssignHearingSchedule: current_user.can_assign_hearing_schedule?,
+  userCanBuildHearingSchedule: current_user.can?('Build HearSched'),
   userCanViewHearingSchedule: current_user.can_view_hearing_schedule?,
+  userCanVsoHearingSchedule: current_user.can_vso_hearing_schedule?,
+  userHasHearingPrepRole: current_user.can?('Hearing Prep'),
+  userInHearingOrTranscriptionOrganization: current_user.in_hearing_or_transcription_organization?,
   userId: current_user.id,
   userCssId: current_user.css_id
 }) %>

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -13,7 +13,7 @@
     feedbackUrl: feedback_url,
     flash: flash,
     buildDate: build_date,
-    hasCaseDetailsRole: (current_user.roles.include? "Case Details"),
+    hasCaseDetailsRole: current_user.roles.include?('Case Details'),
     userCanViewHearingSchedule: current_user.can_view_hearing_schedule?,
     featureToggles: {
       judge_case_review_checkout: FeatureToggle.enabled?(:judge_case_review_checkout, user: current_user),

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -14,6 +14,8 @@
     flash: flash,
     buildDate: build_date,
     hasCaseDetailsRole: (current_user.roles.include? "Case Details"),
+    userRoleView: current_user.can?('RO ViewHearSched') &&
+        !current_user.can?('Build HearSched') && !current_user.can?('Edit HearSched'),
     featureToggles: {
       judge_case_review_checkout: FeatureToggle.enabled?(:judge_case_review_checkout, user: current_user),
       attorney_assignment_to_colocated: FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: current_user)

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -14,8 +14,7 @@
     flash: flash,
     buildDate: build_date,
     hasCaseDetailsRole: (current_user.roles.include? "Case Details"),
-    userRoleView: current_user.can?('RO ViewHearSched') &&
-        !current_user.can?('Build HearSched') && !current_user.can?('Edit HearSched'),
+    userCanViewHearingSchedule: current_user.can_view_hearing_schedule?,
     featureToggles: {
       judge_case_review_checkout: FeatureToggle.enabled?(:judge_case_review_checkout, user: current_user),
       attorney_assignment_to_colocated: FeatureToggle.enabled?(:attorney_assignment_to_colocated, user: current_user)

--- a/client/app/hearings/HearingsApp.jsx
+++ b/client/app/hearings/HearingsApp.jsx
@@ -26,10 +26,10 @@ export default class HearingsApp extends React.PureComponent {
     const {
       userRoleAssign,
       userRoleBuild,
-      userRoleView,
       userRoleVso,
       userRoleHearingPrep,
       userInHearingsOrganization,
+      userCanViewHearingSchedule,
       userId,
       userCssId
     } = this.props;
@@ -37,10 +37,10 @@ export default class HearingsApp extends React.PureComponent {
     return {
       userRoleAssign,
       userRoleBuild,
-      userRoleView,
       userRoleVso,
       userRoleHearingPrep,
       userInHearingsOrganization,
+      userCanViewHearingSchedule,
       userId,
       userCssId
     };
@@ -174,10 +174,10 @@ HearingsApp.propTypes = {
   buildDate: PropTypes.string,
   userRoleAssign: PropTypes.bool,
   userRoleBuild: PropTypes.bool,
-  userRoleView: PropTypes.bool,
   userRoleVso: PropTypes.bool,
   userRoleHearingPrep: PropTypes.bool,
   userInHearingsOrganization: PropTypes.bool,
+  userCanViewHearingSchedule: PropTypes.bool,
   userRole: PropTypes.string,
   userId: PropTypes.number,
   userCssId: PropTypes.string

--- a/client/app/hearings/HearingsApp.jsx
+++ b/client/app/hearings/HearingsApp.jsx
@@ -24,23 +24,23 @@ import UnsupportedBrowserBanner from '../components/UnsupportedBrowserBanner';
 export default class HearingsApp extends React.PureComponent {
   userPermissionProps = () => {
     const {
-      userRoleAssign,
-      userRoleBuild,
-      userRoleVso,
-      userRoleHearingPrep,
-      userInHearingsOrganization,
+      userCanAssignHearingSchedule,
+      userCanBuildHearingSchedule,
       userCanViewHearingSchedule,
+      userCanVsoHearingSchedule,
+      userHasHearingPrepRole,
+      userInHearingOrTranscriptionOrganization,
       userId,
       userCssId
     } = this.props;
 
     return {
-      userRoleAssign,
-      userRoleBuild,
-      userRoleVso,
-      userRoleHearingPrep,
-      userInHearingsOrganization,
+      userCanAssignHearingSchedule,
+      userCanBuildHearingSchedule,
       userCanViewHearingSchedule,
+      userCanVsoHearingSchedule,
+      userHasHearingPrepRole,
+      userInHearingOrTranscriptionOrganization,
       userId,
       userCssId
     };
@@ -172,12 +172,12 @@ HearingsApp.propTypes = {
   applicationUrls: PropTypes.array,
   feedbackUrl: PropTypes.string.isRequired,
   buildDate: PropTypes.string,
-  userRoleAssign: PropTypes.bool,
-  userRoleBuild: PropTypes.bool,
-  userRoleVso: PropTypes.bool,
-  userRoleHearingPrep: PropTypes.bool,
-  userInHearingsOrganization: PropTypes.bool,
+  userCanAssignHearingSchedule: PropTypes.bool,
+  userCanBuildHearingSchedule: PropTypes.bool,
   userCanViewHearingSchedule: PropTypes.bool,
+  userCanVsoHearingSchedule: PropTypes.bool,
+  userHasHearingPrepRole: PropTypes.bool,
+  userInHearingOrTranscriptionOrganization: PropTypes.bool,
   userRole: PropTypes.string,
   userId: PropTypes.number,
   userCssId: PropTypes.string

--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -88,6 +88,8 @@ const SwitchViewDropdown = ({ onSwitchView }) => {
   );
 };
 
+SwitchViewDropdown.propTypes = { onSwitchView: PropTypes.func };
+
 class ListTable extends React.Component {
   render() {
     return (
@@ -116,6 +118,16 @@ class ListTable extends React.Component {
     );
   }
 }
+
+ListTable.propTypes = {
+  hearingScheduleColumns: PropTypes.array,
+  hearingScheduleRows: PropTypes.array,
+  onApply: PropTypes.func,
+  openModal: PropTypes.func,
+  user: {
+    userCanBuildHearingSchedule: PropTypes.bool
+  }
+};
 
 class ListSchedule extends React.Component {
   constructor(props) {
@@ -262,6 +274,7 @@ class ListSchedule extends React.Component {
 }
 
 ListSchedule.propTypes = {
+  endDate: PropTypes.string,
   hearingSchedule: PropTypes.shape({
     scheduledFor: PropTypes.string,
     readableRequestType: PropTypes.string,
@@ -272,9 +285,14 @@ ListSchedule.propTypes = {
     updatedOn: PropTypes.string,
     updatedBy: PropTypes.string
   }),
-  user: PropTypes.object,
   onApply: PropTypes.func,
-  openModal: PropTypes.func
+  onViewStartDateChange: PropTypes.func,
+  onViewEndDateChange: PropTypes.func,
+  openModal: PropTypes.func,
+  startDate: PropTypes.string,
+  switchListView: PropTypes.func,
+  user: PropTypes.object,
+  view: PropTypes.string
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -100,7 +100,7 @@ class ListTable extends React.Component {
         failStatusMessageProps={{
           title: 'Unable to load the hearing schedule.'
         }}>
-        {this.props.user.userRoleBuild && <div style={{ marginBottom: 25 }}>
+        {this.props.user.userCanBuildHearingSchedule && <div style={{ marginBottom: 25 }}>
           <Button linkStyling
             onClick={this.props.openModal}>
             Add Hearing Date
@@ -207,7 +207,7 @@ class ListSchedule extends React.Component {
 
     const { user, view, onApply, openModal } = this.props;
 
-    if (!user.userRoleHearingPrep || view === LIST_SCHEDULE_VIEWS.DEFAULT_VIEW) {
+    if (!user.userHasHearingPrepRole || view === LIST_SCHEDULE_VIEWS.DEFAULT_VIEW) {
       return <ListTable onApply={onApply}
         openModal={openModal}
         key={`hearings${this.state.dateRangeKey}`}
@@ -240,7 +240,7 @@ class ListSchedule extends React.Component {
               onApply={this.setDateRangeKey} />
           </div>
           <div className="cf-push-right list-schedule-buttons" {...downloadButtonStyling} >
-            {this.props.user.userRoleHearingPrep && <SwitchViewDropdown onSwitchView={this.props.switchListView} />}
+            {this.props.user.userHasHearingPrepRole && <SwitchViewDropdown onSwitchView={this.props.switchListView} />}
             <CSVLink
               data={hearingScheduleRows}
               headers={exportHeaders}

--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -192,7 +192,7 @@ export default class DailyDocket extends React.Component {
       {hasDocketHearings &&
         <DailyDocketRows
           hearings={docketHearings}
-          readOnly={user.userRoleView || user.userRoleVso}
+          readOnly={user.userCanViewHearingSchedule || user.userRoleVso}
           saveHearing={this.props.saveHearing}
           openDispositionModal={this.openDispositionModal}
           regionalOffice={regionalOffice}

--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -53,6 +53,17 @@ const Alerts = ({
   </React.Fragment>
 );
 
+Alerts.propTypes = {
+  dailyDocket: {
+    lock: PropTypes.bool,
+    scheduledFor: PropTypes.string
+  },
+  dailyDocketServerError: PropTypes.bool,
+  displayLockSuccessMessage: PropTypes.bool,
+  onErrorHearingDayLock: PropTypes.bool,
+  saveSuccessful: PropTypes.object
+};
+
 export default class DailyDocket extends React.Component {
   constructor (props) {
     super(props);

--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -177,7 +177,7 @@ export default class DailyDocket extends React.Component {
         </div>
         <div className="cf-push-right">
           {
-            user.userRoleHearingPrep &&
+            user.userHasHearingPrepRole &&
             <Button
               classNames={['usa-button-secondary']}
               onClick={this.navigateToPrintAllPage}
@@ -192,7 +192,7 @@ export default class DailyDocket extends React.Component {
       {hasDocketHearings &&
         <DailyDocketRows
           hearings={docketHearings}
-          readOnly={user.userCanViewHearingSchedule || user.userRoleVso}
+          readOnly={user.userCanViewHearingSchedule || user.userCanVsoHearingSchedule}
           saveHearing={this.props.saveHearing}
           openDispositionModal={this.openDispositionModal}
           regionalOffice={regionalOffice}
@@ -201,7 +201,7 @@ export default class DailyDocket extends React.Component {
       {!hasDocketHearings &&
         <div {...css({ marginTop: '75px' })}>
           <StatusMessage
-            title={user.userRoleHearingPrep ? COPY.HEARING_SCHEDULE_DOCKET_JUDGE_WITH_NO_HEARINGS :
+            title={user.userHasHearingPrepRole ? COPY.HEARING_SCHEDULE_DOCKET_JUDGE_WITH_NO_HEARINGS :
               COPY.HEARING_SCHEDULE_DOCKET_NO_VETERANS}
             type="status" />
         </div>}

--- a/client/app/hearings/components/dailyDocket/DailyDocketEditLinks.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketEditLinks.jsx
@@ -20,6 +20,10 @@ const EditHearingDayLink = ({ openModal }) => (
   </Button>
 );
 
+EditHearingDayLink.propTypes = {
+  openModal: PropTypes.func.isRequired
+};
+
 const LockHearingLink = ({ dailyDocket, onDisplayLockModal }) => (
   <Button linkStyling onClick={onDisplayLockModal}>
     <span {...css({ position: 'absolute',
@@ -33,6 +37,13 @@ const LockHearingLink = ({ dailyDocket, onDisplayLockModal }) => (
   </Button>
 );
 
+LockHearingLink.propTypes = {
+  dailyDocket: {
+    lock: PropTypes.bool
+  },
+  onDisplayLockModal: PropTypes.func.isRequired
+};
+
 const RemoveHearingDayLink = ({ onClickRemoveHearingDay }) => (
   <Button
     linkStyling
@@ -40,6 +51,10 @@ const RemoveHearingDayLink = ({ onClickRemoveHearingDay }) => (
     {crossSymbolHtml()}<span{...css({ marginLeft: '3px' })}>Remove Hearing Day</span>
   </Button>
 );
+
+RemoveHearingDayLink.propTypes = {
+  onClickRemoveHearingDay: PropTypes.func.isRequired
+};
 
 export default class DailyDocketEditLinks extends React.Component {
 

--- a/client/app/hearings/components/dailyDocket/DailyDocketEditLinks.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketEditLinks.jsx
@@ -54,14 +54,14 @@ export default class DailyDocketEditLinks extends React.Component {
         marginBottom: '25px'
       })}>
         <Link linkStyling to="/schedule" >&lt; Back to schedule</Link>&nbsp;&nbsp;
-        {user.userRoleAssign &&
+        {user.userCanAssignHearingSchedule &&
           <span>
             <EditHearingDayLink openModal={openModal} />
             &nbsp;&nbsp;
             <LockHearingLink dailyDocket={dailyDocket} onDisplayLockModal={onDisplayLockModal} />
             &nbsp;&nbsp;
           </span>}
-        {(_.isEmpty(hearings) && user.userRoleBuild) &&
+        {(_.isEmpty(hearings) && user.userCanBuildHearingSchedule) &&
           <RemoveHearingDayLink onClickRemoveHearingDay={onClickRemoveHearingDay} />}
 
         {dailyDocket.notes &&

--- a/client/app/hearings/components/dailyDocket/DailyDocketPrinted.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketPrinted.jsx
@@ -22,7 +22,7 @@ export class DailyDocketPrinted extends React.Component {
     openPrintDialogue();
   }
 
-  isUserJudge = () => this.props.user.userRoleHearingPrep;
+  isUserJudge = () => this.props.user.userHasHearingPrepRole;
 
   getTableColumns = () => [
     {

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -272,10 +272,10 @@ HearingActions.propTypes = {
   user: PropTypes.shape({
     userRoleAssign: PropTypes.bool,
     userRoleBuild: PropTypes.bool,
-    userRoleView: PropTypes.bool,
     userRoleVso: PropTypes.bool,
     userRoleHearingPrep: PropTypes.bool,
     userInHearingsOrganization: PropTypes.bool,
+    userCanViewHearingSchedule: PropTypes.bool,
     userId: PropTypes.number,
     userCssId: PropTypes.string
   })

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -116,7 +116,7 @@ class HearingActions extends React.Component {
     const { initialState } = this.state;
     const { user } = this.props;
 
-    if (_.isNil(initialState.advanceOnDocketMotion) || !user.userRoleHearingPrep) {
+    if (_.isNil(initialState.advanceOnDocketMotion) || !user.userHasHearingPrepRole) {
       return false;
     }
 
@@ -196,7 +196,7 @@ class HearingActions extends React.Component {
   }
 
   getRightColumn = () => {
-    const inputs = this.props.user.userRoleHearingPrep ? this.judgeRightInputs() : this.defaultRightInputs();
+    const inputs = this.props.user.userHasHearingPrepRole ? this.judgeRightInputs() : this.defaultRightInputs();
 
     return <div {...inputSpacing}>
       {inputs}
@@ -218,11 +218,11 @@ class HearingActions extends React.Component {
         cancelUpdate={this.cancelUpdate}
         saveHearing={this.saveHearing}
         openDispositionModal={openDispositionModal} />
-      {(user.userRoleHearingPrep && this.isAmaHearing()) &&
+      {(user.userHasHearingPrepRole && this.isAmaHearing()) &&
         <Waive90DayHoldCheckbox {...inputProps} />}
       <TranscriptRequestedCheckbox {...inputProps} />
-      {(user.userRoleAssign && !user.userRoleHearingPrep) && <HearingDetailsLink hearing={hearing} />}
-      <NotesField {...inputProps} readOnly={user.userRoleVso} />
+      {(user.userCanAssignHearingSchedule && !user.userHasHearingPrepRole) && <HearingDetailsLink hearing={hearing} />}
+      <NotesField {...inputProps} readOnly={user.userCanVsoHearingSchedule} />
     </div>;
   }
 
@@ -270,12 +270,12 @@ HearingActions.propTypes = {
     advanceOnDocketMotion: PropTypes.object
   }),
   user: PropTypes.shape({
-    userRoleAssign: PropTypes.bool,
-    userRoleBuild: PropTypes.bool,
-    userRoleVso: PropTypes.bool,
-    userRoleHearingPrep: PropTypes.bool,
-    userInHearingsOrganization: PropTypes.bool,
+    userCanAssignHearingSchedule: PropTypes.bool,
+    userCanBuildHearingSchedule: PropTypes.bool,
     userCanViewHearingSchedule: PropTypes.bool,
+    userCanVsoHearingSchedule: PropTypes.bool,
+    userHasHearingPrepRole: PropTypes.bool,
+    userInHearingOrTranscriptionOrganization: PropTypes.bool,
     userId: PropTypes.number,
     userCssId: PropTypes.string
   })

--- a/client/app/hearings/components/dailyDocket/DailyDocketRowDisplayText.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRowDisplayText.jsx
@@ -77,7 +77,7 @@ export default class HearingText extends React.Component {
     const { hearing, index, user, update, readOnly, initialState } = this.props;
 
     return <React.Fragment>
-      <div>{user.userRoleHearingPrep &&
+      <div>{user.userHasHearingPrepRole &&
         <PreppedCheckbox hearing={hearing} update={update} readOnly={readOnly} />}
       </div>
       <div><strong>{index + 1}</strong></div>

--- a/client/app/hearings/components/dailyDocket/DailyDocketRowDisplayText.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRowDisplayText.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import DocketTypeBadge from '../../../components/DocketTypeBadge';
 
@@ -52,6 +53,21 @@ const AppellantInformation = ({ hearing }) => {
   </div>;
 };
 
+AppellantInformation.propTypes = {
+  hearing: {
+    appealExternalId: PropTypes.string,
+    appellantAddressLine1: PropTypes.string,
+    appellantCity: PropTypes.string,
+    appellantState: PropTypes.string,
+    appellantZip: PropTypes.string,
+    docketName: PropTypes.string,
+    docketNumber: PropTypes.string,
+    representative: PropTypes.string,
+    representativeName: PropTypes.string,
+    veteranFileNumber: PropTypes.string
+  }
+};
+
 const HearingTime = ({ hearing }) => {
   const localTime = getDisplayTime(
     hearing.scheduledTimeString,
@@ -72,6 +88,17 @@ const HearingTime = ({ hearing }) => {
   </div>;
 };
 
+HearingTime.propTypes = {
+  hearing: {
+    centralOfficeTimeString: PropTypes.string,
+    currentIssueCount: PropTypes.string,
+    readableRequestType: PropTypes.string,
+    regionalOfficeName: PropTypes.string,
+    regionalOfficeTimezone: PropTypes.string,
+    scheduledTimeString: PropTypes.string
+  }
+};
+
 export default class HearingText extends React.Component {
   render () {
     const { hearing, index, user, update, readOnly, initialState } = this.props;
@@ -86,3 +113,14 @@ export default class HearingText extends React.Component {
     </React.Fragment>;
   }
 }
+
+HearingText.propTypes = {
+  hearing: PropTypes.object,
+  index: PropTypes.number,
+  initialState: PropTypes.object,
+  readOnly: PropTypes.bool,
+  update: PropTypes.func,
+  user: {
+    userHasHearingPrepRole: PropTypes.bool
+  }
+};

--- a/client/app/hearings/components/dailyDocket/DailyDocketRows.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRows.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import { sortHearings } from '../../utils';
 import DailyDocketRow from './DailyDocketRow';
@@ -54,6 +55,12 @@ const Header = ({ user }) => (
   </div>
 );
 
+Header.propTypes = {
+  user: {
+    userHasHearingPrepRole: PropTypes.bool
+  }
+};
+
 export default class DailyDocketHearingRows extends React.Component {
   render () {
     const { hearings, readOnly, regionalOffice,
@@ -77,3 +84,14 @@ export default class DailyDocketHearingRows extends React.Component {
     </div>;
   }
 }
+
+DailyDocketHearingRows.propTypes = {
+  hearings: PropTypes.array,
+  openDispositionModal: PropTypes.func,
+  readOnly: PropTypes.bool,
+  regionalOffice: PropTypes.string,
+  saveHearing: PropTypes.func,
+  user: {
+    userHasHearingPrepRole: PropTypes.bool
+  }
+};

--- a/client/app/hearings/components/dailyDocket/DailyDocketRows.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRows.jsx
@@ -43,9 +43,9 @@ const Header = ({ user }) => (
         background: 'none !important'
       },
       '& > div > div': { verticalAlign: 'bottom' }
-    })} className={user.userRoleHearingPrep ? 'judge-view' : ''}>
+    })} className={user.userHasHearingPrepRole ? 'judge-view' : ''}>
     <div>
-      <div>{user.userRoleHearingPrep && <strong>Prep</strong>}</div>
+      <div>{user.userHasHearingPrepRole && <strong>Prep</strong>}</div>
       <div></div>
       <div><strong>Appellant/Veteran ID/Representative</strong></div>
       <div><strong>Time/RO(s)</strong></div>
@@ -64,7 +64,7 @@ export default class DailyDocketHearingRows extends React.Component {
     return <div {...rowsMargin}>
       <Header user={user} />
       <div>{sortedHearings.map((hearing, index) => (
-        <div {...docketRowStyle} key={hearing.externalId} className={user.userRoleHearingPrep ? 'judge-view' : ''}>
+        <div {...docketRowStyle} key={hearing.externalId} className={user.userHasHearingPrepRole ? 'judge-view' : ''}>
           <DailyDocketRow hearingId={hearing.externalId}
             index={index}
             readOnly={readOnly}

--- a/client/app/hearings/containers/DetailsContainer.jsx
+++ b/client/app/hearings/containers/DetailsContainer.jsx
@@ -50,7 +50,7 @@ class HearingDetailsContainer extends React.Component {
         title: 'Unable to load the details.'
       }}>
       <HearingDetails
-        disabled={!this.props.userInHearingsOrganization}
+        disabled={!this.props.userInHearingOrTranscriptionOrganization}
         hearing={this.state.hearing}
         goBack={this.goBack}
       />
@@ -60,7 +60,7 @@ class HearingDetailsContainer extends React.Component {
 
 HearingDetailsContainer.propTypes = {
   hearingId: PropTypes.string.isRequired,
-  userInHearingsOrganization: PropTypes.bool,
+  userInHearingOrTranscriptionOrganization: PropTypes.bool,
   history: PropTypes.object
 };
 

--- a/client/app/hearings/containers/ListScheduleContainer.jsx
+++ b/client/app/hearings/containers/ListScheduleContainer.jsx
@@ -167,7 +167,7 @@ export class ListScheduleContainer extends React.Component {
 
     if (user.userCanViewHearingSchedule || user.userRoleVso) {
       return COPY.HEARING_SCHEDULE_VIEW_PAGE_HEADER_NONBOARD_USER;
-    } else if (user.userRoleHearingPrep) {
+    } else if (user.userHasHearingPrepRole) {
       return this.state.view === LIST_SCHEDULE_VIEWS.DEFAULT_VIEW ?
         COPY.HEARING_SCHEDULE_JUDGE_DEFAULT_VIEW_PAGE_HEADER :
         COPY.HEARING_SCHEDULE_JUDGE_SHOW_ALL_VIEW_PAGE_HEADER;
@@ -192,11 +192,11 @@ export class ListScheduleContainer extends React.Component {
           <h1 className="cf-push-left">
             {this.getHeader()}
           </h1>
-          {user.userRoleBuild &&
+          {user.userCanBuildHearingSchedule &&
             <span className="cf-push-right">
               <Link button="secondary" to="/schedule/build">Build Schedule</Link>
             </span>
-          }{user.userRoleAssign &&
+          }{user.userCanAssignHearingSchedule &&
             <span className="cf-push-right"{...actionButtonsStyling} >
               <Link button="primary" to="/schedule/assign">Schedule Veterans</Link>
             </span>

--- a/client/app/hearings/containers/ListScheduleContainer.jsx
+++ b/client/app/hearings/containers/ListScheduleContainer.jsx
@@ -252,6 +252,25 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 }, dispatch);
 
 ListScheduleContainer.propTypes = {
+  endDate: PropTypes.string,
+  hearingSchedule: PropTypes.object,
+  invalidDates: PropTypes.bool,
+  onAssignHearingRoom: PropTypes.func,
+  onInputInvalidDates: PropTypes.func,
+  onReceiveHearingSchedule: PropTypes.func,
+  onRegionalOfficeChange: PropTypes.func,
+  onResetDeleteSuccessful: PropTypes.func,
+  onResetInvalidDates: PropTypes.func,
+  onSelectedHearingDayChange: PropTypes.func,
+  onViewEndDateChange: PropTypes.func,
+  onViewStartDateChange: PropTypes.func,
+  selectedHearingDay: PropTypes.string,
+  selectHearingCoordinator: PropTypes.func,
+  selectRequestType: PropTypes.func,
+  selectVlj: PropTypes.func,
+  setNotes: PropTypes.func,
+  startDate: PropTypes.string,
+  successfulHearingDayDelete: PropTypes.string,
   user: PropTypes.object
 };
 

--- a/client/app/hearings/containers/ListScheduleContainer.jsx
+++ b/client/app/hearings/containers/ListScheduleContainer.jsx
@@ -165,7 +165,7 @@ export class ListScheduleContainer extends React.Component {
   getHeader = () => {
     const { user } = this.props;
 
-    if (user.userCanViewHearingSchedule || user.userRoleVso) {
+    if (user.userCanViewHearingSchedule || user.userCanVsoHearingSchedule) {
       return COPY.HEARING_SCHEDULE_VIEW_PAGE_HEADER_NONBOARD_USER;
     } else if (user.userHasHearingPrepRole) {
       return this.state.view === LIST_SCHEDULE_VIEWS.DEFAULT_VIEW ?

--- a/client/app/hearings/containers/ListScheduleContainer.jsx
+++ b/client/app/hearings/containers/ListScheduleContainer.jsx
@@ -165,7 +165,7 @@ export class ListScheduleContainer extends React.Component {
   getHeader = () => {
     const { user } = this.props;
 
-    if (user.userRoleView || user.userRoleVso) {
+    if (user.userCanViewHearingSchedule || user.userRoleVso) {
       return COPY.HEARING_SCHEDULE_VIEW_PAGE_HEADER_NONBOARD_USER;
     } else if (user.userRoleHearingPrep) {
       return this.state.view === LIST_SCHEDULE_VIEWS.DEFAULT_VIEW ?

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -118,9 +118,15 @@ class CaseDetailsView extends React.PureComponent {
 }
 
 CaseDetailsView.propTypes = {
+  appeal: PropTypes.object,
   appealId: PropTypes.string.isRequired,
+  error: PropTypes.object,
   hasCaseDetailsRole: PropTypes.bool,
+  resetErrorMessages: PropTypes.func,
+  setHearingDay: PropTypes.func,
+  success: PropTypes.object,
   userRoleView: PropTypes.bool
+  veteranCaseListIsVisible: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -82,7 +82,9 @@ class CaseDetailsView extends React.PureComponent {
       <AppSegment filledBackground>
         <CaseTitle appeal={appeal} />
         <CaseTitleDetails appealId={appealId} redirectUrl={window.location.pathname}
-          hasCaseDetailsRole={this.props.hasCaseDetailsRole} />
+          hasCaseDetailsRole={this.props.hasCaseDetailsRole}
+          userRoleView={this.props.userRoleView}
+        />
         { this.props.veteranCaseListIsVisible &&
           <VeteranCasesView
             caseflowVeteranId={appeal.caseflowVeteranId}
@@ -117,7 +119,8 @@ class CaseDetailsView extends React.PureComponent {
 
 CaseDetailsView.propTypes = {
   appealId: PropTypes.string.isRequired,
-  hasCaseDetailsRole: PropTypes.bool
+  hasCaseDetailsRole: PropTypes.bool,
+  userRoleView: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -125,7 +125,7 @@ CaseDetailsView.propTypes = {
   resetErrorMessages: PropTypes.func,
   setHearingDay: PropTypes.func,
   success: PropTypes.object,
-  userRoleView: PropTypes.bool
+  userRoleView: PropTypes.bool,
   veteranCaseListIsVisible: PropTypes.bool
 };
 

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -82,8 +82,7 @@ class CaseDetailsView extends React.PureComponent {
       <AppSegment filledBackground>
         <CaseTitle appeal={appeal} />
         <CaseTitleDetails appealId={appealId} redirectUrl={window.location.pathname}
-          hasCaseDetailsRole={this.props.hasCaseDetailsRole}
-          userCanViewHearingSchedule={this.props.userCanViewHearingSchedule}
+          userCanAccessReader={this.props.userCanAccessReader}
         />
         { this.props.veteranCaseListIsVisible &&
           <VeteranCasesView
@@ -121,11 +120,10 @@ CaseDetailsView.propTypes = {
   appeal: PropTypes.object,
   appealId: PropTypes.string.isRequired,
   error: PropTypes.object,
-  hasCaseDetailsRole: PropTypes.bool,
   resetErrorMessages: PropTypes.func,
   setHearingDay: PropTypes.func,
   success: PropTypes.object,
-  userCanViewHearingSchedule: PropTypes.bool,
+  userCanAccessReader: PropTypes.bool,
   veteranCaseListIsVisible: PropTypes.bool
 };
 

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -83,7 +83,7 @@ class CaseDetailsView extends React.PureComponent {
         <CaseTitle appeal={appeal} />
         <CaseTitleDetails appealId={appealId} redirectUrl={window.location.pathname}
           hasCaseDetailsRole={this.props.hasCaseDetailsRole}
-          userRoleView={this.props.userRoleView}
+          userCanViewHearingSchedule={this.props.userCanViewHearingSchedule}
         />
         { this.props.veteranCaseListIsVisible &&
           <VeteranCasesView
@@ -125,7 +125,7 @@ CaseDetailsView.propTypes = {
   resetErrorMessages: PropTypes.func,
   setHearingDay: PropTypes.func,
   success: PropTypes.object,
-  userRoleView: PropTypes.bool,
+  userCanViewHearingSchedule: PropTypes.bool,
   veteranCaseListIsVisible: PropTypes.bool
 };
 

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -156,9 +156,7 @@ export class CaseTitleDetails extends React.PureComponent {
         </div>
       </React.Fragment>
 
-      { !userIsVsoEmployee &&
-      !this.props.hasCaseDetailsRole &&
-      !this.props.userCanViewHearingSchedule &&
+      { !userIsVsoEmployee && this.props.userCanAccessReader &&
         <React.Fragment>
           <h4>Veteran Documents</h4>
           <div>
@@ -247,12 +245,11 @@ CaseTitleDetails.propTypes = {
   appeal: PropTypes.object.isRequired,
   appealId: PropTypes.string.isRequired,
   canEditAod: PropTypes.bool,
-  hasCaseDetailsRole: PropTypes.bool.isRequired,
   redirectUrl: PropTypes.string,
   requestPatch: PropTypes.func.isRequired,
   taskType: PropTypes.string,
   userIsVsoEmployee: PropTypes.bool.isRequired,
-  userCanViewHearingSchedule: PropTypes.bool
+  userCanAccessReader: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -158,7 +158,7 @@ export class CaseTitleDetails extends React.PureComponent {
 
       { !userIsVsoEmployee &&
       !this.props.hasCaseDetailsRole &&
-      !this.props.userRoleView &&
+      !this.props.userCanViewHearingSchedule &&
         <React.Fragment>
           <h4>Veteran Documents</h4>
           <div>
@@ -252,7 +252,7 @@ CaseTitleDetails.propTypes = {
   requestPatch: PropTypes.func.isRequired,
   taskType: PropTypes.string,
   userIsVsoEmployee: PropTypes.bool.isRequired,
-  userRoleView: PropTypes.bool
+  userCanViewHearingSchedule: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -78,6 +78,8 @@ const CaseDetailTitleScaffolding = (props) => <div {...containingDivStyling}>
   </ul>
 </div>;
 
+CaseDetailTitleScaffolding.propTypes = { children: PropTypes.node.isRequired };
+
 export class CaseTitleDetails extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -242,6 +244,14 @@ export class CaseTitleDetails extends React.PureComponent {
 }
 
 CaseTitleDetails.propTypes = {
+  appeal: PropTypes.object.isRequired,
+  appealId: PropTypes.string.isRequired,
+  canEditAod: PropTypes.bool,
+  hasCaseDetailsRole: PropTypes.bool.isRequired,
+  redirectUrl: PropTypes.string,
+  requestPatch: PropTypes.func.isRequired,
+  taskType: PropTypes.string,
+  userIsVsoEmployee: PropTypes.bool.isRequired,
   userRoleView: PropTypes.bool
 };
 

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -1,5 +1,6 @@
 import { css } from 'glamor';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import Modal from '../components/Modal';
 import TextField from '../components/TextField';
@@ -155,6 +156,7 @@ export class CaseTitleDetails extends React.PureComponent {
 
       { !userIsVsoEmployee &&
       !this.props.hasCaseDetailsRole &&
+      !this.props.userRoleView &&
         <React.Fragment>
           <h4>Veteran Documents</h4>
           <div>
@@ -238,6 +240,10 @@ export class CaseTitleDetails extends React.PureComponent {
     </CaseDetailTitleScaffolding>;
   };
 }
+
+CaseTitleDetails.propTypes = {
+  userRoleView: PropTypes.bool
+};
 
 const mapStateToProps = (state, ownProps) => {
   const { featureToggles, userRole, canEditAod } = state.ui;

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -124,7 +124,9 @@ class QueueApp extends React.PureComponent {
   </QueueLoadingScreen>;
 
   routedQueueDetail = (props) => <CaseDetailsView appealId={props.match.params.appealId}
-    hasCaseDetailsRole={this.props.hasCaseDetailsRole} />;
+    hasCaseDetailsRole={this.props.hasCaseDetailsRole}
+    userRoleView={this.props.userRoleView}
+  />;
 
   routedQueueDetailWithLoadingScreen = (props) => <CaseDetailsLoadingScreen
     {...this.propsForQueueLoadingScreen()}
@@ -544,7 +546,8 @@ QueueApp.propTypes = {
   caseSearchHomePage: PropTypes.bool,
   applicationUrls: PropTypes.array,
   flash: PropTypes.array,
-  reviewActionType: PropTypes.string
+  reviewActionType: PropTypes.string,
+  userRoleView: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -124,8 +124,7 @@ class QueueApp extends React.PureComponent {
   </QueueLoadingScreen>;
 
   routedQueueDetail = (props) => <CaseDetailsView appealId={props.match.params.appealId}
-    hasCaseDetailsRole={this.props.hasCaseDetailsRole}
-    userCanViewHearingSchedule={this.props.userCanViewHearingSchedule}
+    userCanAccessReader={!this.props.hasCaseDetailsRole && !this.props.userCanViewHearingSchedule}
   />;
 
   routedQueueDetailWithLoadingScreen = (props) => <CaseDetailsLoadingScreen

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -125,7 +125,7 @@ class QueueApp extends React.PureComponent {
 
   routedQueueDetail = (props) => <CaseDetailsView appealId={props.match.params.appealId}
     hasCaseDetailsRole={this.props.hasCaseDetailsRole}
-    userRoleView={this.props.userRoleView}
+    userCanViewHearingSchedule={this.props.userCanViewHearingSchedule}
   />;
 
   routedQueueDetailWithLoadingScreen = (props) => <CaseDetailsLoadingScreen
@@ -547,7 +547,7 @@ QueueApp.propTypes = {
   applicationUrls: PropTypes.array,
   flash: PropTypes.array,
   reviewActionType: PropTypes.string,
-  userRoleView: PropTypes.bool
+  userCanViewHearingSchedule: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -25,13 +25,14 @@ RSpec.feature "AmaQueue", :all_dbs do
         expect(current_path).to eq "/search"
       end
 
-      step "searches for a veteran and views their case details" do
+      step "searches for a veteran and clicks the search result" do
         fill_in "searchBarEmptyList", with: appeal.veteran_file_number
         find("#submit-search-searchBarEmptyList").click
         click_on(appeal.docket_number)
       end
 
-      step "does not have the view docs link" do
+      step "views their case details which does not have the view docs link" do
+        expect(page).to have_content("#{veteran.first_name} #{veteran.last_name}")
         expect(page).to_not have_content("Veteran Documents")
       end
     end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -364,17 +364,53 @@ RSpec.feature "Case details", :all_dbs do
       )
     end
 
-    before { attorney_user.update!(roles: attorney_user.roles + ["Reader"]) }
-    after { attorney_user.update!(roles: attorney_user.roles - ["Reader"]) }
+    context "with reader role" do
+      before { attorney_user.update!(roles: attorney_user.roles + ["Reader"]) }
+      after { attorney_user.update!(roles: attorney_user.roles - ["Reader"]) }
 
-    scenario "reader link appears on page and sends us to reader" do
-      visit "/queue"
-      click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
-      click_on "View #{appeal.documents.count} docs"
+      scenario "reader link appears on page and sends us to reader" do
+        visit "/queue"
+        click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+        click_on "View #{appeal.documents.count} docs"
 
-      # ["Caseflow", "> Reader"] are two elements, space handled by margin-left on second
-      expect(page).to have_content("CaseflowQueue")
-      expect(page).to have_content("Back to Your Queue\n#{appeal.veteran_full_name}")
+        expect(page).to have_content("CaseflowQueue")
+        expect(page).to have_content("Back to Your Queue\n#{appeal.veteran_full_name}")
+      end
+    end
+
+    context "with ro view hearing schedule role" do
+      let(:roles) { ["RO ViewHearSched"] }
+      let!(:attorney_user) { create(:user, roles: roles) }
+
+      scenario "reader link does not appear on page" do
+        visit "/queue"
+        click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+        expect(page).to have_content COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL
+        expect(page).to_not have_content COPY::CASE_LIST_TABLE_APPEAL_DOCUMENT_COUNT_COLUMN_TITLE.upcase
+        expect(page).to_not have_content "View #{appeal.documents.count} docs"
+      end
+
+      context "also with build hearing schedule role" do
+        let(:roles) { ["RO ViewHearSched", "Build HearSched"] }
+
+        scenario "reader link appears on page" do
+          visit "/queue"
+          click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+          expect(page).to have_content COPY::CASE_LIST_TABLE_APPEAL_DOCUMENT_COUNT_COLUMN_TITLE.upcase
+          expect(page).to have_content "View #{appeal.documents.count} docs"
+        end
+      end
+
+      context "also with edit hearing schedule role" do
+        let(:roles) { ["RO ViewHearSched", "Edit HearSched"] }
+
+        scenario "reader link appears on page" do
+          visit "/queue"
+          click_on "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})"
+          expect(page).to have_content COPY::CASE_LIST_TABLE_APPEAL_DOCUMENT_COUNT_COLUMN_TITLE.upcase
+          expect(page).to have_content "View #{appeal.documents.count} docs"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #9969

### Description
Don't show the Veteran Documents link in Case Details if a user has the "Case Details" or "RO ViewHearSched" CSEM functions.

**Note:** The link should've already been hidden for "Case Details" users; I updated a flakey test that exercises this and confirmed in production with a selection of users.

Also renames variables and refactors some aspects of passing user roles to the front end.