### PR TITLE
Screen Reader Announces Checkboxes Fix

### DIFF
--- a/client/app/components/Checkbox.jsx
+++ b/client/app/components/Checkbox.jsx
@@ -64,6 +64,9 @@ Checkbox.propTypes = {
   onChange: PropTypes.func.isRequired,
   required: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,
+  id: PropTypes.string,
+  errorMessage: PropTypes.object,
+  unpadded: PropTypes.bool,
   hideLabel: PropTypes.bool,
   value: PropTypes.bool,
   styling: PropTypes.object

--- a/client/app/components/Checkbox.jsx
+++ b/client/app/components/Checkbox.jsx
@@ -43,7 +43,7 @@ export default class Checkbox extends React.Component {
           id={id || name}
           checked={value}
           disabled={disabled}
-          aria-label={label}
+          aria-label={name}
         />
         <label htmlFor={name}>
           <span className={classnames({ 'usa-sr-only': hideLabel })}>


### PR DESCRIPTION
Resolves #12139 

Originally, the aria tags were set to `aria-label={label}`. `label` has been defined as a node in the `PropTypes` at the bottom of the document. It is my understanding that `node` as a proptype refers to an actual HTML element that contains an array, string, object....etc. [React Docs](https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes). This is most likely why the screen reader announced each checkbox as `[object, Object]`

Fix:
changed to `aria-label={name}` will have the screen reader announce each checkbox properly.

