### PR TITLE
Cache of hearing facility addresses

### DIFF
--- a/app/models/hearing_location.rb
+++ b/app/models/hearing_location.rb
@@ -2,4 +2,9 @@
 
 class HearingLocation < ApplicationRecord
   belongs_to :hearing, polymorphic: true
+
+  def street_address
+    addr = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[facility_id]
+    %w[address_1 address_2 address_3].map { |line| addr[line] }.compact.join(", ")
+  end
 end

--- a/app/models/hearing_location.rb
+++ b/app/models/hearing_location.rb
@@ -5,6 +5,6 @@ class HearingLocation < ApplicationRecord
 
   def street_address
     addr = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[facility_id]
-    %w[address_1 address_2 address_3].map { |line| addr[line] }.compact.join(", ")
+    %w[address_1 address_2 address_3].map { |line| addr[line] }.reject(&:blank?).join(", ")
   end
 end

--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -4,7 +4,7 @@ class Api::V2::HearingSerializer
   include FastJsonapi::ObjectSerializer
 
   attribute :address do |hearing|
-    hearing.hearing_location&.address
+    hearing.hearing_location&.street_address
   end
   attribute :city do |hearing|
     hearing.hearing_location&.city || hearing.regional_office.city

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -1,0 +1,1138 @@
+{
+   "vba_301" : {
+      "address_1" : "15 New Sudbury Street",
+      "address_2" : "JFK Federal Building",
+      "address_3" : null,
+      "city" : "Boston",
+      "state" : "MA",
+      "zip" : "02203"
+   },
+   "vba_304" : {
+      "address_1" : "380 Westminster St",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Providence",
+      "state" : "RI",
+      "zip" : "02903"
+   },
+   "vba_306" : {
+      "address_1" : "245 W Houston Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "New York",
+      "state" : "NY",
+      "zip" : "10014"
+   },
+   "vba_306b" : {
+      "address_1" : "113 Holland Avenue",
+      "address_2" : "Room C308",
+      "address_3" : null,
+      "city" : "Albany",
+      "state" : "NY",
+      "zip" : "12208"
+   },
+   "vba_307" : {
+      "address_1" : "130 South Elmwood Ave",
+      "address_2" : "Suite 601",
+      "address_3" : null,
+      "city" : "Buffalo",
+      "state" : "NY",
+      "zip" : "14202"
+   },
+   "vba_308" : {
+      "address_1" : "555 Willard Ave",
+      "address_2" : "Mailing: P.O. Box 310909, zip 06131",
+      "address_3" : null,
+      "city" : "Newington",
+      "state" : "CT",
+      "zip" : "06111"
+   },
+   "vba_309" : {
+      "address_1" : "20 Washington Place",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Newark",
+      "state" : "NJ",
+      "zip" : "07102"
+   },
+   "vba_310" : {
+      "address_1" : "5000 Wissahickon Ave.",
+      "address_2" : "Mailing: P.O. Box 8079, zip 19101",
+      "address_3" : null,
+      "city" : "Philadelphia",
+      "state" : "PA",
+      "zip" : "19144"
+   },
+   "vba_311" : {
+      "address_1" : "1000 Liberty Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Pittsburgh",
+      "state" : "PA",
+      "zip" : "15222"
+   },
+   "vba_313" : {
+      "address_1" : "31 Hopkins Plaza",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Baltimore",
+      "state" : "MD",
+      "zip" : "21201"
+   },
+   "vba_314" : {
+      "address_1" : "210 Franklin Rd, SW",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Roanoke",
+      "state" : "VA",
+      "zip" : "24011"
+   },
+   "vba_315" : {
+      "address_1" : "640 4th Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Huntington",
+      "state" : "WV",
+      "zip" : "25701"
+   },
+   "vba_316" : {
+      "address_1" : "1700 Clairmont Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Decatur",
+      "state" : "GA",
+      "zip" : "30033"
+   },
+   "vba_317" : {
+      "address_1" : "9500 Bay Pines Blvd.",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "St. Petersburg",
+      "state" : "FL",
+      "zip" : "33744"
+   },
+   "vba_317a" : {
+      "address_1" : "7305 N. Military Trail",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "West Palm Beach",
+      "state" : "FL",
+      "zip" : "33410"
+   },
+   "vba_318" : {
+      "address_1" : "251 N. Main Street",
+      "address_2" : "Federal Building",
+      "address_3" : null,
+      "city" : "Winston-Salem",
+      "state" : "NC",
+      "zip" : "27155"
+   },
+   "vba_319" : {
+      "address_1" : "6437 Garners Ferry Rd",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Columbia",
+      "state" : "SC",
+      "zip" : "29209"
+   },
+   "vba_320" : {
+      "address_1" : "110 9th Avenue, South",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Nashville",
+      "state" : "TN",
+      "zip" : "37203"
+   },
+   "vba_321" : {
+      "address_1" : "1250 Poydras Street",
+      "address_2" : "Suite 200",
+      "address_3" : null,
+      "city" : "New Orleans",
+      "state" : "LA",
+      "zip" : "70113"
+   },
+   "vba_321b" : {
+      "address_1" : "3341 Youree Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Shreveport",
+      "state" : "LA",
+      "zip" : "71105"
+   },
+   "vba_322" : {
+      "address_1" : "345 Perry Hill Rd",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Montgomery",
+      "state" : "AL",
+      "zip" : "36109"
+   },
+   "vba_323" : {
+      "address_1" : "1600 E. Woodrow Wilson Ave.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Jackson",
+      "state" : "MS",
+      "zip" : "39216"
+   },
+   "vba_325" : {
+      "address_1" : "1240 E. 9th Street",
+      "address_2" : "A.J. Celebrezze Federal Building",
+      "address_3" : null,
+      "city" : "Cleveland",
+      "state" : "OH",
+      "zip" : "44199"
+   },
+   "vba_325b" : {
+      "address_1" : "36 East Seventh Street",
+      "address_2" : "Suite 210A",
+      "address_3" : null,
+      "city" : "Cincinnati",
+      "state" : "OH",
+      "zip" : "45202"
+   },
+   "vba_326" : {
+      "address_1" : "575 N Pennsylvania St",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Indianapolis",
+      "state" : "IN",
+      "zip" : "46204"
+   },
+   "vba_327" : {
+      "address_1" : "321 W Main St",
+      "address_2" : "Suite 390",
+      "address_3" : null,
+      "city" : "Louisville",
+      "state" : "KY",
+      "zip" : "40202"
+   },
+   "vba_328" : {
+      "address_1" : "2122 W. Taylor Street",
+      "address_2" : "Mailing: VA Claims Intake Center, P.O. Box 5235, Janesville, WI 53547",
+      "address_3" : null,
+      "city" : "Chicago",
+      "state" : "IL",
+      "zip" : "60612"
+   },
+   "vba_329" : {
+      "address_1" : "477 Michigan Avenue",
+      "address_2" : "Patrick V. McNamara Federal Bldg., 12th Floor",
+      "address_3" : null,
+      "city" : "Detroit",
+      "state" : "MI",
+      "zip" : "48226"
+   },
+   "vba_330" : {
+      "address_1" : "5400 W. National Ave.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Milwaukee",
+      "state" : "WI",
+      "zip" : "53214"
+   },
+   "vba_331" : {
+      "address_1" : "9700 Page Ave.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "ST. Louis",
+      "state" : "MO",
+      "zip" : "63132"
+   },
+   "vba_333" : {
+      "address_1" : "210 Walnut Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Des Moines",
+      "state" : "IA",
+      "zip" : "50309"
+   },
+   "vba_334" : {
+      "address_1" : "3800 Village Drive",
+      "address_2" : "Mailing: P.O. Box 85816, zip 68501",
+      "address_3" : null,
+      "city" : "Lincoln",
+      "state" : "NE",
+      "zip" : "68501"
+   },
+   "vba_335" : {
+      "address_1" : "1 Federal Drive",
+      "address_2" : "Fort Snelling",
+      "address_3" : null,
+      "city" : "St. Paul",
+      "state" : "MN",
+      "zip" : "55111"
+   },
+   "vba_339" : {
+      "address_1" : "155 Van Gordon Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Lakewood",
+      "state" : "CO",
+      "zip" : "80228"
+   },
+   "vba_340" : {
+      "address_1" : "500 Gold Ave., SW",
+      "address_2" : "Mailing: P.O. Box 900, zip 87103",
+      "address_3" : null,
+      "city" : "Albuquerque",
+      "state" : "NM",
+      "zip" : "87102"
+   },
+   "vba_341" : {
+      "address_1" : "550 Foothill Drive",
+      "address_2" : "PO Box 581900",
+      "address_3" : null,
+      "city" : "Salt Lake City",
+      "state" : "UT",
+      "zip" : "84158"
+   },
+   "vba_343" : {
+      "address_1" : "1301 Clay Street",
+      "address_2" : "North Tower, Rm. 1400",
+      "address_3" : null,
+      "city" : "Oakland",
+      "state" : "CA",
+      "zip" : "94612"
+   },
+   "vba_343f" : {
+      "address_1" : "3046 Prospect Park",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Rancho Cordova",
+      "state" : "CA",
+      "zip" : "95670"
+   },
+   "vba_344" : {
+      "address_1" : "11000 Wilshire Blvd.",
+      "address_2" : "Federal Building",
+      "address_3" : null,
+      "city" : "Los Angeles",
+      "state" : "CA",
+      "zip" : "90024"
+   },
+   "vba_345" : {
+      "address_1" : "3333 North Central Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Phoenix",
+      "state" : "AZ",
+      "zip" : "85012"
+   },
+   "vba_346" : {
+      "address_1" : "915 Second Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Seattle",
+      "state" : "WA",
+      "zip" : "98174"
+   },
+   "vba_347" : {
+      "address_1" : "444 W. Fort Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Boise",
+      "state" : "ID",
+      "zip" : "83702"
+   },
+   "vba_348" : {
+      "address_1" : "100 SW Main Street",
+      "address_2" : "Floor 2",
+      "address_3" : null,
+      "city" : "Portland",
+      "state" : "OR",
+      "zip" : "97204"
+   },
+   "vba_349" : {
+      "address_1" : "701 Clay Avenue",
+      "address_2" : "One Veterans Plaza",
+      "address_3" : null,
+      "city" : "Waco",
+      "state" : "TX",
+      "zip" : "76799"
+   },
+   "vba_349i" : {
+      "address_1" : "5001 N. Piedras Street",
+      "address_2" : "(Located in the El Paso VA Outpatient Clinic)",
+      "address_3" : null,
+      "city" : "El Paso",
+      "state" : "TX",
+      "zip" : "79930"
+   },
+   "vba_350" : {
+      "address_1" : "2200 Fort Roots Drive",
+      "address_2" : "Bldg. 65",
+      "address_3" : null,
+      "city" : "North Little Rock",
+      "state" : "AR",
+      "zip" : "72114"
+   },
+   "vba_351" : {
+      "address_1" : "125 South Main Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Muskogee",
+      "state" : "OK",
+      "zip" : "74401"
+   },
+   "vba_354" : {
+      "address_1" : "5460 Reno Corporate Dr.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Reno",
+      "state" : "NV",
+      "zip" : "89511"
+   },
+   "vba_354a" : {
+      "address_1" : "6900 North Pecos Rd",
+      "address_2" : "Room 1C301",
+      "address_3" : null,
+      "city" : "North Las Vegas",
+      "state" : "NV",
+      "zip" : "89086"
+   },
+   "vba_355" : {
+      "address_1" : "50 Carr 165",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Guaynabo",
+      "state" : "PR",
+      "zip" : "00968"
+   },
+   "vba_358" : {
+      "address_1" : "1501 Roxas Boulevard",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Pasay City",
+      "state" : "PH",
+      "zip" : "01302"
+   },
+   "vba_362" : {
+      "address_1" : "6900 Almeda Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Houston",
+      "state" : "TX",
+      "zip" : "77030"
+   },
+   "vba_372" : {
+      "address_1" : "1722 I Street, N.W.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Washington",
+      "state" : "DC",
+      "zip" : "20421"
+   },
+   "vba_373" : {
+      "address_1" : "275 Chestnut Street",
+      "address_2" : "Norris Cotton Federal Bldg.",
+      "address_3" : null,
+      "city" : "Manchester",
+      "state" : "NH",
+      "zip" : "03101"
+   },
+   "vba_377" : {
+      "address_1" : "8810 Rio San Diego Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "San Diego",
+      "state" : "CA",
+      "zip" : "92108"
+   },
+   "vba_402" : {
+      "address_1" : "810 Eastern Ave",
+      "address_2" : "1 VA Center, Bldg. 248",
+      "address_3" : null,
+      "city" : "Augusta",
+      "state" : "ME",
+      "zip" : "04330"
+   },
+   "vba_405" : {
+      "address_1" : "163 Veterans Drive",
+      "address_2" : "Mailing: 215 North Main St.",
+      "address_3" : null,
+      "city" : "White River Junction",
+      "state" : "VT",
+      "zip" : "05009"
+   },
+   "vba_436" : {
+      "address_1" : "3633 Veterans Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Fort Harrison",
+      "state" : "MT",
+      "zip" : "59636"
+   },
+   "vba_437" : {
+      "address_1" : "2101 Elm Street N",
+      "address_2" : "Building 40",
+      "address_3" : null,
+      "city" : "Fargo",
+      "state" : "ND",
+      "zip" : "58102"
+   },
+   "vba_438" : {
+      "address_1" : "2501 W 22nd Street",
+      "address_2" : "Building 38",
+      "address_3" : null,
+      "city" : "Sioux Falls",
+      "state" : "SD",
+      "zip" : "57105"
+   },
+   "vba_442" : {
+      "address_1" : "2360 E. Pershing Blvd.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Cheyenne",
+      "state" : "WY",
+      "zip" : "82001"
+   },
+   "vba_452" : {
+      "address_1" : "5500 E Kellogg",
+      "address_2" : "Bldg. 61",
+      "address_3" : null,
+      "city" : "Wichita",
+      "state" : "KS",
+      "zip" : "67218"
+   },
+   "vba_459" : {
+      "address_1" : "459 Patterson Road",
+      "address_2" : "E-Wing",
+      "address_3" : null,
+      "city" : "Honolulu",
+      "state" : "HI",
+      "zip" : "96819"
+   },
+   "vba_459h" : {
+      "address_1" : "770 East Sunset Blvd.",
+      "address_2" : "Suite 165",
+      "address_3" : null,
+      "city" : "Tamuning",
+      "state" : "GU",
+      "zip" : "96913"
+   },
+   "vba_459i" : {
+      "address_1" : "154 Waianuenue Ave.",
+      "address_2" : "Room 327",
+      "address_3" : null,
+      "city" : "Hilo",
+      "state" : "HI",
+      "zip" : "96720"
+   },
+   "vba_460" : {
+      "address_1" : "1601 Kirkwood Hwy",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Wilmington",
+      "state" : "DE",
+      "zip" : "19805"
+   },
+   "vba_463" : {
+      "address_1" : "1201 N. Muldoon Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Anchorage",
+      "state" : "AK",
+      "zip" : "99504"
+   },
+   "vc_0523V" : {
+      "address_1" : "2119 West Lincoln Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Yakima",
+      "state" : "WA",
+      "zip" : "98902"
+   },
+   "vc_0616V" : {
+      "address_1" : "Ottoville Road",
+      "address_2" : "Equator Building",
+      "address_3" : null,
+      "city" : "Pago Pago",
+      "state" : "AS",
+      "zip" : "96799"
+   },
+   "vc_0633V" : {
+      "address_1" : "4485 Pahe'e Street",
+      "address_2" : "Suite 101",
+      "address_3" : null,
+      "city" : "Lihue",
+      "state" : "HI",
+      "zip" : "96765"
+   },
+   "vc_0634V" : {
+      "address_1" : "157 Ma's Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Kahului",
+      "state" : "HI",
+      "zip" : "96732"
+   },
+   "vc_0636V" : {
+      "address_1" : "Hale Ku'i Plaza, 73-4976 Kamanu Street",
+      "address_2" : "Suite 207",
+      "address_3" : null,
+      "city" : "Kailua-Kona",
+      "state" : "HI",
+      "zip" : "96740"
+   },
+   "vc_0701V" : {
+      "address_1" : "2203 McKinley Road",
+      "address_2" : "Suite 254",
+      "address_3" : null,
+      "city" : "Johnson City",
+      "state" : "TN",
+      "zip" : "37604"
+   },
+   "vc_0719V" : {
+      "address_1" : "1407 Union Avenue",
+      "address_2" : "Suite 410",
+      "address_3" : null,
+      "city" : "Memphis",
+      "state" : "TN",
+      "zip" : "38104"
+   },
+   "vc_0720V" : {
+      "address_1" : "1645 Downtown West Blvd #28",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Knoxville",
+      "state" : "TN",
+      "zip" : "37919"
+   },
+   "vha_402GA" : {
+      "address_1" : "163 Van Buren Road",
+      "address_2" : null,
+      "address_3" : "Suite 6",
+      "city" : "Caribou",
+      "state" : "ME",
+      "zip" : "04736-3567"
+   },
+   "vha_402HB" : {
+      "address_1" : "35 State Hospital Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Bangor",
+      "state" : "ME",
+      "zip" : "04401-8816"
+   },
+   "vha_438GA" : {
+      "address_1" : "1850 Royal Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Spirit Lake",
+      "state" : "IA",
+      "zip" : "51360-1092"
+   },
+   "vha_438GC" : {
+      "address_1" : "380 West Anchor Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Dakota Dunes",
+      "state" : "SD",
+      "zip" : "57049-5273"
+   },
+   "vha_459GH" : {
+      "address_1" : "Marina Heights Business Park - Garapan",
+      "address_2" : "Medical Associates of the Pacific",
+      "address_3" : "MH-II Building Suite 100 and 206",
+      "city" : "Saipan",
+      "state" : "MP",
+      "zip" : "96950-9998"
+   },
+   "vha_460HE" : {
+      "address_1" : "1909 New Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Northfield",
+      "state" : "NJ",
+      "zip" : "08225-1537"
+   },
+   "vha_538GB" : {
+      "address_1" : "840 Gallia Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Portsmouth",
+      "state" : "OH",
+      "zip" : "45662-4232"
+   },
+   "vha_539" : {
+      "address_1" : "3200 Vine Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Cincinnati",
+      "state" : "OH",
+      "zip" : "45220-2213"
+   },
+   "vha_542" : {
+      "address_1" : "1400 Black Horse Hill Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Coatesville",
+      "state" : "PA",
+      "zip" : "19320-2096"
+   },
+   "vha_556GD" : {
+      "address_1" : "8207 22nd Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Kenosha",
+      "state" : "WI",
+      "zip" : "53143-6206"
+   },
+   "vha_568" : {
+      "address_1" : "113 Comanche Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Fort Meade",
+      "state" : "SD",
+      "zip" : "57741-1002"
+   },
+   "vha_568A4" : {
+      "address_1" : "500 North Fifth Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Hot Springs",
+      "state" : "SD",
+      "zip" : "57747-1480"
+   },
+   "vha_585" : {
+      "address_1" : "325 East H Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Iron Mountain",
+      "state" : "MI",
+      "zip" : "49801-4760"
+   },
+   "vha_585GC" : {
+      "address_1" : "1110 10th Avenue",
+      "address_2" : null,
+      "address_3" : "Suite 101",
+      "city" : "Menominee",
+      "state" : "MI",
+      "zip" : "49858-3058"
+   },
+   "vha_595" : {
+      "address_1" : "1700 South Lincoln Avenue",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "Lebanon",
+      "state" : "PA",
+      "zip" : "17042-7529"
+   },
+   "vha_596" : {
+      "address_1" : "2250 Leestown Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Lexington",
+      "state" : "KY",
+      "zip" : "40511-1052"
+   },
+   "vha_596GA" : {
+      "address_1" : "300 Medpark Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Somerset",
+      "state" : "KY",
+      "zip" : "42503-3479"
+   },
+   "vha_596GB" : {
+      "address_1" : "333 Beacon Hill Road",
+      "address_2" : null,
+      "address_3" : "Suite 100",
+      "city" : "Morehead",
+      "state" : "KY",
+      "zip" : "40351-6182"
+   },
+   "vha_596GC" : {
+      "address_1" : "210 Black Gold Boulevard",
+      "address_2" : null,
+      "address_3" : "Suite 107",
+      "city" : "Hazard",
+      "state" : "KY",
+      "zip" : "41701-2620"
+   },
+   "vha_596GD" : {
+      "address_1" : "209 Pauline Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Berea",
+      "state" : "KY",
+      "zip" : "40403-8889"
+   },
+   "vha_603GF" : {
+      "address_1" : "619 West Main Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Clarkson",
+      "state" : "KY",
+      "zip" : "42726-7044"
+   },
+   "vha_607" : {
+      "address_1" : "2500 Overlook Terrace",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Madison",
+      "state" : "WI",
+      "zip" : "53705-2254"
+   },
+   "vha_607GC" : {
+      "address_1" : "2419 Morse Street",
+      "address_2" : null,
+      "address_3" : "Suite 120",
+      "city" : "Janesville",
+      "state" : "WI",
+      "zip" : "53545-0221"
+   },
+   "vha_607GD" : {
+      "address_1" : "1670 South Boulevard",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "Baraboo",
+      "state" : "WI",
+      "zip" : "53913-2937"
+   },
+   "vha_607GE" : {
+      "address_1" : "215 Corporate Drive",
+      "address_2" : "",
+      "address_3" : "Suite B",
+      "city" : "Beaver Dam",
+      "state" : "WI",
+      "zip" : "53916-3124"
+   },
+   "vha_618BY" : {
+      "address_1" : "3520 Tower Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Superior",
+      "state" : "WI",
+      "zip" : "54880-5335"
+   },
+   "vha_618GE" : {
+      "address_1" : "475 Chippewa Mall Drive",
+      "address_2" : null,
+      "address_3" : "Suite 418",
+      "city" : "Chippewa Falls",
+      "state" : "WI",
+      "zip" : "54729-5047"
+   },
+   "vha_618GH" : {
+      "address_1" : "15954 Rivers Edge Drive",
+      "address_2" : null,
+      "address_3" : "Suite 103",
+      "city" : "Hayward",
+      "state" : "WI",
+      "zip" : "54843-7800"
+   },
+   "vha_618GM" : {
+      "address_1" : "2700A College Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Rice Lake",
+      "state" : "WI",
+      "zip" : "54868-2449"
+   },
+   "vha_626GC" : {
+      "address_1" : "600 US 31 West Bypass",
+      "address_2" : "Fairview Plaza",
+      "address_3" : "Suite 12",
+      "city" : "Bowling Green",
+      "state" : "KY",
+      "zip" : "42101-4905"
+   },
+   "vha_626GF" : {
+      "address_1" : "6098 Debra Road",
+      "address_2" : null,
+      "address_3" : "6200 Building, Suite 5200",
+      "city" : "Chattanooga",
+      "state" : "TN",
+      "zip" : "37411-5702"
+   },
+   "vha_626GH" : {
+      "address_1" : "851 South Willow Avenue",
+      "address_2" : null,
+      "address_3" : "Suite 108",
+      "city" : "Cookeville",
+      "state" : "TN",
+      "zip" : "38501-4223"
+   },
+   "vha_626GJ" : {
+      "address_1" : "1002 South Virginia Street",
+      "address_2" : "Forbes Place",
+      "address_3" : "Second Floor",
+      "city" : "Hopkinsville",
+      "state" : "KY",
+      "zip" : "42240-3579"
+   },
+   "vha_636" : {
+      "address_1" : "4101 Woolworth Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Omaha",
+      "state" : "NE",
+      "zip" : "68105-1850"
+   },
+   "vha_636GD" : {
+      "address_1" : "101 Iowa Avenue West",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Marshalltown",
+      "state" : "IA",
+      "zip" : "50158-4768"
+   },
+   "vha_636GF" : {
+      "address_1" : "2826 West Locust Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Davenport",
+      "state" : "IA",
+      "zip" : "52804-3354"
+   },
+   "vha_636GH" : {
+      "address_1" : "945 Tower Park Drive",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "Waterloo",
+      "state" : "IA",
+      "zip" : "50701-9098"
+   },
+   "vha_636GJ" : {
+      "address_1" : "2600 Dodge Street",
+      "address_2" : null,
+      "address_3" : "Suite A1",
+      "city" : "Dubuque",
+      "state" : "IA",
+      "zip" : "52003-7159"
+   },
+   "vha_648GA" : {
+      "address_1" : "2650 Northeast Courtney Drive",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "Bend",
+      "state" : "OR",
+      "zip" : "97701-7639"
+   },
+   "vha_653GA" : {
+      "address_1" : "2191 Marion Street",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "North Bend",
+      "state" : "OR",
+      "zip" : "97459-2314"
+   },
+   "vha_653GB" : {
+      "address_1" : "840 Railroad Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Brookings",
+      "state" : "OR",
+      "zip" : "97415-9702"
+   },
+   "vha_657GJ" : {
+      "address_1" : "6211 East Waterford Boulevard",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Evansville",
+      "state" : "IN",
+      "zip" : "47715-2869"
+   },
+   "vha_657GL" : {
+      "address_1" : "2620 Perkins Creek Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Paducah",
+      "state" : "KY",
+      "zip" : "42001-7494"
+   },
+   "vha_657GO" : {
+      "address_1" : "926 Veterans Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Hanson",
+      "state" : "KY",
+      "zip" : "42413-9401"
+   },
+   "vha_657GP" : {
+      "address_1" : "3400 New Hartford Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Owensboro",
+      "state" : "KY",
+      "zip" : "42303-1705"
+   },
+   "vha_660GA" : {
+      "address_1" : "500 South 11th Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Pocatello",
+      "state" : "ID",
+      "zip" : "83201-4835"
+   },
+   "vha_663GC" : {
+      "address_1" : "307 South 13th Street",
+      "address_2" : null,
+      "address_3" : "Suite 200",
+      "city" : "Mount Vernon",
+      "state" : "WA",
+      "zip" : "98274-4100"
+   },
+   "vha_663GE" : {
+      "address_1" : "1114 Georgiana Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Port Angeles",
+      "state" : "WA",
+      "zip" : "98362-4212"
+   },
+   "vha_666GB" : {
+      "address_1" : "4140 South Poplar Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Casper",
+      "state" : "WY",
+      "zip" : "82601-6104"
+   },
+   "vha_668" : {
+      "address_1" : "4815 North Assembly Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Spokane",
+      "state" : "WA",
+      "zip" : "99205-6185"
+   },
+   "vha_668GB" : {
+      "address_1" : "915 West Emma Avenue",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "Coeur d'Alene",
+      "state" : "ID",
+      "zip" : "83814-2531"
+   },
+   "vha_671BY" : {
+      "address_1" : "5788 Eckert Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "San Antonio",
+      "state" : "TX",
+      "zip" : "78240-3900"
+   },
+   "vha_676" : {
+      "address_1" : "500 East Veterans Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Tomah",
+      "state" : "WI",
+      "zip" : "54660-3105"
+   },
+   "vha_676GA" : {
+      "address_1" : "515 South 32 Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Wausau",
+      "state" : "WI",
+      "zip" : "54401-4074"
+   },
+   "vha_676GC" : {
+      "address_1" : "2600 State Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "La Crosse",
+      "state" : "WI",
+      "zip" : "54601-6157"
+   },
+   "vha_676GD" : {
+      "address_1" : "555 West Grand Avenue",
+      "address_2" : null,
+      "address_3" : "Suite B-2",
+      "city" : "Wisconsin Rapids",
+      "state" : "WI",
+      "zip" : "54495-2736"
+   },
+   "vha_676GE" : {
+      "address_1" : "8 Johnson Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Owen",
+      "state" : "WI",
+      "zip" : "54460-9534"
+   },
+   "vha_687" : {
+      "address_1" : "77 Wainwright Drive",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Walla Walla",
+      "state" : "WA",
+      "zip" : "99362-3975"
+   },
+   "vha_687GC" : {
+      "address_1" : "202 12th Street",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "La Grande",
+      "state" : "OR",
+      "zip" : "97850-2879"
+   },
+   "vha_692" : {
+      "address_1" : "8495 Crater Lake Highway",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "White City",
+      "state" : "OR",
+      "zip" : "97503-3011"
+   },
+   "vha_692GA" : {
+      "address_1" : "2225 North Eldorado Boulevard",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Klamath Falls",
+      "state" : "OR",
+      "zip" : "97601-6417"
+   },
+   "vha_693" : {
+      "address_1" : "1111 East End Boulevard",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Wilkes-Barre",
+      "state" : "PA",
+      "zip" : "18711-0030"
+   },
+   "vha_695BY" : {
+      "address_1" : "10 Tri-Park Way",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Appleton",
+      "state" : "WI",
+      "zip" : "54914-1658"
+   },
+   "vha_695GA" : {
+      "address_1" : "21425 Spring Street",
+      "address_2" : "",
+      "address_3" : null,
+      "city" : "Union Grove",
+      "state" : "WI",
+      "zip" : "53182-9707"
+   },
+   "vha_695GD" : {
+      "address_1" : "2851 University Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Green Bay",
+      "state" : "WI",
+      "zip" : "54311-5855"
+   },
+   "vha_740GB" : {
+      "address_1" : "901 East Hackberry Avenue",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "McAllen",
+      "state" : "TX",
+      "zip" : "78501-6502"
+   },
+   "vha_757" : {
+      "address_1" : "420 North James Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Columbus",
+      "state" : "OH",
+      "zip" : "43219-1834"
+   }
+}

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -416,7 +416,7 @@
       "zip" : "77030"
    },
    "vba_372" : {
-      "address_1" : "1722 I Street, N.W.",
+      "address_1" : "425 I Street, N.W.",
       "address_2" : null,
       "address_3" : null,
       "city" : "Washington",

--- a/spec/models/hearing_location_spec.rb
+++ b/spec/models/hearing_location_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe HearingLocation do
+  describe "#street_address" do
+    it "pulls from constants file" do
+      hearing_location = described_class.new(facility_id: "vba_307", address: "123 Main St")
+
+      expect(hearing_location.street_address).to eq("130 South Elmwood Ave, Suite 601")
+    end
+  end
+end

--- a/spec/models/hearing_location_spec.rb
+++ b/spec/models/hearing_location_spec.rb
@@ -9,5 +9,11 @@ describe HearingLocation do
 
       expect(hearing_location.street_address).to eq("130 South Elmwood Ave, Suite 601")
     end
+
+    it "rejects nulls and blank values" do
+      hearing_location = described_class.new(facility_id: "vba_317")
+
+      expect(hearing_location.street_address).to eq("9500 Bay Pines Blvd.")
+    end
   end
 end


### PR DESCRIPTION
Hearings API relies on accurate street address. We have a bug where we are truncating street address in the `hearing_location.address` field. This change pulls the street address from a .json constants file instead.