### PR TITLE
Make checker jobs slack output more readable

### DIFF
--- a/app/services/asyncable_jobs_reporter.rb
+++ b/app/services/asyncable_jobs_reporter.rb
@@ -40,7 +40,8 @@ class AsyncableJobsReporter
         summary[cls][age].keys.sort.each do |err|
           count = summary[cls][age][err]
           total += count
-          output << "#{cls} has #{count} jobs #{age} days old with error #{err}"
+          err_output = err.gsub(/^[#<]+|[,:]+$/, "")
+          output << "#{cls} has #{count} jobs #{age} days old with error #{err_output}"
         end
       end
       output << "#{cls} has #{total} total jobs in queue"

--- a/app/services/open_hearing_tasks_without_active_descendants_checker.rb
+++ b/app/services/open_hearing_tasks_without_active_descendants_checker.rb
@@ -23,6 +23,6 @@ class OpenHearingTasksWithoutActiveDescendantsChecker < DataIntegrityChecker
 
     add_to_report "Found #{count} open #{'HearingTask'.pluralize(count)} with no active descendant tasks."
     add_to_report "The #{'hearing'.pluralize(count)} may not progress without manual intervention."
-    add_to_report "HearingTask.where(id: #{ids})"
+    add_to_report "`HearingTask.where(id: #{ids})`"
   end
 end

--- a/app/services/reviews_with_duplicate_ep_error_checker.rb
+++ b/app/services/reviews_with_duplicate_ep_error_checker.rb
@@ -41,13 +41,13 @@ class ReviewsWithDuplicateEpErrorChecker < DataIntegrityChecker
     if hlr_count.positive?
       add_to_report "Found #{hlr_count} #{'HigherLevelReview'.pluralize(hlr_count)} with " \
         "DuplicateEP #{'error'.pluralize(hlr_count)}."
-      add_to_report "HigherLevelReview.where(id: #{hlr_ids})"
+      add_to_report "`HigherLevelReview.where(id: #{hlr_ids})`"
     end
 
     if sc_count.positive?
       add_to_report "Found #{sc_count} #{'SupplementalClaim'.pluralize(sc_count)} with " \
         "DuplicateEP #{'error'.pluralize(sc_count)}."
-      add_to_report "SupplementalClaim.where(id: #{sc_ids})"
+      add_to_report "`SupplementalClaim.where(id: #{sc_ids})`"
     end
 
     add_to_report "The #{'review'.pluralize(sc_count + hlr_count)} may not progress without manual resolution."

--- a/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
+++ b/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
@@ -60,7 +60,7 @@ describe OpenHearingTasksWithoutActiveDescendantsChecker, :all_dbs do
         report_lines = subject.report.split("\n")
         ids = [hearing_task.id, hearing_task_2.id, hearing_task_3.id].sort
         expect(report_lines).to include("Found #{ids.count} open HearingTasks with no active descendant tasks.")
-        expect(report_lines).to include("HearingTask.where(id: #{ids})")
+        expect(report_lines).to include("`HearingTask.where(id: #{ids})`")
       end
     end
   end


### PR DESCRIPTION
### Description
Improves the readability of some checker jobs' slack output.

#### ExpiredAsyncJobsChecker
Removes `#` and `<` from beginning and `:` and `,` from end of error names.

_before_
> DecisionDocument has 1 jobs 2 days old with error status_code=500,
> RequestIssue has 2 jobs 3 days old with error #<Rating::NilRatingProfileListError:

_after_
> DecisionDocument has 1 jobs 2 days old with error status_code=500
> RequestIssue has 2 jobs 3 days old with error Rating::NilRatingProfileListError

#### OpenHearingTasksWithoutActiveDescendantsChecker
Wraps ruby command in backticks.

_before_
> Found 3 open HearingTasks with no active descendant tasks.
> The hearings may not progress without manual intervention.
> HearingTask.where(id: [47055, 105364, 114033])

_after_
> Found 3 open HearingTasks with no active descendant tasks.
> The hearings may not progress without manual intervention.
> `HearingTask.where(id: [47055, 105364, 114033])`

#### ReviewsWithDuplicateEpErrorChecker
Wraps ruby commands in backticks.

_before_
> Found 1 HigherLevelReview with DuplicateEP error.
> HigherLevelReview.where(id: [38285])
> Found 4 SupplementalClaims with DuplicateEP errors.
> SupplementalClaim.where(id: [64476, 131722, 147667, 149553])
> The reviews may not progress without manual resolution.

_after_
> Found 1 HigherLevelReview with DuplicateEP error.
> `HigherLevelReview.where(id: [38285])`
> Found 4 SupplementalClaims with DuplicateEP errors.
> `SupplementalClaim.where(id: [64476, 131722, 147667, 149553])`
> The reviews may not progress without manual resolution.
