### PR TITLE
fix edge case where JS regex failed to match over multiple lines

### DIFF
--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -81,7 +81,7 @@ class AsyncableJobsPage extends React.PureComponent {
           let errorStr = job.error;
 
           if (errorStr) {
-            errorStr = errorStr.replace(/\s.+/, '');
+            errorStr = errorStr.replace(/\s.+/g, '');
           }
 
           return <span className="cf-job-error">{errorStr}</span>;

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -42,7 +42,7 @@ feature "Asyncable Jobs index", :postgres do
   let!(:pending_hlr) do
     create(:higher_level_review,
            establishment_last_submitted_at: 2.days.ago,
-           establishment_error: "SomeError: this is a really long exception message",
+           establishment_error: "SomeError: this is a really long exception message\nover multiple lines",
            veteran_file_number: veteran2.file_number)
   end
   let!(:request_issues_update) do
@@ -143,6 +143,7 @@ feature "Asyncable Jobs index", :postgres do
       visit "/jobs"
 
       expect(page).to_not have_content("this is a really long exception message")
+      expect(page).to_not have_content("over multiple lines")
     end
 
     it "links to Intake user" do


### PR DESCRIPTION
Fixes edge case observed in UAT where multi-line exception message (with stacktrace) failed to be matched correctly.