### PR TITLE
Create blocking MailTasks as children of DistributionTasks.

### DIFF
--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -28,17 +28,25 @@ class MailTask < GenericTask
       MailTask.subclasses.sort_by(&:label).map { |subclass| { value: subclass.name, label: subclass.label } }
     end
 
-    def create_from_params(params, user)
-      verify_user_can_create!(user, Task.find(params[:parent_id]))
+    def parent_if_blocking_task(parent_task)
+      if blocking? && !parent_task.appeal.distributed_to_a_judge?
+        return parent_task.appeal.tasks.find_by(type: DistributionTask.name)
+      end
 
+      parent_task
+    end
+
+    def create_from_params(params, user)
       parent_task = Task.find(params[:parent_id])
+
+      verify_user_can_create!(user, parent_task)
 
       transaction do
         if parent_task.is_a?(RootTask)
           # Create a task assigned to the mail team with a child task so we can track how that child was created.
           parent_task = create!(
             appeal: parent_task.appeal,
-            parent_id: parent_task.id,
+            parent_id: parent_if_blocking_task(parent_task).id,
             assigned_to: MailTeam.singleton
           )
         end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -348,23 +348,23 @@ RSpec.feature "Task queue", :all_dbs do
         find("button", text: COPY::TASK_SNAPSHOT_ADD_NEW_TASK_LABEL).click
 
         find(".Select-control", text: COPY::MAIL_TASK_DROPDOWN_TYPE_SELECTOR_LABEL).click
-        find("div", class: "Select-option", text: COPY::FOIA_REQUEST_MAIL_TASK_LABEL).click
+        find("div", class: "Select-option", text: COPY::AOD_MOTION_MAIL_TASK_LABEL).click
 
         fill_in("taskInstructions", with: instructions)
         find("button", text: "Submit").click
 
-        success_msg = format(COPY::MAIL_TASK_CREATION_SUCCESS_MESSAGE, COPY::FOIA_REQUEST_MAIL_TASK_LABEL)
+        success_msg = format(COPY::MAIL_TASK_CREATION_SUCCESS_MESSAGE, COPY::AOD_MOTION_MAIL_TASK_LABEL)
         expect(page).to have_content(success_msg)
         expect(page.current_path).to eq("/queue/appeals/#{appeal.uuid}")
 
         mail_task = root_task.children[0]
-        expect(mail_task.class).to eq(FoiaRequestMailTask)
+        expect(mail_task.class).to eq(AodMotionMailTask)
         expect(mail_task.assigned_to).to eq(MailTeam.singleton)
         expect(mail_task.children.length).to eq(1)
 
         child_task = mail_task.children[0]
-        expect(child_task.class).to eq(FoiaRequestMailTask)
-        expect(child_task.assigned_to).to eq(PrivacyTeam.singleton)
+        expect(child_task.class).to eq(AodMotionMailTask)
+        expect(child_task.assigned_to).to eq(AodTeam.singleton)
         expect(child_task.children.length).to eq(0)
       end
     end
@@ -406,23 +406,23 @@ RSpec.feature "Task queue", :all_dbs do
         find("button", text: COPY::TASK_SNAPSHOT_ADD_NEW_TASK_LABEL).click
 
         find(".Select-control", text: COPY::MAIL_TASK_DROPDOWN_TYPE_SELECTOR_LABEL).click
-        find("div", class: "Select-option", text: COPY::FOIA_REQUEST_MAIL_TASK_LABEL).click
+        find("div", class: "Select-option", text: COPY::AOD_MOTION_MAIL_TASK_LABEL).click
 
         fill_in("taskInstructions", with: instructions)
         find("button", text: "Submit").click
 
-        success_msg = format(COPY::MAIL_TASK_CREATION_SUCCESS_MESSAGE, COPY::FOIA_REQUEST_MAIL_TASK_LABEL)
+        success_msg = format(COPY::MAIL_TASK_CREATION_SUCCESS_MESSAGE, COPY::AOD_MOTION_MAIL_TASK_LABEL)
         expect(page).to have_content(success_msg)
         expect(page.current_path).to eq("/queue/appeals/#{appeal.uuid}")
 
         mail_task = root_task.children[0]
-        expect(mail_task.class).to eq(FoiaRequestMailTask)
+        expect(mail_task.class).to eq(AodMotionMailTask)
         expect(mail_task.assigned_to).to eq(MailTeam.singleton)
         expect(mail_task.children.length).to eq(1)
 
         child_task = mail_task.children[0]
-        expect(child_task.class).to eq(FoiaRequestMailTask)
-        expect(child_task.assigned_to).to eq(PrivacyTeam.singleton)
+        expect(child_task.class).to eq(AodMotionMailTask)
+        expect(child_task.assigned_to).to eq(AodTeam.singleton)
         expect(child_task.children.length).to eq(0)
       end
     end


### PR DESCRIPTION
References #11590

### Description
Creates blocking mail tasks as children of distribution tasks to use classic blocking behavior.

### Acceptance Criteria
- [ ] Blocking MailTasks are created as children of DistributionTasks.

### Notes 
There remains logic in [`Appeal`](https://github.com/department-of-veterans-affairs/caseflow/blob/d9f5f017f1556139e4319456cfbc1d78bb283914/app/models/appeal.rb#L159) and [`Docket`](https://github.com/department-of-veterans-affairs/caseflow/blob/d9f5f017f1556139e4319456cfbc1d78bb283914/app/models/docket.rb#L115)that will stay until appeals with blocking `MailTask`s that are not children of distribution tasks closed on their own.

```ruby
> Task.open.where(type: MailTask.blocking_subclasses, parent_id: RootTask.pluck(:id)).count
=> 38
```