### PR TITLE
MTV | Add org tasks to MTV task tree to account for potentially inactive users

### DIFF
--- a/app/models/tasks/abstract_motion_to_vacate_task.rb
+++ b/app/models/tasks/abstract_motion_to_vacate_task.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# This serves as a parent to other tasks that are spawned from `JudgeAddressMotionToVacateTask`
+# We don't want to ever come back to the judge task, so we don't want to add children on it
 class AbstractMotionToVacateTask < Task
   def hide_from_task_snapshot
     true

--- a/app/models/tasks/decided_motion_to_vacate_task.rb
+++ b/app/models/tasks/decided_motion_to_vacate_task.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class DecidedMotionToVacateTask < Task
+  before_create :automatically_create_org_task
+
+  def available_actions(user)
+    actions = super(user)
+
+    actions.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
+
+    actions
+  end
+
+  def self.label
+    COPY::DENIED_MOTION_TO_VACATE_TASK_LABEL
+  end
+
+  def update_status_if_children_tasks_are_closed(_child_task)
+    if assigned_to.is_a?(Organization)
+      return update!(status: :completed)
+    end
+
+    super
+  end
+
+  def automatically_create_org_task
+    if assigned_to.is_a?(Organization)
+      return
+    end
+
+    org_task = dup.tap do |new_task|
+      new_task.assigned_to_type = "Organization"
+      new_task.assigned_to = org
+      new_task.save!
+    end
+    self.parent = org_task
+  end
+
+  def org
+    LitigationSupport.singleton
+  end
+end

--- a/app/models/tasks/decided_motion_to_vacate_task.rb
+++ b/app/models/tasks/decided_motion_to_vacate_task.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DecidedMotionToVacateTask < Task
+  self.abstract_class = true
+
   before_create :automatically_create_org_task
 
   def available_actions(user)

--- a/app/models/tasks/decided_motion_to_vacate_task.rb
+++ b/app/models/tasks/decided_motion_to_vacate_task.rb
@@ -34,8 +34,8 @@ class DecidedMotionToVacateTask < Task
     self.parent = org_task
   end
 
-  def org(_user)
-    self.class.org(_user)
+  def org(user)
+    self.class.org(user)
   end
 
   class << self

--- a/app/models/tasks/decided_motion_to_vacate_task.rb
+++ b/app/models/tasks/decided_motion_to_vacate_task.rb
@@ -35,6 +35,12 @@ class DecidedMotionToVacateTask < Task
   end
 
   def org
-    fail Caseflow::Error::MustImplementInSubclass
+    self.class.org
+  end
+
+  class << self
+    def org
+      fail Caseflow::Error::MustImplementInSubclass
+    end
   end
 end

--- a/app/models/tasks/decided_motion_to_vacate_task.rb
+++ b/app/models/tasks/decided_motion_to_vacate_task.rb
@@ -15,7 +15,7 @@ class DecidedMotionToVacateTask < Task
 
   def update_status_if_children_tasks_are_closed(_child_task)
     if assigned_to.is_a?(Organization)
-      return update!(status: :completed)
+      return update!(status: :completed) unless all_children_cancelled?
     end
 
     super
@@ -28,18 +28,18 @@ class DecidedMotionToVacateTask < Task
 
     org_task = dup.tap do |new_task|
       new_task.assigned_to_type = "Organization"
-      new_task.assigned_to = org
+      new_task.assigned_to = org(assigned_by)
       new_task.save!
     end
     self.parent = org_task
   end
 
-  def org
-    self.class.org
+  def org(_user)
+    self.class.org(_user)
   end
 
   class << self
-    def org
+    def org(_user)
       fail Caseflow::Error::MustImplementInSubclass
     end
   end

--- a/app/models/tasks/decided_motion_to_vacate_task.rb
+++ b/app/models/tasks/decided_motion_to_vacate_task.rb
@@ -13,10 +13,6 @@ class DecidedMotionToVacateTask < Task
     actions
   end
 
-  def self.label
-    COPY::DENIED_MOTION_TO_VACATE_TASK_LABEL
-  end
-
   def update_status_if_children_tasks_are_closed(_child_task)
     if assigned_to.is_a?(Organization)
       return update!(status: :completed)
@@ -39,6 +35,6 @@ class DecidedMotionToVacateTask < Task
   end
 
   def org
-    LitigationSupport.singleton
+    fail Caseflow::Error::MustImplementInSubclass
   end
 end

--- a/app/models/tasks/denied_motion_to_vacate_task.rb
+++ b/app/models/tasks/denied_motion_to_vacate_task.rb
@@ -5,7 +5,7 @@ class DeniedMotionToVacateTask < DecidedMotionToVacateTask
     COPY::DENIED_MOTION_TO_VACATE_TASK_LABEL
   end
 
-  def org
+  def self.org
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/denied_motion_to_vacate_task.rb
+++ b/app/models/tasks/denied_motion_to_vacate_task.rb
@@ -5,7 +5,7 @@ class DeniedMotionToVacateTask < DecidedMotionToVacateTask
     COPY::DENIED_MOTION_TO_VACATE_TASK_LABEL
   end
 
-  def self.org
+  def self.org(_user)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/denied_motion_to_vacate_task.rb
+++ b/app/models/tasks/denied_motion_to_vacate_task.rb
@@ -12,4 +12,12 @@ class DeniedMotionToVacateTask < Task
   def self.label
     COPY::DENIED_MOTION_TO_VACATE_TASK_LABEL
   end
+
+  def update_status_if_children_tasks_are_closed(_child_task)
+    if assigned_to.is_a?(Organization)
+      return update!(status: :completed)
+    end
+
+    super
+  end
 end

--- a/app/models/tasks/denied_motion_to_vacate_task.rb
+++ b/app/models/tasks/denied_motion_to_vacate_task.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
 
-class DeniedMotionToVacateTask < Task
-  def available_actions(user)
-    actions = super(user)
-
-    actions.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
-
-    actions
-  end
-
+class DeniedMotionToVacateTask < DecidedMotionToVacateTask
   def self.label
     COPY::DENIED_MOTION_TO_VACATE_TASK_LABEL
   end
 
-  def update_status_if_children_tasks_are_closed(_child_task)
-    if assigned_to.is_a?(Organization)
-      return update!(status: :completed)
-    end
-
-    super
+  def org
+    LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/dismissed_motion_to_vacate_task.rb
+++ b/app/models/tasks/dismissed_motion_to_vacate_task.rb
@@ -5,7 +5,7 @@ class DismissedMotionToVacateTask < DecidedMotionToVacateTask
     COPY::DISMISSED_MOTION_TO_VACATE_TASK_LABEL
   end
 
-  def self.org
+  def self.org(_user)
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/dismissed_motion_to_vacate_task.rb
+++ b/app/models/tasks/dismissed_motion_to_vacate_task.rb
@@ -12,4 +12,12 @@ class DismissedMotionToVacateTask < Task
   def self.label
     COPY::DISMISSED_MOTION_TO_VACATE_TASK_LABEL
   end
+
+  def update_status_if_children_tasks_are_closed(_child_task)
+    if assigned_to.is_a?(Organization)
+      return update!(status: :completed)
+    end
+
+    super
+  end
 end

--- a/app/models/tasks/dismissed_motion_to_vacate_task.rb
+++ b/app/models/tasks/dismissed_motion_to_vacate_task.rb
@@ -5,7 +5,7 @@ class DismissedMotionToVacateTask < DecidedMotionToVacateTask
     COPY::DISMISSED_MOTION_TO_VACATE_TASK_LABEL
   end
 
-  def org
+  def self.org
     LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/dismissed_motion_to_vacate_task.rb
+++ b/app/models/tasks/dismissed_motion_to_vacate_task.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
 
-class DismissedMotionToVacateTask < Task
-  def available_actions(user)
-    actions = super(user)
-
-    actions.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
-
-    actions
-  end
-
+class DismissedMotionToVacateTask < DecidedMotionToVacateTask
   def self.label
     COPY::DISMISSED_MOTION_TO_VACATE_TASK_LABEL
   end
 
-  def update_status_if_children_tasks_are_closed(_child_task)
-    if assigned_to.is_a?(Organization)
-      return update!(status: :completed)
-    end
-
-    super
+  def org
+    LitigationSupport.singleton
   end
 end

--- a/app/models/tasks/straight_vacate_and_readjudication_task.rb
+++ b/app/models/tasks/straight_vacate_and_readjudication_task.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
 
-class StraightVacateAndReadjudicationTask < Task
-  def available_actions(user)
-    actions = super(user)
-
-    actions.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
-
-    actions
-  end
-
+class StraightVacateAndReadjudicationTask < DecidedMotionToVacateTask
   def self.label
     COPY::STRAIGHT_VACATE_AND_READJUDICATION_TASK_LABEL
   end
 
-  def update_status_if_children_tasks_are_closed(_child_task)
-    if assigned_to.is_a?(Organization)
-      return update!(status: :completed)
-    end
-
-    super
+  def org
+    JudgeTeam.for_judge(assigned_by)
   end
 end

--- a/app/models/tasks/straight_vacate_and_readjudication_task.rb
+++ b/app/models/tasks/straight_vacate_and_readjudication_task.rb
@@ -5,7 +5,7 @@ class StraightVacateAndReadjudicationTask < DecidedMotionToVacateTask
     COPY::STRAIGHT_VACATE_AND_READJUDICATION_TASK_LABEL
   end
 
-  def org
-    JudgeTeam.for_judge(assigned_by)
+  def self.org(_user)
+    JudgeTeam.for_judge(_user.reload)
   end
 end

--- a/app/models/tasks/straight_vacate_and_readjudication_task.rb
+++ b/app/models/tasks/straight_vacate_and_readjudication_task.rb
@@ -5,7 +5,7 @@ class StraightVacateAndReadjudicationTask < DecidedMotionToVacateTask
     COPY::STRAIGHT_VACATE_AND_READJUDICATION_TASK_LABEL
   end
 
-  def self.org(_user)
-    JudgeTeam.for_judge(_user.reload)
+  def self.org(user)
+    JudgeTeam.for_judge(user.reload)
   end
 end

--- a/app/models/tasks/straight_vacate_and_readjudication_task.rb
+++ b/app/models/tasks/straight_vacate_and_readjudication_task.rb
@@ -12,4 +12,12 @@ class StraightVacateAndReadjudicationTask < Task
   def self.label
     COPY::STRAIGHT_VACATE_AND_READJUDICATION_TASK_LABEL
   end
+
+  def update_status_if_children_tasks_are_closed(_child_task)
+    if assigned_to.is_a?(Organization)
+      return update!(status: :completed)
+    end
+
+    super
+  end
 end

--- a/app/models/tasks/vacate_and_de_novo_task.rb
+++ b/app/models/tasks/vacate_and_de_novo_task.rb
@@ -1,23 +1,11 @@
 # frozen_string_literal: true
 
-class VacateAndDeNovoTask < Task
-  def available_actions(user)
-    actions = super(user)
-
-    actions.push(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
-
-    actions
-  end
-
+class VacateAndDeNovoTask < DecidedMotionToVacateTask
   def self.label
     COPY::VACATE_AND_DE_NOVO_TASK_LABEL
   end
 
-  def update_status_if_children_tasks_are_closed(_child_task)
-    if assigned_to.is_a?(Organization)
-      return update!(status: :completed)
-    end
-
-    super
+  def org
+    JudgeTeam.for_judge(assigned_by)
   end
 end

--- a/app/models/tasks/vacate_and_de_novo_task.rb
+++ b/app/models/tasks/vacate_and_de_novo_task.rb
@@ -12,4 +12,12 @@ class VacateAndDeNovoTask < Task
   def self.label
     COPY::VACATE_AND_DE_NOVO_TASK_LABEL
   end
+
+  def update_status_if_children_tasks_are_closed(_child_task)
+    if assigned_to.is_a?(Organization)
+      return update!(status: :completed)
+    end
+
+    super
+  end
 end

--- a/app/models/tasks/vacate_and_de_novo_task.rb
+++ b/app/models/tasks/vacate_and_de_novo_task.rb
@@ -5,7 +5,7 @@ class VacateAndDeNovoTask < DecidedMotionToVacateTask
     COPY::VACATE_AND_DE_NOVO_TASK_LABEL
   end
 
-  def org
-    JudgeTeam.for_judge(assigned_by)
+  def org(_user)
+    JudgeTeam.for_judge(_user.reload)
   end
 end

--- a/app/models/tasks/vacate_and_de_novo_task.rb
+++ b/app/models/tasks/vacate_and_de_novo_task.rb
@@ -5,7 +5,7 @@ class VacateAndDeNovoTask < DecidedMotionToVacateTask
     COPY::VACATE_AND_DE_NOVO_TASK_LABEL
   end
 
-  def org(_user)
-    JudgeTeam.for_judge(_user.reload)
+  def self.org(user)
+    JudgeTeam.for_judge(user.reload)
   end
 end

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -45,7 +45,11 @@ class PostDecisionMotionUpdater
       return
     end
 
-    new_task = create_new_task(abstract_task)
+    if grant_type?
+      judge_sign_task = create_judge_sign_task(abstract_task)
+    end
+
+    new_task = create_new_task((judge_sign_task || abstract_task))
 
     unless new_task.valid?
       errors.messages.merge!(new_task.errors.messages)
@@ -71,6 +75,14 @@ class PostDecisionMotionUpdater
       assigned_by: task.assigned_to,
       assigned_to: assigned_to,
       instructions: [params[:instructions]]
+    )
+  end
+
+  def create_judge_sign_task(parent)
+    JudgeSignMotionToVacateTask.new(
+      appeal: task.appeal,
+      parent: parent,
+      assigned_to: task.assigned_to
     )
   end
 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -541,6 +541,14 @@ FactoryBot.define do
       association :parent, factory: :vacate_motion_mail_task
     end
 
+    factory :denied_motion_to_vacate_task, class: DeniedMotionToVacateTask do
+      type { DeniedMotionToVacateTask.name }
+      appeal
+      association :parent, factory: :abstract_motion_to_vacate_task
+      assigned_by { create(:user, full_name: "Judge User", css_id: "JUDGE_1") }
+      assigned_to { create(:user, full_name: "Motions Attorney", css_id: "LIT_SUPPORT_ATTY_1") }
+    end
+
     factory :judge_sign_motion_to_vacate_task, class: JudgeSignMotionToVacateTask do
       type { JudgeSignMotionToVacateTask.name }
       appeal

--- a/spec/models/decided_motion_to_vacate_task_spec.rb
+++ b/spec/models/decided_motion_to_vacate_task_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require "support/vacols_database_cleaner"
+require "support/database_cleaner"
 require "rails_helper"
 
-RSpec.describe DecidedMotionToVacateTask, :all_dbs, type: :model do
+RSpec.describe DecidedMotionToVacateTask, :postgres, type: :model do
   let(:lit_support_team) { LitigationSupport.singleton }
 
   describe ".automatically_create_org_task" do
@@ -23,8 +23,7 @@ RSpec.describe DecidedMotionToVacateTask, :all_dbs, type: :model do
     let(:task) { create(:denied_motion_to_vacate_task) }
 
     it "should include Pulac Cerullo action in available actions" do
-      actions = subject
-      expect(actions).to include(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
+      expect(subject).to include(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
     end
   end
 end

--- a/spec/models/decided_motion_to_vacate_task_spec.rb
+++ b/spec/models/decided_motion_to_vacate_task_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "support/vacols_database_cleaner"
+require "rails_helper"
+
+RSpec.describe DecidedMotionToVacateTask, :all_dbs, type: :model do
+  let(:lit_support_team) { LitigationSupport.singleton }
+
+  describe ".automatically_create_org_task" do
+    subject { create(:denied_motion_to_vacate_task) }
+
+    it "should automatically create org task" do
+      subject
+      org_task = DeniedMotionToVacateTask.find_by(assigned_to: lit_support_team)
+      expect(org_task).to_not be nil
+    end
+  end
+
+  describe ".available_actions" do
+    subject { task.available_actions(attorney) }
+
+    let(:attorney) { create(:user) }
+    let(:task) { create(:denied_motion_to_vacate_task) }
+
+    it "should include Pulac Cerullo action in available actions" do
+      actions = subject
+      expect(actions).to include(Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h)
+    end
+  end
+end

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -160,20 +160,22 @@ describe PostDecisionMotionUpdater, :all_dbs do
         expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
       end
 
-      # it "should only assign new task to org if prev atty is inactive" do
-      #   motions_atty.update_status!(Constants.USER_STATUSES.inactive)
+      it "should still assign org task if prev atty is inactive" do
+        motions_atty.update_status!(Constants.USER_STATUSES.inactive)
 
-      #   subject.process
-      #   expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
-      #   abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
+        subject.process
+        expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
+        abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
 
-      #   org_task = DeniedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
-      #   expect(org_task).to_not be nil
-      #   expect(org_task.parent).to eq abstract_task
+        org_task = DeniedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
+        expect(org_task).to_not be nil
+        expect(org_task.parent).to eq abstract_task
 
-      #   attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
-      #   expect(attorney_task).to be nil
-      # end
+        # The following check should be added back in once logic is in place to prevent assignment to inactive users
+
+        # attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
+        # expect(attorney_task).to be nil
+      end
 
       it "should close org task if user task is completed" do
         subject.process
@@ -209,20 +211,22 @@ describe PostDecisionMotionUpdater, :all_dbs do
         expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
       end
 
-      # it "should only assign new task to org if prev atty is inactive" do
-      #   motions_atty.update_status!(Constants.USER_STATUSES.inactive)
+      it "should still assign org task if prev atty is inactive" do
+        motions_atty.update_status!(Constants.USER_STATUSES.inactive)
 
-      #   subject.process
-      #   expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
-      #   abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
+        subject.process
+        expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
+        abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
 
-      #   org_task = DismissedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
-      #   expect(org_task).to_not be nil
-      #   expect(org_task.parent).to eq abstract_task
+        org_task = DismissedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
+        expect(org_task).to_not be nil
+        expect(org_task.parent).to eq abstract_task
 
-      #   attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
-      #   expect(attorney_task).to be nil
-      # end
+        # The following check should be added back in once logic is in place to prevent assignment to inactive users
+
+        # attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
+        # expect(attorney_task).to be nil
+      end
 
       it "should close org task if user task is completed" do
         subject.process

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -57,6 +57,19 @@ describe PostDecisionMotionUpdater, :all_dbs do
           expect(attorney_task.assigned_by).to eq task.assigned_to
           expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
         end
+
+        it "should close org task if user task is completed" do
+          subject.process
+
+          org_task = StraightVacateAndReadjudicationTask.find_by(assigned_to_id: judge_team.id)
+          attorney_task = StraightVacateAndReadjudicationTask.find_by(parent: org_task)
+
+          attorney_task.update!(status: Constants.TASK_STATUSES.completed)
+
+          org_task.reload
+
+          expect(org_task.status).to eq Constants.TASK_STATUSES.completed
+        end
       end
 
       context "when vacate type is vacate and de novo" do
@@ -76,6 +89,19 @@ describe PostDecisionMotionUpdater, :all_dbs do
           expect(attorney_task.parent).to eq org_task
           expect(attorney_task.assigned_by).to eq task.assigned_to
           expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
+        end
+
+        it "should close org task if user task is completed" do
+          subject.process
+
+          org_task = VacateAndDeNovoTask.find_by(assigned_to_id: judge_team.id)
+          attorney_task = VacateAndDeNovoTask.find_by(parent: org_task)
+
+          attorney_task.update!(status: Constants.TASK_STATUSES.completed)
+
+          org_task.reload
+
+          expect(org_task.status).to eq Constants.TASK_STATUSES.completed
         end
       end
 
@@ -140,6 +166,19 @@ describe PostDecisionMotionUpdater, :all_dbs do
         attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
         expect(attorney_task).to be nil
       end
+
+      it "should close org task if user task is completed" do
+        subject.process
+
+        org_task = DeniedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
+        attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
+
+        attorney_task.update!(status: Constants.TASK_STATUSES.completed)
+
+        org_task.reload
+
+        expect(org_task.status).to eq Constants.TASK_STATUSES.completed
+      end
     end
 
     context "when disposition is dismissed" do
@@ -175,6 +214,19 @@ describe PostDecisionMotionUpdater, :all_dbs do
 
         attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
         expect(attorney_task).to be nil
+      end
+
+      it "should close org task if user task is completed" do
+        subject.process
+
+        org_task = DismissedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
+        attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
+
+        attorney_task.update!(status: Constants.TASK_STATUSES.completed)
+
+        org_task.reload
+
+        expect(org_task.status).to eq Constants.TASK_STATUSES.completed
       end
     end
   end

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -152,20 +152,20 @@ describe PostDecisionMotionUpdater, :all_dbs do
         expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
       end
 
-      it "should only assign new task to org if prev atty is inactive" do
-        motions_atty.update_status!(Constants.USER_STATUSES.inactive)
+      # it "should only assign new task to org if prev atty is inactive" do
+      #   motions_atty.update_status!(Constants.USER_STATUSES.inactive)
 
-        subject.process
-        expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
-        abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
+      #   subject.process
+      #   expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
+      #   abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
 
-        org_task = DeniedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
-        expect(org_task).to_not be nil
-        expect(org_task.parent).to eq abstract_task
+      #   org_task = DeniedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
+      #   expect(org_task).to_not be nil
+      #   expect(org_task.parent).to eq abstract_task
 
-        attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
-        expect(attorney_task).to be nil
-      end
+      #   attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
+      #   expect(attorney_task).to be nil
+      # end
 
       it "should close org task if user task is completed" do
         subject.process
@@ -201,20 +201,20 @@ describe PostDecisionMotionUpdater, :all_dbs do
         expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
       end
 
-      it "should only assign new task to org if prev atty is inactive" do
-        motions_atty.update_status!(Constants.USER_STATUSES.inactive)
+      # it "should only assign new task to org if prev atty is inactive" do
+      #   motions_atty.update_status!(Constants.USER_STATUSES.inactive)
 
-        subject.process
-        expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
-        abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
+      #   subject.process
+      #   expect(task.reload.status).to eq Constants.TASK_STATUSES.completed
+      #   abstract_task = AbstractMotionToVacateTask.find_by(parent: task.parent)
 
-        org_task = DismissedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
-        expect(org_task).to_not be nil
-        expect(org_task.parent).to eq abstract_task
+      #   org_task = DismissedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
+      #   expect(org_task).to_not be nil
+      #   expect(org_task.parent).to eq abstract_task
 
-        attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
-        expect(attorney_task).to be nil
-      end
+      #   attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
+      #   expect(attorney_task).to be nil
+      # end
 
       it "should close org task if user task is completed" do
         subject.process

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -170,11 +170,6 @@ describe PostDecisionMotionUpdater, :all_dbs do
         org_task = DeniedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
         expect(org_task).to_not be nil
         expect(org_task.parent).to eq abstract_task
-
-        # The following check should be added back in once logic is in place to prevent assignment to inactive users
-
-        # attorney_task = DeniedMotionToVacateTask.find_by(parent: org_task)
-        # expect(attorney_task).to be nil
       end
 
       it "should close org task if user task is completed" do
@@ -221,11 +216,6 @@ describe PostDecisionMotionUpdater, :all_dbs do
         org_task = DismissedMotionToVacateTask.find_by(assigned_to_id: lit_support_team)
         expect(org_task).to_not be nil
         expect(org_task.parent).to eq abstract_task
-
-        # The following check should be added back in once logic is in place to prevent assignment to inactive users
-
-        # attorney_task = DismissedMotionToVacateTask.find_by(parent: org_task)
-        # expect(attorney_task).to be nil
       end
 
       it "should close org task if user task is completed" do

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -8,7 +8,7 @@ describe PostDecisionMotionUpdater, :all_dbs do
   let(:judge) { create(:user, full_name: "Judge User", css_id: "JUDGE_1") }
   let(:attorney) { create(:user) }
   let!(:judge_team) do
-    JudgeTeam.create_for_judge(judge).tap { |jt| OrganizationsUser.add_user_to_organization(attorney, jt) }
+    JudgeTeam.create_for_judge(judge).tap { |jt| jt.add_user(attorney) }
   end
   let!(:motions_atty) { create(:user, full_name: "Motions attorney") }
   let!(:mtv_mail_task) { create(:vacate_motion_mail_task, assigned_to: motions_atty) }

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -6,6 +6,7 @@ require "rails_helper"
 describe PostDecisionMotionUpdater, :all_dbs do
   let!(:lit_support_team) { LitigationSupport.singleton }
   let(:judge) { create(:user, full_name: "Judge User", css_id: "JUDGE_1") }
+  let(:judge_team) { JudgeTeam.create_for_judge(judge) }
   let!(:motions_atty) { create(:user, full_name: "Motions attorney") }
   let!(:mtv_mail_task) { create(:vacate_motion_mail_task, assigned_to: motions_atty) }
   let(:task) { create(:judge_address_motion_to_vacate_task, :in_progress, parent: mtv_mail_task, assigned_to: judge) }
@@ -47,6 +48,11 @@ describe PostDecisionMotionUpdater, :all_dbs do
           expect(attorney_task.parent).to eq abstract_task
           expect(attorney_task.assigned_by).to eq task.assigned_to
           expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
+        end
+
+        it "should create straight vacate and readjudication organization task" do
+          subject.process
+          org_task = StraightVacateAndReadjudicationTask.find_by(assigned_to_id: assigned_to_id)
         end
       end
 

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -62,13 +62,6 @@ describe PostDecisionMotionUpdater, :all_dbs do
           expect(attorney_task.status).to eq Constants.TASK_STATUSES.assigned
         end
 
-        it "should create JudgeSignMotionToVacateTask" do
-          subject.process
-
-          judge_sign_task = JudgeSignMotionToVacateTask.find_by(assigned_to: judge)
-          expect(judge_sign_task).to_not be nil
-        end
-
         it "should close org task if user task is completed" do
           subject.process
 


### PR DESCRIPTION
Connects #12284

### Description
We reorganized MTV task tree to add organization tasks (of same type) as parents to the various tasks that are spawned by `PostDecisionMotionUpdater`. This allows the org to handle things in case the assigned attorney goes inactive.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] We create org task for `DeniedMotionToVacateTask`
- [ ] We create org task for `DismissedMotionToVacateTask`
- [ ] We create org task for `VacateAndDeNovoTask`
- [ ] We create org task for `StraightVacateAndReadjudicationTask`
- [ ] Org tasks are completed if their child atty task is completed (but reopened if atty task is cancelled)

### Testing Plan
1. Go to ...

### Documentation Updates
- [ ] Topline File Descriptions Added or Updated as Needed
