### PR TITLE
Add active status for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,6 +26,8 @@ class User < ApplicationRecord
 
   before_create :normalize_css_id
 
+  scope :active, -> { where(active: true) }
+
   def username
     css_id
   end

--- a/db/migrate/20190816155214_add_active_to_users.rb
+++ b/db/migrate/20190816155214_add_active_to_users.rb
@@ -1,0 +1,5 @@
+class AddActiveToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :active, :boolean, default: true, comment: "Whether or not a user is an active user of caseflow"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190815125313) do
+ActiveRecord::Schema.define(version: 20190816155214) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1042,6 +1042,7 @@ ActiveRecord::Schema.define(version: 20190815125313) do
   end
 
   create_table "users", id: :serial, force: :cascade do |t|
+    t.boolean "active", default: true, comment: "Whether or not a user is an active user of caseflow"
     t.datetime "created_at"
     t.string "css_id", null: false
     t.datetime "efolder_documents_fetched_at", comment: "Date when efolder documents were cached in s3 for this user"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,7 +73,8 @@ describe User, :all_dbs do
         "efolder_documents_fetched_at" => nil,
         "selected_regional_office" => nil,
         :display_name => css_id.upcase,
-        "name" => "Tom Brady"
+        "name" => "Tom Brady",
+        "active" => true
       }
     end
 


### PR DESCRIPTION
References #11631

### Description
Add active flag to the users column which defaults existing users and newly created users to true

### Acceptance Criteria
- [ ] Migration doesn't fail
- [ ] All users are active after migration
- [ ] Scope properly selects all active users
- [ ] Creating a user defaults the status to active

### Testing Plan
1. Ensure migration causes no issues
2. Ensure all users are active after migration
```ruby
> User.count.eql?(User.where(active: true).count)`
=> true
```
3. Ensure the new scope works
```ruby
>User.active.count.eql?(User.where(active: true).count)
SELECT COUNT(*) FROM "users" WHERE "users"."active" = $1  [["active", "t"]]
SELECT COUNT(*) FROM "users" WHERE "users"."active" = $1  [["active", "t"]]
=> true
```
4. Ensure creating a user defaults the status to active
```ruby
> FactoryBot.create(:user, station_id: 101, css_id: "NEW_USER")
=> #<User:0x00007f863a5a9a20
 id: 171,
 created_at: Fri, 16 Aug 2019 16:22:49 UTC +00:00,
 css_id: "NEW_USER",
 efolder_documents_fetched_at: nil,
 email: nil,
 full_name: "Lauren Roth",
 last_login_at: nil,
 roles: nil,
 selected_regional_office: nil,
 station_id: "101",
 updated_at: Fri, 16 Aug 2019 16:22:49 UTC +00:00,
 active: true>
```
5. Ensure creating a user with an inactive status works (no clue why we would ever do this I'm just trying to make a really long testing plan for this tiny PR)
```ruby
> FactoryBot.create(:user, station_id: 101, css_id: "NEW_USER_2", active: false)
=> #<User:0x00007f861fb70690
 id: 172,
 created_at: Fri, 16 Aug 2019 16:23:43 UTC +00:00,
 css_id: "NEW_USER_2",
 efolder_documents_fetched_at: nil,
 email: nil,
 full_name: "Lauren Roth",
 last_login_at: nil,
 roles: nil,
 selected_regional_office: nil,
 station_id: "101",
 updated_at: Fri, 16 Aug 2019 16:23:43 UTC +00:00,
 active: false>
```

*Schema Changes Only*

* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
