### PR TITLE
LegacyAppeal.activated? includes Motion status

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -529,7 +529,7 @@ class LegacyAppeal < ApplicationRecord
 
   def activated?
     # An appeal is currently at the board, and it has passed some data checks
-    status == "Active"
+    %w[Active Motion].include?(status)
   end
 
   def active?

--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -199,6 +199,10 @@ FactoryBot.define do
       bfmpro { "ADV" }
     end
 
+    trait :status_motion do
+      bfmpro { "MOT" }
+    end
+
     trait :disposition_allowed do
       bfdc { "1" }
     end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -43,6 +43,31 @@ describe LegacyAppeal, :all_dbs do
     end
   end
 
+  describe "#activated?" do
+    let(:vacols_case) { create(:case, case_status) }
+    let(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+
+    subject { legacy_appeal.activated? }
+
+    context "status is Active" do
+      let(:case_status) { :status_active }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "status is Motion" do
+      let(:case_status) { :status_motion }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "status is Complete" do
+      let(:case_status) { :status_complete }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe "#veteran_file_number" do
     context "VACOLS has SSN as filenumber" do
       let(:ssn) { "123456789" }


### PR DESCRIPTION
### Description

VACOLS case status "Motion" should be considered "activated" since it means attorneys can be assigned the case and work on them.

Affects IDT API. Reported in https://dsva.slack.com/archives/CD5DAQNCU/p1571422268001600