### PR TITLE
instead of sleep, cache geomatch API responses

### DIFF
--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -36,7 +36,6 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
         appeal.reload # we only selected id and ahl_update_at, reload all columns
         geomatch_result = geomatch(appeal)
         record_geomatched_appeal(appeal.external_id, geomatch_result[:status])
-        sleep 1
       rescue Caseflow::Error::VaDotGovLimitError
         record_geomatched_appeal(appeal.external_id, "limit_error")
         break

--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "json"
+require "digest"
 
 class ExternalApi::VADotGovService
   BASE_URL = ENV["VA_DOT_GOV_API_URL"] || ""
@@ -32,10 +33,13 @@ class ExternalApi::VADotGovService
     private
 
     def send_facilities_request(query:)
-      response = send_va_dot_gov_request(
-        query: query,
-        endpoint: FACILITIES_ENDPOINT
-      )
+      cache_key = Digest::SHA1.hexdigest query.to_json
+      response = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+        send_va_dot_gov_request(
+          query: query,
+          endpoint: FACILITIES_ENDPOINT
+        )
+      end
 
       ExternalApi::VADotGovService::FacilitiesResponse.new(response)
     end
@@ -51,7 +55,6 @@ class ExternalApi::VADotGovService
         remaining_ids -= response.data.pluck(:facility_id)
 
         page += 1
-        sleep 1
       end
 
       if !remaining_ids.empty? && response.success?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1252,36 +1252,43 @@ class SeedDB
     Message.create(text: message2, detail: appeal2, user: user)
   end
 
-  def seed
-    clean_db
-    # Annotations and tags don't come from VACOLS, so our seeding should
-    # create them in all envs
-    create_annotations
-    create_tags
-    create_users
-    create_ama_appeals
-    create_hearing_days
-    create_veterans_ready_for_hearing
-    create_tasks
-    create_higher_level_review_tasks
-
-    setup_dispatch
-    create_previously_held_hearing_data
-    create_legacy_issues_eligible_for_opt_in
-
-    create_higher_level_reviews_and_supplemental_claims
-
-    create_ama_hearing_appeals
-    create_board_grant_tasks
-    create_veteran_record_request_tasks
-
-    create_intake_users
-
-    create_inbox_messages
-
+  def perform_seeding_jobs
     # Active Jobs which populate tables based on seed data
     FetchHearingLocationsForVeteransJob.perform_now
     UpdateCachedAppealsAttributesJob.perform_now
+    NightlySyncsJob.perform_now
+  end
+
+  def call_and_log_seed_step(step)
+    Rails.logger.debug("Starting seed step #{step}")
+    send(step)
+    Rails.logger.debug("Finished seed step #{step}")
+  end
+
+  def seed
+    call_and_log_seed_step :clean_db
+
+    # Annotations and tags don't come from VACOLS, so our seeding should
+    # create them in all envs
+    call_and_log_seed_step :create_annotations
+    call_and_log_seed_step :create_tags
+
+    call_and_log_seed_step :create_users
+    call_and_log_seed_step :create_ama_appeals
+    call_and_log_seed_step :create_hearing_days
+    call_and_log_seed_step :create_veterans_ready_for_hearing
+    call_and_log_seed_step :create_tasks
+    call_and_log_seed_step :create_higher_level_review_tasks
+    call_and_log_seed_step :setup_dispatch
+    call_and_log_seed_step :create_previously_held_hearing_data
+    call_and_log_seed_step :create_legacy_issues_eligible_for_opt_in
+    call_and_log_seed_step :create_higher_level_reviews_and_supplemental_claims
+    call_and_log_seed_step :create_ama_hearing_appeals
+    call_and_log_seed_step :create_board_grant_tasks
+    call_and_log_seed_step :create_veteran_record_request_tasks
+    call_and_log_seed_step :create_intake_users
+    call_and_log_seed_step :create_inbox_messages
+    call_and_log_seed_step :perform_seeding_jobs
 
     return if Rails.env.development?
 

--- a/spec/feature/hearings/add_hearing_day_spec.rb
+++ b/spec/feature/hearings/add_hearing_day_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "support/database_cleaner"
+require "support/vacols_database_cleaner"
 require "rails_helper"
 
-RSpec.feature "Add a Hearing Day", :postgres do
+RSpec.feature "Add a Hearing Day", :all_dbs do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     OrganizationsUser.add_user_to_organization(user, HearingsManagement.singleton)


### PR DESCRIPTION
Our `rake db:seed` task was very slow because we had two `sleep 1` calls in a loop, as part of the `FetchHearingLocationsForVeteransJob` process.

This PR adds some logging to the seed process so it's easier to spot which steps are happening in the Rails logs, and eliminates the `sleep` calls. Instead identical API calls to the geomatching service are cached for 24 hours, which avoids the need I think the `sleep` was filling (throttling our use of that va.gov API). My assumption with the caching logic is that geomatching is a relatively fixed thing (stations don't physically move often).

The speed up is pretty dramatic:
```
before: 5m52.478s
after: 2m11.036s
```