### PR TITLE
Update Loofah gem to mitigate CVE-2019-15587

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,9 @@ gem "fast_jsonapi"
 gem "govdelivery-tms", "2.8.4", require: "govdelivery/tms/mail/delivery_method"
 gem "holidays", "~> 6.4"
 gem "kaminari"
-# active_model_serializers has a default dependency on loofah 2.2.2 which has a security vuln (CVE-2018-16468)
-gem "loofah", ">= 2.2.3"
+# active_model_serializers has a default dependency on loofah 2.2.2 which security vulnerabilities
+# (CVE-2018-16468 and CVE-2019-15587)
+gem "loofah", ">= 2.3.1"
 gem "moment_timezone-rails"
 gem "newrelic_rpm"
 # nokogiri versions before 1.10.4 are vulnerable to CVE-2019-5477.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,7 +177,7 @@ GEM
       colored2 (~> 3.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.5)
     d3-rails (5.9.2)
       railties (>= 3.1)
     danger (5.16.1)
@@ -298,7 +298,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.3)
+    loofah (2.3.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -593,7 +593,7 @@ DEPENDENCIES
   holidays (~> 6.4)
   jshint
   kaminari
-  loofah (>= 2.2.3)
+  loofah (>= 2.3.1)
   meta_request
   moment_timezone-rails
   newrelic_rpm


### PR DESCRIPTION
Mitigates XSS vulnerability in Loofah gem ([described here](https://github.com/flavorjones/loofah/issues/171)) by upgrading gem beyond affected versions.