### PR TITLE
Only compile javascript assets for front-end tests

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -49,6 +49,7 @@ RSpec.configure do |config|
      ENV["REACT_ON_RAILS_ENV"] != "HOT"
 
     # Only compile webpack-bundle.js for feature tests.
+    # https://github.com/shakacode/react_on_rails/blob/master/docs/basics/rspec-configuration.md#rspec-configuration
     ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config, :requires_webpack_assets)
     config.define_derived_metadata(file_path: %r{spec/feature}) do |metadata|
       metadata[:requires_webpack_assets] = true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,12 @@ RSpec.configure do |config|
   # subsequent test runs
   if !File.exist?("#{::Rails.root}/app/assets/javascripts/webpack-bundle.js") &&
      ENV["REACT_ON_RAILS_ENV"] != "HOT"
-    ReactOnRails::TestHelper.ensure_assets_compiled
+
+    # Only compile webpack-bundle.js for feature tests.
+    ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config, :requires_webpack_assets)
+    config.define_derived_metadata(file_path: %r{spec/feature}) do |metadata|
+      metadata[:requires_webpack_assets] = true
+    end
   end
 
   config.before(:each) do


### PR DESCRIPTION
Allows us to run back-end tests (all tests outside of the `spec/feature/` directory) with a stale or non-existent javascript bundle.

### Testing Plan
1. Remove your previously generated javascript file
    * `caseflow $> rm app/assets/javascripts/webpack-bundle.js
2. Run a back-end test
    * `caseflow $> bundle exec rspec spec/models/judge_team_spec.rb`
3. Be frustrated when the computer tells you it is preparing your javascript bundle because the test you are trying to run does not care about any of the front-end javascript.
    * ![image](https://user-images.githubusercontent.com/32683958/67778798-21957180-fa3a-11e9-9653-27affdec243b.png)
4. Change over to this branch
    * `caseflow $> git checkout lowell/compile_js_feature_tests`
5. Remove your previously generated javascript file again
    * `caseflow $> rm app/assets/javascripts/webpack-bundle.js`
6. Try to run a back-end test again
    * `caseflow $> bundle exec rspec spec/models/judge_team_spec.rb`
7. Notice that the back-end test runs without attempting to generate a javascript file.
8. Feel a sense of calm wash over your body as all order and justice is restored to the world.
9. Develop a tinge of unease, concern that maybe this fix prevents the machine from noticing when it needs to generate new javascript bundles for front-end tests.
10. Run a front-end test
    * `caseflow $> bundle exec rspec spec/feature/dropdown_spec.rb`
11. Observe how it is _"Building Webpack assets..."_ for you, just like old times
12. Return to that serenity you just achieved and live in it for a while longer. All is right. Maybe the future isn't so dark after all.