### PR TITLE
Append structure attribute names to appeal label

### DIFF
--- a/app/models/concerns/prints_task_tree.rb
+++ b/app/models/concerns/prints_task_tree.rb
@@ -9,6 +9,7 @@ module PrintsTaskTree
 
   def structure(*atts)
     leaf_name = "#{self.class.name} #{task_tree_attributes(*atts)}"
+    leaf_name += " [#{atts.join(', ')}]" unless is_a? Task
     { "#{leaf_name}": task_tree_children.map { |child| child.structure(*atts) } }
   end
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -20,7 +20,7 @@ describe Appeal, :all_dbs do
 
       it "returns the task structure" do
         expect_any_instance_of(RootTask).to receive(:structure).with(:id)
-        expect(subject.key?(:"Appeal #{appeal.id}")).to be_truthy
+        expect(subject.key?(:"Appeal #{appeal.id} [id]")).to be_truthy
       end
     end
   end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -25,7 +25,7 @@ describe LegacyAppeal, :all_dbs do
 
       it "returns the task structure" do
         expect_any_instance_of(RootTask).to receive(:structure).with(:id)
-        expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
+        expect(subject.key?(:"LegacyAppeal #{appeal.id} [id]")).to be_truthy
       end
 
       context "the appeal has more than one parentless task" do
@@ -36,8 +36,8 @@ describe LegacyAppeal, :all_dbs do
         it "returns all parentless tasks" do
           expect_any_instance_of(RootTask).to receive(:structure).with(:id)
           expect_any_instance_of(ColocatedTask).to receive(:structure).with(:id)
-          expect(subject.key?(:"LegacyAppeal #{appeal.id}")).to be_truthy
-          expect(subject[:"LegacyAppeal #{appeal.id}"].count).to eq 2
+          expect(subject.key?(:"LegacyAppeal #{appeal.id} [id]")).to be_truthy
+          expect(subject[:"LegacyAppeal #{appeal.id} [id]"].count).to eq 2
         end
       end
     end


### PR DESCRIPTION
Small change to `structure_render` output to append the requested attribute names to the appeal label at the top. Should make it easier to copy/paste tree and be able to decipher which dates (e.g.) are being looked at.