### PR TITLE
Assume compensation benefit type for issues contesting rating decisions

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -461,7 +461,10 @@ class RequestIssue < ApplicationRecord
   end
 
   def contested_benefit_type
-    contested_rating_issue&.benefit_type
+    return contested_rating_issue&.benefit_type if associated_rating_issue?
+    return "compensation" if associated_rating_decision?
+
+    guess_benefit_type
   end
 
   def guess_benefit_type

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -462,7 +462,7 @@ class RequestIssue < ApplicationRecord
 
   def contested_benefit_type
     return contested_rating_issue&.benefit_type if associated_rating_issue?
-    return "compensation" if associated_rating_decision?
+    return :compensation if associated_rating_decision?
 
     guess_benefit_type
   end

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1098,7 +1098,7 @@ describe RequestIssue, :all_dbs do
       let(:contested_rating_decision_reference_id) { "rating_decision_ref_id" }
 
       it "returns compensation" do
-        expect(subject).to eq "compensation"
+        expect(subject).to eq :compensation
       end
     end
 

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1088,8 +1088,29 @@ describe RequestIssue, :all_dbs do
   end
 
   context "#contested_benefit_type" do
+    subject { rating_request_issue.contested_benefit_type }
     it "returns the benefit_type of the contested_rating_issue" do
-      expect(rating_request_issue.contested_benefit_type).to eq :compensation
+      expect(subject).to eq :compensation
+    end
+
+    context "when the contested issue is a rating decision issue" do
+      let(:contested_rating_issue_reference_id) { nil }
+      let(:contested_rating_decision_reference_id) { "rating_decision_ref_id" }
+
+      it "returns compensation" do
+        expect(subject).to eq "compensation"
+      end
+    end
+
+    context "when the contested issue is neither a rating issue nor a rating decision" do
+      let(:contested_rating_issue_reference_id) { nil }
+      let(:contested_rating_decision_reference_id) { nil }
+
+      it "calls guess_benefit_type" do
+        expect(rating_request_issue).to receive(:guess_benefit_type)
+
+        subject
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #12151

### Description
If a request issue is contesting a rating decision, assume its business line is "compensation". These issues are from ratings and disabilities, so it's unlikely that they're pension, and they're not non-comp