### PR TITLE
Increase speed of RoundRobinTaskDistributor.next_assignee

### DIFF
--- a/app/models/round_robin_task_distributor.rb
+++ b/app/models/round_robin_task_distributor.rb
@@ -9,7 +9,8 @@ class RoundRobinTaskDistributor
   attr_accessor :assignee_pool, :task_class
 
   def latest_task
-    task_class.where(assigned_to: assignee_pool).max_by(&:created_at)
+    # Use id as a proxy for created_at since the id field is already indexed.
+    task_class.where(assigned_to: assignee_pool).order(id: :desc).first
   end
 
   def last_assignee


### PR DESCRIPTION
The query underlying the `RoundRobinTaskDistributor.next_assignee` function currently relies on the unindexed `created_at` field to determine the next assignee (by way of the previously assigned task). This PR changes the query to use the indexed `id` field instead. Abridged version of [a related Slack thread](https://dsva.slack.com/archives/C2ZAMLK88/p1572634487034600) is reproduced below:

Current way we get the most recent task for the `ColocatedTaskDistributor`:
```
rails c> assignee_pool = Colocated.singleton.non_admins.sort_by(&:id)
rails c> Task.where(assigned_to: assignee_pool).order(created_at: :desc).first
sql> explain analyze SELECT * FROM tasks WHERE assigned_to_type = 'User' AND assigned_to_id IN (803, 1379, 1782, 1829, 1881, 1885, 2012, 2014, 2062, 2101, 2141, 2227, 6169, 7798, 9967, 10627, 10630, 11870) ORDER BY created_at DESC LIMIT 1;
          QUERY PLAN                                                                    
                               
----------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------
-------------------------------
 Limit  (cost=1864.33..1864.33 rows=1 width=156) (actual time=43.234..43.234 rows=1 loop
s=1)
   ->  Sort  (cost=1864.33..1866.52 rows=877 width=156) (actual time=43.233..43.233 rows
=1 loops=1)
         Sort Key: created_at DESC
         Sort Method: top-N heapsort  Memory: 25kB
         ->  Index Scan using index_tasks_on_assigned_to_type_and_assigned_to_id on task
s  (cost=0.42..1859.94 rows=877 width=156) (actual time=0.062..31.765 rows=13371 loops=1
)
               Index Cond: (((assigned_to_type)::text = 'User'::text) AND (assigned_to_i
d = ANY ('{803,1379,1782,1829,1881,1885,2012,2014,2062,2101,2141,2227,6169,7798,9967,106
27,10630,11870}'::integer[])))
 Planning time: 1.252 ms
 Execution time: 43.267 ms
(8 rows)
# Important bit is: cost=1864.33..1864.33
```

Sorting by `id` as a proxy for `created_at` since the former is already indexed:
```
rails c> Task.where(assigned_to: assignee_pool).order(id: :desc).first
sql> explain analyze SELECT * FROM tasks WHERE assigned_to_type = 'User' AND assigned_to_id IN (803, 1379, 1782, 1829, 1881, 1885, 2012, 2014, 2062, 2101, 2141, 2227, 6169, 7798, 9967, 10627, 10630, 11870) ORDER BY id DESC LIMIT 1;
     QUERY PLAN                                                                         
                     
----------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------
---------------------
 Limit  (cost=0.42..59.90 rows=1 width=156) (actual time=0.098..0.098 rows=1 loops=1)
   ->  Index Scan Backward using tasks_pkey on tasks  (cost=0.42..52163.28 rows=877 widt
h=156) (actual time=0.098..0.098 rows=1 loops=1)
         Filter: (((assigned_to_type)::text = 'User'::text) AND (assigned_to_id = ANY ('
{803,1379,1782,1829,1881,1885,2012,2014,2062,2101,2141,2227,6169,7798,9967,10627,10630,1
1870}'::integer[])))
         Rows Removed by Filter: 70
 Planning time: 0.132 ms
 Execution time: 0.118 ms
(6 rows)
# Important bit is: cost=0.42..59.90
```

Reduced the cost of the query from 1864.33 to 59.90!