### PR TITLE
Refactor Veteran class finder methods

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -67,6 +67,7 @@ detectors:
     exclude:
       - QueueConfig
       - RequestIssue
+      - Veteran
   TooManyInstanceVariables:
     exclude:
       - AmaAppealDispatch

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -134,8 +134,7 @@ class IntakesController < ApplicationController
 
   def veteran_file_number
     # param could be file number or SSN. Make sure we return file number.
-    veteran = Veteran.find_by_file_number_or_ssn(params[:file_number])
-    veteran&.update_cached_attributes! if veteran&.cached_attributes_updatable?
+    veteran = Veteran.find_by_file_number_or_ssn_and_sync(params[:file_number])
     veteran ? veteran.file_number : params[:file_number]
   end
 

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -134,7 +134,8 @@ class IntakesController < ApplicationController
 
   def veteran_file_number
     # param could be file number or SSN. Make sure we return file number.
-    veteran = Veteran.find_by_file_number_or_ssn(params[:file_number], sync_name: true)
+    veteran = Veteran.find_by_file_number_or_ssn(params[:file_number])
+    veteran&.update_cached_attributes! if veteran&.cached_attributes_updatable?
     veteran ? veteran.file_number : params[:file_number]
   end
 

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -318,7 +318,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number, sync_name: true)
+    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number)
   end
 
   private

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -318,7 +318,7 @@ class EndProductEstablishment < ApplicationRecord
   end
 
   def veteran
-    @veteran ||= Veteran.find_or_create_by_file_number(veteran_file_number)
+    @veteran ||= Veteran.find_or_create_by_file_number_and_sync(veteran_file_number)
   end
 
   private

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -244,7 +244,7 @@ class Veteran < ApplicationRecord
 
   class << self
     def find_or_create_by_file_number(file_number, sync_name: false)
-      find_and_maybe_backfill_name(file_number, sync_name: sync_name) || create_by_file_number(file_number)
+      find_by_file_number_and_maybe_backfill_name(file_number, sync_name: sync_name) || create_by_file_number(file_number)
     end
 
     def find_by_ssn(ssn, sync_name: false)
@@ -257,21 +257,21 @@ class Veteran < ApplicationRecord
       file_number = BGSService.new.fetch_file_number_by_ssn(ssn)
       return unless file_number
 
-      find_and_maybe_backfill_name(file_number, sync_name: sync_name)
+      find_by_file_number_and_maybe_backfill_name(file_number, sync_name: sync_name)
     end
 
     def find_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
         find_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
-          find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
+          find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
       else
-        find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
+        find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
       end
     end
 
     def find_or_create_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
-        find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
+        find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)
       else
@@ -294,7 +294,7 @@ class Veteran < ApplicationRecord
       find_or_create_by_file_number(file_number, sync_name: sync_name)
     end
 
-    def find_and_maybe_backfill_name(file_number, sync_name: false)
+    def find_by_file_number_and_maybe_backfill_name(file_number, sync_name: false)
       veteran = find_by(file_number: file_number)
       return nil unless veteran
 
@@ -304,7 +304,7 @@ class Veteran < ApplicationRecord
       if sync_name
         Rails.logger.warn(
           %(
-          find_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
+          find_by_file_number_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
           )
         )
 

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -300,9 +300,6 @@ class Veteran < ApplicationRecord
       veteran = find_by(file_number: file_number)
       return nil unless veteran
 
-      # Check to see if veteran is accessible to make sure bgs_record is
-      # a hash and not :not_found. Also if it's not found, bgs_record returns
-      # a symbol that will blow up, so check if bgs_record is a hash first.
       Rails.logger.warn(%( find_by_file_number_and_sync veteran:#{file_number} accessible:#{veteran.accessible?} ))
 
       if veteran.cached_attributes_updatable?
@@ -350,6 +347,9 @@ class Veteran < ApplicationRecord
     # instance_variable_set(:@bgs_record_loaded, false)
   end
 
+  # Check to see if veteran is accessible to make sure bgs_record is
+  # a hash and not :not_found. Also if it's not found, bgs_record returns
+  # a symbol that will blow up, so check if bgs_record is a hash first.
   def cached_attributes_updatable?
     accessible? && bgs_record.is_a?(Hash) && stale_attributes?
   end

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -129,7 +129,6 @@ describe Veteran, :all_dbs do
         veteran.update!(participant_id: nil)
         veteran
       end
-      let(:sync_name) { true }
 
       it "caches it like name" do
         expect(described_class.find_by(file_number: file_number)[:participant_id]).to be_nil


### PR DESCRIPTION
Refactors the Veteran class methods for finding records by file_number or ssn. Gets rid of the `sync_name` flag and instead prefers explicit method names `*_and_sync`.