### PR TITLE
Sort by assigner

### DIFF
--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -156,6 +156,15 @@ class WorkQueue::TaskColumnSerializer
     end
   end
 
+  attribute :assigned_by do |object|
+    {
+      first_name: object.assigned_by_display_name.first,
+      last_name: object.assigned_by_display_name.last,
+      css_id: object.assigned_by.try(:css_id),
+      pg_id: object.assigned_by.try(:id)
+    }
+  end
+
   # UNUSED
 
   attribute :assignee_name do
@@ -208,15 +217,6 @@ class WorkQueue::TaskColumnSerializer
 
   attribute :hide_from_task_snapshot do
     nil
-  end
-
-  attribute :assigned_by do
-    {
-      first_name: nil,
-      last_name: nil,
-      css_id: nil,
-      pg_id: nil
-    }
   end
 
   attribute :docket_range_date do

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -8,9 +8,10 @@ import PropTypes from 'prop-types';
 
 import BulkAssignButton from './components/BulkAssignButton';
 import TabWindow from '../components/TabWindow';
-import { docketNumberColumn, hearingBadgeColumn, detailsColumn,
-  taskColumn, regionalOfficeColumn, issueCountColumn, typeColumn,
-  assignedToColumn, daysWaitingColumn, daysOnHoldColumn, readerLinkColumn } from './components/TaskTableColumns';
+import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, issueCountColumn,
+  typeColumn, assignedToColumn, daysWaitingColumn, daysOnHoldColumn, readerLinkColumn, completedToNameColumn } from
+  './components/TaskTableColumns';
+
 import QueueTable from './QueueTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
 import Alert from '../components/Alert';
@@ -69,6 +70,7 @@ class OrganizationQueue extends React.PureComponent {
       regionalOfficeColumn: regionalOfficeColumn(tasks, this.filterValuesForColumn(column, config)),
       typeColumn: typeColumn(tasks, this.filterValuesForColumn(column, config), false),
       assignedToColumn: assignedToColumn(tasks, this.filterValuesForColumn(column, config)),
+      completedToNameColumn: completedToNameColumn(),
       docketNumberColumn: docketNumberColumn(tasks, this.filterValuesForColumn(column, config), false),
       daysWaitingColumn: daysWaitingColumn(false),
       daysOnHoldColumn: daysOnHoldColumn(false),

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -16,7 +16,8 @@ import PropTypes from 'prop-types';
 import QueueTable from '../QueueTable';
 import Checkbox from '../../components/Checkbox';
 import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, daysWaitingColumn,
-  issueCountColumn, typeColumn, assignedToColumn, readerLinkColumn, daysOnHoldColumn } from './TaskTableColumns';
+  issueCountColumn, typeColumn, assignedToColumn, readerLinkColumn, daysOnHoldColumn, completedToNameColumn } from
+  './TaskTableColumns';
 
 import { setSelectionOfTaskOfUser } from '../QueueActions';
 import { hasDASRecord } from '../utils';
@@ -151,14 +152,8 @@ export class TaskTableUnconnected extends React.PureComponent {
     } : null;
   }
 
-  completedToNameColumn = () => {
-    return this.props.includeCompletedToName ? {
-      header: COPY.CASE_LIST_TABLE_COMPLETED_BACK_TO_NAME_COLUMN_TITLE,
-      name: QUEUE_CONFIG.TASK_ASSIGNER_COLUMN,
-      valueFunction: (task) =>
-        task.assignedBy ? `${task.assignedBy.firstName} ${task.assignedBy.lastName}` : null,
-      getSortValue: (task) => task.assignedBy ? task.assignedBy.lastName : null
-    } : null;
+  caseCompletedToNameColumn = () => {
+    return this.props.includeCompletedToName ? completedToNameColumn() : null;
   }
 
   caseReaderLinkColumn = () => {
@@ -188,7 +183,7 @@ export class TaskTableUnconnected extends React.PureComponent {
         this.caseDaysWaitingColumn(),
         this.caseDaysOnHoldColumn(),
         this.completedDateColumn(),
-        this.completedToNameColumn(),
+        this.caseCompletedToNameColumn(),
         this.caseReaderLinkColumn()
       ])), ['order'], ['desc']);
 

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -232,3 +232,14 @@ export const daysOnHoldColumn = (requireDasRecord) => {
     getSortValue: (task) => numDaysOnHold(task)
   };
 };
+
+export const completedToNameColumn = () => {
+  return {
+    header: COPY.CASE_LIST_TABLE_COMPLETED_BACK_TO_NAME_COLUMN_TITLE,
+    name: QUEUE_CONFIG.TASK_ASSIGNER_COLUMN,
+    backendCanSort: true,
+    valueFunction: (task) =>
+      task.assignedBy ? `${task.assignedBy.firstName} ${task.assignedBy.lastName}` : null,
+    getSortValue: (task) => task.assignedBy ? task.assignedBy.lastName : null
+  };
+};

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -120,6 +120,24 @@ describe TaskSorter, :all_dbs do
         end
       end
 
+      context "when sorting by assigner" do
+        let(:column_name) { Constants.QUEUE_CONFIG.TASK_ASSIGNER_COLUMN }
+
+        before do
+          tasks.each do |task|
+            # Update each task to be assigned some random user
+            task.update!(
+              assigned_by: create(:user, full_name: "#{Faker::Name.unique.first_name} #{Faker::Name.unique.first_name}")
+            )
+          end
+        end
+
+        it "sorts tasks by assigned_by last name" do
+          expected_order = tasks.sort_by { |task| task.assigned_by_display_name.last }
+          expect(subject.pluck(:id)).to eq(expected_order.pluck(:id))
+        end
+      end
+
       context "when sorting by task type" do
         let(:column_name) { Constants.QUEUE_CONFIG.TASK_TYPE_COLUMN }
         let(:tasks) { Task.where(id: create_list(:generic_task, task_types.length).pluck(:id)) }


### PR DESCRIPTION
Resolves #11318

### Description
Sorts tasks by assigner on the back end

<img width="915" alt="Screen Shot 2019-09-16 at 2 18 44 PM" src="https://user-images.githubusercontent.com/45575454/64982779-fd684180-d88c-11e9-9478-55fc0ecf944c.png">

### Acceptance Criteria
- [ ] Tasks can be sorted by assigner

### Testing Plan
1. Create some tasks to play with
```ruby
> ColocatedTask.actions_assigned_to_colocated.map(&:to_sym).each { |action| FactoryBot.create(:ama_colocated_task, action, assigned_to: Colocated.singleton, appeal: FactoryBot.create(:appeal), parent:  FactoryBot.create(:generic_task, assigned_to: User.first, assigned_by: User.order('RANDOM()').first), assigned_by: User.order('RANDOM()').first) }
```
2. Change [this line](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/queue_tabs/assigned_tasks_tab.rb#L35) to `Constants.QUEUE_CONFIG.TASK_ASSIGNER_COLUMN,` so we can muck with this on the front end
3. Sign in as a colocated team member
4. Navigate to /organizations/vlj-support?tab=assigned&sort_by=completedToNameColumn (oooo ahhhh deep links)
5. Sort on the "Send to" column. Note that all users in production have a last name with a capital letter (so feel free to ignore sorting weirdness with the mix of lowercase last names and numeric last names)