### PR TITLE
Do not show on hold or completed legacy colocated tasks in an attorney's assigned tab

### DIFF
--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -235,7 +235,7 @@ export const workableTasksByAssigneeCssIdSelector = createSelector(
   [workTasksByAssigneeCssIdSelector],
   (tasks) => tasks.filter(
     (task) => {
-      return (task.appeal.isLegacyAppeal ||
+      return ((task.appeal.isLegacyAppeal && task.type === 'AttorneyTask') ||
           task.status === TASK_STATUSES.assigned ||
           task.status === TASK_STATUSES.in_progress);
     }

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -231,11 +231,18 @@ export const newTasksByAssigneeCssIdSelector = createSelector(
   (tasks) => tasks.filter((task) => !taskIsOnHold(task))
 );
 
+const taskIsLegacyAttorneyJudgeTask = (task) => {
+  const legacyAttorneyJudgeTaskTypes =
+    ['AttorneyLegacyTask', 'JudgeLegacyTask', 'JudgeLegacyAssignTask', 'JudgeLegacyDecisionReviewTask'];
+
+  return legacyAttorneyJudgeTaskTypes.includes(task.type);
+};
+
 export const workableTasksByAssigneeCssIdSelector = createSelector(
   [workTasksByAssigneeCssIdSelector],
   (tasks) => tasks.filter(
     (task) => {
-      return ((task.appeal.isLegacyAppeal && task.type === 'AttorneyTask') ||
+      return (taskIsLegacyAttorneyJudgeTask(task) ||
           task.status === TASK_STATUSES.assigned ||
           task.status === TASK_STATUSES.in_progress);
     }

--- a/spec/feature/queue/attorney_queue_spec.rb
+++ b/spec/feature/queue/attorney_queue_spec.rb
@@ -165,7 +165,7 @@ RSpec.feature "Attorney queue", :all_dbs do
 
     context "when the attorney has an on hold legacy ColocatedTask assigned to them" do
       let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
-      let!(:colocated_user) { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
+      let!(:colocated_user) { Colocated.singleton.add_user(create(:user)) }
       let!(:colocated_org_task) do
         create(
           :colocated_task,

--- a/spec/feature/queue/attorney_queue_spec.rb
+++ b/spec/feature/queue/attorney_queue_spec.rb
@@ -92,9 +92,7 @@ RSpec.feature "Attorney queue", :all_dbs do
           parent: judge_task
         )
       end
-      let!(:colocated_users) do
-        3.times { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
-      end
+      let!(:colocated_users) { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
       let!(:colocated_org_task) do
         create(
           :colocated_task,
@@ -116,9 +114,7 @@ RSpec.feature "Attorney queue", :all_dbs do
 
     context "when a LegacyAppeal has a ColocatedTask" do
       let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
-      let!(:colocated_users) do
-        3.times { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
-      end
+      let!(:colocated_users) { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
       let!(:colocated_org_task) do
         create(
           :colocated_task,
@@ -139,9 +135,7 @@ RSpec.feature "Attorney queue", :all_dbs do
 
     context "when a LegacyAppeal's ColocatedTask is re-assigned from one member of the VLJ support staff to another" do
       let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
-      let!(:colocated_users) do
-        3.times { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
-      end
+      let!(:colocated_users) { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
       let(:colocated_org_task) do
         create(
           :colocated_task,
@@ -164,6 +158,31 @@ RSpec.feature "Attorney queue", :all_dbs do
 
         click_on(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 1))
 
+        expect(page).to have_content(appeal.veteran_full_name)
+        expect(page).to have_content(Constants::CO_LOCATED_ADMIN_ACTIONS[colocated_org_task.label])
+      end
+    end
+
+    context "when the attorney has an on hold legacy ColocatedTask assigned to them" do
+      let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
+      let!(:colocated_users) { OrganizationsUser.add_user_to_organization(create(:user), Colocated.singleton) }
+      let!(:colocated_org_task) do
+        create(
+          :colocated_task,
+          :on_hold,
+          appeal: appeal,
+          assigned_by: attorney
+        )
+      end
+
+      before { colocated_org_task.children.first.update!(assigned_to: attorney) }
+
+      it "displays a single row for the appeal in the attorney's on hold tab" do
+        visit("/queue")
+
+        click_on(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 1))
+
+        expect(page).to have_content(format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, 0))
         expect(page).to have_content(appeal.veteran_full_name)
         expect(page).to have_content(Constants::CO_LOCATED_ADMIN_ACTIONS[colocated_org_task.label])
       end


### PR DESCRIPTION
Resolves #12500

### Description
The selector `task.appeal.isLegacyAppeal` assumes only `AttorneyTask`s will be sent to the attorney queue. We've discovered an attorney who is being assigned other tasks due to the fact that they are on the VLJ Support team. This PR ensures that only legacy `AttorneyTask`s and all other active tasks assigned to the attorney appear in their assigned tab.

### Acceptance Criteria
- [ ] Legacy `ColocatedTask`s assigned to an attorney do not show up in their assigned tab.