### PR TITLE
Fix task filter flakey test

### DIFF
--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -199,7 +199,9 @@ describe TaskFilter, :postgres do
       let(:hearing_tasks) { create_list(:task, tasks_per_type) }
       let(:legacy_tasks) { create_list(:task, tasks_per_type) }
       let(:all_tasks) do
-        Task.where(id: (review_tasks + evidence_tasks + hearing_tasks + legacy_tasks).pluck(:id).sort)
+        Task
+          .where(id: (review_tasks + evidence_tasks + hearing_tasks + legacy_tasks).pluck(:id).sort)
+          .order(id: :asc)
       end
 
       before do


### PR DESCRIPTION
### Description

Was seeing this test failure in CI:

```
Failure/Error: expect(subject.map(&:id)).to match_array(review_tasks.map(&:id) + hearing_tasks.map(&:id))

  expected collection contained:  [779, 780, 781, 785, 786, 787]
  actual collection contained:    [780, 781, 782, 786, 787, 788]
  the missing elements were:      [779, 785]
  the extra elements were:        [782, 788]
./spec/models/task_filter_spec.rb:246:in `block (5 levels) in <top (required)>'
```

The tests passed locally for me. I noticed that the expected collection was ordered differently, so added an order by to make sure it was consistent each time.

  - Order tasks for flakey test