### PR TITLE
consider modifiers on recently closed claims taken

### DIFF
--- a/app/models/end_product.rb
+++ b/app/models/end_product.rb
@@ -266,6 +266,10 @@ class EndProduct
     status_type_code == "CAN"
   end
 
+  def recent?
+    [Time.zone.today, 1.day.ago.to_date].include? last_action_date
+  end
+
   def contentions
     @contentions ||= claim_id ? VBMSService.fetch_contentions(claim_id: claim_id) : nil
   end

--- a/app/services/reviews_with_duplicate_ep_error_checker.rb
+++ b/app/services/reviews_with_duplicate_ep_error_checker.rb
@@ -25,7 +25,7 @@ class ReviewsWithDuplicateEpErrorChecker < DataIntegrityChecker
       review.veteran.end_products.select do |ep|
         ep.claim_type_code.include?(type) &&
           %w[CAN CLR].include?(ep.status_type_code) &&
-          [Time.zone.today, 1.day.ago.to_date].include?(ep.last_action_date)
+          ep.recent?
       end.empty?
     end
   end

--- a/app/workflows/end_product_modifier_finder.rb
+++ b/app/workflows/end_product_modifier_finder.rb
@@ -47,7 +47,7 @@ class EndProductModifierFinder
   end
 
   def taken_modifiers
-    @taken_modifiers ||= veteran.end_products.select(&:active?).map(&:modifier)
+    @taken_modifiers ||= veteran.end_products.select { |ep| ep.active? || ep.recent? }.map(&:modifier)
   end
 
   def correction_end_product?


### PR DESCRIPTION
Resolves #11043

### Description
Consider a modifier taken if its end product was acted upon in the last 24-48 hours.