### PR TITLE
Add webmock gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,4 +118,8 @@ group :development do
   # POSIX systems should have this already, so we're not going to bring it in on other platforms
   gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 end
+
+group :test do
+  gem "webmock"
+end
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
     connection_pool (2.2.1)
     cork (0.3.0)
       colored2 (~> 3.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     d3-rails (5.9.2)
       railties (>= 3.1)
@@ -248,6 +250,7 @@ GEM
       rspec (>= 2.99.0, < 4.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
+    hashdiff (1.0.0)
     heapy (0.1.4)
     holidays (6.6.1)
     httpclient (2.8.3)
@@ -456,6 +459,7 @@ GEM
       sexp_processor (~> 4.9)
     rubyzip (1.2.3)
     safe_shell (1.1.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -527,6 +531,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (~> 3.0)
+    webmock (3.6.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -620,6 +628,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   webdrivers
+  webmock
 
 BUNDLED WITH
    1.17.3

--- a/app/jobs/dependencies_check_job.rb
+++ b/app/jobs/dependencies_check_job.rb
@@ -3,18 +3,30 @@
 class DependenciesCheckJob < ApplicationJob
   queue_as :low_priority
 
-  def perform
-    if ENV["MONITOR_URL"].present?
-      begin
-        request = HTTPI::Request.new
-        request.url = ENV["MONITOR_URL"]
-        http = HTTPI.get(request, :httpclient)
-        Rails.cache.write(:dependencies_report, http.raw_body)
-      rescue StandardError
-        Rails.logger.error "There was a problem with HTTP request to #{ENV['MONITOR_URL']}"
-      end
-    else
-      Rails.logger.error "ENV[\"MONITOR_URL\"] not set"
-    end
+  def perform(_http_library = HTTPI)
+    return log_missing_env_var if monitor_url.blank?
+
+    Rails.cache.write(:dependencies_report, monitor_response.raw_body)
+  rescue StandardError => error
+    log_message = "There was a problem with HTTP request to #{monitor_url}: #{error}"
+    Rails.logger.error(log_message)
+  end
+
+  private
+
+  def log_missing_env_var
+    Rails.logger.error "ENV[\"MONITOR_URL\"] not set"
+  end
+
+  def monitor_response
+    http_library.get(monitor_url, :httpclient)
+  end
+
+  def monitor_url
+    ENV["MONITOR_URL"]
+  end
+
+  def http_library
+    arguments.first || HTTPI
   end
 end

--- a/spec/jobs/dependencies_check_job_spec.rb
+++ b/spec/jobs/dependencies_check_job_spec.rb
@@ -4,30 +4,52 @@ require "rails_helper"
 
 describe DependenciesCheckJob do
   context "when Monitor env is set" do
-    before do
-      allow_any_instance_of(HTTPI::Response).to receive(:raw_body).and_return('{
-        "BGS":{"name":"BGS","up_rate_5":100.0},
-        "VACOLS":{"name":"VACOLS","up_rate_5":10.0},
-        "VBMS":{"name":"VBMS","up_rate_5":49.0},
-        "VBMS.FindDocumentVersionReference":{"name":"VBMS.FindDocumentVersionReference","up_rate_5":100.0}
-      }')
-    end
     it "writes report in cache" do
-      stub_const("ENV", "MONITOR_URL" => "http://www.example.com")
-      DependenciesCheckJob.perform_now
-      expect(Rails.cache.read(:dependencies_report)).to match(/up_rate_5/)
+      monitor_url = "http://www.example.com"
+      stub_const("ENV", "MONITOR_URL" => monitor_url)
+      http_library = FakeHttpLibrary.new
+      allow(http_library).to receive(:get).with(monitor_url, any_args)
+        .and_return(FakeResponse.new)
+
+      DependenciesCheckJob.perform_now(http_library)
+
+      expect(Rails.cache.read(:dependencies_report)).to eq "fake raw body"
     end
 
-    it "when invalid url, it catches error" do
-      stub_const("ENV", "MONITOR_URL" => "www.example.com")
+    it "uses HTTPI by default" do
+      monitor_url = "http://www.example.com"
+      stub_const("ENV", "MONITOR_URL" => monitor_url)
+
+      expect(HTTPI).to receive(:get).and_return(FakeResponse.new)
+
       DependenciesCheckJob.perform_now
+    end
+
+    context "when monitor URL is invalid" do
+      it "rescues error and logs an error message" do
+        monitor_url = "www.example.com"
+        stub_const("ENV", "MONITOR_URL" => monitor_url)
+        http_library = FakeHttpLibrary.new
+        allow(http_library).to receive(:get).and_raise(ArgumentError, "invalid url")
+        allow(Rails.logger).to receive(:error)
+        log_message = "There was a problem with HTTP request to #{monitor_url}: invalid url"
+
+        DependenciesCheckJob.perform_now(http_library)
+
+        expect(Rails.logger).to have_received(:error).with(log_message)
+      end
     end
   end
 
   context "when Monitor env is not set" do
-    it "returns with no error" do
+    it "does not run the job and logs the missing env var" do
       stub_const("ENV", "MONITOR_URL" => nil)
-      DependenciesCheckJob.perform_now
+      http_library = FakeHttpLibrary.new
+
+      expect(http_library).to_not receive(:get)
+      expect(Rails.logger).to receive(:error).with("ENV[\"MONITOR_URL\"] not set")
+
+      DependenciesCheckJob.perform_now(http_library)
     end
   end
 end

--- a/spec/support/fake_http_library.rb
+++ b/spec/support/fake_http_library.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class FakeHttpLibrary
+  def get(_url, _params = nil); end
+end

--- a/spec/support/fake_response.rb
+++ b/spec/support/fake_response.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FakeResponse
+  def raw_body
+    "fake raw body"
+  end
+end


### PR DESCRIPTION
**Why**: To make sure we don't accidentally make external calls in our
tests.

This caused one spec to fail which I fixed by refactoring the job class
to use dependency injection so we can pass in any HTTP library in our
tests, and not have our tests depend on which library we're using.
