### PR TITLE
PoC for SQL snippet library, tests

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,6 +2,20 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  # this simple transform should match the basic ActiveRecord::Result format
+  # for db results.
+  def as_hash
+    as_json.tap do |rec|
+      rec.transform_values! do |value|
+        if value.is_a?(Time) || value.is_a?(DateTime)
+          value.utc.strftime("%Y-%m-%d %H:%M:%S.%6N")
+        else
+          value.as_json
+        end
+      end
+    end
+  end
 end
 
 # :nocov:

--- a/app/sql/basic_appeal.sql
+++ b/app/sql/basic_appeal.sql
@@ -1,0 +1,1 @@
+select * from appeals

--- a/spec/sql/basic_spec.rb
+++ b/spec/sql/basic_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "support/database_cleaner"
+
+describe "Basic SQL Snippet Library Test", :postgres do
+  include SQLHelpers
+
+  context "one Appeal exists" do
+    let!(:appeal) { create(:appeal) }
+
+    it "runs SQL" do
+      expect_sql('basic_appeal').to eq([appeal.as_hash])
+    end
+  end
+end

--- a/spec/support/sql_helpers.rb
+++ b/spec/support/sql_helpers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SQLHelpers
+  def expect_sql(file_name)
+    base_dir = Rails.root.join("app", "sql")
+    sql_file = File.join(base_dir, file_name + ".sql")
+    if !File.exist?(sql_file)
+      sql_file = File.join(base_dir, file_name)
+    end
+    sql = File.read(sql_file)
+
+    result = ApplicationRecord.connection.exec_query(sql)
+
+    expect(result.to_ary)
+  end
+end


### PR DESCRIPTION
connects #12044 

### Description
Basic proof of concept for SQL snippet library.

Adds a spec helper `expect_sql` that returns the results of a SQL query as an array of hashes, suitable for comparing to ActiveRecord objects.

Also adds a `as_hash` method to all our ActiveRecord models to make such comparisons possible.