### PR TITLE
Ensure AVLJs can assign to people not on their team

### DIFF
--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -120,7 +120,7 @@ class QueueApp extends React.PureComponent {
   );
 
   routedJudgeQueueList = (label) => ({ match }) => (
-    <QueueLoadingScreen {...this.propsForQueueLoadingScreen()}>
+    <QueueLoadingScreen {...this.propsForQueueLoadingScreen()} loadAttorneys={label === 'assign'}>
       {label === 'assign' ? (
         <JudgeAssignTaskListView {...this.props} match={match} />
       ) : (

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -72,7 +72,7 @@ class QueueLoadingScreen extends React.PureComponent {
   };
 
   maybeLoadJudgeData = () => {
-    if (this.props.userRole !== USER_ROLE_TYPES.judge) {
+    if (this.props.userRole !== USER_ROLE_TYPES.judge && !this.props.loadAttorneys) {
       return Promise.resolve();
     }
 
@@ -122,6 +122,7 @@ QueueLoadingScreen.propTypes = {
   fetchAllAttorneys: PropTypes.func,
   fetchAmaTasksOfUser: PropTypes.func,
   loadedUserId: PropTypes.number,
+  loadAttorneys: PropTypes.bool,
   onReceiveQueue: PropTypes.func,
   setAttorneysOfJudge: PropTypes.func,
   setUserId: PropTypes.func,

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -58,6 +58,27 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
     end
   end
 
+  context "Acting judge can see team and other users load" do
+    let!(:vacols_user_one) { create(:staff, :attorney_judge_role, user: judge_one.user) }
+
+    scenario "visits 'Assign' view" do
+      visit "/queue"
+
+      find(".cf-dropdown-trigger", text: COPY::CASE_LIST_TABLE_QUEUE_DROPDOWN_LABEL).click
+      expect(page).to have_content(COPY::JUDGE_ASSIGN_DROPDOWN_LINK_LABEL)
+      click_on COPY::JUDGE_ASSIGN_DROPDOWN_LINK_LABEL
+
+      expect(page).to have_content("Cases to Assign")
+      expect(page).to have_content("Moe Syzlak")
+      expect(page).to have_content("Alice Macgyvertwo")
+
+      safe_click ".Select"
+      click_dropdown(text: "Other")
+      safe_click ".dropdown-Other"
+      expect(page.find(".dropdown-Other")).to have_content judge_two.user.full_name
+    end
+  end
+
   context "Can move appeals between attorneys" do
     scenario "submits draft decision" do
       judge_task_one = create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, appeal: appeal_one)


### PR DESCRIPTION
### Description
AVLJs have an 'Attorney' role on the front end, so [relying solely on that](https://github.com/department-of-veterans-affairs/caseflow/pull/12179/files#diff-95d123c754d311c1600237dbbc5a111aR75) to load attorney data is incorrect. This fix will always load all judges and attorneys when viewing the assign cases page.

### Acceptance Criteria
- [ ] Code compiles correctly