### PR TITLE
Edit Virtual Hearing Modal

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -456,7 +456,7 @@
   "USER_MANAGEMENT_REMOVE_USER_FROM_ORG_BUTTON_TEXT": "Remove user",
   "USER_MANAGEMENT_ADD_USER_TO_ORG_DROPDOWN_NAME": "Add user",
   "USER_MANAGEMENT_ADD_USER_TO_ORG_DROPDOWN_LABEL": "Add a user to the team:",
-  "USER_MANAGEMENT_ADD_USER_TO_ORG_DROPDOWN_TEXT": "Select user to add",
+  "USER_MANAGEMENT_ADD_USER_TO_ORG_DROPDOWN_TEXT": "User CSS ID to add",
 
   "ACCESS_DENIED_TITLE": "Additional access needed",
   "UNAUTHORIZED_PAGE_ACCESS_MESSAGE": "You aren't authorized to use this part of Caseflow yet.",

--- a/client/app/hearings/components/VirtualHearingModal.jsx
+++ b/client/app/hearings/components/VirtualHearingModal.jsx
@@ -7,19 +7,30 @@ import TextField from '../../components/TextField';
 import moment from 'moment';
 import COPY from '../../../COPY.json';
 
-const formatTimeString = (hearing) => {
-  let timeString = `${moment(hearing.centralOfficeTimeString, 'hh:mm').format('h:mm a')} ET`;
+const getCentralOfficeTime = (hearing) => {
+  const newTime = `${moment(hearing.scheduledFor).format('YYYY-MM-DD')}T${hearing.scheduledTimeString}`;
 
-  if (hearing.regionalOfficeTimezone !== 'America/New_York') {
-    timeString += ` / ${moment(hearing.scheduledTimeString, 'hh:mm').format('h:mm a')} `;
-    timeString += moment().tz(hearing.regionalOfficeTimezone).
-      format('z');
+  return moment.tz(newTime, hearing.regionalOfficeTimezone).tz('America/New_York').
+    format('hh:mm');
+};
+
+const formatTimeString = (hearing, timeWasEdited) => {
+  if (hearing.regionalOfficeTimezone === 'America/New_York') {
+    return `${moment(hearing.scheduledTimeString, 'hh:mm').format('h:mm a')} ET`;
   }
+
+  const centralOfficeTime = timeWasEdited ? getCentralOfficeTime(hearing) : hearing.centralOfficeTimeString;
+
+  let timeString = `${moment(centralOfficeTime, 'hh:mm').format('h:mm a')} ET`;
+
+  timeString += ` / ${moment(hearing.scheduledTimeString, 'hh:mm').format('h:mm a')} `;
+  timeString += moment().tz(hearing.regionalOfficeTimezone).
+    format('z');
 
   return timeString;
 };
 
-const VirtualHearingModal = ({ virtualHearing, hearing, update, submit, reset }) => (
+const VirtualHearingModal = ({ virtualHearing, hearing, timeWasEdited, update, submit, reset }) => (
   <div>
     <Modal
       title="Change to Virtual Hearing"
@@ -38,7 +49,7 @@ const VirtualHearingModal = ({ virtualHearing, hearing, update, submit, reset })
       </p>
       <div>
         <strong>{'Date:'}&nbsp;</strong>{moment(hearing.scheduledFor).format('MM/DD/YYYY')}<br />
-        <strong>{'Time:'}&nbsp;</strong>{formatTimeString(hearing)}
+        <strong>{'Time:'}&nbsp;</strong>{formatTimeString(hearing, timeWasEdited)}
       </div>
       <TextField
         strongLabel
@@ -69,6 +80,7 @@ VirtualHearingModal.propTypes = {
     regionalOfficeTimezone: PropTypes.string,
     centralOfficeTimeString: PropTypes.string
   }).isRequired,
+  timeWasEdited: PropTypes.bool,
   update: PropTypes.func,
   submit: PropTypes.func,
   reset: PropTypes.func

--- a/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
+++ b/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
       end
     end
 
-    context "A virtual hearing has been scheduled", focus: true do
+    context "A virtual hearing has been scheduled" do
       before do
         FeatureToggle.enable!(:schedule_virtual_hearings)
       end

--- a/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
+++ b/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
@@ -6,6 +6,7 @@ require "rails_helper"
 RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
   let!(:actcode) { create(:actcode, actckey: "B", actcdtc: "30", actadusr: "SBARTELL", acspare1: "59") }
   let!(:current_user) { User.authenticate!(css_id: "BVATWARNER", roles: ["Hearing Prep"]) }
+  # let!(:vh_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
   let!(:hearing_day) { create(:hearing_day, judge: current_user) }
 
   context "with a legacy hearing" do
@@ -83,6 +84,41 @@ RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
         click_button("Confirm")
 
         expect(page).to have_content("You have successfully updated")
+      end
+    end
+
+    context "A virtual hearing has been scheduled", focus: true do
+      let!(:current_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
+      let!(:legacy_hearing) { create(:legacy_hearing, :with_tasks, user: current_user, hearing_day: hearing_day) }
+      FeatureToggle.enable!(:schedule_virtual_hearings)
+
+      scenario "User can update Virtual Hearing time" do
+        visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+        choose("hearingTime1_other", allow_label_click: true)
+        find(".dropdown-optionalHearingTime1").click
+        # go to the page
+        # select the first radio
+        # press "confirm and send"
+        # expect(page).to have_content("You have successfully updated")
+      end
+      scenario "Virtual Hearing time has been reassigned" do
+        visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+        choose("hearingTime1_13:00", allow_label_click: true)
+        # go to page
+        # select the "other radio"
+        # pick the first option
+        # press "confirm and send"
+        click_button("Save")
+        expect(page).to have_content("You have successfully updated")
+      end
+
+      scenario "Changes to Virtual Hearing have been cancelled" do
+        visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+        choose("hearingTime1_09:00", allow_label_click: true)
+        # go to page
+        # select the first radio
+        # press cancel
+        click_button("Cancel")
       end
     end
 

--- a/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
+++ b/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
@@ -6,7 +6,6 @@ require "rails_helper"
 RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
   let!(:actcode) { create(:actcode, actckey: "B", actcdtc: "30", actadusr: "SBARTELL", acspare1: "59") }
   let!(:current_user) { User.authenticate!(css_id: "BVATWARNER", roles: ["Hearing Prep"]) }
-  # let!(:vh_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
   let!(:hearing_day) { create(:hearing_day, judge: current_user) }
 
   context "with a legacy hearing" do
@@ -88,37 +87,31 @@ RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
     end
 
     context "A virtual hearing has been scheduled", focus: true do
-      let!(:current_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
-      let!(:legacy_hearing) { create(:legacy_hearing, :with_tasks, user: current_user, hearing_day: hearing_day) }
-      FeatureToggle.enable!(:schedule_virtual_hearings)
+      before do
+        FeatureToggle.enable!(:schedule_virtual_hearings)
+      end
 
-      scenario "User can update Virtual Hearing time" do
+      let!(:current_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
+      let!(:hearing) { create(:hearing, :with_tasks, hearing_day: hearing_day) }
+      let!(:hearing_day) { create(:hearing_day, judge: current_user) }
+
+      scenario "User can select Virtual Hearing time" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
         choose("hearingTime1_other", allow_label_click: true)
-        find(".dropdown-optionalHearingTime1").click
-        # go to the page
-        # select the first radio
-        # press "confirm and send"
-        # expect(page).to have_content("You have successfully updated")
-      end
-      scenario "Virtual Hearing time has been reassigned" do
-        visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
-        choose("hearingTime1_13:00", allow_label_click: true)
-        # go to page
-        # select the "other radio"
-        # pick the first option
-        # press "confirm and send"
-        click_button("Save")
+        click_dropdown(name: "optionalHearingTime1", index: 3)
+        click_button("Change and Send Email")
         expect(page).to have_content("You have successfully updated")
       end
-
+      scenario "Virtual Hearing time has been updated" do
+        visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+        choose("hearingTime1_13:00", allow_label_click: true)
+        click_button("Change and Send Email")
+        expect(page).to have_content("You have successfully updated")
+      end
       scenario "Changes to Virtual Hearing have been cancelled" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
         choose("hearingTime1_09:00", allow_label_click: true)
-        # go to page
-        # select the first radio
-        # press cancel
-        click_button("Cancel")
+        click_button("Change-to-Virtual-Hearing-button-id-close")
       end
     end
 


### PR DESCRIPTION
Resolves #11952 

_this PR is under a feature flag_ 

* When you use the radio buttons to edit the time of a hearing, a `Virtual Hearing` modal will appear, confirming the time change. 
* When using the `Other` radio button the modal will appear upon selecting a new time from the dropdown.
* Time conversions in `VirtualHearingModal.jsx` have been refactored so that the timezone is accurate for local timezones and will appear in the modal as the time changes.

To Do:
as of (10/28/19) the modal will appear when the time changes regardless of hearing type. When the functionality for Virtual Hearings is created:
* [ ] update this PR so that it only appears when a Virtual Hearing is being edited.

