### PR TITLE
Fix AOD filter in appeal type column

### DIFF
--- a/app/models/queue_filter_parameter.rb
+++ b/app/models/queue_filter_parameter.rb
@@ -23,7 +23,11 @@ class QueueFilterParameter
       (URI.unescape(value) == COPY::NULL_FILTER_LABEL) ? nil : URI.unescape(value)
     end
 
-    new(column: filter_hash["col"], values: values)
+    if filter_hash["col"].eql?(Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name)
+      values.reject! { |value| value.eql?("is_aod") }
+    end
+
+    values.present? ? new(column: filter_hash["col"], values: values) : nil
   end
 
   private

--- a/app/models/queue_filter_parameter.rb
+++ b/app/models/queue_filter_parameter.rb
@@ -25,7 +25,7 @@ class QueueFilterParameter
       values.reject! { |value| value.eql?("is_aod") }
     end
 
-    values.present? ? new(column: filter_hash["col"], values: values) : nil
+    new(column: filter_hash["col"], values: values)
   end
 
   def self.escaped_value(value)

--- a/app/models/queue_filter_parameter.rb
+++ b/app/models/queue_filter_parameter.rb
@@ -19,15 +19,17 @@ class QueueFilterParameter
     # ->
     # { "col": "docketNumberColumn", "val": ["legacy", "evidence_submission"] }
     filter_hash = Rack::Utils.parse_query(filter_string)
-    values = filter_hash["val"]&.split(",")&.map do |value|
-      (URI.unescape(value) == COPY::NULL_FILTER_LABEL) ? nil : URI.unescape(value)
-    end
+    values = filter_hash["val"]&.split(",")&.map { |value| escaped_value(value) }
 
     if filter_hash["col"].eql?(Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name)
       values.reject! { |value| value.eql?("is_aod") }
     end
 
     values.present? ? new(column: filter_hash["col"], values: values) : nil
+  end
+
+  def self.escaped_value(value)
+    (URI.unescape(value) == COPY::NULL_FILTER_LABEL) ? nil : URI.unescape(value)
   end
 
   private

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -31,9 +31,9 @@ class TaskFilter
   def where_clause
     return [] if filter_params.empty?
 
-    filters = filter_params.map { |filter_string| QueueFilterParameter.from_string(filter_string) }.compact
+    filters = filter_params.map { |filter_string| QueueFilterParameter.from_string(filter_string) }
 
-    where_string = filters.map { |filter| "#{table_column_from_name(filter.column)} IN (?)" }.join(" AND ")
+    where_string = TaskFilter.where_string_from_filters(filters)
     where_arguments = filters.map(&:values)
 
     if filter_params.any? { |filter_string| filter_string[/typeColumn&val=.*is_aod/] }
@@ -43,9 +43,13 @@ class TaskFilter
     [where_string] + where_arguments
   end
 
-  private
+  def self.where_string_from_filters(filters)
+    filters.map do |filter|
+      filter.values.present? ? "#{table_column_from_name(filter.column)} IN (?)" : nil
+    end.compact.join(" AND ")
+  end
 
-  def table_column_from_name(column_name)
+  def self.table_column_from_name(column_name)
     case column_name
     when Constants.QUEUE_CONFIG.TASK_TYPE_COLUMN
       "tasks.type"
@@ -62,6 +66,8 @@ class TaskFilter
       fail(Caseflow::Error::InvalidTaskTableColumnFilter, column: column_name)
     end
   end
+
+  private
 
   def filter_params_is_array
     errors.add(:filter_params, "must be an array") unless filter_params&.is_a?(Array)

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -31,13 +31,13 @@ class TaskFilter
   def where_clause
     return [] if filter_params.empty?
 
-    filters = filter_params.map { |filter_string| QueueFilterParameter.from_string(filter_string) }
+    filters = filter_params.map { |filter_string| QueueFilterParameter.from_string(filter_string) }.compact
 
     where_string = filters.map { |filter| "#{table_column_from_name(filter.column)} IN (?)" }.join(" AND ")
     where_arguments = filters.map(&:values)
 
     if filter_params.any? { |filter_string| filter_string[/typeColumn&val=.*is_aod/] }
-      where_string << " AND cached_appeal_attributes.is_aod = true"
+      where_string << "#{where_string.present? ? ' AND ' : ''}cached_appeal_attributes.is_aod = true"
     end
 
     [where_string] + where_arguments

--- a/spec/models/queue_filter_parameter_spec.rb
+++ b/spec/models/queue_filter_parameter_spec.rb
@@ -49,5 +49,22 @@ describe QueueFilterParameter do
         expect(subject.values).to match_array([non_null_value, nil])
       end
     end
+
+    context "when typeColumn has 'is_aod' filter" do
+      let(:filter_string) { "col=#{Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name}&val=is_aod" }
+
+      it "returns nil" do
+        expect(subject).to eq nil
+      end
+
+      context "when there are other values present" do
+        let(:good_value) { "good_value" }
+        let(:filter_string) { "col=#{Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name}&val=is_aod,#{good_value}" }
+
+        it "rejects the is_aod value" do
+          expect(subject.values).to match_array([good_value])
+        end
+      end
+    end
   end
 end

--- a/spec/models/queue_filter_parameter_spec.rb
+++ b/spec/models/queue_filter_parameter_spec.rb
@@ -51,19 +51,11 @@ describe QueueFilterParameter do
     end
 
     context "when typeColumn has 'is_aod' filter" do
-      let(:filter_string) { "col=#{Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name}&val=is_aod" }
+      let(:good_value) { "good_value" }
+      let(:filter_string) { "col=#{Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name}&val=is_aod,#{good_value}" }
 
-      it "returns nil" do
-        expect(subject).to eq nil
-      end
-
-      context "when there are other values present" do
-        let(:good_value) { "good_value" }
-        let(:filter_string) { "col=#{Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name}&val=is_aod,#{good_value}" }
-
-        it "rejects the is_aod value" do
-          expect(subject.values).to match_array([good_value])
-        end
+      it "rejects the is_aod value" do
+        expect(subject.values).to match_array([good_value])
       end
     end
   end

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -302,17 +302,21 @@ describe TaskFilter, :postgres do
         end
 
         it "returns tasks with Original or Supplemental case types" do
-          expect(subject.map(&:id)).to match_array(type_1_tasks.map(&:id) + type_2_tasks.map(&:id))
+          expect(subject.map(&:id)).to contain_exactly(type_1_tasks.map(&:id) + type_2_tasks.map(&:id))
         end
       end
 
-      context "when filter includes Original and Supplemental and AOD" do
-        let(:filter_params) do
-          ["col=#{Constants.QUEUE_CONFIG.APPEAL_TYPE_COLUMN}&val=#{case_types['1']},#{case_types['2']},is_aod"]
-        end
+      context "when filter includes AOD" do
+        let(:filter_params) { ["col=#{Constants.QUEUE_CONFIG.APPEAL_TYPE_COLUMN}&val=is_aod"] }
 
-        it "returns tasks with Original or Supplemental case types that are also AOD" do
-          expect(subject.map(&:id)).to match_array([type_1_tasks.first.id, type_2_tasks.first.id])
+        fit "returns tasks with all case types that are also AOD" do
+          expect(subject.map(&:id)).to contain_exactly([
+                                                         type_1_tasks.first.id,
+                                                         type_2_tasks.first.id,
+                                                         type_3_tasks.first.id,
+                                                         type_5_tasks.first.id,
+                                                         type_5_tasks.first.id
+                                                       ])
         end
       end
     end

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -306,17 +306,27 @@ describe TaskFilter, :postgres do
         end
       end
 
-      context "when filter includes AOD" do
+      context "when filter includes Original and Supplemental and AOD" do
+        let(:filter_params) do
+          ["col=#{Constants.QUEUE_CONFIG.APPEAL_TYPE_COLUMN}&val=#{case_types['1']},#{case_types['2']},is_aod"]
+        end
+
+        it "returns tasks with Original or Supplemental case types that are also AOD" do
+          expect(subject.map(&:id)).to match_array([type_1_tasks.first.id, type_2_tasks.first.id])
+        end
+      end
+
+      context "when filter includes only AOD" do
         let(:filter_params) { ["col=#{Constants.QUEUE_CONFIG.APPEAL_TYPE_COLUMN}&val=is_aod"] }
 
-        fit "returns tasks with all case types that are also AOD" do
-          expect(subject.map(&:id)).to contain_exactly([
-                                                         type_1_tasks.first.id,
-                                                         type_2_tasks.first.id,
-                                                         type_3_tasks.first.id,
-                                                         type_5_tasks.first.id,
-                                                         type_5_tasks.first.id
-                                                       ])
+        it "returns tasks with all case types that are also AOD" do
+          expect(subject.map(&:id)).to contain_exactly(
+            type_1_tasks.first.id,
+            type_2_tasks.first.id,
+            type_3_tasks.first.id,
+            type_4_tasks.first.id,
+            type_5_tasks.first.id
+          )
         end
       end
     end

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -302,7 +302,7 @@ describe TaskFilter, :postgres do
         end
 
         it "returns tasks with Original or Supplemental case types" do
-          expect(subject.map(&:id)).to contain_exactly(type_1_tasks.map(&:id) + type_2_tasks.map(&:id))
+          expect(subject.map(&:id)).to match_array(type_1_tasks.map(&:id) + type_2_tasks.map(&:id))
         end
       end
 


### PR DESCRIPTION
### Description
We were previously constructing our sql as `cached_appeal_attributes.case_type IN ('is_aod') AND cached_appeal_attributes.is_aod = true` when 'is_aod' was included in the case type filter. This was returning no tasks and was obfuscated by our tests as `cached_appeal_attributes.case_type IN ('is_aod', 'any_other_type')` returns correctly. This PR removes 'is_aod' from the case_type filter.