### PR TITLE
Fix edge case where dispatched case has incomplete tasks

### DIFF
--- a/app/sql/bva-decision-progress.sql
+++ b/app/sql/bva-decision-progress.sql
@@ -76,6 +76,7 @@ WITH undistributed_appeals AS (select '1. Not distributed'::text as decision_sta
             WHERE tasks.type IN ('BvaDispatchTask') 
               AND tasks.appeal_type='Appeal'
               AND tasks.status IN ('completed')
+              AND tasks.appeal_id NOT IN (SELECT appeal_id FROM tasks WHERE tasks.appeal_type='Appeal' AND tasks.status IN ('on_hold', 'assigned', 'in_progress'))
 -- The Appeal is currently on a timed hold
       ), appeal_on_hold AS (select 'ON HOLD'::text as decision_status, count(1) as num
             FROM tasks

--- a/app/sql/bva-decision-progress.sql
+++ b/app/sql/bva-decision-progress.sql
@@ -69,7 +69,7 @@ WITH undistributed_appeals AS (select '1. Not distributed'::text as decision_sta
             WHERE tasks.type IN ('BvaDispatchTask', 'QualityReviewTask') 
               AND tasks.appeal_type='Appeal'
               AND tasks.status IN ('assigned', 'in_progress')
--- The Appeal dispatch is completed. Case is complete
+-- The Appeal dispatch is completed. Case is complete with no open tasks.
       ), decision_dispatched AS (select '8. Decision dispatched'::text as decision_status, count(DISTINCT(appeal_id)) as num
             FROM tasks
             JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id  

--- a/spec/sql/bva_decision_progress_spec.rb
+++ b/spec/sql/bva_decision_progress_spec.rb
@@ -10,7 +10,7 @@ describe "BVA Decision Progress report", :postgres do
       [
         { "decision_status" => "1. Not distributed", "num" => 1 },
         { "decision_status" => "2. Distributed to judge", "num" => 1 },
-        { "decision_status" => "3. Assigned to attorney", "num" => 1 },
+        { "decision_status" => "3. Assigned to attorney", "num" => 2 },
         { "decision_status" => "4. Assigned to colocated", "num" => 1 },
         { "decision_status" => "5. Decision in progress", "num" => 1 },
         { "decision_status" => "6. Decision ready for signature", "num" => 1 },
@@ -49,6 +49,12 @@ describe "BVA Decision Progress report", :postgres do
     let!(:decision_dispatched) do
       create(:appeal).tap do |appeal|
         create(:bva_dispatch_task, :completed, appeal: appeal)
+      end
+    end
+    let!(:dispatched_with_subsequent_assigned_task) do
+      create(:appeal).tap do |appeal|
+        create(:bva_dispatch_task, :completed, appeal: appeal)
+        create(:ama_attorney_task, assigned_to: user, appeal: appeal)
       end
     end
     let!(:cancelled) do


### PR DESCRIPTION
Resolves #12236 

### Description

Double-counting appeals since some have open tasks after `BvaDispatchTask` is complete.