### PR TITLE
Refactor SlackService

### DIFF
--- a/app/jobs/caseflow_job.rb
+++ b/app/jobs/caseflow_job.rb
@@ -1,11 +1,4 @@
 # frozen_string_literal: true
 
 class CaseflowJob < ApplicationJob
-  def slack_url
-    ENV["SLACK_DISPATCH_ALERT_URL"]
-  end
-
-  def slack_service
-    @slack_service ||= SlackService.new(url: slack_url)
-  end
 end

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -23,7 +23,10 @@ class DataIntegrityChecksJob < CaseflowJob
   private
 
   def send_to_slack(checker)
-    slack = SlackService.new(url: ENV["SLACK_DISPATCH_ALERT_URL"])
-    slack.send_notification(checker.report, checker.class.name, checker.slack_channel)
+    SlackService.new(
+      msg: checker.report,
+      title: checker.class.name,
+      channel: checker.slack_channel
+    ).send_notification
   end
 end

--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -100,6 +100,6 @@ class HearingDispositionChangeJob < CaseflowJob
     Rails.logger.info(hearing_ids)
     Rails.logger.info(err.backtrace.join("\n")) if err
 
-    slack_service.send_notification(msg)
+    SlackService.new(msg: msg).send_notification
   end
 end

--- a/app/jobs/monitor_business_critical_jobs_job.rb
+++ b/app/jobs/monitor_business_critical_jobs_job.rb
@@ -20,7 +20,7 @@ class MonitorBusinessCriticalJobsJob < CaseflowJob
 
     # Log monitoring information to both logs & slack
     Rails.logger.info(results_message)
-    slack_service.send_notification(slack_message)
+    SlackService.new(msg: slack_message).send_notification
   end
 
   # build a hash of keys with their last started and completed timestamps

--- a/app/jobs/out_of_service_reminder_job.rb
+++ b/app/jobs/out_of_service_reminder_job.rb
@@ -13,8 +13,10 @@ class OutOfServiceReminderJob < ApplicationJob
       out_of_service_apps.push(app.humanize) if Rails.cache.read(app + "_out_of_service")
     end
 
-    SlackService.new(url: url).send_notification(message(out_of_service_apps)) unless out_of_service_apps.empty?
+    SlackService.new(msg: message(out_of_service_apps)).send_notification unless out_of_service_apps.empty?
   end
+
+  private
 
   def message(apps)
     if apps.include?("Caseflow")
@@ -22,9 +24,5 @@ class OutOfServiceReminderJob < ApplicationJob
     else
       "Reminder: #{apps.to_sentence} are out of service."
     end
-  end
-
-  def url
-    ENV["SLACK_DISPATCH_ALERT_URL"]
   end
 end

--- a/app/jobs/prepare_establish_claim_tasks_job.rb
+++ b/app/jobs/prepare_establish_claim_tasks_job.rb
@@ -28,10 +28,6 @@ class PrepareEstablishClaimTasksJob < ApplicationJob
     msg = "PrepareEstablishClaimTasksJob successfully ran: #{count[:success]} tasks " \
           "prepared and #{count[:fail]} tasks failed"
     Rails.logger.info msg
-    SlackService.new(url: url).send_notification(msg)
-  end
-
-  def url
-    ENV["SLACK_DISPATCH_ALERT_URL"]
+    SlackService.new(msg: msg).send_notification
   end
 end

--- a/app/jobs/sync_intake_job.rb
+++ b/app/jobs/sync_intake_job.rb
@@ -12,17 +12,26 @@ class SyncIntakeJob < CaseflowJob
 
     Intake.close_expired_intakes!
 
-    appeals_to_reclose = RampClosedAppeal.appeals_to_reclose
-    reclosed_appeals = []
-    appeals_to_reclose.each do |appeal|
+    SlackService.new(msg: slack_message).send_notification
+  end
+
+  private
+
+  def slack_message
+    "Intake: Successfully reclosed #{reclosed_appeals.count} out of #{appeals_to_reclose.count} RAMP VACOLS appeals"
+  end
+
+  def reclosed_appeals
+    appeals_to_reclose.each_with_object([]) do |appeal, result|
       appeal.reclose!
-      reclosed_appeals << appeal
+      result << appeal
     rescue StandardError => error
       # Rescue and capture errors so they don't cause the job to stop
       capture_exception(error: error, extra: { ramp_closed_appeal_id: appeal.id })
     end
-    slack_service.send_notification(
-      "Intake: Successfully reclosed #{reclosed_appeals.count} out of #{appeals_to_reclose.count} RAMP VACOLS appeals"
-    )
+  end
+
+  def appeals_to_reclose
+    @appeals_to_reclose ||= RampClosedAppeal.appeals_to_reclose
   end
 end

--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -109,7 +109,7 @@ class UpdateAppellantRepresentationJob < CaseflowJob
     Rails.logger.info(msg)
     Rails.logger.info(err.backtrace.join("\n"))
 
-    slack_service.send_notification(msg)
+    SlackService.new(msg: msg).send_notification
 
     record_runtime(start_time)
   end

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -130,7 +130,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     Rails.logger.info(msg)
     Rails.logger.info(err.backtrace.join("\n"))
 
-    slack_service.send_notification(msg)
+    SlackService.new(msg: msg).send_notification
 
     record_runtime(start_time)
   end

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -70,7 +70,6 @@ class WarmBgsCachesJob < CaseflowJob
   end
 
   def notify_slack(msg)
-    slack = SlackService.new(url: ENV["SLACK_DISPATCH_ALERT_URL"])
-    slack.send_notification(msg, "WarmBgsCachesJob")
+    SlackService.new(msg: msg, title: "WarmBgsCachesJob").send_notification
   end
 end

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -6,7 +6,7 @@ describe DataIntegrityChecksJob do
   let(:expired_async_jobs_checker) { ExpiredAsyncJobsChecker.new }
   let(:open_hearing_tasks_without_active_descendants_checker) { OpenHearingTasksWithoutActiveDescendantsChecker.new }
   let(:untracked_legacy_appeals_checker) { UntrackedLegacyAppealsChecker.new }
-  let(:slack_service) { SlackService.new(url: "http://www.example.com") }
+  let(:slack_service) { instance_double(SlackService) }
 
   before do
     allow(ExpiredAsyncJobsChecker).to receive(:new).and_return(expired_async_jobs_checker)
@@ -52,6 +52,9 @@ describe DataIntegrityChecksJob do
       end
 
       it "sends slack notification if there is a report" do
+        expect(SlackService).to receive(:new)
+          .with(msg: "1 expired async job", title: "ExpiredAsyncJobsChecker", channel: "#appeals-app-alerts")
+
         described_class.perform_now
 
         expect(expired_async_jobs_checker).to have_received(:call).once

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -179,16 +179,15 @@ describe HearingDispositionChangeJob, :all_dbs do
 
     context "when the job runs successfully" do
       it "logs and sends the correct message to slack" do
-        slack_msg = ""
-        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+        expected_msg = "HearingDispositionChangeJob completed after running for .*." \
+          " Encountered errors for #{error_count} hearings."
+        slack_service = instance_double(SlackService)
 
+        expect(SlackService).to receive(:new).with(msg: /#{expected_msg}/).and_return(slack_service)
+        expect(slack_service).to receive(:send_notification)
         expect(Rails.logger).to receive(:info).exactly(2).times
 
         HearingDispositionChangeJob.new.log_info(start_time, task_count_for, error_count, hearing_ids, error)
-
-        expected_msg = "HearingDispositionChangeJob completed after running for .*." \
-          " Encountered errors for #{error_count} hearings."
-        expect(slack_msg).to match(/#{expected_msg}/)
       end
     end
 
@@ -196,16 +195,16 @@ describe HearingDispositionChangeJob, :all_dbs do
       let(:task_count_for) { { first_key: 0, second_key: 13 } }
 
       it "includes a sentence in the output message for each element of the hash" do
-        slack_msg = ""
-        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
-
-        HearingDispositionChangeJob.new.log_info(start_time, task_count_for, error_count, hearing_ids, error)
-
         expected_msg = "HearingDispositionChangeJob completed after running for .*." \
           " Processed 0 First key hearings." \
           " Processed 13 Second key hearings." \
           " Encountered errors for #{error_count} hearings."
-        expect(slack_msg).to match(/#{expected_msg}/)
+        slack_service = instance_double(SlackService)
+
+        expect(SlackService).to receive(:new).with(msg: /#{expected_msg}/).and_return(slack_service)
+        expect(slack_service).to receive(:send_notification)
+
+        HearingDispositionChangeJob.new.log_info(start_time, task_count_for, error_count, hearing_ids, error)
       end
     end
 
@@ -219,16 +218,15 @@ describe HearingDispositionChangeJob, :all_dbs do
       end
 
       it "logs an error message and sends the correct message to slack" do
-        slack_msg = ""
-        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+        expected_msg = "HearingDispositionChangeJob failed after running for .*." \
+          " Encountered errors for #{error_count} hearings. Fatal error: #{err_msg}"
+        slack_service = instance_double(SlackService)
 
+        expect(SlackService).to receive(:new).with(msg: /#{expected_msg}/).and_return(slack_service)
+        expect(slack_service).to receive(:send_notification)
         expect(Rails.logger).to receive(:info).exactly(3).times
 
         HearingDispositionChangeJob.new.log_info(start_time, task_count_for, error_count, hearing_ids, error)
-
-        expected_msg = "HearingDispositionChangeJob failed after running for .*." \
-          " Encountered errors for #{error_count} hearings. Fatal error: #{err_msg}"
-        expect(slack_msg).to match(/#{expected_msg}/)
       end
     end
   end

--- a/spec/jobs/monitor_business_critical_jobs_job_spec.rb
+++ b/spec/jobs/monitor_business_critical_jobs_job_spec.rb
@@ -54,8 +54,12 @@ describe MonitorBusinessCriticalJobsJob do
           "#{@failure_job_class} failed to complete in the last 5 hours",
           "here"
         ]
-        expect(job.slack_service).to receive(:send_notification)
-          .with(including(*included_values))
+        slack_service = instance_double(SlackService)
+
+        expect(SlackService).to receive(:new)
+          .with(msg: including(*included_values)).and_return(slack_service)
+        expect(slack_service).to receive(:send_notification)
+
         job.perform
       end
     end
@@ -67,8 +71,12 @@ describe MonitorBusinessCriticalJobsJob do
           "failed to compelete",
           "here"
         ]
-        expect(job.slack_service).to receive(:send_notification)
-          .with(excluding(*excluded_values))
+        slack_service = instance_double(SlackService)
+
+        expect(SlackService).to receive(:new)
+          .with(msg: excluding(*excluded_values)).and_return(slack_service)
+        expect(slack_service).to receive(:send_notification)
+
         job.perform
       end
     end

--- a/spec/jobs/sync_intake_job_spec.rb
+++ b/spec/jobs/sync_intake_job_spec.rb
@@ -4,12 +4,6 @@ require "rails_helper"
 
 describe SyncIntakeJob do
   context ".perform" do
-    before do
-      slack_service = double("SlackService")
-      expect(slack_service).to receive(:send_notification)
-      allow_any_instance_of(SyncIntakeJob).to receive(:slack_service).and_return(slack_service)
-    end
-
     it "calls Intake.close_expired_intakes!" do
       expect(RampClosedAppeal).to receive(:appeals_to_reclose).and_return([])
       expect(Intake).to receive(:close_expired_intakes!)
@@ -26,8 +20,13 @@ describe SyncIntakeJob do
       end
 
       it "attempts to reclose them" do
+        slack_service = instance_double(SlackService)
+        expected_msg = "Intake: Successfully reclosed 2 out of 2 RAMP VACOLS appeals"
+
         expect(appeal_1).to receive(:reclose!)
         expect(appeal_2).to receive(:reclose!)
+        expect(SlackService).to receive(:new).with(msg: expected_msg).and_return(slack_service)
+        expect(slack_service).to receive(:send_notification)
 
         SyncIntakeJob.perform_now
       end
@@ -35,8 +34,14 @@ describe SyncIntakeJob do
       context "when an error is thrown" do
         it "captures it and carries on" do
           allow(appeal_1).to receive(:reclose!).and_raise(StandardError.new)
+
+          slack_service = instance_double(SlackService)
+          expected_msg = "Intake: Successfully reclosed 1 out of 2 RAMP VACOLS appeals"
+
           expect(Raven).to receive(:capture_exception)
           expect(appeal_2).to receive(:reclose!)
+          expect(SlackService).to receive(:new).with(msg: expected_msg).and_return(slack_service)
+          expect(slack_service).to receive(:send_notification)
 
           SyncIntakeJob.perform_now
         end

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -67,14 +67,13 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
     end
 
     it "sends a message to Slack that includes the error" do
-      slack_msg = ""
-      allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+      expected_msg = "UpdateCachedAppealsAttributesJob failed after running for .*. Fatal error: #{error_msg}"
+      slack_service = instance_double(SlackService)
+
+      expect(SlackService).to receive(:new).with(msg: /#{expected_msg}/).and_return(slack_service)
+      expect(slack_service).to receive(:send_notification)
 
       UpdateCachedAppealsAttributesJob.perform_now
-
-      expected_msg = "UpdateCachedAppealsAttributesJob failed after running for .*. Fatal error: #{error_msg}"
-
-      expect(slack_msg).to match(/#{expected_msg}/)
     end
   end
 end

--- a/spec/jobs/warm_bgs_caches_job_spec.rb
+++ b/spec/jobs/warm_bgs_caches_job_spec.rb
@@ -40,7 +40,13 @@ describe WarmBgsCachesJob, :all_dbs do
     end
 
     it "fetches all hearings and warms the Rails cache" do
+      slack_service = instance_double(SlackService)
+
       # validate data before we run job
+      expect(SlackService).to receive(:new)
+        .with(msg: "Updated cached attributes for 1 Veteran records", title: "WarmBgsCachesJob")
+        .and_return(slack_service)
+      expect(slack_service).to receive(:send_notification)
       expect(appeal.reload.veteran[:ssn]).to be_nil
       expect(Rails.cache.exist?(poa_cache_key)).to eq(false)
       expect(Rails.cache.exist?(address_cache_key)).to eq(false)
@@ -54,7 +60,6 @@ describe WarmBgsCachesJob, :all_dbs do
       expect(Rails.cache.exist?(poa_cache_key)).to eq(true)
       expect(Rails.cache.exist?(address_cache_key)).to eq(true)
       expect(appeal.veteran.reload[:ssn]).to_not be_nil
-      expect(@slack_msg).to eq("Updated cached attributes for 1 Veteran records")
     end
   end
 end

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -1,19 +1,158 @@
 # frozen_string_literal: true
 
-describe SlackService do
-  let(:slack_service) { SlackService.new(url: "http://www.example.com") }
+require "rails_helper"
 
-  it "posts to http" do
-    allow_any_instance_of(HTTPClient).to receive(:post).and_return("response")
-    response = slack_service.send_notification("hello")
+describe SlackService do
+  context "channel and title not specified, DEPLOY_ENV not set" do
+    it "makes a POST HTTP request with default Slack params" do
+      http_library = FakeHttpLibrary.new
+      url = "http://www.example.com"
+      stub_const("ENV", "SLACK_DISPATCH_ALERT_URL" => url)
+      slack_service = SlackService.new(msg: "hello", http_service: http_library)
+      slack_msg = {
+        username: "Caseflow (development)",
+        channel: "#appeals-app-alerts",
+        attachments: [
+          {
+            title: "",
+            color: "#ccc",
+            text: "hello"
+          }
+        ]
+      }
+
+      params = {
+        body: slack_msg.to_json,
+        headers: { "Content-Type" => "application/json" }
+      }
+
+      expect(http_library).to receive(:post).with(url, params)
+
+      slack_service.send_notification
+    end
+  end
+
+  context "DEPLOY_ENV is set" do
+    it "lists value of DEPLOY_ENV in username attribute" do
+      http_library = FakeHttpLibrary.new
+      url = "http://www.example.com"
+      stub_const("ENV", "SLACK_DISPATCH_ALERT_URL" => url, "DEPLOY_ENV" => "test")
+      slack_service = SlackService.new(msg: "hello", http_service: http_library)
+      slack_msg = {
+        username: "Caseflow (test)",
+        channel: "#appeals-app-alerts",
+        attachments: [
+          {
+            title: "",
+            color: "#ccc",
+            text: "hello"
+          }
+        ]
+      }
+
+      params = {
+        body: slack_msg.to_json,
+        headers: { "Content-Type" => "application/json" }
+      }
+
+      expect(http_library).to receive(:post).with(url, params)
+
+      slack_service.send_notification
+    end
+  end
+
+  context "channel specified and already starts with the # character" do
+    it "does not add another # character to the channel param" do
+      http_library = FakeHttpLibrary.new
+      url = "http://www.example.com"
+      stub_const("ENV", "SLACK_DISPATCH_ALERT_URL" => url)
+      slack_service = SlackService.new(
+        msg: "hello", title: "title", channel: "#channel", http_service: http_library
+      )
+      slack_msg = {
+        username: "Caseflow (development)",
+        channel: "#channel",
+        attachments: [
+          {
+            title: "title",
+            color: "#ccc",
+            text: "hello"
+          }
+        ]
+      }
+
+      params = {
+        body: slack_msg.to_json,
+        headers: { "Content-Type" => "application/json" }
+      }
+
+      expect(http_library).to receive(:post).with(url, params)
+
+      slack_service.send_notification
+    end
+  end
+
+  context "channel specified but doesn't include # character" do
+    it "does prepends channel name with # character" do
+      http_library = FakeHttpLibrary.new
+      url = "http://www.example.com"
+      stub_const("ENV", "SLACK_DISPATCH_ALERT_URL" => url)
+      slack_service = SlackService.new(
+        msg: "hello", title: "title", channel: "channel", http_service: http_library
+      )
+      slack_msg = {
+        username: "Caseflow (development)",
+        channel: "#channel",
+        attachments: [
+          {
+            title: "title",
+            color: "#ccc",
+            text: "hello"
+          }
+        ]
+      }
+
+      params = {
+        body: slack_msg.to_json,
+        headers: { "Content-Type" => "application/json" }
+      }
+
+      expect(http_library).to receive(:post).with(url, params)
+
+      slack_service.send_notification
+    end
+  end
+
+  it "returns the http response" do
+    http_library = FakeHttpLibrary.new
+    slack_service = SlackService.new(msg: "hello", http_service: http_library)
+    stub_const("ENV", "SLACK_DISPATCH_ALERT_URL" => "http://www.example.com")
+    allow(http_library).to receive(:post).and_return("response")
+    response = slack_service.send_notification
+
     expect(response).to eq("response")
   end
 
   context "when it is run in the uat environment" do
     it "does not make post request" do
+      http_library = FakeHttpLibrary.new
+      slack_service = SlackService.new(msg: "hello", http_service: http_library)
       stub_const("ENV", "DEPLOY_ENV" => "uat")
-      expect_any_instance_of(HTTPClient).to_not receive(:post)
-      slack_service.send_notification("filler message contents")
+
+      expect(http_library).to_not receive(:post)
+
+      slack_service.send_notification
+    end
+  end
+
+  context "when SLACK_DISPATCH_ALERT_URL env var is not set" do
+    it "does not make post request" do
+      http_library = FakeHttpLibrary.new
+      slack_service = SlackService.new(msg: "hello", http_service: http_library)
+
+      expect(http_library).to_not receive(:post)
+
+      slack_service.send_notification
     end
   end
 end

--- a/spec/support/fake_http_library.rb
+++ b/spec/support/fake_http_library.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class FakeHttpLibrary
+  def post(_url, _params); end
+end


### PR DESCRIPTION
**Why**:
- To make the tests less brittle by using dependency injection. If we
end up using a different HTTP library, such as Faraday, we won't have
to change the tests
- To eliminate the use of `allow_any_instance_of`, which is discouraged
by the RSpec maintainers
- To use named keywords so that's it's clear what each argument
represents
- To fix the FeatureEnvy code smell by making the msg, title, and
channel arguments part of the initialization as opposed to arguments
for the `send_notification` method.

This PR also improves test coverage for SlackService, which revealed
a bug when the channel argument did not start with the # character.

Further improvements could be to rename the class from the generic
`SlackService` to something more precise such as `SlackNotification`
and then rename the `send_notification` method to `call`.