### PR TITLE
Rename private Veteran class method

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -10,10 +10,12 @@ detectors:
   BooleanParameter:
     exclude:
       - HearingRepository#slot_new_hearing
+      - Veteran
   ControlParameter:
     exclude:
       - HearingRepository#slot_new_hearing
       - TaskSorter#sort_requires_case_norm?
+      - Veteran
   UncommunicativeVariableName:
     exclude:
       - Address

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -244,7 +244,7 @@ class Veteran < ApplicationRecord
 
   class << self
     def find_or_create_by_file_number(file_number, sync_name: false)
-      find_and_maybe_backfill_name(file_number, sync_name: sync_name) || create_by_file_number(file_number)
+      find_by_file_number_and_maybe_backfill_name(file_number, sync_name: sync_name) || create_by_file_number(file_number)
     end
 
     def find_by_ssn(ssn, sync_name: false)
@@ -257,21 +257,21 @@ class Veteran < ApplicationRecord
       file_number = BGSService.new.fetch_file_number_by_ssn(ssn)
       return unless file_number
 
-      find_and_maybe_backfill_name(file_number, sync_name: sync_name)
+      find_by_file_number_and_maybe_backfill_name(file_number, sync_name: sync_name)
     end
 
     def find_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
         find_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
-          find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
+          find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
       else
-        find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
+        find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
       end
     end
 
     def find_or_create_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
-        find_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
+        find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)
       else
@@ -294,7 +294,7 @@ class Veteran < ApplicationRecord
       find_or_create_by_file_number(file_number, sync_name: sync_name)
     end
 
-    def find_and_maybe_backfill_name(file_number, sync_name: false)
+    def find_by_file_number_and_maybe_backfill_name(file_number, sync_name: false)
       veteran = find_by(file_number: file_number)
       return nil unless veteran
 
@@ -304,7 +304,7 @@ class Veteran < ApplicationRecord
       if sync_name
         Rails.logger.warn(
           %(
-          find_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
+          find_by_file_number_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
           )
         )
 

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -244,7 +244,7 @@ class Veteran < ApplicationRecord
 
   class << self
     def find_or_create_by_file_number(file_number, sync_name: false)
-      find_by_file_number_and_maybe_backfill_name(file_number, sync_name: sync_name) || create_by_file_number(file_number)
+      find_by_file_number_and_sync(file_number, sync_name: sync_name) || create_by_file_number(file_number)
     end
 
     def find_by_ssn(ssn, sync_name: false)
@@ -257,21 +257,21 @@ class Veteran < ApplicationRecord
       file_number = BGSService.new.fetch_file_number_by_ssn(ssn)
       return unless file_number
 
-      find_by_file_number_and_maybe_backfill_name(file_number, sync_name: sync_name)
+      find_by_file_number_and_sync(file_number, sync_name: sync_name)
     end
 
     def find_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
         find_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
-          find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
+          find_by_file_number_and_sync(file_number_or_ssn, sync_name: sync_name)
       else
-        find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name)
+        find_by_file_number_and_sync(file_number_or_ssn, sync_name: sync_name)
       end
     end
 
     def find_or_create_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
-        find_by_file_number_and_maybe_backfill_name(file_number_or_ssn, sync_name: sync_name) ||
+        find_by_file_number_and_sync(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)
       else
@@ -294,7 +294,7 @@ class Veteran < ApplicationRecord
       find_or_create_by_file_number(file_number, sync_name: sync_name)
     end
 
-    def find_by_file_number_and_maybe_backfill_name(file_number, sync_name: false)
+    def find_by_file_number_and_sync(file_number, sync_name: false)
       veteran = find_by(file_number: file_number)
       return nil unless veteran
 
@@ -302,13 +302,9 @@ class Veteran < ApplicationRecord
       # a hash and not :not_found. Also if it's not found, bgs_record returns
       # a symbol that will blow up, so check if bgs_record is a hash first.
       if sync_name
-        Rails.logger.warn(
-          %(
-          find_by_file_number_and_maybe_backfill_name veteran:#{file_number} accessible:#{veteran.accessible?}
-          )
-        )
+        Rails.logger.warn(%(find_by_file_number_and_sync veteran:#{file_number} accessible:#{veteran.accessible?}))
 
-        if veteran.accessible? && veteran.bgs_record.is_a?(Hash) && veteran.stale_attributes?
+        if veteran.cached_attributes_updatable?
           veteran.update_cached_attributes!
         end
       end
@@ -341,6 +337,10 @@ class Veteran < ApplicationRecord
     def before_create_veteran_by_file_number
       # noop - used to simulate race conditions
     end
+  end
+
+  def cached_attributes_updatable?
+    accessible? && bgs_record.is_a?(Hash) && stale_attributes?
   end
 
   def deceased?


### PR DESCRIPTION
follows #12007 

### Description
Renames private method for clarity.

Adds new public instance method to reduce cognitive complexity of the private class method.