### PR TITLE
Override name/address/zip for vba_372

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -72,6 +72,7 @@ detectors:
     enabled: false
   RepeatedConditional:
     exclude:
+      - HearingLocation
       - QueueConfig
       - RequestIssue
   TooManyInstanceVariables:

--- a/app/models/hearing_location.rb
+++ b/app/models/hearing_location.rb
@@ -3,8 +3,32 @@
 class HearingLocation < ApplicationRecord
   belongs_to :hearing, polymorphic: true
 
+  # backwards compat data fix for "central" office.
+  # we have mistakenly been using facility_id "vba_372"
+  # and should have been using the VACO RO (101) which does not have a facility_id
+  # For the purposes of the Hearings API, override name and address
+  # where appropriate till we can remove vba_372 from the list of eligible locations.
+  def name
+    return Constants::REGIONAL_OFFICE_INFORMATION["VACO"]["label"] if vba_372?
+
+    super
+  end
+
+  def zip_code
+    return Constants::REGIONAL_OFFICE_FACILITY_ADDRESS["VACO"]["zip"] if vba_372?
+
+    super
+  end
+
   def street_address
-    addr = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[facility_id]
-    %w[address_1 address_2 address_3].map { |line| addr[line] }.reject(&:blank?).join(", ")
+    key = vba_372? ? "VACO" : facility_id
+    addr = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[key]
+    addr["address_1"]
+  end
+
+  private
+
+  def vba_372?
+    facility_id == "vba_372"
   end
 end

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -416,12 +416,20 @@
       "zip" : "77030"
    },
    "vba_372" : {
-      "address_1" : "425 I Street, N.W.",
+      "address_1" : "1722 I Street, N.W.",
       "address_2" : null,
       "address_3" : null,
       "city" : "Washington",
       "state" : "DC",
       "zip" : "20421"
+   },
+   "VACO" : {
+      "address_1" : "425 I Street, N.W.",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "Washington",
+      "state" : "DC",
+      "zip" : "20001"
    },
    "vba_373" : {
       "address_1" : "275 Chestnut Street",

--- a/client/constants/REGIONAL_OFFICE_INFORMATION.json
+++ b/client/constants/REGIONAL_OFFICE_INFORMATION.json
@@ -909,11 +909,11 @@
     "alternate_locations": null
   },
   "VACO": {
-    "label": null,
+    "label": "Board of Veterans' Appeals CO Office",
     "city": "Washington",
     "state": "DC",
     "timezone": "America/New_York",
-    "hold_hearings": false,
+    "hold_hearings": true,
     "facility_locator_id": null,
     "alternate_locations": null
   },

--- a/client/constants/REGIONAL_OFFICE_INFORMATION.json
+++ b/client/constants/REGIONAL_OFFICE_INFORMATION.json
@@ -913,7 +913,7 @@
     "city": "Washington",
     "state": "DC",
     "timezone": "America/New_York",
-    "hold_hearings": true,
+    "hold_hearings": false,
     "facility_locator_id": null,
     "alternate_locations": null
   },

--- a/spec/models/hearing_location_spec.rb
+++ b/spec/models/hearing_location_spec.rb
@@ -7,13 +7,23 @@ describe HearingLocation do
     it "pulls from constants file" do
       hearing_location = described_class.new(facility_id: "vba_307", address: "123 Main St")
 
-      expect(hearing_location.street_address).to eq("130 South Elmwood Ave, Suite 601")
+      expect(hearing_location.street_address).to eq("130 South Elmwood Ave")
     end
 
     it "rejects nulls and blank values" do
       hearing_location = described_class.new(facility_id: "vba_317")
 
       expect(hearing_location.street_address).to eq("9500 Bay Pines Blvd.")
+    end
+  end
+
+  describe "vba_372" do
+    it "read name, street address and ZIP code from .json constants" do
+      hearing_location = described_class.new(facility_id: "vba_372", address: "123 Main St")
+
+      expect(hearing_location.street_address).to eq("425 I Street, N.W.")
+      expect(hearing_location.name).to eq("Board of Veterans' Appeals CO Office")
+      expect(hearing_location.zip_code).to eq("20001")
     end
   end
 end


### PR DESCRIPTION
Resolves #12251 

### Description

We need to override Hearing API responses for the BVA central office location, because we have been using the wrong facility_id for that physical space.

Also, we are only returning address line one, rather than concatenating all 3 address lines.