### PR TITLE
Remove reference to task action field in factory

### DIFF
--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -115,10 +115,8 @@ FactoryBot.define do
 
         JudgeAssignTask.create!(appeal: appeal,
                                 parent: appeal.root_task,
-                                appeal_type: Appeal.name,
                                 assigned_at: evaluator.active_task_assigned_at,
-                                assigned_to: evaluator.associated_judge,
-                                action: COPY::JUDGE_ASSIGN_TASK_LABEL)
+                                assigned_to: evaluator.associated_judge)
         appeal.tasks.where(type: DistributionTask.name).update(status: :completed)
       end
     end


### PR DESCRIPTION
Connects #9057. Removes a stray reference to the `tasks.action` field [from the appeal factory](https://github.com/department-of-veterans-affairs/caseflow/issues/9057#issuecomment-524119590) that we missed on the first pass.

Running `bundle exec rake db:seed` succeeds after this PR but failed before with the following error:
```
ActiveModel::UnknownAttributeError: unknown attribute 'action' for JudgeAssignTask
```

Confident that we have removed all references to the `action` field from our factories for a few reasons:
1. Searching the code reveals no remaining references: `caseflow $ git grep "\baction\b" spec/factories/`
1. Automated tests pass
1. Seeding the database succeeds