### PR TITLE
Create acting judge seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1072,6 +1072,25 @@ class SeedDB
       :with_post_intake_tasks,
       docket_type: Constants.AMA_DOCKETS.direct_review
     )
+
+    create_tasks_at_acting_judge
+  end
+
+  def create_tasks_at_acting_judge
+    attorney = User.find_by(css_id: "BVASCASPER1")
+    judge = User.find_by(css_id: "BVAAABSHIRE")
+
+    acting_judge = FactoryBot.create(:user, css_id: "BVAACTING", station_id: 101, full_name: "AVLJ - Acting judge")
+    FactoryBot.create(:staff, :attorney_judge_role, user: acting_judge)
+
+    JudgeTeam.create_for_judge(acting_judge)
+    OrganizationsUser.add_user_to_organization(acting_judge, JudgeTeam.for_judge(judge))
+
+    create_appeal_at_judge_assignment(judge: acting_judge)
+    create_task_at_attorney_review(FactoryBot.create(:appeal), judge, acting_judge)
+    create_task_at_attorney_review(FactoryBot.create(:appeal), acting_judge, attorney)
+    create_task_at_judge_review(FactoryBot.create(:appeal), judge, acting_judge)
+    create_task_at_judge_review(FactoryBot.create(:appeal), acting_judge, attorney)
   end
 
   def create_board_grant_tasks


### PR DESCRIPTION
### Description
Creates an acting judge when we seed our dev DB

### Acceptance Criteria
- [ ] There is an acting judge created after seeding the dev DB

### Testing Plan
1. Seed the dev DB
```bash
make reset
OR
bundle exec rake db:drop db:create db:schema:load local:vacols:seed db:seed
```
2. Ensure there is an acting judge in the DB
```ruby
user =  User.find_by(css_id: "BVAACTING")
user.vacols_roles
=> ["attorney", "judge"]
JudgeTeam.for_judge(user)
=> #<JudgeTeam:0x00007fe8a473fe80
 id: 27,
 created_at: Tue, 29 Oct 2019 17:47:47 UTC +00:00,
 name: "BVAACTING",
 participant_id: nil,
 role: nil,
 type: "JudgeTeam",
 updated_at: Tue, 29 Oct 2019 17:47:47 UTC +00:00,
 url: "bvaacting">
```