### PR TITLE
Fix judge checkout for acting judges: the sequel

### DIFF
--- a/client/app/queue/LegacySelectDispositionsView.jsx
+++ b/client/app/queue/LegacySelectDispositionsView.jsx
@@ -59,7 +59,6 @@ class LegacySelectDispositionsView extends React.PureComponent {
       appealId,
       taskId,
       checkoutFlow,
-      userRole,
       appeal: { issues }
     } = this.props;
     let nextStep;
@@ -202,9 +201,23 @@ class LegacySelectDispositionsView extends React.PureComponent {
 }
 
 LegacySelectDispositionsView.propTypes = {
+  appeal: PropTypes.shape({
+    issues: PropTypes.array,
+    isLegacyAppeal: PropTypes.bool
+  }),
+  success: PropTypes.shape({
+    title: PropTypes.string,
+    detail: PropTypes.string
+  }),
   appealId: PropTypes.string.isRequired,
+  taskId: PropTypes.string.isRequired,
   checkoutFlow: PropTypes.string.isRequired,
-  userRole: PropTypes.string.isRequired
+  userRole: PropTypes.string.isRequired,
+  updateEditingAppealIssue: PropTypes.func,
+  setDecisionOptions: PropTypes.func,
+  startEditingAppealIssue: PropTypes.func,
+  saveEditedAppealIssue: PropTypes.func,
+  hideSuccessMessage: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/client/app/queue/LegacySelectDispositionsView.jsx
+++ b/client/app/queue/LegacySelectDispositionsView.jsx
@@ -50,6 +50,8 @@ const tbodyStyling = css({
 const smallTopMargin = css({ marginTop: '1rem' });
 
 class LegacySelectDispositionsView extends React.PureComponent {
+  decisionReviewCheckoutFlow = () => this.props.checkoutFlow === 'dispatch_decision';
+
   getPageName = () => PAGE_TITLES.DISPOSITIONS[this.props.userRole.toUpperCase()];
 
   getNextStepUrl = () => {
@@ -68,7 +70,7 @@ class LegacySelectDispositionsView extends React.PureComponent {
 
     if (remandedIssues) {
       nextStep = 'remands';
-    } else if (userRole === USER_ROLE_TYPES.judge) {
+    } else if (this.decisionReviewCheckoutFlow()) {
       nextStep = 'evaluate';
     } else {
       nextStep = 'submit';

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -35,7 +35,7 @@ class SelectRemandReasonsView extends React.Component {
   getPageName = () => PAGE_TITLES.REMANDS[this.props.userRole.toUpperCase()];
 
   getNextStepUrl = () => {
-    const { appealId, userRole, checkoutFlow, taskId } = this.props;
+    const { appealId, checkoutFlow, taskId } = this.props;
     const baseUrl = `/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}`;
 
     return `${baseUrl}/${checkoutFlow === 'dispatch_decision' ? 'evaluate' : 'submit'}`;
@@ -126,9 +126,25 @@ class SelectRemandReasonsView extends React.Component {
 }
 
 SelectRemandReasonsView.propTypes = {
+  appeal: PropTypes.shape({
+    issues: PropTypes.arrayOf(
+      PropTypes.shape({
+        id: PropTypes.string
+      })
+    ),
+    decisionIssues: PropTypes.array,
+    isLegacyAppeal: PropTypes.bool
+  }),
+  issues: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string
+    })
+  ),
   appealId: PropTypes.string.isRequired,
+  taskId: PropTypes.string.isRequired,
   checkoutFlow: PropTypes.string.isRequired,
-  userRole: PropTypes.string.isRequired
+  userRole: PropTypes.string.isRequired,
+  editStagedAppeal: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -38,7 +38,7 @@ class SelectRemandReasonsView extends React.Component {
     const { appealId, userRole, checkoutFlow, taskId } = this.props;
     const baseUrl = `/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}`;
 
-    return `${baseUrl}/${userRole === USER_ROLE_TYPES.judge ? 'evaluate' : 'submit'}`;
+    return `${baseUrl}/${checkoutFlow === 'dispatch_decision' ? 'evaluate' : 'submit'}`;
   }
 
   goToPrevStep = () => _.each(this.state.renderedChildren, (child) => child.updateStoreIssue());

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -237,7 +237,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       )
     end
     let!(:decision_issue) do
-      create(:decision_issue, decision_review: appeal, request_issues: appeal.request_issues)
+      create(:decision_issue, :imo, decision_review: appeal, request_issues: appeal.request_issues)
     end
 
     let(:root_task) { create(:root_task, appeal: appeal) }
@@ -270,7 +270,12 @@ RSpec.feature "Judge checkout flow", :all_dbs do
         expect(page).to have_content(COPY::DECISION_ISSUE_PAGE_TITLE)
       end
 
-      step("Navigate to evaluation page from decision issues page") do
+      step("Navigate to remand reasons page from decision issues page") do
+        click_on("Continue")
+        expect(page).to have_content("Remand Reasons")
+      end
+
+      step("Navigate to evaluation page from remand reasons page") do
         click_on("Continue")
         expect(page).to have_content(COPY::EVALUATE_DECISION_PAGE_TITLE)
       end


### PR DESCRIPTION
### Description
In #11585 we ensured acting judges could complete a checkout flow as a judge. However, this fix is sidestepped when one of the issues is remanded and the remand reasons page is visited. This PR extends the fix to both the remands reason page and legacy select dispositions page.

#### Before
![Untitled](https://user-images.githubusercontent.com/45575454/64206754-2dfdb380-ce69-11e9-83f8-fa8f866d54ca.gif)

#### After
![Untitled1](https://user-images.githubusercontent.com/45575454/64206753-2dfdb380-ce69-11e9-9572-daf6f77ec555.gif)

### Acceptance Criteria
- [ ] AVLJs can successfully complete ama checkout flows with remanded issues
- [ ] AVLJs can successfully complete legacy checkout flows