### PR TITLE
add diagnostic code 9917 & 9918

### DIFF
--- a/client/constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json
+++ b/client/constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json
@@ -3207,6 +3207,14 @@
     "staff_description": "Maxilla, malunion or nonunion of",
     "status_description": "malunion or nonunion of upper jaw"
   },
+  "9917": {
+    "staff_description": "Neoplasm, hard and soft tissue, benign",
+    "status_description": "benign tissue neoplasm"
+  },
+  "9918": {
+    "staff_description": "Neoplasm, hard and soft tissue, malignant",
+    "status_description": "malignant tissue neoplasm"
+  },
   "9999": {
     "staff_description": "Other dental or oral condition",
     "status_description": "dental or oral condition"


### PR DESCRIPTION
See [Slack thread 1](https://dsva.slack.com/archives/CHX8FMP28/p1572444726321700) & [Slack thread 2](https://dsva.slack.com/archives/C2ZAMLK88/p1572448256301900)

### Description
Add diagnostic code 9917 & 9918 which have been added to VA data but not caseflow. Now users can add these diagnostic codes to issues. 