### PR TITLE
Add Support for "Help" Text to RadioField

### DIFF
--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -12,13 +12,12 @@ import StringUtil from '../util/StringUtil';
  */
 
 export default class RadioField extends React.Component {
-
   isVertical() {
     return this.props.vertical || this.props.options.length > 2;
   }
 
   render() {
-    let {
+    const {
       id,
       className,
       label,
@@ -30,63 +29,58 @@ export default class RadioField extends React.Component {
       errorMessage,
       strongLabel,
       hideLabel,
+      help,
       styling
     } = this.props;
 
-    required = required || false;
+    const radioClass = className.
+      concat(this.isVertical() ? 'cf-form-radio' : 'cf-form-radio-inline').
+      concat(errorMessage ? 'usa-input-error' : '');
 
-    let radioClass = className.concat(
-      this.isVertical() ? 'cf-form-radio' : 'cf-form-radio-inline'
-    ).concat(
-      errorMessage ? 'usa-input-error' : ''
-    );
-
-    let labelClass = '';
-
-    if (hideLabel) {
-      labelClass += ' usa-sr-only';
-    }
+    const labelClass = hideLabel ? 'usa-sr-only' : '';
 
     // Since HTML5 IDs should not contain spaces...
-    let idPart = StringUtil.html5CompliantId(id || name);
+    const idPart = StringUtil.html5CompliantId(id || name);
 
-    const labelContents = <span>{(label || name)} {(required && <RequiredIndicator />)}</span>;
+    const labelContents = (
+      <span>
+        {label || name} {required && <RequiredIndicator />}
+      </span>
+    );
 
-    return <fieldset className={radioClass.join(' ')} {...styling}>
-      <legend className={labelClass}>
-        {
-          strongLabel ?
-            <strong>{labelContents}</strong> :
-            labelContents
-        }
-      </legend>
+    return (
+      <fieldset className={radioClass.join(' ')} {...styling}>
+        <legend className={labelClass}>{strongLabel ? <strong>{labelContents}</strong> : labelContents}</legend>
 
-      {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
+        {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
 
-      <div className="cf-form-radio-options">
-        {options.map((option, i) =>
-          <div className="cf-form-radio-option" key={`${idPart}-${option.value}-${i}`}>
-            <input
-              name={name}
-              onChange={(event) => {
-                onChange(event.target.value);
-              }}
-              type="radio"
-              id={`${idPart}_${option.value}`}
-              value={option.value}
-              checked={value === option.value}
-              disabled={Boolean(option.disabled)}
-            />
-            <label className={option.disabled ? 'disabled' : ''}
-              htmlFor={`${idPart}_${option.value}`}>{option.displayText || option.displayElem}</label>
-          </div>
-        )}
-      </div>
-    </fieldset>;
+        <div className="cf-form-radio-options">
+          {options.map((option, i) => (
+            <div className="cf-form-radio-option" key={`${idPart}-${option.value}-${i}`}>
+              <input
+                name={name}
+                onChange={(event) => {
+                  onChange(event.target.value);
+                }}
+                type="radio"
+                id={`${idPart}_${option.value}`}
+                value={option.value}
+                checked={value === option.value}
+                disabled={Boolean(option.disabled)}
+              />
+              <label className={option.disabled ? 'disabled' : ''} htmlFor={`${idPart}_${option.value}`}>
+                {option.displayText || option.displayElem}
+              </label>
+            </div>
+          ))}
+        </div>
+      </fieldset>
+    );
   }
 }
 
 RadioField.defaultProps = {
+  required: false,
   className: ['usa-fieldset-inputs']
 };
 
@@ -104,5 +98,10 @@ RadioField.propTypes = {
     })
   ),
   value: PropTypes.string,
+  vertical: PropTypes.bool,
+  errorMessage: PropTypes.string,
+  strongLabel: PropTypes.bool,
+  hideLabel: PropTypes.bool,
+  help: PropTypes.string,
   styling: PropTypes.object
 };

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -109,7 +109,8 @@ RadioField.propTypes = {
   options: PropTypes.arrayOf(
     PropTypes.shape({
       displayText: PropTypes.node,
-      value: PropTypes.string
+      value: PropTypes.string,
+      help: PropTypes.string
     })
   ),
   value: PropTypes.string,

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -1,8 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import classNames from 'classnames';
+
 import RequiredIndicator from './RequiredIndicator';
 import StringUtil from '../util/StringUtil';
+
+import { helpText } from './RadioField.module.scss';
+
+const RadioFieldHelpText = ({ help, className }) => {
+  const helpClasses = classNames('cf-form-radio-help', helpText, className);
+
+  return <div className={helpClasses}>{help}</div>;
+};
+
+RadioFieldHelpText.propTypes = {
+  help: PropTypes.string.isRequired,
+  className: PropTypes.string
+};
 
 /**
  * Radio button component.
@@ -29,7 +44,6 @@ export default class RadioField extends React.Component {
       errorMessage,
       strongLabel,
       hideLabel,
-      help,
       styling
     } = this.props;
 
@@ -71,6 +85,7 @@ export default class RadioField extends React.Component {
               <label className={option.disabled ? 'disabled' : ''} htmlFor={`${idPart}_${option.value}`}>
                 {option.displayText || option.displayElem}
               </label>
+              {option.help && <RadioFieldHelpText help={option.help} />}
             </div>
           ))}
         </div>
@@ -102,6 +117,5 @@ RadioField.propTypes = {
   errorMessage: PropTypes.string,
   strongLabel: PropTypes.bool,
   hideLabel: PropTypes.bool,
-  help: PropTypes.string,
   styling: PropTypes.object
 };

--- a/client/app/components/RadioField.module.scss
+++ b/client/app/components/RadioField.module.scss
@@ -1,0 +1,11 @@
+.helpText {
+  margin-top: -0.65em;
+  margin-bottom: 0.65em;
+  margin-left: calc(1.4rem + 0.75em + 3px);
+  color: #5b616b;
+  font-family: ‘Source Sans Pro’;
+  font-style: Italic;
+  font-weight: 400;
+  font-size: 17px;
+  line-height: 1.5em;
+}

--- a/client/app/components/RadioField.module.scss
+++ b/client/app/components/RadioField.module.scss
@@ -3,8 +3,7 @@
   margin-bottom: 0.65em;
   margin-left: calc(1.4rem + 0.75em + 3px);
   color: #5b616b;
-  font-family: ‘Source Sans Pro’;
-  font-style: Italic;
+  font-family: 'Source Sans Pro';
   font-weight: 400;
   font-size: 17px;
   line-height: 1.5em;

--- a/client/app/containers/StyleGuide/RadioFieldExamples/Example5.jsx
+++ b/client/app/containers/StyleGuide/RadioFieldExamples/Example5.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+
+// components
+import RadioField from '../../../components/RadioField';
+
+const options = [
+  { displayText: <span>Yosemite National Park</span>,
+    value: '1' },
+  { displayText: 'Grand Canyon National Park',
+    value: '2',
+    help: 'Lorem ipsum dolor sit amet' },
+  { displayText: 'Yellowstone National Park and related services',
+    value: '3' }
+];
+
+const Example5 = () => {
+  const [value, setValue] = useState('1');
+
+  const onChange = (val) => setValue(val);
+
+  return (
+    <RadioField
+      label={<h3 id="vertical-radio">With help text</h3>}
+      name="radio_example_5"
+      options={options}
+      value={value}
+      onChange={onChange}
+    />
+  );
+};
+
+export default Example5;

--- a/client/app/containers/StyleGuide/StyleGuideRadioField.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideRadioField.jsx
@@ -7,6 +7,7 @@ import Example1 from './RadioFieldExamples/Example1';
 import Example2 from './RadioFieldExamples/Example2';
 import Example3 from './RadioFieldExamples/Example3';
 import Example4 from './RadioFieldExamples/Example4';
+import Example5 from './RadioFieldExamples/Example5';
 
 export default class StyleGuideRadioField extends React.PureComponent {
 
@@ -25,6 +26,7 @@ export default class StyleGuideRadioField extends React.PureComponent {
       <Example3 />
       <h3>Required Radio Button</h3>
       <Example4 />
+      <Example5 />
     </div>;
   }
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -6,12 +6,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const devBuild = process.env.NODE_ENV !== 'production'; // eslint-disable-line no-process-env
 
 const config = {
-  entry: [
-    'es5-shim/es5-shim',
-    'es5-shim/es5-sham',
-    'babel-polyfill',
-    './app/index'
-  ],
+  entry: ['es5-shim/es5-shim', 'es5-shim/es5-sham', 'babel-polyfill', './app/index'],
   output: {
     filename: 'webpack-bundle.js',
     sourceMapFilename: 'sourcemap-[file].map',
@@ -46,41 +41,65 @@ const config = {
         loader: 'url-loader?limit=1024&name=fonts/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/'
       },
       {
+        test: /\.module\.s(a|c)ss$/,
+        use: [
+          {
+            loader: 'style-loader'
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
+          }
+        ]
+      },
+      {
         test: /\.scss?$/,
-        use: [{
-          loader: 'style-loader'
-        },
-        {
-          loader: 'css-loader',
-          options: {
-            sourceMap: true
+        exclude: /\.module.(s(a|c)ss)$/,
+        use: [
+          {
+            loader: 'style-loader'
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true
+            }
+          },
+          {
+            loader: 'sass-loader',
+            options: {
+              sourceMap: true
+            }
           }
-        },
-        {
-          loader: 'sass-loader',
-          options: {
-            sourceMap: true
-          }
-        }]
+        ]
       },
       {
         test: /\.css?$/,
-        use: [{
-          loader: 'style-loader'
-        },
-        {
-          loader: 'css-loader',
-          options: {
-            sourceMap: true,
-            url: false
+        use: [
+          {
+            loader: 'style-loader'
+          },
+          {
+            loader: 'css-loader',
+            options: {
+              sourceMap: true,
+              url: false
+            }
           }
-        }]
+        ]
       },
       {
         test: /\.(png|svg|jpg|gif)$/,
-        use: [
-          'url-loader?limit=1024&name=images/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/'
-        ]
+        use: ['url-loader?limit=1024&name=images/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/']
       }
     ]
   }


### PR DESCRIPTION
Connects #12450

### Description
Added optional support for "help" text for the `RadioField` component. This should be set via a `help` property on the objects passed via the `options` prop.

### Acceptance Criteria
- [ ] Styles for new "help" text are correct

### Testing Plan
1. Go to Caseflow Styleguide
2. Click on "Radio Buttons" option
3. Look at the "With help text" example
