### PR TITLE
Optimize most recently held hearing controller action

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -4,7 +4,14 @@ class AppealsController < ApplicationController
   before_action :react_routed
   before_action :set_application, only: [:document_count, :power_of_attorney]
   # Only whitelist endpoints VSOs should have access to.
-  skip_before_action :deny_vso_access, only: [:index, :power_of_attorney, :show_case_list, :show, :veteran, :hearings]
+  skip_before_action :deny_vso_access, only: [
+    :index,
+    :power_of_attorney,
+    :show_case_list,
+    :show,
+    :veteran,
+    :most_recent_hearing
+  ]
 
   def index
     respond_to do |format|
@@ -56,7 +63,7 @@ class AppealsController < ApplicationController
     }
   end
 
-  def hearings
+  def most_recent_hearing
     log_hearings_request
 
     most_recently_held_hearing = appeal.hearings

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -66,11 +66,13 @@ class AppealsController < ApplicationController
   def most_recent_hearing
     log_hearings_request
 
-    most_recently_held_hearing = held_hearings_for_appeal.max_by(&:scheduled_for)
+    most_recently_held_hearing = HearingsForAppeal.new(url_appeal_uuid)
+      .held_hearings
+      .max_by(&:scheduled_for)
 
     render json:
       if most_recently_held_hearing
-        AppealHearingSerializer::new(most_recently_held_hearing).serializable_hash[:data][:attributes]
+        AppealHearingSerializer.new(most_recently_held_hearing).serializable_hash[:data][:attributes]
       else
         {}
       end
@@ -107,31 +109,6 @@ class AppealsController < ApplicationController
 
   def appeal
     @appeal ||= Appeal.find_appeal_by_id_or_find_or_create_legacy_appeal_by_vacols_id(params[:appeal_id])
-  end
-
-  # This method is optimized to avoid calling VACOLS for legacy appeals.
-  def held_hearings_for_appeal
-    id = url_appeal_uuid
-
-    if Appeal::UUID_REGEX.match?(id)
-      Appeal.find_by_uuid!(id).hearings.where(disposition: Constants.HEARING_DISPOSITION_TYPES.held)
-    else
-      # Assumes that an appeal exists in VACOLS if there are hearings
-      # for it.
-      legacy_hearings = HearingRepository.hearings_for_appeal(id)
-
-      # If there are no hearings for the VACOLS id, maybe the case doesn't
-      # actually exist? This is SLOW! Only load VACOLS data if the Legacy Appeal
-      # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
-      # ALWAYS load data from VACOLS.
-      if legacy_hearings.empty?
-        LegacyAppeal.find_or_create_by_vacols_id(id) unless LegacyAppeal.exists?(id)
-      end
-
-      legacy_hearings.select do |hearing|
-        hearing.disposition.to_s == Constants.HEARING_DISPOSITION_TYPES.held
-      end
-    end
   end
 
   def url_appeal_uuid

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -129,8 +129,7 @@ class AppealsController < ApplicationController
 
       # If there are no hearings for the VACOLS id, maybe the case doesn't
       # actually exist? This is SLOW! Only load VACOLS data if the Legacy Appeal
-      # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
-      # ALWAYS load data from VACOLS.
+      # doesn't exist in Caseflow yet.
       if legacy_hearings.empty?
         LegacyAppeal.find_or_create_by_vacols_id(id)
       end

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -122,7 +122,8 @@ class AppealsController < ApplicationController
 
       # If there are no hearings for the VACOLS id, maybe the case doesn't
       # actually exist? This is SLOW! Only load VACOLS data if the Legacy Appeal
-      # doesn't exist in Caseflow yet.
+      # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
+      # ALWAYS load data from VACOLS.
       if legacy_hearings.empty?
         LegacyAppeal.find_or_create_by_vacols_id(id)
       end

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -70,14 +70,7 @@ class AppealsController < ApplicationController
 
     render json:
       if most_recently_held_hearing
-        {
-          held_by: most_recently_held_hearing.judge.present? ? most_recently_held_hearing.judge.full_name : "",
-          viewed_by_judge: !most_recently_held_hearing.hearing_views.empty?,
-          date: most_recently_held_hearing.scheduled_for,
-          type: most_recently_held_hearing.readable_request_type,
-          external_id: most_recently_held_hearing.external_id,
-          disposition: most_recently_held_hearing.disposition
-        }
+        AppealHearingSerializer::new(most_recently_held_hearing).serializable_hash[:data][:attributes]
       else
         {}
       end

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -75,10 +75,12 @@ class AppealsController < ApplicationController
                  legacy_hearings = HearingRepository.hearings_for_appeal(id)
 
                  # If there are no hearings for the VACOLS id, maybe the case doesn't
-                 # actually exist.
-                 fail ActiveRecord::RecordNotFound if legacy_hearings.empty? && (
-                   !LegacyAppeal.exists?(vacols_id: id) ||  !VACOLS::Case.exists?(id)
-                 )
+                 # actually exist? This is SLOW! Only load VACOLS data if the Legacy Appeal
+                 # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
+                 # ALWAYS load data from VACOLS.
+                 if legacy_hearings.empty?
+                   LegacyAppeal.find_or_create_by_vacols_id(id) unless LegacyAppeal.exists?(id)
+                 end
 
                  legacy_hearings
                end

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -125,7 +125,7 @@ class AppealsController < ApplicationController
       # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
       # ALWAYS load data from VACOLS.
       if legacy_hearings.empty?
-        LegacyAppeal.find_or_create_by_vacols_id(id)
+        LegacyAppeal.find_or_create_by_vacols_id(id) unless LegacyAppeal.exists?(id)
       end
 
       legacy_hearings.select do |hearing|

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -134,8 +134,8 @@ class AppealsController < ApplicationController
         LegacyAppeal.find_or_create_by_vacols_id(id)
       end
 
-      legacy_hearings.select do
-        |hearing| hearing.disposition.to_s == Constants.HEARING_DISPOSITION_TYPES.held
+      legacy_hearings.select do |hearing|
+        hearing.disposition.to_s == Constants.HEARING_DISPOSITION_TYPES.held
       end
     end
   end

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -132,7 +132,7 @@ class AppealsController < ApplicationController
       # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
       # ALWAYS load data from VACOLS.
       if legacy_hearings.empty?
-        LegacyAppeal.find_or_create_by_vacols_id(id) unless LegacyAppeal.exists?(id)
+        LegacyAppeal.find_or_create_by_vacols_id(id)
       end
 
       legacy_hearings.select do

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -833,9 +833,12 @@ class LegacyAppeal < ApplicationRecord
     def find_or_create_by_vacols_id(vacols_id)
       appeal = find_or_initialize_by(vacols_id: vacols_id)
 
-      fail ActiveRecord::RecordNotFound unless appeal.check_and_load_vacols_data!
+      if appeal.new_record?
+        fail ActiveRecord::RecordNotFound unless appeal.check_and_load_vacols_data!
 
-      appeal.save
+        appeal.save
+      end
+
       appeal
     end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -833,12 +833,9 @@ class LegacyAppeal < ApplicationRecord
     def find_or_create_by_vacols_id(vacols_id)
       appeal = find_or_initialize_by(vacols_id: vacols_id)
 
-      if appeal.new_record?
-        fail ActiveRecord::RecordNotFound unless appeal.check_and_load_vacols_data!
+      fail ActiveRecord::RecordNotFound unless appeal.check_and_load_vacols_data!
 
-        appeal.save
-      end
-
+      appeal.save
       appeal
     end
 

--- a/app/queries/hearings_for_appeal.rb
+++ b/app/queries/hearings_for_appeal.rb
@@ -1,4 +1,4 @@
-  # frozen_string_literal: true
+# frozen_string_literal: true
 
 class HearingsForAppeal
   def initialize(appeal_id)
@@ -29,4 +29,4 @@ class HearingsForAppeal
   private
 
   attr_reader :appeal_id
-  end
+end

--- a/app/queries/hearings_for_appeal.rb
+++ b/app/queries/hearings_for_appeal.rb
@@ -24,8 +24,9 @@ class HearingsForAppeal
         hearing.disposition.to_s == Constants.HEARING_DISPOSITION_TYPES.held
       end
     end
+  end
 
-    private
+  private
 
-    attr_reader :appeal_id
+  attr_reader :appeal_id
   end

--- a/app/queries/hearings_for_appeal.rb
+++ b/app/queries/hearings_for_appeal.rb
@@ -1,0 +1,31 @@
+  # frozen_string_literal: true
+
+class HearingsForAppeal
+  def initialize(appeal_id)
+    @appeal_id = appeal_id
+  end
+
+  # This method is optimized to avoid calling VACOLS for legacy appeals.
+  def held_hearings
+    if Appeal::UUID_REGEX.match?(appeal_id)
+      Appeal.find_by_uuid!(id).hearings.where(disposition: Constants.HEARING_DISPOSITION_TYPES.held)
+    else
+      # Assumes that an appeal exists in VACOLS if there are hearings
+      # for it.
+      legacy_hearings = HearingRepository.hearings_for_appeal(appeal_id)
+
+      # If there are no hearings for the VACOLS id, maybe the case doesn't
+      # actually exist? This is SLOW! Only load VACOLS data if the Legacy Appeal
+      # doesn't exist in Caseflow. `LegacyAppeal.find_or_create_by_vacols_id` will
+      # ALWAYS load data from VACOLS.
+      LegacyAppeal.find_or_create_by_vacols_id(appeal_id) if legacy_hearings.empty? && !LegacyAppeal.exists?(appeal_id)
+
+      legacy_hearings.select do |hearing|
+        hearing.disposition.to_s == Constants.HEARING_DISPOSITION_TYPES.held
+      end
+    end
+
+    private
+
+    attr_reader :appeal_id
+  end

--- a/app/queries/hearings_for_appeal.rb
+++ b/app/queries/hearings_for_appeal.rb
@@ -8,7 +8,7 @@ class HearingsForAppeal
   # This method is optimized to avoid calling VACOLS for legacy appeals.
   def held_hearings
     if Appeal::UUID_REGEX.match?(appeal_id)
-      Appeal.find_by_uuid!(id).hearings.where(disposition: Constants.HEARING_DISPOSITION_TYPES.held)
+      Appeal.find_by_uuid!(appeal_id).hearings.where(disposition: Constants.HEARING_DISPOSITION_TYPES.held)
     else
       # Assumes that an appeal exists in VACOLS if there are hearings
       # for it.

--- a/app/serializers/hearings/appeal_hearing_serializer.rb
+++ b/app/serializers/hearings/appeal_hearing_serializer.rb
@@ -2,7 +2,7 @@
 
 class AppealHearingSerializer
   include FastJsonapi::ObjectSerializer
-    
+
   attribute :date, &:scheduled_for
   attribute :disposition
   attribute :external_id

--- a/app/serializers/hearings/appeal_hearing_serializer.rb
+++ b/app/serializers/hearings/appeal_hearing_serializer.rb
@@ -9,7 +9,7 @@ class AppealHearingSerializer
   attribute :held_by do |hearing|
     hearing.judge.present? ? hearing.judge.full_name : ""
   end
-  attribute :readable_request_type
+  attribute :type, &:readable_request_type
   # this assumes only the assigned judge will view the hearing worksheet. otherwise,
   # we should check `hearing.hearing_views.map(&:user_id).include? judge.css_id`
   attribute :viewed_by_judge do |hearing|

--- a/app/serializers/hearings/appeal_hearing_serializer.rb
+++ b/app/serializers/hearings/appeal_hearing_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AppealHearingSerializer
+  include FastJsonapi::ObjectSerializer
+    
+  attribute :date, &:scheduled_for
+  attribute :disposition
+  attribute :external_id
+  attribute :held_by do |hearing|
+    hearing.judge.present? ? hearing.judge.full_name : ""
+  end
+  attribute :readable_request_type
+  # this assumes only the assigned judge will view the hearing worksheet. otherwise,
+  # we should check `hearing.hearing_views.map(&:user_id).include? judge.css_id`
+  attribute :viewed_by_judge do |hearing|
+    !hearing.hearing_views.empty?
+  end
+end

--- a/app/serializers/helpers/appeal_hearing_helper.rb
+++ b/app/serializers/helpers/appeal_hearing_helper.rb
@@ -21,16 +21,7 @@ module Helpers::AppealHearingHelper
 
   def hearings(appeal)
     appeal.hearings.map do |hearing|
-      {
-        held_by: hearing.judge.present? ? hearing.judge.full_name : "",
-        # this assumes only the assigned judge will view the hearing worksheet. otherwise,
-        # we should check `hearing.hearing_views.map(&:user_id).include? judge.css_id`
-        viewed_by_judge: !hearing.hearing_views.empty?,
-        date: hearing.scheduled_for,
-        type: hearing.readable_request_type,
-        external_id: hearing.external_id,
-        disposition: hearing.disposition
-      }
+      AppealHearingSerializer::new(hearing).serializable_hash[:data][:attributes]
     end
   end
 end

--- a/app/serializers/helpers/appeal_hearing_helper.rb
+++ b/app/serializers/helpers/appeal_hearing_helper.rb
@@ -21,7 +21,7 @@ module Helpers::AppealHearingHelper
 
   def hearings(appeal)
     appeal.hearings.map do |hearing|
-      AppealHearingSerializer::new(hearing).serializable_hash[:data][:attributes]
+      AppealHearingSerializer.new(hearing).serializable_hash[:data][:attributes]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,7 +115,7 @@ Rails.application.routes.draw do
       get :document_count
       get :veteran
       get :power_of_attorney
-      get :hearings
+      get 'hearings', to: "appeals#most_recent_hearing"
       resources :issues, only: [:create, :update, :destroy], param: :vacols_sequence_id
       resources :special_issues, only: [:create, :index]
       resources :advance_on_docket_motions, only: [:create]


### PR DESCRIPTION
Related to #12002 

### Description

The `/appeal/:id/hearings` is overall one of the most time consuming calls in Caseflow. It's a fairly simple action, which probably means it's called a lot:

<img width="1118" alt="Screen Shot 2019-09-13 at 4 18 13 PM" src="https://user-images.githubusercontent.com/1298274/64892400-509a8400-d642-11e9-959d-013a778718a6.png">

The actual code is just finding a list of associated hearings for a specific appeal, and getting the most recent one that was held. For legacy appeals, the route triggers a bunch of VACOLS calls:

<img width="717" alt="Screen Shot 2019-09-13 at 4 21 57 PM" src="https://user-images.githubusercontent.com/1298274/64892532-a2dba500-d642-11e9-916a-eeedacda1ab0.png">

4/5 of those VACOLS calls are triggered from getting the appeal. Using `kcachegrind` and `ruby-prof`, it was really easy to see this:

<img width="864" alt="Screen Shot 2019-09-13 at 4 25 20 PM" src="https://user-images.githubusercontent.com/1298274/64892687-1bdafc80-d643-11e9-9f5c-7678aa01aa2c.png">

Roughly 80% of the time spent in the controller action is spend in `AppealsController::appeal`, which is responsible for getting a legacy appeal from VACOLS.

The controller action isn't actually using the vast majority of the data we're getting back from VACOLS other than the hearings data. I changed the route to make an assumption that if there are hearings in VACOLS, there probably is a case in VACOLS as well. This lets us skip 4/5 of the VACOLS calls in most cases. The only time these VACOLS calls are still made is if the appeal doesn't exist yet in the Caseflow database.

After these changes, the vast majority of the time is spent trying to get the hearings, and the `wall_time` is cut roughly in half:

<img width="864" alt="Screen Shot 2019-09-13 at 4 30 54 PM" src="https://user-images.githubusercontent.com/1298274/64893006-f39fcd80-d643-11e9-8fa5-3a281892f469.png">

#### Changes

  * Change the name of the controller method to match more what it is doing
  * Create a serializer for the hearings hash
  * Only get VACOLS Case data if no VACOLS hearings are found