### PR TITLE
Cache veteran participant_id

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -231,6 +231,8 @@ class Veteran < ApplicationRecord
     CACHED_BGS_ATTRIBUTES.each do |attr|
       self[attr] = bgs_record[attr]
     end
+    # participant_id is odd case because the name is different.
+    self[:participant_id] ||= ptcpnt_id
     save!
   end
 

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -222,7 +222,7 @@ class Veteran < ApplicationRecord
   def stale_attributes?
     return false unless accessible? && bgs_record.is_a?(Hash)
 
-    is_stale = (first_name.nil? || last_name.nil? || self[:ssn].nil?)
+    is_stale = (first_name.nil? || last_name.nil? || self[:ssn].nil? || self[:participant_id].nil?)
     is_stale ||= CACHED_BGS_ATTRIBUTES.any? { |name| self[name] != bgs_record[name] }
     is_stale
   end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -46,7 +46,15 @@ class Veteran < ApplicationRecord
   BENEFIT_TYPE_CODE_LIVE = "1"
   BENEFIT_TYPE_CODE_DEATH = "2"
 
-  CACHED_BGS_ATTRIBUTES = [:first_name, :last_name, :middle_name, :name_suffix, :ssn].freeze
+  # key is local attribute name; value is corresponding bgs attribute name
+  CACHED_BGS_ATTRIBUTES = {
+    first_name: :first_name,
+    last_name: :last_name,
+    middle_name: :middle_name,
+    name_suffix: :name_suffix,
+    ssn: :ssn,
+    participant_id: :ptcpnt_id
+  }.freeze
 
   # TODO: get middle initial from BGS
   def name
@@ -223,16 +231,14 @@ class Veteran < ApplicationRecord
     return false unless accessible? && bgs_record.is_a?(Hash)
 
     is_stale = (first_name.nil? || last_name.nil? || self[:ssn].nil? || self[:participant_id].nil?)
-    is_stale ||= CACHED_BGS_ATTRIBUTES.any? { |name| self[name] != bgs_record[name] }
+    is_stale ||= CACHED_BGS_ATTRIBUTES.any? { |local_attr, bgs_attr| self[local_attr] != bgs_record[bgs_attr] }
     is_stale
   end
 
   def update_cached_attributes!
-    CACHED_BGS_ATTRIBUTES.each do |attr|
-      self[attr] = bgs_record[attr]
+    CACHED_BGS_ATTRIBUTES.each do |local_attr, bgs_attr|
+      self[local_attr] = bgs_record[bgs_attr]
     end
-    # participant_id is odd case because the name is different.
-    self[:participant_id] ||= ptcpnt_id
     save!
   end
 

--- a/app/services/claim_review_async_stats_reporter.rb
+++ b/app/services/claim_review_async_stats_reporter.rb
@@ -71,8 +71,9 @@ class ClaimReviewAsyncStatsReporter
 
   def completion_times(claims)
     claims.reject(&:canceled?).map do |claim|
-      hash = claim.asyncable_ui_hash
-      hash[:processed_at] - hash[:submitted_at]
+      processed_at = claim[claim.class.processed_at_column]
+      submitted_at = claim[claim.class.submitted_at_column]
+      processed_at - submitted_at
     end
   end
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -143,6 +143,21 @@ describe Veteran, :postgres do
         end
       end
     end
+
+    context "when local participant_id attribute is nil" do
+      let!(:veteran) do
+        veteran = create(:veteran, file_number: file_number)
+        veteran.update!(participant_id: nil)
+        veteran
+      end
+      let(:sync_name) { true }
+
+      it "caches it like name" do
+        expect(described_class.find_by(file_number: file_number)[:participant_id]).to be_nil
+        described_class.find_or_create_by_file_number(file_number, sync_name: sync_name)
+        expect(described_class.find_by(file_number: file_number)[:participant_id]).to_not be_nil
+      end
+    end
   end
 
   context "lazily loaded bgs attributes" do


### PR DESCRIPTION
connects #11174  

There are 240+ Veteran records without a participant_id. Double-check that we cache it locally just like we do for names.