### PR TITLE
Show automatically routed ColocatedTasks in attorney's on hold tab

### DIFF
--- a/app/models/queues/attorney_queue.rb
+++ b/app/models/queues/attorney_queue.rb
@@ -10,7 +10,7 @@ class AttorneyQueue
   # using assigned by user. We set status to being on_hold and placed_on_hold_at to assigned_at timestamp
   def tasks
     colocated_tasks_grouped = ColocatedTask.includes(*task_includes)
-      .open.where(assigned_by: user, assigned_to: Colocated.singleton, appeal_type: LegacyAppeal.name)
+      .open.where(assigned_by: user, assigned_to_type: Organization.name, appeal_type: LegacyAppeal.name)
       .order(:created_at).group_by(&:appeal_id)
     colocated_tasks_for_attorney_tasks = colocated_tasks_grouped.each_with_object([]) do |(_k, value), result|
       result << value.first.tap do |record|

--- a/app/models/queues/attorney_queue.rb
+++ b/app/models/queues/attorney_queue.rb
@@ -14,8 +14,10 @@ class AttorneyQueue
       .order(:created_at).group_by(&:appeal_id)
     colocated_tasks_for_attorney_tasks = colocated_tasks_grouped.each_with_object([]) do |(_k, value), result|
       result << value.first.tap do |record|
-        record.placed_on_hold_at = record.assigned_at
-        record.status = Constants.TASK_STATUSES.on_hold
+        record.update!(
+          placed_on_hold_at: record.assigned_at,
+          status: Constants.TASK_STATUSES.on_hold
+        )
       end
     end
 

--- a/app/models/queues/attorney_queue.rb
+++ b/app/models/queues/attorney_queue.rb
@@ -14,10 +14,8 @@ class AttorneyQueue
       .order(:created_at).group_by(&:appeal_id)
     colocated_tasks_for_attorney_tasks = colocated_tasks_grouped.each_with_object([]) do |(_k, value), result|
       result << value.first.tap do |record|
-        record.update!(
-          placed_on_hold_at: record.assigned_at,
-          status: Constants.TASK_STATUSES.on_hold
-        )
+        record.placed_on_hold_at = record.assigned_at
+        record.status = Constants.TASK_STATUSES.on_hold
       end
     end
 


### PR DESCRIPTION
Resolves #12502

### Description
Colocated tasks assigned to organizations other than the Colocated organization were not showing up under the assigning attorney's On Hold tab; this PR checks for tasks assigned to any organization to catch tasks created after #11113.
