### PR TITLE
Fix hiding add issues button on dta corrections

### DIFF
--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -272,7 +272,7 @@ class AddIssuesPage extends React.Component {
 
     rowObjects = rowObjects.concat({
       field: ' ',
-      content: !intakeData.isDtaError && addIssueButton()
+      content: addIssueButton()
     });
 
     return (

--- a/spec/feature/intake/end_product_correction_spec.rb
+++ b/spec/feature/intake/end_product_correction_spec.rb
@@ -419,10 +419,10 @@ feature "End Product Correction (EP 930)", :postgres do
     end
 
     context "when the end product is cleared" do
-      it "allows edit and hides the add issue button" do
+      it "allows edit and shows the add issue button" do
         visit edit_path
         expect(page).to have_content("Edit Issues")
-        expect(page).to_not have_css("#button-add-issue")
+        expect(page).to have_css("#button-add-issue")
       end
     end
   end


### PR DESCRIPTION
connects #12186

### Description
I mistakenly, prematurely started to hide the "Add issues" button on DTA claims, which should not happen on correction claims.  This undoes that.

This is the first PR for a quick fix to allow for VBMS testing of DTA corrections.  There will be another follow on PR to hide the button when appropriate and limit the issue options to issues resulting from that DTA supplemental claim.