### PR TITLE
Filter out nil hearing locations

### DIFF
--- a/app/controllers/api/v2/hearings_controller.rb
+++ b/app/controllers/api/v2/hearings_controller.rb
@@ -13,9 +13,8 @@ class Api::V2::HearingsController < Api::ApplicationController
     rescue ActiveRecord::RecordNotFound
       return hearing_day_not_found
     end
-
     hash_serialized = Api::V2::HearingSerializer.new(
-      hearings.reject { |hearing| hearing.hearing_location.nil? }, is_collection: true
+      hearings.select { |hearing| hearing.hearing_location.present? }, is_collection: true
     ).serializable_hash[:data]
 
     render json: {

--- a/app/controllers/api/v2/hearings_controller.rb
+++ b/app/controllers/api/v2/hearings_controller.rb
@@ -15,7 +15,7 @@ class Api::V2::HearingsController < Api::ApplicationController
     end
 
     hash_serialized = Api::V2::HearingSerializer.new(
-      hearings, is_collection: true
+      hearings.reject { |hearing| hearing.hearing_location.nil? }, is_collection: true
     ).serializable_hash[:data]
 
     render json: {

--- a/app/models/hearing_location.rb
+++ b/app/models/hearing_location.rb
@@ -23,6 +23,9 @@ class HearingLocation < ApplicationRecord
   def street_address
     key = vba_372? ? "VACO" : facility_id
     addr = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[key]
+
+    return unless addr
+
     addr["address_1"]
   end
 

--- a/spec/controllers/api/v2/hearings_controller_spec.rb
+++ b/spec/controllers/api/v2/hearings_controller_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
             expect(JSON.parse(subject.body)["hearings"][0]["timezone"]).to eq("America/New_York")
           end
           it do
-            expect(JSON.parse(subject.body)["hearings"][0]["hearing_location"]).to eq("Board of Veterans' Appeals CO Office")
+            first_location = JSON.parse(subject.body)["hearings"][0]["hearing_location"]
+            expect(first_location).to eq("Board of Veterans' Appeals CO Office")
           end
 
           it do

--- a/spec/controllers/api/v2/hearings_controller_spec.rb
+++ b/spec/controllers/api/v2/hearings_controller_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
         context "ama hearings" do
           let!(:hearings) do
             [
-              create(:hearing, hearing_day: hearing_day, scheduled_time: "9:30AM"),
-              create(:hearing, hearing_day: hearing_day, scheduled_time: "10:30AM")
+              create(:hearing, regional_office: "VACO", hearing_day: hearing_day, scheduled_time: "9:30AM"),
+              create(:hearing, regional_office: "VACO", hearing_day: hearing_day, scheduled_time: "10:30AM")
             ]
           end
 
@@ -74,7 +74,7 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
             expect(JSON.parse(subject.body)["hearings"][0]["timezone"]).to eq("America/New_York")
           end
           it do
-            expect(JSON.parse(subject.body)["hearings"][0]["hearing_location"]).to eq("Central")
+            expect(JSON.parse(subject.body)["hearings"][0]["hearing_location"]).to eq("Board of Veterans' Appeals CO Office")
           end
 
           it do
@@ -93,7 +93,7 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
         context "legacy hearings" do
           let!(:hearings) do
             [
-              create(:legacy_hearing, hearing_day: hearing_day)
+              create(:legacy_hearing, regional_office: "RO42", hearing_day: hearing_day)
             ]
           end
 
@@ -117,8 +117,10 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
         end
         let!(:hearings) do
           [
+            create(:hearing, regional_office: "RO42", hearing_day: hearing_days[0]),
             create(:hearing, hearing_day: hearing_days[0]),
-            create(:legacy_hearing, hearing_day: hearing_days[1])
+            create(:legacy_hearing, hearing_day: hearing_days[1]),
+            create(:legacy_hearing, regional_office: "RO42", hearing_day: hearing_days[1])
           ]
         end
 

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -15,6 +15,11 @@ FactoryBot.define do
              judge: judge,
              request_type: regional_office.nil? ? "C" : "V")
     end
+    hearing_location do
+      if regional_office.present?
+        create(:hearing_location, regional_office: regional_office)
+      end
+    end
     scheduled_time { "8:30AM" }
     created_by { create(:user) }
     updated_by { create(:user) }

--- a/spec/factories/hearing_location.rb
+++ b/spec/factories/hearing_location.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :hearing_location do
+    transient do
+      regional_office { nil }
+    end
+
+    after(:build) do |hearing_location, evaluator|
+      if evaluator.regional_office
+        ro = evaluator.regional_office
+        facility_id = RegionalOffice.facility_ids_for_ro(ro).first || "VACO"
+        facility_address = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[facility_id]
+        hearing_location.name = Constants::REGIONAL_OFFICE_INFORMATION[ro]["label"] 
+        hearing_location.address = facility_address["address_1"]
+        hearing_location.city = facility_address["city"]
+        hearing_location.state = facility_address["state"]
+        hearing_location.zip_code = facility_address["zip"]
+      end
+    end
+  end
+end

--- a/spec/factories/hearing_location.rb
+++ b/spec/factories/hearing_location.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
         ro = evaluator.regional_office
         facility_id = RegionalOffice.facility_ids_for_ro(ro).first || "VACO"
         facility_address = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[facility_id]
-        hearing_location.name = Constants::REGIONAL_OFFICE_INFORMATION[ro]["label"] 
+        hearing_location.name = Constants::REGIONAL_OFFICE_INFORMATION[ro]["label"]
         hearing_location.address = facility_address["address_1"]
         hearing_location.city = facility_address["city"]
         hearing_location.state = facility_address["state"]

--- a/spec/factories/legacy_hearing.rb
+++ b/spec/factories/legacy_hearing.rb
@@ -13,8 +13,7 @@ FactoryBot.define do
 
     hearing_location do
       if regional_office.present?
-        venue = LegacyHearing.venues[regional_office]
-        HearingLocation.create(name: venue[:label])
+        create(:hearing_location, regional_office: regional_office)
       end
     end
 


### PR DESCRIPTION
connects #12265 

### Description
Some `Hearing` objects have no related `HearingLocation` record. Instead of showing nil values in Hearing API response, just filter them out.