### PR TITLE
Do not query BGS when matching SSN (allow nil attribute)

### DIFF
--- a/app/services/veteran_finder.rb
+++ b/app/services/veteran_finder.rb
@@ -22,7 +22,7 @@ class VeteranFinder
 
     def find_best_match_by_ssn(ssn)
       vets = find_or_create_by_file_number_or_ssn(ssn)
-      vets.find { |vet| vet.ssn.to_s == ssn.to_s } || vets.first
+      vets.select { |vet| vet[:ssn].present? }.find { |vet| vet.ssn.to_s == ssn.to_s } || vets.first
     end
 
     def find_best_match_by_file_number(file_number)


### PR DESCRIPTION
## Description

Avoid BGS query when comparing SSN attribute on Veteran records for best match. This fixes a regression in loading hearing tasks endpoints where lots of BGS calls were getting made.

This works around missing data that will be fixed in #12521 