### PR TITLE
Send file number mismatches to DataDog instead of Sentry

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -662,7 +662,14 @@ class LegacyAppeal < ApplicationRecord
 
     caseflow_file_number = veteran.file_number
     if vacols_file_number != caseflow_file_number
-      Raven.capture_message("legacy appeal #{external_id} has file_number mismatch with VACOLS and Caseflow")
+      DataDogService.increment_counter(
+        metric_group: "database_disagreement",
+        metric_name: "file_number",
+        app_name: RequestStore[:application],
+        attrs: {
+          appeal_id: external_id
+        }
+      )
     end
     caseflow_file_number # prefer for now
   end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -51,7 +51,7 @@ describe LegacyAppeal, :all_dbs do
       let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case, bfcorlid: "#{ssn}S")) }
 
       before do
-        allow(Raven).to receive(:capture_message) { @raven_called = true }
+        allow(DataDogService).to receive(:increment_counter) { @datadog_called = true }
       end
 
       it "prefers the Caseflow Veteran.file_number" do
@@ -59,7 +59,7 @@ describe LegacyAppeal, :all_dbs do
         expect(legacy_appeal.vbms_id).to eq("#{ssn}S")
         expect(legacy_appeal.sanitized_vbms_id).to eq(ssn)
         expect(legacy_appeal.veteran_file_number).to eq(legacy_appeal.veteran.file_number)
-        expect(@raven_called).to eq(true)
+        expect(@datadog_called).to eq(true)
       end
     end
   end


### PR DESCRIPTION
Related to [this slack conversation](https://dsva.slack.com/archives/CLRTL92TW/p1568132995090000).