### PR TITLE
Geomatch cache for 2 hours, not 24

### DIFF
--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -34,7 +34,7 @@ class ExternalApi::VADotGovService
 
     def send_facilities_request(query:)
       cache_key = Digest::SHA1.hexdigest query.to_json
-      response = Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      response = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
         send_va_dot_gov_request(
           query: query,
           endpoint: FACILITIES_ENDPOINT


### PR DESCRIPTION
connects #12366 

### Description
24 hour cache means we fill up redis at a much higher rate.

2 hours is enough to hit the main use case (caching station locations), and provide enough overlap for multiple hits to the same veteran location over the hourly cron job runs.