### PR TITLE
Fix warning appearing in attorney checkout feature tests

### DIFF
--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -646,7 +646,7 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
           expect(page).to have_content "Program"
           selected_vals = select_issue_level_options(opt_set)
           click_on "Continue"
-          selected_vals.each { |v| expect(page).to have_content v }
+          selected_vals.compact.each { |v| expect(page).to have_content v }
         end
       end
 


### PR DESCRIPTION
### Description

Occasionally seeing tests timeout, like this one:

https://app.circleci.com/jobs/github/department-of-veterans-affairs/caseflow/86975/parallel-runs/3?filterBy=FAILED

There isn't a lot of debug info, but I was seeing this warning:

```
Checking for expected text of nil is confusing and/or pointless since it will always match. Please specify a string or regexp instead.
```

The warning shows up 4 times locally and on successful runs in CircleCI, but only once in the failed run, so I think fixing it might help. 
