### PR TITLE
Add aria-label to CopyTextButton

### DIFF
--- a/client/app/components/CopyTextButton.jsx
+++ b/client/app/components/CopyTextButton.jsx
@@ -28,13 +28,15 @@ const clipboardButtonStyling = css({
 export default class CopyTextButton extends React.PureComponent {
   render = () => {
     const {
-      text
+      text,
+      label
     } = this.props;
 
     return <Tooltip id={`tooltip-${text}`} text="Click to copy" position="bottom">
       <CopyToClipboard text={text}>
         <button type="submit"
           className="cf-apppeal-id"
+          aria-label={`Copy ${label} ${text}`}
           {...clipboardButtonStyling} >
           {text}&nbsp;
           <ClipboardIcon />
@@ -45,5 +47,6 @@ export default class CopyTextButton extends React.PureComponent {
 }
 
 CopyTextButton.propTypes = {
-  text: PropTypes.string
+  text: PropTypes.string,
+  label: PropTypes.string
 };

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -194,7 +194,10 @@ class HearingDetails extends React.Component {
 HearingDetails.propTypes = {
   hearing: PropTypes.object.isRequired,
   goBack: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  onChangeFormData: PropTypes.func,
+  hearingDetailsForm: PropTypes.object,
+  transcriptionDetailsForm: PropTypes.object
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -153,7 +153,7 @@ class HearingDetails extends React.Component {
         <div {...inputFix}>
           <div {...row}>
             <h1 className="cf-margin-bottom-0">{`${veteranFirstName} ${veteranLastName}`}</h1>
-            <div>Veteran ID: <CopyTextButton text={veteranFileNumber} /></div>
+            <div>Veteran ID: <CopyTextButton text={veteranFileNumber} label="Veteran ID" /></div>
           </div>
 
           <div className="cf-help-divider" />

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -66,10 +66,21 @@ class CaseTitle extends React.PureComponent {
   }
 }
 
-CaseTitle.propTypes = {
+const CaseTitleScaffolding = (props) => <div {...containingDivStyling}>
+  <h1 {...headerStyling}>{props.heading}</h1>
+  <ul {...listStyling}>
+    {props.children.map((child, i) => child && <li key={i} {...listItemStyling}>{child}</li>)}
+  </ul>
+</div>;
+
+CaseTitle.propTypes = CaseTitleScaffolding.propTypes = {
   appeal: PropTypes.object.isRequired,
   taskType: PropTypes.string,
-  analyticsSource: PropTypes.string
+  analyticsSource: PropTypes.string,
+  veteranCaseListIsVisible: PropTypes.bool,
+  toggleVeteranCaseList: PropTypes.func,
+  heading: PropTypes.string,
+  children: PropTypes.node
 };
 
 CaseTitle.defaultProps = {
@@ -87,10 +98,3 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(CaseTitle);
-
-const CaseTitleScaffolding = (props) => <div {...containingDivStyling}>
-  <h1 {...headerStyling}>{props.heading}</h1>
-  <ul {...listStyling}>
-    {props.children.map((child, i) => child && <li key={i} {...listItemStyling}>{child}</li>)}
-  </ul>
-</div>;

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -54,7 +54,7 @@ class CaseTitle extends React.PureComponent {
     return <CaseTitleScaffolding heading={appeal.veteranFullName}>
       <React.Fragment>
         Veteran ID:&nbsp;
-        <CopyTextButton text={appeal.veteranFileNumber} />
+        <CopyTextButton text={appeal.veteranFileNumber} label="Veteran ID" />
       </React.Fragment>
 
       <span {...viewCasesStyling}>

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -191,7 +191,11 @@ export class CaseTitleDetails extends React.PureComponent {
       { !userIsVsoEmployee && appeal && appeal.documentID &&
         <React.Fragment>
           <h4>{COPY.TASK_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL}</h4>
-          <div id="document-id"><CopyTextButton text={this.state.value || appeal.documentID} />
+          <div id="document-id">
+            <CopyTextButton
+              text={this.state.value || appeal.documentID}
+              label={COPY.TASK_SNAPSHOT_DECISION_DOCUMENT_ID_LABEL}
+            />
             { appeal.canEditDocumentId &&
               <Button
                 linkStyling

--- a/client/app/reader/PdfViewer.jsx
+++ b/client/app/reader/PdfViewer.jsx
@@ -274,6 +274,7 @@ export class PdfViewer extends React.Component {
           title="Share Comment">
           <CopyTextButton
             text={`${location.origin}${location.pathname}?annotation=${this.props.shareAnnotationModalIsOpenFor}`}
+            label="Link to annotation"
           />
         </Modal>}
       </div>


### PR DESCRIPTION
Resolves #12100. Resolves #12099. Resolves #12098. Resolves #12097.

### Description
Gives a descriptive label for CopyTextButton to be read by screen readers.

### Acceptance Criteria
- [ ] Screen readers announce the label, function, and value of the CopyTextButton

### Testing Plan
1. Case details for any judge review task
2. Enable screen reader (See instructions in #12095)
3. Tab to the veteran id and the decision document id to confirm the label and value are read, as well as the "copy" function.