### PR TITLE
subsecond rounding bug

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,7 +9,7 @@ class ApplicationRecord < ActiveRecord::Base
     as_json.tap do |rec|
       rec.transform_values! do |value|
         if value.is_a?(Time) || value.is_a?(DateTime)
-          value.utc.strftime("%Y-%m-%d %H:%M:%S.%6N")
+          value.utc.strftime("%Y-%m-%d %H:%M:%S.") + value.utc.strftime(".%6N").to_f.to_s.tr("0.", "")
         else
           value.as_json
         end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,7 +9,9 @@ class ApplicationRecord < ActiveRecord::Base
     as_json.tap do |rec|
       rec.transform_values! do |value|
         if value.is_a?(Time) || value.is_a?(DateTime)
-          value.utc.strftime("%Y-%m-%d %H:%M:%S.") + value.utc.strftime(".%6N").to_f.to_s.tr("0.", "")
+          ymdhms = dt_utc.strftime("%Y-%m-%d %H:%M:%S")
+          subseconds = value.utc.strftime(".%6N").to_f.to_s.tr("0.", "")
+          "#{ymdhms}.#{subseconds}"
         else
           value.as_json
         end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,7 +9,7 @@ class ApplicationRecord < ActiveRecord::Base
     as_json.tap do |rec|
       rec.transform_values! do |value|
         if value.is_a?(Time) || value.is_a?(DateTime)
-          ymdhms = dt_utc.strftime("%Y-%m-%d %H:%M:%S")
+          ymdhms = value.utc.strftime("%Y-%m-%d %H:%M:%S")
           subseconds = value.utc.strftime(".%6N").to_f.to_s.tr("0.", "")
           "#{ymdhms}.#{subseconds}"
         else

--- a/spec/sql/basic_spec.rb
+++ b/spec/sql/basic_spec.rb
@@ -14,7 +14,7 @@ describe "Basic SQL Snippet Library Test", :postgres do
   end
 
   context "one Appeal exists with 2f precision milliseconds" do
-    let!(:appeal) { create(:appeal, established_at: Time.utc(2010,3,30, 5,43,"25.12".to_r)) }
+    let!(:appeal) { create(:appeal, established_at: Time.utc(2010, 3, 30, 5, 43, "25.12".to_r)) }
 
     it "rounds correctly" do
       expect_sql("basic_appeal").to eq([appeal.as_hash])

--- a/spec/sql/basic_spec.rb
+++ b/spec/sql/basic_spec.rb
@@ -12,4 +12,12 @@ describe "Basic SQL Snippet Library Test", :postgres do
       expect_sql("basic_appeal").to eq([appeal.as_hash])
     end
   end
+
+  context "one Appeal exists with 2f precision milliseconds" do
+    let!(:appeal) { create(:appeal, established_at: Time.utc(2010,3,30, 5,43,"25.12".to_r)) }
+
+    it "rounds correctly" do
+      expect_sql("basic_appeal").to eq([appeal.as_hash])
+    end
+  end
 end


### PR DESCRIPTION
Postgresql will remove trailing 0 (zero) when a subsecond time
like .1230 is returned. It will return .123 instead, which causes
strftime() formatting to break on comparison, since strftime() only allows for fixed number
of precision w/o dropping the trailing zeroes.

fixes flakey test where randomly the autogenerated time would return something like `123.12` and the strftime() would return `123.120` causing string comparison to fail.