### PR TITLE
Create JudgeTeamLead when creating JudgeTeams for judges

### DIFF
--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -6,6 +6,8 @@ class JudgeTeam < Organization
   end
 
   def self.create_for_judge(user)
+    fail(Caseflow::Error::DuplicateJudgeTeam, user_id: user.id) if JudgeTeam.for_judge(user)
+
     create!(name: user.css_id, url: user.css_id.downcase).tap do |org|
       org_user = OrganizationsUser.make_user_admin(user, org)
       JudgeTeamLead.create!(organizations_user: org_user)

--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -7,7 +7,8 @@ class JudgeTeam < Organization
 
   def self.create_for_judge(user)
     create!(name: user.css_id, url: user.css_id.downcase).tap do |org|
-      OrganizationsUser.make_user_admin(user, org)
+      org_user = OrganizationsUser.make_user_admin(user, org)
+      JudgeTeamLead.create!(organizations_user: org_user)
     end
   end
 

--- a/app/models/organizations_user.rb
+++ b/app/models/organizations_user.rb
@@ -13,7 +13,9 @@ class OrganizationsUser < ApplicationRecord
   end
 
   def self.make_user_admin(user, organization)
-    add_user_to_organization(user, organization).update!(admin: true)
+    add_user_to_organization(user, organization).tap do |org_user|
+      org_user.update!(admin: true)
+    end
   end
 
   def self.remove_admin_rights_from_user(user, organization)

--- a/spec/models/judge_spec.rb
+++ b/spec/models/judge_spec.rb
@@ -42,6 +42,7 @@ describe Judge, :postgres do
     subject { judge.attorneys }
 
     it "returns a list of the judge's attorneys" do
+      judge.user.reload
       expect(subject).to match_array attorneys
     end
   end

--- a/spec/models/judge_team_spec.rb
+++ b/spec/models/judge_team_spec.rb
@@ -70,6 +70,7 @@ describe JudgeTeam, :postgres do
       let!(:judge_team) { JudgeTeam.create_for_judge(user) }
 
       it "should return judge team" do
+        user.reload
         expect(JudgeTeam.for_judge(user)).to eq(judge_team)
       end
     end
@@ -84,6 +85,7 @@ describe JudgeTeam, :postgres do
       end
 
       it "should return first judge team even when they admin two judge teams" do
+        user.reload
         expect(JudgeTeam.for_judge(user)).to eq(first_judge_team)
         expect(user.administered_teams.length).to eq(2)
       end

--- a/spec/models/judge_team_spec.rb
+++ b/spec/models/judge_team_spec.rb
@@ -7,17 +7,41 @@ describe JudgeTeam, :postgres do
   let(:judge) { create(:user) }
 
   describe ".create_for_judge" do
+    subject { JudgeTeam.create_for_judge(judge) }
+
     context "when user is not already an admin of an existing JudgeTeam" do
       it "should create a new organization and make the user an admin of that group" do
         expect(judge.organizations.length).to eq(0)
 
-        expect { JudgeTeam.create_for_judge(judge) }.to_not raise_error
+        expect { subject }.to_not raise_error
         judge.reload
 
         expect(judge.organizations.length).to eq(1)
         expect(judge.administered_teams.length).to eq(1)
         expect(judge.administered_teams.first.class).to eq(JudgeTeam)
         expect(judge.administered_teams.first.url).to eq(judge.css_id.downcase.parameterize.dasherize)
+      end
+
+      it "creates association with a JudgeTeamLead role with the judge" do
+        # Confirm there are no JudgeTeamLead entities associated with this judge.
+        expect(JudgeTeamLead.count).to eq(0)
+
+        judge_team = subject
+
+        # Find the association we should have created.
+        org_user = OrganizationsUser.find_by(organization: judge_team, user: judge)
+
+        # Make sure there is a JudgeTeamLead connected to it.
+        expect(org_user.judge_team_role).to be_a(JudgeTeamLead)
+      end
+    end
+
+    context "when a JudgeTeam already exists for this user" do
+      before { JudgeTeam.create_for_judge(judge) }
+
+      it "raises an error and fails to create the new JudgeTeam" do
+        judge.reload
+        expect { subject }.to raise_error(Caseflow::Error::DuplicateJudgeTeam)
       end
     end
   end

--- a/spec/models/organizations_user_spec.rb
+++ b/spec/models/organizations_user_spec.rb
@@ -36,4 +36,12 @@ describe OrganizationsUser, :postgres do
       end
     end
   end
+
+  describe ".make_user_admin" do
+    subject { OrganizationsUser.make_user_admin(user, organization) }
+
+    it "returns an instance of OrganizationsUser" do
+      expect(subject).to be_a(OrganizationsUser)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -312,6 +312,7 @@ describe User, :all_dbs do
       before { JudgeTeam.create_for_judge(user) }
 
       it "assign cases is returned" do
+        user.reload
         is_expected.to include(
           name: "Assign",
           url: format("queue/%<id>s/assign", id: user.id)

--- a/spec/workflows/das_deprecation/assign_task_to_attorney_spec.rb
+++ b/spec/workflows/das_deprecation/assign_task_to_attorney_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "support/database_cleaner"
+require "support/vacols_database_cleaner"
 require "rails_helper"
 
-describe DasDeprecation::AssignTaskToAttorney do
+describe DasDeprecation::AssignTaskToAttorney, :all_dbs do
   before do
     FeatureToggle.enable!(:legacy_das_deprecation)
     User.authenticate!(user: judge)


### PR DESCRIPTION
Connects #12481. Implements 1 part of 4 for the base ticket by creating a `JudgeTeamLead` instance associated with the `OrganizationsUser` object when a new `JudgeTeam` is created for a `User`.