### PR TITLE
Allow AVLJs to perform judge tasks on legacy appeals

### DIFF
--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -26,7 +26,7 @@ class LegacyTasksController < ApplicationController
                               name: "LegacyTasksController.index") do
           tasks = LegacyWorkQueue.tasks_for_user(user)
           render json: {
-            tasks: json_tasks(tasks, current_role)
+            tasks: json_tasks(tasks, user, current_role)
           }
         end
       end
@@ -98,7 +98,7 @@ class LegacyTasksController < ApplicationController
     ::WorkQueue::LegacyTaskSerializer.new(task)
   end
 
-  def json_tasks(tasks, role)
-    ::WorkQueue::LegacyTaskSerializer.new(tasks, is_collection: true, params: { role: role })
+  def json_tasks(tasks, user, role)
+    ::WorkQueue::LegacyTaskSerializer.new(tasks, is_collection: true, params: { user: user, role: role })
   end
 end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -734,11 +734,7 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def attorney_case_review
-    AttorneyCaseReview.find_by(task_id: "#{vacols_id}-#{vacols_case_review_creation_date_in_string_format}")
-  end
-
-  def vacols_case_review_creation_date_in_string_format
-    VacolsHelper.day_only_str(vacols_case_review.created_at)
+    AttorneyCaseReview.find_by(task_id: "#{vacols_id}-#{VacolsHelper.day_only_str(vacols_case_review.created_at)}")
   end
 
   def vacols_case_review

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -733,6 +733,18 @@ class LegacyAppeal < ApplicationRecord
     file_type.eql? "Paper"
   end
 
+  def attorney_case_review
+    AttorneyCaseReview.find_by(task_id: "#{vacols_id}-#{vacols_case_review_creation_date_in_string_format}")
+  end
+
+  def vacols_case_review_creation_date_in_string_format
+    VacolsHelper.day_only_str(vacols_case_review.created_at)
+  end
+
+  def vacols_case_review
+    VACOLS::CaseAssignment.latest_task_for_appeal(vacols_id)
+  end
+
   private
 
   def soc_date_eligible_for_opt_in?(receipt_date)

--- a/app/models/legacy_tasks/judge_legacy_decision_review_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_decision_review_task.rb
@@ -9,8 +9,8 @@ class JudgeLegacyDecisionReviewTask < JudgeLegacyTask
     end
   end
 
-  def available_actions(current_user, role)
-    return [] if role != "judge" || current_user != assigned_to
+  def available_actions(current_user, _role)
+    return [] if current_user.vacols_roles.none? { |vrole| vrole.casecmp("judge").zero? } || current_user != assigned_to
 
     [
       Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,

--- a/app/models/legacy_tasks/judge_legacy_decision_review_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_decision_review_task.rb
@@ -10,7 +10,7 @@ class JudgeLegacyDecisionReviewTask < JudgeLegacyTask
   end
 
   def available_actions(current_user, _role)
-    return [] if current_user.vacols_roles.none? { |vrole| vrole.casecmp("judge").zero? } || current_user != assigned_to
+    return [] if current_user != assigned_to || !current_user.judge_in_vacols?
 
     [
       Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -27,7 +27,7 @@ class LegacyWorkQueue
       vacols_tasks.zip(vacols_appeals).map do |task, appeal|
         user = validate_or_create_user(user, task.assigned_to_css_id)
 
-        task_class = (user&.vacols_roles&.first&.downcase == "judge") ? JudgeLegacyTask : AttorneyLegacyTask
+        task_class = (user_is_judge(user) && issues_have_dispositions(appeal)) ? JudgeLegacyTask : AttorneyLegacyTask
 
         task_class.from_vacols(task, appeal, user)
       end
@@ -39,6 +39,14 @@ class LegacyWorkQueue
       elsif css_id
         User.find_by_css_id_or_create_with_default_station_id(css_id)
       end
+    end
+
+    def issues_have_dispositions(appeal)
+      appeal.issues.all? { |issue| !issue.disposition.nil? }
+    end
+
+    def user_is_judge(user)
+      user&.vacols_roles&.any? { |role| role.casecmp("judge").zero? }
     end
   end
 end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -27,7 +27,7 @@ class LegacyWorkQueue
       vacols_tasks.zip(vacols_appeals).map do |task, appeal|
         user = validate_or_create_user(user, task.assigned_to_css_id)
 
-        task_class = (user_is_judge(user) && issues_have_dispositions(appeal)) ? JudgeLegacyTask : AttorneyLegacyTask
+        task_class = (user.judge_in_vacols? && issues_have_dispositions(appeal)) ? JudgeLegacyTask : AttorneyLegacyTask
 
         task_class.from_vacols(task, appeal, user)
       end
@@ -43,10 +43,6 @@ class LegacyWorkQueue
 
     def issues_have_dispositions(appeal)
       appeal.issues.all? { |issue| issue.disposition.present? }
-    end
-
-    def user_is_judge(user)
-      user&.vacols_roles&.any? { |role| role.casecmp("judge").zero? }
     end
   end
 end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -27,7 +27,10 @@ class LegacyWorkQueue
       vacols_tasks.zip(vacols_appeals).map do |task, appeal|
         user = validate_or_create_user(user, task.assigned_to_css_id)
 
-        task_class = (user.judge_in_vacols? && appeal.attorney_case_review) ? JudgeLegacyTask : AttorneyLegacyTask
+        task_class = AttorneyLegacyTask
+        if user&.vacols_roles&.first&.downcase == "judge" || (user&.judge_in_vacols? && appeal.attorney_case_review)
+          task_class = JudgeLegacyTask
+        end
 
         task_class.from_vacols(task, appeal, user)
       end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -27,7 +27,7 @@ class LegacyWorkQueue
       vacols_tasks.zip(vacols_appeals).map do |task, appeal|
         user = validate_or_create_user(user, task.assigned_to_css_id)
 
-        task_class = (user.judge_in_vacols? && issues_have_dispositions(appeal)) ? JudgeLegacyTask : AttorneyLegacyTask
+        task_class = (user.judge_in_vacols? && appeal.attorney_case_review) ? JudgeLegacyTask : AttorneyLegacyTask
 
         task_class.from_vacols(task, appeal, user)
       end
@@ -39,10 +39,6 @@ class LegacyWorkQueue
       elsif css_id
         User.find_by_css_id_or_create_with_default_station_id(css_id)
       end
-    end
-
-    def issues_have_dispositions(appeal)
-      appeal.issues.all? { |issue| issue.disposition.present? }
     end
   end
 end

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -42,7 +42,7 @@ class LegacyWorkQueue
     end
 
     def issues_have_dispositions(appeal)
-      appeal.issues.all? { |issue| !issue.disposition.nil? }
+      appeal.issues.all? { |issue| issue.disposition.present? }
     end
 
     def user_is_judge(user)

--- a/app/workflows/update_legacy_attorney_case_review.rb
+++ b/app/workflows/update_legacy_attorney_case_review.rb
@@ -29,6 +29,10 @@ class UpdateLegacyAttorneyCaseReview
 
   attr_reader :id, :document_id, :user, :success
 
+  def appeal
+    @appeal ||= LegacyAppeal.find_by(vacols_id: id)
+  end
+
   def update_attorney_case_review
     return unless appeal.attorney_case_review
 

--- a/app/workflows/update_legacy_attorney_case_review.rb
+++ b/app/workflows/update_legacy_attorney_case_review.rb
@@ -29,21 +29,29 @@ class UpdateLegacyAttorneyCaseReview
 
   attr_reader :id, :document_id, :user, :success
 
-  def appeal
-    @appeal ||= LegacyAppeal.find_by(vacols_id: id)
+  def update_attorney_case_review
+    return unless attorney_case_review
+
+    attorney_case_review.update!(document_id: document_id)
   end
 
-  def update_attorney_case_review
-    return unless appeal.attorney_case_review
-
-    appeal.attorney_case_review.update!(document_id: document_id)
+  def attorney_case_review
+    AttorneyCaseReview.find_by(task_id: "#{id}-#{vacols_case_review_creation_date_in_string_format}")
   end
 
   def update_vacols_decass_table
     VACOLS::Decass.where(
       defolder: id,
-      deadtim: appeal.vacols_case_review_creation_date_in_string_format.to_date
+      deadtim: vacols_case_review_creation_date_in_vacols_format
     ).update_all(dedocid: document_id)
+  end
+
+  def vacols_case_review_creation_date_in_vacols_format
+    vacols_case_review_creation_date_in_string_format.to_date
+  end
+
+  def vacols_case_review_creation_date_in_string_format
+    VacolsHelper.day_only_str(vacols_case_review.created_at)
   end
 
   def vacols_case_review_exists
@@ -53,7 +61,7 @@ class UpdateLegacyAttorneyCaseReview
   end
 
   def vacols_case_review
-    @vacols_case_review ||= appeal.vacols_case_review
+    @vacols_case_review ||= VACOLS::CaseAssignment.latest_task_for_appeal(id)
   end
 
   def authorized_to_edit

--- a/app/workflows/update_legacy_attorney_case_review.rb
+++ b/app/workflows/update_legacy_attorney_case_review.rb
@@ -30,28 +30,16 @@ class UpdateLegacyAttorneyCaseReview
   attr_reader :id, :document_id, :user, :success
 
   def update_attorney_case_review
-    return unless attorney_case_review
+    return unless appeal.attorney_case_review
 
-    attorney_case_review.update!(document_id: document_id)
-  end
-
-  def attorney_case_review
-    AttorneyCaseReview.find_by(task_id: "#{id}-#{vacols_case_review_creation_date_in_string_format}")
+    appeal.attorney_case_review.update!(document_id: document_id)
   end
 
   def update_vacols_decass_table
     VACOLS::Decass.where(
       defolder: id,
-      deadtim: vacols_case_review_creation_date_in_vacols_format
+      deadtim: appeal.vacols_case_review_creation_date_in_string_format.to_date
     ).update_all(dedocid: document_id)
-  end
-
-  def vacols_case_review_creation_date_in_vacols_format
-    vacols_case_review_creation_date_in_string_format.to_date
-  end
-
-  def vacols_case_review_creation_date_in_string_format
-    VacolsHelper.day_only_str(vacols_case_review.created_at)
   end
 
   def vacols_case_review_exists
@@ -61,7 +49,7 @@ class UpdateLegacyAttorneyCaseReview
   end
 
   def vacols_case_review
-    @vacols_case_review ||= VACOLS::CaseAssignment.latest_task_for_appeal(id)
+    @vacols_case_review ||= appeal.vacols_case_review
   end
 
   def authorized_to_edit

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -298,6 +298,19 @@ RSpec.feature "Judge checkout flow", :all_dbs do
   context "when an acting judge is checking out a legacy appeal" do
     let(:vacols_role_trait) { :attorney_judge_role }
 
+    let(:created_at) { "2019-02-14" }
+    let(:document_id) { "12345-12345678" }
+    let(:vacols_id) { appeal.vacols_id }
+
+    let!(:case_review) do
+      create(
+        :attorney_case_review,
+        work_product: "Decision",
+        document_id: document_id,
+        task_id: "#{appeal.vacols_id}-#{created_at}"
+      )
+    end
+
     let!(:appeal) do
       create(
         :legacy_appeal,
@@ -320,6 +333,16 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       FeatureToggle.enable!(:judge_case_review_checkout)
 
       User.authenticate!(user: judge_user)
+
+      case_assignment = double(
+        vacols_id: vacols_id,
+        assigned_by_css_id: attorney_user.css_id,
+        assigned_to_css_id: judge_user.css_id,
+        document_id: "1234-567890",
+        work_product: :draft_decision,
+        created_at: created_at.to_date
+      )
+      allow(VACOLS::CaseAssignment).to receive(:latest_task_for_appeal).with(vacols_id).and_return(case_assignment)
     end
 
     after do

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -294,4 +294,95 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       end
     end
   end
+
+  context "when an acting judge is checking out a legacy appeal" do
+    let(:vacols_role_trait) { :attorney_judge_role }
+
+    let!(:appeal) do
+      create(
+        :legacy_appeal,
+        :with_veteran,
+        vacols_case: create(
+          :case,
+          :assigned,
+          user: judge_user,
+          assigner: attorney_user,
+          case_issues: [
+            create(:case_issue, :disposition_allowed),
+            create(:case_issue, :disposition_granted_by_aoj)
+          ],
+          work_product: :draft_decision
+        )
+      )
+    end
+
+    before do
+      FeatureToggle.enable!(:judge_case_review_checkout)
+
+      User.authenticate!(user: judge_user)
+    end
+
+    after do
+      FeatureToggle.disable!(:judge_case_review_checkout)
+    end
+
+    scenario "starts dispatch checkout flow" do
+      visit "/queue"
+      click_on "#{appeal.veteran_full_name} (#{appeal.sanitized_vbms_id})"
+
+      click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_LEGACY_CHECKOUT.label)
+      click_label "vamc"
+      click_on "Continue"
+
+      # Ensure we can reload the flow and the special issue is saved
+      click_on "Cancel"
+      click_on "Yes, cancel"
+
+      click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_LEGACY_CHECKOUT.label)
+
+      # Vamc should still be checked
+      expect(page).to have_field("vamc", checked: true, visible: false)
+
+      # Vamc should also be marked in the database
+      expect(appeal.special_issue_list.vamc).to eq(true)
+      click_on "Continue"
+
+      # one issue is decided, excluded from checkout flow
+      expect(appeal.issues.length).to eq 2
+
+      expect(page.find_all(".issue-disposition-dropdown").length).to eq 1
+
+      click_on "Edit Issue"
+      click_on "Delete Issue"
+      click_on "Delete issue"
+
+      click_on "Continue"
+      expect(page).to have_content("Evaluate Decision")
+
+      expect(page).to_not have_content("Select an action")
+      expect(page).to have_content("One Touch Initiative")
+      find("label", text: COPY::JUDGE_EVALUATE_DECISION_CASE_ONE_TOUCH_INITIATIVE_SUBHEAD).click
+
+      find("label", text: Constants::JUDGE_CASE_REVIEW_OPTIONS["COMPLEXITY"]["easy"]).click
+      text_to_click = "1 - #{Constants::JUDGE_CASE_REVIEW_OPTIONS['QUALITY']['does_not_meet_expectations']}"
+      find("label", text: text_to_click).click
+
+      find("#issues_are_not_addressed", visible: false).sibling("label").click
+
+      dummy_note = generate_words 5
+      fill_in "additional-factors", with: dummy_note
+      expect(page).to have_content(dummy_note[0..5])
+
+      click_on "Continue"
+
+      expect(page).to have_content(COPY::JUDGE_CHECKOUT_DISPATCH_SUCCESS_MESSAGE_TITLE % appeal.veteran_full_name)
+
+      expect(VACOLS::Decass.find(appeal.vacols_id).de1touch).to eq "Y"
+
+      page.driver.go_back
+      appeal_id = LegacyAppeal.last.vacols_id
+
+      expect(page).to have_current_path("/queue/appeals/#{appeal_id}")
+    end
+  end
 end


### PR DESCRIPTION
Resolves #11971

### Description
Due to the way we determine [task type for legacy work queues](https://github.com/department-of-veterans-affairs/caseflow/blob/a86c1e04e52faf6911b99281908576790fc692df/app/models/queues/legacy_work_queue.rb#L30), acting judges have been receiving judge tasks, but cannot act upon them. This PR classes any appeal with an associated AttorneyCaseReview assigned to someone with a judge vacols_role as a JudgeTask, allowing AVLJs to review legacy cases.