### PR TITLE
Only save new codes if it has changed since last checked

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -483,8 +483,8 @@ class EndProductEstablishment < ApplicationRecord
 
   def save_updated_end_product_code!
     if code != result.claim_type_code
-      return if code == end_product_code_updates.last&.code
-      
+      return if result.claim_type_code == end_product_code_updates.last&.code
+
       end_product_code_updates.create(code: result.claim_type_code)
     end
   end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -483,6 +483,8 @@ class EndProductEstablishment < ApplicationRecord
 
   def save_updated_end_product_code!
     if code != result.claim_type_code
+      return if code == end_product_code_updates.last&.code
+      
       end_product_code_updates.create(code: result.claim_type_code)
     end
   end

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -828,7 +828,7 @@ describe EndProductEstablishment, :postgres do
             end_product_establishment.end_product_code_updates.create(code: "040SCNR", created_at: 1.hour.ago)
 
             subject
-            
+
             epcus = end_product_establishment.end_product_code_updates
             expect(epcus.count).to eq 1
             expect(epcus.first.created_at).to eq 1.hour.ago

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -824,11 +824,15 @@ describe EndProductEstablishment, :postgres do
         end
 
         context "when the new claim_type_code has already been saved" do
-          end_product_establishment.end_product_code_updates.create(code: "040SCNR")
+          it "does not create a new record" do
+            end_product_establishment.end_product_code_updates.create(code: "040SCNR", created_at: 1.hour.ago)
 
-          subject
-
-          expect(end_product_establishment.end_product_code_updates.count).to eq 1
+            subject
+            
+            epcus = end_product_establishment.end_product_code_updates
+            expect(epcus.count).to eq 1
+            expect(epcus.first.created_at).to eq 1.hour.ago
+          end
         end
       end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -822,6 +822,14 @@ describe EndProductEstablishment, :postgres do
           expect(epcu.code).to eq "040SCNR"
           expect(epcu.created_at).to eq(Time.zone.now)
         end
+
+        context "when the new claim_type_code has already been saved" do
+          end_product_establishment.end_product_code_updates.create(code: "040SCNR")
+
+          subject
+
+          expect(end_product_establishment.end_product_code_updates.count).to eq 1
+        end
       end
 
       context "when source exists" do


### PR DESCRIPTION
### Description
This is an update to a new table, currently if an EP's claim_type_code has changed, it will save an end_product_code_update every time the EP gets synced.  We only want to save one record for each "code change".
