### PR TITLE
Update connect_vbms gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "0e39b66ff1224f27419f8f2838e4c5a72e6c7233"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "b4f43a9e52fcb322c28532ad3d30efdfe588c940"
 gem "dogstatsd-ruby"
 gem "fast_jsonapi"
 gem "holidays", "~> 6.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 0e39b66ff1224f27419f8f2838e4c5a72e6c7233
-  ref: 0e39b66ff1224f27419f8f2838e4c5a72e6c7233
+  revision: b4f43a9e52fcb322c28532ad3d30efdfe588c940
+  ref: b4f43a9e52fcb322c28532ad3d30efdfe588c940
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
**Why**: To take advantage of a recent fix to allow custom errors to
be sent to Sentry.
