### PR TITLE
Fix pager sort to ignore case and consistent ruby-vs-sql

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -13,6 +13,7 @@ detectors:
   ControlParameter:
     exclude:
       - HearingRepository#slot_new_hearing
+      - TaskSorter#sort_requires_case_norm?
   UncommunicativeVariableName:
     exclude:
       - Address

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -31,8 +31,24 @@ class TaskSorter
 
   private
 
+  def sort_requires_case_norm?(col)
+    return false if col =~ /_at$/
+    return false if col =~ /^is_/
+    return false if col =~ /_count$/
+
+    true
+  end
+
   def order_clause
-    column.sorting_columns.map { |col| "#{column.sorting_table}.#{col} #{sort_order}" }.join(", ")
+    clauses = column.sorting_columns.map do |col|
+      tbl_clause = if sort_requires_case_norm?(col)
+                     "UPPER(#{column.sorting_table}.#{col})"
+                   else
+                     "#{column.sorting_table}.#{col}"
+                   end
+      "#{tbl_clause} #{sort_order}"
+    end
+    clauses.join(", ")
   end
 
   def column_is_valid

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -31,10 +31,11 @@ class TaskSorter
 
   private
 
+  # some columns cannot be cast through SQL UPPER for normalized sorting.
   def sort_requires_case_norm?(col)
-    return false if col =~ /_at$/
-    return false if col =~ /^is_/
-    return false if col =~ /_count$/
+    return false if col =~ /_at$/ # no timestamps
+    return false if col =~ /^is_/ # no booleans
+    return false if col =~ /_count$/ # no integers
 
     true
   end

--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -243,7 +243,7 @@ describe TaskPager, :all_dbs do
 
       it "sorts by regional office city" do
         expected_order = created_tasks.sort_by do |task|
-          RegionalOffice::CITIES[task.appeal.closest_regional_office][:city].downcase
+          RegionalOffice::CITIES[task.appeal.closest_regional_office][:city].upcase.gsub(" ", "_")
         end
         expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id))
       end

--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -243,7 +243,7 @@ describe TaskPager, :all_dbs do
 
       it "sorts by regional office city" do
         expected_order = created_tasks.sort_by do |task|
-          RegionalOffice::CITIES[task.appeal.closest_regional_office][:city].upcase.gsub(" ", "_")
+          RegionalOffice::CITIES[task.appeal.closest_regional_office][:city].upcase.tr(" ", "_")
         end
         expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id))
       end


### PR DESCRIPTION
If you ask Ruby which comes first alphabetically, `Newark` or `New York`, you'll get a different answer than if you ask PostgreSQL the same question. Substituting an underscore for a space in Ruby makes them sort the same way, predictably.