### PR TITLE
warm hearing caches 2 weeks out, catch all errors

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -76,6 +76,8 @@ class ExternalApi::BGSService
       client.people.find_person_by_ptcpnt_id(participant_id)
     end
 
+    return {} unless bgs_info
+
     @person_info[participant_id] ||= {
       first_name: bgs_info[:first_nm],
       last_name: bgs_info[:last_nm],

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -120,5 +120,11 @@ describe Person, :postgres do
 
       it { is_expected.to eq(true) }
     end
+
+    context "BGS returns nil" do
+      let(:bgs_person) { {} }
+
+      it { is_expected.to eq(true) }
+    end
   end
 end


### PR DESCRIPTION
The job was getting re-run by shoryuken due to uncaught errors.

Fixes bug where BGS returns nil for Person info.

Also shrinks the window for hearings to 2 weeks from 3, to help reduce run time.