### PR TITLE
Return queue config to the front end for user queues

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -39,7 +39,7 @@ class TasksController < ApplicationController
   #      GET /tasks?user_id=xxx&role=judge
   def index
     tasks = QueueForRole.new(user_role).create(user: user).tasks
-    render json: { tasks: json_tasks(tasks) }
+    render json: { tasks: json_tasks(tasks), queue_config: queue_config }
   end
 
   # To create colocated task
@@ -152,6 +152,10 @@ class TasksController < ApplicationController
   end
 
   private
+
+  def queue_config
+    QueueConfig.new(assignee: user).to_hash_for_user(current_user)
+  end
 
   def verify_task_access
     if current_user.vso_employee? && task_classes.exclude?(InformalHearingPresentationTask.name.to_sym)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,6 +75,10 @@ class Organization < ApplicationRecord
     "#{path}/users"
   end
 
+  def default_active_tab
+    Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME
+  end
+
   def queue_tabs
     [
       unassigned_tasks_tab,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,7 +75,7 @@ class Organization < ApplicationRecord
     "#{path}/users"
   end
 
-  def default_active_tab
+  def self.default_active_tab
     Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME
   end
 

--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -18,10 +18,9 @@ class QueueConfig
 
   def to_hash_for_user(user)
     table_title = COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE
-    active_tab = Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME
     {
       table_title: assignee_is_org? ? format(COPY::ORGANIZATION_QUEUE_TABLE_TITLE, assignee.name) : table_title,
-      active_tab: assignee_is_org? ? active_tab : Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME,
+      active_tab: assignee.default_active_tab,
       tasks_per_page: TaskPager::TASKS_PER_PAGE,
       use_task_pages_api: use_task_pages_api?(user),
       tabs: tabs(user).map { |tab| attach_tasks_to_tab(tab, user) }

--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -18,9 +18,10 @@ class QueueConfig
 
   def to_hash_for_user(user)
     table_title = COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE
+    active_tab = Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME
     {
       table_title: assignee_is_org? ? format(COPY::ORGANIZATION_QUEUE_TABLE_TITLE, assignee.name) : table_title,
-      active_tab: Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME,
+      active_tab: assignee_is_org? ? active_tab : Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME,
       tasks_per_page: TaskPager::TASKS_PER_PAGE,
       use_task_pages_api: use_task_pages_api?(user),
       tabs: tabs(user).map { |tab| attach_tasks_to_tab(tab, user) }

--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -20,7 +20,7 @@ class QueueConfig
     table_title = COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE
     {
       table_title: assignee_is_org? ? format(COPY::ORGANIZATION_QUEUE_TABLE_TITLE, assignee.name) : table_title,
-      active_tab: assignee.default_active_tab,
+      active_tab: assignee.class.default_active_tab,
       tasks_per_page: TaskPager::TASKS_PER_PAGE,
       use_task_pages_api: use_task_pages_api?(user),
       tabs: tabs(user).map { |tab| attach_tasks_to_tab(tab, user) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,7 +293,7 @@ class User < ApplicationRecord
     ]
   end
 
-  def default_active_tab
+  def self.default_active_tab
     Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -293,6 +293,10 @@ class User < ApplicationRecord
     ]
   end
 
+  def default_active_tab
+    Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME
+  end
+
   def assigned_tasks_tab
     ::AssignedTasksTab.new(assignee: self, show_regional_office_column: show_regional_office_in_queue?)
   end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -152,6 +152,14 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(response.status).to eq 200
       end
 
+      it "should return queue config" do
+        get :index, params: { user_id: user.id, role: "unknown" }
+        expect(response.status).to eq 200
+        queue_config = JSON.parse(response.body)["queue_config"]
+
+        expect(queue_config.keys).to match_array(%w[table_title active_tab tasks_per_page use_task_pages_api tabs])
+      end
+
       context "and theres a task to return" do
         let!(:vacols_case) do
           create(

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -71,8 +71,16 @@ describe QueueConfig, :postgres do
     end
 
     describe "active_tab" do
-      it "is always the unassigned tab" do
+      it "is the unassigned tab" do
         expect(subject[:active_tab]).to eq(Constants.QUEUE_CONFIG.UNASSIGNED_TASKS_TAB_NAME)
+      end
+
+      context "when assigned to a user" do
+        let(:assignee) { user }
+
+        it "is the assigned tab" do
+          expect(subject[:active_tab]).to eq(Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME)
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #11697

### Description
Returns queue config to the front end for user queues

<img width="481" alt="Screen Shot 2019-10-01 at 10 58 22 AM" src="https://user-images.githubusercontent.com/45575454/65974129-6b3e6c80-e43a-11e9-8a4e-85992dcb0c08.png">

### Acceptance Criteria
- [ ] Returns queue config to the front end for user queues

### Testing Plan
1. Go to a user's queue
2. Ensure queue config is returned to the front end for user's queue