### PR TITLE
Contestable rating decisions

### DIFF
--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -49,7 +49,7 @@ class ContestableIssue
       new(
         rating_issue_reference_id: rating_decision.rating_issue_reference_id,
         rating_issue_profile_date: rating_decision.profile_date.to_date,
-        rating_decision_reference_id: rating_decision.rating_sequence_number,
+        rating_decision_reference_id: rating_decision.reference_id,
         approx_decision_date: rating_decision.decision_date.to_date,
         description: rating_decision.diagnostic_text,
         contesting_decision_review: contesting_decision_review,

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -51,7 +51,7 @@ class ContestableIssue
         rating_issue_profile_date: rating_decision.profile_date.to_date,
         rating_decision_reference_id: rating_decision.reference_id,
         approx_decision_date: rating_decision.decision_date.to_date,
-        description: rating_decision.diagnostic_text,
+        description: rating_decision.decision_text,
         contesting_decision_review: contesting_decision_review,
         rating_issue_diagnostic_code: rating_decision.diagnostic_code,
         is_rating: true # true even if rating_reference_id is nil

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -24,7 +24,8 @@ class Rating
 
   # WARNING: profile_date is a misnomer adopted from BGS terminology.
   # It is a datetime, not a date.
-  attr_accessor :participant_id, :profile_date, :promulgation_date, :rating_profile
+  attr_accessor :participant_id, :profile_date, :promulgation_date
+  attr_writer :rating_profile
 
   ONE_YEAR_PLUS_DAYS = 372.days
   TWO_LIFETIMES_DAYS = 250.years

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -24,7 +24,7 @@ class Rating
 
   # WARNING: profile_date is a misnomer adopted from BGS terminology.
   # It is a datetime, not a date.
-  attr_accessor :participant_id, :profile_date, :promulgation_date
+  attr_accessor :participant_id, :profile_date, :promulgation_date, :rating_profile
 
   ONE_YEAR_PLUS_DAYS = 372.days
   TWO_LIFETIMES_DAYS = 250.years

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -51,6 +51,10 @@ class RatingDecision
     end
   end
 
+  def decision_text
+    service_connected? ? service_connected_decision_text : not_service_connected_decision_text
+  end
+
   def decision_date
     return promulgation_date if rating_issue?
 
@@ -85,5 +89,15 @@ class RatingDecision
 
   def service_connected?
     type_name == "Service Connected"
+  end
+
+  private
+
+  def service_connected_decision_text
+    "#{diagnostic_type} (#{diagnostic_text}) is granted as Service Connected"
+  end
+
+  def not_service_connected_decision_text
+    "#{diagnostic_type} (#{diagnostic_text}) is denied as Not Service Connected"
   end
 end

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -57,7 +57,7 @@ class RatingDecision
     original_denial_date || converted_begin_date || begin_date
   end
 
-  def part_of_rating?
+  def contestable?
     return true if rating_issue?
 
     return false unless decision_date

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -55,6 +55,10 @@ class RatingDecision
     original_denial_date || converted_begin_date || begin_date || promulgation_date
   end
 
+  def reference_id
+    disability_id
+  end
+
   # If you change this method, you will need to clear cache in prod for your changes to
   # take effect immediately. See DecisionReview#cached_serialized_ratings
   def serialize

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -52,7 +52,23 @@ class RatingDecision
   end
 
   def decision_date
-    original_denial_date || converted_begin_date || begin_date || promulgation_date
+    return promulgation_date if rating_issue?
+
+    original_denial_date || converted_begin_date || begin_date
+  end
+
+  def part_of_rating?
+    return true if rating_issue?
+
+    return false unless decision_date
+
+    the_decision = decision_date.to_date
+    the_promulgation = promulgation_date.to_date
+    the_decision.between?((the_promulgation - 10.days), (the_promulgation + 10.days))
+  end
+
+  def rating_issue?
+    rating_issue_reference_id.present?
   end
 
   def reference_id

--- a/spec/models/contestable_issue_spec.rb
+++ b/spec/models/contestable_issue_spec.rb
@@ -73,7 +73,7 @@ describe ContestableIssue, :postgres do
         rating_issue_profile_date: profile_date,
         decision_issue: nil,
         approx_decision_date: rating_decision.begin_date,
-        description: rating_decision.diagnostic_text,
+        description: rating_decision.decision_text,
         contesting_decision_review: decision_review,
         rating_issue_diagnostic_code: diagnostic_code,
         source_review_type: nil
@@ -86,7 +86,7 @@ describe ContestableIssue, :postgres do
         ratingIssueDiagnosticCode: diagnostic_code,
         decisionIssueId: nil,
         approxDecisionDate: rating_decision.begin_date,
-        description: rating_decision.diagnostic_text,
+        description: rating_decision.decision_text,
         isRating: true,
         rampClaimId: nil,
         titleOfActiveReview: nil,

--- a/spec/models/contestable_issue_spec.rb
+++ b/spec/models/contestable_issue_spec.rb
@@ -81,7 +81,7 @@ describe ContestableIssue, :postgres do
 
       expect(contestable_issue.serialize).to eq(
         ratingIssueReferenceId: nil,
-        ratingDecisionReferenceId: rating_decision.rating_sequence_number,
+        ratingDecisionReferenceId: rating_decision.reference_id,
         ratingIssueProfileDate: profile_date,
         ratingIssueDiagnosticCode: diagnostic_code,
         decisionIssueId: nil,

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -149,5 +149,11 @@ describe RatingDecision do
         expect(subject.decision_date).to eq(begin_date)
       end
     end
+
+    describe "#reference_id" do
+      it "uses the disability id" do
+        expect(subject.reference_id).to eq("67468264")
+      end
+    end
   end
 end

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -149,6 +149,28 @@ describe RatingDecision do
       end
     end
 
+    describe "#contestable?" do
+      subject { described_class.from_bgs_disability(rating, bgs_record).contestable? }
+
+      context "rating_issue? is true" do
+        it { is_expected.to eq(true) }
+      end
+
+      context "rating_issue? is false" do
+        let(:rating_issue_reference_id) { nil }
+
+        context "promulgation date and original_denial_date are close" do
+          it { is_expected.to eq(true) }
+        end
+
+        context "promulgation date and original_denial_date are not close" do
+          let(:original_denial_date) { promulgation_date + 6.months }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+
     describe "#decision_date" do
       context "decision is a rating issue" do
         let(:rating_issue_reference_id) { "123" }

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -18,6 +18,9 @@ describe RatingDecision do
   let(:promulgation_date) { Time.zone.today - 30 }
   let(:participant_id) { "1234567" }
   let(:begin_date) { profile_date + 30.days }
+  let(:disability_id) { "5678" }
+  let(:rating_issue_reference_id) { "123" }
+  let(:original_denial_date) { promulgation_date - 7 }
 
   context ".deserialize" do
     subject { described_class.deserialize(rating_decision.serialize) }
@@ -27,7 +30,8 @@ describe RatingDecision do
         profile_date: profile_date,
         promulgation_date: promulgation_date,
         rating_sequence_number: "1234",
-        disability_id: "5678",
+        rating_issue_reference_id: rating_issue_reference_id,
+        disability_id: disability_id,
         diagnostic_text: "tinnitus",
         diagnostic_code: "6260",
         begin_date: begin_date,
@@ -63,7 +67,8 @@ describe RatingDecision do
     let(:bgs_record) do
       {
         decn_tn: decision_type_name,
-        dis_sn: "67468264",
+        dis_sn: disability_id,
+        orig_denial_dt: original_denial_date,
         disability_evaluations: {
           begin_dt: begin_date,
           dgnstc_tc: "6260",
@@ -71,7 +76,7 @@ describe RatingDecision do
           dgnstc_txt: "tinnitus",
           prfl_dt: profile_date,
           rating_sn: "227606458",
-          rba_issue_id: "56780000"
+          rba_issue_id: rating_issue_reference_id
         }
       }
     end
@@ -82,8 +87,8 @@ describe RatingDecision do
       is_expected.to have_attributes(
         type_name: decision_type_name,
         rating_sequence_number: "227606458",
-        rating_issue_reference_id: "56780000",
-        disability_id: "67468264",
+        rating_issue_reference_id: rating_issue_reference_id,
+        disability_id: disability_id,
         diagnostic_text: "tinnitus",
         diagnostic_type: "Tinnitus",
         diagnostic_code: "6260",
@@ -94,12 +99,12 @@ describe RatingDecision do
       )
     end
 
-    context "with multiple disabilities" do
+    context "with multiple disability evaluations" do
       let(:bgs_record) do
         {
           decn_tn: decision_type_name,
           dis_dt: 1.year.ago,
-          dis_sn: "67468264",
+          dis_sn: disability_id,
           disability_evaluations: [
             {
               dis_dt: 1.year.ago - 1.day,
@@ -145,14 +150,35 @@ describe RatingDecision do
     end
 
     describe "#decision_date" do
-      it "uses the begin_date if available" do
-        expect(subject.decision_date).to eq(begin_date)
+      context "decision is a rating issue" do
+        let(:rating_issue_reference_id) { "123" }
+
+        it "uses the promulgation_date if the decision is a rating issue" do
+          expect(subject.decision_date).to eq(promulgation_date)
+        end
+      end
+
+      context "decision is not a rating issue" do
+        let(:rating_issue_reference_id) { nil }
+        let(:original_denial_date) { Time.zone.today }
+
+        it "prefers the original_denial_date" do
+          expect(subject.decision_date).to eq(original_denial_date)
+        end
+
+        context "original_denial_date is nil" do
+          let(:original_denial_date) { nil }
+
+          it "defaults to begin_date" do
+            expect(subject.decision_date).to eq(begin_date)
+          end
+        end
       end
     end
 
     describe "#reference_id" do
       it "uses the disability id" do
-        expect(subject.reference_id).to eq("67468264")
+        expect(subject.reference_id).to eq(disability_id)
       end
     end
   end

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -149,6 +149,24 @@ describe RatingDecision do
       end
     end
 
+    describe "#decision_text" do
+      context "Not Service Connected" do
+        let(:decision_type_name) { "Not Service Connected" }
+
+        it "returns formatted diagnosis statement" do
+          expect(subject.decision_text).to eq("Tinnitus (tinnitus) is denied as Not Service Connected")
+        end
+      end
+
+      context "Service Connected" do
+        let(:decision_type_name) { "Service Connected" }
+
+        it "returns formatted diagnosis statement" do
+          expect(subject.decision_text).to eq("Tinnitus (tinnitus) is granted as Service Connected")
+        end
+      end
+    end
+
     describe "#contestable?" do
       subject { described_class.from_bgs_disability(rating, bgs_record).contestable? }
 


### PR DESCRIPTION
connects #11840 

### Description
Consider a RatingDecision contestable if its decision (original_denial_date) date is within 10 days +/- of the parent Rating's promulgation (decision) date.

Successfully tested locally with production data for participant ids 31140273 and 4563635

using this:
```ruby
ratings.map { |r| r.decisions.select(&:contestable?).reject(&:rating_issue?) }.flatten
```