### PR TITLE
Unify sorting of task type on the front and back end

### DIFF
--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -41,6 +41,10 @@ class TaskSorter
   end
 
   def order_clause
+    if column.eql?(Constants.QUEUE_CONFIG.Task_TYPE_COLUMN)
+      return task_type_order_clause
+    end
+
     clauses = column.sorting_columns.map do |col|
       tbl_clause = if sort_requires_case_norm?(col)
                      "UPPER(#{column.sorting_table}.#{col})"
@@ -50,6 +54,10 @@ class TaskSorter
       "#{tbl_clause} #{sort_order}"
     end
     clauses.join(", ")
+  end
+
+  def task_type_order_clause
+    "TODO"
   end
 
   def column_is_valid

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -41,7 +41,7 @@ class TaskSorter
   end
 
   def order_clause
-    if column.eql?(Constants.QUEUE_CONFIG.Task_TYPE_COLUMN)
+    if column.name.eql?(Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name)
       return task_type_order_clause
     end
 
@@ -57,7 +57,8 @@ class TaskSorter
   end
 
   def task_type_order_clause
-    "TODO"
+    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name)
+    "position(type in '#{task_types_sorted_by_label.join(',')}') #{sort_order}"
   end
 
   def column_is_valid

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -120,7 +120,7 @@ describe TaskSorter, :all_dbs do
         end
       end
 
-      fcontext "when sorting by task type" do
+      context "when sorting by task type" do
         let(:column_name) { Constants.QUEUE_CONFIG.TASK_TYPE_COLUMN }
         let(:tasks) { Task.where(id: create_list(:generic_task, task_types.length).pluck(:id)) }
 


### PR DESCRIPTION
Resolves #11319

### Description
Sorts tasks on the back end by their label

### Acceptance Criteria
- [ ] Back end sorts taskColumn by the task's label 

### Testing Plan
1. Ensure sorting the task column results in alphabetical order task labels when sorting with the pagination api