### PR TITLE
Cache friendly labels for appeal case type

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -33,7 +33,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       {
         appeal_id: appeal.id,
         appeal_type: Appeal.name,
-        case_type: appeal.type.downcase,
+        case_type: appeal.type,
         closest_regional_office_city: regional_office ? regional_office[:city] : COPY::UNKNOWN_REGIONAL_OFFICE,
         issue_count: request_issues_to_cache[appeal.id] || 0,
         docket_type: appeal.docket_type,
@@ -150,7 +150,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
   def case_status_for_vacols_id(vacols_ids)
     statuses = VACOLS::Case.where(bfkey: vacols_ids).pluck(:bfac).map do |value|
-      VACOLS::Case::BFAC_TYPE_CACHE_KEY[value]
+      VACOLS::Case::TYPES[value]
     end
     vacols_ids.zip(statuses).to_h
   end

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -20,18 +20,6 @@ class VACOLS::Case < VACOLS::Record
 
   BVA_DISPOSITION_CODES = %w[1 3 4 5 6 8 9].freeze
 
-  BFAC_TYPE_CACHE_KEY = {
-    "1" => "original",
-    "2" => "supplemental",
-    "3" => "post_remand",
-    "4" => "reconsideration",
-    "5" => "vacate",
-    "6" => "de_novo",
-    "7" => "post_cavc_remand",
-    "8" => "designation_of_record",
-    "9" => "cue"
-  }.freeze
-
   TYPES = {
     "1" => "Original",
     "2" => "Supplemental",

--- a/spec/factories/cached_appeals.rb
+++ b/spec/factories/cached_appeals.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     docket_number { rand(1_000_000..9_999_999) }
     docket_type { "evidence_submission" }
     appeal_type { Appeal.name }
-    case_type { "original" }
+    case_type { "Original" }
     is_aod { false }
     appeal_id { rand(1..9_999) }
     vacols_id { nil }

--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -312,7 +312,7 @@ describe TaskPager, :all_dbs do
           create(:cached_appeal,
                  appeal_id: appeal.id,
                  appeal_type: LegacyAppeal.name,
-                 case_type: LegacyAppeal::TYPE_CODES[appeal.type])
+                 case_type: appeal.type)
         end
         appeals = [appeal_1, appeal_2]
         appeals.map do |appeal|
@@ -320,7 +320,7 @@ describe TaskPager, :all_dbs do
           create(:cached_appeal,
                  appeal_id: appeal.id,
                  appeal_type: Appeal.name,
-                 case_type: appeal.type.downcase,
+                 case_type: appeal.type,
                  is_aod: appeal.aod)
         end
       end

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -240,7 +240,7 @@ describe TaskSorter, :all_dbs do
             create(:cached_appeal,
                    appeal_id: appeal.id,
                    appeal_type: LegacyAppeal.name,
-                   case_type: LegacyAppeal::TYPE_CODES[appeal.type])
+                   case_type: appeal.type)
           end
 
           appeals = [create(:appeal, :advanced_on_docket_due_to_motion), create(:appeal)]
@@ -249,7 +249,7 @@ describe TaskSorter, :all_dbs do
             create(:cached_appeal,
                    appeal_id: appeal.id,
                    appeal_type: Appeal.name,
-                   case_type: appeal.type.downcase,
+                   case_type: appeal.type,
                    is_aod: appeal.aod)
           end
         end


### PR DESCRIPTION
Makes it so we only have to transform case type once (on the way into the cache table) instead of twice (again on the way out when we want to display it to the user).