### PR TITLE
BGSService.may_modify depends on conflict checker

### DIFF
--- a/app/models/validators/intake_start_validator.rb
+++ b/app/models/validators/intake_start_validator.rb
@@ -71,6 +71,6 @@ class IntakeStartValidator
   end
 
   def user_may_modify_veteran_file?
-    BGSService.new.may_modify?(veteran_file_number)
+    BGSService.new.may_modify?(veteran_file_number, veteran.participant_id)
   end
 end

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -200,11 +200,11 @@ class ExternalApi::BGSService
 
   # can_access? reflects whether a user may read a veteran's records.
   # may_modify? reflects whether a user may establish a new claim.
-  def may_modify?(vbms_id)
+  def may_modify?(vbms_id, veteran_participant_id)
     return false unless can_access?(vbms_id)
 
     conflict_checker = ExternalApi::BgsVeteranStationUserConflict.new(
-      veteran_participant_id: @veteran_info[vbms_id][:ptcpnt_id],
+      veteran_participant_id: veteran_participant_id,
       client: client
     )
     !conflict_checker.call

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -198,16 +198,16 @@ class ExternalApi::BGSService
     end
   end
 
-  # Passing false to can_access? client method will use the find_flashes method underneath
-  # which has more robust sensitivity checks.
+  # can_access? reflects whether a user may read a veteran's records.
+  # may_modify? reflects whether a user may establish a new claim.
   def may_modify?(vbms_id)
-    DBService.release_db_connections
+    return false unless can_access?(vbms_id)
 
-    MetricsService.record("BGS: can_access (find_flashes): #{vbms_id}",
-                          service: :bgs,
-                          name: "may_modify?") do
-      client.can_access?(vbms_id, false)
-    end
+    conflict_checker = ExternalApi::BgsVeteranStationUserConflict.new(
+      veteran_participant_id: @veteran_info[vbms_id][:ptcpnt_id],
+      client: client
+    )
+    !conflict_checker.call
   end
 
   def bust_can_access_cache(user, vbms_id)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -203,11 +203,10 @@ class ExternalApi::BGSService
   def may_modify?(vbms_id, veteran_participant_id)
     return false unless can_access?(vbms_id)
 
-    conflict_checker = ExternalApi::BgsVeteranStationUserConflict.new(
+    !ExternalApi::BgsVeteranStationUserConflict.new(
       veteran_participant_id: veteran_participant_id,
       client: client
-    )
-    !conflict_checker.call
+    ).conflict?
   end
 
   def bust_can_access_cache(user, vbms_id)

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExternalApi::BgsVeteranStationUserConflict
   def initialize(veteran_participant_id:, client: nil)
     @veteran_participant_id = veteran_participant_id
@@ -12,7 +14,6 @@ class ExternalApi::BgsVeteranStationUserConflict
     return true if station_dtos.any? && !veteran_dto
 
     # otherwise we must check sensitivity reason
-
   end
 
   private
@@ -36,7 +37,7 @@ class ExternalApi::BgsVeteranStationUserConflict
 
     return false unless veteran_dto
 
-    return veteran_dto[:station_number] == current_user_station
+    veteran_dto[:station_number] == current_user_station
   end
 
   def veteran_station_id
@@ -60,9 +61,11 @@ class ExternalApi::BgsVeteranStationUserConflict
   end
 
   def sensitivity_level
-    @sensitivity_level ||= MetricsService.record("BGS: fetch sensitivity level by participant id: #{veteran_participant_id}",
-                                                 service: :bgs,
-                                                 name: "security.find_sensitivity_level_by_participant_id") do
+    @sensitivity_level ||= MetricsService.record(
+      "BGS: fetch sensitivity level by participant id: #{veteran_participant_id}",
+      service: :bgs,
+      name: "security.find_sensitivity_level_by_participant_id"
+    ) do
       client.security.find_sensitivity_level_by_participant_id(veteran_participant_id)
     end
   end

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -1,0 +1,73 @@
+class ExternalApi::BgsVeteranStationUserConflict
+  def initialize(veteran_participant_id:, client: nil)
+    @veteran_participant_id = veteran_participant_id
+    @client = client
+  end
+
+  # logic detailed in https://github.com/department-of-veterans-affairs/caseflow/issues/10087#issuecomment-507783830
+  def call
+    DBService.release_db_connections
+
+    # simple case if DTOs exist and do not contain a Veteran record
+    return true if station_dtos.any? && !veteran_dto
+
+    # otherwise we must check sensitivity reason
+
+  end
+
+  private
+
+  attr_reader :veteran_participant_id
+
+  def current_user_station
+    RequestStore[:current_user].station_id.to_s
+  end
+
+  def station_dtos
+    [employee_dtos[:station]].flatten
+  end
+
+  def veteran_dto
+    station_dtos.find { |dto| dto[:ptcpnt_rlnshp_type_nm] == "Veteran" }
+  end
+
+  def veteran_at_same_station?
+    return false unless station_dtos
+
+    return false unless veteran_dto
+
+    return veteran_dto[:station_number] == current_user_station
+  end
+
+  def veteran_station_id
+    "#{sensitivity_level[:fclty_type_cd]}#{sensitivity_level[:cd]}"
+  end
+
+  def sensitivity_reason
+    sensitivity_level[:sntvty_reason_type_nm]
+  end
+
+  def violates_sensitivity_reason?
+    ["Relative of Local VA Employee", "VBA Employee", "Veteran", "Work Study"].include?(sensitivity_reason)
+  end
+
+  def employee_dtos
+    @employee_dtos ||= MetricsService.record("BGS: fetch employee by participant id: #{veteran_participant_id}",
+                                             service: :bgs,
+                                             name: "people.find_employee_by_participant_id") do
+      client.people.find_employee_by_participant_id(veteran_participant_id)
+    end
+  end
+
+  def sensitivity_level
+    @sensitivity_level ||= MetricsService.record("BGS: fetch sensitivity level by participant id: #{veteran_participant_id}",
+                                                 service: :bgs,
+                                                 name: "security.find_sensitivity_level_by_participant_id") do
+      client.security.find_sensitivity_level_by_participant_id(veteran_participant_id)
+    end
+  end
+
+  def client
+    @client ||= ExternalApi::BGSService.new.client
+  end
+end

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -7,6 +7,9 @@ class ExternalApi::BgsVeteranStationUserConflict
   end
 
   # logic detailed in https://github.com/department-of-veterans-affairs/caseflow/issues/10087#issuecomment-507783830
+  # a good example in production is veteran_participant_id 3309696 and user id 2321
+  # "true" return value in this case means there is a conflict.
+  # "false" means no conflict.
   def call
     DBService.release_db_connections
 
@@ -14,6 +17,10 @@ class ExternalApi::BgsVeteranStationUserConflict
     return true if station_dtos.any? && !veteran_dto
 
     # otherwise we must check sensitivity reason
+    return true if violates_sensitivity_reason?
+
+    # default is no conflict
+    false
   end
 
   private
@@ -37,7 +44,7 @@ class ExternalApi::BgsVeteranStationUserConflict
 
     return false unless veteran_dto
 
-    veteran_dto[:station_number] == current_user_station
+    veteran_station_id == current_user_station
   end
 
   def veteran_station_id

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -12,7 +12,7 @@ class ExternalApi::BgsVeteranStationUserConflict
   # a good example in production is veteran_participant_id 3309696 and user id 2321
   # "true" return value in this case means there is a conflict.
   # "false" means no conflict.
-  def call
+  def conflict?
     DBService.release_db_connections
 
     return false unless station_dtos.any?

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # tests are all via ExternalApi::BGSService
-# :nocov:
 class ExternalApi::BgsVeteranStationUserConflict
+# :nocov:
   def initialize(veteran_participant_id:, client: nil)
     @veteran_participant_id = veteran_participant_id
     @client = client
@@ -94,5 +94,5 @@ class ExternalApi::BgsVeteranStationUserConflict
   def client
     @client ||= ExternalApi::BGSService.new.client
   end
-end
 # :nocov:
+end

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+# tests are all via ExternalApi::BGSService
+# :nocov:
 class ExternalApi::BgsVeteranStationUserConflict
-  # tests are all via ExternalApi::BGSService
-  # :nocov:
   def initialize(veteran_participant_id:, client: nil)
     @veteran_participant_id = veteran_participant_id
     @client = client
@@ -29,7 +29,6 @@ class ExternalApi::BgsVeteranStationUserConflict
     # default is no conflict
     false
   end
-  # :nocov:
 
   private
 
@@ -95,3 +94,4 @@ class ExternalApi::BgsVeteranStationUserConflict
     @client ||= ExternalApi::BGSService.new.client
   end
 end
+# :nocov:

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -12,16 +12,17 @@ class ExternalApi::BgsVeteranStationUserConflict
   # a good example in production is veteran_participant_id 3309696 and user id 2321
   # "true" return value in this case means there is a conflict.
   # "false" means no conflict.
+  # a "DTO" is a Data Type Object which is just BGS SOAP API speak.
   def conflict?
     DBService.release_db_connections
 
     return false unless station_dtos.any?
 
     # simple case if DTOs exist and contain a Veteran record
-    return true if veteran_dto
+    return true if veteran_at_same_station
 
     # likewise for spouse
-    return true if spouse_dto
+    return true if spouse_at_same_station
 
     # otherwise we must check sensitivity reason
     return true if violates_sensitivity_reason?
@@ -42,11 +43,11 @@ class ExternalApi::BgsVeteranStationUserConflict
     [employee_dtos[:station]].flatten
   end
 
-  def veteran_dto
+  def veteran_at_same_station
     station_dtos.find { |dto| dto[:ptcpnt_rlnshp_type_nm] == "Veteran" }
   end
 
-  def spouse_dto
+  def spouse_at_same_station
     station_dtos.find { |dto| dto[:ptcpnt_rlnshp_type_nm] == "Spouse" }
   end
 

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -13,8 +13,13 @@ class ExternalApi::BgsVeteranStationUserConflict
   def call
     DBService.release_db_connections
 
-    # simple case if DTOs exist and do not contain a Veteran record
-    return true if station_dtos.any? && !veteran_dto
+    return false unless station_dtos.any?
+
+    # simple case if DTOs exist and contain a Veteran record
+    return true if veteran_dto
+
+    # likewise for spouse
+    return true if spouse_dto
 
     # otherwise we must check sensitivity reason
     return true if violates_sensitivity_reason?
@@ -39,6 +44,10 @@ class ExternalApi::BgsVeteranStationUserConflict
     station_dtos.find { |dto| dto[:ptcpnt_rlnshp_type_nm] == "Veteran" }
   end
 
+  def spouse_dto
+    station_dtos.find { |dto| dto[:ptcpnt_rlnshp_type_nm] == "Spouse" }
+  end
+
   def veteran_at_same_station?
     return false unless station_dtos
 
@@ -56,6 +65,8 @@ class ExternalApi::BgsVeteranStationUserConflict
   end
 
   def violates_sensitivity_reason?
+    return false unless sensitivity_level
+
     ["Relative of Local VA Employee", "VBA Employee", "Veteran", "Work Study"].include?(sensitivity_reason)
   end
 

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -2,7 +2,7 @@
 
 # tests are all via ExternalApi::BGSService
 class ExternalApi::BgsVeteranStationUserConflict
-# :nocov:
+  # :nocov:
   def initialize(veteran_participant_id:, client: nil)
     @veteran_participant_id = veteran_participant_id
     @client = client
@@ -97,5 +97,5 @@ class ExternalApi::BgsVeteranStationUserConflict
   def client
     @client ||= ExternalApi::BGSService.new.client
   end
-# :nocov:
+  # :nocov:
 end

--- a/app/services/external_api/bgs_veteran_station_user_conflict.rb
+++ b/app/services/external_api/bgs_veteran_station_user_conflict.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ExternalApi::BgsVeteranStationUserConflict
+  # tests are all via ExternalApi::BGSService
+  # :nocov:
   def initialize(veteran_participant_id:, client: nil)
     @veteran_participant_id = veteran_participant_id
     @client = client
@@ -27,6 +29,7 @@ class ExternalApi::BgsVeteranStationUserConflict
     # default is no conflict
     false
   end
+  # :nocov:
 
   private
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -497,7 +497,7 @@ class Fakes::BGSService
     end
   end
 
-  def may_modify?(vbms_id)
+  def may_modify?(vbms_id, veteran_participant_id)
     !(self.class.inaccessible_appeal_vbms_ids || []).include?(vbms_id)
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -497,7 +497,7 @@ class Fakes::BGSService
     end
   end
 
-  def may_modify?(vbms_id, veteran_participant_id)
+  def may_modify?(vbms_id, _veteran_participant_id)
     !(self.class.inaccessible_appeal_vbms_ids || []).include?(vbms_id)
   end
 

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -3,6 +3,7 @@
 describe ExternalApi::BGSService do
   let(:bgs_veteran_service) { double("veteran") }
   let(:bgs_people_service) { double("people") }
+  let(:bgs_security_service) { double("security") }
   let(:bgs_client) { double("BGS::Services") }
   let(:bgs) { ExternalApi::BGSService.new(client: bgs_client) }
   let(:veteran_record) { { name: "foo", ssn: "123" } }
@@ -53,9 +54,13 @@ describe ExternalApi::BGSService do
     before do
       allow(bgs_client).to receive(:people).and_return(bgs_people_service)
       allow(bgs_people_service).to receive(:find_employee_by_participant_id) { employee_dtos }
+
+      allow(bgs_client).to receive(:security).and_return(bgs_security_service)
+      allow(bgs_security_service).to receive(:find_sensitivity_level_by_participant_id) { sensitivity_level }
     end
 
     let(:veteran) { build(:veteran) }
+    let(:sensitivity_level) { nil }
 
     context "when Veteran is completely unrelated to user" do
       let(:employee_dtos) do
@@ -72,6 +77,48 @@ describe ExternalApi::BGSService do
         {
           ptcpnt_id: veteran.participant_id,
           station: { ptcpnt_id: "456", ptcpnt_rlnshp_type_nm: "Spouse", station_number: user.station_id }
+        }
+      end
+
+      it "returns false" do
+        expect(subject).to be_falsey
+      end
+    end
+
+    context "when Veteran is a non-VBA employee" do
+      let(:employee_dtos) do
+        {
+          ptcpnt_id: veteran.participant_id,
+          station: { ptcpnt_id: "456", ptcpnt_rlnshp_type_nm: "non-VBA employee", station_number: user.station_id }
+        }
+      end
+      let(:sensitivity_level) do
+        {
+          cd: user.station_id[1..2],
+          fclty_type_cd: user.station_id[0],
+          scrty_level_type_cd: "6",
+          sntvty_reason_type_nm: "Non-VBA Employee"
+        }
+      end
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when Veteran is a VBA employee" do
+      let(:employee_dtos) do
+        {
+          ptcpnt_id: veteran.participant_id,
+          station: { ptcpnt_id: "456", ptcpnt_rlnshp_type_nm: "VBA employee", station_number: user.station_id }
+        }
+      end
+      let(:sensitivity_level) do
+        {
+          cd: user.station_id[1..2],
+          fclty_type_cd: user.station_id[0],
+          scrty_level_type_cd: "6",
+          sntvty_reason_type_nm: "VBA Employee"
         }
       end
 


### PR DESCRIPTION
Resolves #11736 

### Description
Implements additional sensitivity checks to prevent user not authorized errors during intake establishment.

The full algorithm is in https://github.com/department-of-veterans-affairs/caseflow/issues/10087#issuecomment-507783830

Tested in production with the following user_id/veteran_participant_id pairs that had previously failed:

```ruby
tests = [
  ["2321", "3309696"],
  ["3309", "4012373"],
  ["5290", "35206608"],
]

tests.each do |pair|
  RequestStore[:current_user] = User.find pair[0]
  checker = ExternalApi::BgsVeteranStationUserConflict.new(veteran_participant_id: pair[1])
  puts "#{pair} => #{checker.conflict?}" # should return true
end
```