### PR TITLE
Do not get dispositions for ineligible noncomp issues

### DIFF
--- a/app/models/serializers/work_queue/decision_review_task_serializer.rb
+++ b/app/models/serializers/work_queue/decision_review_task_serializer.rb
@@ -38,7 +38,8 @@ class WorkQueue::DecisionReviewTaskSerializer
     {
       id: decision_review(object).external_id,
       isLegacyAppeal: false,
-      issueCount: decision_review(object).request_issues.active_or_ineligible.count
+      issueCount: decision_review(object).request_issues.active_or_ineligible.count,
+      activeRequestIssues: decision_review(object).request_issues.active.map(&:ui_hash)
     }
   end
 

--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import update from 'immutability-helper';
 
@@ -94,7 +95,7 @@ class NonCompDispositions extends React.PureComponent {
 
     this.state = {
       requestIssues: formatRequestIssuesWithDecisionIssues(
-        this.props.appeal.requestIssues, this.props.appeal.decisionIssues),
+        this.props.task.appeal.activeRequestIssues, this.props.appeal.decisionIssues),
       decisionDate: today,
       isFilledOut: false
     };
@@ -209,12 +210,27 @@ class NonCompDispositions extends React.PureComponent {
   }
 }
 
-const Dispositions = connect(
+NonCompDecisionIssue.propTypes = {
+  issue: PropTypes.object,
+  index: PropTypes.number,
+  onDispositionChange: PropTypes.func,
+  onDescriptionChange: PropTypes.func,
+  decisionDescription: PropTypes.string,
+  decisionDisposition: PropTypes.string,
+  disabled: PropTypes.bool
+};
+
+NonCompDispositions.propTypes = {
+  task: PropTypes.object,
+  appeal: PropTypes.object,
+  decisionIssuesStatus: PropTypes.object,
+  handleSave: PropTypes.func
+};
+
+export default connect(
   (state) => ({
     appeal: state.appeal,
     task: state.task,
     decisionIssuesStatus: state.decisionIssuesStatus
   })
 )(NonCompDispositions);
-
-export default Dispositions;

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -67,6 +67,17 @@ feature "NonComp Dispositions Task Page", :postgres do
       end
     end
 
+    let!(:ineligible_request_issue) do
+      create(:request_issue,
+             :nonrating,
+             :ineligible,
+             nonrating_issue_description: "ineligible issue",
+             end_product_establishment: epe,
+             veteran_participant_id: veteran.participant_id,
+             decision_review: decision_review,
+             benefit_type: decision_review.benefit_type)
+    end
+
     let!(:in_progress_task) do
       create(:higher_level_review_task, :in_progress, appeal: decision_review, assigned_to: non_comp_org)
     end
@@ -126,12 +137,13 @@ feature "NonComp Dispositions Task Page", :postgres do
       expect(page).to have_current_path("/#{business_line_url}")
     end
 
-    scenario "saves decision issues" do
+    scenario "saves decision issues for eligible request issues" do
       visit dispositions_url
       expect(page).to have_button("Complete", disabled: true)
       expect(page).to have_link("Edit Issues")
+      expect(page).to_not have_content("ineligible issue")
 
-      # set description & disposition for each request issue
+      # set description & disposition for each active request issue
       fill_in_disposition(0, "Granted")
       fill_in_disposition(1, "DTA Error", "test description")
       fill_in_disposition(2, "Denied", "denied")

--- a/spec/models/serializers/work_queue/decision_review_task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/decision_review_task_serializer_spec.rb
@@ -18,7 +18,7 @@ describe WorkQueue::DecisionReviewTaskSerializer, :postgres do
         type: :decision_review_task,
         attributes: {
           claimant: { name: hlr.veteran_full_name, relationship: "self" },
-          appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0 },
+          appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0, activeRequestIssues: [] },
           veteran_participant_id: veteran.participant_id,
           assigned_on: task.assigned_at,
           closed_at: task.closed_at,
@@ -43,7 +43,7 @@ describe WorkQueue::DecisionReviewTaskSerializer, :postgres do
           type: :decision_review_task,
           attributes: {
             claimant: { name: "claimant", relationship: "claimant" },
-            appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0 },
+            appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0, activeRequestIssues: [] },
             veteran_participant_id: veteran.participant_id,
             assigned_on: task.assigned_at,
             closed_at: task.closed_at,
@@ -78,7 +78,7 @@ describe WorkQueue::DecisionReviewTaskSerializer, :postgres do
           type: :decision_review_task,
           attributes: {
             claimant: { name: claimant.name, relationship: "claimant" },
-            appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0 },
+            appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0, activeRequestIssues: [] },
             veteran_participant_id: veteran.participant_id,
             assigned_on: task.assigned_at,
             closed_at: task.closed_at,


### PR DESCRIPTION
Resolves #12153

### Description
Previously in the noncomp queue we asked the user to enter dispositions for active, ineligible, or withdrawn issues. We only want to ask for dispositions for active issues.  Validation on the backend checking that all active issues have dispositions was failing because we were sending dispositions for extra issues.