### PR TITLE
Persist Fake Ratings storage

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -14,6 +14,7 @@ detectors:
       - Veteran
   ControlParameter:
     exclude:
+      - Fakes::BGSService
       - HearingRepository#slot_new_hearing
       - Task#actions_allowable?
       - TaskSorter#sort_requires_case_norm?
@@ -43,6 +44,7 @@ detectors:
       - DataIntegrityChecksJob
       - DecisionIssueSyncJob
       - Fakes::EndProductStore
+      - Fakes::BGSService#get_participant_id_for_user
       - Fakes::BGSServiceRecordMaker
       - FetchDocumentsForReaderJob#fetch_for_appeal
       - HearingSerializerBase
@@ -99,6 +101,7 @@ detectors:
       - LatestRatingDisabilityEvaluation#latest_disability_evaluation
       - OrganizationOnHoldTasksTab#name
       - OrganizationTrackingTasksTab#column_names
+      - Fakes::BGSService
       - Fakes::PexipService
 
 ### Directory specific configuration

--- a/.reek.yml
+++ b/.reek.yml
@@ -22,6 +22,7 @@ detectors:
   UncommunicativeVariableName:
     exclude:
       - Address
+      - Fakes::PersistentStore#convert_dates_from
   LongParameterList:
     exclude:
       - Address
@@ -46,6 +47,7 @@ detectors:
       - Fakes::EndProductStore
       - Fakes::BGSService#get_participant_id_for_user
       - Fakes::BGSServiceRecordMaker
+      - Fakes::PersistentStore#convert_dates_from
       - FetchDocumentsForReaderJob#fetch_for_appeal
       - HearingSerializerBase
       - MonthlyMetricsReportJob#build_report

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -47,28 +47,6 @@ class WarmBgsCachesJob < CaseflowJob
     end
   end
 
-  def warm_veteran_file_number_caches(limit)
-    # look for Veteran records where we only have a 9 digit file_number
-    # and look for a *real* 8 digit file number.
-    bgs = BGSService.new
-    vets_with_one_record_looks_like_ssn = Veteran
-      .where("char_length(file_number) = 9")
-      .where(participant_id: Veteran.group(:participant_id).having("count(*) = 1").select(:participant_id))
-      .order(id: :asc)
-    vets_with_one_record_looks_like_ssn.limit(limit).each do |veteran|
-      cache_key = "bgs-pid-lookup-#{veteran.participant_id}"
-      file_number = Rails.cache.fetch(cache_key, expires_in: 90.days) do
-        bgs_vet = bgs.client.veteran.find_by_participant_id veteran.participant_id
-        return unless bgs_vet
-
-        bgs_vet[:file_number]
-      end
-      next unless file_number && file_number != veteran.file_number
-
-      Veteran.find_or_create_by_file_number(file_number, sync_name: true)
-    end
-  end
-
   def warm_veteran_attribute_caches
     # look for hearings for each day up to 3 weeks out and make sure
     # veteran attributes have been cached locally. This optimizes the VETText API.

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1140,6 +1140,8 @@ class SeedDB
     cm = CacheManager.new
     CacheManager::BUCKETS.keys.each { |bucket| cm.clear(bucket) }
     Fakes::EndProductStore.new.clear!
+    Fakes::RatingStore.new.clear!
+    Fakes::VeteranStore.new.clear!
   end
 
   def setup_dispatch

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -2,6 +2,7 @@
 
 require "bgs"
 require "fakes/end_product_store"
+require "fakes/rating_store"
 
 # rubocop:disable Metrics/ClassLength
 class Fakes::BGSService
@@ -13,8 +14,6 @@ class Fakes::BGSService
   cattr_accessor :power_of_attorney_records
   cattr_accessor :address_records
   cattr_accessor :ssn_not_found
-  cattr_accessor :rating_records
-  cattr_accessor :rating_profile_records
   cattr_accessor :manage_claimant_letter_v2_requests
   cattr_accessor :generate_tracked_items_requests
   attr_accessor :client
@@ -81,9 +80,8 @@ class Fakes::BGSService
     def clean!
       self.ssn_not_found = false
       self.inaccessible_appeal_vbms_ids = []
-      self.rating_records = {}
-      self.rating_profile_records = {}
       end_product_store.clear!
+      rating_store.clear!
       veteran_store.clear!
       self.manage_claimant_letter_v2_requests = nil
       self.generate_tracked_items_requests = nil
@@ -97,8 +95,14 @@ class Fakes::BGSService
       @veteran_store ||= Fakes::VeteranStore.new
     end
 
+    def rating_store
+      @rating_store ||= Fakes::RatingStore.new
+    end
+
     delegate :store_end_product_record, to: :end_product_store
     delegate :store_veteran_record, to: :veteran_store
+    delegate :store_rating_record, to: :rating_store
+    delegate :store_rating_profile_record, to: :rating_store
 
     def get_veteran_record(file_number)
       veteran_store.fetch_and_inflate(file_number)
@@ -119,6 +123,10 @@ class Fakes::BGSService
 
   def get_veteran_record(file_number)
     self.class.get_veteran_record(file_number)
+  end
+
+  def get_rating_record(participant_id)
+    self.class.rating_store.fetch_and_inflate(participant_id) || {}
   end
 
   def cancel_end_product(file_number, end_product_code, end_product_modifier)
@@ -279,7 +287,7 @@ class Fakes::BGSService
   end
 
   def fetch_ratings_in_range(participant_id:, start_date:, end_date:)
-    ratings = (self.class.rating_records || {})[participant_id]
+    ratings = get_rating_record(participant_id)[:ratings] || []
 
     # mimic errors
     if participant_id == "locked_rating"
@@ -289,7 +297,7 @@ class Fakes::BGSService
     end
 
     # Simulate the error bgs throws if participant doesn't exist or doesn't have any ratings
-    unless ratings
+    if ratings.blank?
       fail Savon::Error, "java.lang.IndexOutOfBoundsException: Index: 0, Size: 0"
     end
 
@@ -308,10 +316,7 @@ class Fakes::BGSService
   end
 
   def fetch_rating_profile(participant_id:, profile_date:)
-    self.class.rating_profile_records ||= {}
-    self.class.rating_profile_records[participant_id] ||= {}
-
-    rating_profile = self.class.rating_profile_records[participant_id][profile_date]
+    rating_profile = (get_rating_record(participant_id)[:profiles] || {})[profile_date]
 
     # Simulate the error bgs throws if rating profile doesn't exist
     unless rating_profile

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -316,7 +316,8 @@ class Fakes::BGSService
   end
 
   def fetch_rating_profile(participant_id:, profile_date:)
-    rating_profile = (get_rating_record(participant_id)[:profiles] || {})[profile_date.to_s.to_sym]
+    normed_date_key = self.class.rating_store.normed_profile_date_key(profile_date).to_sym
+    rating_profile = (get_rating_record(participant_id)[:profiles] || {})[normed_date_key]
 
     # Simulate the error bgs throws if rating profile doesn't exist
     unless rating_profile

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -305,8 +305,8 @@ class Fakes::BGSService
   end
 
   def build_ratings_in_range(all_ratings, start_date, end_date)
-    ratings = all_ratings.select do |r|
-      start_date <= r[:prmlgn_dt] && end_date >= r[:prmlgn_dt]
+    ratings = all_ratings.select do |rating|
+      start_date <= rating[:prmlgn_dt] && end_date >= rating[:prmlgn_dt]
     end
 
     # BGS returns the data not as an array if there is only one rating
@@ -316,7 +316,7 @@ class Fakes::BGSService
   end
 
   def fetch_rating_profile(participant_id:, profile_date:)
-    normed_date_key = self.class.rating_store.normed_profile_date_key(profile_date).to_sym
+    normed_date_key = Fakes::RatingStore.normed_profile_date_key(profile_date).to_sym
     rating_profile = (get_rating_record(participant_id)[:profiles] || {})[normed_date_key]
 
     # Simulate the error bgs throws if rating profile doesn't exist

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -316,7 +316,7 @@ class Fakes::BGSService
   end
 
   def fetch_rating_profile(participant_id:, profile_date:)
-    rating_profile = (get_rating_record(participant_id)[:profiles] || {})[profile_date]
+    rating_profile = (get_rating_record(participant_id)[:profiles] || {})[profile_date.to_s.to_sym]
 
     # Simulate the error bgs throws if rating profile doesn't exist
     unless rating_profile

--- a/lib/fakes/end_product_store.rb
+++ b/lib/fakes/end_product_store.rb
@@ -7,13 +7,7 @@ class Fakes::EndProductStore < Fakes::PersistentStore
     end
   end
 
-  class Contention < OpenStruct
-    def initialize(hash)
-      super
-#      self.start_date = Time.zone.parse(start_date)
-#      self.submit_date = Time.zone.parse(submit_date)
-    end
-  end
+  class Contention < OpenStruct; end
 
   # we call it a "child" because even though Redis has only key:value pairs,
   # logically the object is a child of an EndProduct

--- a/lib/fakes/end_product_store.rb
+++ b/lib/fakes/end_product_store.rb
@@ -10,8 +10,8 @@ class Fakes::EndProductStore < Fakes::PersistentStore
   class Contention < OpenStruct
     def initialize(hash)
       super
-      self.start_date = Time.zone.parse(start_date)
-      self.submit_date = Time.zone.parse(submit_date)
+#      self.start_date = Time.zone.parse(start_date)
+#      self.submit_date = Time.zone.parse(submit_date)
     end
   end
 

--- a/lib/fakes/persistent_store.rb
+++ b/lib/fakes/persistent_store.rb
@@ -40,10 +40,18 @@ class Fakes::PersistentStore
     json_str = self.class.cache_store.get(key)
     return if json_str.nil? || json_str == "null"
 
-    json_str ? JSON.parse(json_str, symbolize_names: true) : nil
+    json_str ? decode_json(json_str) : nil
   end
 
   def deflate_and_store(key, payload)
     self.class.cache_store.set(key, payload.to_json)
+  end
+
+  private
+
+  # we abuse the ActiveSupport::JSON date parsing private method, since we also want to symbolize keys,
+  # which ActiveSupport::JSON.decode does not do.
+  def decode_json(json_str)
+    ActiveSupport::JSON.send(:convert_dates_from, JSON.parse(json_str, symbolize_names: true))
   end
 end

--- a/lib/fakes/persistent_store.rb
+++ b/lib/fakes/persistent_store.rb
@@ -56,6 +56,8 @@ class Fakes::PersistentStore
     convert_dates_from(JSON.parse(json_str, symbolize_names: true))
   end
 
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/CyclomaticComplexity
   def convert_dates_from(data)
     case data
     when nil
@@ -82,4 +84,6 @@ class Fakes::PersistentStore
       data
     end
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/lib/fakes/rating_store.rb
+++ b/lib/fakes/rating_store.rb
@@ -21,10 +21,10 @@ class Fakes::RatingStore < Fakes::PersistentStore
     deflate_and_store(participant_id, ratings)
   end
 
-  def store_rating_profile_record(participant_id, record)
+  def store_rating_profile_record(participant_id, profile_date, record)
     ratings = fetch_and_inflate(participant_id) || {}
     ratings[:profiles] ||= {}
-    ratings[:profiles][record[:profile_date]] = record
+    ratings[:profiles][profile_date] = record
     deflate_and_store(participant_id, ratings)
   end
 end

--- a/lib/fakes/rating_store.rb
+++ b/lib/fakes/rating_store.rb
@@ -21,10 +21,14 @@ class Fakes::RatingStore < Fakes::PersistentStore
     deflate_and_store(participant_id, ratings)
   end
 
+  def normed_profile_date_key(profile_date)
+    (profile_date.try(:to_datetime) ? profile_date.to_datetime.utc : profile_date).iso8601
+  end
+
   def store_rating_profile_record(participant_id, profile_date, record)
     ratings = fetch_and_inflate(participant_id) || {}
     ratings[:profiles] ||= {}
-    ratings[:profiles][profile_date] = record
+    ratings[:profiles][normed_profile_date_key(profile_date)] = record
     deflate_and_store(participant_id, ratings)
   end
 end

--- a/lib/fakes/rating_store.rb
+++ b/lib/fakes/rating_store.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Fakes::RatingStore < Fakes::PersistentStore
+  class << self
+    def redis_ns
+      "ratings_#{Rails.env}"
+    end
+  end
+
+  def init_store(participant_id)
+    ratings = fetch_and_inflate(participant_id) || {}
+    ratings[:ratings] ||= []
+    ratings[:profiles] ||= {}
+    deflate_and_store(participant_id, ratings)
+  end
+
+  def store_rating_record(participant_id, record)
+    ratings = fetch_and_inflate(participant_id) || {}
+    ratings[:ratings] ||= []
+    ratings[:ratings] << record
+    deflate_and_store(participant_id, ratings)
+  end
+
+  def store_rating_profile_record(participant_id, record)
+    ratings = fetch_and_inflate(participant_id) || {}
+    ratings[:profiles] ||= {}
+    ratings[:profiles][record[:profile_date]] = record
+    deflate_and_store(participant_id, ratings)
+  end
+end

--- a/lib/fakes/rating_store.rb
+++ b/lib/fakes/rating_store.rb
@@ -5,6 +5,10 @@ class Fakes::RatingStore < Fakes::PersistentStore
     def redis_ns
       "ratings_#{Rails.env}"
     end
+
+    def normed_profile_date_key(profile_date)
+      (profile_date.try(:to_datetime) ? profile_date.to_datetime.utc : profile_date).iso8601
+    end
   end
 
   def init_store(participant_id)
@@ -21,14 +25,10 @@ class Fakes::RatingStore < Fakes::PersistentStore
     deflate_and_store(participant_id, ratings)
   end
 
-  def normed_profile_date_key(profile_date)
-    (profile_date.try(:to_datetime) ? profile_date.to_datetime.utc : profile_date).iso8601
-  end
-
   def store_rating_profile_record(participant_id, profile_date, record)
     ratings = fetch_and_inflate(participant_id) || {}
     ratings[:profiles] ||= {}
-    ratings[:profiles][normed_profile_date_key(profile_date)] = record
+    ratings[:profiles][self.class.normed_profile_date_key(profile_date)] = record
     deflate_and_store(participant_id, ratings)
   end
 end

--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -43,7 +43,11 @@ class Generators::Rating
 
       Fakes::BGSService.store_rating_record(attrs[:participant_id], bgs_rating_data(attrs))
 
-      Fakes::BGSService.store_rating_profile_record(attrs[:participant_id], attrs[:profile_date], bgs_rating_profile_data(attrs))
+      Fakes::BGSService.store_rating_profile_record(
+        attrs[:participant_id],
+        attrs[:profile_date],
+        bgs_rating_profile_data(attrs)
+      )
 
       Rating.new(attrs.except(:issues, :decisions, :associated_claims, :disabilities))
     end

--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -4,7 +4,7 @@ class Generators::Rating
   extend Generators::Base
 
   class << self
-    DATE_LIST = (0..100).map { |offset_days| Time.zone.now - offset_days.days }
+    DATE_LIST = (0..100).map { |offset_days| (Time.zone.now - offset_days.days).to_date }
 
     def default_attrs
       {
@@ -43,7 +43,7 @@ class Generators::Rating
 
       Fakes::BGSService.store_rating_record(attrs[:participant_id], bgs_rating_data(attrs))
 
-      Fakes::BGSService.store_rating_profile_record(attrs[:participant_id], bgs_rating_profile_data(attrs))
+      Fakes::BGSService.store_rating_profile_record(attrs[:participant_id], attrs[:profile_date], bgs_rating_profile_data(attrs))
 
       Rating.new(attrs.except(:issues, :decisions, :associated_claims, :disabilities))
     end

--- a/lib/generators/rating.rb
+++ b/lib/generators/rating.rb
@@ -38,13 +38,12 @@ class Generators::Rating
 
       attrs[:decisions] = populate_decision_ids(attrs)
 
-      existing_rating = Fakes::BGSService.rating_profile_records[attrs[:participant_id]][attrs[:profile_date]]
+      existing_rating = rating_store.fetch_and_inflate(attrs[:participant_id])[:profiles].try(attrs[:profile_date].to_s)
       fail "You may not override an existing rating for #{attrs[:profile_date]}" if existing_rating
 
-      Fakes::BGSService.rating_records[attrs[:participant_id]] << bgs_rating_data(attrs)
+      Fakes::BGSService.store_rating_record(attrs[:participant_id], bgs_rating_data(attrs))
 
-      Fakes::BGSService.rating_profile_records[attrs[:participant_id]][attrs[:profile_date]] =
-        bgs_rating_profile_data(attrs)
+      Fakes::BGSService.store_rating_profile_record(attrs[:participant_id], bgs_rating_profile_data(attrs))
 
       Rating.new(attrs.except(:issues, :decisions, :associated_claims, :disabilities))
     end
@@ -117,17 +116,17 @@ class Generators::Rating
       }
     end
 
+    def rating_store
+      @rating_store ||= Fakes::RatingStore.new
+    end
+
     def init_fakes(participant_id)
-      Fakes::BGSService.rating_profile_records ||= {}
-      Fakes::BGSService.rating_profile_records[participant_id] ||= {}
-      Fakes::BGSService.rating_records ||= {}
-      Fakes::BGSService.rating_records[participant_id] ||= []
+      rating_store.init_store(participant_id)
     end
 
     def generate_profile_datetime(participant_id)
-      DATE_LIST.find do |date|
-        !Fakes::BGSService.rating_profile_records[participant_id][date]
-      end
+      ratings = rating_store.fetch_and_inflate(participant_id) || {}
+      DATE_LIST.find { |date| !ratings[:profiles].try(date.to_s) }
     end
 
     def populate_issue_ids(attrs)

--- a/lib/tasks/local/fakes.rake
+++ b/lib/tasks/local/fakes.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :fakes do
+  desc "Clear local Fakes stores"
+  task clear: :environment do
+    cm = CacheManager.new
+    CacheManager::BUCKETS.keys.each { |bucket| cm.clear(bucket) }
+    Fakes::EndProductStore.new.clear!
+    Fakes::RatingStore.new.clear!
+    Fakes::VeteranStore.new.clear!
+  end
+
+  desc "Build local Fakes stores"
+  task build: :environment do
+    Fakes::BGSServiceRecordMaker.new.call
+  end
+end

--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -37,7 +37,7 @@ feature "Appeal Intake", :all_dbs do
   let(:future_date) { (Time.zone.now + 30.days).to_date }
   let(:receipt_date) { (post_ama_start_date - 30.days).to_date }
   let(:untimely_days) { 372.days }
-  let(:profile_date) { (post_ama_start_date - 35.days).to_datetime }
+  let(:profile_date) { (post_ama_start_date - 35.days).utc.to_datetime }
   let(:nonrating_date) { Time.zone.yesterday }
   let(:untimely_date) { (receipt_date - untimely_days - 1.day).to_date }
   let(:promulgation_date) { receipt_date - 5.days }

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -182,6 +182,10 @@ feature "NonComp Dispositions Task Page", :postgres do
     end
 
     context "when there is an error saving" do
+      before do
+        expect_any_instance_of(DecisionReviewTask).to receive(:complete_with_payload!).and_throw("Error!")
+      end
+
       scenario "Shows an error when something goes wrong" do
         visit dispositions_url
 

--- a/spec/models/hearings/virtual_hearing_spec.rb
+++ b/spec/models/hearings/virtual_hearing_spec.rb
@@ -2,7 +2,7 @@
 
 require "support/vacols_database_cleaner"
 
-describe VirtualHearing do
+describe VirtualHearing, :all_dbs do
   context "validation tests" do
     let(:virtual_hearing) { build(:virtual_hearing) }
 


### PR DESCRIPTION
Similar to #12024 store fakes BGS Ratings in Redis rather than as class methods.

This allows us to persist across local app restarts, and allows us to inspect the same data via the console as is available to the browser.