### PR TITLE
Close root tasks on legacy appeal dispatch

### DIFF
--- a/app/workflows/legacy_appeal_dispatch.rb
+++ b/app/workflows/legacy_appeal_dispatch.rb
@@ -18,7 +18,7 @@ class LegacyAppealDispatch
 
     if success
       create_decision_document_and_submit_for_processing!(params)
-      complete_dispatch_root_task!
+      complete_root_task!
     end
 
     FormResponse.new(success: success, errors: [errors.full_messages.join(", ")])
@@ -33,7 +33,7 @@ class LegacyAppealDispatch
     DecisionDocument.create!(params).tap(&:submit_for_processing!)
   end
 
-  def complete_dispatch_root_task!
+  def complete_root_task!
     @appeal.root_task.update!(status: Constants.TASK_STATUSES.completed)
   end
 end

--- a/app/workflows/legacy_appeal_dispatch.rb
+++ b/app/workflows/legacy_appeal_dispatch.rb
@@ -16,7 +16,10 @@ class LegacyAppealDispatch
   def call
     @success = valid?
 
-    create_decision_document_and_submit_for_processing!(params) if success
+    if success
+      create_decision_document_and_submit_for_processing!(params)
+      complete_dispatch_root_task!
+    end
 
     FormResponse.new(success: success, errors: [errors.full_messages.join(", ")])
   end
@@ -28,5 +31,9 @@ class LegacyAppealDispatch
 
   def create_decision_document_and_submit_for_processing!(params)
     DecisionDocument.create!(params).tap(&:submit_for_processing!)
+  end
+
+  def complete_dispatch_root_task!
+    @appeal.root_task.update!(status: Constants.TASK_STATUSES.completed)
   end
 end

--- a/spec/models/tasks/bva_dispatch_task_spec.rb
+++ b/spec/models/tasks/bva_dispatch_task_spec.rb
@@ -103,7 +103,7 @@ describe BvaDispatchTask, :all_dbs do
 
         before { create(:root_task, appeal: legacy_appeal) }
 
-        it "should not complete the BvaDispatchTask and but should close the root task" do
+        it "should not complete the BvaDispatchTask but should close the root task" do
           allow(ProcessDecisionDocumentJob).to receive(:perform_later)
 
           BvaDispatchTask.outcode(legacy_appeal, params_legacy, user)

--- a/spec/models/tasks/bva_dispatch_task_spec.rb
+++ b/spec/models/tasks/bva_dispatch_task_spec.rb
@@ -101,13 +101,19 @@ describe BvaDispatchTask, :all_dbs do
           p
         end
 
-        it "should not complete the BvaDispatchTask and the task assigned to the BvaDispatch org" do
+        before { create(:root_task, appeal: legacy_appeal) }
+
+        it "should not complete the BvaDispatchTask and but should close the root task" do
           allow(ProcessDecisionDocumentJob).to receive(:perform_later)
 
           BvaDispatchTask.outcode(legacy_appeal, params_legacy, user)
 
           tasks = BvaDispatchTask.where(appeal: legacy_appeal, assigned_to: user)
           expect(tasks.length).to eq(0)
+
+          root_tasks = RootTask.where(appeal: legacy_appeal)
+          expect(root_tasks.length).to eq(1)
+          expect(root_tasks.first.status).to eq("completed")
 
           decision_document = DecisionDocument.find_by(appeal_id: legacy_appeal.id)
 


### PR DESCRIPTION
Resolves #12021

### Description
Closes the root task on a legacy appeal when dispatched

### Acceptance Criteria
- [ ] The root task on a legacy appeal is completed when appeal is dispatched