### PR TITLE
Cache initial set of paginated rows

### DIFF
--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -226,6 +226,13 @@ export default class QueueTable extends React.PureComponent {
     }
   }
 
+  componentDidMount = () => {
+    if (this.props.rowObjects.length) {
+      this.setState({ cachedTasks: { ...this.state.cachedTasks,
+        [this.requestUrl()]: this.props.rowObjects } });
+    }
+  }
+
   getFilters = (filterParams) => {
     const filters = {};
 


### PR DESCRIPTION
Resolves #11310. Notice that we no longer make an API call when clearing the "Task(s)" filter.

![cache-initial](https://user-images.githubusercontent.com/32683958/65081573-e8b1a980-d971-11e9-86fe-fb013c98bce6.gif)
