### PR TITLE
Bump sentry alert one month

### DIFF
--- a/app/models/tasks/judge_assign_task.rb
+++ b/app/models/tasks/judge_assign_task.rb
@@ -14,7 +14,7 @@ class JudgeAssignTask < JudgeTask
     # Tell sentry so we know this is still happening. Remove this in a month
     msg = "Still changing JudgeAssignTask type to JudgeDecisionReviewTask."\
           "See: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295487938"
-    Raven.capture_message(msg, extra: { application: "tasks" }) if Time.zone.now > Time.zone.local(2019, 9, 1)
+    Raven.capture_message(msg, extra: { application: "tasks" }) if Time.zone.now > Time.zone.local(2019, 11, 1)
   end
 
   def self.label

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -220,7 +220,7 @@ describe JudgeTask, :all_dbs do
         )
       end
 
-      before { Timecop.freeze(Time.zone.local(2019, 9, 2)) }
+      before { Timecop.freeze(Time.zone.local(2019, 11, 2)) }
 
       it "changes the judge task type to decision review and sends an error to sentry" do
         expect(judge_task.type).to eq(JudgeAssignTask.name)


### PR DESCRIPTION
Repeats #11651

### Description
Related to this comment: https://github.com/department-of-veterans-affairs/caseflow/pull/11140#discussion_r295849637

There are [still 50 tasks in this state](https://caseflow-looker.va.gov/sql/9vbvbc9qznxsth) so we need to extend the deadline another month.