### PR TITLE
Use hearing_location.name for regional_office in hearings API

### DIFF
--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -20,10 +20,10 @@ class Api::V2::HearingSerializer
   end
   # deprecated :regional_office
   attribute :regional_office do |hearing|
-    hearing.hearing_location&.name
+    hearing.hearing_location&.name || hearing.regional_office_name
   end
   attribute :hearing_location do |hearing|
-    hearing.hearing_location&.name
+    hearing.hearing_location&.name || hearing.regional_office_name
   end
   attribute :room do |hearing|
     hearing.hearing_day.room

--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -18,7 +18,11 @@ class Api::V2::HearingSerializer
   attribute :participant_id do |hearing|
     hearing.appeal.veteran.participant_id
   end
+  # deprecated :regional_office
   attribute :regional_office do |hearing|
+    hearing.hearing_location&.name
+  end
+  attribute :hearing_location do |hearing|
     hearing.hearing_location&.name
   end
   attribute :room do |hearing|

--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -18,7 +18,9 @@ class Api::V2::HearingSerializer
   attribute :participant_id do |hearing|
     hearing.appeal.veteran.participant_id
   end
-  attribute :regional_office, &:regional_office_name
+  attribute :regional_office do |hearing|
+    hearing.hearing_location&.name
+  end
   attribute :room do |hearing|
     hearing.hearing_day.room
   end

--- a/docs/caseflow-apis.md
+++ b/docs/caseflow-apis.md
@@ -324,7 +324,8 @@ On success returns `200` HTTP code and a body like:
          "first_name" : "John",
          "last_name" : "Veteran",
          "participant_id" : "12345",
-         "regional_office" : "Boston",
+         "regional_office" : "Boston",  // deprecated
+         "hearing_location" : "Boston",
          "room" : "123",
          "scheduled_for" : "2019-07-24T13:30:00.000-04:00",
          "ssn" : "666456999",
@@ -340,7 +341,8 @@ On success returns `200` HTTP code and a body like:
          "first_name" : "Jane",
          "last_name" : "Veteran",
          "participant_id" : "23456",
-         "regional_office" : "Providence",
+         "regional_office" : "Providence", // deprecated
+         "hearing_location" : "Providence",
          "room" : "456",
          "scheduled_for" : "2019-07-24T13:30:00.000-04:00",
          "ssn" : "666456000",


### PR DESCRIPTION
Resolves #11834 

### Description
use the hearing_location.name as the `regional_office` value.