### PR TITLE
Preserve line breaks added to task instructions

### DIFF
--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -1,6 +1,7 @@
 import { css } from 'glamor';
 import React from 'react';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import Button from '../../components/Button';
 import COPY from '../../../COPY.json';
 import { GrayDot, GreenCheckmark, CancelIcon } from '../../components/RenderFunctions';
@@ -186,7 +187,7 @@ class TaskRows extends React.PureComponent {
 
     return <React.Fragment key={`${task.uniqueId} fragment`}>
       {task.instructions.map((text) => <React.Fragment key={`${task.uniqueId} span`}>
-        <span key={`${task.uniqueId} instructions`}>{text}</span><br /></React.Fragment>)}
+        <span key={`${task.uniqueId} instructions`}>{StringUtil.nl2br(text)}</span><br /></React.Fragment>)}
     </React.Fragment>;
   }
 
@@ -223,8 +224,8 @@ class TaskRows extends React.PureComponent {
   showActionsSection = (task) => (task && !this.props.hideDropdown);
 
   mapDecisionDateToSortableObject = (appeal) => {
-    // if there's no decision date, then this object should be at the top 
-    // of the case timeline, thus the negative infinity default 
+    // if there's no decision date, then this object should be at the top
+    // of the case timeline, thus the negative infinity default
     return {
       isDecisionDate: true,
       createdAt: appeal.decisionDate || Number.NEGATIVE_INFINITY
@@ -318,5 +319,12 @@ class TaskRows extends React.PureComponent {
     </React.Fragment>;
   }
 }
+
+TaskRows.propTypes = {
+  appeal: PropTypes.object,
+  hideDropdown: PropTypes.bool,
+  taskList: PropTypes.array,
+  timeline: PropTypes.bool
+};
 
 export default TaskRows;


### PR DESCRIPTION
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/32683958/67960880-4e2fc180-fbd1-11e9-8f35-9b19af94f71b.png) | ![image](https://user-images.githubusercontent.com/32683958/67960821-36f0d400-fbd1-11e9-817f-41a8816543d8.png)

I noticed [the `nl2br` utility function](https://github.com/department-of-veterans-affairs/caseflow/blob/edc8f49bfdd1a00219c9a07f564d37b3980e91c3/client/app/util/StringUtil.js#L85) while motoring around the code yesterday so I thought it'd be nice to use it to preserve new lines that VA employees put into the task instructions field.