### PR TITLE
Send message to Sentry when child task created for closed task

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -84,6 +84,7 @@ detectors:
       - QueueConfig
       - RequestIssue
       - BulkTaskReassignment
+      - Task
   TooManyInstanceVariables:
     exclude:
       - AmaAppealDispatch

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -438,7 +438,11 @@ class Task < ApplicationRecord
 
   def when_child_task_created(child_task)
     cancel_timed_hold unless child_task.is_a?(TimedHoldTask)
-    update!(status: :on_hold) if !on_hold?
+
+    if !on_hold?
+      Raven.capture_message("Closed task #{id} re-opened because child task created") if !open?
+      update!(status: :on_hold)
+    end
   end
 
   def task_is_assigned_to_users_organization?(user)

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -16,8 +16,14 @@ class RootTask < Task
   def when_child_task_completed(_child_task); end
 
   # Do not change the status of closed or on_hold RootTasks when child tasks are created for them.
-  def when_child_task_created(_child_task)
-    update!(status: :on_hold) if active?
+  def when_child_task_created(child_task)
+    if active?
+      update!(status: :on_hold)
+    elsif !child_task.is_a?(TrackVeteranTask)
+      # Expect TrackVeteranTasks to occasionally be created for closed RootTasks because of timing complications
+      # described in https://github.com/department-of-veterans-affairs/caseflow/issues/12574#issuecomment-549463832
+      Raven.capture_message("Created child task for RootTask #{id} but did not update RootTask status")
+    end
   end
 
   def update_children_status_after_closed

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -976,7 +976,7 @@ describe Task, :all_dbs do
       allow(Raven).to receive(:capture_message)
     end
 
-    context "when the RootTask is active" do
+    context "when the task is active" do
       it "does not send a message to Sentry" do
         expect(parent_task.status).to eq(Constants.TASK_STATUSES.assigned)
         expect(parent_task.children.count).to eq(0)
@@ -989,7 +989,7 @@ describe Task, :all_dbs do
       end
     end
 
-    context "when the RootTask is closed" do
+    context "when the task is closed" do
       before { parent_task.update!(status: Constants.TASK_STATUSES.completed) }
 
       it "sends a message to Sentry" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -966,4 +966,36 @@ describe Task, :all_dbs do
       end
     end
   end
+
+  describe ".when_child_task_created" do
+    let(:parent_task) { create(:task, appeal: create(:appeal)) }
+
+    subject { create(:task, parent: parent_task, appeal: parent_task.appeal) }
+
+    context "when the RootTask is active" do
+      it "does not send a message to Sentry" do
+        expect(parent_task.status).to eq(Constants.TASK_STATUSES.assigned)
+        expect(parent_task.children.count).to eq(0)
+
+        subject
+
+        expect(parent_task.status).to eq(Constants.TASK_STATUSES.on_hold)
+        expect(parent_task.children.count).to eq(1)
+      end
+    end
+
+    context "when the RootTask is closed" do
+      before { parent_task.update!(status: Constants.TASK_STATUSES.completed) }
+
+      it "does sends a message to Sentry" do
+        expect(parent_task.status).to eq(Constants.TASK_STATUSES.completed)
+        expect(parent_task.children.count).to eq(0)
+
+        subject
+
+        expect(parent_task.status).to eq(Constants.TASK_STATUSES.on_hold)
+        expect(parent_task.children.count).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Adds an alert when the application creates a child task of a closed task as suggested by this comment on a recent PR: https://github.com/department-of-veterans-affairs/caseflow/pull/12576#pullrequestreview-311225292