### PR TITLE
Handle null error body in AppealHearingLocations dropdown

### DIFF
--- a/client/app/components/DataDropdowns/AppealHearingLocations.jsx
+++ b/client/app/components/DataDropdowns/AppealHearingLocations.jsx
@@ -96,13 +96,13 @@ class AppealHearingLocationsDropdown extends React.Component {
       this.props.onDropdownError(dropdownName, null);
     }).
       catch(({ response }) => {
-        let errorReason = '.';
+        let errorReason = _.get(response, 'body.errors[0].detail') || '';
 
-        if (!_.isNil(response)) {
-          errorReason = `. ${response.body.errors[0].detail}`;
+        if (errorReason !== '') {
+          errorReason = ` ${errorReason}`;
         }
 
-        const errorMsg = `Could not find hearing locations for this appellant${errorReason}`;
+        const errorMsg = `Could not find hearing locations for this appellant.${errorReason}`;
 
         this.props.onReceiveDropdownData(dropdownName, []);
         this.props.onDropdownError(dropdownName, errorMsg);


### PR DESCRIPTION
Resolves #11911

### Description

Saw that this call to the API triggered the null exception:

```
GET /hearings/find_closest_hearing_locations?regional_office=RO21&appeal_id=2898162 [500]
```

Reproduced this locally by calling a bogus method in the controller to trigger a 500.

#### Changes

- Updated the frontend to safely traverse the response body with lodash `_.get`