### PR TITLE
Validate Appeal.receipt_date only on intake

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -23,9 +23,9 @@ class Appeal < DecisionReview
   has_one :special_issue_list
   has_many :record_synced_by_job, as: :record
 
-  validate :validate_receipt_date, on: :create
   with_options on: :intake_review do
     validates :receipt_date, :docket_type, presence: { message: "blank" }
+    validate :validate_receipt_date
     validates :veteran_is_not_claimant, inclusion: { in: [true, false], message: "blank" }
     validates :legacy_opt_in_approved, inclusion: { in: [true, false], message: "blank" }
     validates_associated :claimants

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -23,7 +23,7 @@ class Appeal < DecisionReview
   has_one :special_issue_list
   has_many :record_synced_by_job, as: :record
 
-  validate :validate_receipt_date
+  validate :validate_receipt_date, on: :create
   with_options on: :intake_review do
     validates :receipt_date, :docket_type, presence: { message: "blank" }
     validates :veteran_is_not_claimant, inclusion: { in: [true, false], message: "blank" }

--- a/spec/models/appeal_intake_spec.rb
+++ b/spec/models/appeal_intake_spec.rb
@@ -168,14 +168,21 @@ describe AppealIntake, :all_dbs do
 
       context "claimant is nil" do
         let(:claimant) { nil }
-        let(:receipt_date) { 3.days.from_now }
 
         it "is expected to add an error that claimant cannot be blank" do
           expect(subject).to be_falsey
           expect(detail.errors[:claimant]).to include("blank")
-          expect(detail.errors[:receipt_date]).to include("in_future")
           expect(detail.claimants).to be_empty
         end
+      end
+    end
+
+    context "receipt date is in the future" do
+      let(:receipt_date) { 3.days.from_now }
+
+      it "is invalid" do
+        expect(subject).to be_falsey
+        expect(detail.errors[:receipt_date]).to include("in_future")
       end
     end
   end


### PR DESCRIPTION
Resolves #11769 

### Description
receipt_date validation should only apply at creation time. Dispatch and other subsequent outcoding steps can skip that requirement.

This affects appeals that were intaken during the "grey area" between RAMP activation (11/2017) and when we started enforcing the AMA day 2/19 (enforced in 4/2019).