### PR TITLE
Fix address initialization bug

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -630,15 +630,17 @@ class Appeal < DecisionReview
   end
 
   def address
-    @address ||= Address.new(
-      address_line_1: appellant.address_line_1,
-      address_line_2: appellant.address_line_2,
-      address_line_3: appellant.address_line_3,
-      city: appellant.city,
-      country: appellant.country,
-      state: appellant.state,
-      zip: appellant.zip
-    ) if appellant.address.present?
+    if appellant.address.present?
+      @address ||= Address.new(
+        address_line_1: appellant.address_line_1,
+        address_line_2: appellant.address_line_2,
+        address_line_3: appellant.address_line_3,
+        city: appellant.city,
+        country: appellant.country,
+        state: appellant.state,
+        zip: appellant.zip
+      )
+    end
   end
 
   # we always want to show ratings on intake

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -630,7 +630,15 @@ class Appeal < DecisionReview
   end
 
   def address
-    @address ||= Address.new(appellant.address) if appellant.address.present?
+    @address ||= Address.new(
+      address_line_1: appellant.address_line_1,
+      address_line_2: appellant.address_line_2,
+      address_line_3: appellant.address_line_3,
+      city: appellant.city,
+      country: appellant.country,
+      state: appellant.state,
+      zip: appellant.zip
+    ) if appellant.address.present?
   end
 
   # we always want to show ratings on intake

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -35,7 +35,8 @@ class Claimant < ApplicationRecord
   end
 
   delegate :date_of_birth, :advanced_on_docket?, :name, :first_name, :last_name, :middle_name, to: :person
-  delegate :address, :address_line_1, :address_line_2, :city, :country, :state, :zip, to: :bgs_address_service
+  delegate :address, :address_line_1, :address_line_2, :address_line_3, :city, :country, :state, :zip,
+           to: :bgs_address_service
 
   def fetch_bgs_record
     general_info = bgs.fetch_claimant_info_by_participant_id(participant_id)


### PR DESCRIPTION
Resolves #12323 

### Description

An unexpected `type` keyword argument is being passed to the `Address` initializer, causing an error. This change initializes the arguments on the appeal address explicitly to avoid initializing with unexpected arguments.