### PR TITLE
Add rating decisions to Intake Add Issues page

### DIFF
--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -79,10 +79,6 @@ class RatingDecision
     disability_id
   end
 
-  def reference_id
-    disability_id
-  end
-
   # If you change this method, you will need to clear cache in prod for your changes to
   # take effect immediately. See DecisionReview#cached_serialized_ratings
   def serialize

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -79,6 +79,10 @@ class RatingDecision
     disability_id
   end
 
+  def reference_id
+    disability_id
+  end
+
   # If you change this method, you will need to clear cache in prod for your changes to
   # take effect immediately. See DecisionReview#cached_serialized_ratings
   def serialize

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -56,9 +56,9 @@ class RatingDecision
   end
 
   def decision_date
-    return promulgation_date if rating_issue?
+    return promulgation_date if rating_issue? || denial_date_near_promulgation_date?
 
-    original_denial_date || converted_begin_date || begin_date
+    denial_date
   end
 
   def contestable?
@@ -66,9 +66,7 @@ class RatingDecision
 
     return false unless decision_date
 
-    the_decision = decision_date.to_date
-    the_promulgation = promulgation_date.to_date
-    the_decision.between?((the_promulgation - 10.days), (the_promulgation + 10.days))
+    denial_date_near_promulgation_date?
   end
 
   def rating_issue?
@@ -92,6 +90,18 @@ class RatingDecision
   end
 
   private
+
+  def denial_date
+    original_denial_date || converted_begin_date || begin_date
+  end
+
+  def denial_date_near_promulgation_date?
+    return false unless denial_date
+
+    the_decision = denial_date.to_date
+    the_promulgation = promulgation_date.to_date
+    the_decision.between?((the_promulgation - 10.days), (the_promulgation + 10.days))
+  end
 
   def service_connected_decision_text
     "#{diagnostic_type} (#{diagnostic_text}) is granted as Service Connected"

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -263,7 +263,7 @@ class RequestIssue < ApplicationRecord
 
     # rubocop:disable Metrics/MethodLength
     def attributes_from_intake_data(data)
-      contested_issue_present = data[:rating_issue_reference_id] || data[:contested_decision_issue_id]
+      contested_issue_present = attributes_look_like_contested_issue?(data)
 
       {
         contested_rating_issue_reference_id: data[:rating_issue_reference_id],
@@ -290,6 +290,12 @@ class RequestIssue < ApplicationRecord
       }
     end
     # rubocop:enable Metrics/MethodLength
+
+    def attributes_look_like_contested_issue?(data)
+      data[:rating_issue_reference_id] ||
+        data[:contested_decision_issue_id] ||
+        data[:rating_decision_reference_id]
+    end
   end
 
   delegate :veteran, to: :decision_review

--- a/client/app/intake/actions/addIssues.js
+++ b/client/app/intake/actions/addIssues.js
@@ -109,6 +109,7 @@ export const addContestableIssue = (args) => (dispatch) => {
       index: args.contestableIssueIndex,
       isRating: args.isRating,
       ratingIssueReferenceId: currentIssue.ratingIssueReferenceId,
+      ratingDecisionReferenceId: currentIssue.ratingDecisionReferenceId,
       ratingIssueProfileDate: currentIssue.ratingIssueProfileDate,
       ratingIssueDiagnosticCode: currentIssue.ratingIssueDiagnosticCode,
       decisionIssueId: currentIssue.decisionIssueId,

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -17,7 +17,8 @@ class AddedIssue extends React.PureComponent {
       return true;
     }
 
-    let existingRequestIssue = _.filter(requestIssues, { rating_issue_reference_id: issue.ratingIssueReferenceId })[0];
+    let existingRequestIssue = _.filter(requestIssues, { rating_issue_reference_id: issue.ratingIssueReferenceId })[0] ||
+                               _.filter(requestIssues, { rating_decision_reference_id: issue.ratingDecisionReferenceId })[0];
 
     if (existingRequestIssue && !existingRequestIssue.ineligible_reason) {
       return false;

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -94,7 +94,8 @@ const contestableIssueIndexByRequestIssue = (contestableIssuesByDate, requestIss
   const foundContestableIssue = _.reduce(contestableIssuesByDate, (foundIssue, contestableIssues) => {
     return foundIssue || _.find(contestableIssues, {
       decisionIssueId: requestIssue.contested_decision_issue_id,
-      ratingIssueReferenceId: requestIssue.rating_issue_reference_id
+      ratingIssueReferenceId: requestIssue.rating_issue_reference_id,
+      ratingDecisionReferenceId: requestIssue.rating_decision_reference_id
     });
   }, null);
 
@@ -162,6 +163,7 @@ export const formatRequestIssues = (requestIssues, contestableIssues) => {
       index: contestableIssueIndexByRequestIssue(contestableIssues, issue),
       isRating: true,
       ratingIssueReferenceId: issue.rating_issue_reference_id,
+      ratingDecisionReferenceId: issue.rating_decision_reference_id,
       ratingIssueProfileDate: issueDate.toISOString(),
       approxDecisionDate: issue.approx_decision_date,
       decisionIssueId: issue.contested_decision_issue_id,
@@ -232,6 +234,7 @@ const formatRatingRequestIssues = (state) => {
       return {
         request_issue_id: issue.id,
         rating_issue_reference_id: issue.ratingIssueReferenceId,
+        rating_decision_reference_id: issue.ratingDecisionReferenceId,
         decision_date: issue.decisionDate,
         decision_text: issue.description,
         rating_issue_profile_date: issue.ratingIssueProfileDate,

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -221,5 +221,11 @@ describe RatingDecision do
         expect(subject.reference_id).to eq(disability_id)
       end
     end
+
+    describe "#reference_id" do
+      it "uses the disability id" do
+        expect(subject.reference_id).to eq("67468264")
+      end
+    end
   end
 end

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -189,28 +189,6 @@ describe RatingDecision do
       end
     end
 
-    describe "#contestable?" do
-      subject { described_class.from_bgs_disability(rating, bgs_record).contestable? }
-
-      context "rating_issue? is true" do
-        it { is_expected.to eq(true) }
-      end
-
-      context "rating_issue? is false" do
-        let(:rating_issue_reference_id) { nil }
-
-        context "promulgation date and original_denial_date are close" do
-          it { is_expected.to eq(true) }
-        end
-
-        context "promulgation date and original_denial_date are not close" do
-          let(:original_denial_date) { promulgation_date + 6.months }
-
-          it { is_expected.to eq(false) }
-        end
-      end
-    end
-
     describe "#decision_date" do
       context "decision is a rating issue" do
         let(:rating_issue_reference_id) { "123" }

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -221,11 +221,5 @@ describe RatingDecision do
         expect(subject.reference_id).to eq(disability_id)
       end
     end
-
-    describe "#reference_id" do
-      it "uses the disability id" do
-        expect(subject.reference_id).to eq("67468264")
-      end
-    end
   end
 end

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -189,6 +189,28 @@ describe RatingDecision do
       end
     end
 
+    describe "#contestable?" do
+      subject { described_class.from_bgs_disability(rating, bgs_record).contestable? }
+
+      context "rating_issue? is true" do
+        it { is_expected.to eq(true) }
+      end
+
+      context "rating_issue? is false" do
+        let(:rating_issue_reference_id) { nil }
+
+        context "promulgation date and original_denial_date are close" do
+          it { is_expected.to eq(true) }
+        end
+
+        context "promulgation date and original_denial_date are not close" do
+          let(:original_denial_date) { promulgation_date + 6.months }
+
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+
     describe "#decision_date" do
       context "decision is a rating issue" do
         let(:rating_issue_reference_id) { "123" }


### PR DESCRIPTION
connects #11840 

[WIP]

### Description
Adds the `RatingDecision` contestable issues to the Add Issues page, grouping them with the Ratings to which they belong.