### PR TITLE
Update Nokogiri to protect against CVE-2019-5477

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ gem "kaminari"
 gem "loofah", ">= 2.2.3"
 gem "moment_timezone-rails"
 gem "newrelic_rpm"
-# nokogiri versions before 1.10.3 are affected by CVE-2019-11068. Explicitly define nokogiri version here to avoid that.
-# https://github.com/sparklemotion/nokogiri/issues/1892
-gem "nokogiri", "1.10.3"
+# nokogiri versions before 1.10.4 are vulnerable to CVE-2019-5477.
+# https://github.com/sparklemotion/nokogiri/issues/1915
+gem "nokogiri", "~> 1.10.4"
 gem "paper_trail", "8.1.2"
 # Used to speed up reporting
 gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -315,7 +315,7 @@ GEM
     newrelic_rpm (6.3.0.355)
     nio4r (2.3.1)
     no_proxy_fix (0.1.2)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     notiffany (0.1.1)
@@ -580,7 +580,7 @@ DEPENDENCIES
   meta_request
   moment_timezone-rails
   newrelic_rpm
-  nokogiri (= 1.10.3)
+  nokogiri (~> 1.10.4)
   paper_trail (= 8.1.2)
   parallel
   paranoia (~> 2.2)


### PR DESCRIPTION
`bundle exec rake security` alerted us to a vulnerability in the Nokogiri library we use for XML and HTML parsing. This PR updates the library to a version that is not vulnerable to the disclosed CVE as per the directions presented by the maintainers (https://github.com/sparklemotion/nokogiri/issues/1915).

```bash
$> bundle exec rake security
...
Updated ruby-advisory-db
ruby-advisory-db: 384 advisories
Looking for ~/Projects/caseflow/.security.yml
bundle-audit check --ignore=
Name: nokogiri
Version: 1.10.3
Advisory: CVE-2019-5477
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1915
Title: Nokogiri Command Injection Vulnerability via Nokogiri::CSS::Tokenizer#load_file
Solution: upgrade to >= 1.10.4

Vulnerabilities found!

Failed. Security vulnerabilities were found. Find the dependency in Gemfile.lock,
then specify a safe version of the dependency in the Gemfile (preferred) or
snooze the CVE in .security.yml for a week.
```