### PR TITLE
Async jobs page style

### DIFF
--- a/client/app/asyncableJobs/components/AsyncModelNav.jsx
+++ b/client/app/asyncableJobs/components/AsyncModelNav.jsx
@@ -1,21 +1,33 @@
 import React from 'react';
 import moment from 'moment';
+import PropTypes from 'prop-types';
+import DropdownButton from '../../components/DropdownButton';
 
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
 export default class AsyncModelNav extends React.PureComponent {
   modelNameLinks = () => {
-    let links = [];
+    const links = [];
+    const modelNames = this.props.models.sort();
+    const numLinks = modelNames.length;
 
-    for (let modelName of this.props.models.sort()) {
-      let modelLink = <span key={modelName} className="cf-model-jobs-link">
-        <a href={`/asyncable_jobs/${modelName}/jobs`}>{modelName}</a>
-      </span>;
+    for (let modelName of modelNames) {
+      const url = `/asyncable_jobs/${modelName}/jobs`;
+      let modelLink;
+
+      if (numLinks > 4) {
+        modelLink = {
+          title: modelName,
+          target: url
+        };
+      } else {
+        modelLink = <span key={modelName} className="cf-model-jobs-link"><a href={url}>{modelName}</a></span>;
+      }
 
       links.push(modelLink);
     }
 
-    return links;
+    return numLinks > 4 ? <DropdownButton lists={links} label="Job Type" /> : links;
   }
 
   render = () => {
@@ -23,8 +35,13 @@ export default class AsyncModelNav extends React.PureComponent {
     return <div>
       <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}
       &nbsp;&#183;&nbsp;
-      <a href="/jobs">All jobs</a>
+      <a href="/jobs" className="cf-link-btn">All jobs</a>
       <div>{this.modelNameLinks()}</div>
     </div>;
   }
 }
+
+AsyncModelNav.propTypes = {
+  models: PropTypes.array,
+  fetchedAt: PropTypes.string
+};

--- a/client/app/asyncableJobs/components/AsyncModelNav.jsx
+++ b/client/app/asyncableJobs/components/AsyncModelNav.jsx
@@ -27,16 +27,17 @@ export default class AsyncModelNav extends React.PureComponent {
       links.push(modelLink);
     }
 
-    return numLinks > 4 ? <DropdownButton lists={links} label="Job Type" /> : links;
+    return numLinks > 4 ? <DropdownButton lists={links} label="Filter by Job Type" /> : links;
   }
 
   render = () => {
 
     return <div>
       <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}
-      &nbsp;&#183;&nbsp;
-      <a href="/jobs" className="cf-link-btn">All jobs</a>
-      <div>{this.modelNameLinks()}</div>
+      <div>
+        {this.modelNameLinks()}
+        <a style={{ float: 'right' }} href="/jobs" className="cf-link-btn">All jobs</a>
+      </div>
     </div>;
   }
 }

--- a/client/app/asyncableJobs/components/JobRestartButton.jsx
+++ b/client/app/asyncableJobs/components/JobRestartButton.jsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import Button from '../../components/Button';
+import ApiUtil from '../../util/ApiUtil';
+
+class JobRestartButton extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      restarted: false,
+      restarting: false
+    };
+  }
+
+  restartJob = () => {
+    this.setState({ restarting: true });
+    this.sendRestart();
+  }
+
+  sendRestart = () => {
+    const page = this;
+    const job = this.props.job;
+    const url = `/asyncable_jobs/${job.klass}/jobs/${job.id}`;
+
+    ApiUtil.patch(url, {}).
+      then(
+        (response) => {
+          const responseObject = JSON.parse(response.text);
+
+          Object.assign(job, responseObject);
+
+          job.error = '';
+          job.restarted = true;
+
+          page.setState({
+            restarted: true,
+            restarting: false
+          });
+        },
+        (error) => {
+          throw error;
+        }
+      ).
+      catch((error) => error);
+  }
+
+  getButtonClassNames = () => {
+    let classNames = ['usa-button'];
+
+    if (this.state.restarting || this.state.restarted) {
+      classNames.push('usa-button-disabled');
+    }
+
+    return classNames;
+  }
+
+  getButtonText = () => {
+    let txt = 'Restart';
+
+    if (this.state.restarting) {
+      txt = 'Restarting';
+    } else if (this.state.restarted) {
+      txt = 'Restarted';
+    } else if (this.disableRestart()) {
+      txt = 'Queued';
+    }
+
+    return txt;
+  }
+
+  disableRestart = () => {
+    const job = this.props.job;
+
+    if (!job.attempted_at) {
+      return true;
+    }
+
+    const fiveMinutes = 300000;
+
+    const lastAttempted = new Date(job.attempted_at).getTime();
+    const submittedAt = new Date(job.last_submitted_at).getTime();
+    const now = new Date().getTime();
+
+    if ((now - lastAttempted) < fiveMinutes || (now - submittedAt) < fiveMinutes) {
+      return true;
+    }
+
+    return false;
+  }
+
+  render = () => {
+    const job = this.props.job;
+
+    return <Button
+      id={`job-${job.klass}-${job.id}`}
+      title={`${job.klass} ${job.id}`}
+      loading={this.state.restarting}
+      loadingText="Restarting..."
+      disabled={this.disableRestart()}
+      onClick={() => {
+        this.restartJob();
+      }}
+      classNames={this.getButtonClassNames()}
+      >{this.getButtonText()}</Button>;
+  }
+}
+
+export default JobRestartButton;

--- a/client/app/asyncableJobs/components/JobRestartButton.jsx
+++ b/client/app/asyncableJobs/components/JobRestartButton.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Button from '../../components/Button';
 import ApiUtil from '../../util/ApiUtil';
+import PropTypes from 'prop-types';
 
 class JobRestartButton extends React.PureComponent {
   constructor(props) {
@@ -101,8 +102,12 @@ class JobRestartButton extends React.PureComponent {
         this.restartJob();
       }}
       classNames={this.getButtonClassNames()}
-      >{this.getButtonText()}</Button>;
+    >{this.getButtonText()}</Button>;
   }
 }
+
+JobRestartButton.propTypes = {
+  job: PropTypes.object
+};
 
 export default JobRestartButton;

--- a/client/app/asyncableJobs/components/JobRestartButton.jsx
+++ b/client/app/asyncableJobs/components/JobRestartButton.jsx
@@ -19,7 +19,8 @@ class JobRestartButton extends React.PureComponent {
   }
 
   sendRestart = () => {
-    const page = this;
+    const button = this;
+    const page = this.props.page;
     const job = this.props.job;
     const url = `/asyncable_jobs/${job.klass}/jobs/${job.id}`;
 
@@ -33,10 +34,15 @@ class JobRestartButton extends React.PureComponent {
           job.error = '';
           job.restarted = true;
 
-          page.setState({
+          button.setState({
             restarted: true,
             restarting: false
           });
+
+          // trigger table rerender
+          const jobsRestarted = page.state.restarted + 1;
+
+          page.setState({ restarted: jobsRestarted });
         },
         (error) => {
           throw error;
@@ -107,7 +113,8 @@ class JobRestartButton extends React.PureComponent {
 }
 
 JobRestartButton.propTypes = {
-  job: PropTypes.object
+  job: PropTypes.object,
+  page: PropTypes.object
 };
 
 export default JobRestartButton;

--- a/client/app/asyncableJobs/components/JobRestartButton.jsx
+++ b/client/app/asyncableJobs/components/JobRestartButton.jsx
@@ -43,12 +43,8 @@ class JobRestartButton extends React.PureComponent {
           const jobsRestarted = page.state.restarted + 1;
 
           page.setState({ restarted: jobsRestarted });
-        },
-        (error) => {
-          throw error;
         }
-      ).
-      catch((error) => error);
+      );
   }
 
   getButtonClassNames = () => {

--- a/client/app/asyncableJobs/pages/JobPage.jsx
+++ b/client/app/asyncableJobs/pages/JobPage.jsx
@@ -30,8 +30,7 @@ class AsyncableJobPage extends React.PureComponent {
 
     return <div className="cf-asyncable-job-table">
       <h1>{this.props.asyncableJobKlass} Job {job.id}</h1>
-      <AsyncModelNav models={this.props.models} fetchedAt={this.props.fetchedAt} />
-      <hr />
+      <AsyncModelNav models={[]} fetchedAt={this.props.fetchedAt} />
       <table className="cf-job-details">
         <tbody>
           <tr>
@@ -70,12 +69,11 @@ class AsyncableJobPage extends React.PureComponent {
             <th>User</th>
             <td><a href={`/intake/manager?user_css_id=${job.user}`}>{job.user}</a></td>
           </tr>
-          <tr>
-            <th></th>
-            <td><JobRestartButton job={job} page={this} /></td>
-          </tr>
         </tbody>
       </table>
+      <div>
+        <JobRestartButton job={job} page={this} />
+      </div>
     </div>;
   }
 }

--- a/client/app/asyncableJobs/pages/JobPage.jsx
+++ b/client/app/asyncableJobs/pages/JobPage.jsx
@@ -9,6 +9,14 @@ import JobRestartButton from '../components/JobRestartButton';
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
 class AsyncableJobPage extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      restarted: 0
+    };
+  }
+
   formatDate = (datetime) => {
     if (!datetime) {
       return 'n/a';
@@ -64,7 +72,7 @@ class AsyncableJobPage extends React.PureComponent {
           </tr>
           <tr>
             <th></th>
-            <td><JobRestartButton job={job} /></td>
+            <td><JobRestartButton job={job} page={this} /></td>
           </tr>
         </tbody>
       </table>

--- a/client/app/asyncableJobs/pages/JobPage.jsx
+++ b/client/app/asyncableJobs/pages/JobPage.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 
 import AsyncModelNav from '../components/AsyncModelNav';
+import JobRestartButton from '../components/JobRestartButton';
 
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
@@ -19,7 +20,7 @@ class AsyncableJobPage extends React.PureComponent {
   render = () => {
     const { job } = this.props;
 
-    return <div className="cf-asyncable-jobs-table">
+    return <div className="cf-asyncable-job-table">
       <h1>{this.props.asyncableJobKlass} Job {job.id}</h1>
       <AsyncModelNav models={this.props.models} fetchedAt={this.props.fetchedAt} />
       <hr />
@@ -60,6 +61,10 @@ class AsyncableJobPage extends React.PureComponent {
           <tr>
             <th>User</th>
             <td><a href={`/intake/manager?user_css_id=${job.user}`}>{job.user}</a></td>
+          </tr>
+          <tr>
+            <th></th>
+            <td><JobRestartButton job={job} /></td>
           </tr>
         </tbody>
       </table>

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -78,7 +78,12 @@ class AsyncableJobsPage extends React.PureComponent {
       {
         header: 'Error',
         valueFunction: (job) => {
-          return <span className="cf-job-error">{job.error}</span>;
+          let errorStr = job.error;
+
+          if (errorStr) {
+            errorStr = errorStr.replace(/\s.+/, '');
+          }
+          return <span className="cf-job-error">{errorStr}</span>;
         }
       },
       {

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -86,7 +86,7 @@ class AsyncableJobsPage extends React.PureComponent {
       {
         align: 'right',
         valueFunction: (job) => {
-          return <JobRestartButton job={job} />
+          return <JobRestartButton job={job} />;
         }
       }
     ];

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -12,6 +12,14 @@ import JobRestartButton from '../components/JobRestartButton';
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
 class AsyncableJobsPage extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      restarted: 0
+    };
+  }
+
   formatDate = (datetime) => {
     if (datetime === 'restarted') {
       return datetime;
@@ -30,7 +38,7 @@ class AsyncableJobsPage extends React.PureComponent {
 
     if (rowObjects.length === 0) {
       return <div>
-        <h1>Success! There are no pending jobs.</h1>
+        <h1>{`Success! There are no pending ${this.props.asyncableJobKlass} jobs.`}</h1>
         <AsyncModelNav models={this.props.models} fetchedAt={this.props.fetchedAt} />
       </div>;
     }
@@ -39,8 +47,8 @@ class AsyncableJobsPage extends React.PureComponent {
       {
         header: 'Name',
         valueFunction: (job, rowId) => {
-          let title = `row ${rowId}`;
-          let href = `/asyncable_jobs/${job.klass}/jobs/${job.id}`;
+          const title = `row ${rowId}`;
+          const href = `/asyncable_jobs/${job.klass}/jobs/${job.id}`;
 
           return <a title={title} href={href}>{job.klass} {job.id}</a>;
         }
@@ -86,7 +94,7 @@ class AsyncableJobsPage extends React.PureComponent {
       {
         align: 'right',
         valueFunction: (job) => {
-          return <JobRestartButton job={job} />;
+          return <JobRestartButton job={job} page={this} />;
         }
       }
     ];

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -83,6 +83,7 @@ class AsyncableJobsPage extends React.PureComponent {
           if (errorStr) {
             errorStr = errorStr.replace(/\s.+/, '');
           }
+
           return <span className="cf-job-error">{errorStr}</span>;
         }
       },

--- a/client/app/asyncableJobs/reducers/index.js
+++ b/client/app/asyncableJobs/reducers/index.js
@@ -1,10 +1,9 @@
 export const mapDataToInitialState = function(props = {}) {
   const { serverJobs } = props;
-
-  let state = serverJobs;
+  const state = serverJobs;
 
   if (!state.asyncableJobKlass) {
-    state.asyncableJobKlass = 'All';
+    state.asyncableJobKlass = '';
   }
 
   return state;

--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -16,3 +16,7 @@
     font-weight: bold;
   }
 }
+
+.cf-asyncable-jobs-table {
+  font-size: 90%;
+}

--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -1,10 +1,3 @@
-.cf-job-error {
-  max-width: 200px;
-  max-height: 90px;
-  overflow: auto;
-  display: inline-block;
-}
-
 .cf-model-jobs-link {
   margin-right: 8px;
   padding-right: 8px;

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -42,6 +42,7 @@ feature "Asyncable Jobs index", :postgres do
   let!(:pending_hlr) do
     create(:higher_level_review,
            establishment_last_submitted_at: 2.days.ago,
+           establishment_error: "SomeError: this is a really long exception message",
            veteran_file_number: veteran2.file_number)
   end
   let!(:request_issues_update) do
@@ -136,6 +137,12 @@ feature "Asyncable Jobs index", :postgres do
       click_link "HigherLevelReview #{hlr.id}"
 
       expect(current_path).to eq("/asyncable_jobs/HigherLevelReview/jobs/#{hlr.id}")
+    end
+
+    it "filters out long error messages" do
+      visit "/jobs"
+
+      expect(page).to_not have_content("this is a really long exception message")
     end
 
     it "links to Intake user" do

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -101,12 +101,12 @@ feature "Asyncable Jobs index", :postgres do
 
       expect(page).to have_content("oops!")
       expect(page).to have_content("wrong!")
-      expect(page).to have_content(hlr.establishment_submitted_at.strftime(date_format))
-      expect(page).to have_content(hlr.establishment_attempted_at.strftime(date_format))
+      expect(page).to have_content(hlr.establishment_submitted_at.unix_format)
+      expect(page).to have_content(hlr.establishment_attempted_at.unix_format)
       expect(page).to_not have_content("Restarted")
 
-      hlr_submitted = hlr.establishment_submitted_at.strftime(date_format)
-      hlr_attempted = hlr.establishment_attempted_at.strftime(date_format)
+      hlr_submitted = hlr.establishment_submitted_at.unix_format
+      hlr_attempted = hlr.establishment_attempted_at.unix_format
 
       expect(page).to have_content("HigherLevelReview #{hlr.id} #{hlr_submitted} #{hlr_attempted}")
 


### PR DESCRIPTION
connects #11907 

### Description
Improves UX of the /jobs page:

* fits content better horizontally on the /jobs page, reducing scroll and table overflow
* adds Restart button to details job page
* changes Job Type filter to a dropdown button instead of links (better horizontal fit)
* shows only the exception name on the /jobs page, full error stack on the details page

![Screen Shot 2019-08-29 at 1 01 33 PM](https://user-images.githubusercontent.com/1205061/63979249-09c36080-ca7e-11e9-8ebc-d259e7f6ff73.png)

![Screen Shot 2019-08-30 at 9 27 50 AM](https://user-images.githubusercontent.com/1205061/64028608-90248480-cb08-11e9-9336-1a16a6b80c74.png)

