### PR TITLE
Intake alerts quiet after 4 hours

### DIFF
--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -37,7 +37,7 @@ class DecisionReviewProcessJob < CaseflowJob
   attr_reader :decision_review
 
   def ok_to_ping_sentry?
-    decision_review.sort_by_last_submitted_at > (Time.zone.now - 1.day)
+    decision_review.sort_by_last_submitted_at > (Time.zone.now - 4.hours)
   end
 
   def add_extra_context_to_sentry

--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -6,20 +6,26 @@ class DecisionReviewProcessJob < CaseflowJob
   queue_with_priority :low_priority
   application_attr :intake
 
-  def perform(decision_review)
+  def perform(thing_to_establish)
+    @decision_review = thing_to_establish
+
     # restore whatever the user was when we finish, in case we are not running async (as during tests)
     current_user = RequestStore.store[:current_user]
     RequestStore.store[:current_user] = User.system_user
 
     return_value = nil
 
-    add_extra_context_to_sentry(decision_review)
+    add_extra_context_to_sentry
 
     begin
       return_value = decision_review.establish!
     rescue StandardError => error
       decision_review.update_error!(error.inspect)
-      capture_exception(error: error)
+      if ok_to_ping_sentry?
+        capture_exception(error: error)
+      else
+        Rails.logger.error(error)
+      end
     end
 
     RequestStore.store[:current_user] = current_user
@@ -28,7 +34,13 @@ class DecisionReviewProcessJob < CaseflowJob
 
   private
 
-  def add_extra_context_to_sentry(decision_review)
+  attr_reader :decision_review
+
+  def ok_to_ping_sentry?
+    decision_review.sort_by_last_submitted_at > (Time.zone.now - 1.day)
+  end
+
+  def add_extra_context_to_sentry
     Raven.extra_context(class: decision_review.class.to_s, id: decision_review.id)
   end
 end

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -6,7 +6,7 @@ class RequestIssue < ApplicationRecord
   include DecisionSyncable
 
   # how many days before we give up trying to sync decisions
-  REQUIRES_PROCESSING_WINDOW_DAYS = 14
+  REQUIRES_PROCESSING_WINDOW_DAYS = 30
 
   # don't need to try as frequently as default 3 hours
   DEFAULT_REQUIRES_PROCESSING_RETRY_WINDOW_HOURS = 12

--- a/spec/jobs/decision_review_process_job_spec.rb
+++ b/spec/jobs/decision_review_process_job_spec.rb
@@ -16,6 +16,7 @@ class AClaimReview
   end
 
   def establish!; end
+  def sort_by_last_submitted_at; end
 end
 
 describe DecisionReviewProcessJob do
@@ -61,6 +62,18 @@ describe DecisionReviewProcessJob do
       subject
 
       expect(claim_review.error).to eq(vbms_error.inspect)
+      expect(@raven_called).to be_falsey
+    end
+  end
+
+  context "job is retried after 4 hours" do
+    it "does not send error to sentry" do
+      allow(claim_review).to receive(:sort_by_last_submitted_at) { 4.hours.ago }
+      allow(claim_review).to receive(:establish!).and_raise(vbms_error)
+      capture_raven_log
+
+      subject
+
       expect(@raven_called).to be_falsey
     end
   end

--- a/spec/jobs/decision_review_process_job_spec.rb
+++ b/spec/jobs/decision_review_process_job_spec.rb
@@ -3,12 +3,10 @@
 require "rails_helper"
 
 class AClaimReview
-  def update_error!(err)
-    @err = err
-  end
+  attr_reader :error
 
-  def error
-    @err
+  def update_error!(err)
+    @error = err
   end
 
   def id
@@ -16,6 +14,7 @@ class AClaimReview
   end
 
   def establish!; end
+
   def sort_by_last_submitted_at; end
 end
 


### PR DESCRIPTION
Help improve signal:noise ratio in #appeals-intake-alerts channel.

Also extends the re-try window for decision issue sync to a full month.