### PR TITLE
Fix test around inbox read message button content

### DIFF
--- a/spec/support/date_time_helper.rb
+++ b/spec/support/date_time_helper.rb
@@ -44,7 +44,7 @@ class Time
   end
 
   def friendly_full_format
-    strftime("%a %b %e %Y at %H:%M")
+    strftime("%a %b %d %Y at %H:%M")
   end
 end
 


### PR DESCRIPTION
# Description

Was seeing this error in CircleCI:

```
Failure/Error: expect(page).to have_content("Read #{message.read_at.friendly_full_format}")
```

The issue was around the date time in the test looking differently than the one in the UI due to a discrepancy in how the values were formatted:

```
Tue Sep  3 2019 at 11:35
Tue Sep 03 2019 at 11:35
```

One is 0-padded, the other is not. I updated the format the test was checking for to match what was being shown.
