### PR TITLE
Death Dismissal Part 2 Backend Logic

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -46,6 +46,7 @@ detectors:
       - Fakes::BGSServiceRecordMaker
       - FetchDocumentsForReaderJob#fetch_for_appeal
       - HearingSerializerBase
+      - LegacyAppeal#cancel_open_caseflow_tasks!
       - MonthlyMetricsReportJob#build_report
       - SyncReviewsJob
       - TaskTimerJob

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -773,7 +773,11 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def cancel_open_caseflow_tasks!
-    tasks.open.update_all(status: Constants.TASK_STATUSES.cancelled)
+    tasks.open.each do |task|
+      task.update!(status: Constants.TASK_STATUSES.cancelled)
+      task.instructions << "Task cancelled due to death dismissal"
+      task.save
+    end
   end
 
   def eligible_for_death_dismissal?(user)

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -158,6 +158,7 @@ class LegacyAppeal < ApplicationRecord
     transcription: "33",
     translation: "14",
     schedule_hearing: "57",
+    sr_council_dvc: "66",
     case_storage: "81",
     service_organization: "55",
     closed: "99"
@@ -762,6 +763,17 @@ class LegacyAppeal < ApplicationRecord
 
   def vacols_case_review
     VACOLS::CaseAssignment.latest_task_for_appeal(vacols_id)
+  end
+
+  def death_dismissal!
+    multi_transaction do
+      cancel_open_caseflow_tasks!
+      LegacyAppeal.repository.update_location_for_death_dismissal!(appeal: self)
+    end
+  end
+
+  def cancel_open_caseflow_tasks!
+    tasks.open.update_all(status: Constants.TASK_STATUSES.cancelled)
   end
 
   private

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -359,7 +359,7 @@ class AppealRepository
   end
 
   def self.update_location_for_death_dismissal!(appeal:)
-    location = LegacyAppeal::LOCATION_CODES[:sr_council_dvc])
+    location = LegacyAppeal::LOCATION_CODES[:sr_council_dvc]
     appeal.case_record.update_vacols_location!(location)
   end
 

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -358,6 +358,11 @@ class AppealRepository
     appeal.case_record.update_vacols_location!(location)
   end
 
+  def self.update_location_for_death_dismissal!(appeal:)
+    location = LegacyAppeal::LOCATION_CODES[:sr_council_dvc])
+    appeal.case_record.update_vacols_location!(location)
+  end
+
   def self.update_location!(appeal, location)
     appeal.case_record.update_vacols_location!(location)
   end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2415,6 +2415,16 @@ describe LegacyAppeal, :all_dbs do
           expect(appeal2.tasks.closed.count).to eq(3)
           expect(appeal3.tasks.open.count).to eq(3)
         end
+
+        context "when a note has instructions" do
+          it "should append a note to the canceled tasks" do
+            task = appeal2.tasks.first
+            task.update(instructions: ["Existing instructions"])
+            appeal2.cancel_open_caseflow_tasks!
+            expect(task.reload.instructions)
+              .to eq(["Existing instructions", "Task cancelled due to death dismissal"])
+          end
+        end
       end
 
       context "open and closed caseflow tasks" do

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2393,6 +2393,43 @@ describe LegacyAppeal, :all_dbs do
     end
   end
 
+  context "#cancel_open_caseflow_tasks!" do
+    let(:vacols_case) { create(:case, bfcurloc: "CASEFLOW") }
+    let(:vacols_case2) { create(:case, bfcurloc: "CASEFLOW") }
+    let(:appeal2) { create(:legacy_appeal, :with_schedule_hearing_tasks, vacols_case: vacols_case2) }
+    let(:vacols_case3) { create(:case, bfcurloc: "CASEFLOW") }
+    let(:appeal3) { create(:legacy_appeal, :with_schedule_hearing_tasks, vacols_case: vacols_case3) }
+
+    context "if there are no Caseflow tasks on the legacy appeal" do
+      it "throws no errors" do
+        expect { appeal.cancel_open_caseflow_tasks! }.not_to raise_error
+      end
+    end
+
+    context "if there are Caseflow tasks on the legacy appeal" do
+      context "multiple open caseflow tasks" do
+        it "cancels all the open tasks" do
+          appeal2.cancel_open_caseflow_tasks!
+
+          expect(appeal2.tasks.open.count).to eq(0)
+          expect(appeal2.tasks.closed.count).to eq(3)
+          expect(appeal3.tasks.open.count).to eq(3)
+        end
+      end
+
+      context "open and closed caseflow tasks" do
+        it "doesn't affect the already closed tasks" do
+          appeal3.root_task.update!(status: Constants.TASK_STATUSES.cancelled)
+          original_closed_at = appeal3.root_task.closed_at
+
+          appeal3.cancel_open_caseflow_tasks!
+
+          expect(appeal3.root_task.closed_at).to eq(original_closed_at)
+        end
+      end
+    end
+  end
+
   context "#assigned_to_location" do
     context "if the case is complete" do
       let!(:vacols_case) { create(:case, :status_complete) }

--- a/spec/repositories/appeal_repository_spec.rb
+++ b/spec/repositories/appeal_repository_spec.rb
@@ -224,7 +224,7 @@ describe AppealRepository, :all_dbs do
       LegacyAppeal.repository.update_location_for_death_dismissal!(appeal: appeal)
       appeal.case_record.reload
       refreshed_appeal = LegacyAppeal.find(appeal.id)
-      final_location = LegacyAppeal::LOCATION_CODES[:sr_council_dvc])
+      final_location = LegacyAppeal::LOCATION_CODES[:sr_council_dvc]
 
       expect(appeal.case_record.bfcurloc).to eq(final_location)
       expect(refreshed_appeal.location_code).to eq(final_location)

--- a/spec/repositories/appeal_repository_spec.rb
+++ b/spec/repositories/appeal_repository_spec.rb
@@ -215,6 +215,22 @@ describe AppealRepository, :all_dbs do
     end
   end
 
+  context "#update_location_for_death_dismissal!" do
+    let(:appeal) do
+      create(:legacy_appeal, vacols_case: create(:case))
+    end
+
+    it "should end up in location 66" do
+      LegacyAppeal.repository.update_location_for_death_dismissal!(appeal: appeal)
+      appeal.case_record.reload
+      refreshed_appeal = LegacyAppeal.find(appeal.id)
+      final_location = LegacyAppeal::LOCATION_CODES[:sr_council_dvc])
+
+      expect(appeal.case_record.bfcurloc).to eq(final_location)
+      expect(refreshed_appeal.location_code).to eq(final_location)
+    end
+  end
+
   context "#location_after_dispatch" do
     let(:appeal) do
       create(:legacy_appeal, vacols_case: create(:case))


### PR DESCRIPTION
Connects #12211 

Connects with, but independent from, #12529

### Description
Adds the logic for cancelling open caseflow tasks and reassigning the VACOLs location for a Death Dismissal

### Acceptance Criteria
- [x] Tests Pass

A part of a larger set of PRs.
#12529 `#12535` #12543 #12544 #12545