### PR TITLE
Remove actions on on-hold tasks for judges

### DIFF
--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -2,8 +2,12 @@
 
 ##
 # Parent class for all tasks to be completed by judges, including
-# JudgeQualityReviewTasks, JudgeDecisionReviewTasks,
-# JudgeDispatchReturnTasks, and JudgeAssignTasks.
+# - JudgeQualityReviewTasks
+# - JudgeDecisionReviewTasks
+# - JudgeDispatchReturnTasks
+# - JudgeAssignTasks
+# - JudgeAddressMotionToVacateTasks
+# - JudgeSignMotionToVacateTasks
 
 class JudgeTask < Task
   def available_actions(user)
@@ -13,10 +17,6 @@ class JudgeTask < Task
       Constants.TASK_ACTIONS.REASSIGN_TO_JUDGE.to_h,
       additional_available_actions(user)
     ].flatten
-  end
-
-  def actions_available?(user)
-    assigned_to == user
   end
 
   def additional_available_actions(_user)

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -19,9 +19,11 @@ class JudgeTask < Task
     ].flatten
   end
 
+  # :nocov:
   def additional_available_actions(_user)
     fail Caseflow::Error::MustImplementInSubclass
   end
+  # :nocov:
 
   def timeline_title
     COPY::CASE_TIMELINE_JUDGE_TASK

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -22,9 +22,17 @@ describe JudgeTask, :all_dbs do
 
     subject { subject_task.available_actions_unwrapper(user) }
 
-    context "the task is not assigned to the current user" do
-      let(:user) { judge2 }
+    context "when the task is on hold" do
+      let(:user) { judge }
+      let(:subject_task) do
+        create(:judge_address_motion_to_vacate_task, assigned_to: judge, appeal: create(:appeal))
+      end
+      let(:child_task) do
+        create(:pulac_cerullo_task, assigned_by: judge, parent: subject_task, assigned_to: create(:user))
+      end
+
       it "should return an empty array" do
+        child_task
         expect(subject).to eq([])
       end
     end

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -22,21 +22,6 @@ describe JudgeTask, :all_dbs do
 
     subject { subject_task.available_actions_unwrapper(user) }
 
-    context "when the task is on hold" do
-      let(:user) { judge }
-      let(:subject_task) do
-        create(:judge_address_motion_to_vacate_task, assigned_to: judge, appeal: create(:appeal))
-      end
-      let(:child_task) do
-        create(:pulac_cerullo_task, assigned_by: judge, parent: subject_task, assigned_to: create(:user))
-      end
-
-      it "should return an empty array" do
-        child_task
-        expect(subject).to eq([])
-      end
-    end
-
     context "the task is assigned to the current user" do
       context "in the assign phase" do
         it "should return the assignment action" do


### PR DESCRIPTION
Resolves #12412 

### Description
Removes `JudgeTask`'s `actions_available?` method so that it reverts to the default implementation, which is to return false when the task is on hold. I consulted with @tomas-nava who is more familiar with this area and believes the override was an out-of-date work-around that's no longer needed.

### Acceptance Criteria
- [ ] A Judge cannot perform actions on their MTV tasks while they are on hold, unless it is a timed hold (default task behavior)
- [ ] Update top line comments in JudgeTask with the MTV JudgeTasks

### Testing Plan
- [ ] Manual smoke-test to confirm that judges' on-hold tasks do not allow any actions (the default behavior)

### Documentation Updates
- Updated topline comment in `judge_task.rb` to reflect the new MTV subclasses