### PR TITLE
Serialize assigned at for days waiting column

### DIFF
--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -119,7 +119,7 @@ class WorkQueue::TaskColumnSerializer
   end
 
   attribute :assigned_at do |object, params|
-    columns = [Constants.QUEUE_CONFIG.DAYS_ON_HOLD_COLUMN]
+    columns = [Constants.QUEUE_CONFIG.DAYS_WAITING_COLUMN]
 
     if serialize_attribute?(params, columns)
       object.assigned_at


### PR DESCRIPTION
### Description
Fixes NaN in the unassigned tasks tab when pagination is enabled

|Before|After|
|---|---|
|<img width="683" alt="Screen Shot 2019-09-17 at 10 14 02 AM" src="https://user-images.githubusercontent.com/45575454/65049845-78386780-d934-11e9-9b7b-ca3a86386e02.png">|<img width="672" alt="Screen Shot 2019-09-17 at 10 14 16 AM" src="https://user-images.githubusercontent.com/45575454/65049857-7b335800-d934-11e9-9156-6eecfeee3492.png">|



### Acceptance Criteria
- [ ] Unassigned tab does not show NaN for all days waiting

### Testing Plan
1. Log in as a VSO user
2. Navigate to /organizations/veterans-service-organization
3. Ensure there are no NaNs in the days waiting column