### PR TITLE
Build individual generic queues from config

### DIFF
--- a/client/app/components/TabWindow.jsx
+++ b/client/app/components/TabWindow.jsx
@@ -86,14 +86,18 @@ export default class TabWindow extends React.Component {
             )}
           </div>
       }
-      <div className="cf-tab-window-body-full-screen" {...bodyStyling}>
+      { tabs && tabs.length && <div className="cf-tab-window-body-full-screen" {...bodyStyling}>
         {tabs[this.state.currentPage].page}
       </div>
+      }
     </div>;
   }
 }
 
 TabWindow.propTypes = {
+  bodyStyling: PropTypes.object,
+  fullPage: PropTypes.bool,
+  name: PropTypes.string,
   onChange: PropTypes.func,
   tabs: PropTypes.arrayOf(PropTypes.shape({
     disable: PropTypes.bool,

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -3,9 +3,14 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
 
-import TaskTable from './components/TaskTable';
+import QueueTable from './QueueTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
+import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, typeColumn,
+  daysWaitingColumn, daysOnHoldColumn, readerLinkColumn, completedToNameColumn, taskCompletedDateColumn,
+  readerLinkColumnWithNewDocsIcon } from
+  './components/TaskTableColumns';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
 import {
@@ -15,11 +20,11 @@ import {
 } from './selectors';
 import { hideSuccessMessage } from './uiReducer/uiActions';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
-import COPY from '../../COPY.json';
 import {
   fullWidth,
   marginBottom
 } from './constants';
+import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
 
 import Alert from '../components/Alert';
 import TabWindow from '../components/TabWindow';
@@ -35,34 +40,72 @@ class ColocatedTaskListView extends React.PureComponent {
 
   componentWillUnmount = () => this.props.hideSuccessMessage();
 
-  render = () => {
-    const {
-      success,
-      organizations,
-      numNewTasks,
-      numOnHoldTasks
-    } = this.props;
+  tasksForTab = (tabName) => {
+    const mapper = {
+      [QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME]: this.props.assignedTasks,
+      [QUEUE_CONFIG.INDIVIDUALLY_ON_HOLD_TASKS_TAB_NAME]: this.props.onHoldTasks,
+      [QUEUE_CONFIG.INDIVIDUALLY_COMPLETED_TASKS_TAB_NAME]: this.props.completedTasks
+    };
 
-    const tabs = [
-      {
-        label: sprintf(COPY.COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE, numNewTasks),
-        page: <NewTasksTab />
-      },
-      {
-        label: sprintf(COPY.QUEUE_PAGE_ON_HOLD_TAB_TITLE, numOnHoldTasks),
-        page: <OnHoldTasksTab />
-      },
-      {
-        label: COPY.QUEUE_PAGE_COMPLETE_TAB_TITLE,
-        page: <CompleteTasksTab />
-      }
-    ];
+    return mapper[tabName];
+  }
+
+  createColumnObject = (column, config, tasks) => {
+    const functionForColumn = {
+      [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
+      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, false, config.userRole),
+      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false),
+      [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, false),
+      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, false),
+      [QUEUE_CONFIG.COLUMNS.TASK_ASSIGNER.name]: completedToNameColumn(),
+      [QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name]: taskCompletedDateColumn(),
+      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, false),
+      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(false),
+      [QUEUE_CONFIG.COLUMNS.DAYS_ON_HOLD.name]: daysOnHoldColumn(false),
+      [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(false, true),
+      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(false)
+    };
+
+    return functionForColumn[column.name];
+  }
+
+  columnsFromConfig = (config, tabConfig, tasks) =>
+    tabConfig.columns.map((column) => this.createColumnObject(column, config, tasks));
+
+  taskTableTabFactory = (tabConfig, config) => {
+    const tasks = this.tasksForTab(tabConfig.name);
+
+    // debugger;
+
+    return {
+      label: sprintf(tabConfig.label, tasks.length),
+      page: <React.Fragment>
+        <p className="cf-margin-top-0">{tabConfig.description}</p>
+        <QueueTable
+          key={tabConfig.name}
+          columns={this.columnsFromConfig(config, tabConfig, tasks)}
+          rowObjects={tasks}
+          getKeyForRow={(_rowNumber, task) => task.uniqueId}
+          enablePagination
+        />
+      </React.Fragment>
+    };
+  }
+
+  tabsFromConfig = (config) => config.tabs.map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
+
+  makeQueueComponents = (config) => <React.Fragment>
+    <h1 {...fullWidth}>{config.table_title}</h1>
+    <QueueOrganizationDropdown organizations={this.props.organizations} />
+    <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} />
+  </React.Fragment>;
+
+  render = () => {
+    const { success } = this.props;
 
     return <AppSegment filledBackground styling={containerStyles}>
       {success && <Alert type="success" title={success.title} message={success.detail} styling={marginBottom(1)} />}
-      <h1 {...fullWidth}>{COPY.COLOCATED_QUEUE_PAGE_TABLE_TITLE}</h1>
-      <QueueOrganizationDropdown organizations={organizations} />
-      <TabWindow name="tasks-tabwindow" tabs={tabs} />
+      {this.makeQueueComponents(this.props.queueConfig)}
     </AppSegment>;
   };
 }
@@ -73,8 +116,10 @@ const mapStateToProps = (state) => {
   return {
     success,
     organizations: state.ui.organizations,
-    numNewTasks: newTasksByAssigneeCssIdSelector(state).length,
-    numOnHoldTasks: onHoldTasksByAssigneeCssIdSelector(state).length
+    assignedTasks: newTasksByAssigneeCssIdSelector(state),
+    onHoldTasks: onHoldTasksByAssigneeCssIdSelector(state),
+    completedTasks: completeTasksByAssigneeCssIdSelector(state),
+    queueConfig: state.queue.queueConfig
   };
 };
 
@@ -85,71 +130,13 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 
 export default (connect(mapStateToProps, mapDispatchToProps)(ColocatedTaskListView));
 
-const NewTasksTab = connect(
-  (state) => ({
-    tasks: newTasksByAssigneeCssIdSelector(state),
-    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearings Management')
-  }))(
-  (props) => {
-    return <React.Fragment>
-      <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION}</p>
-      <TaskTable
-        includeHearingBadge
-        includeDetailsLink
-        includeTask
-        includeRegionalOffice={props.belongsToHearingSchedule}
-        includeType
-        includeDocketNumber
-        includeDaysWaiting
-        includeReaderLink
-        tasks={props.tasks}
-      />
-    </React.Fragment>;
-  });
-
-const OnHoldTasksTab = connect(
-  (state) => ({
-    tasks: onHoldTasksByAssigneeCssIdSelector(state),
-    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearings Management')
-  }))(
-  (props) => {
-    return <React.Fragment>
-      <p className="cf-margin-top-0">{COPY.COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}</p>
-      <TaskTable
-        includeHearingBadge
-        includeDetailsLink
-        includeTask
-        includeRegionalOffice={props.belongsToHearingSchedule}
-        includeType
-        includeDocketNumber
-        includeDaysOnHold
-        includeReaderLink
-        includeNewDocsIcon
-        useOnHoldDate
-        tasks={props.tasks}
-      />
-    </React.Fragment>;
-  });
-
-const CompleteTasksTab = connect(
-  (state) => ({
-    tasks: completeTasksByAssigneeCssIdSelector(state),
-    belongsToHearingSchedule: state.ui.organizations.find((org) => org.name === 'Hearings Management')
-  }))(
-  (props) => {
-    return <React.Fragment>
-      <p className="cf-margin-top-0">{COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}</p>
-      <TaskTable
-        includeHearingBadge
-        includeDetailsLink
-        includeTask
-        includeRegionalOffice={props.belongsToHearingSchedule}
-        includeType
-        includeDocketNumber
-        includeCompletedDate
-        includeCompletedToName
-        includeReaderLink
-        tasks={props.tasks}
-      />
-    </React.Fragment>;
-  });
+ColocatedTaskListView.propTypes = {
+  assignedTasks: PropTypes.array,
+  clearCaseSelectSearch: PropTypes.func,
+  completedTasks: PropTypes.array,
+  hideSuccessMessage: PropTypes.func,
+  onHoldTasks: PropTypes.array,
+  organizations: PropTypes.array,
+  queueConfig: PropTypes.object,
+  success: PropTypes.object
+};

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -70,12 +70,10 @@ class ColocatedTaskListView extends React.PureComponent {
   }
 
   columnsFromConfig = (config, tabConfig, tasks) =>
-    tabConfig.columns.map((column) => this.createColumnObject(column, config, tasks));
+    (tabConfig.columns || []).map((column) => this.createColumnObject(column, config, tasks));
 
   taskTableTabFactory = (tabConfig, config) => {
     const tasks = this.tasksForTab(tabConfig.name);
-
-    // debugger;
 
     return {
       label: sprintf(tabConfig.label, tasks.length),
@@ -92,7 +90,7 @@ class ColocatedTaskListView extends React.PureComponent {
     };
   }
 
-  tabsFromConfig = (config) => config.tabs.map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
+  tabsFromConfig = (config) => (config.tabs || []).map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
 
   makeQueueComponents = (config) => <React.Fragment>
     <h1 {...fullWidth}>{config.table_title}</h1>

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -16,12 +16,12 @@ import PropTypes from 'prop-types';
 import QueueTable from '../QueueTable';
 import Checkbox from '../../components/Checkbox';
 import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, daysWaitingColumn,
-  issueCountColumn, typeColumn, assignedToColumn, readerLinkColumn, daysOnHoldColumn, completedToNameColumn } from
+  issueCountColumn, typeColumn, assignedToColumn, readerLinkColumn, daysOnHoldColumn, completedToNameColumn,
+  taskCompletedDateColumn } from
   './TaskTableColumns';
 
 import { setSelectionOfTaskOfUser } from '../QueueActions';
 import { hasDASRecord } from '../utils';
-import { DateString } from '../../util/DateUtil';
 import COPY from '../../../COPY.json';
 import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG.json';
 
@@ -143,13 +143,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   completedDateColumn = () => {
-    return this.props.includeCompletedDate ? {
-      header: COPY.CASE_LIST_TABLE_COMPLETED_ON_DATE_COLUMN_TITLE,
-      name: QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name,
-      valueFunction: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null,
-      backendCanSort: true,
-      getSortValue: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null
-    } : null;
+    return this.props.includeCompletedDate ? taskCompletedDateColumn() : null;
   }
 
   caseCompletedToNameColumn = () => {

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -11,6 +11,7 @@ import OnHoldLabel, { numDaysOnHold } from './OnHoldLabel';
 
 import { taskHasCompletedHold, hasDASRecord, collapseColumn, actionNameOfTask, regionalOfficeCity,
   renderAppealType } from '../utils';
+import { DateString } from '../../util/DateUtil';
 
 import COPY from '../../../COPY.json';
 import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG.json';
@@ -193,6 +194,8 @@ export const readerLinkColumn = (requireDasRecord, includeNewDocsIcon) => {
   };
 };
 
+export const readerLinkColumnWithNewDocsIcon = (requireDasRecord) => readerLinkColumn(requireDasRecord, true);
+
 export const daysWaitingColumn = (requireDasRecord) => {
   return {
     header: COPY.CASE_LIST_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
@@ -241,5 +244,15 @@ export const completedToNameColumn = () => {
     valueFunction: (task) =>
       task.assignedBy ? `${task.assignedBy.firstName} ${task.assignedBy.lastName}` : null,
     getSortValue: (task) => task.assignedBy ? task.assignedBy.lastName : null
+  };
+};
+
+export const taskCompletedDateColumn = () => {
+  return {
+    header: COPY.CASE_LIST_TABLE_COMPLETED_ON_DATE_COLUMN_TITLE,
+    name: QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name,
+    valueFunction: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null,
+    backendCanSort: true,
+    getSortValue: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null
   };
 };

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -8,7 +8,7 @@ import moment from 'moment';
 import thunk from 'redux-thunk';
 import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
 import rootReducer from '../../../app/queue/reducers';
-import { onReceiveQueue, receiveNewDocumentsForTask, errorFetchingDocumentCount, setAppealDocCount }
+import { onReceiveQueue, receiveNewDocumentsForTask, errorFetchingDocumentCount, setAppealDocCount, setQueueConfig }
   from '../../../app/queue/QueueActions';
 import { setUserCssId } from '../../../app/queue/uiReducer/uiActions';
 import { BrowserRouter } from 'react-router-dom';
@@ -117,6 +117,208 @@ describe('ColocatedTaskListView', () => {
 
   const getStore = () => createStore(rootReducer, applyMiddleware(thunk));
 
+  const queueConfig = {
+    "active_tab": "assigned",
+    "table_title": "Your cases",
+    "tabs": [
+        {
+            "allow_bulk_assign": false,
+            "columns": [
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "hearingBadgeColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "detailsColumn"
+                },
+                {
+                    "filter_options": [
+                        {
+                            "displayText": "Stayed appeal (3)",
+                            "value": "StayedAppealColocatedTask"
+                        },
+                        {
+                            "displayText": "Hearing clarification (3)",
+                            "value": "HearingClarificationColocatedTask"
+                        },
+                        {
+                            "displayText": "New rep arguments (2)",
+                            "value": "NewRepArgumentsColocatedTask"
+                        },
+                        {
+                            "displayText": "Extension (2)",
+                            "value": "ExtensionColocatedTask"
+                        },
+                        {
+                            "displayText": "IHP (2)",
+                            "value": "IhpColocatedTask"
+                        },
+                        {
+                            "displayText": "Retired VLJ (2)",
+                            "value": "RetiredVljColocatedTask"
+                        },
+                        {
+                            "displayText": "Address verification (2)",
+                            "value": "AddressVerificationColocatedTask"
+                        }
+                    ],
+                    "filterable": true,
+                    "name": "taskColumn"
+                },
+                {
+                    "filter_options": [
+                        {
+                            "displayText": "Original (16)",
+                            "value": "Original"
+                        }
+                    ],
+                    "filterable": true,
+                    "name": "typeColumn"
+                },
+                {
+                    "filter_options": [
+                        {
+                            "displayText": "Evidence (14)",
+                            "value": "evidence_submission"
+                        },
+                        {
+                            "displayText": "Direct Review (1)",
+                            "value": "direct_review"
+                        },
+                        {
+                            "displayText": "Legacy (1)",
+                            "value": "legacy"
+                        }
+                    ],
+                    "filterable": true,
+                    "name": "docketNumberColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "daysWaitingColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "readerLinkColumn"
+                }
+            ],
+            "description": "Cases assigned to you:",
+            "label": "Assigned (%d)",
+            "name": "assigned_person",
+            "task_page_count": 2,
+            "task_page_endpoint_base_path": "task_pages?tab=assigned_person",
+            "tasks": [],
+            "total_task_count": 16
+        },
+        {
+            "allow_bulk_assign": false,
+            "columns": [
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "hearingBadgeColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "detailsColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": true,
+                    "name": "taskColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": true,
+                    "name": "typeColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": true,
+                    "name": "docketNumberColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "daysOnHoldColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "readerLinkWithNewDocIconColumn"
+                }
+            ],
+            "description": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
+            "label": "On hold (%d)",
+            "name": "on_hold_person",
+            "task_page_count": 0,
+            "task_page_endpoint_base_path": "task_pages?tab=on_hold_person",
+            "tasks": [],
+            "total_task_count": 0
+        },
+        {
+            "allow_bulk_assign": false,
+            "columns": [
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "hearingBadgeColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "detailsColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": true,
+                    "name": "taskColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": true,
+                    "name": "typeColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": true,
+                    "name": "docketNumberColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "completedDateColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "completedToNameColumn"
+                },
+                {
+                    "filter_options": [],
+                    "filterable": false,
+                    "name": "readerLinkColumn"
+                }
+            ],
+            "description": "Cases completed (last two weeks):",
+            "label": "Completed",
+            "name": "completed_person",
+            "task_page_count": 0,
+            "task_page_endpoint_base_path": "task_pages?tab=completed_person",
+            "tasks": [],
+            "total_task_count": 0
+        }
+    ],
+    "tasks_per_page": 15,
+    "use_task_pages_api": false
+};
+
   /* eslint-disable no-unused-expressions */
   describe('Assigned tab', () => {
     it('shows only new tasks and tasks with a completed hold', () => {
@@ -150,6 +352,7 @@ describe('ColocatedTaskListView', () => {
         amaTasks,
         appeals }));
       store.dispatch(setUserCssId(taskNewAssigned.assignedTo.cssId));
+      store.dispatch(setQueueConfig(queueConfig));
 
       const wrapper = getWrapperColocatedTaskListView(store);
 
@@ -241,6 +444,7 @@ describe('ColocatedTaskListView', () => {
         taskId: taskWithNewDocs.taskId,
         newDocuments: [{}]
       }));
+      store.dispatch(setQueueConfig(queueConfig));
 
       const wrapper = getWrapperColocatedTaskListView(store);
 


### PR DESCRIPTION
Resolves #11698. Individual queues for Caseflow users who are neither attorneys nor judges will now be generated using the configuration from the back-end.

Deferring sharing code with `OrganizationQueue` until a later PR so we can confirm this works before we start to refactor. Does that seem like a fair approach?