### PR TITLE
VirtualHearingMailer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "6c0c2908a9e4a61f5bcf2a768061909e3c763fe8"
 gem "dogstatsd-ruby"
 gem "fast_jsonapi"
+gem "govdelivery-tms", "2.8.4", require: "govdelivery/tms/mail/delivery_method"
 gem "holidays", "~> 6.4"
 gem "kaminari"
 # active_model_serializers has a default dependency on loofah 2.2.2 which has a security vuln (CVE-2018-16468)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
     fasterer (0.6.0)
@@ -235,6 +237,11 @@ GEM
     git (1.5.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govdelivery-tms (2.8.4)
+      activesupport
+      faraday
+      faraday_middleware
+      mime-types
     guard (2.14.2)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -302,6 +309,9 @@ GEM
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 7)
     method_source (0.9.2)
+    mime-types (3.3)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.1009)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -578,6 +588,7 @@ DEPENDENCIES
   fast_jsonapi
   fasterer
   foreman
+  govdelivery-tms (= 2.8.4)
   guard-rspec
   holidays (~> 6.4)
   jshint

--- a/app/mailers/virtual_hearing_mailer.rb
+++ b/app/mailers/virtual_hearing_mailer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class VirtualHearingMailer < ActionMailer::Base
+  default from: "do-not-reply@va.gov"
+  layout "mailer"
+  attr_reader :recipient
+
+  RECIPIENT_TITLES = {
+    judge: "Judge",
+    veteran: "Veteran",
+    representative: "Representative"
+  }.freeze
+
+  def cancellation(mail_recipient:, virtual_hearing: nil)
+    @recipient = mail_recipient
+    @virtual_hearing = virtual_hearing
+    mail(to: recipient.email, subject: "Cancellation Subject")
+  end
+
+  def confirmation(mail_recipient:, virtual_hearing: nil)
+    @recipient = mail_recipient
+    @virtual_hearing = virtual_hearing
+    mail(to: recipient.email, subject: "Confirmation Subject")
+  end
+end

--- a/app/models/mail_recipient.rb
+++ b/app/models/mail_recipient.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class MailerRecipient
+class MailRecipient
   attr_reader :full_name, :email, :title
 
   def initialize(full_name:, email:, title: nil)

--- a/app/models/mailer_recipient.rb
+++ b/app/models/mailer_recipient.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class MailerRecipient
+  attr_reader :full_name, :email, :title
+
+  def initialize(full_name:, email:, title: nil)
+    @full_name = full_name
+    @email = email
+    @title = title
+  end
+end

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/virtual_hearing_mailer/cancellation.html.erb
+++ b/app/views/virtual_hearing_mailer/cancellation.html.erb
@@ -1,0 +1,3 @@
+Hi <%= @recipient.full_name %>,
+
+Your virtual hearing on <%= "virtual_hearing_date" %> was cancelled

--- a/app/views/virtual_hearing_mailer/confirmation.html.erb
+++ b/app/views/virtual_hearing_mailer/confirmation.html.erb
@@ -1,0 +1,3 @@
+Hi <%= @recipient.full_name %>,
+
+Your virtual hearing on <%= "virtual_hearing_date" %> is confirmed.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,6 +83,12 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  config.action_mailer.delivery_method = :govdelivery_tms
+  config.action_mailer.govdelivery_tms_settings = {
+    auth_token: ENV["GOVDELIVERY_TOKEN"],
+    api_root: "https://#{ENV["GOVDELIVERY_SERVER"]}"
+  }
+
   # eFolder API URL to retrieve appeal documents
   config.efolder_url = "http://localhost:4000"
   config.efolder_key = "token"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,6 +66,8 @@ Rails.application.configure do
     config.log_level = :error
   end
 
+  config.action_mailer.delivery_method = :test
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 describe VirtualHearingMailer do
   let(:title) { VirtualHearingMailer::RECIPIENT_TITLES[:judge] }
-  let(:recipient) { MailerRecipient.new(full_name: "FirstName LastName", email: "email@test.com", title: title) }
+  let(:recipient) { MailRecipient.new(full_name: "FirstName LastName", email: "email@test.com", title: title) }
 
   describe "#cancellation" do
     it "sends a cancellation email" do

--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe VirtualHearingMailer, focus: true do
+describe VirtualHearingMailer do
   let(:title) { VirtualHearingMailer::RECIPIENT_TITLES[:judge] }
   let(:recipient) { MailerRecipient.new(full_name: "FirstName LastName", email: "email@test.com", title: title) }
 

--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe VirtualHearingMailer, focus: true do
+  let(:title) { VirtualHearingMailer::RECIPIENT_TITLES[:judge] }
+  let(:recipient) { MailerRecipient.new(full_name: "FirstName LastName", email: "email@test.com", title: title) }
+
+  describe "#cancellation" do
+    it "sends a cancellation email" do
+      expect { VirtualHearingMailer.cancellation(mail_recipient: recipient).deliver_now }
+        .to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+
+  describe "#confirmation" do
+    it "sends a confirmation email" do
+      expect { VirtualHearingMailer.confirmation(mail_recipient: recipient).deliver_now }
+        .to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end


### PR DESCRIPTION
connects #12330 

- creates `MailRecipient` class
- creates `VirtualHearingMailer` with 2 methods `cancellation` and `confirmation`

to use:
```ruby
recipient = MailRecipient.new(
  full_name: "Name",
  email: "address@email.com",
  title: VirtualHearingMailer::RECIPIENT_TITLES[:veteran]
)
VirtualHearingMailer.cancellation(mail_recipient: recipient, virtual_hearing; VirtualHearing.first)
  .deliver_later # or .deliver_now
```

Follow up work:
- Use GovDelivery tokens and test in UAT
- Add templates for each recipient title 