### PR TITLE
Prevent MailRoutingErrors from triggering Sentry alerts

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -79,6 +79,8 @@ class TasksController < ApplicationController
     render json: { tasks: json_tasks(tasks_to_return) }
   rescue ActiveRecord::RecordInvalid => error
     invalid_record_error(error.record)
+  rescue Caseflow::Error::MailRoutingError => error
+    render(error.serialize_response)
   end
 
   # To update attorney task

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -254,6 +254,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
   describe "POST /tasks" do
     let(:attorney) { create(:user) }
+    let(:role) { nil }
     let(:user) { create(:user) }
     let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
 
@@ -578,6 +579,39 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(
           HearingAdminActionContestedClaimantTask.all.map(&:instructions).flatten
         ).to match_array([contested_instructions_1, contested_instructions_2])
+      end
+    end
+
+    context "When the current user is a member of the Mail team" do
+      before do
+        mail_team_user = create(:user)
+        OrganizationsUser.add_user_to_organization(mail_team_user, MailTeam.singleton)
+        User.authenticate!(user: mail_team_user)
+      end
+
+      context "when an EvidenceOrArgumentMailTask is created for an inactive appeal" do
+        let(:root_task) { create(:root_task) }
+
+        let(:params) do
+          [{
+            "external_id": root_task.appeal.external_id,
+            "type": EvidenceOrArgumentMailTask.name,
+            "parent_id": root_task.id
+          }]
+        end
+
+        before do
+          allow(EvidenceOrArgumentMailTask).to receive(:case_active?).and_return(false)
+        end
+
+        it "returns a response indicating failure to create task" do
+          subject
+
+          response_body = JSON.parse(response.body)
+
+          expect(response_body["errors"].first["status"]).to eq(500)
+          expect(response_body["errors"].first["detail"]).to eq(Caseflow::Error::MailRoutingError.new.message)
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #10615. Catch `MailRoutingError`s in the controller so that we don't send the error to Sentry as we previously were by relying on the [error catching logic in `ApplicationController`](https://github.com/department-of-veterans-affairs/caseflow/blob/8f168920a70b82899c28b4e99e2551774c1c0c64/app/controllers/application_controller.rb#L12).