### PR TITLE
Simplify Hearing Location Job Query

### DIFF
--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -28,7 +28,7 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
   def geomatch(appeal)
     geomatch_result = appeal.va_dot_gov_address_validator.update_closest_ro_and_ahls
     if geomatch_result[:status] == VaDotGovAddressValidator::STATUSES[:matched_available_hearing_locations]
-      cancel_admin_actions_for_matched_appeals(appeal)
+      cancel_admin_actions_for_matched_appeal(appeal)
     end
 
     geomatch_result

--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -49,10 +49,10 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
 
     case geomatch_result[:status]
     when VaDotGovAddressValidator::STATUSES[:matched_available_hearing_locations],
-      VaDotGovLimitError::STATUSES[:philippines_exception]
+      VaDotGovAddressValidator::STATUSES[:philippines_exception]
       cancel_admin_actions_for_matched_appeal(appeal)
     when VaDotGovAddressValidator::STATUSES[:created_verify_address_admin_action],
-      VaDotGovLimitError::STATUSES[:created_foreign_veteran_admin_action]
+      VaDotGovAddressValidator::STATUSES[:created_foreign_veteran_admin_action]
       create_available_hearing_location_for_errored_appeal(appeal)
     end
 

--- a/spec/factories/legacy_appeal.rb
+++ b/spec/factories/legacy_appeal.rb
@@ -9,6 +9,13 @@ FactoryBot.define do
     vacols_id { vacols_case&.bfkey }
     vbms_id { vacols_case&.bfcorlid }
 
+    trait :with_schedule_hearing_tasks do
+      after(:create) do |appeal, _evaluator|
+        root_task = RootTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
+        ScheduleHearingTask.create!(appeal: appeal, parent: root_task)
+      end
+    end
+
     trait :with_veteran do
       after(:create) do |legacy_appeal, evaluator|
         veteran = create(

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -69,54 +69,13 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
         end
         let!(:legacy_appeal_2) { create(:legacy_appeal, vbms_id: "999999999S", vacols_case: vacols_case_2) }
         let!(:task_1) { create(:schedule_hearing_task, appeal: legacy_appeal_2) }
-        # AMA appeal with schedule taks
+        # AMA appeal with schedule task
         let!(:veteran_3) { create(:veteran, file_number: "000000000") }
         let!(:appeal) { create(:appeal, veteran_file_number: "000000000") }
         let!(:task_2) { create(:schedule_hearing_task, appeal: appeal) }
-        # AMA appeal with completed address admin action
-        let!(:veteran_4) { create(:veteran, file_number: "222222222") }
-        let!(:appeal_2) { create(:appeal, veteran_file_number: "222222222") }
-        let!(:task_3) { create(:schedule_hearing_task, appeal: appeal_2) }
-        let!(:completed_admin_action) do
-          create(
-            :hearing_admin_action_verify_address_task,
-            :completed,
-            appeal: appeal_2,
-            assigned_to: HearingsManagement.singleton,
-            parent: task_3
-          )
-        end
+
         # should not be returned
         before do
-          # tasks marked completed
-          (0..2).each do |number|
-            create(:veteran, file_number: "23456781#{number}")
-            app = create(:appeal, veteran_file_number: "23456781#{number}")
-            create(:schedule_hearing_task, :completed, appeal: app)
-          end
-
-          # task with Address admin action
-          create(:veteran, file_number: "234567815")
-          app_2 = create(:appeal, veteran_file_number: "234567815")
-          tsk = create(:schedule_hearing_task, appeal: app_2)
-          create(
-            :hearing_admin_action_verify_address_task,
-            appeal: app_2,
-            assigned_to: HearingsManagement.singleton,
-            parent: tsk
-          )
-
-          # task with Foreign Case admin action
-          create(:veteran, file_number: "234567816")
-          app_3 = create(:appeal, veteran_file_number: "234567816")
-          tsk_2 = create(:schedule_hearing_task, appeal: app_3)
-          create(
-            :hearing_admin_action_verify_address_task,
-            appeal: app_3,
-            assigned_to: HearingsManagement.singleton,
-            parent: tsk_2
-          )
-
           # legacy not in location 57
           create(:veteran, file_number: "111111111")
           vac_case = create(:case, bfcurloc: "39", bfregoff: "RO01", bfcorlid: "111111111S", bfhr: "2", bfdocind: "V")
@@ -149,6 +108,25 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
         expect(legacy_appeal.tasks.count).to eq(3)
         expect(legacy_appeal.tasks.open.where(type: "ScheduleHearingTask").count).to eq(1)
         expect(legacy_appeal.tasks.open.where(type: "HearingTask").count).to eq(1)
+      end
+
+      context "when appeal has open admin action" do
+        before do
+          HearingAdminActionVerifyAddressTask.create!(
+            appeal: legacy_appeal,
+            assigned_to: HearingsManagement.singleton,
+            parent: ScheduleHearingTask.create(
+              appeal: legacy_appeal,
+              parent: RootTask.find_or_create_by(appeal: legacy_appeal)
+            )
+          )
+        end
+
+        it "closes admin action" do
+          subject.perform
+
+          expect(HearingAdminActionVerifyAddressTask.first.status).to eq(Constants.TASK_STATUSES.cancelled)
+        end
       end
 
       context "when API limit is reached" do

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -135,7 +135,7 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
         before do
           allow_any_instance_of(VaDotGovAddressValidator).to receive(:update_closest_ro_and_ahls)
             .and_return(status: :created_verify_address_admin_action)
-          AvailableHearingLocations.create(appeal: appeal, facility_id: "fake_152")
+          AvailableHearingLocations.create(appeal: appeal, facility_id: "fake_152", updated_at: Time.zone.now - 15.days)
         end
 
         it "pushes appeal to the bottom of job query by creating a blank

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -111,7 +111,7 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
       end
 
       context "when there are more appeals to match than query limit" do
-        let!(:number_of_appeals_ready) { 10 }
+        let!(:number_of_appeals_ready) { 20 }
         let!(:number_of_legacy_appeals_ready) { 10 } # - 1 from above context
         let!(:query_limit) { 2 }
         before do
@@ -125,10 +125,10 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
         end
 
         it "geomatches all appeals" do
-          (1..(number_of_appeals_ready + number_of_legacy_appeals_ready) / 2).each do
+          (1..(number_of_appeals_ready + number_of_legacy_appeals_ready)).each do
             job = FetchHearingLocationsForVeteransJob.new
             job.perform
-            # let's pretend the validator actually updated the RO and AHL
+            # let's pretend the job actually updated the RO and AHL
             job.appeals.each do |appeal|
               appeal.update(closest_regional_office: "RO01")
               AvailableHearingLocations.create(appeal: appeal)


### PR DESCRIPTION
- This PR simplifies hearing location job query to not worry about verify address admin actions and instead close and open admin actions after the job is completed
- adds test to ensure query eventually reaches all appeals