### PR TITLE
Optimize query for appeals with zero tasks

### DIFF
--- a/app/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query.rb
+++ b/app/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query.rb
@@ -42,7 +42,7 @@ class AppealsWithNoTasksOrAllTasksOnHoldQuery
   end
 
   def appeals_with_zero_tasks
-    established_appeals.where.not(id: Task.select(:appeal_id).where(appeal_type: Appeal.name))
+    established_appeals.left_outer_joins(:tasks).where(tasks: { id: nil })
   end
 
   def tasks_for(klass_name)


### PR DESCRIPTION
Data integrity check was timing out after 30 seconds due to some (surprisingly) inefficient SQL.