### PR TITLE
Update label for ColocatedTasks created by judges

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -76,16 +76,9 @@ class ColocatedTask < Task
   def available_actions(user)
     if assigned_to == user ||
        (task_is_assigned_to_user_within_organization?(user) && Colocated.singleton.user_is_admin?(user))
-      
-      # Use assigner so that we handle creation of the ColcoatedTask from LegacyTasks gracefully.
-      return_action = if JudgeTeam.for_judge(assigned_by)
-                        Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_JUDGE.to_h
-                      else
-                        Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_ATTORNEY.to_h
-                      end
 
       actions = [
-        return_action,
+        return_to_assigner_action,
         Constants.TASK_ACTIONS.CHANGE_TASK_TYPE.to_h,
         Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
         Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.to_h,
@@ -98,6 +91,15 @@ class ColocatedTask < Task
     end
 
     []
+  end
+
+  def return_to_assigner_action
+    # Use assigner so that we handle creation of the ColcoatedTask from LegacyTasks gracefully.
+    if JudgeTeam.for_judge(assigned_by)
+      Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_JUDGE.to_h
+    else
+      Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_ATTORNEY.to_h
+    end
   end
 
   def actions_available?(_user)

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -76,8 +76,16 @@ class ColocatedTask < Task
   def available_actions(user)
     if assigned_to == user ||
        (task_is_assigned_to_user_within_organization?(user) && Colocated.singleton.user_is_admin?(user))
+      
+      # Use assigner so that we handle creation of the ColcoatedTask from LegacyTasks gracefully.
+      return_action = if JudgeTeam.for_judge(assigned_by)
+                        Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_JUDGE.to_h
+                      else
+                        Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_ATTORNEY.to_h
+                      end
+
       actions = [
-        Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_ATTORNEY.to_h,
+        return_action,
         Constants.TASK_ACTIONS.CHANGE_TASK_TYPE.to_h,
         Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
         Constants.TASK_ACTIONS.ASSIGN_TO_PRIVACY_TEAM.to_h,

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -61,6 +61,10 @@
     "label": "Send back to attorney",
     "value": "modal/mark_task_complete"
   },
+  "COLOCATED_RETURN_TO_JUDGE": {
+    "label": "Send back to judge",
+    "value": "modal/mark_task_complete"
+  },
   "COMPLETE_TRANSCRIPTION": {
     "label": "Mark as complete: Transcribed",
     "value": "modal/mark_task_complete",

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -525,7 +525,7 @@ RSpec.feature "Task queue", :all_dbs do
         visit("/queue/appeals/#{appeal.external_id}")
 
         find(".Select-control", text: "Select an action…").click
-        find("div .Select-option", text: Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_ATTORNEY.to_h[:label]).click
+        find("div .Select-option", text: Constants.TASK_ACTIONS.COLOCATED_RETURN_TO_JUDGE.label).click
         expect(page).to have_content("Instructions:")
         find("button", text: COPY::MARK_TASK_COMPLETE_BUTTON).click
 


### PR DESCRIPTION
Resolves #8759. Changes the label of the "mark task complete" action to "Send back to judge" if the creator of the task is a judge.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/63276909-5767ee00-c272-11e9-9bd1-3837d40adf38.png) | ![image](https://user-images.githubusercontent.com/32683958/63276865-40c19700-c272-11e9-858c-09d19ea2c0d1.png)