### PR TITLE
Prepare frontend for backend column structure change

### DIFF
--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { css } from 'glamor';
 import { sprintf } from 'sprintf-js';
+import PropTypes from 'prop-types';
 
 import BulkAssignButton from './components/BulkAssignButton';
 import TabWindow from '../components/TabWindow';
@@ -75,7 +76,9 @@ class OrganizationQueue extends React.PureComponent {
 
   columnsFromConfig = (tabConfig, tasks) => {
     return tabConfig.columns.map((column) => {
-      return this.createColumnObject(column, tabConfig, tasks);
+      const columnName = typeof (column) === 'string' ? column : column.name;
+
+      return this.createColumnObject(columnName, tabConfig, tasks);
     });
   }
 
@@ -158,6 +161,19 @@ class OrganizationQueue extends React.PureComponent {
     </AppSegment>;
   };
 }
+
+OrganizationQueue.propTypes = {
+  assignedTasks: PropTypes.array,
+  clearCaseSelectSearch: PropTypes.func,
+  completedTasks: PropTypes.array,
+  onHoldTasks: PropTypes.array,
+  organizations: PropTypes.array,
+  queueConfig: PropTypes.object,
+  success: PropTypes.object,
+  tasksAssignedByBulk: PropTypes.object,
+  trackingTasks: PropTypes.array,
+  unassignedTasks: PropTypes.array
+};
 
 const mapStateToProps = (state) => {
   const { success } = state.ui.messages;


### PR DESCRIPTION
Allows the front-end to accept an array of either strings or objects in anticipation of the data structure changes that back-end will return when #11833 is merged (will change from strings to objects then). Since the javascript bundles are cached by the browser we need to get this front-end change into production before the back-end change to avoid page rendering errors that would result from the old front-end code being called with the new data structure.