### PR TITLE
When filtering on RO join on legacy appeals as well

### DIFF
--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -43,10 +43,10 @@ class BulkTaskAssignment
         .limit(task_count).order(:created_at)
       if regional_office
         tasks = tasks.joins(
-          "INNER JOIN appeals ON appeals.id = appeal_id AND appeal_type = 'Appeal'"
+          "INNER JOIN appeals ON appeals.id = appeal_id AND appeal_type = '#{Appeal.name}'"
         ).where("closest_regional_office = ?", regional_office) +
                 tasks.joins("INNER JOIN legacy_appeals ON legacy_appeals.id = appeal_id \
-                  AND appeal_type = 'LegacyAppeal'").where("closest_regional_office = ?", regional_office)
+                  AND appeal_type = '#{LegacyAppeal.name}'").where("closest_regional_office = ?", regional_office)
       end
       tasks
     end

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -43,8 +43,10 @@ class BulkTaskAssignment
         .limit(task_count).order(:created_at)
       if regional_office
         tasks = tasks.joins(
-          "INNER JOIN appeals ON appeals.id = appeal_id AND tasks.appeal_type = 'Appeal'"
-        ).where("appeals.closest_regional_office = ?", regional_office)
+          "INNER JOIN appeals ON appeals.id = appeal_id AND appeal_type = 'Appeal'"
+        ).where("closest_regional_office = ?", regional_office) +
+                tasks.joins("INNER JOIN legacy_appeals ON legacy_appeals.id = appeal_id \
+                  AND appeal_type = 'LegacyAppeal'").where("closest_regional_office = ?", regional_office)
       end
       tasks
     end

--- a/spec/factories/legacy_appeal.rb
+++ b/spec/factories/legacy_appeal.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
       vacols_case { nil }
     end
 
-    vacols_id { vacols_case&.bfkey }
+    vacols_id { vacols_case&.bfkey || "123456" }
     vbms_id { vacols_case&.bfcorlid }
 
     trait :with_schedule_hearing_tasks do

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -73,8 +73,15 @@ describe BulkTaskAssignment, :postgres do
       end
     end
 
-    context "when regional office is passed" do
+    context "when there are legacy apeals and regional office is passed" do
       let(:regional_office) { "RO17" }
+      let(:legacy_appeal) { create(:legacy_appeal, closest_regional_office: regional_office) }
+      let!(:no_show_hearing_task_with_legacy_appeal) do
+        create(:no_show_hearing_task,
+               appeal: legacy_appeal,
+               assigned_to: organization,
+               created_at: 2.days.ago)
+      end
 
       it "filters by regional office" do
         no_show_hearing_task2.appeal.update(closest_regional_office: regional_office)
@@ -85,13 +92,18 @@ describe BulkTaskAssignment, :postgres do
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq true
         result = bulk_assignment.process
-        expect(Task.count).to eq count_before + 1
-        expect(result.count).to eq 1
-        expect(result.first.assigned_to).to eq assigned_to
-        expect(result.first.type).to eq "NoShowHearingTask"
-        expect(result.first.assigned_by).to eq assigned_by
-        expect(result.first.appeal).to eq no_show_hearing_task2.appeal
-        expect(result.first.parent_id).to eq no_show_hearing_task2.id
+        expect(Task.count).to eq count_before + 2
+        expect(result.count).to eq 2
+        task_with_ama_appeal = result.find { |task| task.appeal == no_show_hearing_task2.appeal }
+        expect(task_with_ama_appeal.assigned_to).to eq assigned_to
+        expect(task_with_ama_appeal.type).to eq "NoShowHearingTask"
+        expect(task_with_ama_appeal.assigned_by).to eq assigned_by
+        expect(task_with_ama_appeal.parent_id).to eq no_show_hearing_task2.id
+
+        task_with_legacy_appeal = result.find { |task| task.appeal == legacy_appeal }
+        expect(task_with_legacy_appeal.assigned_to).to eq assigned_to
+        expect(task_with_legacy_appeal.type).to eq "NoShowHearingTask"
+        expect(task_with_legacy_appeal.assigned_by).to eq assigned_by
       end
     end
 


### PR DESCRIPTION
### Description
Bulk assignment: when filtering on a RO we should join on legacy appeals as well

