### PR TITLE
Match format of veteran name as saved in appeals attributes table

### DIFF
--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -278,16 +278,20 @@ describe TaskPager, :all_dbs do
           create(
             :cached_appeal,
             appeal_id: task.appeal_id,
-            veteran_name: "#{last_name.split(' ').last}, #{first_name.split(' ').first}"
+            veteran_name: "#{last_name.split(' ').last}, #{first_name}"
           )
         end
       end
 
       it "sorts by veteran last and first name" do
         expected_order = created_tasks.sort_by do |task|
-          "#{task.appeal.veteran_last_name.split(' ').last}, #{task.appeal.veteran_first_name.split(' ').first}"
+          "#{task.appeal.veteran_last_name.split(' ').last}, #{task.appeal.veteran_first_name}"
         end
-        expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id))
+        expect(subject.map do |task|
+          "#{task.appeal.veteran_last_name.split(' ').last}, #{task.appeal.veteran_first_name}"
+        end).to eq(expected_order.map do |task|
+          "#{task.appeal.veteran_last_name.split(' ').last}, #{task.appeal.veteran_first_name}"
+        end)
       end
     end
 

--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -273,7 +273,7 @@ describe TaskPager, :all_dbs do
       before do
         created_tasks.each do |task|
           first_name = Faker::Name.unique.first_name
-          last_name = "#{Faker::Name.unique.middle_name} #{Faker::Name.unique.last_name}"
+          last_name = "#{Faker::Name.unique.first_name} #{Faker::Name.unique.first_name}"
           task.appeal.veteran.update!(first_name: first_name, last_name: last_name)
           create(
             :cached_appeal,


### PR DESCRIPTION
### Description
Match test of name format to [how veteran names are saved](https://github.com/department-of-veterans-affairs/caseflow/blob/086e0d822c6966712edea67f8e52e1dc47444ec6/app/jobs/update_cached_appeals_attributes_job.rb#L177) in the cache appeal attributes job