### PR TITLE
Prefer veteran.file_number over vbms_id

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -230,7 +230,7 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.find_or_create_by_file_number_or_ssn(veteran_file_number)
+    @veteran ||= Veteran.find_or_create_by_file_number_or_ssn(sanitized_vbms_id)
   end
 
   def veteran_ssn

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -653,6 +653,9 @@ class LegacyAppeal < ApplicationRecord
   # Alias sanitized_vbms_id becauase file_number is the term used VBA wide for this veteran identifier
   def veteran_file_number
     vacols_file_number = sanitized_vbms_id
+
+    return vacols_file_number unless veteran
+
     caseflow_file_number = veteran.file_number
     if vacols_file_number != caseflow_file_number
       Raven.capture_message("legacy appeal #{external_id} has file_number mismatch with VACOLS and Caseflow")

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -650,7 +650,10 @@ class LegacyAppeal < ApplicationRecord
     LegacyAppeal.veteran_file_number_from_bfcorlid vbms_id
   end
 
-  # Alias sanitized_vbms_id becauase file_number is the term used VBA wide for this veteran identifier
+  # The sanitized_vbms_id may be a SSN value, which may or may not be a
+  # valid file number as recognized by VBMS.
+  # Prefer what we have in the Veteran record since that originates from VBMS
+  # and therefore should be valid for external use.
   def veteran_file_number
     vacols_file_number = sanitized_vbms_id
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -652,7 +652,12 @@ class LegacyAppeal < ApplicationRecord
 
   # Alias sanitized_vbms_id becauase file_number is the term used VBA wide for this veteran identifier
   def veteran_file_number
-    sanitized_vbms_id
+    vacols_file_number = sanitized_vbms_id
+    caseflow_file_number = veteran.file_number
+    if vacols_file_number != caseflow_file_number
+      Raven.capture_message("legacy appeal #{external_id} has file_number mismatch with VACOLS and Caseflow")
+    end
+    caseflow_file_number # prefer for now
   end
 
   def pending_eps

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -271,7 +271,8 @@ class Veteran < ApplicationRecord
 
     def find_or_create_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
-        find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
+        find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
+          find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)
       else
         find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -466,6 +466,9 @@
   "INTAKE_EDIT_WITHDRAW_DATE": "Please include the date the withdrawal was requested",
   "INTAKE_WITHDRAWN_BANNER": "This review will be withdrawn. You can intake these issues as a different type of decision review, if that was requested.",
   "INTAKE_RATING_MAY_BE_PROCESS": "Rating may be in progress",
+  "INTAKE_SEARCH_ERROR_INVALID_FILE_NUMBER": "Please enter a valid Veteran ID and try again.",
+  "INTAKE_SEARCH_ERROR_NOT_ACCESSIBLE": "It looks like you do not have the necessary level of access to view this information. Please alert your manager so they can assign the form to someone else.",
+  "INTAKE_SEARCH_ERROR_NOT_MODIFIABLE": "You do not appear to have permission to establish a claim for this Veteran. Often this is because they are an employee at the same station as you. Please alert your manager so they can assign the form to someone else.",
 
   "VACOLS_OPTIN_ISSUE_NEW": "Adding this issue will automatically close VACOLS issue",
   "VACOLS_OPTIN_ISSUE_CLOSED_EDIT": "This issue has automatically closed the VACOLS issue",

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -73,7 +73,7 @@ class Search extends React.PureComponent {
     const searchErrors = {
       invalid_file_number: {
         title: 'Veteran ID not found',
-        body: 'Please enter a valid Veteran ID and try again.'
+        body: COPY.INTAKE_SEARCH_ERROR_INVALID_FILE_NUMBER
       },
       veteran_not_found: {
         title: 'Veteran not found',
@@ -81,7 +81,7 @@ class Search extends React.PureComponent {
       },
       reserved_veteran_file_number: {
         title: 'Invalid file number',
-        body: 'Please enter a valid Veteran ID and try again.'
+        body: COPY.INTAKE_SEARCH_ERROR_INVALID_FILE_NUMBER
       },
       veteran_has_multiple_phone_numbers: {
         title: 'The Veteran has multiple active phone numbers',
@@ -89,14 +89,11 @@ class Search extends React.PureComponent {
       },
       veteran_not_accessible: {
         title: "You don't have permission to view this Veteran's information",
-        body: 'It looks like you do not have the necessary level of access to view this information.' +
-          ' Please alert your manager so they can assign the form to someone else.'
+        body: COPY.INTAKE_SEARCH_ERROR_NOT_ACCESSIBLE
       },
       veteran_not_modifiable: {
         title: "You don't have permission to intake this Veteran",
-        body: 'You do not appear to have permission to establish a claim for this Veteran.' +
-          ' Often this is because they are an employee at the same station as you.' +
-          ' Please alert your manager so they can assign the form to someone else.'
+        body: COPY.INTAKE_SEARCH_ERROR_NOT_MODIFIABLE
       },
       veteran_not_valid: {
         title: 'The Veteran\'s profile has missing or invalid information required to create an EP.',

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/prop-types */
+
 import React from 'react';
 import SearchBar from '../../components/SearchBar';
 import Alert from '../../components/Alert';

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -487,13 +487,14 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
   describe "GET veteran/:appeal_id" do
     let(:veteran_first_name) { "Test" }
     let(:veteran_last_name) { "User" }
+    let(:veteran_file_number) { "0000000000" }
     let(:correspondent) { create(:correspondent, snamef: veteran_first_name, snamel: veteran_last_name) }
     let(:appeal) do
       create(
         :legacy_appeal,
         vacols_case: create(
           :case,
-          bfcorlid: "0000000000S",
+          bfcorlid: "#{veteran_file_number}S",
           correspondent: correspondent
         )
       )
@@ -503,7 +504,7 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
         :veteran,
         first_name: veteran_first_name,
         last_name: veteran_last_name,
-        file_number: appeal.veteran_file_number,
+        file_number: veteran_file_number,
         email_address: "test@test.com"
       )
     end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -145,6 +145,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
     context "when user has no role" do
       let(:role) { nil }
+      let(:veteran_file_number) { create(:veteran).file_number }
 
       it "should return 200" do
         get :index, params: { user_id: user.id, role: "unknown" }
@@ -158,6 +159,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
             folder: create(:folder, tinum: "docket-number"),
             bfregoff: "RO04",
             bfcurloc: "57",
+            bfcorlid: "#{veteran_file_number}C",
             bfhr: "2",
             bfdocind: HearingDay::REQUEST_TYPES[:video]
           )

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -140,7 +140,7 @@ feature "Intake", :all_dbs do
 
     context "Veteran has too high of a sensitivity level for user" do
       before do
-        Fakes::BGSService.inaccessible_appeal_vbms_ids << appeal.veteran_file_number
+        Fakes::BGSService.mark_veteran_not_accessible(appeal.veteran_file_number)
       end
 
       scenario "Search for a veteran with a sensitivity error" do
@@ -157,7 +157,7 @@ feature "Intake", :all_dbs do
 
     context "Veteran records have been merged and Veteran has multiple active phone numbers in SHARE" do
       before do
-        Fakes::BGSService.inaccessible_appeal_vbms_ids << appeal.veteran_file_number
+        Fakes::BGSService.mark_veteran_not_accessible(appeal.veteran_file_number)
         allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info)
           .and_raise(BGS::ShareError.new("NonUniqueResultException"))
       end
@@ -174,6 +174,8 @@ feature "Intake", :all_dbs do
 
         cache_key = Fakes::BGSService.new.can_access_cache_key(current_user, "12341234")
         expect(Rails.cache.exist?(cache_key)).to eq(false)
+
+        # retry after SHARE is fixed
 
         allow_any_instance_of(Fakes::BGSService).to receive(:fetch_veteran_info).and_call_original
         Fakes::BGSService.inaccessible_appeal_vbms_ids = []

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -181,7 +181,7 @@ describe LegacyHearing, :all_dbs do
     let!(:veteran) { create(:veteran, file_number: vbms_id) }
     let(:appeal) do
       create(:legacy_appeal, vacols_case:
-        create( :case_with_form_9, bfcorlid: vbms_id, case_issues: [create(:case_issue)]))
+        create(:case_with_form_9, bfcorlid: vbms_id, case_issues: [create(:case_issue)]))
     end
     let!(:additional_appeal) do
       create(:legacy_appeal, vacols_case:

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -177,17 +177,15 @@ describe LegacyHearing, :all_dbs do
   context "#to_hash_for_worksheet" do
     subject { hearing.to_hash_for_worksheet(nil).with_indifferent_access }
 
+    let(:vbms_id) { "12345678" }
+    let!(:veteran) { create(:veteran, file_number: vbms_id) }
     let(:appeal) do
-      create(:legacy_appeal, :with_veteran, vacols_case:
-        create(
-          :case_with_form_9,
-          bfcorlid: "12345678",
-          case_issues: [create(:case_issue)]
-        ))
+      create(:legacy_appeal, vacols_case:
+        create( :case_with_form_9, bfcorlid: vbms_id, case_issues: [create(:case_issue)]))
     end
     let!(:additional_appeal) do
       create(:legacy_appeal, vacols_case:
-        create(:case_with_form_9, bfkey: "other id", bfcorlid: "12345678", case_issues: [create(:case_issue)]))
+        create(:case_with_form_9, bfkey: "other id", bfcorlid: vbms_id, case_issues: [create(:case_issue)]))
     end
     let!(:hearing) do
       create(:legacy_hearing, appeal: appeal, case_hearing: create(:case_hearing, folder_nr: appeal.vacols_id))


### PR DESCRIPTION
## Description

LegacyAppeal assumes that `vbms_id` correlates with what BGS/VBMS think of as a file_number, but that isn't always true.

See https://dsva.slack.com/archives/CHX8FMP28/p1567615019135700