### PR TITLE
Allow QueueTab to return tasks

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -86,7 +86,7 @@ class Organization < ApplicationRecord
 
   def unassigned_tasks_tab
     ::UnassignedTasksTab.new(
-      assignee_name: name,
+      assignee: self,
       show_regional_office_column: show_regional_office_in_queue?,
       show_reader_link_column: show_reader_link_column?,
       allow_bulk_assign: can_bulk_assign_tasks?
@@ -94,15 +94,15 @@ class Organization < ApplicationRecord
   end
 
   def assigned_tasks_tab
-    ::AssignedTasksTab.new(assignee_name: name, show_regional_office_column: show_regional_office_in_queue?)
+    ::AssignedTasksTab.new(assignee: self, show_regional_office_column: show_regional_office_in_queue?)
   end
 
   def on_hold_tasks_tab
-    ::OnHoldTasksTab.new(assignee_name: name, show_regional_office_column: show_regional_office_in_queue?)
+    ::OnHoldTasksTab.new(assignee: self, show_regional_office_column: show_regional_office_in_queue?)
   end
 
   def completed_tasks_tab
-    ::CompletedTasksTab.new(assignee_name: name, show_regional_office_column: show_regional_office_in_queue?)
+    ::CompletedTasksTab.new(assignee: self, show_regional_office_column: show_regional_office_in_queue?)
   end
 
   def ama_task_serializer

--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -49,7 +49,7 @@ class QueueConfig
     tab.to_hash.merge(
       tasks: tasks,
       task_page_count: task_pager.task_page_count,
-      total_task_count: task_pager.total_task_count,
+      total_task_count: tab.tasks.count,
       task_page_endpoint_base_path: endpoint
     )
   end

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -3,7 +3,14 @@
 class QueueTab
   include ActiveModel::Model
 
+  validate :assignee_is_organization
+
   attr_accessor :assignee, :show_regional_office_column
+
+  def initialize(args)
+    super
+    fail(Caseflow::Error::MissingRequiredProperty, message: errors.full_messages.join(", ")) unless valid?
+  end
 
   def self.from_name(tab_name)
     tab = subclasses.find { |subclass| subclass.tab_name == tab_name }
@@ -54,6 +61,10 @@ class QueueTab
       :children,
       :parent
     ]
+  end
+
+  def assignee_is_organization
+    errors.add(:assignee, COPY::TASK_PAGE_INVALID_ASSIGNEE_MESSAGE) unless assignee&.is_a?(Organization)
   end
 end
 

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -3,13 +3,20 @@
 class QueueTab
   include ActiveModel::Model
 
-  attr_accessor :assignee_name, :show_regional_office_column
+  attr_accessor :assignee, :show_regional_office_column
+
+  def self.from_name(tab_name)
+    tab = subclasses.find { |subclass| subclass.tab_name == tab_name }
+    fail(Caseflow::Error::InvalidTaskTableTab, tab_name: tab_name) unless tab
+
+    tab
+  end
 
   def to_hash
     {
       label: label,
       name: name,
-      description: format(description, assignee_name),
+      description: format(description, assignee.name),
       columns: columns,
       allow_bulk_assign: allow_bulk_assign?
     }
@@ -17,13 +24,41 @@ class QueueTab
 
   def label; end
 
-  def name; end
+  def self.tab_name; end
+
+  def tasks; end
 
   def description; end
 
   def columns; end
 
+  def name
+    self.class.tab_name
+  end
+
   def allow_bulk_assign?
     false
   end
+
+  private
+
+  def on_hold_tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.where(assigned_to: assignee).on_hold
+  end
+
+  def task_includes
+    [
+      { appeal: [:available_hearing_locations, :claimants] },
+      :assigned_by,
+      :assigned_to,
+      :children,
+      :parent
+    ]
+  end
 end
+
+require_dependency "assigned_tasks_tab"
+require_dependency "completed_tasks_tab"
+require_dependency "on_hold_tasks_tab"
+require_dependency "tracking_tasks_tab"
+require_dependency "unassigned_tasks_tab"

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -5,12 +5,16 @@ class AssignedTasksTab < QueueTab
     COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE
   end
 
-  def name
+  def self.tab_name
     Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME
   end
 
   def description
     COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.active.where(parent: on_hold_tasks)
   end
 
   def columns

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -5,12 +5,16 @@ class CompletedTasksTab < QueueTab
     COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE
   end
 
-  def name
+  def self.tab_name
     Constants.QUEUE_CONFIG.COMPLETED_TASKS_TAB_NAME
   end
 
   def description
     COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.where(assigned_to: assignee).recently_closed
   end
 
   def columns

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -5,12 +5,16 @@ class OnHoldTasksTab < QueueTab
     COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE
   end
 
-  def name
+  def self.tab_name
     Constants.QUEUE_CONFIG.ON_HOLD_TASKS_TAB_NAME
   end
 
   def description
     COPY::ORGANIZATIONAL_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.on_hold.where(parent: on_hold_tasks)
   end
 
   def columns

--- a/app/models/queue_tabs/tracking_tasks_tab.rb
+++ b/app/models/queue_tabs/tracking_tasks_tab.rb
@@ -5,12 +5,16 @@ class TrackingTasksTab < QueueTab
     COPY::TRACKING_TASKS_TAB_TITLE
   end
 
-  def name
+  def self.tab_name
     Constants.QUEUE_CONFIG.TRACKING_TASKS_TAB_NAME
   end
 
   def description
     COPY::TRACKING_TASKS_TAB_DESCRIPTION
+  end
+
+  def tasks
+    TrackVeteranTask.includes(*task_includes).active.where(assigned_to: assignee)
   end
 
   def columns

--- a/app/models/queue_tabs/unassigned_tasks_tab.rb
+++ b/app/models/queue_tabs/unassigned_tasks_tab.rb
@@ -7,12 +7,16 @@ class UnassignedTasksTab < QueueTab
     COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE
   end
 
-  def name
+  def self.tab_name
     Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME
   end
 
   def description
     COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.where(assigned_to: assignee).active
   end
 
   def columns

--- a/app/models/representative.rb
+++ b/app/models/representative.rb
@@ -32,7 +32,7 @@ class Representative < Organization
   end
 
   def tracking_tasks_tab
-    ::TrackingTasksTab.new(assignee_name: name)
+    ::TrackingTasksTab.new(assignee: self)
   end
 
   def ama_task_serializer

--- a/app/models/task_pager.rb
+++ b/app/models/task_pager.rb
@@ -92,62 +92,16 @@ class TaskPager
     @task_page_count ||= paged_tasks.total_pages
   end
 
-  def total_task_count
-    @total_task_count ||= tasks_for_tab.count
-  end
-
   def filtered_tasks
     where_clause = QueueWhereClauseArgumentsFactory.new(filter_params: filters).arguments
     where_clause.empty? ? tasks_for_tab : tasks_for_tab.joins(cached_attributes_join_clause).where(*where_clause)
   end
 
   def tasks_for_tab
-    case tab_name
-    when Constants.QUEUE_CONFIG.TRACKING_TASKS_TAB_NAME
-      tracking_tasks
-    when Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME
-      active_tasks
-    when Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME
-      assigned_child_tasks
-    when Constants.QUEUE_CONFIG.ON_HOLD_TASKS_TAB_NAME
-      on_hold_child_tasks
-    when Constants.QUEUE_CONFIG.COMPLETED_TASKS_TAB_NAME
-      recently_completed_tasks
-    else
-      fail(Caseflow::Error::InvalidTaskTableTab, tab_name: tab_name)
-    end
+    QueueTab.from_name(tab_name).new(assignee: organization).tasks
   end
 
   private
-
-  def tracking_tasks
-    TrackVeteranTask.includes(*task_includes).active.where(assigned_to: assignee)
-  end
-
-  def active_tasks
-    Task.includes(*task_includes)
-      .visible_in_queue_table_view.where(assigned_to: assignee).active
-  end
-
-  def on_hold_tasks
-    Task.includes(*task_includes)
-      .visible_in_queue_table_view.where(assigned_to: assignee).on_hold
-  end
-
-  def assigned_child_tasks
-    Task.includes(*task_includes)
-      .visible_in_queue_table_view.active.where(parent: on_hold_tasks)
-  end
-
-  def on_hold_child_tasks
-    Task.includes(*task_includes)
-      .visible_in_queue_table_view.on_hold.where(parent: on_hold_tasks)
-  end
-
-  def recently_completed_tasks
-    Task.includes(*task_includes)
-      .visible_in_queue_table_view.where(assigned_to: assignee).recently_closed
-  end
 
   def assignee_is_user_or_organization
     unless assignee.is_a?(User) || assignee.is_a?(Organization)
@@ -158,15 +112,5 @@ class TaskPager
   def sort_order_is_valid
     valid_sort_orders = [Constants.QUEUE_CONFIG.COLUMN_SORT_ORDER_ASC, Constants.QUEUE_CONFIG.COLUMN_SORT_ORDER_DESC]
     errors.add(:sort_order, COPY::TASK_PAGE_INVALID_SORT_ORDER) unless valid_sort_orders.include?(sort_order)
-  end
-
-  def task_includes
-    [
-      { appeal: [:available_hearing_locations, :claimants] },
-      :assigned_by,
-      :assigned_to,
-      :children,
-      :parent
-    ]
   end
 end

--- a/app/models/task_pager.rb
+++ b/app/models/task_pager.rb
@@ -98,7 +98,7 @@ class TaskPager
   end
 
   def tasks_for_tab
-    QueueTab.from_name(tab_name).new(assignee: organization).tasks
+    QueueTab.from_name(tab_name).new(assignee: assignee).tasks
   end
 
   private

--- a/spec/models/queue_tab_spec.rb
+++ b/spec/models/queue_tab_spec.rb
@@ -7,11 +7,11 @@ describe QueueTab do
   let(:tab) { AssignedTasksTab.new(params) }
   let(:params) do
     {
-      assignee_name: assignee_name,
+      assignee: assignee,
       show_regional_office_column: show_regional_office_column
     }
   end
-  let(:assignee_name) { "organization name" }
+  let(:assignee) { create(:organization) }
   let(:show_regional_office_column) { false }
 
   describe ".allow_bulk_assign?" do
@@ -33,8 +33,37 @@ describe QueueTab do
       expect(subject.keys).to match_array([:label, :name, :description, :columns, :allow_bulk_assign])
     end
 
-    it "interpolates assignee_name name in description element of hash" do
-      expect(subject[:description]).to eq(format(tab.description, assignee_name))
+    it "interpolates assignee name in description element of hash" do
+      expect(subject[:description]).to eq(format(tab.description, assignee.name))
+    end
+  end
+
+  describe ".new" do
+    subject { tab }
+
+    context "when the assignee is not an organization" do
+      let(:assignee) { create(:user) }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Caseflow::Error::MissingRequiredProperty)
+      end
+    end
+
+    context "when there is no assignee parameter passed when instantiating the tab" do
+      let(:params) { { show_regional_office_column: show_regional_office_column } }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Caseflow::Error::MissingRequiredProperty)
+      end
+    end
+
+    context "when the assignee is an organization" do
+      let(:assignee) { create(:organization) }
+
+      it "is created successfully" do
+        expect { subject }.to_not raise_error
+        expect(subject).to be_a(AssignedTasksTab)
+      end
     end
   end
 

--- a/spec/models/queue_tab_spec.rb
+++ b/spec/models/queue_tab_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/database_cleaner"
 
-describe QueueTab do
+describe QueueTab, :postgres do
   # Use AssignedTasksTab as our example since we don't expect QueueTab to ever be instantiated directly.
   let(:tab) { AssignedTasksTab.new(params) }
   let(:params) do
@@ -17,8 +18,8 @@ describe QueueTab do
   describe ".allow_bulk_assign?" do
     subject { tab.allow_bulk_assign? }
 
-    context "when no arguments are passed when instantiating the object" do
-      let(:params) { {} }
+    context "when only the assignee argument is passed when instantiating the object" do
+      let(:params) { { assignee: assignee } }
 
       it "returns false" do
         expect(subject).to eq(false)

--- a/spec/models/queue_tab_spec.rb
+++ b/spec/models/queue_tab_spec.rb
@@ -37,4 +37,25 @@ describe QueueTab do
       expect(subject[:description]).to eq(format(tab.description, assignee_name))
     end
   end
+
+  describe "#from_name" do
+    subject { QueueTab.from_name(tab_name) }
+
+    context "when not tab class exists with the given name" do
+      let(:tab_name) { "non-existent tab name" }
+
+      it "raises an error" do
+        expect { subject }.to raise_error(Caseflow::Error::InvalidTaskTableTab)
+      end
+    end
+
+    context "when a tab class with that name exists" do
+      let(:tab_name) { Constants.QUEUE_CONFIG.COMPLETED_TASKS_TAB_NAME }
+
+      it "returns the class" do
+        expect { subject }.to_not raise_error
+        expect(subject).to eq(CompletedTasksTab)
+      end
+    end
+  end
 end

--- a/spec/models/queue_tabs/assigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/assigned_tasks_tab_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/database_cleaner"
 
-describe AssignedTasksTab do
+describe AssignedTasksTab, :postgres do
   let(:tab) { AssignedTasksTab.new(params) }
-  let(:params) do
+  let!(:params) do
     {
-      assignee_name: assignee_name,
+      assignee: create(:organization),
       show_regional_office_column: show_regional_office_column
     }
   end
-  let(:assignee_name) { "organization name" }
   let(:show_regional_office_column) { false }
 
   describe ".columns" do
     subject { tab.columns }
 
-    context "when no arguments are passed when instantiating the object" do
-      let(:params) { {} }
+    context "when only the assignee argument is passed when instantiating the object" do
+      let(:params) { { assignee: create(:organization) } }
 
       it "returns the correct number of columns" do
         expect(subject.length).to eq(7)

--- a/spec/models/queue_tabs/assigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/assigned_tasks_tab_spec.rb
@@ -5,7 +5,7 @@ require "support/database_cleaner"
 
 describe AssignedTasksTab, :postgres do
   let(:tab) { AssignedTasksTab.new(params) }
-  let!(:params) do
+  let(:params) do
     {
       assignee: assignee,
       show_regional_office_column: show_regional_office_column
@@ -53,7 +53,7 @@ describe AssignedTasksTab, :postgres do
         end.flatten
       end
 
-      it "only returns the tasks that are children of the assignee's on hold tasks" do
+      it "only returns the active tasks that are children of the assignee's on hold tasks" do
         expect(subject).to match_array(on_hold_tasks_children)
       end
     end

--- a/spec/models/queue_tabs/completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/completed_tasks_tab_spec.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/database_cleaner"
 
-describe CompletedTasksTab do
+describe CompletedTasksTab, :postgres do
   let(:tab) { CompletedTasksTab.new(params) }
-  let(:params) do
+  let!(:params) do
     {
-      assignee_name: assignee_name,
+      assignee: create(:organization),
       show_regional_office_column: show_regional_office_column
     }
   end
-  let(:assignee_name) { "organization name" }
   let(:show_regional_office_column) { false }
 
   describe ".columns" do
     subject { tab.columns }
 
-    context "when no arguments are passed when instantiating the object" do
-      let(:params) { {} }
+    context "when only the assignee argument is passed when instantiating the object" do
+      let(:params) { { assignee: create(:organization) } }
 
       it "returns the correct number of columns" do
         expect(subject.length).to eq(7)

--- a/spec/models/queue_tabs/on_hold_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/on_hold_tasks_tab_spec.rb
@@ -5,12 +5,13 @@ require "support/database_cleaner"
 
 describe OnHoldTasksTab, :postgres do
   let(:tab) { OnHoldTasksTab.new(params) }
-  let!(:params) do
+  let(:params) do
     {
-      assignee: create(:organization),
+      assignee: assignee,
       show_regional_office_column: show_regional_office_column
     }
   end
+  let(:assignee) { create(:organization) }
   let(:show_regional_office_column) { false }
 
   describe ".columns" do
@@ -33,6 +34,31 @@ describe OnHoldTasksTab, :postgres do
 
       it "includes the regional office column" do
         expect(subject).to include(Constants.QUEUE_CONFIG.REGIONAL_OFFICE_COLUMN)
+      end
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+
+    context "when there are tasks assigned to the assignee and other folks" do
+      let!(:other_folks_tasks) { create_list(:generic_task, 11) }
+      let!(:assignee_active_tasks) { create_list(:generic_task, 4, :assigned, assigned_to: assignee) }
+      let!(:assignee_on_hold_tasks) { create_list(:generic_task, 3, :assigned, assigned_to: assignee) }
+      let!(:on_hold_tasks_children) do
+        assignee_on_hold_tasks.map do |task|
+          create_list(:generic_task, 2, parent_id: task.id)
+          task.update!(status: Constants.TASK_STATUSES.on_hold)
+          task.children
+        end.flatten
+      end
+
+      before do
+        on_hold_tasks_children.each { |task| task.update!(status: Constants.TASK_STATUSES.on_hold) }
+      end
+
+      it "only returns the on hold tasks that are children of the assignee's on hold tasks" do
+        expect(subject).to match_array(on_hold_tasks_children)
       end
     end
   end

--- a/spec/models/queue_tabs/on_hold_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/on_hold_tasks_tab_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "support/database_cleaner"
+
+describe OnHoldTasksTab, :postgres do
+  let(:tab) { OnHoldTasksTab.new(params) }
+  let!(:params) do
+    {
+      assignee: create(:organization),
+      show_regional_office_column: show_regional_office_column
+    }
+  end
+  let(:show_regional_office_column) { false }
+
+  describe ".columns" do
+    subject { tab.columns }
+
+    context "when only the assignee argument is passed when instantiating the object" do
+      let(:params) { { assignee: create(:organization) } }
+
+      it "returns the correct number of columns" do
+        expect(subject.length).to eq(7)
+      end
+
+      it "does not include regional office column" do
+        expect(subject).to_not include(Constants.QUEUE_CONFIG.REGIONAL_OFFICE_COLUMN)
+      end
+    end
+
+    context "when we want to show the regional office column" do
+      let(:show_regional_office_column) { true }
+
+      it "includes the regional office column" do
+        expect(subject).to include(Constants.QUEUE_CONFIG.REGIONAL_OFFICE_COLUMN)
+      end
+    end
+  end
+end

--- a/spec/models/queue_tabs/tracking_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/tracking_tasks_tab_spec.rb
@@ -1,27 +1,17 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/database_cleaner"
 
-describe TrackingTasksTab do
+describe TrackingTasksTab, :postgres do
   let(:tab) { TrackingTasksTab.new(params) }
-  let(:params) { { assignee_name: assignee_name } }
-  let(:assignee_name) { "organization name" }
+  let!(:params) { { assignee: create(:organization) } }
 
   describe ".columns" do
     subject { tab.columns }
 
-    context "when no arguments are passed when instantiating the object" do
-      let(:params) { {} }
-
-      it "returns the correct number of columns" do
-        expect(subject.length).to eq(4)
-      end
-    end
-
-    context "when arguments are passed when instantiating the object" do
-      it "returns the correct number of columns" do
-        expect(subject.length).to eq(4)
-      end
+    it "returns the correct number of columns" do
+      expect(subject.length).to eq(4)
     end
   end
 end

--- a/spec/models/queue_tabs/tracking_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/tracking_tasks_tab_spec.rb
@@ -5,13 +5,28 @@ require "support/database_cleaner"
 
 describe TrackingTasksTab, :postgres do
   let(:tab) { TrackingTasksTab.new(params) }
-  let!(:params) { { assignee: create(:organization) } }
+  let(:params) { { assignee: assignee } }
+  let(:assignee) { create(:organization) }
 
   describe ".columns" do
     subject { tab.columns }
 
     it "returns the correct number of columns" do
       expect(subject.length).to eq(4)
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+
+    context "when there are tasks assigned to the assignee and other folks" do
+      let!(:other_folks_tasks) { create_list(:generic_task, 11) }
+      let!(:assignee_other_tasks) { create_list(:generic_task, 4, :assigned, assigned_to: assignee) }
+      let!(:assignee_tracking_tasks) { create_list(:track_veteran_task, 3, :assigned, assigned_to: assignee) }
+
+      it "only returns the assignee's TrackVeteranTasks" do
+        expect(subject).to match_array(assignee_tracking_tasks)
+      end
     end
   end
 end

--- a/spec/models/queue_tabs/unassigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/unassigned_tasks_tab_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/database_cleaner"
 
-describe UnassignedTasksTab do
+describe UnassignedTasksTab, :postgres do
   let(:tab) { UnassignedTasksTab.new(params) }
-  let(:params) do
+  let!(:params) do
     {
-      assignee_name: assignee_name,
+      assignee: create(:organization),
       show_regional_office_column: show_regional_office_column,
       show_reader_link_column: show_reader_link_column,
       allow_bulk_assign: allow_bulk_assign
     }
   end
-  let(:assignee_name) { "organization name" }
   let(:show_regional_office_column) { false }
   let(:show_reader_link_column) { false }
   let(:allow_bulk_assign) { false }
@@ -20,8 +20,8 @@ describe UnassignedTasksTab do
   describe ".columns" do
     subject { tab.columns }
 
-    context "when no arguments are passed when instantiating the object" do
-      let(:params) { {} }
+    context "when only the assignee argument is passed when instantiating the object" do
+      let(:params) { { assignee: create(:organization) } }
 
       it "returns the correct number of columns" do
         expect(subject.length).to eq(6)
@@ -53,8 +53,8 @@ describe UnassignedTasksTab do
   describe ".allow_bulk_assign?" do
     subject { tab.allow_bulk_assign? }
 
-    context "when no arguments are passed when instantiating the object" do
-      let(:params) { {} }
+    context "when only the assignee argument is passed when instantiating the object" do
+      let(:params) { { assignee: create(:organization) } }
 
       it "returns false" do
         expect(subject).to eq(false)

--- a/spec/models/queue_tabs/unassigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/unassigned_tasks_tab_spec.rb
@@ -5,14 +5,15 @@ require "support/database_cleaner"
 
 describe UnassignedTasksTab, :postgres do
   let(:tab) { UnassignedTasksTab.new(params) }
-  let!(:params) do
+  let(:params) do
     {
-      assignee: create(:organization),
+      assignee: assignee,
       show_regional_office_column: show_regional_office_column,
       show_reader_link_column: show_reader_link_column,
       allow_bulk_assign: allow_bulk_assign
     }
   end
+  let(:assignee) { create(:organization) }
   let(:show_regional_office_column) { false }
   let(:show_reader_link_column) { false }
   let(:allow_bulk_assign) { false }
@@ -66,6 +67,24 @@ describe UnassignedTasksTab, :postgres do
 
       it "returns true" do
         expect(subject).to eq(true)
+      end
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+
+    context "when there are tasks assigned to the assignee and other folks" do
+      let!(:other_folks_tasks) { create_list(:generic_task, 11) }
+      let!(:assignee_active_tasks) { create_list(:generic_task, 4, :assigned, assigned_to: assignee) }
+      let!(:assignee_on_hold_tasks) { create_list(:generic_task, 3, :assigned, assigned_to: assignee) }
+
+      before do
+        assignee_on_hold_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.on_hold) }
+      end
+
+      it "only returns assignee's active tasks" do
+        expect(subject).to match_array(assignee_active_tasks)
       end
     end
   end


### PR DESCRIPTION
Connects #11733. Moves logic for fetching tasks for a given tab from `TaskPager` to each individual `QueueTab`.

Three major changes included in this PR:
1. `TaskPager` no longer controls which tasks a given tab is supposed to return. That responsibility is transferred to the various `QueueTab` subclasses' `tasks` method.
1. `QueueTab`s now require an `assignee` argument when they are created.
1. Added a new `QueueTab.from_name` function for returning a tab class given the tab's name string we receive from the front-end.