### PR TITLE
Add output to enable features script

### DIFF
--- a/scripts/duplicate_decass_deleter.rb
+++ b/scripts/duplicate_decass_deleter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-# bundle exec rails runner scripts/enable_features_dev.rb
+# bundle exec rails runner scripts/duplicate_decass_deleter.rb
+# bundle exec rails runner scripts/duplicate_decass_deleter.rb --nodry_run
 
 def sql_fmt(attribute)
   if attribute.nil?

--- a/scripts/enable_features_dev.rb
+++ b/scripts/enable_features_dev.rb
@@ -57,3 +57,5 @@ all_features.each_with_object([]) do |feature, result|
   result << { "feature" => feature, "enable_all" => true }
   FeatureToggle.sync! result.to_yaml
 end
+
+puts "Enabled #{all_features.count} features: #{all_features.sort.join(', ')}"


### PR DESCRIPTION
### Description
Adds output to the `enable_features_dev` script that describes the number and names of the features enabled.

_before_
```
$ bundle exec rails runner scripts/enable_features_dev.rb

```

_after_
```
$ bundle exec rails runner scripts/enable_features_dev.rb
Enabled 3 features: allow_judge_edit_issues, api_v3, window_slider
```