### PR TITLE
Remove voided decision issue code

### DIFF
--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -93,12 +93,6 @@ class DecisionIssue < ApplicationRecord
     request_issues.none?(&:nonrating?)
   end
 
-  # If a decision issue is associated with request issues that were corrected,
-  # consider it invalid
-  def voided?
-    request_issues.any? && request_issues.all?(&:corrected?)
-  end
-
   def finalized?
     appeal? ? decision_review.outcoded? : disposition.present?
   end

--- a/app/workflows/contestable_issue_generator.rb
+++ b/app/workflows/contestable_issue_generator.rb
@@ -22,10 +22,6 @@ class ContestableIssueGenerator
     from_ratings.reject { |contestable_issue| decision_issue_duplicate_exists?(contestable_issue) }
   end
 
-  def contestable_decision_issues
-    from_decision_issues.reject { |contestable_issue| contestable_issue.decision_issue&.voided? }
-  end
-
   def contestable_rating_decisions
     return [] unless FeatureToggle.enabled?(:contestable_rating_decisions, user: RequestStore[:current_user])
 
@@ -40,8 +36,8 @@ class ContestableIssueGenerator
       .map { |rating_issue| ContestableIssue.from_rating_issue(rating_issue, review) }
   end
 
-  def from_decision_issues
-    @from_decision_issues ||= finalized_decision_issues_before_receipt_date.map do |decision_issue|
+  def contestable_decision_issues
+    @contestable_decision_issues ||= finalized_decision_issues_before_receipt_date.map do |decision_issue|
       ContestableIssue.from_decision_issue(decision_issue, review)
     end
   end
@@ -73,7 +69,7 @@ class ContestableIssueGenerator
   end
 
   def decision_issue_duplicate_exists?(contestable_issue)
-    from_decision_issues.any? do |potential_duplicate|
+    contestable_decision_issues.any? do |potential_duplicate|
       contestable_issue.rating_issue_reference_id == potential_duplicate.rating_issue_reference_id
     end
   end

--- a/spec/models/decision_issue_spec.rb
+++ b/spec/models/decision_issue_spec.rb
@@ -265,27 +265,6 @@ describe DecisionIssue, :postgres do
     end
   end
 
-  context "#voided?" do
-    subject { decision_issue.voided? }
-
-    context "when all request issues are corrected" do
-      let(:request_issues) do
-        [create(:request_issue, corrected_by_request_issue_id: create(:request_issue).id)]
-      end
-
-      it { is_expected.to eq true }
-    end
-
-    context "when not all request issues are corrected" do
-      let(:request_issues) do
-        [create(:request_issue, corrected_by_request_issue_id: create(:request_issue).id),
-         create(:request_issue)]
-      end
-
-      it { is_expected.to eq false }
-    end
-  end
-
   context "#approx_decision_date" do
     subject { decision_issue.approx_decision_date }
 

--- a/spec/models/decision_review_spec.rb
+++ b/spec/models/decision_review_spec.rb
@@ -213,42 +213,6 @@ describe DecisionReview, :postgres do
       end
     end
 
-    context "when a decision issue is voided" do
-      let(:request_issue) { create(:request_issue, corrected_by_request_issue_id: create(:request_issue).id) }
-      let!(:voided_decision_issue) do
-        create(:decision_issue,
-               :rating,
-               request_issues: [request_issue],
-               participant_id: participant_id,
-               rating_issue_reference_id: "321",
-               decision_text: "voided decision issue 1",
-               benefit_type: higher_level_review.benefit_type,
-               rating_profile_date: profile_date,
-               rating_promulgation_date: promulgation_date,
-               decision_review: higher_level_review)
-      end
-
-      let!(:rating) do
-        Generators::Rating.build(
-          issues: [
-            { reference_id: "321", decision_text: "rating issue 1" },
-            { reference_id: "654", decision_text: "rating issue 2" }
-          ],
-          promulgation_date: promulgation_date,
-          profile_date: profile_date,
-          participant_id: participant_id,
-          associated_claims: associated_claims
-        )
-      end
-
-      it "does not return voided decision issues and voided ratings" do
-        expect(subject.map(&:serialize)).to include(hash_including(description: "decision issue 3"))
-        expect(subject.map(&:serialize)).to_not include(hash_including(description: "voided decision issue"))
-        expect(subject.map(&:serialize)).to_not include(hash_including(description: "rating issue 1"))
-        expect(subject.map(&:serialize)).to include(hash_including(description: "rating issue 2"))
-      end
-    end
-
     context "when the issue is from an appeal that is not outcoded" do
       let(:outcoded_appeal) { create(:appeal, :outcoded, veteran: veteran, receipt_date: receipt_date) }
       let!(:outcoded_decision_doc) { create(:decision_document, decision_date: profile_date, appeal: outcoded_appeal) }


### PR DESCRIPTION
### Description
We will no longer be using `voided` for decision issues so removing that. 

