### PR TITLE
Allow vso admins to see other vso user's tasks and reassign them

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -395,6 +395,10 @@ class Task < ApplicationRecord
       parent.assigned_to.user_has_access?(user)
   end
 
+  def assigned_to_vso_user?
+    assigned_to.is_a?(User) && assigned_to.vso_employee?
+  end
+
   def can_be_updated_by_user?(user)
     available_actions_unwrapper(user).any?
   end

--- a/app/models/tasks/informal_hearing_presentation_task.rb
+++ b/app/models/tasks/informal_hearing_presentation_task.rb
@@ -12,29 +12,41 @@ class InformalHearingPresentationTask < Task
 
   def available_actions(user)
     if assigned_to == user
-      return [
-        Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h,
-        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-        Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
-        Constants.TASK_ACTIONS.CANCEL_TASK.to_h
-      ]
+      return user_actions
     end
 
     if task_is_assigned_to_user_within_organization?(user) && parent.assigned_to.user_is_admin?(user)
-      return [
-        Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h
-      ]
+      return admin_actions
     end
 
     if task_is_assigned_to_users_organization?(user)
-      return [
-        Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h,
-        Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
-        Constants.TASK_ACTIONS.CANCEL_TASK.to_h
-      ]
+      return org_actions
     end
 
     []
+  end
+
+  def user_actions
+    [
+      Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h,
+      Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
+      Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
+      Constants.TASK_ACTIONS.CANCEL_TASK.to_h
+    ]
+  end
+
+  def admin_actions
+    [
+      Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h
+    ]
+  end
+
+  def org_actions
+    [
+      Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h,
+      Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
+      Constants.TASK_ACTIONS.CANCEL_TASK.to_h
+    ]
   end
 
   def self.label

--- a/app/models/tasks/informal_hearing_presentation_task.rb
+++ b/app/models/tasks/informal_hearing_presentation_task.rb
@@ -20,6 +20,12 @@ class InformalHearingPresentationTask < Task
       ]
     end
 
+    if task_is_assigned_to_user_within_organization?(user) && parent.assigned_to.user_is_admin?(user)
+      return [
+        Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h
+      ]
+    end
+
     if task_is_assigned_to_users_organization?(user)
       return [
         Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h,

--- a/app/models/tasks/informal_hearing_presentation_task.rb
+++ b/app/models/tasks/informal_hearing_presentation_task.rb
@@ -6,47 +6,42 @@
 # BVA typically (but not always) waits for an IHP to be submitted before making a decision.
 
 class InformalHearingPresentationTask < Task
-  # TODO: figure out how long IHP tasks will take to expire,
+  # https://github.com/department-of-veterans-affairs/caseflow/issues/10824
+  # Figure out how long IHP tasks will take to expire,
   # then make them timeable
   # include TimeableTask
 
+  USER_ACTIONS = [
+    Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h,
+    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
+    Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
+    Constants.TASK_ACTIONS.CANCEL_TASK.to_h
+  ].freeze
+
+  ADMIN_ACTIONS = [
+    Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h
+  ].freeze
+
+  ORG_ACTIONS = [
+    Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h,
+    Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
+    Constants.TASK_ACTIONS.CANCEL_TASK.to_h
+  ].freeze
+
   def available_actions(user)
     if assigned_to == user
-      return user_actions
+      return USER_ACTIONS
     end
 
     if task_is_assigned_to_user_within_organization?(user) && parent.assigned_to.user_is_admin?(user)
-      return admin_actions
+      return ADMIN_ACTIONS
     end
 
     if task_is_assigned_to_users_organization?(user)
-      return org_actions
+      return ORG_ACTIONS
     end
 
     []
-  end
-
-  def user_actions
-    [
-      Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h,
-      Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-      Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
-      Constants.TASK_ACTIONS.CANCEL_TASK.to_h
-    ]
-  end
-
-  def admin_actions
-    [
-      Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h
-    ]
-  end
-
-  def org_actions
-    [
-      Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h,
-      Constants.TASK_ACTIONS.MARK_COMPLETE.to_h,
-      Constants.TASK_ACTIONS.CANCEL_TASK.to_h
-    ]
   end
 
   def self.label

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -30,7 +30,11 @@ class TasksForAppeal
   def tasks_assigned_to_user_or_any_other_vso_employee
     appeal.tasks
       .includes(*task_includes)
-      .select { |task| task.assigned_to.is_a?(Representative) || user == task.assigned_to }
+      .select do |task|
+        task.assigned_to.is_a?(Representative) ||
+          (task.assigned_to.is_a?(User) && task.assigned_to.vso_employee?) ||
+          user == task.assigned_to
+      end
   end
 
   def all_tasks_except_for_decision_review_tasks

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -31,9 +31,7 @@ class TasksForAppeal
     appeal.tasks
       .includes(*task_includes)
       .select do |task|
-        task.assigned_to.is_a?(Representative) ||
-          (task.assigned_to.is_a?(User) && task.assigned_to.vso_employee?) ||
-          user == task.assigned_to
+        task.assigned_to.is_a?(Representative) || task.assigned_to_vso_user? || user == task.assigned_to
       end
   end
 

--- a/spec/models/tasks/informal_hearing_presentation_task_spec.rb
+++ b/spec/models/tasks/informal_hearing_presentation_task_spec.rb
@@ -45,6 +45,23 @@ describe InformalHearingPresentationTask, :postgres do
       end
     end
 
+    context "when task is assigned to another user in organization the user is an admin of" do
+      let(:org) { create(:organization) }
+      let(:another_user) { create(:user, roles: ["VSO"]) }
+      let(:org_task) { create(:informal_hearing_presentation_task, assigned_to: org) }
+      let(:task) { create(:informal_hearing_presentation_task, assigned_to: another_user, parent: org_task) }
+      let(:expected_actions) { [Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h] }
+
+      before do
+        allow_any_instance_of(Organization).to receive(:user_has_access?).and_return(true)
+        OrganizationsUser.make_user_admin(user, org)
+      end
+
+      it "should return team reassign action" do
+        expect(subject).to eq(expected_actions)
+      end
+    end
+
     context "when task is assigned to user" do
       let(:task) do
         InformalHearingPresentationTask.find(create(:informal_hearing_presentation_task).id)


### PR DESCRIPTION
### Description
Allow VSO users to view other VSO users's tasks. Allow VSO admins to reassign tasks. [Relevant slack thread](https://dsva.slack.com/archives/CJL810329/p1569421603162400)

|Before|After|
|---|---|
|<img width="819" alt="Screen Shot 2019-09-26 at 7 57 13 AM" src="https://user-images.githubusercontent.com/45575454/65688282-d6520280-e038-11e9-87c5-bcdb13260f03.png">|<img width="820" alt="Screen Shot 2019-09-26 at 7 56 09 AM" src="https://user-images.githubusercontent.com/45575454/65688295-dc47e380-e038-11e9-96cb-0e09d0a7e2bb.png">|

### Acceptance Criteria
- [ ] VSO users can view other VSO users's tasks
- [ ] VSO admins can reassign tasks

### Testing Plan
1. Make Billy_vso an admin
```ruby
org = Vso.first
user = User.find_by(css_id: "BILLIE_VSO")
OrganizationsUser.make_user_admin(user, org)
pp user.reload.administered_teams
# [#<Vso:0x00007fc2b4495e70
#   id: 7,
#   name: "VSO",
#   participant_id: "2452415",
#   role: "VSO",
#   type: "Vso",
#   url: "veterans-service-organization",
#   created_at: nil,
#   updated_at: nil>]
```
2. Navigate to http://localhost:3000/organizations/veterans-service-organization?tab=assigned
3. Select a task not assigned to Billy
4. Ensure we can see the task in task snapshot and it has a reassign action
5. Ensure reassigning works
