### PR TITLE
Set long timeout for index migration

### DIFF
--- a/db/migrate/20191031211321_add_request_id_index_to_versions.rb
+++ b/db/migrate/20191031211321_add_request_id_index_to_versions.rb
@@ -2,6 +2,10 @@ class AddRequestIdIndexToVersions < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
   def change
+    # Versions table has millions of rows. Make sure migration doesn't fail by timing out.
+    transaction_time_out = 10 * 60 * 1000
+    ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = #{transaction_time_out}"
+
     add_index :versions, :request_id, algorithm: :concurrently
   end
 end


### PR DESCRIPTION
(hopefully) Resolves [failed migration](https://dsva.slack.com/archives/C2ZAMLK88/p1572626022025000)