### PR TITLE
Skip appeals that do not have a veteran associated

### DIFF
--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -67,9 +67,7 @@ class WarmBgsCachesJob < CaseflowJob
     hearings.each do |hearing|
       veteran = hearing.appeal.veteran
 
-      next unless veteran
-
-      if veteran.stale_attributes?
+      if veteran&.stale_attributes?
         veteran.update_cached_attributes!
         veterans_updated += 1
       end

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -66,6 +66,9 @@ class WarmBgsCachesJob < CaseflowJob
     hearings = HearingsForDayQuery.new(day: date_to_cache).call
     hearings.each do |hearing|
       veteran = hearing.appeal.veteran
+
+      next unless veteran
+
       if veteran.stale_attributes?
         veteran.update_cached_attributes!
         veterans_updated += 1


### PR DESCRIPTION
Resolves #11975 

### Description
Fixes no such method on nil object error.