### PR TITLE
Add DecisionReviewTasksForInactiveAppealsChecker

### DIFF
--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -5,6 +5,7 @@ class DataIntegrityChecksJob < CaseflowJob
   application_attr :queue
 
   CHECKERS = %w[
+    DecisionReviewTasksForInactiveAppealsChecker
     ExpiredAsyncJobsChecker
     OpenHearingTasksWithoutActiveDescendantsChecker
     UntrackedLegacyAppealsChecker

--- a/app/services/decision_review_tasks_for_inactive_appeals_checker.rb
+++ b/app/services/decision_review_tasks_for_inactive_appeals_checker.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DecisionReviewTasksForInactiveAppealsChecker < DataIntegrityChecker
+  def call
+    tasks_with_inactive_appeals.each do |task|
+      add_to_report "#{task.type} #{task.id} should be canceled"
+    end
+  end
+
+  private
+
+  def tasks_with_inactive_appeals
+    @tasks_with_inactive_appeals ||= build_task_list
+  end
+
+  def build_task_list
+    suspect_tasks = []
+    BusinessLine.all.each do |business|
+      tasks = business.tasks.open.includes([:assigned_to, :appeal])
+      suspect_tasks << tasks.select { |task| task.appeal.request_issues.active.none? }
+    end
+    suspect_tasks.flatten
+  end
+end

--- a/app/services/decision_review_tasks_for_inactive_appeals_checker.rb
+++ b/app/services/decision_review_tasks_for_inactive_appeals_checker.rb
@@ -3,7 +3,7 @@
 class DecisionReviewTasksForInactiveAppealsChecker < DataIntegrityChecker
   def call
     tasks_with_inactive_appeals.each do |task|
-      add_to_report "#{task.type} #{task.id} should be canceled"
+      add_to_report "#{task.type} #{task.id} should be cancelled"
     end
   end
 

--- a/app/services/decision_review_tasks_for_inactive_appeals_checker.rb
+++ b/app/services/decision_review_tasks_for_inactive_appeals_checker.rb
@@ -17,7 +17,13 @@ class DecisionReviewTasksForInactiveAppealsChecker < DataIntegrityChecker
     suspect_tasks = []
     BusinessLine.all.each do |business|
       tasks = business.tasks.open.includes([:assigned_to, :appeal])
-      suspect_tasks << tasks.select { |task| task.appeal.request_issues.active.none? }
+      suspect_tasks << tasks.select do |task|
+        # BoardGrantEffectuationTask only exist for appeals where all the request_issues
+        # are decided, so they are not "active". Therefore we want to keep those tasks open.
+        next if task.is_a?(BoardGrantEffectuationTask)
+
+        task.appeal.request_issues.active.none?
+      end
     end
     suspect_tasks.flatten
   end

--- a/spec/services/decision_review_tasks_for_inactive_appeals_checker_spec.rb
+++ b/spec/services/decision_review_tasks_for_inactive_appeals_checker_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "support/database_cleaner"
+require "rails_helper"
+
+describe DecisionReviewTasksForInactiveAppealsChecker, :postgres do
+  before do
+    seven_am_random_date = Time.new(2019, 3, 29, 7, 0, 0).in_time_zone
+    Timecop.freeze(seven_am_random_date)
+  end
+
+  let(:education) { create(:business_line, url: "education") }
+  let(:veteran) { create(:veteran) }
+  let(:hlr) do
+    create(:higher_level_review, benefit_type: "education", veteran_file_number: veteran.file_number)
+  end
+  let!(:request_issue) { create(:request_issue, :removed, decision_review: hlr) }
+  let!(:task) { create(:higher_level_review_task, appeal: hlr, assigned_to: education) }
+
+  describe "#call" do
+    it "reports one orphaned task" do
+      subject.call
+
+      expect(subject.report?).to eq(true)
+      expect(subject.report).to eq("#{task.type} #{task.id} should be canceled")
+    end
+  end
+end

--- a/spec/services/decision_review_tasks_for_inactive_appeals_checker_spec.rb
+++ b/spec/services/decision_review_tasks_for_inactive_appeals_checker_spec.rb
@@ -16,6 +16,7 @@ describe DecisionReviewTasksForInactiveAppealsChecker, :postgres do
   end
   let!(:request_issue) { create(:request_issue, :removed, decision_review: hlr) }
   let!(:task) { create(:higher_level_review_task, appeal: hlr, assigned_to: education) }
+  let!(:board_grant_effectuation_task) { create(:board_grant_effectuation_task, appeal: hlr, assigned_to: education) }
 
   describe "#call" do
     it "reports one orphaned task" do

--- a/spec/services/decision_review_tasks_for_inactive_appeals_checker_spec.rb
+++ b/spec/services/decision_review_tasks_for_inactive_appeals_checker_spec.rb
@@ -22,7 +22,7 @@ describe DecisionReviewTasksForInactiveAppealsChecker, :postgres do
       subject.call
 
       expect(subject.report?).to eq(true)
-      expect(subject.report).to eq("#{task.type} #{task.id} should be canceled")
+      expect(subject.report).to eq("#{task.type} #{task.id} should be cancelled")
     end
   end
 end


### PR DESCRIPTION
connects #12110 

### Description
Sends Slack message when we have open Business Line tasks for inactive appeals.