### PR TITLE
Do not attempt to move annotation if we don't have coords

### DIFF
--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -86,7 +86,7 @@ export class PdfViewer extends React.Component {
       ArrowDown: Constants.MOVE_ANNOTATION_ICON_DIRECTIONS.DOWN
     }[event.key];
 
-    if (this.props.isPlacingAnnotation && direction >= 0) {
+    if (this.props.isPlacingAnnotation && this.props.placingAnnotationIconPageCoords && direction >= 0) {
       const { pageIndex, ...origCoords } = this.props.placingAnnotationIconPageCoords;
       const constrainedCoords = getNextAnnotationIconPageCoords(
         direction,
@@ -155,6 +155,7 @@ export class PdfViewer extends React.Component {
     window.removeEventListener('keydown', this.keyListener);
   }
 
+  /* eslint-disable camelcase */
   UNSAFE_componentWillReceiveProps = (nextProps) => {
     const nextDocId = Number(nextProps.match.params.docId);
 
@@ -162,6 +163,7 @@ export class PdfViewer extends React.Component {
       this.props.handleSelectCurrentPdf(nextDocId);
     }
   }
+  /* eslint-enable "camelcase" */
 
   selectedDocIndex = () => (
     _.findIndex(this.props.documents, { id: this.selectedDocId() })
@@ -311,11 +313,30 @@ export default connect(
 )(PdfViewer);
 
 PdfViewer.propTypes = {
+  annotations: PropTypes.object,
+  appeal: PropTypes.object,
+  closeAnnotationDeleteModal: PropTypes.func,
+  closeAnnotationShareModal: PropTypes.func,
+  closeDocumentUpdatedModal: PropTypes.func,
+  deleteAnnotation: PropTypes.func,
   doc: PropTypes.object,
+  documentPathBase: PropTypes.string,
+  featureToggles: PropTypes.object,
+  fetchAppealDetails: PropTypes.func,
+  handleSelectCurrentPdf: PropTypes.func,
+  history: PropTypes.object,
+  isPlacingAnnotation: PropTypes.bool,
+  match: PropTypes.object,
+  onJumpToComment: PropTypes.func,
+  onScrollToComment: PropTypes.func,
+  pageDimensions: PropTypes.object,
   pdfWorker: PropTypes.string,
+  placingAnnotationIconPageCoords: PropTypes.object,
   scrollToComment: PropTypes.shape({
     id: PropTypes.number
   }),
+  showPlaceAnnotationIcon: PropTypes.func,
+  stopPlacingAnnotation: PropTypes.func,
   deleteAnnotationModalIsOpenFor: PropTypes.number,
   shareAnnotationModalIsOpenFor: PropTypes.number,
   documents: PropTypes.array.isRequired,


### PR DESCRIPTION
Resolves `errorCannot read property 'pageIndex' of null` errors we [see regularly in Sentry](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/2036/) by not attempting to move the annotation if we don't have the coordinates for the annotation. I don't know for sure why we would end up in this situation (perhaps we can reset the value of `placingAnnotationIconPageCoords` to null without change the value of `isPlacingAnnotation` to false somehow?), but this bug seems to be recoverable by user intervention alone (or I'd imagine) we would hear complaints, so this ticket only aims to stop sending these messages to Sentry.