### PR TITLE
Cache Hearing Day id from VACOLS

### DIFF
--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -108,6 +108,14 @@ class LegacyHearing < ApplicationRecord
   end
 
   def hearing_day
+    if hearing_day_id.nil?
+      begin
+        update!(hearing_day_id: hearing_day_vacols_id)
+      rescue ActiveRecord::InvalidForeignKey
+        # Hearing day doesn't exist yet in DB. Ignore for now.
+      end
+    end
+
     # access with caution. this retrieves the hearing_day_id from vacols
     # then looks up the HearingDay in Caseflow
     @hearing_day ||= HearingDay.find_by_id(hearing_day_id)

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -118,8 +118,6 @@ class LegacyHearing < ApplicationRecord
       end
     end
 
-    # access with caution. this retrieves the hearing_day_id from vacols
-    # then looks up the HearingDay in Caseflow
     @hearing_day ||= HearingDay.find_by_id(hearing_day_id)
   end
 

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -112,7 +112,9 @@ class LegacyHearing < ApplicationRecord
       begin
         update!(hearing_day_id: hearing_day_vacols_id)
       rescue ActiveRecord::InvalidForeignKey
-        # Hearing day doesn't exist yet in DB. Ignore for now.
+        # Hearing day doesn't exist yet in DB. Set hearing_day_id to nil
+        # explicitly for clarity (even though we already know it's nil).
+        hearing_day_id = nil
       end
     end
 

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -14,7 +14,7 @@ class LegacyHearing < ApplicationRecord
   vacols_attr_accessor :scheduled_for, :request_type, :venue_key, :vacols_record, :disposition
   vacols_attr_accessor :aod, :hold_open, :transcript_requested, :notes, :add_on
   vacols_attr_accessor :transcript_sent_date, :appeal_vacols_id
-  vacols_attr_accessor :representative_name, :hearing_day_id
+  vacols_attr_accessor :representative_name, :hearing_day_vacols_id
   vacols_attr_accessor :docket_number, :appeal_type, :room, :bva_poc, :judge_id
 
   belongs_to :appeal, class_name: "LegacyAppeal"

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -108,14 +108,12 @@ class LegacyHearing < ApplicationRecord
   end
 
   def hearing_day_id_refers_to_vacols_row?
-    (request_type == HearingDay::REQUEST_TYPES[:central] &&
-      scheduled_for.to_date < Date.new(2019, 1, 1)) ||
-    (request_type == HearingDay::REQUEST_TYPES[:video] &&
-      scheduled_for.to_date < Date.new(2019, 4, 1))
+    (request_type == HearingDay::REQUEST_TYPES[:central] && scheduled_for.to_date < Date.new(2019, 1, 1)) ||
+      (request_type == HearingDay::REQUEST_TYPES[:video] && scheduled_for.to_date < Date.new(2019, 4, 1))
   end
 
   def hearing_day_id
-    if self[:hearing_day_id].nil? and !hearing_day_id_refers_to_vacols_row?
+    if self[:hearing_day_id].nil? && !hearing_day_id_refers_to_vacols_row?
       begin
         update!(hearing_day_id: hearing_day_vacols_id)
       rescue ActiveRecord::InvalidForeignKey

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -172,7 +172,7 @@ class HearingRepository
         room: vacols_record.room,
         request_type: vacols_record.hearing_type,
         scheduled_for: date,
-        hearing_day_id: vacols_record.vdkey,
+        hearing_day_vacols_id: vacols_record.vdkey,
         bva_poc: vacols_record.vdbvapoc,
         judge_id: hearing.user_id
       }

--- a/spec/factories/legacy_hearing.rb
+++ b/spec/factories/legacy_hearing.rb
@@ -18,7 +18,7 @@ FactoryBot.define do
       end
     end
 
-    scheduled_for { hearing_day.scheduled_for }
+    scheduled_for { hearing_day&.scheduled_for }
 
     transient do
       case_hearing do

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -384,7 +384,13 @@ describe LegacyHearing, :all_dbs do
     end
 
     context "associated hearing day does not exist" do
-      let(:legacy_hearing) { create(:legacy_hearing, hearing_day: nil) }
+      let(:legacy_hearing) do
+        create(
+          :legacy_hearing,
+          hearing_day: nil,
+          case_hearing: create(:case_hearing, vdkey: '123456')
+        )
+      end
 
       it "get hearing day returns nil" do
         expect(legacy_hearing.hearing_day).to eq nil

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -388,7 +388,7 @@ describe LegacyHearing, :all_dbs do
         create(
           :legacy_hearing,
           hearing_day: nil,
-          case_hearing: create(:case_hearing, vdkey: '123456')
+          case_hearing: create(:case_hearing, vdkey: "123456")
         )
       end
 

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -365,4 +365,30 @@ describe LegacyHearing, :all_dbs do
       end
     end
   end
+
+  context "#hearing_day", focus: true do
+    context "associated hearing day exists" do
+      let(:hearing_day) { create(:hearing_day) }
+      let(:legacy_hearing) { create(:legacy_hearing, hearing_day: hearing_day) }
+
+      it "get hearing day returns the associated hearing day successfully" do
+        expect(legacy_hearing.hearing_day).to eq hearing_day
+      end
+
+      it "get hearing day calls VACOLS only once" do
+        expect(HearingRepository).to receive(:load_vacols_data).once
+
+        legacy_hearing.hearing_day
+        legacy_hearing.hearing_day
+      end
+    end
+
+    context "associated hearing day does not exist" do
+      let(:legacy_hearing) { create(:legacy_hearing, hearing_day: nil) }
+
+      it "get hearing day returns nil" do
+        expect(legacy_hearing.hearing_day).to eq nil
+      end
+    end
+  end
 end

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -366,7 +366,7 @@ describe LegacyHearing, :all_dbs do
     end
   end
 
-  context "#hearing_day", focus: true do
+  context "#hearing_day" do
     context "associated hearing day exists" do
       let(:hearing_day) { create(:hearing_day) }
       let(:legacy_hearing) { create(:legacy_hearing, hearing_day: hearing_day) }

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -394,7 +394,7 @@ describe LegacyHearing, :all_dbs do
         let(:hearing_day) do
           create(
             :hearing_day,
-            scheduled_for: DateTime.new(2018, 1, 1),
+            scheduled_for: Time.zone.local(2018, 1, 1),
             request_type: HearingDay::REQUEST_TYPES[:central]
           )
         end


### PR DESCRIPTION
Resolves #11377 

### Description

  - rename `hearing_day_id` to `hearing_day_vacols_id`
  - save hearing day id from VACOLS in `hearing_day_id`
  - added some tests for `hearing_day` method on `LegacyHearing`