### PR TITLE
Backfill people names

### DIFF
--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -16,9 +16,7 @@ class WarmBgsCachesJob < CaseflowJob
   private
 
   def warm_people_caches
-    Person.where(first_name: nil, last_name: nil).order(created_at: :desc).limit(5000).each do |person|
-      person.update_cached_attributes!
-    end
+    Person.where(first_name: nil, last_name: nil).order(created_at: :desc).limit(5000).each(&:update_cached_attributes!)
   end
 
   def warm_participant_caches

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -10,9 +10,16 @@ class WarmBgsCachesJob < CaseflowJob
 
     warm_participant_caches
     warm_veteran_attribute_caches
+    warm_people_caches
   end
 
   private
+
+  def warm_people_caches
+    Person.where(first_name: nil, last_name: nil).order(created_at: :desc).limit(5000).each do |person|
+      person.update_cached_attributes!
+    end
+  end
 
   def warm_participant_caches
     RegionalOffice::CITIES.each_key do |ro_id|

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -240,7 +240,7 @@ class Intake < ApplicationRecord
   def update_person!
     # Update the person when a claimant is created
     Person.find_or_create_by(participant_id: detail.claimant_participant_id).tap do |person|
-      person.update!(date_of_birth: BGSService.new.fetch_person_info(detail.claimant_participant_id)[:birth_date])
+      person.update_cached_attributes!
     end
   end
 

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -239,9 +239,7 @@ class Intake < ApplicationRecord
 
   def update_person!
     # Update the person when a claimant is created
-    Person.find_or_create_by(participant_id: detail.claimant_participant_id).tap do |person|
-      person.update_cached_attributes!
-    end
+    Person.find_or_create_by(participant_id: detail.claimant_participant_id).tap(&:update_cached_attributes!)
   end
 
   def find_or_build_initial_detail


### PR DESCRIPTION
Resolves #11612 

### Description
1. Fixes bug where creating a new Person during Intake did not cache all relevant attributes from BGS
2. Incrementally backfill 5k Person records each night during the regular BGS cache warming job.