### PR TITLE
Inbox message detail

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,6 +2,7 @@
 
 class Message < ApplicationRecord
   belongs_to :user
+  belongs_to :detail, polymorphic: true
 
   scope :read, -> { where.not(read_at: nil) }
   scope :unread, -> { where(read_at: nil) }

--- a/db/migrate/20191010195542_add_inbox_message_detail.rb
+++ b/db/migrate/20191010195542_add_inbox_message_detail.rb
@@ -1,0 +1,10 @@
+class AddInboxMessageDetail < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :messages, :detail_type, :string, comment: "Model name of the related object"
+    add_column :messages, :detail_id, :integer, comment: "ID of the related object"
+
+    add_index :messages, [:detail_type, :detail_id], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191010164748) do
+ActiveRecord::Schema.define(version: 20191010195542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -780,10 +780,13 @@ ActiveRecord::Schema.define(version: 20191010164748) do
 
   create_table "messages", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "detail_id", comment: "ID of the related object"
+    t.string "detail_type", comment: "Model name of the related object"
     t.datetime "read_at", comment: "When the message was read"
     t.string "text", comment: "The message"
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false, comment: "The user for whom the message is intended"
+    t.index ["detail_type", "detail_id"], name: "index_messages_on_detail_type_and_detail_id"
   end
 
   create_table "non_availabilities", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1223,6 +1223,35 @@ class SeedDB
     end
   end
 
+  def create_inbox_messages
+    user = User.find_by_css_id "BVAYELLOW"
+
+    veteran1 = Veteran.find_or_create_by_file_number "994806951"
+    veteran2 = Veteran.find_or_create_by_file_number "520353651"
+
+    appeal1 = FactoryBot.create(:appeal, veteran_file_number: veteran1.file_number)
+    appeal2 = FactoryBot.create(
+      :legacy_appeal,
+      vacols_case: FactoryBot.create(:case),
+      vbms_id: "#{veteran2.file_number}S"
+    )
+
+    message1 = <<~MSG
+      <a href="/queue/appeals/#{appeal1.uuid}">Veteran ID #{veteran1.file_number}</a> - Virtual hearing not scheduled
+      Caseflow is having trouble contacting the virtual hearing scheduler.
+      For help, submit a support ticket using <a href="https://yourit.va.gov/">YourIT</a>.
+    MSG
+
+    message2 = <<~MSG
+      <a href="/queue/appeals/#{appeal2.vacols_id}">Veteran ID #{veteran2.file_number}</a> - Hearing time not updated
+      Caseflow is having trouble contacting the virtual hearing scheduler.
+      For help, submit a support ticket using <a href="https://yourit.va.gov/">YourIT</a>.
+    MSG
+
+    Message.create(text: message1, detail: appeal1, user: user)
+    Message.create(text: message2, detail: appeal2, user: user)
+  end
+
   def seed
     clean_db
     # Annotations and tags don't come from VACOLS, so our seeding should
@@ -1247,6 +1276,8 @@ class SeedDB
     create_veteran_record_request_tasks
 
     create_intake_users
+
+    create_inbox_messages
 
     # Active Jobs which populate tables based on seed data
     FetchHearingLocationsForVeteransJob.perform_now

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -11,4 +11,12 @@ describe Message, :postgres do
       expect(described_class.unread.count).to eq(1)
     end
   end
+
+  describe "#detail" do
+    let!(:message) { create(:message, detail: create(:appeal)) }
+
+    it "allows us to optionally associate another object" do
+      expect(message.detail).to be_a(Appeal)
+    end
+  end
 end


### PR DESCRIPTION
connects #11907 

### Description

Adds `detail` polymorphic association to inbox messages. This allows us to attach misc objects to a message, e.g. to relate to a specific async job or job note.

Also adds some seeds for demo purposes.

![Screen Shot 2019-10-10 at 5 28 54 PM](https://user-images.githubusercontent.com/1205061/66611432-25914a80-eb84-11e9-8ab0-5bfa2bd3e60c.png)


*Schema Changes Only*

* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
