### PR TITLE
Fix front end case type sort order

### DIFF
--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -30,7 +30,6 @@ import { DateString } from '../../util/DateUtil';
 import {
   CATEGORIES,
   redText,
-  LEGACY_APPEAL_TYPES,
   DOCKET_NAME_FILTERS
 } from '../constants';
 import COPY from '../../../COPY.json';

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -164,13 +164,11 @@ export const typeColumn = (tasks, requireDasRecord) => {
       <span {...redText}>{COPY.ATTORNEY_QUEUE_TABLE_TASK_NEEDS_ASSIGNMENT_ERROR_MESSAGE}</span>,
     span: (task) => hasDASRecord(task, requireDasRecord) ? 1 : 5,
     getSortValue: (task) => {
+      const sortString = `${task.appeal.caseType} ${task.appeal.docketNumber}`;
+
       // We append a * before the docket number if it's a priority case since * comes before
       // numbers in sort order, this forces these cases to the top of the sort.
-      if (task.appeal.isAdvancedOnDocket || task.appeal.caseType === LEGACY_APPEAL_TYPES.CAVC_REMAND) {
-        return `*${task.appeal.docketNumber}`;
-      }
-
-      return task.appeal.docketNumber;
+      return task.appeal.isAdvancedOnDocket ? `*${sortString}` : sortString;
     }
   };
 };


### PR DESCRIPTION
Resolves #11687

### Description
Match front end sort order to [back end](https://github.com/department-of-veterans-affairs/caseflow/blob/8d3967a415e290354f4c7eb43e1e62e9b9a9360f/spec/models/task_pager_spec.rb#L326) sort order.

|BEFORE|AFTER|
|---|---|
|<img width="777" alt="Screen Shot 2019-08-20 at 2 51 01 PM" src="https://user-images.githubusercontent.com/45575454/63376048-e7816280-c35a-11e9-98a4-c7d9073617c5.png">|<img width="780" alt="Screen Shot 2019-08-20 at 2 54 45 PM" src="https://user-images.githubusercontent.com/45575454/63376058-ea7c5300-c35a-11e9-9e65-a868041c315b.png">|



### Acceptance Criteria
- [ ] Cases are sorted by whether the case is AOD, then the case type, then the docket number.

### Testing Plan
1. Log in as BVAAABSHIRE and go to your queue
2. Toggle the case type sort and confirm the AC