### PR TITLE
Fix BGS participant ID lookup

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,9 @@ class UsersController < ApplicationController
     when Constants::USER_ROLE_TYPES["hearing_coordinator"]
       return render json: { coordinators: User.list_hearing_coordinators }
     when "non_judges"
-      return render json: { non_judges: json_users(User.where.not(id: JudgeTeam.all.map(&:judge).pluck(:id))) }
+      return render json: {
+        non_judges: json_users(User.where.not(id: JudgeTeam.all.map(&:judge).reject(&:nil?).map(&:id)))
+      }
     end
     render json: {}
   end


### PR DESCRIPTION
Fixes errors that were preventing Martina from looking up the BGS participant ID using the feature we added in #11794. Example of one of those errors: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/6147/

The error was caused by two judge teams not having a judges associated with them:
```ruby
rails c> JudgeTeam.all.select { |jt| jt.judge.nil? }
# IDs 313 and 317
```