### PR TITLE
Add Aria labels for Reader table sorting controls

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -168,6 +168,7 @@ class DocumentsTable extends React.Component {
           name="Receipt Date"
           id="receipt-date-header"
           classNames={['cf-document-list-button-header']}
+          ariaLabel="Sort by Receipt Date"
           onClick={() => this.props.changeSortState('receivedAt')}>
           Receipt Date {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ? sortArrowIcon : notSortedIcon }
         </Button>,
@@ -182,6 +183,7 @@ class DocumentsTable extends React.Component {
         header: <Button id="type-header"
           name="Document Type"
           classNames={['cf-document-list-button-header']}
+          ariaLabel="Sort by Document Type"
           onClick={() => this.props.changeSortState('type')}>
           Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortArrowIcon : notSortedIcon }
         </Button>,

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -259,8 +259,20 @@ DocumentsTable.propTypes = {
   onJumpToComment: PropTypes.func,
   sortBy: PropTypes.string,
   pdfList: PropTypes.shape({
-    lastReadDocId: PropTypes.number
-  })
+    lastReadDocId: PropTypes.number,
+    scrollTop: PropTypes.number
+  }),
+  changeSortState: PropTypes.func.isRequired,
+  clearCategoryFilters: PropTypes.func,
+  clearTagFilters: PropTypes.func,
+  documentPathBase: PropTypes.string,
+  annotationsPerDocument: PropTypes.object,
+  docFilterCriteria: PropTypes.object,
+  setCategoryFilter: PropTypes.func.isRequired,
+  setTagFilter: PropTypes.func.isRequired,
+  setDocListScrollPosition: PropTypes.func.isRequired,
+  toggleDropdownFilterVisibility: PropTypes.func.isRequired,
+  tagOptions: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({


### PR DESCRIPTION
Resolves #12135 

### Description
Added `aria-label` attributes to Reader's buttons for sorting by Receipt Date and Document Type.

### Acceptance Criteria
- [ ] "Sort by Receipt Date" and "Sort by Document Type" are read by VoiceOver when tabbing to select these two buttons via keyboard.

### Testing Plan
1. Switch user to a judge who has cases to review (`BVAAABSHIRE` works for this)
2. Go to the document list view in Reader
3. Enable VoiceOver (see instructions in #12095)
4. Use keyboard to tab over to "Receipt Date" and "Document Type" in the table header, and verify that the additional words "Sort by..." are read.
