### PR TITLE
Fix test flake on attorney task validation

### DIFF
--- a/spec/sql/ama_cases_sql_spec.rb
+++ b/spec/sql/ama_cases_sql_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/database_cleaner"
 
-describe "AMA Cases Tableau data source", :postgres do
+describe "AMA Cases Tableau data source", :all_dbs do
   include SQLHelpers
 
   include_context "AMA Tableau SQL"

--- a/spec/sql/ama_tasks_sql_spec.rb
+++ b/spec/sql/ama_tasks_sql_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/database_cleaner"
 
-describe "AMA Tasks Tableau data source", :postgres do
+describe "AMA Tasks Tableau data source", :all_dbs do
   include SQLHelpers
 
   include_context "AMA Tableau SQL"

--- a/spec/support/shared_examples/ama_sql.rb
+++ b/spec/support/shared_examples/ama_sql.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 shared_context "AMA Tableau SQL", shared_context: :metadata do
-  let!(:staff) { create(:staff) }
+  let!(:staff) { create(:staff, :attorney_judge_role) }
   let(:user) do
     CachedUser.sync_from_vacols
     user = create(:user, css_id: CachedUser.first.sdomainid)


### PR DESCRIPTION
### Description

Seeing a test flaking in Circle CI. I am able to reproduce this locally.

Log:

```
  1) AMA Tasks Tableau data source one row for each Appeal join staff tables and computes status
     Failure/Error: create(:ama_attorney_task, assigned_to: user, appeal: appeal, parent: root_task)

     ActiveRecord::RecordInvalid:
       Validation failed: Assigned to has to be an attorney
     # ./spec/support/shared_examples/ama_sql.rb:65:in `block (3 levels) in <top (required)>'
     # ./spec/support/shared_examples/ama_sql.rb:62:in `tap'
     # ./spec/support/shared_examples/ama_sql.rb:62:in `block (2 levels) in <top (required)>'
```

#### Changes

  * Updated tests that use `AMA Tableau SQL` context with VACOLS cleaner. I think this is needed because the shared context creates some `VACOLS::Staff` rows (?)
  * Updated shared user to satisfy attorney and judge roles