### PR TITLE
Fix issue where filter options were shown as blank for Type and Docket

### DIFF
--- a/client/app/components/TableFilter.jsx
+++ b/client/app/components/TableFilter.jsx
@@ -25,6 +25,8 @@ const iconStyle = css(
  *   - @enableFilter {boolean} whether filtering is turned on for each column
  *   - @enableFilterTextTransform {boolean} when true, filter text that gets displayed
  *     is automatically capitalized. default is true.
+ *   - @getFilterIconRef {function}
+ *   - @getFilterValues {function} DEPRECATED
  *   - @tableData {array} the entire data set for the table (required to calculate
  *     the options each column can be filtered on)
  *   - @columnName {string} the name of the column in the table data
@@ -189,6 +191,8 @@ TableFilter.defaultProps = {
 TableFilter.propTypes = {
   enableFilter: PropTypes.bool,
   enableFilterTextTransform: PropTypes.bool,
+  getFilterIconRef: PropTypes.func,
+  getFilterValues: PropTypes.func,
   tableData: PropTypes.array,
   columnName: PropTypes.string,
   anyFiltersAreSet: PropTypes.bool,

--- a/client/app/components/TableFilter.jsx
+++ b/client/app/components/TableFilter.jsx
@@ -59,7 +59,7 @@ class TableFilter extends React.PureComponent {
     const { customFilterLabels, enableFilterTextTransform } = this.props;
     const countByColumnName = _.countBy(
       tableDataByRow,
-      (row) => this.transformColumnValue(row[columnName])
+      (row) => this.transformColumnValue(_.get(row, columnName))
     );
     const uniqueOptions = [];
     const filtersForColumn = _.get(this.props.filteredByList, columnName);


### PR DESCRIPTION
https://dsva.slack.com/archives/CHX8FMP28/p1565785588369200

<img width="1008" alt="Screen Shot 2019-08-14 at 1 52 44 PM" src="https://user-images.githubusercontent.com/1298274/63043758-d805a380-be9a-11e9-8d9f-1da8aef72b0f.png">

### Description

This line was changed:

https://github.com/department-of-veterans-affairs/caseflow/commit/25f579064e9953aa41c05c6b942175467dca5424#diff-9f502b8ca40c397109e5b1a4302ba58dL40

to:

https://github.com/department-of-veterans-affairs/caseflow/commit/25f579064e9953aa41c05c6b942175467dca5424#diff-9f502b8ca40c397109e5b1a4302ba58dR60-R63

to support filtering of columns of objects. It looks like `_.countBy` can resolve dotted column paths, where as using `row[columnName]` does not. Modifying the row column accessor to use `_.get` fixed the issue since it works with dotted column paths.