### PR TITLE
Created LegacyAppeal `eligible_for_death_dismissal`

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -678,7 +678,7 @@ class Appeal < DecisionReview
     AppealsWithNoTasksOrAllTasksOnHoldQuery.new.ama_appeal_stuck?(self)
   end
 
-  def eligible_for_death_dismissal?(user)
+  def eligible_for_death_dismissal?(_user)
     # Death dismissal processing is only for VACOLs/Legacy appeals
     false
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -678,6 +678,11 @@ class Appeal < DecisionReview
     AppealsWithNoTasksOrAllTasksOnHoldQuery.new.ama_appeal_stuck?(self)
   end
 
+  def eligible_for_death_dismissal?(user)
+    # Death dismissal processing is only for VACOLs/Legacy appeals
+    false
+  end
+
   private
 
   def most_recently_assigned_to_label(tasks)

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -767,9 +767,8 @@ class LegacyAppeal < ApplicationRecord
   def eligible_for_death_dismissal?(user)
     return false if notice_of_death_date.nil?
 
-    user_has_actionable_open_tasks = tasks.open.where(type: ColocatedTask.subclasses.map(&:name)).any?
-
-    user_has_actionable_open_tasks && Colocated.singleton.user_is_admin?(user)
+    user_has_relevent_open_tasks = tasks.open.where(type: ColocatedTask.subclasses.map(&:name)).any?
+    user_has_relevent_open_tasks && Colocated.singleton.user_is_admin?(user)
   end
 
   private

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -764,6 +764,14 @@ class LegacyAppeal < ApplicationRecord
     VACOLS::CaseAssignment.latest_task_for_appeal(vacols_id)
   end
 
+  def eligible_for_death_dismissal?(user)
+    return false if notice_of_death_date.nil?
+
+    user_has_actionable_open_tasks = tasks.open.where(type: ColocatedTask.subclasses.map(&:name)).any?
+
+    user_has_actionable_open_tasks && Colocated.singleton.user_is_admin?(user)
+  end
+
   private
 
   def soc_date_eligible_for_opt_in?(receipt_date)

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2428,7 +2428,7 @@ describe LegacyAppeal, :all_dbs do
       end
 
       context "it has no open colocated tasks" do
-        let!(:colocated_task) { }
+        let!(:colocated_task) {}
         it "returns not eligible" do
           expect(subject).to eq(false)
         end
@@ -2443,7 +2443,6 @@ describe LegacyAppeal, :all_dbs do
         expect(subject).to eq(false)
       end
     end
-
   end
 
   context "#assigned_to_location" do


### PR DESCRIPTION
Starts #12211 

### Description
LegacyAppeals now can determine if a given Appeal & User are eligible for death dismissal

### Acceptance Criteria
- [ ] Tests pass

A part of a larger set of PRs.