### PR TITLE
Remove references to GenericTask

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -14,6 +14,7 @@ class TasksController < ApplicationController
     AttorneyTask: AttorneyTask,
     AttorneyQualityReviewTask: AttorneyQualityReviewTask,
     GenericTask: GenericTask,
+    Task: Task,
     QualityReviewTask: QualityReviewTask,
     JudgeAssignTask: JudgeAssignTask,
     JudgeQualityReviewTask: JudgeQualityReviewTask,

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -154,7 +154,7 @@ class ColocatedTask < Task
     appeal.tasks.open.select { |task| task.is_a?(ColocatedTask) }.none?
   end
 
-  # GenericTask.verify_org_task_unique already performs this check
+  # Task.verify_org_task_unique already performs this check
   def verify_org_task_unique; end
 
   def task_is_unique

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -13,7 +13,7 @@ class TaskActionRepository
       {
         selected: nil,
         options: organizations,
-        type: GenericTask.name
+        type: Task.name
       }
     end
 

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -69,7 +69,7 @@ class AssignToView extends React.Component {
     const action = getAction(this.props);
     const isPulacCerullo = action && action.label === 'Pulac-Cerullo';
 
-    const taskType = taskActionData(this.props).type ? taskActionData(this.props).type : 'GenericTask';
+    const taskType = taskActionData(this.props).type ? taskActionData(this.props).type : 'Task';
 
     const payload = {
       data: {

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -48,7 +48,7 @@ describe('ColocatedTaskListView', () => {
 
   const getAmaTaskTemplate = () => ({
     uniqueId: '1',
-    type: 'GenericTask',
+    type: 'Task',
     isLegacy: false,
     appealType: 'Appeal',
     addedByCssId: null,

--- a/client/test/karma/queue/mtv/sample.js
+++ b/client/test/karma/queue/mtv/sample.js
@@ -147,7 +147,7 @@ export const tasks = [
               value: 5
             }
           ],
-          type: 'GenericTask'
+          type: 'Task'
         }
       },
       {

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -599,7 +599,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       before do
         task_count.times do
           org_task = BvaDispatchTask.create_from_root_task(root_task)
-          # Set status of org-level task to completed to avoid getting caught by GenericTask.verify_org_task_unique.
+          # Set status of org-level task to completed to avoid getting caught by Task.verify_org_task_unique.
           org_task.update!(status: Constants.TASK_STATUSES.completed)
         end
       end

--- a/spec/controllers/organizations/tasks_controller_spec.rb
+++ b/spec/controllers/organizations/tasks_controller_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe Organizations::TasksController, :all_dbs, type: :controller do
           :task,
           appeal: appeal,
           appeal_type: "LegacyAppeal",
-          type: :GenericTask,
+          type: :Task,
           assigned_to: vso
         ),
         create(
           :task,
           appeal: create(:appeal),
-          type: :GenericTask,
+          type: :Task,
           assigned_to: vso
         )
       ]

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -326,7 +326,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         let(:params) do
           [{
             "external_id": appeal.external_id,
-            "type": GenericTask.name,
+            "type": Task.name,
             "assigned_to_id": user.id,
             "parent_id": root_task.id
           }]

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -94,8 +94,8 @@ FactoryBot.define do
       end
     end
 
-    factory :generic_task, class: GenericTask do
-      type { GenericTask.name }
+    factory :generic_task, class: Task do
+      type { Task.name }
       appeal { create(:appeal) }
     end
 
@@ -425,8 +425,8 @@ FactoryBot.define do
       assigned_to { TranscriptionTeam.singleton }
     end
 
-    factory :ama_vso_task, class: GenericTask do
-      type { GenericTask.name }
+    factory :ama_vso_task, class: Task do
+      type { Task.name }
       appeal { create(:appeal) }
       parent { create(:root_task) }
     end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -922,7 +922,7 @@ RSpec.feature "Case details", :all_dbs do
              appeal: appeal,
              assigned_by: judge_user,
              assigned_to: attorney_user,
-             type: GenericTask,
+             type: Task,
              parent_id: root_task.id,
              started_at: rand(1..10).days.ago,
              instructions: [instructions_text])
@@ -991,7 +991,7 @@ RSpec.feature "Case details", :all_dbs do
       end
       let!(:legacy_task) do
         create(:task, :in_progress, appeal: legacy_appeal,
-                                    assigned_by: judge_user, assigned_to: attorney_user, type: GenericTask,
+                                    assigned_by: judge_user, assigned_to: attorney_user, type: Task,
                                     parent_id: root_task.id, started_at: rand(1..10).days.ago)
       end
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -440,8 +440,8 @@ RSpec.feature "Task queue", :all_dbs do
     before do
       OrganizationsUser.add_user_to_organization(organization_user, organization)
       User.authenticate!(user: organization_user)
-      create_list(:generic_task, unassigned_count, :in_progress, assigned_to: organization)
-      create_list(:generic_task, assigned_count, :on_hold, assigned_to: organization)
+      create_list(:privacy_act_task, unassigned_count, :in_progress, assigned_to: organization)
+      create_list(:privacy_act_task, assigned_count, :on_hold, assigned_to: organization)
     end
 
     context "when not using pagination" do
@@ -583,7 +583,7 @@ RSpec.feature "Task queue", :all_dbs do
               expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
             end
             (foia_task_count + 1..unassigned_count).each do |index|
-              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
+              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(PrivacyActTask.label)
             end
           end
         end
@@ -597,7 +597,7 @@ RSpec.feature "Task queue", :all_dbs do
 
           it "sorts the correct column descending" do
             (1..foia_task_count).each do |index|
-              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
+              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(PrivacyActTask.label)
             end
             (foia_task_count + 1..unassigned_count).each do |index|
               expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
@@ -643,7 +643,7 @@ RSpec.feature "Task queue", :all_dbs do
             end
             expect(page).to have_content("Viewing 1-#{foia_task_count} of #{foia_task_count} total")
             expect(find("tbody").find_all("tr").length).to eq(foia_task_count)
-            expect(find("tbody")).not_to have_content(Task.label)
+            expect(find("tbody")).not_to have_content(PrivacyActTask.label)
           end
         end
       end
@@ -697,7 +697,7 @@ RSpec.feature "Task queue", :all_dbs do
           visit(organization.path)
           page.find_all("svg.table-icon")[1].click
           (1..foia_task_count).each do |index|
-            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
+            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(PrivacyActTask.label)
           end
           (foia_task_count + 1..unassigned_count).each do |index|
             expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
@@ -708,7 +708,7 @@ RSpec.feature "Task queue", :all_dbs do
             expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
           end
           (foia_task_count + 1..unassigned_count).each do |index|
-            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
+            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(PrivacyActTask.label)
           end
           expect(URI.parse(current_url).query).to eq "#{default_query_string}&#{query_string_asc}"
         end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -518,7 +518,7 @@ RSpec.feature "Task queue", :all_dbs do
 
         it "shows the correct filters" do
           page.find_all("path.unselected-filter-icon-inner").first.click
-          expect(page).to have_content("#{GenericTask.label.humanize} (#{unassigned_count / 2})")
+          expect(page).to have_content("#{Task.label.humanize} (#{unassigned_count / 2})")
           expect(page).to have_content("#{TranslationTask.label.humanize} (#{translation_task_count})")
         end
 
@@ -583,7 +583,7 @@ RSpec.feature "Task queue", :all_dbs do
               expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
             end
             (foia_task_count + 1..unassigned_count).each do |index|
-              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(GenericTask.label)
+              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
             end
           end
         end
@@ -597,7 +597,7 @@ RSpec.feature "Task queue", :all_dbs do
 
           it "sorts the correct column descending" do
             (1..foia_task_count).each do |index|
-              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(GenericTask.label)
+              expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
             end
             (foia_task_count + 1..unassigned_count).each do |index|
               expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
@@ -643,7 +643,7 @@ RSpec.feature "Task queue", :all_dbs do
             end
             expect(page).to have_content("Viewing 1-#{foia_task_count} of #{foia_task_count} total")
             expect(find("tbody").find_all("tr").length).to eq(foia_task_count)
-            expect(find("tbody")).not_to have_content(GenericTask.label)
+            expect(find("tbody")).not_to have_content(Task.label)
           end
         end
       end
@@ -697,7 +697,7 @@ RSpec.feature "Task queue", :all_dbs do
           visit(organization.path)
           page.find_all("svg.table-icon")[1].click
           (1..foia_task_count).each do |index|
-            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(GenericTask.label)
+            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
           end
           (foia_task_count + 1..unassigned_count).each do |index|
             expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
@@ -708,7 +708,7 @@ RSpec.feature "Task queue", :all_dbs do
             expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(FoiaTask.label)
           end
           (foia_task_count + 1..unassigned_count).each do |index|
-            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(GenericTask.label)
+            expect(page.find("tbody>tr:nth-of-type(#{index})")).to have_content(Task.label)
           end
           expect(URI.parse(current_url).query).to eq "#{default_query_string}&#{query_string_asc}"
         end
@@ -749,7 +749,7 @@ RSpec.feature "Task queue", :all_dbs do
             format(COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, organization.name)
           )
           page.find_all("path.unselected-filter-icon-inner").first.click
-          expect(page).to have_content("#{GenericTask.label} (#{unassigned_count / 2})")
+          expect(page).to have_content("#{Task.label} (#{unassigned_count / 2})")
           expect(page).to have_content("#{FoiaTask.label} (#{foia_task_count})")
         end
 
@@ -1134,7 +1134,7 @@ RSpec.feature "Task queue", :all_dbs do
     end
   end
 
-  describe "GenericTask" do
+  describe "Task" do
     context "when it is assigned to the current user" do
       let(:user) { create(:user) }
       let(:root_task) { create(:root_task) }

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -518,7 +518,7 @@ RSpec.feature "Task queue", :all_dbs do
 
         it "shows the correct filters" do
           page.find_all("path.unselected-filter-icon-inner").first.click
-          expect(page).to have_content("#{Task.label.humanize} (#{unassigned_count / 2})")
+          expect(page).to have_content("#{PrivacyActTask.label.humanize} (#{unassigned_count / 2})")
           expect(page).to have_content("#{TranslationTask.label.humanize} (#{translation_task_count})")
         end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -186,7 +186,7 @@ describe Task, :all_dbs do
       end
 
       context "when child task has a different type than parent" do
-        let!(:child) { create(:generic_task, :completed, parent_id: task.id) }
+        let!(:child) { create(:quality_review_task, :completed, parent_id: task.id) }
         it "sets the status of the parent to assigned" do
           subject
           expect(task.reload.status).to eq(Constants.TASK_STATUSES.assigned)
@@ -300,7 +300,7 @@ describe Task, :all_dbs do
       let(:task) do
         t = create(:generic_task, parent_id: root_task.id)
         5.times { t = create(:generic_task, parent_id: t.id) }
-        GenericTask.last
+        Task.last
       end
 
       it "should return the root_task" do
@@ -312,7 +312,7 @@ describe Task, :all_dbs do
       let(:task) do
         t = create(:generic_task)
         5.times { t = create(:generic_task, parent_id: t.id) }
-        GenericTask.last
+        Task.last
       end
 
       it "should throw an error" do

--- a/spec/models/tasks/generic_task_spec.rb
+++ b/spec/models/tasks/generic_task_spec.rb
@@ -3,14 +3,14 @@
 require "support/database_cleaner"
 require "rails_helper"
 
-describe GenericTask, :postgres do
+describe Task, :postgres do
   describe ".available_actions" do
     let(:task) { nil }
     let(:user) { nil }
     subject { task.available_actions(user) }
 
     context "when task is assigned to user" do
-      let(:task) { GenericTask.find(create(:generic_task).id) }
+      let(:task) { create(:generic_task) }
       let(:user) { task.assigned_to }
       let(:expected_actions) do
         [
@@ -27,7 +27,7 @@ describe GenericTask, :postgres do
     end
 
     context "when task is assigned to somebody else" do
-      let(:task) { GenericTask.find(create(:generic_task).id) }
+      let(:task) { create(:generic_task) }
       let(:user) { create(:user) }
       let(:expected_actions) { [] }
       it "should return an empty array" do
@@ -37,7 +37,7 @@ describe GenericTask, :postgres do
 
     context "when task is assigned to an organization the user is a member of" do
       let(:org) { Organization.find(create(:organization).id) }
-      let(:task) { GenericTask.find(create(:generic_task, assigned_to: org).id) }
+      let(:task) { create(:generic_task, assigned_to: org) }
       let(:user) { create(:user) }
       let(:expected_actions) do
         [
@@ -173,7 +173,7 @@ describe GenericTask, :postgres do
 
   describe ".available_actions_unwrapper" do
     let(:user) { create(:user) }
-    let(:task) { GenericTask.find(create(:generic_task, trait, assigned_to: assignee).id) }
+    let(:task) { create(:generic_task, trait, assigned_to: assignee) }
     subject { task.available_actions_unwrapper(user) }
 
     context "when task assigned to the user is has been completed" do
@@ -201,7 +201,7 @@ describe GenericTask, :postgres do
     let(:other_user) { create(:user) }
     let(:org) { create(:organization) }
     let(:other_org) { create(:organization) }
-    let(:task) { GenericTask.find(create(:generic_task, :in_progress, assigned_to: assignee).id) }
+    let(:task) { create(:generic_task, :in_progress, assigned_to: assignee) }
 
     before do
       OrganizationsUser.add_user_to_organization(user, org)
@@ -239,7 +239,7 @@ describe GenericTask, :postgres do
   describe ".update_from_params" do
     let(:user) { create(:user) }
     let(:org) { create(:organization) }
-    let(:task) { GenericTask.find(create(:generic_task, :in_progress, assigned_to: assignee).id) }
+    let(:task) { create(:generic_task, :in_progress, assigned_to: assignee) }
 
     context "task is assigned to an organization" do
       let(:assignee) { org }
@@ -258,7 +258,7 @@ describe GenericTask, :postgres do
         end
 
         it "should update the task's status" do
-          expect_any_instance_of(GenericTask).to receive(:update!)
+          expect_any_instance_of(Task).to receive(:update!)
           task.update_from_params({ status: Constants.TASK_STATUSES.completed }, user)
         end
       end
@@ -276,7 +276,7 @@ describe GenericTask, :postgres do
 
       context "who is the current user" do
         it "should receive the update" do
-          expect_any_instance_of(GenericTask).to receive(:update!)
+          expect_any_instance_of(Task).to receive(:update!)
           task.update_from_params({ status: Constants.TASK_STATUSES.completed }, user)
         end
 
@@ -288,9 +288,9 @@ describe GenericTask, :postgres do
       end
 
       context "and the parameters include a reassign parameter" do
-        it "should call GenericTask.reassign" do
-          allow_any_instance_of(GenericTask).to receive(:reassign).and_return(true)
-          expect_any_instance_of(GenericTask).to receive(:reassign)
+        it "should call Task.reassign" do
+          allow_any_instance_of(Task).to receive(:reassign).and_return(true)
+          expect_any_instance_of(Task).to receive(:reassign)
           task.update_from_params({ status: Constants.TASK_STATUSES.completed, reassign: { instructions: nil } }, user)
         end
       end
@@ -301,10 +301,7 @@ describe GenericTask, :postgres do
     let(:parent_assignee) { create(:user) }
     let(:current_user) { create(:user) }
     let(:assignee) { create(:user) }
-    let(:parent) do
-      t = create(:generic_task, :in_progress, assigned_to: parent_assignee)
-      GenericTask.find(t.id)
-    end
+    let(:parent) { create(:generic_task, :in_progress, assigned_to: parent_assignee) }
 
     let(:good_params) do
       {
@@ -325,7 +322,7 @@ describe GenericTask, :postgres do
         }]
       end
       it "should raise error before not creating child task nor update status" do
-        expect { GenericTask.create_many_from_params(params, parent_assignee).first }.to raise_error(TypeError)
+        expect { Task.create_many_from_params(params, parent_assignee).first }.to raise_error(TypeError)
       end
     end
 
@@ -338,7 +335,7 @@ describe GenericTask, :postgres do
         }]
       end
       it "should raise error before not creating child task nor update status" do
-        expect { GenericTask.create_many_from_params(params, parent_assignee).first }
+        expect { Task.create_many_from_params(params, parent_assignee).first }
           .to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -353,8 +350,8 @@ describe GenericTask, :postgres do
       end
       it "should create child task and not update parent task's status" do
         status_before = parent.status
-        GenericTask.create_many_from_params(params, parent_assignee)
-        expect(GenericTask.where(params.first).count).to eq(1)
+        Task.create_many_from_params(params, parent_assignee)
+        expect(Task.where(params.first).count).to eq(1)
         expect(parent.status).to eq(status_before)
       end
     end
@@ -362,7 +359,7 @@ describe GenericTask, :postgres do
     context "when parent task is assigned to a user" do
       context "when there is no current user" do
         it "should raise error and not create the child task nor update status" do
-          expect { GenericTask.create_many_from_params(good_params_array, nil).first }.to(
+          expect { Task.create_many_from_params(good_params_array, nil).first }.to(
             raise_error(Caseflow::Error::ActionForbiddenError)
           )
         end
@@ -371,7 +368,7 @@ describe GenericTask, :postgres do
       context "when the currently logged-in user owns the parent task" do
         let(:parent_assignee) { current_user }
         it "should create child task assigned by currently logged-in user" do
-          child = GenericTask.create_many_from_params(good_params_array, current_user).first
+          child = Task.create_many_from_params(good_params_array, current_user).first
           expect(child.assigned_by_id).to eq(current_user.id)
         end
       end
@@ -379,11 +376,11 @@ describe GenericTask, :postgres do
 
     context "when parent task is assigned to an organization" do
       let(:org) { create(:organization) }
-      let(:parent) { GenericTask.find(create(:generic_task, :in_progress, assigned_to: org).id) }
+      let(:parent) { create(:generic_task, :in_progress, assigned_to: org) }
 
       context "when there is no current user" do
         it "should raise error and not create the child task nor update status" do
-          expect { GenericTask.create_many_from_params(good_params_array, nil).first }.to(
+          expect { Task.create_many_from_params(good_params_array, nil).first }.to(
             raise_error(Caseflow::Error::ActionForbiddenError)
           )
         end
@@ -394,7 +391,7 @@ describe GenericTask, :postgres do
           OrganizationsUser.add_user_to_organization(current_user, org)
         end
         it "should create child task assigned by currently logged-in user" do
-          child = GenericTask.create_many_from_params(good_params_array, current_user).first
+          child = Task.create_many_from_params(good_params_array, current_user).first
           expect(child.assigned_by_id).to eq(current_user.id)
         end
       end
@@ -404,8 +401,8 @@ describe GenericTask, :postgres do
   describe ".reassign" do
     let(:org) { Organization.find(create(:organization).id) }
     let(:root_task) { RootTask.find(create(:root_task).id) }
-    let(:org_task) { GenericTask.find(create(:generic_task, parent_id: root_task.id, assigned_to: org).id) }
-    let(:task) { GenericTask.find(create(:generic_task, parent_id: org_task.id).id) }
+    let(:org_task) { create(:generic_task, parent_id: root_task.id, assigned_to: org) }
+    let(:task) { create(:generic_task, parent_id: org_task.id) }
     let(:old_assignee) { task.assigned_to }
     let(:new_assignee) { create(:user) }
     let(:params) do
@@ -502,9 +499,10 @@ describe GenericTask, :postgres do
         expect do
           appeals.each do |a|
             root_task = RootTask.create(appeal: a)
-            GenericTask.create!(
+            Task.create!(
               assigned_to: organization,
               parent_id: root_task.id,
+              type: Task.name,
               appeal: a
             )
           end

--- a/spec/models/tasks/mail_task_spec.rb
+++ b/spec/models/tasks/mail_task_spec.rb
@@ -489,21 +489,21 @@ describe MailTask, :postgres do
 
       context "for a ClearAndUnmistakeableErrorMailTask" do
         let(:task_class) { ClearAndUnmistakeableErrorMailTask }
-        it "returns the available_actions as defined by GenericTask" do
+        it "returns the available_actions as defined by Task" do
           expect(subject).to eq(generic_task_actions)
         end
       end
 
       context "for a ReconsiderationMotionMailTask" do
         let(:task_class) { ReconsiderationMotionMailTask }
-        it "returns the available_actions as defined by GenericTask" do
+        it "returns the available_actions as defined by Task" do
           expect(subject).to eq(generic_task_actions)
         end
       end
 
       context "for a VacateMotionMailTask" do
         let(:task_class) { VacateMotionMailTask }
-        it "returns the available_actions as defined by GenericTask" do
+        it "returns the available_actions as defined by Task" do
           expect(subject).to eq(generic_task_actions)
         end
       end

--- a/spec/models/tasks/privacy_act_task_spec.rb
+++ b/spec/models/tasks/privacy_act_task_spec.rb
@@ -3,7 +3,7 @@
 require "support/database_cleaner"
 require "rails_helper"
 
-describe GenericTask, :postgres do
+describe Task, :postgres do
   describe ".available_actions" do
     let(:task) { nil }
     let(:user) { nil }

--- a/spec/models/tasks/quality_review_task_spec.rb
+++ b/spec/models/tasks/quality_review_task_spec.rb
@@ -67,9 +67,9 @@ describe QualityReviewTask, :all_dbs do
     end
   end
 
-  describe "completing a child GenericTask" do
+  describe "completing a child Task" do
     let!(:generic_task_child) do
-      GenericTask.create!(appeal: qr_task.appeal, parent: qr_task, assigned_to: create(:user))
+      Task.create!(type: Task.name, appeal: qr_task.appeal, parent: qr_task, assigned_to: create(:user))
     end
     it "sets the status of the parent QualityReviewTask to assigned" do
       expect(qr_task.status).to eq(Constants.TASK_STATUSES.on_hold)

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -85,11 +85,11 @@ describe TimedHoldTask, :postgres do
         end
       end
 
-      context "when there is an active sibling TimedHoldTask and an active sibling GenericTask" do
+      context "when there is an active sibling TimedHoldTask and an active sibling Task" do
         let!(:existing_generic_task_sibling) { create(:generic_task, parent: parent, appeal: appeal) }
         let!(:existing_timed_hold_task) { create(:timed_hold_task, **args, parent: parent.reload) }
 
-        it "cancels the TimedHoldTask but leaves the GenericTask alone" do
+        it "cancels the TimedHoldTask but leaves the Task alone" do
           expect(subject.open?).to be_truthy
           expect(parent.children.count).to eq(3)
           expect(existing_generic_task_sibling.reload.open?).to eq(true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -406,7 +406,7 @@ describe User, :all_dbs do
 
     context "when appeal has task assigned to user" do
       let(:appeal) { create(:appeal) }
-      let!(:task) { create(:task, type: "GenericTask", appeal: appeal, assigned_to: user) }
+      let!(:task) { create(:task, appeal: appeal, assigned_to: user) }
 
       it "should return true" do
         expect(user.appeal_has_task_assigned_to_user?(appeal)).to eq(true)


### PR DESCRIPTION
Connects #11607. Removes references to `GenericTask` from application code and tests, and creates `Task`s instead of `GenericTask`s when assigning tasks without types.