### PR TITLE
Remove unused env vars

### DIFF
--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -81,7 +81,4 @@ Rails.application.configure do
   config.s3_bucket_name = ENV["AWS_BUCKET_NAME"]
 
   config.google_analytics_account = "UA-74789258-5"
-
-  ENV["SIDEKIQ_USERNAME"] ||= "caseflow"
-  ENV["SIDEKIQ_PASSWORD"] ||= "caseflow"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,12 +82,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  #
-
-  ENV["METRICS_USERNAME"] ||= "caseflow"
-  ENV["METRICS_PASSWORD"] ||= "caseflow"
-  ENV["SIDEKIQ_USERNAME"] ||= "caseflow"
-  ENV["SIDEKIQ_PASSWORD"] ||= "caseflow"
 
   # eFolder API URL to retrieve appeal documents
   config.efolder_url = "http://localhost:4000"

--- a/config/environments/ssh_forwarding.rb
+++ b/config/environments/ssh_forwarding.rb
@@ -45,12 +45,6 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  #
-
-  ENV["METRICS_USERNAME"] ||= "caseflow"
-  ENV["METRICS_PASSWORD"] ||= "caseflow"
-  ENV["SIDEKIQ_USERNAME"] ||= "caseflow"
-  ENV["SIDEKIQ_PASSWORD"] ||= "caseflow"
 
   # eFolder API URL to retrieve appeal documents
   config.efolder_url = "http://localhost:4000"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -71,10 +71,6 @@ Rails.application.configure do
   #
   ENV["CASEFLOW_FEEDBACK_URL"] = "test.feedback.url"
 
-  ENV["METRICS_USERNAME"] = "caseflow"
-  ENV["METRICS_PASSWORD"] = "caseflow"
-  ENV["SIDEKIQ_USERNAME"] ||= "caseflow"
-  ENV["SIDEKIQ_PASSWORD"] ||= "caseflow"
   ENV["VA_DOT_GOV_API_URL"] = "https://staging-api.va.gov/"
 
   # For testing uncertification methods

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,27 +18,22 @@
 development:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
 
 demo:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
-  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] %>
 
 ssh_forwarding:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
 
 test:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
 
 staging:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] || "8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862" %>
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
-  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] || "redis://localhost:6379" %>
   user_ip_address: <%= ENV["USER_IP_ADDRESS"] %>
 
 # Do not keep production secrets in the unencrypted secrets file.
@@ -48,5 +43,4 @@ staging:
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
-  redis_url_sidekiq: <%= ENV["REDIS_URL_SIDEKIQ"] %>
   user_ip_address: <%= ENV["USER_IP_ADDRESS"] %>


### PR DESCRIPTION
* Removing sidekiq env variables as we no longer use sidekiq.
* Removing metrics password/username since these were used by Prometheus

Test plan: 
- [x] deploy to UAT, run any job from the rails console, make sure it works