### PR TITLE
Exclude TimedHoldTasks from bulk assignment

### DIFF
--- a/app/controllers/organizations/task_summary_controller.rb
+++ b/app/controllers/organizations/task_summary_controller.rb
@@ -13,23 +13,23 @@ class Organizations::TaskSummaryController < OrganizationsController
       left join (
         select closest_regional_office
         , id
-        , '#{LegacyAppeal.name}' as type
+        , 'LegacyAppeal' as type
         from legacy_appeals
         union
         select closest_regional_office
         , id
-        , '#{Appeal.name}' as type
+        , 'Appeal' as type
         from appeals
       ) all_appeals
         on tasks.appeal_id = all_appeals.id
         and tasks.appeal_type = all_appeals.type
       where assigned_to_id = #{organization.id}
-        and assigned_to_type = '#{Organization.name}'
-        and status in ('#{Constants.TASK_STATUSES.assigned}', '#{Constants.TASK_STATUSES.in_progress}')
+        and assigned_to_type = 'Organization'
+        and status in ('assigned', 'in_progress')
       -- Exclude TimedHoldTasks from being available for bulk assignment because they should not have child tasks
       -- and should only be created as children of NoShowHearingTasks, and those tasks will become available for
       -- bulk assignment after the timed hold has been completed.
-        and tasks.type <> '#{TimedHoldTask.name}'
+        and tasks.type <> 'TimedHoldTask'
       group by 2, 3
       order by 2, 1 desc;
     })


### PR DESCRIPTION
Resolves bug exposed by [this sentry alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/6516/) (and [related slack conversation](https://dsva.slack.com/archives/C4JECDLSE/p1568136167020400)).

The bug here is that the application attempts to create child tasks for `TimedHoldTask`s assigned to the `HearingsManagement` organization. That attempt will fail because `TimedHoldTask`s [should not have any child tasks](https://caseflow-looker.va.gov/sql/dns58vwdwyszry) (ticketed in #12037) and, more specifically, the request from the front-end does not pass a field required by the `TimedHoldTask` (`days_on_hold`) so validation thankfully fails to create the invalid task.

This PR prevents this issue by excluding `TimedHoldTask`s from being returned to the front-end as an option in the dropdown menu.