### PR TITLE
Async job notes

### DIFF
--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -26,6 +26,16 @@ class AsyncableJobsController < ApplicationController
     render json: job.asyncable_ui_hash
   end
 
+  def add_note
+    job_note = JobNote.create!(
+      job: job,
+      user: current_user,
+      note: allowed_params[:note],
+      send_to_intake_user: allowed_params[:send_to_intake_user]
+    )
+    render json: job_note.ui_hash
+  end
+
   private
 
   helper_method :jobs, :job, :allowed_params, :pagination
@@ -83,6 +93,6 @@ class AsyncableJobsController < ApplicationController
   end
 
   def allowed_params
-    params.permit(:asyncable_job_klass, :id, :page)
+    params.permit(:asyncable_job_klass, :id, :page, :note, :send_to_intake_user)
   end
 end

--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -12,6 +12,7 @@ class BoardGrantEffectuation < ApplicationRecord
   belongs_to :granted_decision_issue, class_name: "DecisionIssue"
   belongs_to :decision_document
   belongs_to :end_product_establishment
+  has_many :job_notes, as: :job
 
   validates :granted_decision_issue, presence: true
   before_save :hydrate_from_granted_decision_issue, on: :create

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -10,6 +10,7 @@ class DecisionDocument < ApplicationRecord
   belongs_to :appeal, polymorphic: true
   has_many :end_product_establishments, as: :source
   has_many :effectuations, class_name: "BoardGrantEffectuation"
+  has_many :job_notes, as: :job
 
   validates :citation_number, format: { with: /\AA?\d{8}\Z/i }
 

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -15,6 +15,7 @@ class DecisionReview < ApplicationRecord
   has_many :tasks, as: :appeal, dependent: :destroy
   has_many :request_issues_updates, as: :review, dependent: :destroy
   has_one :intake, as: :detail
+  has_many :job_notes, as: :job
 
   cache_attribute :cached_serialized_ratings, cache_key: :ratings_cache_key, expires_in: 1.day do
     ratings_with_issues.map(&:serialize)

--- a/app/models/job_note.rb
+++ b/app/models/job_note.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class JobNote < ApplicationRecord
+  belongs_to :user
+  belongs_to :job, polymorphic: true
+
+  scope :newest_first, -> { order(created_at: :desc) }
+
+  def ui_hash
+    {
+      id: id,
+      user: user.css_id,
+      created_at: created_at,
+      note: note,
+      sent_to_intake_user: send_to_intake_user
+    }
+  end
+end

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -18,6 +18,7 @@ class RequestIssue < ApplicationRecord
   has_many :remand_reasons, through: :decision_issues
   has_many :duplicate_but_ineligible, class_name: "RequestIssue", foreign_key: "ineligible_due_to_id"
   has_many :hearing_issue_notes
+  has_many :job_notes, as: :job
   has_one :legacy_issue_optin
   belongs_to :correction_request_issue, class_name: "RequestIssue", foreign_key: "corrected_by_request_issue_id"
   belongs_to :ineligible_due_to, class_name: "RequestIssue", foreign_key: "ineligible_due_to_id"

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -8,6 +8,7 @@ class RequestIssuesUpdate < ApplicationRecord
 
   belongs_to :user
   belongs_to :review, polymorphic: true
+  has_many :job_notes, as: :job
 
   attr_writer :request_issues_data
   attr_reader :error_code

--- a/app/views/asyncable_jobs/show.html.erb
+++ b/app/views/asyncable_jobs/show.html.erb
@@ -7,6 +7,7 @@
     flash: flash,
     serverJobs: {
       job: job.asyncable_ui_hash,
+      notes: job.job_notes.newest_first.map(&:ui_hash),
       models: AsyncableJobs.models.map(&:name),
       fetchedAt: Time.zone.now,
       asyncableJobKlass: allowed_params[:asyncable_job_klass]

--- a/client/app/asyncableJobs/components/JobNotes.jsx
+++ b/client/app/asyncableJobs/components/JobNotes.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import Button from '../../components/Button';
 import ApiUtil from '../../util/ApiUtil';
@@ -18,7 +17,7 @@ class NewNoteForm extends React.PureComponent {
     this.state = {
       saveInProgress: false,
       checkboxSelected: false,
-      newNote: ""
+      newNote: ''
     };
   }
 
@@ -31,7 +30,7 @@ class NewNoteForm extends React.PureComponent {
     const data = {
       note: this.state.newNote,
       send_to_intake_user: this.state.checkboxSelected
-    }
+    };
 
     ApiUtil.post(url, { data }).
       then(
@@ -41,7 +40,7 @@ class NewNoteForm extends React.PureComponent {
           form.setState({
             saveInProgress: false,
             checkboxSelected: false,
-            newNote: ""
+            newNote: ''
           });
 
           // add note to current page.
@@ -66,7 +65,7 @@ class NewNoteForm extends React.PureComponent {
   render = () => {
     return <div className="comment-size-container">
       <TextareaField
-        hideLabel={true}
+        hideLabel
         name="Add Note"
         aria-label="Add Note"
         onChange={this.onChange}
@@ -94,6 +93,8 @@ class NewNoteForm extends React.PureComponent {
 }
 
 NewNoteForm.propTypes = {
+  job: PropTypes.object,
+  notes: PropTypes.array,
   onSave: PropTypes.func,
   onCancel: PropTypes.func
 };
@@ -130,5 +131,6 @@ export default class JobNotes extends React.PureComponent {
 }
 
 JobNotes.propTypes = {
+  job: PropTypes.object,
   notes: PropTypes.array
 };

--- a/client/app/asyncableJobs/components/JobNotes.jsx
+++ b/client/app/asyncableJobs/components/JobNotes.jsx
@@ -69,6 +69,7 @@ class NewNoteForm extends React.PureComponent {
         name="Add Note"
         aria-label="Add Note"
         onChange={this.onChange}
+        value={this.state.newNote}
       />
       <div className="comment-save-button-container">
         <span className="cf-right-side">
@@ -105,19 +106,19 @@ export default class JobNotes extends React.PureComponent {
       <h3>Notes</h3>
       <NewNoteForm job={job} notes={this} />
       <div>
-        { notes.map((note) => {
-          return <div className="job-note" key={`job-note-container-${note.index}`}>
+        { notes.map((note, index) => {
+          return <div className="job-note" key={`job-note-container-${index}`}>
             <div
               className="job-note-details"
-              data-key={`job-note-${note.index}`}
-              key={`job-note-${note.index}`}
+              data-key={`job-note-${index}`}
+              key={`job-note-${index}`}
               id={`job-note-${note.id}`}>
 
               <div>
                 <span className="job-note-time">{moment(note.created_at).format(DATE_TIME_FORMAT)}</span>
                 <span className="job-note-user">{note.user}</span>
               </div>
-              <div>{note.note}</div>
+              <div className="job-note-note">{note.note}</div>
 
             </div>
           </div>;

--- a/client/app/asyncableJobs/components/JobNotes.jsx
+++ b/client/app/asyncableJobs/components/JobNotes.jsx
@@ -1,0 +1,132 @@
+import _ from 'lodash';
+import React from 'react';
+import Button from '../../components/Button';
+import ApiUtil from '../../util/ApiUtil';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+
+const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
+
+import Checkbox from '../../components/Checkbox';
+import TextareaField from '../../components/TextareaField';
+
+class NewNoteForm extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      saveInProgress: false,
+      checkboxSelected: false,
+      newNote: ""
+    };
+  }
+
+  onSave = () => {
+    const job = this.props.job;
+    const url = `/asyncable_jobs/${job.klass}/jobs/${job.id}/note`;
+    const form = this;
+    const notes = this.props.notes;
+
+    const data = {
+      note: this.state.newNote,
+      send_to_intake_user: this.state.checkboxSelected
+    }
+
+    ApiUtil.post(url, { data }).
+      then(
+        (response) => {
+          const newNote = JSON.parse(response.text);
+
+          form.setState({
+            saveInProgress: false,
+            checkboxSelected: false,
+            newNote: ""
+          });
+
+          // add note to current page.
+          notes.props.notes.unshift(newNote);
+          notes.setState({ reloaded: true });
+        }
+      );
+  }
+
+  onChange = (event) => {
+    this.setState({ newNote: event });
+  }
+
+  onCheckboxChange = (event) => {
+    this.setState({ checkboxSelected: event });
+  }
+
+  isSaveDisabled = () => {
+    return this.state.saveInProgress || this.state.newNote.trim().length === 0;
+  }
+
+  render = () => {
+    return <div className="comment-size-container">
+      <TextareaField
+        hideLabel={true}
+        name="Add Note"
+        aria-label="Add Note"
+        onChange={this.onChange}
+      />
+      <div className="comment-save-button-container">
+        <span className="cf-right-side">
+          <Checkbox
+            label="Send as message to user"
+            name="send_to_intake_user"
+            onChange={this.onCheckboxChange}
+            disabled={this.isSaveDisabled()}
+          />
+          <Button
+            name="save"
+            disabled={this.isSaveDisabled()}
+            onClick={this.onSave}>
+              Add Note
+          </Button>
+        </span>
+      </div>
+    </div>;
+  }
+
+}
+
+NewNoteForm.propTypes = {
+  onSave: PropTypes.func,
+  onCancel: PropTypes.func
+};
+
+export default class JobNotes extends React.PureComponent {
+
+  render = () => {
+    const { notes, job } = this.props;
+
+    return <div className="job-notes">
+      <h3>Notes</h3>
+      <NewNoteForm job={job} notes={this} />
+      <div>
+        { notes.map((note) => {
+          return <div className="job-note" key={`job-note-container-${note.index}`}>
+            <div
+              className="job-note-details"
+              data-key={`job-note-${note.index}`}
+              key={`job-note-${note.index}`}
+              id={`job-note-${note.id}`}>
+
+              <div>
+                <span className="job-note-time">{moment(note.created_at).format(DATE_TIME_FORMAT)}</span>
+                <span className="job-note-user">{note.user}</span>
+              </div>
+              <div>{note.note}</div>
+
+            </div>
+          </div>;
+        })}
+      </div>
+    </div>;
+  }
+}
+
+JobNotes.propTypes = {
+  notes: PropTypes.array
+};

--- a/client/app/asyncableJobs/components/JobNotes.jsx
+++ b/client/app/asyncableJobs/components/JobNotes.jsx
@@ -4,6 +4,7 @@ import Button from '../../components/Button';
 import ApiUtil from '../../util/ApiUtil';
 import PropTypes from 'prop-types';
 import moment from 'moment';
+import ReactMarkdown from 'react-markdown';
 
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
@@ -118,7 +119,7 @@ export default class JobNotes extends React.PureComponent {
                 <span className="job-note-time">{moment(note.created_at).format(DATE_TIME_FORMAT)}</span>
                 <span className="job-note-user">{note.user}</span>
               </div>
-              <div className="job-note-note">{note.note}</div>
+              <div className="job-note-note"><ReactMarkdown source={note.note} /></div>
 
             </div>
           </div>;

--- a/client/app/asyncableJobs/components/JobNotes.jsx
+++ b/client/app/asyncableJobs/components/JobNotes.jsx
@@ -7,7 +7,7 @@ import ReactMarkdown from 'react-markdown';
 
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
-import Checkbox from '../../components/Checkbox';
+// import Checkbox from '../../components/Checkbox';  // enable once supported
 import TextareaField from '../../components/TextareaField';
 
 class NewNoteForm extends React.PureComponent {
@@ -31,6 +31,8 @@ class NewNoteForm extends React.PureComponent {
       note: this.state.newNote,
       send_to_intake_user: this.state.checkboxSelected
     };
+
+    notes.setState({ reloaded: false });
 
     ApiUtil.post(url, { data }).
       then(
@@ -62,6 +64,25 @@ class NewNoteForm extends React.PureComponent {
     return this.state.saveInProgress || this.state.newNote.trim().length === 0;
   }
 
+  isCheckboxChecked = () => {
+    return this.state.checkboxSelected;
+  }
+
+  sendToUserCheckbox = () => {
+    return <span />;
+
+    // enable once server supports it
+  /*
+    return <Checkbox
+      label="Send as message to user"
+      name="send_to_intake_user"
+      value={this.isCheckboxChecked()}
+      onChange={this.onCheckboxChange}
+      disabled={this.isSaveDisabled()}
+    />;
+  */
+  }
+
   render = () => {
     return <div className="comment-size-container">
       <TextareaField
@@ -73,12 +94,7 @@ class NewNoteForm extends React.PureComponent {
       />
       <div className="comment-save-button-container">
         <span className="cf-right-side">
-          <Checkbox
-            label="Send as message to user"
-            name="send_to_intake_user"
-            onChange={this.onCheckboxChange}
-            disabled={this.isSaveDisabled()}
-          />
+          { this.sendToUserCheckbox() }
           <Button
             name="save"
             disabled={this.isSaveDisabled()}
@@ -94,7 +110,7 @@ class NewNoteForm extends React.PureComponent {
 
 NewNoteForm.propTypes = {
   job: PropTypes.object,
-  notes: PropTypes.array,
+  notes: PropTypes.object,
   onSave: PropTypes.func,
   onCancel: PropTypes.func
 };

--- a/client/app/asyncableJobs/pages/JobPage.jsx
+++ b/client/app/asyncableJobs/pages/JobPage.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 
 import AsyncModelNav from '../components/AsyncModelNav';
 import JobRestartButton from '../components/JobRestartButton';
+import JobNotes from '../components/JobNotes';
 
 const DATE_TIME_FORMAT = 'ddd MMM DD HH:mm:ss YYYY';
 
@@ -26,7 +27,7 @@ class AsyncableJobPage extends React.PureComponent {
   }
 
   render = () => {
-    const { job } = this.props;
+    const { job, notes } = this.props;
 
     return <div className="cf-asyncable-job-table">
       <h1>{this.props.asyncableJobKlass} Job {job.id}</h1>
@@ -74,6 +75,9 @@ class AsyncableJobPage extends React.PureComponent {
       <div>
         <JobRestartButton job={job} page={this} />
       </div>
+      <div>
+        <JobNotes job={job} notes={notes} />
+      </div>
     </div>;
   }
 }
@@ -81,6 +85,7 @@ class AsyncableJobPage extends React.PureComponent {
 const JobPage = connect(
   (state) => ({
     job: state.job,
+    notes: state.notes,
     fetchedAt: state.fetchedAt,
     models: state.models,
     asyncableJobKlass: state.asyncableJobKlass

--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -13,3 +13,28 @@
 .cf-asyncable-jobs-table {
   font-size: 90%;
 }
+
+.job-notes {
+  margin-top: 16px;
+
+  .job-note {
+    border-top: 1px solid $color-gray-light;
+    padding: 6px;
+
+    .job-note-time {
+      font-style: italic;
+      font-size: 95%;
+    }
+
+    .job-note-user {
+      margin-left: 1rem;
+      font-style: italic;
+      font-size: 95%;
+    }
+  }
+
+  .cf-form-checkboxes, .cf-form-checkbox {
+    display: inline-block;
+    margin-right: 1rem;
+  }
+}

--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -19,7 +19,7 @@
 
   .job-note {
     border-top: 1px solid $color-gray-light;
-    padding: 6px;
+    padding: 16px 0;
 
     .job-note-time {
       font-style: italic;
@@ -30,6 +30,10 @@
       margin-left: 1rem;
       font-style: italic;
       font-size: 95%;
+    }
+
+    .job-note-note {
+      white-space: pre;
     }
   }
 

--- a/client/app/styles/_jobs.scss
+++ b/client/app/styles/_jobs.scss
@@ -37,7 +37,8 @@
     }
   }
 
-  .cf-form-checkboxes, .cf-form-checkbox {
+  .cf-form-checkboxes,
+  .cf-form-checkbox {
     display: inline-block;
     margin-right: 1rem;
   }

--- a/client/package.json
+++ b/client/package.json
@@ -70,6 +70,7 @@
     "react-draft-wysiwyg": "^1.12.11",
     "react-highlight-words": "^0.8.0",
     "react-hot-loader": "^3.0.0-beta.6",
+    "react-markdown": "^4.2.2",
     "react-on-rails": "^8.0.6",
     "react-redux": "5.1.1",
     "react-router": "^5.0.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2670,6 +2670,14 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "~1.1.1"
     entities "~1.1.1"
 
+dom-serializer@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.1.tgz#13650c850daffea35d8b626a4cfc4d3a17643fdb"
+  integrity sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==
+  dependencies:
+    domelementtype "^2.0.1"
+    entities "^2.0.0"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
@@ -2687,6 +2695,11 @@ domelementtype@1, domelementtype@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
 
+domelementtype@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
+  integrity sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ==
+
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
@@ -2696,6 +2709,13 @@ domhandler@^2.3.0:
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.1.tgz#892e47000a99be55bbf3774ffea0561d8879c259"
   dependencies:
     domelementtype "1"
+
+domhandler@^3.0, domhandler@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-3.0.0.tgz#51cd13efca31da95bbb0c5bee3a48300e333b3e9"
+  integrity sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==
+  dependencies:
+    domelementtype "^2.0.1"
 
 dompurify@^1.0.3:
   version "1.0.3"
@@ -2711,6 +2731,15 @@ domutils@1.5.1, domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+domutils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-2.0.0.tgz#15b8278e37bfa8468d157478c58c367718133c08"
+  integrity sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==
+  dependencies:
+    dom-serializer "^0.2.1"
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
 
 draft-js@^0.10.5:
   version "0.10.5"
@@ -2849,6 +2878,11 @@ ent@~2.2.0:
 entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
+
+entities@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
 enzyme-adapter-react-16@^1.14.0:
   version "1.14.0"
@@ -4133,6 +4167,16 @@ html-to-draftjs@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/html-to-draftjs/-/html-to-draftjs-1.3.0.tgz#9de3de81d8ff801f167ef34a6b93cbd7a9c2f85c"
 
+html-to-react@^1.3.4:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/html-to-react/-/html-to-react-1.4.2.tgz#7b628ab56cd63a52f2d0b79d0fa838a51f088a57"
+  integrity sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==
+  dependencies:
+    domhandler "^3.0"
+    htmlparser2 "^4.0"
+    lodash.camelcase "^4.3.0"
+    ramda "^0.26"
+
 htmlescape@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/htmlescape/-/htmlescape-1.1.1.tgz#3a03edc2214bca3b66424a3e7959349509cb0351"
@@ -4147,6 +4191,16 @@ htmlparser2@^3.9.1:
     entities "^1.1.1"
     inherits "^2.0.1"
     readable-stream "^2.0.2"
+
+htmlparser2@^4.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-4.0.0.tgz#6034658db65b7713a572a9ebf79f650832dceec8"
+  integrity sha512-cChwXn5Vam57fyXajDtPXL1wTYc8JtLbr2TN76FYu05itVVVealxLowe2B3IEznJG4p9HAYn/0tJaRlGuEglFQ==
+  dependencies:
+    domelementtype "^2.0.1"
+    domhandler "^3.0.0"
+    domutils "^2.0.0"
+    entities "^2.0.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -5308,6 +5362,13 @@ md5@^2.1.0:
     crypt "~0.0.1"
     is-buffer "~1.1.1"
 
+mdast-add-list-metadata@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz#95e73640ce2fc1fa2dcb7ec443d09e2bfe7db4cf"
+  integrity sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==
+  dependencies:
+    unist-util-visit-parents "1.1.2"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -6186,6 +6247,18 @@ parse-entities@^1.0.2:
     is-decimal "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+parse-entities@^1.1.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
+  integrity sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
+
 parse-glob@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/parse-glob/-/parse-glob-3.0.4.tgz#b2c376cfb11f35513badd173ef0bb6e3a388391c"
@@ -6619,6 +6692,11 @@ ramda@^0.24.1:
   version "0.24.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
 
+ramda@^0.26:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+
 randexp@^0.4.2:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
@@ -6777,6 +6855,20 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-markdown@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.2.2.tgz#b378774fcffb354653db8749153fc8740f9ed2f1"
+  integrity sha512-/STJiRFmJuAIUdeBPp/VyO5bcenTIqP3LXuC3gYvregmYGKjnszGiFc2Ph0LsWC17Un3y/CT8TfxnwJT7v9EJw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
 
 react-on-rails@^8.0.6:
   version "8.0.6"
@@ -7145,6 +7237,27 @@ remark-parse@^4.0.0:
     is-word-character "^1.0.0"
     markdown-escapes "^1.0.0"
     parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
+remark-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
+  integrity sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==
+  dependencies:
+    collapse-white-space "^1.0.2"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.1.0"
     repeat-string "^1.5.4"
     state-toggle "^1.0.0"
     trim "0.0.1"
@@ -8472,6 +8585,11 @@ unist-util-is@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.1.tgz#0c312629e3f960c66e931e812d3d80e77010947b"
 
+unist-util-is@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-3.0.0.tgz#d9e84381c2468e82629e4a5be9d7d05a2dd324cd"
+  integrity sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==
+
 unist-util-remove-position@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.1.tgz#5a85c1555fc1ba0c101b86707d15e50fa4c871bb"
@@ -8482,11 +8600,30 @@ unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.1.tgz#3ccbdc53679eed6ecf3777dd7f5e3229c1b6aa3c"
 
+unist-util-visit-parents@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz#f6e3afee8bdbf961c0e6f028ea3c0480028c3d06"
+  integrity sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q==
+
+unist-util-visit-parents@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz#25e43e55312166f3348cae6743588781d112c1e9"
+  integrity sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==
+  dependencies:
+    unist-util-is "^3.0.0"
+
 unist-util-visit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.3.0.tgz#41ca7c82981fd1ce6c762aac397fc24e35711444"
   dependencies:
     unist-util-is "^2.1.1"
+
+unist-util-visit@^1.3.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.1.tgz#4724aaa8486e6ee6e26d7ff3c8685960d560b1e3"
+  integrity sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -198,6 +198,7 @@ Rails.application.routes.draw do
 
   resources :asyncable_jobs, param: :klass, only: [] do
     resources :jobs, controller: :asyncable_jobs, param: :id, only: [:index, :show, :update]
+    post "jobs/:id/note", to: "asyncable_jobs#add_note"
   end
   match '/jobs' => 'asyncable_jobs#index', via: [:get]
 

--- a/db/migrate/20190925205112_create_job_notes.rb
+++ b/db/migrate/20190925205112_create_job_notes.rb
@@ -4,7 +4,7 @@ class CreateJobNotes < ActiveRecord::Migration[5.1]
       t.belongs_to :job, polymorphic: true, null: false, comment: "The job to which the note applies"
       t.belongs_to :user, null: false, comment: "The user who created the note"
       t.timestamps null: false, comment: "Default created_at/updated_at"
-      t.string :note, null: false, comment: "The note"
+      t.text :note, null: false, comment: "The note"
       t.boolean :send_to_intake_user, default: false, comment: "Should the note trigger a message to the job intake user"
     end
   end

--- a/db/migrate/20190925205112_create_job_notes.rb
+++ b/db/migrate/20190925205112_create_job_notes.rb
@@ -1,0 +1,11 @@
+class CreateJobNotes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :job_notes do |t|
+      t.belongs_to :job, polymorphic: true, null: false, comment: "The job to which the note applies"
+      t.belongs_to :user, null: false, comment: "The user who created the note"
+      t.timestamps null: false, comment: "Default created_at/updated_at"
+      t.string :note, null: false, comment: "The note"
+      t.boolean :send_to_intake_user, default: false, comment: "Should the note trigger a message to the job intake user"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190924110338) do
+ActiveRecord::Schema.define(version: 20190925205112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -665,6 +665,18 @@ ActiveRecord::Schema.define(version: 20190924110338) do
     t.index ["user_id"], name: "index_intakes_on_user_id"
     t.index ["user_id"], name: "unique_index_to_avoid_multiple_intakes", unique: true, where: "(completed_at IS NULL)"
     t.index ["veteran_file_number"], name: "index_intakes_on_veteran_file_number"
+  end
+
+  create_table "job_notes", force: :cascade do |t|
+    t.datetime "created_at", null: false, comment: "Default created_at/updated_at"
+    t.bigint "job_id", null: false, comment: "The job to which the note applies"
+    t.string "job_type", null: false
+    t.text "note", null: false, comment: "The note"
+    t.boolean "send_to_intake_user", default: false, comment: "Should the note trigger a message to the job intake user"
+    t.datetime "updated_at", null: false, comment: "Default created_at/updated_at"
+    t.bigint "user_id", null: false, comment: "The user who created the note"
+    t.index ["job_type", "job_id"], name: "index_job_notes_on_job_type_and_job_id"
+    t.index ["user_id"], name: "index_job_notes_on_user_id"
   end
 
   create_table "judge_case_reviews", force: :cascade do |t|

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -76,6 +76,20 @@ feature "Asyncable Jobs index", :postgres do
       expect(page).to have_button("Restarted", disabled: true)
       expect(page).to have_content("Attempted n/a")
     end
+
+    it "displays and adds notes" do
+      note_one = hlr.job_notes << JobNote.new(note: "hello world", user: hlr_intake.user)
+
+      visit "/asyncable_jobs/HigherLevelReview/jobs/#{hlr.id}"
+
+      expect(page).to have_content("hello world")
+
+      fill_in "Add Note", with: "another note\nwith\n## markdown header!"
+      click_button "Add Note"
+
+      expect(page).to have_content("another note\nwith\nmarkdown header!")
+      expect(hlr.reload.job_notes.count).to eq(2)
+    end
   end
 
   describe "index page" do

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -78,7 +78,7 @@ feature "Asyncable Jobs index", :postgres do
     end
 
     it "displays and adds notes" do
-      note_one = hlr.job_notes << JobNote.new(note: "hello world", user: hlr_intake.user)
+      hlr.job_notes << JobNote.new(note: "hello world", user: hlr_intake.user)
 
       visit "/asyncable_jobs/HigherLevelReview/jobs/#{hlr.id}"
 


### PR DESCRIPTION
Resolves #12214 

### Description

Adds job notes for ad hoc annotation of async jobs.

This is intended for tracking errors and creating xrefs to GH tickets, YourIT tickets, etc.

*Schema Changes Only*

* [x] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
