### PR TITLE
Claim review async stats

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -33,6 +33,7 @@ detectors:
       - Api::ApplicationController#on_external_error
       - Api::ApplicationController#upstream_known_error
       - AsyncableJobsReporter
+      - ClaimReviewAsyncStatsReporter#as_csv
       - DataIntegrityChecksJob
       - DecisionIssueSyncJob
       - Fakes::EndProductStore

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -115,6 +115,14 @@ module Asyncable
         .where(canceled_at_column => nil)
         .order_by_oldest_submitted
     end
+
+    def processed
+      where.not(processed_at_column => nil)
+    end
+
+    def processed_or_canceled
+      processed.or(canceled)
+    end
   end
 
   def submit_for_processing!(delay: 0)

--- a/app/services/claim_review_async_stats_reporter.rb
+++ b/app/services/claim_review_async_stats_reporter.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class ClaimReviewAsyncStatsReporter
+  attr_reader :stats
+
+  def initialize(start_date: Constants::DATES["AMA_ACTIVATION"].to_date, end_date: Time.zone.today)
+    @start_date = start_date
+    @end_date = end_date
+    @stats = build
+  end
+
+  def as_csv
+    CSV.generate do |csv|
+      csv << %w[type total cancelled processed median avg max min]
+      stats.each do |type, stat|
+        csv << [
+          type,
+          stat[:total],
+          stat[:canceled],
+          stat[:processed],
+          seconds_to_hms(stat[:median].to_i),
+          seconds_to_hms(stat[:avg].to_i),
+          seconds_to_hms(stat[:max].to_i),
+          seconds_to_hms(stat[:min].to_i)
+        ]
+      end
+    end
+  end
+
+  private
+
+  attr_reader :start_date, :end_date
+
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+  def build
+    {
+      supplemental_claims: {
+        total: supplemental_claims.count,
+        canceled: supplemental_claims.canceled.count,
+        processed: supplemental_claims.processed.count,
+        median: median_time(supplemental_claims_completion_times),
+        avg: avg_time(supplemental_claims_completion_times),
+        max: supplemental_claims_completion_times.max,
+        min: supplemental_claims_completion_times.min
+      },
+      higher_level_reviews: {
+        total: higher_level_reviews.count,
+        canceled: higher_level_reviews.canceled.count,
+        processed: higher_level_reviews.processed.count,
+        median: median_time(higher_level_reviews_completion_times),
+        avg: avg_time(higher_level_reviews_completion_times),
+        max: higher_level_reviews_completion_times.max,
+        min: higher_level_reviews_completion_times.min
+      },
+      request_issues_updates: {
+        total: request_issues_updates.count,
+        canceled: request_issues_updates.canceled.count,
+        processed: request_issues_updates.processed.count,
+        median: median_time(request_issues_updates_completion_times),
+        avg: avg_time(request_issues_updates_completion_times),
+        max: request_issues_updates_completion_times.max,
+        min: request_issues_updates_completion_times.min
+      }
+    }
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+
+  def completion_times(claims)
+    claims.reject(&:canceled?).map do |claim|
+      hash = claim.asyncable_ui_hash
+      hash[:processed_at] - hash[:submitted_at]
+    end
+  end
+
+  def supplemental_claims_completion_times
+    @supplemental_claims_completion_times ||= completion_times(supplemental_claims)
+  end
+
+  def higher_level_reviews_completion_times
+    @higher_level_reviews_completion_times ||= completion_times(higher_level_reviews)
+  end
+
+  def request_issues_updates_completion_times
+    @request_issues_updates_completion_times ||= completion_times(request_issues_updates)
+  end
+
+  def supplemental_claims
+    @supplemental_claims ||= begin
+      SupplementalClaim.processed_or_canceled
+        .where("establishment_submitted_at >= ? AND establishment_submitted_at <= ?", start_date, end_date)
+    end
+  end
+
+  def higher_level_reviews
+    @higher_level_reviews ||= begin
+      HigherLevelReview.processed_or_canceled
+        .where("establishment_submitted_at >= ? AND establishment_submitted_at <= ?", start_date, end_date)
+    end
+  end
+
+  def request_issues_updates
+    @request_issues_updates ||= begin
+      RequestIssuesUpdate.processed_or_canceled.where("submitted_at >= ? AND submitted_at <= ?", start_date, end_date)
+    end
+  end
+
+  def seconds_to_hms(secs)
+    [secs / 3600, secs / 60 % 60, secs % 60].map { |segment| segment.to_s.rjust(2, "0") }.join(":")
+  end
+
+  def median_time(times)
+    return 0 if times.empty?
+
+    len = times.length
+    (times[(len - 1) / 2] + times[len / 2]) / 2.0
+  end
+
+  def avg_time(times)
+    return 0 if times.empty?
+
+    times.sum.to_f / times.length
+  end
+end

--- a/spec/services/claim_review_async_stats_reporter_spec.rb
+++ b/spec/services/claim_review_async_stats_reporter_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "support/database_cleaner"
+require "rails_helper"
+
+describe ClaimReviewAsyncStatsReporter, :postgres do
+  before do
+    seven_am_random_date = Time.new(2019, 3, 29, 7, 0, 0).in_time_zone
+    Timecop.freeze(seven_am_random_date)
+  end
+
+  let(:veteran) { create(:veteran) }
+
+  let!(:hlrs) do
+    create(:higher_level_review, veteran_file_number: veteran.file_number)
+    create(:higher_level_review,
+           establishment_submitted_at: 7.days.ago,
+           establishment_processed_at: 6.days.ago,
+           veteran_file_number: veteran.file_number)
+    create(:higher_level_review,
+           establishment_submitted_at: 6.days.ago,
+           establishment_canceled_at: 5.days.ago,
+           veteran_file_number: veteran.file_number)
+    create(:higher_level_review,
+           establishment_submitted_at: 7.days.ago,
+           establishment_processed_at: 7.days.ago + 1.hour,
+           veteran_file_number: veteran.file_number)
+    create(:higher_level_review,
+           establishment_submitted_at: 7.days.ago,
+           establishment_processed_at: 7.days.ago + 4.hours,
+           veteran_file_number: veteran.file_number)
+  end
+
+  let!(:scs) do
+    create(:supplemental_claim, veteran_file_number: veteran.file_number)
+    create(:supplemental_claim,
+           establishment_submitted_at: 7.days.ago,
+           establishment_processed_at: 6.days.ago,
+           veteran_file_number: veteran.file_number)
+    create(:supplemental_claim,
+           establishment_submitted_at: 6.days.ago,
+           establishment_processed_at: 5.days.ago,
+           veteran_file_number: veteran.file_number)
+    create(:supplemental_claim,
+           establishment_submitted_at: 7.days.ago,
+           establishment_canceled_at: 7.days.ago + 1.hour,
+           veteran_file_number: veteran.file_number)
+    create(:supplemental_claim,
+           establishment_submitted_at: 7.days.ago,
+           establishment_processed_at: 7.days.ago + 4.hours,
+           veteran_file_number: veteran.file_number)
+  end
+
+  let!(:rius) do
+    create(:request_issues_update)
+    create(:request_issues_update,
+           submitted_at: 7.days.ago,
+           processed_at: 5.days.ago)
+    create(:request_issues_update,
+           submitted_at: 6.days.ago,
+           processed_at: 5.days.ago)
+    create(:request_issues_update,
+           submitted_at: 7.days.ago,
+           processed_at: 7.days.ago + 1.hour)
+    create(:request_issues_update,
+           submitted_at: 7.days.ago,
+           canceled_at: 7.days.ago + 4.hours)
+  end
+
+  describe "#stats" do
+    subject { described_class.new.stats }
+
+    it "returns nested hash" do
+      expect(subject).to eq(
+        supplemental_claims: {
+          total: 4,
+          canceled: 1,
+          processed: 3,
+          median: 86_400.0,
+          avg: 62_400.0,
+          max: 86_400.0,
+          min: 14_400.0
+        },
+        higher_level_reviews: {
+          total: 4,
+          canceled: 1,
+          processed: 3,
+          median: 3_600.0,
+          avg: 34_800.0,
+          max: 86_400.0,
+          min: 3_600.0
+        },
+        request_issues_updates: {
+          total: 4,
+          canceled: 1,
+          processed: 3,
+          median: 86_400.0,
+          avg: 87_600.0,
+          max: 172_800.0,
+          min: 3_600.0
+        }
+      )
+    end
+  end
+
+  describe "#as_csv" do
+    subject { described_class.new.as_csv }
+
+    it "returns CSV" do
+      csv = subject
+      expect(csv).to match(/supplemental_claims,4,1,3,24:00:00,17:20:00,24:00:00,04:00:00/)
+    end
+  end
+end


### PR DESCRIPTION
connects #11927 

### Description
Reporter class for gathering statistics for async claim review jobs.

Intended to be run via the console on demand, to generate a report for mailing.