### PR TITLE
Fix edge case with double counting timed hold tasks

### DIFF
--- a/app/sql/bva-decision-progress.sql
+++ b/app/sql/bva-decision-progress.sql
@@ -3,7 +3,6 @@
 ---- LIMITATIONS
 -- This report may under count or overcount appeals in error states or extraordinary states. 
 -- i.e. open root task with no active task; cases with multiple contridictory open tasks; etc.
--- ON HOLD and Waiting for Distribution will doublecount if the hold is with hearings or translation. This would properly be considered Waiting for Distribution.
 
 ---- Collecting each status & count
 -- It is possible for some tasks to be worked simultaneously within a category, so we count distinct appeal ids rather than total number of tasks.

--- a/app/sql/bva-decision-progress.sql
+++ b/app/sql/bva-decision-progress.sql
@@ -15,6 +15,7 @@ WITH undistributed_appeals AS (select '1. Not distributed'::text as decision_sta
             WHERE tasks.type IN ('DistributionTask')
               AND tasks.appeal_type='Appeal'
               AND tasks.status IN  ('on_hold', 'assigned', 'in_progress')
+              AND tasks.appeal_id NOT IN (SELECT appeal_id FROM tasks WHERE tasks.appeal_type='Appeal' AND tasks.type = 'TimedHoldTask' AND tasks.status IN ('on_hold', 'assigned', 'in_progress'))
 -- The Appeal has been distributed to the judge, but not yet assigned to an attorney for working.
       ), distributed_to_judge AS (select '2. Distributed to judge'::text as decision_status, count(DISTINCT(appeal_id)) as num
             FROM tasks

--- a/spec/sql/bva_decision_progress_spec.rb
+++ b/spec/sql/bva_decision_progress_spec.rb
@@ -18,12 +18,17 @@ describe "BVA Decision Progress report", :postgres do
         { "decision_status" => "8. Decision dispatched", "num" => 1 },
         { "decision_status" => "CANCELLED", "num" => 1 },
         { "decision_status" => "MISC", "num" => 1 },
-        { "decision_status" => "ON HOLD", "num" => 1 }
+        { "decision_status" => "ON HOLD", "num" => 2 }
       ]
     end
 
     let(:user) { create(:default_user) }
     let!(:not_distributed) { create(:appeal, :ready_for_distribution) }
+    let!(:not_distributed_with_timed_hold) do
+      create(:appeal, :ready_for_distribution).tap do |appeal|
+        create(:timed_hold_task, appeal: appeal)
+      end
+    end
     let!(:distributed_to_judge) { create(:appeal, :assigned_to_judge) }
     let!(:assigned_to_attorney) { create(:appeal).tap { |appeal| create(:ama_attorney_task, appeal: appeal) } }
     let!(:assigned_to_colocated) do


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/dsva-vacols/issues/80

### Description
Appeals with an on-hold DistributionTask were double-counted when they also have TimedHoldTask task.