### PR TITLE
Remove inactive users from organizations that automatically assign tasks to their users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,8 +27,6 @@ class User < ApplicationRecord
 
   before_create :normalize_css_id
 
-  after_update :remove_user_from_auto_assign_orgs, if: :user_just_made_inactive?
-
   enum status: {
     Constants.USER_STATUSES.active.to_sym => Constants.USER_STATUSES.active,
     Constants.USER_STATUSES.inactive.to_sym => Constants.USER_STATUSES.inactive
@@ -281,6 +279,7 @@ class User < ApplicationRecord
 
   def update_status!(new_status)
     update!(status: new_status, status_updated_at: Time.zone.now)
+    remove_user_from_auto_assign_orgs if new_status.eql?(Constants.USER_STATUSES.inactive)
   end
 
   def use_task_pages_api?
@@ -324,10 +323,6 @@ class User < ApplicationRecord
   end
 
   private
-
-  def user_just_made_inactive?
-    saved_change_to_attribute?("status") && inactive?
-  end
 
   def remove_user_from_auto_assign_orgs
     auto_assign_orgs = organizations.select(&:automatically_assign_to_member?)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -278,8 +278,10 @@ class User < ApplicationRecord
   end
 
   def update_status!(new_status)
-    update!(status: new_status, status_updated_at: Time.zone.now)
-    remove_user_from_auto_assign_orgs if new_status.eql?(Constants.USER_STATUSES.inactive)
+    transaction do
+      remove_user_from_auto_assign_orgs if new_status.eql?(Constants.USER_STATUSES.inactive)
+      update!(status: new_status, status_updated_at: Time.zone.now)
+    end
   end
 
   def use_task_pages_api?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -637,6 +637,38 @@ describe User, :all_dbs do
         expect(user.reload.status).to eq status
         expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s
       end
+
+      context "when the user is a member of an org that automatically assigns tasks" do
+        before do
+          OrganizationsUser.add_user_to_organization(user, create(:organization))
+          OrganizationsUser.add_user_to_organization(user, Colocated.singleton)
+        end
+
+        context "when marking the user inactive" do
+          it "only removes users from the auto assign organization" do
+            expect(user.selectable_organizations.length).to eq 2
+            expect(subject).to eq true
+            expect(user.reload.status).to eq status
+            expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s
+            expect(user.selectable_organizations.length).to eq 1
+            expect(user.selectable_organizations).not_to include Colocated.singleton
+          end
+        end
+
+        context "when marking the user active" do
+          let(:user) { create(:user, status: Constants.USER_STATUSES.inactive) }
+          let(:status) { Constants.USER_STATUSES.active }
+
+          it "does not remove the user from any organizations" do
+            expect(user.selectable_organizations.length).to eq 2
+            expect(subject).to eq true
+            expect(user.reload.status).to eq status
+            expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s
+            expect(user.selectable_organizations.length).to eq 2
+            expect(user.selectable_organizations).to include Colocated.singleton
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #12303

### Description
Revokes inactive user membership to organizations that automatically assign organization tasks. This keeps new tasks from being assigned to inactive users.

### Acceptance Criteria
- [ ] Inactive users are removed only from organizations what do not have an automatic assignee