### PR TITLE
move att name printout to task_tree_attributes

### DIFF
--- a/app/models/concerns/prints_task_tree.rb
+++ b/app/models/concerns/prints_task_tree.rb
@@ -9,7 +9,6 @@ module PrintsTaskTree
 
   def structure(*atts)
     leaf_name = "#{self.class.name} #{task_tree_attributes(*atts)}"
-    leaf_name += " [#{atts.join(', ')}]" unless is_a? Task
     { "#{leaf_name}": task_tree_children.map { |child| child.structure(*atts) } }
   end
 
@@ -24,7 +23,7 @@ module PrintsTaskTree
   def task_tree_attributes(*atts)
     return attributes_to_s(*atts) if is_a? Task
 
-    id.to_s
+    "#{id} [#{atts.join(', ')}]"
   end
 
   def attributes_to_s(*atts)


### PR DESCRIPTION
Connects #12305

### Description
Tiny refactor of the prints_task_tree concern; moves the attribute name printout to the `task_tree_attributes` method so we don't have to check whether we're a task or not.