### PR TITLE
check for open tasks with closed_at value

### DIFF
--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -7,6 +7,7 @@ class DataIntegrityChecksJob < CaseflowJob
   CHECKERS = %w[
     ExpiredAsyncJobsChecker
     OpenHearingTasksWithoutActiveDescendantsChecker
+    OpenTasksWithClosedAtChecker
     UntrackedLegacyAppealsChecker
   ].freeze
 

--- a/app/services/open_tasks_with_closed_at_checker.rb
+++ b/app/services/open_tasks_with_closed_at_checker.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class OpenTasksWithClosedAtChecker < DataIntegrityChecker
+  def call
+    suspect_tasks = open_tasks_with_closed_at_defined
+    if suspect_tasks.count > 0
+      add_to_report "#{suspect_tasks.count} open Task(s) with a closed_at value"
+      add_to_report "Verify data error with `Task.open.where.not(closed_at: nil)`"
+      add_to_report "These tasks likely were manually re-opened and should have closed_at set to NULL"
+    end
+  end
+
+  private
+
+  def open_tasks_with_closed_at_defined
+    Task.open.where.not(closed_at: nil)
+  end
+end

--- a/spec/services/open_tasks_with_closed_at_checker_spec.rb
+++ b/spec/services/open_tasks_with_closed_at_checker_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "support/database_cleaner"
+require "rails_helper"
+
+describe OpenTasksWithClosedAtChecker, :postgres do
+  before do
+    seven_am_random_date = Time.new(2019, 3, 29, 7, 0, 0).in_time_zone
+    Timecop.freeze(seven_am_random_date)
+  end
+
+  let!(:task) do
+    task = create(:task, :assigned, appeal: create(:appeal))
+    task.update!(closed_at: Time.zone.now)
+    task
+  end
+
+  describe "#call" do
+    it "reports one Task in bad state" do
+      subject.call
+
+      expect(subject.report?).to eq(true)
+      expect(subject.report).to match(/1 open Task\(s\) with a closed_at value/)
+    end
+  end
+end


### PR DESCRIPTION
connects #12157 

### Description
Metrics team spotted bad data in production, where we have 101 tasks with a `closed_at` value that are not really closed.