### PR TITLE
Edit issues after intake

### DIFF
--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -3,7 +3,9 @@
 class AsyncableJobsController < ApplicationController
   include PaginationConcern
 
-  before_action :verify_access, :react_routed, :set_application
+  before_action :react_routed, :set_application
+  before_action :verify_access, only: [:index]
+  before_action :verify_job_access, only: [:show]
 
   def index
     if allowed_params[:asyncable_job_klass]
@@ -70,6 +72,12 @@ class AsyncableJobsController < ApplicationController
 
     session["return_to"] = request.original_url
     redirect_to "/unauthorized"
+  end
+
+  def verify_job_access
+    return true if current_user.css_id == job&.asyncable_user
+
+    verify_access
   end
 
   def allowed_params

--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -4,6 +4,7 @@ class ClaimReviewController < ApplicationController
   before_action :verify_access, :react_routed, :set_application
 
   EDIT_ERRORS = {
+    "ClaimReview::NotYetProcessed" => COPY::CLAIM_REVIEW_NOT_YET_PROCESSED_ERROR,
     "RequestIssue::MissingDecisionDate" => COPY::CLAIM_REVIEW_EDIT_ERROR_MISSING_DECISION_DATE,
     "StandardError" => COPY::CLAIM_REVIEW_EDIT_ERROR_DEFAULT
   }.freeze
@@ -60,7 +61,7 @@ class ClaimReviewController < ApplicationController
     Rails.logger.error("#{error.message}\n#{error.backtrace.join("\n")}")
     Raven.capture_exception(error, extra: { error_uuid: error_uuid })
     error_class = error.class.to_s
-    flash[:error] = EDIT_ERRORS[error_class] || EDIT_ERRORS["StandardError"]
+    flash[:error] = format(EDIT_ERRORS[error_class] || EDIT_ERRORS["StandardError"], claim_review.async_job_url)
     render "errors/500", layout: "application", status: :unprocessable_entity
   end
 

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -71,7 +71,7 @@ class IntakesController < ApplicationController
 
   def log_error(error)
     Raven.capture_exception(error, extra: { error_uuid: error_uuid })
-    Rails.logger.error("Error UUID #{error_uuid} : #{error}")
+    Rails.logger.error("Error UUID #{error_uuid} : #{error}\n" + error.backtrace.join("\n"))
   end
 
   helper_method :index_props

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -70,10 +70,6 @@ class Appeal < DecisionReview
     )
   end
 
-  def caseflow_only_edit_issues_url
-    "/appeals/#{uuid}/edit"
-  end
-
   def type
     "Original"
   end

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -63,6 +63,10 @@ class ClaimReview < DecisionReview
     "/#{self.class.to_s.underscore.pluralize}/#{uuid}/edit"
   end
 
+  def async_job_url
+    "/asyncable_jobs/#{self.class.to_s}/jobs/#{id}"
+  end
+
   def finalized_decision_issues_before_receipt_date
     return [] unless receipt_date
 

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -42,6 +42,7 @@ class ClaimReview < DecisionReview
 
   def ui_hash
     super.merge(
+      asyncJobUrl: async_job_url,
       benefitType: benefit_type,
       payeeCode: payee_code,
       hasClearedRatingEp: cleared_rating_ep?,

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -50,7 +50,7 @@ class ClaimReview < DecisionReview
   end
 
   def validate_prior_to_edit
-    raise NotYetProcessed unless processed?
+    fail NotYetProcessed unless processed?
 
     # force sync on initial edit call so that we have latest EP status.
     # This helps prevent us editing something that recently closed upstream.
@@ -67,7 +67,7 @@ class ClaimReview < DecisionReview
   end
 
   def async_job_url
-    "/asyncable_jobs/#{self.class.to_s}/jobs/#{id}"
+    "/asyncable_jobs/#{self.class}/jobs/#{id}"
   end
 
   def finalized_decision_issues_before_receipt_date

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -63,10 +63,6 @@ class ClaimReview < DecisionReview
     ui_hash
   end
 
-  def caseflow_only_edit_issues_url
-    "/#{self.class.to_s.underscore.pluralize}/#{uuid}/edit"
-  end
-
   def async_job_url
     "/asyncable_jobs/#{self.class}/jobs/#{id}"
   end

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -23,6 +23,7 @@ class ClaimReview < DecisionReview
   self.abstract_class = true
 
   class NoEndProductsRequired < StandardError; end
+  class NotYetProcessed < StandardError; end
 
   class << self
     def find_by_uuid_or_reference_id!(claim_id)
@@ -49,6 +50,8 @@ class ClaimReview < DecisionReview
   end
 
   def validate_prior_to_edit
+    raise NotYetProcessed unless processed?
+
     # force sync on initial edit call so that we have latest EP status.
     # This helps prevent us editing something that recently closed upstream.
     sync_end_product_establishments!

--- a/app/models/claim_review_intake.rb
+++ b/app/models/claim_review_intake.rb
@@ -5,6 +5,8 @@ class ClaimReviewIntake < DecisionReviewIntake
 
   def ui_hash
     super.merge(
+      detail_edit_url: detail&.reload&.caseflow_only_edit_issues_url, # reload for uuid
+      async_job_url: detail&.async_job_url,
       benefit_type: detail.benefit_type,
       processed_in_caseflow: detail.processed_in_caseflow?
     )

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -109,6 +109,8 @@ class DecisionReview < ApplicationRecord
         formName: veteran&.name&.formatted(:form),
         ssn: veteran&.ssn
       },
+      intakeUser: intake.user.css_id,
+      processedAt: establishment_processed_at,
       relationships: veteran&.relationships&.map(&:ui_hash),
       claimant: claimant_participant_id,
       veteranIsNotClaimant: veteran_is_not_claimant,
@@ -121,6 +123,7 @@ class DecisionReview < ApplicationRecord
       activeNonratingRequestIssues: active_nonrating_request_issues.map(&:ui_hash),
       contestableIssuesByDate: contestable_issues.map(&:serialize),
       editIssuesUrl: caseflow_only_edit_issues_url,
+      asyncJobUrl: async_job_url,
       veteranValid: veteran&.valid?(:bgs),
       veteranInvalidFields: veteran_invalid_fields,
       processedInCaseflow: processed_in_caseflow?

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -109,7 +109,8 @@ class DecisionReview < ApplicationRecord
         formName: veteran&.name&.formatted(:form),
         ssn: veteran&.ssn
       },
-      intakeUser: intake.user.css_id,
+      intakeUser: asyncable_user,
+      editIssuesUrl: caseflow_only_edit_issues_url,
       processedAt: establishment_processed_at,
       relationships: veteran&.relationships&.map(&:ui_hash),
       claimant: claimant_participant_id,
@@ -122,12 +123,14 @@ class DecisionReview < ApplicationRecord
       decisionIssues: decision_issues.map(&:ui_hash),
       activeNonratingRequestIssues: active_nonrating_request_issues.map(&:ui_hash),
       contestableIssuesByDate: contestable_issues.map(&:serialize),
-      editIssuesUrl: caseflow_only_edit_issues_url,
-      asyncJobUrl: async_job_url,
       veteranValid: veteran&.valid?(:bgs),
       veteranInvalidFields: veteran_invalid_fields,
       processedInCaseflow: processed_in_caseflow?
     }
+  end
+
+  def caseflow_only_edit_issues_url
+    nil # must override in subclass
   end
 
   def async_job_url

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -130,7 +130,7 @@ class DecisionReview < ApplicationRecord
   end
 
   def caseflow_only_edit_issues_url
-    nil # must override in subclass
+    "/#{self.class.to_s.underscore.pluralize}/#{uuid}/edit"
   end
 
   def async_job_url

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -127,6 +127,10 @@ class DecisionReview < ApplicationRecord
     }
   end
 
+  def async_job_url
+    nil # must override in subclass
+  end
+
   def timely_issue?(decision_date)
     return true unless receipt_date && decision_date
 

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -194,8 +194,6 @@ class Intake < ApplicationRecord
       veteran_form_name: veteran&.name&.formatted(:form),
       veteran_is_deceased: veteran&.deceased?,
       completed_at: completed_at,
-      detail_edit_url: detail&.reload&.caseflow_only_edit_issues_url,
-      async_job_url: detail&.async_job_url,
       relationships: veteran&.relationships&.map(&:ui_hash)
     }
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -194,6 +194,8 @@ class Intake < ApplicationRecord
       veteran_form_name: veteran&.name&.formatted(:form),
       veteran_is_deceased: veteran&.deceased?,
       completed_at: completed_at,
+      detail_edit_url: detail&.caseflow_only_edit_issues_url,
+      async_job_url: detail&.async_job_url,
       relationships: veteran&.relationships&.map(&:ui_hash)
     }
   end

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -194,7 +194,7 @@ class Intake < ApplicationRecord
       veteran_form_name: veteran&.name&.formatted(:form),
       veteran_is_deceased: veteran&.deceased?,
       completed_at: completed_at,
-      detail_edit_url: detail&.caseflow_only_edit_issues_url,
+      detail_edit_url: detail&.reload&.caseflow_only_edit_issues_url,
       async_job_url: detail&.async_job_url,
       relationships: veteran&.relationships&.map(&:ui_hash)
     }

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -149,7 +149,7 @@ class Veteran < ApplicationRecord
   end
 
   def incident_flash?
-    bgs_record[:block_cadd_ind] == "S"
+    bgs_record.is_a?(Hash) && bgs_record[:block_cadd_ind] == "S"
   end
 
   # Postal code might be stored in address line 3 for international addresses

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -550,6 +550,7 @@
   "HEARING_DATE_LOADING": "Finding upcoming hearing dates for this regional office...",
 
   "CLAIM_REVIEW_EDIT_ERROR_MISSING_DECISION_DATE": "VBMS or SHARE: One or more ratings may be locked on this Claim. Please try again in 24 hours.",
+  "CLAIM_REVIEW_NOT_YET_PROCESSED_ERROR": "Review not yet established in VBMS. Check <a href='%s'>the job page</a> for details.",
   "CLAIM_REVIEW_EDIT_ERROR_DEFAULT": "There was an error preparing this Review for edit.",
 
   "UNKNOWN_REGIONAL_OFFICE": "Unknown",

--- a/client/app/asyncableJobs/components/JobRestartButton.jsx
+++ b/client/app/asyncableJobs/components/JobRestartButton.jsx
@@ -64,6 +64,8 @@ class JobRestartButton extends React.PureComponent {
       txt = 'Restarting';
     } else if (this.state.restarted) {
       txt = 'Restarted';
+    } else if (this.props.job.processed_at) {
+      txt = 'Processed';
     } else if (this.disableRestart()) {
       txt = 'Queued';
     }
@@ -73,6 +75,10 @@ class JobRestartButton extends React.PureComponent {
 
   disableRestart = () => {
     const job = this.props.job;
+
+    if (job.processed_at) {
+      return true;
+    }
 
     if (!job.attempted_at) {
       return true;

--- a/client/app/errors/Error500.jsx
+++ b/client/app/errors/Error500.jsx
@@ -18,7 +18,7 @@ class Error500 extends React.PureComponent {
 
     if (this.props.flashError) {
       detailedErrorMessage = <React.Fragment>
-        <p>Error: {this.props.flashError}</p>
+        <p>Error: <span dangerouslySetInnerHTML={{ __html: this.props.flashError }} /></p>
       </React.Fragment>;
     }
 

--- a/client/app/errors/Error500.jsx
+++ b/client/app/errors/Error500.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import AppFrame from '../components/AppFrame';
 import NavigationBar from '../components/NavigationBar';

--- a/client/app/intake/components/UnidentifiedIssueAlert.jsx
+++ b/client/app/intake/components/UnidentifiedIssueAlert.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Alert from '../../components/Alert';
+import COPY from '../../../COPY.json';
+
+class UnidentifiedIssueAlert extends React.Component {
+  render() {
+    const unidentifiedIssues = this.props.unidentifiedIssues;
+
+    return <Alert type="warning">
+      <h2>Unidentified issue</h2>
+      <p>{COPY.UNIDENTIFIED_ALERT}</p>
+      {unidentifiedIssues.map((ri, i) => <p className="cf-red-text" key={`unidentified-alert-${i}`}>
+        Unidentified issue: no issue matched for requested "{ri.description}"
+      </p>)}
+    </Alert>;
+  }
+}
+
+UnidentifiedIssueAlert.propTypes = {
+  unidentifiedIssues: PropTypes.arrayOf(PropTypes.object)
+};
+
+export default UnidentifiedIssueAlert;

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 
 import _ from 'lodash';
@@ -117,6 +119,15 @@ export class AddIssuesPage extends React.Component {
     } else if (intakeData.isOutcoded) {
       return <Redirect to={PAGE_PATHS.OUTCODED} />;
     }
+  }
+
+  establishmentCredits() {
+    const tstamp = moment(this.props.processedAt).format('ddd MMM DD YYYY [at] HH:mm');
+
+    return <div className="cf-intake-establish-credits">
+      Established <a href={this.props.asyncJobUrl}>{tstamp}</a>
+      <span> by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a></span>
+    </div>;
   }
 
   render() {
@@ -302,12 +313,7 @@ export class AddIssuesPage extends React.Component {
           <ErrorAlert errorCode="veteran_not_valid" errorData={intakeData.veteranInvalidFields} />
         )}
 
-        {editPage && (
-          <div className="cf-intake-establish-credits">
-            Established <a href={this.props.asyncJobUrl}>{moment(this.props.processedAt).format('ddd MMM DD YYYY [at] HH:mm')}</a>
-            <span> by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a></span>
-          </div>
-        )}
+        {editPage && this.establishmentCredits()}
 
         <Table columns={columns} rowObjects={rowObjects} rowClassNames={issueChangeClassname} slowReRendersAreOk />
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -303,10 +303,11 @@ export class AddIssuesPage extends React.Component {
         )}
 
         {editPage && (
-          <div className="cf-txt-c">Intake established by&nbsp;
+          <div className="cf-intake-establish-credits">
+            Established
+            <a href={this.props.asyncJobUrl}>{moment(this.props.processedAt).format('ddd MMM DD YYYY [at] HH:mm')}</a>
+            by
             <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a>
-            &nbsp;at&nbsp;
-            <a href={this.props.asyncJobUrl}>{moment(this.props.processedAt).format('MM/DD/YYYY HH:mm Z')}</a>
           </div>
         )}
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -121,11 +121,19 @@ export class AddIssuesPage extends React.Component {
     }
   }
 
-  establishmentCredits() {
+  establishmentCreditsTimestamp() {
     const tstamp = moment(this.props.processedAt).format('ddd MMM DD YYYY [at] HH:mm');
 
+    if (this.props.asyncJobUrl) {
+      return <a href={this.props.asyncJobUrl}>{tstamp}</a>;
+    }
+
+    return tstamp;
+  }
+
+  establishmentCredits() {
     return <div className="cf-intake-establish-credits">
-      Established <a href={this.props.asyncJobUrl}>{tstamp}</a>
+      Established {this.establishmentCreditsTimestamp()}
       <span> by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a></span>
     </div>;
   }

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -304,10 +304,8 @@ export class AddIssuesPage extends React.Component {
 
         {editPage && (
           <div className="cf-intake-establish-credits">
-            Established
-            <a href={this.props.asyncJobUrl}>{moment(this.props.processedAt).format('ddd MMM DD YYYY [at] HH:mm')}</a>
-            by
-            <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a>
+            Established <a href={this.props.asyncJobUrl}>{moment(this.props.processedAt).format('ddd MMM DD YYYY [at] HH:mm')}</a>
+            <span> by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a></span>
           </div>
         )}
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import _ from 'lodash';
+import moment from 'moment';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Redirect } from 'react-router-dom';
@@ -301,6 +302,14 @@ export class AddIssuesPage extends React.Component {
           <ErrorAlert errorCode="veteran_not_valid" errorData={intakeData.veteranInvalidFields} />
         )}
 
+        {editPage && (
+          <div className="cf-txt-c">Intake established by&nbsp;
+            <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a>
+            &nbsp;at&nbsp;
+            <a href={this.props.asyncJobUrl}>{moment(this.props.processedAt).format('MM/DD/YYYY HH:mm Z')}</a>
+          </div>
+        )}
+
         <Table columns={columns} rowObjects={rowObjects} rowClassNames={issueChangeClassname} slowReRendersAreOk />
 
         {!_.isEmpty(issuesPendingWithdrawal) && (
@@ -358,6 +367,9 @@ export const EditAddIssuesPage = connect(
       supplemental_claim: state,
       appeal: state
     },
+    processedAt: state.processedAt,
+    intakeUser: state.intakeUser,
+    asyncJobUrl: state.asyncJobUrl,
     formType: state.formType,
     veteran: state.veteran,
     featureToggles: state.featureToggles,

--- a/client/app/intake/pages/decisionReviewEditCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewEditCompleted.jsx
@@ -1,14 +1,15 @@
+/* eslint-disable react/prop-types */
+
 import React, { Fragment } from 'react';
 import StatusMessage from '../../components/StatusMessage';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { PAGE_PATHS, FORM_TYPES } from '../constants';
 import _ from 'lodash';
-import Alert from '../../components/Alert';
+import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 import IneligibleIssuesList from '../components/IneligibleIssuesList';
 import SmallLoader from '../../components/SmallLoader';
 import { LOGO_COLORS } from '../../constants/AppConstants';
-import COPY from '../../../COPY.json';
 import END_PRODUCT_CODES from '../../../constants/END_PRODUCT_CODES.json';
 
 const leadMessageList = ({ veteran, formName, requestIssues, addedIssues }) => {
@@ -31,15 +32,7 @@ const leadMessageList = ({ veteran, formName, requestIssues, addedIssues }) => {
 
   if (eligibleRequestIssues.length !== 0) {
     if (unidentifiedIssues.length > 0) {
-      leadMessageArr.push(
-        <Alert type="warning">
-          <h2>Unidentified issue</h2>
-          <p>{COPY.UNIDENTIFIED_ALERT}</p>
-          {unidentifiedIssues.map((ri, i) => <p className="cf-red-text" key={`unidentified-alert-${i}`}>
-            Unidentified issue: no issue matched for requested "{ri.description}"
-          </p>)}
-        </Alert>
-      );
+      leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
     } else {
       leadMessageArr.push(
         'If you need to edit this, go to VBMS claim details and click the “Edit in Caseflow” button.'

--- a/client/app/intake/pages/decisionReviewEditCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewEditCompleted.jsx
@@ -12,7 +12,7 @@ import SmallLoader from '../../components/SmallLoader';
 import { LOGO_COLORS } from '../../constants/AppConstants';
 import END_PRODUCT_CODES from '../../../constants/END_PRODUCT_CODES.json';
 
-const leadMessageList = ({ veteran, formName, requestIssues, addedIssues }) => {
+const leadMessageList = ({ veteran, formName, requestIssues, addedIssues, detailEditUrl }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
 
@@ -27,16 +27,13 @@ const leadMessageList = ({ veteran, formName, requestIssues, addedIssues }) => {
   };
 
   const leadMessageArr = [
-    `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been ${editMessage()}.`
+    `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been ${editMessage()}.`,
+    <div>If needed, you may <a href={detailEditUrl}>correct the issues</a>.</div>
   ];
 
   if (eligibleRequestIssues.length !== 0) {
     if (unidentifiedIssues.length > 0) {
       leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
-    } else {
-      leadMessageArr.push(
-        'If you need to edit this, go to VBMS claim details and click the “Edit in Caseflow” button.'
-      );
     }
   }
 
@@ -70,6 +67,7 @@ class DecisionReviewEditCompletedPage extends React.PureComponent {
       afterIssues,
       updatedIssues,
       addedIssues,
+      detailEditUrl,
       redirectTo
     } = this.props;
 
@@ -111,6 +109,7 @@ class DecisionReviewEditCompletedPage extends React.PureComponent {
         type="success"
         leadMessageList={
           leadMessageList({
+            detailEditUrl,
             veteran,
             formName: selectedForm.name,
             requestIssues: afterIssues,

--- a/client/app/intake/pages/decisionReviewEditCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewEditCompleted.jsx
@@ -31,10 +31,8 @@ const leadMessageList = ({ veteran, formName, requestIssues, addedIssues, detail
     <div>If needed, you may <a href={detailEditUrl}>correct the issues</a>.</div>
   ];
 
-  if (eligibleRequestIssues.length !== 0) {
-    if (unidentifiedIssues.length > 0) {
-      leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
-    }
+  if (eligibleRequestIssues.length !== 0 && unidentifiedIssues.length > 0) {
+    leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
   }
 
   leadMessageArr.push(

--- a/client/app/intake/pages/decisionReviewEditCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewEditCompleted.jsx
@@ -23,7 +23,7 @@ const leadMessageList = ({ veteran, formName, requestIssues, addedIssues, detail
       return 'withdrawn';
     }
 
-    return 'processed';
+    return 'submitted';
   };
 
   const leadMessageArr = [

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -16,7 +16,7 @@ const leadMessageList = ({ veteran, formName, requestIssues }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
 
-  const leadMessageArr = [`${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been processed.`];
+  const leadMessageArr = [`${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`];
 
   if (eligibleRequestIssues.length !== 0) {
     if (unidentifiedIssues.length > 0) {

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -12,11 +12,14 @@ import SmallLoader from '../../components/SmallLoader';
 import { LOGO_COLORS } from '../../constants/AppConstants';
 import COPY from '../../../COPY.json';
 
-const leadMessageList = ({ veteran, formName, requestIssues }) => {
+const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, detailEditUrl }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
 
-  const leadMessageArr = [`${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`];
+  const leadMessageArr = [
+    `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`,
+    <div>You may check on the <a href={asyncJobUrl}>establishment status of the request</a>.</div>
+  ];
 
   if (eligibleRequestIssues.length !== 0) {
     if (unidentifiedIssues.length > 0) {
@@ -31,7 +34,7 @@ const leadMessageList = ({ veteran, formName, requestIssues }) => {
       );
     } else {
       leadMessageArr.push(
-        'If you need to edit this, go to VBMS claim details and click the “Edit in Caseflow” button.'
+        <div>If necessary you may <a href={detailEditUrl}>edit the issues</a> on this {formName}.</div>
       );
     }
   }
@@ -107,7 +110,9 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
     const {
       veteran,
       formType,
-      intakeStatus
+      intakeStatus,
+      asyncJobUrl,
+      detailEditUrl
     } = this.props;
     const selectedForm = _.find(FORM_TYPES, { key: formType });
     const completedReview = this.props.decisionReviews[selectedForm.key];
@@ -147,6 +152,8 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       type="success"
       leadMessageList={
         leadMessageList({
+          asyncJobUrl,
+          detailEditUrl,
           veteran,
           formName: selectedForm.name,
           requestIssues
@@ -172,6 +179,8 @@ export default connect(
   (state) => ({
     veteran: state.intake.veteran,
     formType: state.intake.formType,
+    asyncJobUrl: state.intake.asyncJobUrl,
+    detailEditUrl: state.intake.detailEditUrl,
     decisionReviews: {
       higher_level_review: state.higherLevelReview,
       supplemental_claim: state.supplementalClaim,

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -20,16 +20,16 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, detail
 
   const leadMessageArr = [
     `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`,
-    <div>You may check on the <a href={asyncJobUrl}>status of the VBMS establishment</a>.</div>
+    <div>If needed, you may <a href={detailEditUrl}>correct the issues</a>.</div>
   ];
+
+  if (asyncJobUrl) {
+    leadMessageArr.push(<div>You may check on the <a href={asyncJobUrl}>status of the VBMS establishment</a>.</div>);
+  }
 
   if (eligibleRequestIssues.length !== 0) {
     if (unidentifiedIssues.length > 0) {
       leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
-    } else {
-      leadMessageArr.push(
-        <div>Once established in VBMS, you may <a href={detailEditUrl}>edit the issues</a>.</div>
-      );
     }
   }
 

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -27,10 +27,8 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, detail
     leadMessageArr.push(<div>You may check on the <a href={asyncJobUrl}>status of the VBMS establishment</a>.</div>);
   }
 
-  if (eligibleRequestIssues.length !== 0) {
-    if (unidentifiedIssues.length > 0) {
-      leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
-    }
+  if (eligibleRequestIssues.length !== 0 && unidentifiedIssues.length > 0) {
+    leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
   }
 
   leadMessageArr.push(

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 import React, { Fragment } from 'react';
 import StatusMessage from '../../components/StatusMessage';
 import { connect } from 'react-redux';
@@ -5,12 +7,12 @@ import { Redirect } from 'react-router-dom';
 import { PAGE_PATHS, INTAKE_STATES, FORM_TYPES } from '../constants';
 import { getIntakeStatus } from '../selectors';
 import _ from 'lodash';
-import Alert from '../../components/Alert';
 import { legacyIssue } from '../util/issues';
 import IneligibleIssuesList from '../components/IneligibleIssuesList';
 import SmallLoader from '../../components/SmallLoader';
 import { LOGO_COLORS } from '../../constants/AppConstants';
 import COPY from '../../../COPY.json';
+import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 
 const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, detailEditUrl }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
@@ -18,23 +20,15 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, detail
 
   const leadMessageArr = [
     `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`,
-    <div>You may check on the <a href={asyncJobUrl}>establishment status of the request</a>.</div>
+    <div>You may check on the <a href={asyncJobUrl}>status of the VBMS establishment</a>.</div>
   ];
 
   if (eligibleRequestIssues.length !== 0) {
     if (unidentifiedIssues.length > 0) {
-      leadMessageArr.push(
-        <Alert type="warning">
-          <h2>Unidentified issue</h2>
-          <p>{COPY.UNIDENTIFIED_ALERT}</p>
-          {unidentifiedIssues.map((ri, i) => <p className="cf-red-text" key={`unidentified-alert-${i}`}>
-            Unidentified issue: no issue matched for requested "{ri.description}"
-          </p>)}
-        </Alert>
-      );
+      leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
     } else {
       leadMessageArr.push(
-        <div>If necessary you may <a href={detailEditUrl}>edit the issues</a> on this {formName}.</div>
+        <div>Once established in VBMS, you may <a href={detailEditUrl}>edit the issues</a>.</div>
       );
     }
   }

--- a/client/app/intake/reducers/appeal.js
+++ b/client/app/intake/reducers/appeal.js
@@ -68,6 +68,15 @@ const updateFromServerIntake = (state, serverIntake) => {
     relationships: {
       $set: formatRelationships(serverIntake.relationships)
     },
+    intakeUser: {
+     $set: serverIntake.intakeUser
+    },
+    asyncJobUrl: {
+      $set: serverIntake.asyncJobUrl
+    },
+    processedAt: {
+      $set: serverIntake.processedAt
+    },
     veteranValid: {
       $set: serverIntake.veteranValid
     },
@@ -102,6 +111,9 @@ export const mapDataToInitialAppeal = (data = { serverIntake: {} }) => (
     isReviewed: false,
     isComplete: false,
     issueCount: 0,
+    intakeUser: null,
+    processedAt: null,
+    asyncJobUrl: null,
     nonRatingRequestIssues: { },
     contestableIssues: { },
     reviewIntakeError: null,

--- a/client/app/intake/reducers/higherLevelReview.js
+++ b/client/app/intake/reducers/higherLevelReview.js
@@ -73,6 +73,15 @@ const updateFromServerIntake = (state, serverIntake) => {
     relationships: {
       $set: formatRelationships(serverIntake.relationships)
     },
+    intakeUser: {
+      $set: serverIntake.intakeUser
+    },
+    asyncJobUrl: {
+      $set: serverIntake.asyncJobUrl
+    },
+    processedAt: {
+      $set: serverIntake.processedAt
+    },
     veteranValid: {
       $set: serverIntake.veteranValid
     },
@@ -116,6 +125,9 @@ export const mapDataToInitialHigherLevelReview = (data = { serverIntake: {} }) =
     isReviewed: false,
     isComplete: false,
     issueCount: 0,
+    intakeUser: null,
+    processedAt: null,
+    asyncJobUrl: null,
     nonRatingRequestIssues: { },
     contestableIssues: { },
     reviewIntakeError: null,

--- a/client/app/intake/reducers/intake.js
+++ b/client/app/intake/reducers/intake.js
@@ -11,6 +11,12 @@ const updateFromServerIntake = (state, serverIntake) => {
     formType: {
       $set: serverIntake.form_type
     },
+    asyncJobUrl: {
+      $set: serverIntake.async_job_url
+    },
+    detailEditUrl: {
+      $set: serverIntake.detail_edit_url
+    },
     veteran: {
       name: {
         $set: serverIntake.veteran_name
@@ -31,6 +37,8 @@ const updateFromServerIntake = (state, serverIntake) => {
 export const mapDataToInitialIntake = (data = { serverIntake: {} }) => (
   updateFromServerIntake({
     id: null,
+    asyncJobUrl: null,
+    detailEditUrl: null,
     formType: null,
     fileNumberSearch: '',
     searchErrorCode: null,

--- a/client/app/intake/reducers/supplementalClaim.js
+++ b/client/app/intake/reducers/supplementalClaim.js
@@ -67,6 +67,15 @@ const updateFromServerIntake = (state, serverIntake) => {
     relationships: {
       $set: formatRelationships(serverIntake.relationships)
     },
+    intakeUser: {
+      $set: serverIntake.intakeUser
+   },
+    asyncJobUrl: {
+      $set: serverIntake.asyncJobUrl
+    },
+    processedAt: {
+      $set: serverIntake.processedAt
+    },
     veteranValid: {
       $set: serverIntake.veteranValid
     },
@@ -105,6 +114,9 @@ export const mapDataToInitialSupplementalClaim = (data = { serverIntake: {} }) =
     isReviewed: false,
     isComplete: false,
     issueCount: 0,
+    intakeUser: null,
+    processedAt: null,
+    asyncJobUrl: null,
     nonRatingRequestIssues: { },
     contestableIssues: { },
     reviewIntakeError: null,

--- a/client/app/styles/_intake.scss
+++ b/client/app/styles/_intake.scss
@@ -3,6 +3,16 @@
   padding-left: 0.5em;
 }
 
+.cf-intake-establish-credits {
+  text-align: center;
+  font-size: 95%;
+
+  a {
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+}
+
 // the .cf-app-intake ancestor is needed for these rules to ensure a higher
 // specificity than the stock .cf component classes.
 .cf-app-intake {

--- a/client/app/styles/_intake.scss
+++ b/client/app/styles/_intake.scss
@@ -6,11 +6,6 @@
 .cf-intake-establish-credits {
   text-align: center;
   font-size: 95%;
-
-  a {
-    margin-left: 6px;
-    margin-right: 6px;
-  }
 }
 
 // the .cf-app-intake ancestor is needed for these rules to ensure a higher

--- a/spec/controllers/asyncable_jobs_controller_spec.rb
+++ b/spec/controllers/asyncable_jobs_controller_spec.rb
@@ -11,10 +11,10 @@ describe AsyncableJobsController, :postgres, type: :controller do
   describe "#show" do
     context "User is not asyncable_user" do
       let(:user) { create(:default_user) }
-      let(:intake) { create(:intake) }
+      let!(:job) { create(:higher_level_review, intake: create(:intake)) }
 
       it "returns unauthorized" do
-        get :show, params: { asyncable_job_klass: intake.detail.class.to_s, id: intake.detail.id }
+        get :show, params: { asyncable_job_klass: job.class.to_s, id: job.id }
 
         expect(response.status).to eq 302
         expect(response.body).to match(/unauthorized/)
@@ -23,10 +23,10 @@ describe AsyncableJobsController, :postgres, type: :controller do
 
     context "User is asyncable_user" do
       let(:user) { create(:default_user) }
-      let(:intake) { create(:intake, user: user) }
+      let!(:job) { create(:higher_level_review, intake: create(:intake, user: user)) }
 
       it "allows view" do
-        get :show, params: { asyncable_job_klass: intake.detail.class.to_s, id: intake.detail.id }
+        get :show, params: { asyncable_job_klass: job.class.to_s, id: job.id }
 
         expect(response.status).to eq 200
       end

--- a/spec/controllers/asyncable_jobs_controller_spec.rb
+++ b/spec/controllers/asyncable_jobs_controller_spec.rb
@@ -8,6 +8,31 @@ describe AsyncableJobsController, :postgres, type: :controller do
     User.stub = user
   end
 
+  describe "#show" do
+    context "User is not asyncable_user" do
+      let(:user) { create(:default_user) }
+      let(:intake) { create(:intake) }
+
+      it "returns unauthorized" do
+        get :show, params: { asyncable_job_klass: intake.detail.class.to_s, id: intake.detail.id }
+
+        expect(response.status).to eq 302
+        expect(response.body).to match(/unauthorized/)
+      end
+    end
+
+    context "User is asyncable_user" do
+      let(:user) { create(:default_user) }
+      let(:intake) { create(:intake, user: user) }
+
+      it "allows view" do
+        get :show, params: { asyncable_job_klass: intake.detail.class.to_s, id: intake.detail.id }
+
+        expect(response.status).to eq 200
+      end
+    end
+  end
+
   describe "#index" do
     context "user is not Admin Intake" do
       let(:user) { create(:default_user) }

--- a/spec/controllers/higher_level_reviews_controller_spec.rb
+++ b/spec/controllers/higher_level_reviews_controller_spec.rb
@@ -10,7 +10,11 @@ describe HigherLevelReviewsController, :postgres, type: :controller do
 
   let(:veteran) { create(:veteran) }
   let(:hlr) do
-    create(:higher_level_review, :with_end_product_establishment, veteran_file_number: veteran.file_number).reload
+    create(:higher_level_review,
+           :with_end_product_establishment,
+           :processed,
+           intake: create(:intake),
+           veteran_file_number: veteran.file_number).reload
   end
   let(:user) { User.authenticate!(roles: ["Mail Intake"]) }
 

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -10,12 +10,6 @@ FactoryBot.define do
       number_of_claimants { nil }
     end
 
-    after(:create) do |higher_level_review|
-      if !higher_level_review.intake
-        create(:intake, detail: higher_level_review, veteran_file_number: higher_level_review.veteran_file_number)
-      end
-    end
-
     trait :with_end_product_establishment do
       after(:create) do |higher_level_review|
         create(

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     sequence(:veteran_file_number, &:to_s)
     receipt_date { 1.month.ago }
     benefit_type { "compensation" }
-    association :intake
 
     transient do
       number_of_claimants { nil }

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:veteran_file_number, &:to_s)
     receipt_date { 1.month.ago }
     benefit_type { "compensation" }
+    association :intake
 
     transient do
       number_of_claimants { nil }
@@ -18,6 +19,10 @@ FactoryBot.define do
           source: higher_level_review
         )
       end
+    end
+
+    trait :processed do
+      establishment_processed_at { Time.zone.now }
     end
 
     trait :requires_processing do

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -10,6 +10,12 @@ FactoryBot.define do
       number_of_claimants { nil }
     end
 
+    after(:create) do |higher_level_review|
+      if !higher_level_review.intake
+        create(:intake, detail: higher_level_review, veteran_file_number: higher_level_review.veteran_file_number)
+      end
+    end
+
     trait :with_end_product_establishment do
       after(:create) do |higher_level_review|
         create(

--- a/spec/factories/supplemental_claim.rb
+++ b/spec/factories/supplemental_claim.rb
@@ -11,10 +11,6 @@ FactoryBot.define do
     end
 
     after(:create) do |sc, evaluator|
-      if !sc.intake
-        create(:intake, detail: sc, veteran_file_number: sc.veteran_file_number)
-      end
-
       if evaluator.number_of_claimants
         sc.claimants = create_list(:claimant, evaluator.number_of_claimants, decision_review: sc)
       end

--- a/spec/factories/supplemental_claim.rb
+++ b/spec/factories/supplemental_claim.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       number_of_claimants { nil }
     end
 
+    trait :processed do
+      establishment_processed_at { Time.zone.now }
+    end
+
     after(:create) do |sc, evaluator|
       if evaluator.number_of_claimants
         sc.claimants = create_list(:claimant, evaluator.number_of_claimants, decision_review: sc)

--- a/spec/factories/supplemental_claim.rb
+++ b/spec/factories/supplemental_claim.rb
@@ -11,6 +11,10 @@ FactoryBot.define do
     end
 
     after(:create) do |sc, evaluator|
+      if !sc.intake
+        create(:intake, detail: sc, veteran_file_number: sc.veteran_file_number)
+      end
+
       if evaluator.number_of_claimants
         sc.claimants = create_list(:claimant, evaluator.number_of_claimants, decision_review: sc)
       end

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -149,7 +149,7 @@ feature "Intake Add Issues Page", :all_dbs do
       expect(page).to have_content("Right knee")
       click_intake_finish
 
-      expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+      expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
       expect(page).to have_content("Right knee")
       expect(RequestIssue.where(edited_description: "Right knee")).to_not be_nil
     end

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -150,7 +150,7 @@ feature "Appeal Intake", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
+    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
     expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES_SHORT.appeal} created:")
     expect(page).to have_content("Issue: Active Duty Adjustments - Description for Active Duty Adjustments")
 
@@ -254,7 +254,7 @@ feature "Appeal Intake", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
+    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
   end
 
   def complete_appeal
@@ -273,7 +273,7 @@ feature "Appeal Intake", :all_dbs do
     )
 
     click_intake_finish
-    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
+    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
   end
 
   scenario "intake can still be completed when ratings are backfilled" do
@@ -485,7 +485,7 @@ feature "Appeal Intake", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
+    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
     expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
     expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
 
@@ -622,7 +622,7 @@ feature "Appeal Intake", :all_dbs do
       )
       click_intake_finish
 
-      expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been processed.")
+      expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
       expect(
         RequestIssue.find_by(contested_issue_description: "appeal decision issue").ineligible_reason
       ).to eq("appeal_to_appeal")

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -27,7 +27,7 @@ feature "Intake Confirmation Page", :postgres do
           add_untimely_exemption_response("Yes")
           click_intake_finish
           expect(page).to have_content("Intake completed")
-          expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
+          expect(page).to_not have_content("Once established in VBMS, you may edit the issues")
           expect(page).to_not have_content("Informal Conference Tracked Item")
           expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
         end
@@ -46,7 +46,7 @@ feature "Intake Confirmation Page", :postgres do
             click_intake_finish
             expect(page).to have_content("Intake completed")
             expect(page).to have_content("Nonrating EP is being established")
-            expect(page).to have_content("If you need to edit this, go to VBMS claim details")
+            expect(page).to have_content("Once established in VBMS, you may edit the issues")
             expect(page).to have_content("Tracked Item") if claim_review_type == :higher_level_review
             expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
           end

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -42,7 +42,7 @@ feature "Intake Confirmation Page", :postgres do
             click_intake_continue
             click_intake_add_issue
             # Add an eligible issue
-            add_intake_nonrating_issue(date: 6.months.ago.strftime("%m/%d/%Y"))
+            add_intake_nonrating_issue(date: 6.months.ago.mdY)
             click_intake_finish
             expect(page).to have_content("Intake completed")
             expect(page).to have_content("Nonrating EP is being established")

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -16,7 +16,7 @@ feature "Intake Confirmation Page", :postgres do
       context "HRL allows ineligible issues to remain due to untimeliness" do
         let(:claim_review_type) { :higher_level_review }
 
-        it "does not show edit in VBMS or tracked item if there is no End Product" do
+        it "does not show tracked item if there is no End Product" do
           start_claim_review(claim_review_type)
 
           visit "/intake"
@@ -27,7 +27,7 @@ feature "Intake Confirmation Page", :postgres do
           add_untimely_exemption_response("Yes")
           click_intake_finish
           expect(page).to have_content("Intake completed")
-          expect(page).to_not have_content("Once established in VBMS, you may edit the issues")
+          expect(page).to have_content("If needed, you may correct the issues")
           expect(page).to_not have_content("Informal Conference Tracked Item")
           expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
         end
@@ -46,7 +46,7 @@ feature "Intake Confirmation Page", :postgres do
             click_intake_finish
             expect(page).to have_content("Intake completed")
             expect(page).to have_content("Nonrating EP is being established")
-            expect(page).to have_content("Once established in VBMS, you may edit the issues")
+            expect(page).to have_content("If needed, you may correct the issues")
             expect(page).to have_content("Tracked Item") if claim_review_type == :higher_level_review
             expect(page).to have_content("Edit the notice letter to reflect the status of requested issues")
           end

--- a/spec/feature/intake/end_product_correction_spec.rb
+++ b/spec/feature/intake/end_product_correction_spec.rb
@@ -61,11 +61,17 @@ feature "End Product Correction (EP 930)", :postgres do
     )
   end
 
+  let(:processed_claim_review) do
+    create(claim_review_type.to_sym,
+           :processed,
+           intake: create(:intake),
+           veteran_file_number: veteran.file_number,
+           receipt_date: receipt_date)
+  end
+
   feature "with cleared end product on higher level review" do
     let(:claim_review_type) { "higher_level_review" }
-    let!(:claim_review) do
-      create(claim_review_type.to_sym, veteran_file_number: veteran.file_number, receipt_date: receipt_date)
-    end
+    let!(:claim_review) { processed_claim_review }
     let(:edit_path) { "#{claim_review_type.pluralize}/#{cleared_end_product.claim_id}/edit" }
     let(:ep_code) { "030HLRR" }
 
@@ -162,9 +168,7 @@ feature "End Product Correction (EP 930)", :postgres do
 
   feature "with cleared end product on supplemental claim" do
     let(:claim_review_type) { "supplemental_claim" }
-    let!(:claim_review) do
-      create(claim_review_type.to_sym, veteran_file_number: veteran.file_number, receipt_date: receipt_date)
-    end
+    let!(:claim_review) { processed_claim_review }
     let(:edit_path) { "#{claim_review_type.pluralize}/#{cleared_end_product.claim_id}/edit" }
     let(:ep_code) { "040SCR" }
 

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -37,7 +37,8 @@ feature "Higher Level Review Edit issues", :all_dbs do
   let(:benefit_type) { "compensation" }
 
   let!(:higher_level_review) do
-    HigherLevelReview.create!(
+    create(
+      :higher_level_review,
       veteran_file_number: veteran.file_number,
       receipt_date: receipt_date,
       informal_conference: false,
@@ -49,7 +50,10 @@ feature "Higher Level Review Edit issues", :all_dbs do
   end
 
   let!(:another_higher_level_review) do
-    HigherLevelReview.create!(
+    create(
+      :higher_level_review,
+      :processed,
+      intake: create(:intake),
       veteran_file_number: veteran.file_number,
       receipt_date: receipt_date,
       informal_conference: false,
@@ -60,8 +64,9 @@ feature "Higher Level Review Edit issues", :all_dbs do
 
   # create associated intake
   let!(:intake) do
-    Intake.create!(
-      user_id: current_user.id,
+    create(
+      :intake,
+      user: current_user,
       detail: higher_level_review,
       veteran_file_number: veteran.file_number,
       started_at: Time.zone.now,

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -1291,8 +1291,11 @@ feature "Higher Level Review Edit issues", :all_dbs do
     let(:last_week) { Time.zone.now - 7.days }
     let(:higher_level_review) do
       # reload to get uuid
-      create(:higher_level_review, :with_end_product_establishment, veteran_file_number: veteran.file_number,
-                                                                    benefit_type: benefit_type).reload
+      create(:higher_level_review,
+             :with_end_product_establishment,
+             :processed,
+             veteran_file_number: veteran.file_number,
+             benefit_type: benefit_type).reload
     end
     let!(:existing_request_issues) do
       [create(:request_issue, :nonrating, decision_review: higher_level_review),

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -449,7 +449,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
   context "Nonrating issue with untimely date and VACOLS opt-in" do
     before do
       setup_legacy_opt_in_appeals(veteran.file_number)
-      higher_level_review.reload # get UUID
+      higher_level_review.reload.establish!
     end
 
     let(:legacy_opt_in_approved) { true }

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -718,6 +718,54 @@ feature "Higher Level Review Edit issues", :all_dbs do
     end
   end
 
+  describe "Establishment credits" do
+    let(:url_path) { "higher_level_reviews" }
+    let(:decision_review) { higher_level_review }
+    let(:request_issues) { [request_issue] }
+    let(:request_issue) do
+      create(
+        :request_issue,
+        contested_rating_issue_reference_id: "def456",
+        contested_rating_issue_profile_date: rating.profile_date,
+        decision_review: decision_review,
+        benefit_type: benefit_type,
+        contested_issue_description: "PTSD denied"
+      )
+    end
+
+    context "when the EP has not yet been established" do
+      before do
+        decision_review.reload.create_issues!(request_issues)
+      end
+
+      it "disallows editing" do
+        visit "#{url_path}/#{decision_review.uuid}/edit"
+
+        expect(page).to have_content("Review not yet established in VBMS. Check the job page for details.")
+        expect(page).to have_link("the job page")
+
+        click_link "the job page"
+
+        expect(current_path).to eq decision_review.async_job_url
+      end
+    end
+
+    context "when the EP has been established" do
+      before do
+        decision_review.reload.create_issues!(request_issues)
+        decision_review.establish!
+      end
+
+      it "shows when and by whom the Intake was performed" do
+        visit "#{url_path}/#{decision_review.uuid}/edit"
+
+        expect(page).to have_content(
+          "Established #{decision_review.establishment_processed_at.friendly_full_format} by #{intake.user.css_id}"
+        )
+      end
+    end
+  end
+
   context "when there is a rating end product" do
     let!(:request_issue) do
       create(

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -228,7 +228,7 @@ feature "Higher-Level Review", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
     expect(page).to have_content(
       "A #{Constants.INTAKE_FORM_NAMES_SHORT.higher_level_review} Rating EP is being established:"
     )
@@ -434,7 +434,7 @@ feature "Higher-Level Review", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
 
     expect(Fakes::VBMSService).to have_received(:create_contentions!).with(
       veteran_file_number: veteran_file_number,
@@ -509,7 +509,7 @@ feature "Higher-Level Review", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
   end
 
   def complete_higher_level_review
@@ -528,7 +528,7 @@ feature "Higher-Level Review", :all_dbs do
     )
 
     click_intake_finish
-    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+    expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
   end
 
   scenario "intake can still be completed when ratings are backfilled" do
@@ -861,7 +861,7 @@ feature "Higher-Level Review", :all_dbs do
 
       click_intake_finish
 
-      expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+      expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
       expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
       success_checklist = find("ul.cf-success-checklist")
@@ -1082,7 +1082,7 @@ feature "Higher-Level Review", :all_dbs do
         )
         click_intake_finish
 
-        expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been processed.")
+        expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
 
         expect(
           RequestIssue.find_by(contested_issue_description: "appeal decision issue").ineligible_reason

--- a/spec/feature/intake/intake_edit_confirmation_spec.rb
+++ b/spec/feature/intake/intake_edit_confirmation_spec.rb
@@ -115,7 +115,7 @@ feature "Intake Edit Confirmation", :postgres do
 
           expect(page).to have_current_path("/#{edit_path}/confirmation")
           expect(page).to have_content("A #{decision_review.class.review_title} Rating EP is being canceled")
-          expect(page).to_not have_content("If you need to edit this, go to VBMS claim details")
+          expect(page).to_not have_content("Once established in VBMS, you may edit the issues")
         end
       end
     end

--- a/spec/feature/intake/ramp_refiling_spec.rb
+++ b/spec/feature/intake/ramp_refiling_spec.rb
@@ -421,7 +421,7 @@ RSpec.feature "RAMP Refiling Intake", :postgres do
       expect(ramp_refiling.issues.count).to eq(1)
       expect(ramp_refiling.issues.first.contention_reference_id).to_not be_nil
       expect(page).to have_content(
-        "Ed Merica's (ID #12341234) VA Form 21-4138 has been submitted."
+        "Ed Merica's (ID #12341234) VA Form 21-4138 has been processed."
       )
       expect(page).to have_content(
         "Established EP: 683SCRRRAMP - Supplemental Claim Review Rating for Station 397"

--- a/spec/feature/intake/ramp_refiling_spec.rb
+++ b/spec/feature/intake/ramp_refiling_spec.rb
@@ -421,7 +421,7 @@ RSpec.feature "RAMP Refiling Intake", :postgres do
       expect(ramp_refiling.issues.count).to eq(1)
       expect(ramp_refiling.issues.first.contention_reference_id).to_not be_nil
       expect(page).to have_content(
-        "Ed Merica's (ID #12341234) VA Form 21-4138 has been processed."
+        "Ed Merica's (ID #12341234) VA Form 21-4138 has been submitted."
       )
       expect(page).to have_content(
         "Established EP: 683SCRRRAMP - Supplemental Claim Review Rating for Station 397"

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -719,7 +719,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
     let(:last_week) { Time.zone.now - 7.days }
     let(:supplemental_claim) do
       # reload to get uuid
-      create(:supplemental_claim, veteran_file_number: veteran.file_number).reload
+      create(:supplemental_claim, :processed, veteran_file_number: veteran.file_number).reload
     end
     let!(:existing_request_issues) do
       [create(:request_issue, :nonrating, decision_review: supplemental_claim),
@@ -781,8 +781,10 @@ feature "Supplemental Claim Edit issues", :all_dbs do
       context "show alert when issues are withdrawn" do
         let(:supplemental_claim) do
           # reload to get uuid
-          create(:supplemental_claim, veteran_file_number: veteran.file_number,
-                                      benefit_type: "education").reload
+          create(:supplemental_claim,
+                 :processed,
+                 veteran_file_number: veteran.file_number,
+                 benefit_type: "education").reload
         end
 
         before do

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -188,7 +188,7 @@ feature "Supplemental Claim Intake", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
+    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been submitted.")
     expect(page).to have_content(
       "A #{Constants.INTAKE_FORM_NAMES_SHORT.supplemental_claim} Rating EP is being established:"
     )
@@ -385,7 +385,7 @@ feature "Supplemental Claim Intake", :all_dbs do
 
     click_intake_finish
 
-    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
+    expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been submitted.")
   end
 
   context "ratings with disabiliity codes" do
@@ -563,7 +563,7 @@ feature "Supplemental Claim Intake", :all_dbs do
 
       click_intake_finish
 
-      expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been processed.")
+      expect(page).to have_content("Request for #{Constants.INTAKE_FORM_NAMES.supplemental_claim} has been submitted.")
       expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
       expect(page).to have_content('Unidentified issue: no issue matched for requested "This is an unidentified issue"')
       expect(page).to have_content(old_rating_decision_text)

--- a/spec/feature/queue/delete_request_issues_spec.rb
+++ b/spec/feature/queue/delete_request_issues_spec.rb
@@ -85,6 +85,7 @@ feature "correcting issues", :postgres do
   def appeal_with_one_decision_issue
     appeal = create(
       :appeal,
+      intake: create(:intake),
       number_of_claimants: 1,
       request_issues: [
         create_request_issue(notes: "first request issue", decision_issues: [decision_issue(1)]),
@@ -99,6 +100,7 @@ feature "correcting issues", :postgres do
     multiple_decision_issues = [decision_issue(1), decision_issue(2)]
     appeal = create(
       :appeal,
+      intake: create(:intake),
       number_of_claimants: 1,
       request_issues: [
         create_request_issue(notes: "with many decision issues", decision_issues: multiple_decision_issues),
@@ -114,6 +116,7 @@ feature "correcting issues", :postgres do
     unique_issue = decision_issue(2)
     appeal = create(
       :appeal,
+      intake: create(:intake),
       number_of_claimants: 1,
       request_issues: [
         create_request_issue(notes: "with a shared decision issue", decision_issues: [shared_issue, unique_issue]),

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -75,7 +75,9 @@ RSpec.feature "Search", :all_dbs do
       context "when a claim has a higher level review and/or supplemental claim" do
         context "and it has no appeals" do
           let!(:veteran) { create(:veteran) }
-          let!(:higher_level_review) { create(:higher_level_review, veteran_file_number: veteran.file_number) }
+          let!(:higher_level_review) do
+            create(:higher_level_review, :processed, veteran_file_number: veteran.file_number)
+          end
           let!(:intake_user) { create(:intake_user) }
 
           before do

--- a/spec/requests/api/v3/decision_review/higher_level_reviews_controller_spec.rb
+++ b/spec/requests/api/v3/decision_review/higher_level_reviews_controller_spec.rb
@@ -125,8 +125,9 @@ describe Api::V3::DecisionReview::HigherLevelReviewsController, :all_dbs, type: 
         expect(response).to have_http_status(202)
       end
 
-      describe do
+      context "params are missing" do
         let(:params) { {} }
+
         it "should return an error status on failure" do
           post_params
           error = Api::V3::DecisionReview::IntakeError.new(:malformed_request)

--- a/spec/support/date_time_helper.rb
+++ b/spec/support/date_time_helper.rb
@@ -39,6 +39,12 @@ class Date
 end
 
 class Time
+  # rubocop:disable Naming/MethodName
+  def mdY
+    strftime("%m/%d/%Y")
+  end
+  # rubocop:enable Naming/MethodName
+
   def unix_format
     strftime("%a %b %d %T %Y")
   end

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -737,7 +737,7 @@ module IntakeHelpers
       expect(page).to have_content("View all cases")
     else
       click_intake_finish
-      expect(page).to have_content("#{form_name} has been processed.")
+      expect(page).to have_content("#{form_name} has been submitted.")
     end
 
     expect(
@@ -852,7 +852,7 @@ module IntakeHelpers
     add_intake_rating_issue("Issue with legacy issue not withdrawn")
 
     click_edit_submit
-    expect(page).to have_content("has been processed")
+    expect(page).to have_content("has been submitted")
 
     first_not_modified_request_issue = RequestIssue.find_by(
       decision_review: decision_review,


### PR DESCRIPTION
connects #11388 #11758 #11907 

### Description
Adds links to the async job page and user stats pages on every completed Intake and the Edit Issues page. This should help increase visibility as to who/when/what for each Intake.

Example edit page change:
![Screen Shot 2019-09-04 at 9 00 56 AM](https://user-images.githubusercontent.com/1205061/64261704-89c04f00-cef2-11e9-8166-9b5e4e3a9c74.png)

Example confirmation page change (the message about VBMS does not appear for Board Appeals):
![Screen Shot 2019-09-07 at 7 12 47 AM](https://user-images.githubusercontent.com/1205061/64474773-f16ada00-d13e-11e9-88a8-1d1d65331d96.png)

When the claim review has not finished processing, give a custom error message with a link to the job details page:
![Screen Shot 2019-09-06 at 5 59 42 PM](https://user-images.githubusercontent.com/1205061/64465073-47ecff80-d0d0-11e9-9697-24d0d950a12f.png)
