### PR TITLE
do not save changesets for documents and annotations

### DIFF
--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -5,7 +5,7 @@ class Annotation < ApplicationRecord
   belongs_to :user
   validates :comment, presence: true
 
-  has_paper_trail
+  has_paper_trail, save_changes: false
 
   def to_hash
     serializable_hash(

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -5,7 +5,7 @@ class Annotation < ApplicationRecord
   belongs_to :user
   validates :comment, presence: true
 
-  has_paper_trail, save_changes: false
+  has_paper_trail save_changes: false, on: [:update, :destroy]
 
   def to_hash
     serializable_hash(

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,7 +5,8 @@ class Document < ApplicationRecord
   has_many :document_views
   has_many :documents_tags
   has_many :tags, through: :documents_tags
-  has_paper_trail only: [:description, :category_case_summary, :category_medical, :category_other, :category_procedural]
+  has_paper_trail only: [:description, :category_case_summary, :category_medical, :category_other, :category_procedural],
+                  save_changes: false
 
   self.inheritance_column = nil
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,7 +5,11 @@ class Document < ApplicationRecord
   has_many :document_views
   has_many :documents_tags
   has_many :tags, through: :documents_tags
-  has_paper_trail only: [:description, :category_case_summary, :category_medical, :category_other, :category_procedural],
+  has_paper_trail only: [:description,
+                         :category_case_summary,
+                         :category_medical,
+                         :category_other,
+                         :category_procedural],
                   on: [:update, :destroy], save_changes: false
 
   self.inheritance_column = nil

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -6,7 +6,7 @@ class Document < ApplicationRecord
   has_many :documents_tags
   has_many :tags, through: :documents_tags
   has_paper_trail only: [:description, :category_case_summary, :category_medical, :category_other, :category_procedural],
-                  save_changes: false
+                  on: [:update, :destroy], save_changes: false
 
   self.inheritance_column = nil
 

--- a/app/models/documents_tag.rb
+++ b/app/models/documents_tag.rb
@@ -4,5 +4,5 @@ class DocumentsTag < ApplicationRecord
   belongs_to :document
   belongs_to :tag
 
-  has_paper_trail, save_changes: false
+  has_paper_trail save_changes: false, on: [:update, :destroy]
 end

--- a/app/models/documents_tag.rb
+++ b/app/models/documents_tag.rb
@@ -4,5 +4,5 @@ class DocumentsTag < ApplicationRecord
   belongs_to :document
   belongs_to :tag
 
-  has_paper_trail
+  has_paper_trail, save_changes: false
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -299,13 +299,13 @@ describe Document, :postgres do
   context "versioning" do
     it "saves new version on update description" do
       document.save
-      expect(document.versions.length).to eq 1
+      expect(document.versions.length).to eq 0
       expect(document.description).to eq("Document description")
 
       document.description = "Updated description"
       document.save
 
-      expect(document.versions.length).to eq 2
+      expect(document.versions.length).to eq 1
       expect(document.reload.description).to eq("Updated description")
     end
   end


### PR DESCRIPTION
Minimize writes to the `versions` table by only creating a new record when something is updated or destroyed.