### PR TITLE
MTV | Save partial grant to database with selected issues

### DIFF
--- a/app/controllers/post_decision_motions_controller.rb
+++ b/app/controllers/post_decision_motions_controller.rb
@@ -28,6 +28,6 @@ class PostDecisionMotionsController < ApplicationController
   end
 
   def motion_params
-    params.permit(:disposition, :task_id, :vacate_type, :instructions, :assigned_to_id)
+    params.permit(:disposition, :task_id, :vacate_type, :instructions, :assigned_to_id, vacated_issue_ids: [])
   end
 end

--- a/app/controllers/post_decision_motions_controller.rb
+++ b/app/controllers/post_decision_motions_controller.rb
@@ -28,6 +28,6 @@ class PostDecisionMotionsController < ApplicationController
   end
 
   def motion_params
-    params.permit(:disposition, :task_id, :vacate_type, :instructions, :assigned_to_id, vacated_issue_ids: [])
+    params.permit(:disposition, :task_id, :vacate_type, :instructions, :assigned_to_id, vacated_decision_issue_ids: [])
   end
 end

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -3,8 +3,11 @@
 class PostDecisionMotion < ApplicationRecord
   belongs_to :task, optional: false
 
+  # has_many :decision_issues as: :vacated_issues
+
   validates :disposition, presence: true
   validate :vacate_type_is_present_if_granted
+  validate :vacated_issues_present_if_partial
 
   enum disposition: {
     granted: "granted",
@@ -19,11 +22,23 @@ class PostDecisionMotion < ApplicationRecord
     vacate_and_de_novo: "vacate_and_de_novo"
   }
 
+  def vacated_issues
+    return [] unless vacated_issue_ids
+
+    DecisionIssue.find(vacated_issue_ids)
+  end
+
   private
 
   def vacate_type_is_present_if_granted
     return unless granted?
 
     errors.add(:vacate_type, "is required for granted disposition") unless vacate_type
+  end
+
+  def vacated_issues_present_if_partial
+    return unless partial?
+
+    errors.add(:vacated_issue_ids, "is required for partial disposition") unless vacated_issue_ids
   end
 end

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -11,7 +11,7 @@ class PostDecisionMotion < ApplicationRecord
 
   enum disposition: {
     granted: "granted",
-    partial: "partial",
+    partially_granted: "partially_granted",
     denied: "denied",
     withdrawn: "withdrawn",
     dismissed: "dismissed"
@@ -37,8 +37,8 @@ class PostDecisionMotion < ApplicationRecord
   end
 
   def vacated_issues_present_if_partial
-    return unless partial?
+    return unless partially_granted?
 
-    errors.add(:vacated_issue_ids, "is required for partial disposition") unless vacated_issue_ids
+    errors.add(:vacated_issue_ids, "is required for partially_granted disposition") unless vacated_issue_ids
   end
 end

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -31,7 +31,7 @@ class PostDecisionMotion < ApplicationRecord
   private
 
   def vacate_type_is_present_if_granted
-    return unless granted?
+    return unless granted? || partially_granted?
 
     errors.add(:vacate_type, "is required for granted disposition") unless vacate_type
   end

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -23,9 +23,9 @@ class PostDecisionMotion < ApplicationRecord
   }
 
   def vacated_issues
-    return [] unless vacated_issue_ids
+    return [] unless vacated_decision_issue_ids
 
-    DecisionIssue.find(vacated_issue_ids)
+    DecisionIssue.find(vacated_decision_issue_ids)
   end
 
   private
@@ -39,6 +39,6 @@ class PostDecisionMotion < ApplicationRecord
   def vacated_issues_present_if_partial
     return unless partially_granted?
 
-    errors.add(:vacated_issue_ids, "is required for partially_granted disposition") unless vacated_issue_ids
+    errors.add(:vacated_decision_issue_ids, "is required for partially_granted disposition") unless vacated_decision_issue_ids
   end
 end

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -39,6 +39,11 @@ class PostDecisionMotion < ApplicationRecord
   def vacated_issues_present_if_partial
     return unless partially_granted?
 
-    errors.add(:vacated_decision_issue_ids, "is required for partially_granted disposition") unless vacated_decision_issue_ids
+    unless vacated_decision_issue_ids
+      errors.add(
+        :vacated_decision_issue_ids,
+        "is required for partially_granted disposition"
+      )
+    end
   end
 end

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -29,7 +29,7 @@ class PostDecisionMotionUpdater
     )
 
     if params.key?(:vacated_issue_ids)
-      motion.vacated_issue_ids = params[:vacated_issue_ids].map(&:to_i)
+      motion.vacated_issue_ids = params[:vacated_issue_ids]
     end
 
     unless motion.valid?

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -27,10 +27,16 @@ class PostDecisionMotionUpdater
       disposition: params[:disposition],
       vacate_type: params[:vacate_type]
     )
+
+    if params.key?(:vacated_issue_ids)
+      motion.vacated_issue_ids = params[:vacated_issue_ids].map(&:to_i)
+    end
+
     unless motion.valid?
       errors.messages.merge!(motion.errors.messages)
       return
     end
+
     motion.save
   end
 

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -24,7 +24,7 @@ class PostDecisionMotionUpdater
   def create_motion
     motion = PostDecisionMotion.new(
       task: task,
-      disposition: params[:disposition],
+      disposition: disposition,
       vacate_type: params[:vacate_type]
     )
 
@@ -110,5 +110,14 @@ class PostDecisionMotionUpdater
 
   def mtv_mail_task
     task.parent
+  end
+
+  def disposition
+    case params[:disposition]
+    when "partial"
+      "partially_granted"
+    else
+      params[:disposition]
+    end
   end
 end

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -28,8 +28,8 @@ class PostDecisionMotionUpdater
       vacate_type: params[:vacate_type]
     )
 
-    if params.key?(:vacated_issue_ids)
-      motion.vacated_issue_ids = params[:vacated_issue_ids]
+    if params.key?(:vacated_decision_issue_ids)
+      motion.vacated_decision_issue_ids = params[:vacated_decision_issue_ids]
     end
 
     unless motion.valid?

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -116,6 +116,4 @@ class PostDecisionMotionUpdater
   def mtv_mail_task
     task.parent
   end
-
-  
 end

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -77,7 +77,12 @@ class PostDecisionMotionUpdater
   end
 
   def disposition
-    params[:disposition]
+    case params[:disposition]
+    when "partial"
+      "partially_granted"
+    else
+      params[:disposition]
+    end
   end
 
   def task_class
@@ -112,12 +117,5 @@ class PostDecisionMotionUpdater
     task.parent
   end
 
-  def disposition
-    case params[:disposition]
-    when "partial"
-      "partially_granted"
-    else
-      params[:disposition]
-    end
-  end
+  
 end

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -87,7 +87,7 @@ export const MTVJudgeDisposition = ({
     };
 
     if (issueIds.length) {
-      result.issueIds = issueIds;
+      result.vacated_issue_ids = issueIds;
     }
     if (attorneyId) {
       result.assigned_to_id = attorneyId;

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -87,7 +87,7 @@ export const MTVJudgeDisposition = ({
     };
 
     if (issueIds.length) {
-      result.vacated_issue_ids = issueIds;
+      result.vacated_decision_issue_ids = issueIds;
     }
     if (attorneyId) {
       result.assigned_to_id = attorneyId;

--- a/db/migrate/20191028200741_add_issues_to_post_decision_motions.rb
+++ b/db/migrate/20191028200741_add_issues_to_post_decision_motions.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIssuesToPostDecisionMotions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :post_decision_motions, :vacated_issue_ids, :integer, array: true, comment: "An array of the request issue IDs that were chosen for partial vactur in this post-decision motion."
+  end
+end

--- a/db/migrate/20191028200741_add_issues_to_post_decision_motions.rb
+++ b/db/migrate/20191028200741_add_issues_to_post_decision_motions.rb
@@ -2,6 +2,6 @@
 
 class AddIssuesToPostDecisionMotions < ActiveRecord::Migration[5.1]
   def change
-    add_column :post_decision_motions, :vacated_issue_ids, :integer, array: true, comment: "An array of the request issue IDs that were chosen for partial vactur in this post-decision motion."
+    add_column :post_decision_motions, :vacated_issue_ids, :integer, array: true, comment: "When a motion to vacate is partially granted, this includes an array of the appeal's decision issue IDs that were chosen for vacatur in this post-decision motion".
   end
 end

--- a/db/migrate/20191028200741_add_issues_to_post_decision_motions.rb
+++ b/db/migrate/20191028200741_add_issues_to_post_decision_motions.rb
@@ -2,6 +2,6 @@
 
 class AddIssuesToPostDecisionMotions < ActiveRecord::Migration[5.1]
   def change
-    add_column :post_decision_motions, :vacated_issue_ids, :integer, array: true, comment: "When a motion to vacate is partially granted, this includes an array of the appeal's decision issue IDs that were chosen for vacatur in this post-decision motion".
+    add_column :post_decision_motions, :vacated_decision_issue_ids, :integer, array: true, comment: "When a motion to vacate is partially granted, this includes an array of the appeal's decision issue IDs that were chosen for vacatur in this post-decision motion".
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191023204446) do
+ActiveRecord::Schema.define(version: 20191028200741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -854,6 +854,7 @@ ActiveRecord::Schema.define(version: 20191023204446) do
     t.bigint "task_id"
     t.datetime "updated_at", null: false
     t.string "vacate_type", comment: "Granted motion to vacate can be either Straight Vacate and Readjudication or Vacate and De Novo."
+    t.integer "vacated_issue_ids", comment: "An array of the request issue IDs that were chosen for partial vactur in this post-decision motion.", array: true
     t.index ["task_id"], name: "index_post_decision_motions_on_task_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -854,7 +854,7 @@ ActiveRecord::Schema.define(version: 20191031211321) do
     t.bigint "task_id"
     t.datetime "updated_at", null: false
     t.string "vacate_type", comment: "Granted motion to vacate can be either Straight Vacate and Readjudication or Vacate and De Novo."
-    t.integer "vacated_issue_ids", comment: "An array of the request issue IDs that were chosen for partial vactur in this post-decision motion.", array: true
+    t.integer "vacated_decision_issue_ids", comment: "An array of the request issue IDs that were chosen for partial vactur in this post-decision motion.", array: true
     t.index ["task_id"], name: "index_post_decision_motions_on_task_id"
   end
 

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -269,7 +269,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
       # Verify PostDecisionMotion is created
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
       expect(motion).to_not be_nil
-      expect(motion.disposition).to eq("partial")
+      expect(motion.disposition).to eq("partially_granted")
       expect(motion.vacated_issues.length).to eq(issues_to_select.length)
 
       # Verify new task creation

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -9,22 +9,19 @@ RSpec.feature "Motion to vacate", :all_dbs do
   let!(:lit_support_team) { LitigationSupport.singleton }
   let(:receipt_date) { Time.zone.today - 20 }
   let!(:appeal) do
-    create(:appeal,
-           receipt_date: receipt_date,
-           request_issues: build_list(
-             :request_issue, 1,
-             contested_issue_description: "Tinnitus"
-           ))
+    create(:appeal, receipt_date: receipt_date)
   end
-  let!(:decision_issue) do
-    create(
-      :decision_issue,
-      decision_review: appeal,
-      request_issues: appeal.request_issues,
-      disposition: "denied",
-      description: "Decision issue description",
-      decision_text: "decision issue"
-    )
+  let!(:decision_issues) do
+    3.times do |idx|
+      create(
+        :decision_issue,
+        :rating,
+        decision_review: appeal,
+        disposition: "denied",
+        description: "Decision issue description #{idx}",
+        decision_text: "decision issue"
+      )
+    end
   end
   let!(:root_task) { create(:root_task, appeal: appeal) }
   let!(:motions_attorney) { create(:user, full_name: "Motions attorney") }
@@ -34,6 +31,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
   before do
     create(:staff, :judge_role, sdomainid: judge.css_id)
     OrganizationsUser.add_user_to_organization(motions_attorney, lit_support_team)
+
+    appeal.reload
   end
 
   describe "Motion to vacate mail task" do
@@ -259,7 +258,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
       # Ensure it has pre-selected attorney previously assigned to case
       expect(dropdown_selected_value(find(".dropdown-attorney"))).to eq atty_option_txt
 
-      select_issue_for_vacature(1)
+      issues_to_select = [1, 3]
+      issues_to_select.each { |idx| select_issue_for_vacature(idx) }
 
       click_button(text: "Submit")
 
@@ -270,6 +270,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
       expect(motion).to_not be_nil
       expect(motion.disposition).to eq("partial")
+      expect(motion.vacated_issues.length).to eq(issues_to_select.length)
 
       # Verify new task creation
       instructions = format_judge_instructions(


### PR DESCRIPTION
Connects #12370

### Description
Updated DB schema to add `vacated_issue_ids` to `post_decisions_motions` table, and added support for saving the selected issue IDs when submitting from a judge "address motion to vacate" view.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests updated to validate new functionality

*Schema Changes Only*

* [x] Column comments updated
* [ ] ~~Query profiling performed (eyeball Rails log, check bullet and fasterer output)~~
* [x] #appeals-schema notified with summary and link to this PR
