### PR TITLE
Add RatingDecision for not-service-connected decisions

### DIFF
--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -72,13 +72,7 @@ class Rating
     return {} unless rating_profile[:disabilities]
 
     Array.wrap(rating_profile[:disabilities]).map do |disability|
-      decision = {}
-      decision[:type_name] = disability[:decn_tn]
-      decision[:rating_sequence_number] = disability[:disability_evaluations][:rating_sn]
-      decision[:disability_id] = disability[:dis_sn]
-      decision[:diagnostic_text] = disability[:disability_evaluations][:dgnstc_txt]
-      decision[:profile_date] = disability[:disability_evaluations][:prfl_dt]
-      RatingDecision.from_bgs_hash(decision)
+      RatingDecision.from_bgs_disability(self, disability)
     end
   end
 

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -69,7 +69,7 @@ class Rating
   end
 
   def decisions
-    return {} unless rating_profile[:disabilities]
+    return [] unless rating_profile[:disabilities]
 
     Array.wrap(rating_profile[:disabilities]).map do |disability|
       RatingDecision.from_bgs_disability(self, disability)

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -41,7 +41,8 @@ class Rating
       participant_id: participant_id,
       profile_date: profile_date,
       promulgation_date: promulgation_date,
-      issues: issues.map(&:serialize)
+      issues: issues.map(&:serialize),
+      decisions: decisions.map(&:serialize)
     }
   end
 
@@ -65,6 +66,20 @@ class Rating
 
   def pension?
     associated_claims_data.any? { |ac| ac[:bnft_clm_tc].match(/PMC$/) }
+  end
+
+  def decisions
+    return {} unless rating_profile[:disabilities]
+
+    Array.wrap(rating_profile[:disabilities]).map do |disability|
+      decision = {}
+      decision[:type_name] = disability[:decn_tn]
+      decision[:rating_sequence_number] = disability[:disability_evaluations][:rating_sn]
+      decision[:disability_id] = disability[:dis_sn]
+      decision[:diagnostic_text] = disability[:disability_evaluations][:dgnstc_txt]
+      decision[:profile_date] = disability[:disability_evaluations][:prfl_dt]
+      RatingDecision.from_bgs_hash(decision)
+    end
   end
 
   private

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -7,14 +7,24 @@
 class RatingDecision
   include ActiveModel::Model
 
-  attr_accessor :type_name, :rating_sequence_number, :disability_id, :disability_date, :diagnostic_text, :profile_date,
-                :diagnostic_code, :benefit_type, :participant_id, :diagnostic_type
+  attr_accessor :benefit_type,
+                :diagnostic_code,
+                :diagnostic_text,
+                :diagnostic_type,
+                :disability_date,
+                :disability_id,
+                :participant_id,
+                :profile_date,
+                :rating_sequence_number,
+                :rating_reference_id,
+                :type_name
 
   class << self
     def from_bgs_disability(rating, disability)
       new(
         type_name: disability[:decn_tn],
         rating_sequence_number: disability[:disability_evaluations][:rating_sn],
+        rating_reference_id: disability[:disability_evaluations][:rba_issue_id], # ok if nil
         disability_id: disability[:dis_sn],
         diagnostic_text: disability[:disability_evaluations][:dgnstc_txt],
         diagnostic_type: disability[:disability_evaluations][:dgnstc_tn],

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 # ephemeral class used for caching Rating Decisions
+# A Rating Decision may or may not have an associated Rating Issue,
+# notably if the type_name = "Service Connected" then we should expect an associated Rating Issue.
 
 class RatingDecision
   include ActiveModel::Model
 
   attr_accessor :type_name, :rating_sequence_number, :disability_id, :disability_date, :diagnostic_text, :profile_date,
-                :diagnostic_code, :benefit_type
+                :diagnostic_code, :benefit_type, :participant_id, :diagnostic_type
 
   class << self
     def from_bgs_disability(rating, disability)
@@ -15,21 +17,29 @@ class RatingDecision
         rating_sequence_number: disability[:disability_evaluations][:rating_sn],
         disability_id: disability[:dis_sn],
         diagnostic_text: disability[:disability_evaluations][:dgnstc_txt],
+        diagnostic_type: disability[:disability_evaluations][:dgnstc_tn],
         diagnostic_code: disability[:disability_evaluations][:dgnstc_tc],
         disability_date: disability[:dis_dt],
         profile_date: disability[:disability_evaluations][:prfl_dt],
+        participant_id: rating.participant_id,
         benefit_type: rating.pension? ? :pension : :compensation
       )
     end
-  end
 
-  def ui_hash
-    serialize
+    def deserialize(hash)
+      new(hash)
+    end
   end
 
   # If you change this method, you will need to clear cache in prod for your changes to
   # take effect immediately. See DecisionReview#cached_serialized_ratings
   def serialize
-    to_h
+    as_json.symbolize_keys
+  end
+
+  alias ui_hash serialize
+
+  def service_connected?
+    type_name == "Service Connected"
   end
 end

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# ephemeral class used for caching Rating Decisions
+
+class RatingDecision
+  include ActiveModel::Model
+
+  attr_accessor :type_name, :rating_sequence_number, :disability_id, :diagnostic_text, :profile_date
+
+  class << self
+    def from_bgs_hash(bgs_data)
+      new(bgs_data)
+    end
+  end
+
+  def ui_hash
+    serialize
+  end
+
+  # If you change this method, you will need to clear cache in prod for your changes to
+  # take effect immediately. See DecisionReview#cached_serialized_ratings
+  def serialize
+    to_h
+  end
+end

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -5,11 +5,21 @@
 class RatingDecision
   include ActiveModel::Model
 
-  attr_accessor :type_name, :rating_sequence_number, :disability_id, :diagnostic_text, :profile_date
+  attr_accessor :type_name, :rating_sequence_number, :disability_id, :disability_date, :diagnostic_text, :profile_date,
+                :diagnostic_code, :benefit_type
 
   class << self
-    def from_bgs_hash(bgs_data)
-      new(bgs_data)
+    def from_bgs_disability(rating, disability)
+      new(
+        type_name: disability[:decn_tn],
+        rating_sequence_number: disability[:disability_evaluations][:rating_sn],
+        disability_id: disability[:dis_sn],
+        diagnostic_text: disability[:disability_evaluations][:dgnstc_txt],
+        diagnostic_code: disability[:disability_evaluations][:dgnstc_tc],
+        disability_date: disability[:dis_dt],
+        profile_date: disability[:disability_evaluations][:prfl_dt],
+        benefit_type: rating.pension? ? :pension : :compensation
+      )
     end
   end
 

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -8,12 +8,13 @@ class RatingIssue
 
   attr_accessor :reference_id, :decision_text, :profile_date, :associated_end_products,
                 :promulgation_date, :participant_id, :rba_contentions_data, :diagnostic_code,
-                :benefit_type
+                :benefit_type, :rating_sequence_number
 
   class << self
     def from_bgs_hash(rating, bgs_data)
       new(
         reference_id: bgs_data[:rba_issue_id],
+        rating_sequence_number: bgs_data[:rating_sn],
         rba_contentions_data: ensure_array_of_hashes(bgs_data.dig(:rba_issue_contentions)),
         profile_date: rating.profile_date,
         decision_text: bgs_data[:decn_txt],
@@ -29,6 +30,7 @@ class RatingIssue
       new(
         participant_id: serialized_hash[:participant_id],
         reference_id: serialized_hash[:reference_id],
+        rating_sequence_number: serialized_hash[:rating_sequence_number],
         decision_text: serialized_hash[:decision_text],
         associated_end_products: deserialize_end_products(serialized_hash),
         promulgation_date: serialized_hash[:promulgation_date],
@@ -64,6 +66,7 @@ class RatingIssue
     {
       participant_id: participant_id,
       reference_id: reference_id,
+      rating_sequence_number: rating_sequence_number,
       decision_text: decision_text,
       promulgation_date: promulgation_date,
       profile_date: profile_date,

--- a/app/models/rating_issue.rb
+++ b/app/models/rating_issue.rb
@@ -8,13 +8,12 @@ class RatingIssue
 
   attr_accessor :reference_id, :decision_text, :profile_date, :associated_end_products,
                 :promulgation_date, :participant_id, :rba_contentions_data, :diagnostic_code,
-                :benefit_type, :rating_sequence_number
+                :benefit_type
 
   class << self
     def from_bgs_hash(rating, bgs_data)
       new(
         reference_id: bgs_data[:rba_issue_id],
-        rating_sequence_number: bgs_data[:rating_sn],
         rba_contentions_data: ensure_array_of_hashes(bgs_data.dig(:rba_issue_contentions)),
         profile_date: rating.profile_date,
         decision_text: bgs_data[:decn_txt],
@@ -30,7 +29,6 @@ class RatingIssue
       new(
         participant_id: serialized_hash[:participant_id],
         reference_id: serialized_hash[:reference_id],
-        rating_sequence_number: serialized_hash[:rating_sequence_number],
         decision_text: serialized_hash[:decision_text],
         associated_end_products: deserialize_end_products(serialized_hash),
         promulgation_date: serialized_hash[:promulgation_date],
@@ -66,7 +64,6 @@ class RatingIssue
     {
       participant_id: participant_id,
       reference_id: reference_id,
-      rating_sequence_number: rating_sequence_number,
       decision_text: decision_text,
       promulgation_date: promulgation_date,
       profile_date: profile_date,

--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -86,7 +86,7 @@ class Generators::Rating
       decisions_data = attrs[:decisions].map do |decision|
         {
           disability_evaluations: {
-            rba_decision_id: decision[:reference_id] || generate_external_id,
+            rba_issue_id: decision[:reference_id] || generate_external_id,
             dgnstc_txt: decision[:diagnostic_text],
             dgnstc_tn: decision[:diagnostic_type],
             dgnstc_tc: decision[:diagnostic_code],

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -63,6 +63,7 @@ describe RatingDecision do
           dgnstc_txt: "tinnitus",
           prfl_dt: profile_date,
           rating_sn: "227606458",
+          rba_issue_id: "56780000"
         }
       }
     end
@@ -73,6 +74,7 @@ describe RatingDecision do
       is_expected.to have_attributes(
         type_name: decision_type_name,
         rating_sequence_number: "227606458",
+        rating_reference_id: "56780000",
         disability_id: "67468264",
         diagnostic_text: "tinnitus",
         diagnostic_type: "Tinnitus",

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe RatingDecision do
+  before do
+    Time.zone = "UTC"
+    Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
+  end
+
+  let(:profile_date) { Time.zone.today - 40 }
+  let(:promulgation_date) { Time.zone.today - 30 }
+  let(:participant_id) { "1234567" }
+
+  context ".deserialize" do
+    subject { described_class.deserialize(rating_decision.serialize) }
+
+    let(:rating_decision) do
+      described_class.new(
+        profile_date: profile_date,
+        rating_sequence_number: "1234",
+        disability_id: "5678",
+        diagnostic_text: "tinnitus",
+        diagnostic_code: "6260",
+        disability_date: profile_date + 30.days,
+        participant_id: participant_id,
+        benefit_type: :compensation
+      )
+    end
+
+    it { is_expected.to be_a(described_class) }
+  end
+
+  context ".from_bgs_disability" do
+    subject { described_class.from_bgs_disability(rating, bgs_record) }
+
+    let(:decision_type_name) { "Service Connected" }
+
+    let(:associated_claims) do
+      [
+        { clm_id: "abc123", bnft_clm_tc: "040SCR" },
+        { clm_id: "dcf345", bnft_clm_tc: "154IVMC9PMC" }
+      ]
+    end
+
+    let!(:rating) do
+      Generators::Rating.build(
+        participant_id: participant_id,
+        promulgation_date: promulgation_date,
+        profile_date: profile_date,
+        associated_claims: associated_claims
+      )
+    end
+
+    let(:bgs_record) do
+      {
+        decn_tn: decision_type_name,
+        dis_dt: 1.year.ago,
+        dis_sn: "67468264",
+        disability_evaluations: {
+          dgnstc_tc: "6260",
+          dgnstc_tn: "Tinnitus",
+          dgnstc_txt: "tinnitus",
+          prfl_dt: profile_date,
+          rating_sn: "227606458",
+        }
+      }
+    end
+
+    it { is_expected.to be_a(described_class) }
+
+    it do
+      is_expected.to have_attributes(
+        type_name: decision_type_name,
+        rating_sequence_number: "227606458",
+        disability_id: "67468264",
+        diagnostic_text: "tinnitus",
+        diagnostic_type: "Tinnitus",
+        diagnostic_code: "6260",
+        disability_date: 1.year.ago,
+        profile_date: profile_date,
+        participant_id: rating.participant_id,
+        benefit_type: :pension
+      )
+    end
+
+    describe "#service_connected?" do
+      it "returns true" do
+        expect(subject.service_connected?).to eq(true)
+      end
+
+      context "decision type name is Not Service Connected" do
+        let(:decision_type_name) { "Not Service Connected" }
+
+        it "returns false" do
+          expect(subject.service_connected?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -8,7 +8,7 @@ describe RatingIssue do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end
 
-  let(:profile_date) { Time.zone.today - 30 }
+  let(:profile_date) { Time.zone.today - 40 }
   let(:promulgation_date) { Time.zone.today - 30 }
 
   context ".deserialize" do
@@ -17,6 +17,7 @@ describe RatingIssue do
     let(:rating_issue) do
       RatingIssue.new(
         reference_id: "NBA",
+        rating_sequence_number: "5678",
         participant_id: "123",
         profile_date: profile_date,
         promulgation_date: promulgation_date,
@@ -32,6 +33,7 @@ describe RatingIssue do
     it do
       is_expected.to have_attributes(
         reference_id: "NBA",
+        rating_sequence_number: "5678",
         participant_id: "123",
         profile_date: profile_date,
         promulgation_date: promulgation_date,
@@ -64,6 +66,7 @@ describe RatingIssue do
     let(:bgs_record) do
       {
         rba_issue_id: "NBA",
+        rating_sn: "5678",
         decn_txt: "This broadcast may not be reproduced",
         dgnstc_tc: "3001"
       }
@@ -74,6 +77,7 @@ describe RatingIssue do
     it do
       is_expected.to have_attributes(
         reference_id: "NBA",
+        rating_sequence_number: "5678",
         decision_text: "This broadcast may not be reproduced",
         profile_date: profile_date,
         contention_reference_ids: [],
@@ -86,6 +90,7 @@ describe RatingIssue do
       let(:bgs_record) do
         {
           rba_issue_id: "NBA",
+          rating_sn: "5678",
           decn_txt: "This broadcast may not be reproduced",
           rba_issue_contentions: { prfil_dt: Time.zone.now, cntntn_id: "foul" }
         }
@@ -94,6 +99,7 @@ describe RatingIssue do
       it do
         is_expected.to have_attributes(
           reference_id: "NBA",
+          rating_sequence_number: "5678",
           decision_text: "This broadcast may not be reproduced",
           profile_date: profile_date,
           contention_reference_ids: ["foul"],
@@ -106,6 +112,7 @@ describe RatingIssue do
       let(:bgs_record) do
         {
           rba_issue_id: "NBA",
+          rating_sn: "5678",
           decn_txt: "This broadcast may not be reproduced",
           rba_issue_contentions: [
             { prfil_dt: Time.zone.now, cntntn_id: "foul" },
@@ -117,6 +124,7 @@ describe RatingIssue do
       it do
         is_expected.to have_attributes(
           reference_id: "NBA",
+          rating_sequence_number: "5678",
           decision_text: "This broadcast may not be reproduced",
           profile_date: profile_date,
           contention_reference_ids: %w[foul dunk]

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -10,7 +10,6 @@ describe RatingIssue do
 
   let(:profile_date) { Time.zone.today - 30 }
   let(:promulgation_date) { Time.zone.today - 30 }
-  let(:profile_date) { Time.zone.today - 40 }
 
   context ".deserialize" do
     subject { RatingIssue.deserialize(rating_issue.serialize) }

--- a/spec/models/rating_issue_spec.rb
+++ b/spec/models/rating_issue_spec.rb
@@ -8,7 +8,7 @@ describe RatingIssue do
     Timecop.freeze(Time.utc(2015, 1, 1, 12, 0, 0))
   end
 
-  let(:profile_date) { Time.zone.today - 40 }
+  let(:profile_date) { Time.zone.today - 30 }
   let(:promulgation_date) { Time.zone.today - 30 }
 
   context ".deserialize" do
@@ -17,7 +17,6 @@ describe RatingIssue do
     let(:rating_issue) do
       RatingIssue.new(
         reference_id: "NBA",
-        rating_sequence_number: "5678",
         participant_id: "123",
         profile_date: profile_date,
         promulgation_date: promulgation_date,
@@ -33,7 +32,6 @@ describe RatingIssue do
     it do
       is_expected.to have_attributes(
         reference_id: "NBA",
-        rating_sequence_number: "5678",
         participant_id: "123",
         profile_date: profile_date,
         promulgation_date: promulgation_date,
@@ -66,7 +64,6 @@ describe RatingIssue do
     let(:bgs_record) do
       {
         rba_issue_id: "NBA",
-        rating_sn: "5678",
         decn_txt: "This broadcast may not be reproduced",
         dgnstc_tc: "3001"
       }
@@ -77,7 +74,6 @@ describe RatingIssue do
     it do
       is_expected.to have_attributes(
         reference_id: "NBA",
-        rating_sequence_number: "5678",
         decision_text: "This broadcast may not be reproduced",
         profile_date: profile_date,
         contention_reference_ids: [],
@@ -90,7 +86,6 @@ describe RatingIssue do
       let(:bgs_record) do
         {
           rba_issue_id: "NBA",
-          rating_sn: "5678",
           decn_txt: "This broadcast may not be reproduced",
           rba_issue_contentions: { prfil_dt: Time.zone.now, cntntn_id: "foul" }
         }
@@ -99,7 +94,6 @@ describe RatingIssue do
       it do
         is_expected.to have_attributes(
           reference_id: "NBA",
-          rating_sequence_number: "5678",
           decision_text: "This broadcast may not be reproduced",
           profile_date: profile_date,
           contention_reference_ids: ["foul"],
@@ -112,7 +106,6 @@ describe RatingIssue do
       let(:bgs_record) do
         {
           rba_issue_id: "NBA",
-          rating_sn: "5678",
           decn_txt: "This broadcast may not be reproduced",
           rba_issue_contentions: [
             { prfil_dt: Time.zone.now, cntntn_id: "foul" },
@@ -124,7 +117,6 @@ describe RatingIssue do
       it do
         is_expected.to have_attributes(
           reference_id: "NBA",
-          rating_sequence_number: "5678",
           decision_text: "This broadcast may not be reproduced",
           profile_date: profile_date,
           contention_reference_ids: %w[foul dunk]

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -19,6 +19,7 @@ describe Rating do
   let(:rating) do
     Generators::Rating.build(
       issues: issues,
+      decisions: decisions,
       promulgation_date: promulgation_date,
       profile_date: profile_date,
       participant_id: participant_id,
@@ -39,8 +40,22 @@ describe Rating do
     }
   end
 
+  def build_decision(num)
+    {
+      participant_id: participant_id,
+      rating_sequence_number: "RatingSN#{num}",
+      diagnostic_text: "Diagnostic#{num}",
+      disability_date: promulgation_date,
+      profile_date: profile_date
+    }
+  end
+
   let(:issues) do
     [build_issue(1), build_issue(2)]
+  end
+
+  let(:decisions) do
+    [build_decision(1), build_decision(2)]
   end
 
   context "with disabilities" do
@@ -188,6 +203,21 @@ describe Rating do
     end
   end
 
+  context "#decisions" do
+    subject { rating.decisions }
+
+    it "returns the decisions" do
+      binding.pry
+      expect(subject.count).to eq(2)
+      expect(subject.first).to have_attributes(
+        rating_sequence_number: "RatingSN1", diagnostic_text: "Diagnostic1"
+      )
+      expect(subject.second).to have_attributes(
+        rating_sequence_number: "RatingSN2", diagnostic_text: "Diagnostic2"
+      )
+    end
+  end
+
   context "#associated_end_products" do
     subject { rating.associated_end_products }
 
@@ -263,7 +293,8 @@ describe Rating do
         participant_id: rating.participant_id,
         profile_date: rating.profile_date,
         promulgation_date: rating.promulgation_date,
-        issues: rating.issues.map(&:serialize)
+        issues: rating.issues.map(&:serialize),
+        decisions: rating.decisions.map(&:serialize)
       )
     end
 
@@ -275,7 +306,8 @@ describe Rating do
           participant_id: rating.participant_id,
           profile_date: rating.profile_date,
           promulgation_date: rating.promulgation_date,
-          issues: []
+          issues: [],
+          decisions: []
         )
       end
     end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -301,12 +301,14 @@ describe Rating do
       let(:issues) { nil }
 
       it "should have no issues" do
-        is_expected.to match(hash_including(
-          participant_id: rating.participant_id,
-          profile_date: rating.profile_date,
-          promulgation_date: rating.promulgation_date,
-          issues: []
-        ))
+        is_expected.to match(
+          hash_including(
+            participant_id: rating.participant_id,
+            profile_date: rating.profile_date,
+            promulgation_date: rating.promulgation_date,
+            issues: []
+          )
+        )
       end
     end
   end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -207,7 +207,6 @@ describe Rating do
     subject { rating.decisions }
 
     it "returns the decisions" do
-      binding.pry
       expect(subject.count).to eq(2)
       expect(subject.first).to have_attributes(
         rating_sequence_number: "RatingSN1", diagnostic_text: "Diagnostic1"
@@ -302,13 +301,12 @@ describe Rating do
       let(:issues) { nil }
 
       it "should have no issues" do
-        is_expected.to match(
+        is_expected.to match(hash_including(
           participant_id: rating.participant_id,
           profile_date: rating.profile_date,
           promulgation_date: rating.promulgation_date,
-          issues: [],
-          decisions: []
-        )
+          issues: []
+        ))
       end
     end
   end


### PR DESCRIPTION
connects #10511 #11840 

### Description
BGS API returns not-service connected decisions. This adds a method `decisions` to the `Rating` model that returns `RatingDecision` records. These would be a superset of `RatingIssue` which seems to include only service connected decisions, or not-service-connected decisions that have explicit rating issue associated.