### PR TITLE
Cached user table

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -11,6 +11,7 @@ class Api::V1::JobsController < Api::ApplicationController
     "heartbeat" => HeartbeatTasksJob,
     "missed_job_sweeper" => MissedJobSweeperJob,
     "monthly_metrics" => MonthlyMetricsReportJob,
+    "nightly_syncs" => NightlySyncsJob,
     "out_of_service_reminder" => OutOfServiceReminderJob,
     "prepare_establish_claim" => PrepareEstablishClaimTasksJob,
     "reassign_old_tasks" => ReassignOldTasksJob,

--- a/app/jobs/caseflow_job.rb
+++ b/app/jobs/caseflow_job.rb
@@ -15,6 +15,17 @@ class CaseflowJob < ApplicationJob
     )
   end
 
+  def datadog_report_time_segment(segment:, start_time:)
+    job_duration_seconds = Time.zone.now - start_time
+
+    DataDogService.emit_gauge(
+      app_name: "caseflow_job_segment",
+      metric_group: segment,
+      metric_name: "runtime",
+      metric_value: job_duration_seconds
+    )
+  end
+
   def slack_url
     ENV["SLACK_DISPATCH_ALERT_URL"]
   end

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# run once a day, overnight, to synchronize systems
+
+class NightlySyncsJob < CaseflowJob
+  queue_with_priority :low_priority
+  application_attr :queue # arbitrary
+
+  def perform
+    RequestStore.store[:current_user] = User.system_user
+
+    sync_vacols_users
+
+    datadog_report_runtime(metric_group_name: "nightly_syncs_job")
+  end
+
+  private
+
+  def sync_vacols_users
+    user_cache_start = Time.zone.now
+    CachedUser.sync_from_vacols
+    datadog_report_time_segment(segment: "sync_users_from_vacols", start_time: user_cache_start)
+  end
+end

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -19,6 +19,10 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     cache_legacy_appeals
     time_segment(segment: "cache_legacy_appeals", start_time: legacy_appeals_start)
 
+    user_cache_start = Time.zone.now
+    CacheUser.sync_from_vacols
+    time_segment(segment: "cache_users", start_time: user_cache_start)
+
     datadog_report_runtime(metric_group_name: METRIC_GROUP_NAME)
   rescue StandardError => error
     log_error(@start_time, error)

--- a/app/models/cached_user.rb
+++ b/app/models/cached_user.rb
@@ -2,6 +2,7 @@
 
 class CachedUser < ApplicationRecord
   self.table_name = "cached_user_attributes"
+  self.primary_key = "sdomainid"
 
   class << self
     def sync_from_vacols

--- a/app/models/cached_user.rb
+++ b/app/models/cached_user.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 # cache VACOLS staff data in the Caseflow db for easier correlation
-# between systems.
+# between systems. Best use case is SQL joins for metrics/reporting.
 
-# TODO some methods in app/repositories/user_repository.rb might be able to
+# For future work: some methods in app/repositories/user_repository.rb might be able to
 # take advantage of this table, rather than using the Redis cache of VACOLS::Staff.
 
 class CachedUser < ApplicationRecord

--- a/app/models/cached_user.rb
+++ b/app/models/cached_user.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CachedUser < ApplicationRecord
+  self.table_name = "cached_user_attributes"
+
+  class << self
+    def sync_from_vacols
+      VACOLS::Staff.find_each do |staff|
+        # we set attributes both in find_or_create_by block for not-null constraints
+        # on initial creation, and to update stale attributes
+        cached_user = find_or_create_by(sdomainid: staff.sdomainid) do |cuser|
+          cuser.sattyid = staff.sattyid
+          cuser.svlj = staff.svlj
+          cuser.slogid = staff.slogid
+          cuser.stafkey = staff.stafkey
+          cuser.sactive = staff.sactive
+        end
+        cached_user.sattyid = staff.sattyid
+        cached_user.svlj = staff.svlj
+        cached_user.slogid = staff.slogid
+        cached_user.stafkey = staff.stafkey
+        cached_user.sactive = staff.sactive
+        cached_user.save! if cached_user.changed?
+      end
+    end
+  end
+end

--- a/app/models/cached_user.rb
+++ b/app/models/cached_user.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# cache VACOLS staff data in the Caseflow db for easier correlation
+# between systems.
+
+# TODO some methods in app/repositories/user_repository.rb might be able to
+# take advantage of this table, rather than using the Redis cache of VACOLS::Staff.
+
 class CachedUser < ApplicationRecord
   self.table_name = "cached_user_attributes"
   self.primary_key = "sdomainid"

--- a/db/migrate/20191010164748_created_cached_user_attributes.rb
+++ b/db/migrate/20191010164748_created_cached_user_attributes.rb
@@ -1,0 +1,15 @@
+class CreatedCachedUserAttributes < ActiveRecord::Migration[5.1]
+  def change
+    create_table :cached_user_attributes, id: false do |t|
+      t.timestamps null: false
+      t.string :sdomainid, length: 20, null: false
+      t.string :sattyid, length: 4
+      t.string :svlj, length: 1
+      t.string :slogid, length: 16, null: false
+      t.string :stafkey, length: 16, null: false
+      t.string :sactive, length: 1, null: false
+    end
+
+    add_index :cached_user_attributes, [:sdomainid], unique: true
+  end
+end

--- a/db/migrate/20191010164748_created_cached_user_attributes.rb
+++ b/db/migrate/20191010164748_created_cached_user_attributes.rb
@@ -1,6 +1,6 @@
 class CreatedCachedUserAttributes < ActiveRecord::Migration[5.1]
   def change
-    create_table :cached_user_attributes, id: false do |t|
+    create_table :cached_user_attributes, id: false, comment: "VACOLS cached staff table attributes" do |t|
       t.timestamps null: false
       t.string :sdomainid, length: 20, null: false
       t.string :sattyid, length: 4

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -183,7 +183,7 @@ ActiveRecord::Schema.define(version: 20191010164748) do
     t.index ["vacols_id"], name: "index_cached_appeal_attributes_on_vacols_id", unique: true
   end
 
-  create_table "cached_user_attributes", id: false, force: :cascade do |t|
+  create_table "cached_user_attributes", id: false, force: :cascade, comment: "VACOLS cached staff table attributes" do |t|
     t.datetime "created_at", null: false
     t.string "sactive", null: false
     t.string "sattyid"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191001224339) do
+ActiveRecord::Schema.define(version: 20191010164748) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,18 @@ ActiveRecord::Schema.define(version: 20191001224339) do
     t.string "veteran_name", comment: "'LastName, FirstName' of the veteran"
     t.index ["appeal_id", "appeal_type"], name: "index_cached_appeal_attributes_on_appeal_id_and_appeal_type", unique: true
     t.index ["vacols_id"], name: "index_cached_appeal_attributes_on_vacols_id", unique: true
+  end
+
+  create_table "cached_user_attributes", id: false, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "sactive", null: false
+    t.string "sattyid"
+    t.string "sdomainid", null: false
+    t.string "slogid", null: false
+    t.string "stafkey", null: false
+    t.string "svlj"
+    t.datetime "updated_at", null: false
+    t.index ["sdomainid"], name: "index_cached_user_attributes_on_sdomainid", unique: true
   end
 
   create_table "certification_cancellations", id: :serial, force: :cascade do |t|

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "support/vacols_database_cleaner"
+require "rails_helper"
+
+describe NightlySyncsJob, :all_dbs do
+  context "when the job runs successfully" do
+    before do
+      5.times { create(:staff) }
+    end
+
+    subject { described_class.perform_now }
+
+    it "updates cached_user_attributes table" do
+      subject
+
+      expect(CachedUser.count).to eq(5)
+    end
+
+    it "updates DataDog" do
+      emitted_gauges = []
+      allow(DataDogService).to receive(:emit_gauge) do |args|
+        emitted_gauges.push(args)
+      end
+
+      subject
+
+      expect(emitted_gauges).to include(
+        app_name: "caseflow_job",
+        metric_group: "nightly_syncs_job",
+        metric_name: "runtime",
+        metric_value: anything
+      )
+    end
+  end
+end

--- a/spec/models/cached_user_spec.rb
+++ b/spec/models/cached_user_spec.rb
@@ -20,7 +20,7 @@ describe CachedUser, :all_dbs do
     end
 
     context "VACOLS staff attributes change" do
-       before do
+      before do
         5.times { create(:staff) }
       end
 

--- a/spec/models/cached_user_spec.rb
+++ b/spec/models/cached_user_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "support/vacols_database_cleaner"
+require "rails_helper"
+
+describe CachedUser, :all_dbs do
+  describe ".sync_from_vacols" do
+    context "5 VACOLS staff exist" do
+      before do
+        5.times { create(:staff) }
+      end
+
+      it "copies relevant attributes" do
+        expect(CachedUser.count).to eq(0)
+
+        described_class.sync_from_vacols
+
+        expect(CachedUser.count).to eq(5)
+      end
+    end
+
+    context "VACOLS staff attributes change" do
+       before do
+        5.times { create(:staff) }
+      end
+
+      it "updates local cache" do
+        described_class.sync_from_vacols
+
+        staff = VACOLS::Staff.first
+        cached_user = described_class.find_by(sdomainid: staff.sdomainid)
+
+        staff.stafkey = "foobar"
+        staff.save!
+
+        described_class.sync_from_vacols
+
+        expect(cached_user.reload.stafkey).to eq("foobar")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #12357 

### Description
Adds new table `cached_user_attributes` to mirror `cached_appeal_attributes`.

This can be used for reconciling users across Caseflow and VACOLS.

*Schema Changes Only*

* [x] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
