### PR TITLE
Only reopen judge assign tasks if attorney tasks are cancelled

### DIFF
--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -14,7 +14,7 @@ class AttorneyTask < Task
   validate :assigned_to_role_is_valid
   validate :child_attorney_tasks_are_completed, on: :create
 
-  after_update :send_back_to_judge_assign, if: :task_just_cancelled?
+  after_update :send_back_to_judge_assign, if: :attorney_task_just_cancelled?
 
   def available_actions(user)
     # Both the judge who assigned this task and the judge who is assigned the parent review task get these actions
@@ -63,8 +63,8 @@ class AttorneyTask < Task
     errors.add(:assigned_by, "has to be a judge") if assigned_by && !assigned_by.judge_in_vacols?
   end
 
-  def task_just_cancelled?
-    saved_change_to_attribute?("status") && cancelled?
+  def attorney_task_just_cancelled?
+    type.eql?(AttorneyTask.name) && saved_change_to_attribute?("status") && cancelled?
   end
 
   def send_back_to_judge_assign

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -412,6 +412,12 @@ FactoryBot.define do
       end
     end
 
+    factory :ama_attorney_rewrite_task, class: AttorneyRewriteTask do
+      type { AttorneyRewriteTask.name }
+      appeal { create(:appeal) }
+      parent { create(:ama_judge_decision_review_task) }
+    end
+
     factory :ama_judge_dispatch_return_to_attorney_task, class: AttorneyDispatchReturnTask do
       type { AttorneyDispatchReturnTask.name }
       appeal { create(:appeal) }

--- a/spec/models/tasks/attorney_quality_review_task_spec.rb
+++ b/spec/models/tasks/attorney_quality_review_task_spec.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "support/database_cleaner"
+require "support/vacols_database_cleaner"
 
-describe AttorneyQualityReviewTask do
+describe AttorneyQualityReviewTask, :all_dbs do
   context ".create" do
     it "returns the correct label" do
       expect(AttorneyQualityReviewTask.new.label).to eq(

--- a/spec/models/tasks/attorney_quality_review_task_spec.rb
+++ b/spec/models/tasks/attorney_quality_review_task_spec.rb
@@ -16,4 +16,23 @@ describe AttorneyQualityReviewTask do
       )
     end
   end
+
+  fcontext "when cancelling the task" do
+    let(:atty) { create(:user) }
+    let(:judge) { create(:user) }
+    let!(:atty_staff) { create(:staff, :attorney_role, sdomainid: atty.css_id) }
+    let!(:judge_staff) { create(:staff, :judge_role, sdomainid: judge.css_id) }
+    let(:parent) { create(:ama_judge_dispatch_return_task) }
+    let!(:task) do
+      create(:ama_judge_dispatch_return_to_attorney_task, assigned_by: judge, assigned_to: atty, parent: parent)
+    end
+
+    subject { task.update!(status: Constants.TASK_STATUSES.cancelled) }
+
+    it "cancels the task and moves the parent back to the judge's queue" do
+      expect(subject).to be true
+      expect(task.reload.status).to eq Constants.TASK_STATUSES.cancelled
+      expect(parent.reload.status).to eq Constants.TASK_STATUSES.assigned
+    end
+  end
 end

--- a/spec/models/tasks/attorney_rewrite_task_spec.rb
+++ b/spec/models/tasks/attorney_rewrite_task_spec.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "rails_helper"
+require "support/database_cleaner"
+require "support/vacols_database_cleaner"
 
-describe AttorneyRewriteTask do
+describe AttorneyRewriteTask, :all_dbs do
   context "when cancelling the task" do
     let(:atty) { create(:user) }
     let(:judge) { create(:user) }

--- a/spec/models/tasks/attorney_rewrite_task_spec.rb
+++ b/spec/models/tasks/attorney_rewrite_task_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "rails_helper"
-require "rails_helper"
 require "support/database_cleaner"
 require "support/vacols_database_cleaner"
 

--- a/spec/models/tasks/attorney_rewrite_task_spec.rb
+++ b/spec/models/tasks/attorney_rewrite_task_spec.rb
@@ -2,29 +2,15 @@
 
 require "rails_helper"
 
-describe AttorneyQualityReviewTask do
-  context ".create" do
-    it "returns the correct label" do
-      expect(AttorneyQualityReviewTask.new.label).to eq(
-        COPY::ATTORNEY_QUALITY_REVIEW_TASK_LABEL
-      )
-    end
-
-    it "returns the correct timeline title" do
-      expect(AttorneyQualityReviewTask.new.timeline_title).to eq(
-        COPY::CASE_TIMELINE_ATTORNEY_QUALITY_REVIEW_TASK
-      )
-    end
-  end
-
+describe AttorneyRewriteTask do
   context "when cancelling the task" do
     let(:atty) { create(:user) }
     let(:judge) { create(:user) }
     let!(:atty_staff) { create(:staff, :attorney_role, sdomainid: atty.css_id) }
     let!(:judge_staff) { create(:staff, :judge_role, sdomainid: judge.css_id) }
-    let(:parent) { create(:ama_judge_dispatch_return_task) }
+    let(:parent) { create(:ama_judge_decision_review_task) }
     let!(:task) do
-      create(:ama_judge_dispatch_return_to_attorney_task, assigned_by: judge, assigned_to: atty, parent: parent)
+      create(:ama_attorney_rewrite_task, assigned_by: judge, assigned_to: atty, parent: parent)
     end
 
     subject { task.update!(status: Constants.TASK_STATUSES.cancelled) }


### PR DESCRIPTION
Resolves bug where all attorney tasks would cancel their parent and open another `JudgeAssignTask` when cancelled

### Acceptance Criteria
- [x] ONLY `AttorneyTask`s cancel their parent and open another `JudgeAssignTask` when cancelled

### Testing Plan
#### AttorneyQualityReviewTask
1. Sign in as QR_USER and return any ama task to a judge
2. Sign in as that judge and send that task back to the attorney
3. Cancel the task that was just created
4. Ensure the QR task is still in the judge's queue and an assign task has not been created
#### AttorneyDispatchReturnTask
1. Sign in as BVAGWHITE and return any ama task to a judge
2. Sign in as that judge and send that task back to the attorney
3. Cancel the task that was just created
4. Ensure the dispatch task is still in the judge's queue and an assign task has not been created
#### AttorneyRewriteTask
1. SIgn in as BVAAASHIRE and return any ama task to an attorney
2. Cancel the task that was just created
3. Ensure the decision review task is still in the judge's queue and an assign task has not been created