### PR TITLE
Nil check for tasks on change type

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -227,7 +227,7 @@ class Task < ApplicationRecord
   end
 
   def same_task_type?(task_to_check)
-    type.eql?(task_to_check.type)
+    type.eql?(task_to_check&.type)
   end
 
   def cancel_descendants


### PR DESCRIPTION
### Description
Legacy colocated org tasks do not always have parents
```
LegacyAppeal 198515
├── RootTask
└── OtherColocatedTask
    └── OtherColocatedTask
        └── TimedHoldTask
```
so the[ check for task type equality ](https://github.com/department-of-veterans-affairs/caseflow/blob/15bdbfaa4b8f2c7c31354d260c2640907d020c95/app/models/task.rb#L221)fails with a NoMethodError. 