### PR TITLE
Prevent creation of duplicate TrackVeteranTasks on intake

### DIFF
--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -16,8 +16,10 @@ class InitialTasksFactory
   private
 
   def create_vso_tracking_tasks
-    @appeal.representatives.map do |vso_organization|
-      TrackVeteranTask.create!(appeal: @appeal, parent: @root_task, assigned_to: vso_organization)
+    @appeal.representatives.map do |rep|
+      if TrackVeteranTask.where(appeal: @appeal, assigned_to: rep).empty?
+        TrackVeteranTask.create!(appeal: @appeal, parent: @root_task, assigned_to: rep)
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #12054.

When we intake an appeal [we create `TrackVeteranTask`s](https://github.com/department-of-veterans-affairs/caseflow/blob/6233df2662fb44e736bb7ef2bf88c56be3151b84/app/workflows/initial_tasks_factory.rb#L19) for each of the appellant's representatives. However, it make take minutes or longer to get a response from BGS about who those representatives are. During that period it is possible that the `UpdateAppellantRepresentationJob` runs, [selects the appeal](https://github.com/department-of-veterans-affairs/caseflow/blob/6233df2662fb44e736bb7ef2bf88c56be3151b84/app/jobs/update_appellant_representation_job.rb#L76) that we are in the process of taking in because we have already created the `RootTask`, and the job creates a `TrackVeteranTask` for the VSO.

This change prevents us from creating duplicate `TrackVeteranTask`s in these cases.