### PR TITLE
Don't send message to Sentry when we create a child task for a RootTask that is already on hold

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -19,7 +19,7 @@ class RootTask < Task
   def when_child_task_created(child_task)
     if active?
       update!(status: :on_hold)
-    elsif !child_task.is_a?(TrackVeteranTask)
+    elsif !child_task.is_a?(TrackVeteranTask) && !on_hold?
       # Expect TrackVeteranTasks to occasionally be created for closed RootTasks because of timing complications
       # described in https://github.com/department-of-veterans-affairs/caseflow/issues/12574#issuecomment-549463832
       Raven.capture_message("Created child task for RootTask #{id} but did not update RootTask status")


### PR DESCRIPTION
Related [Slack conversation](https://dsva.slack.com/archives/C2ZAMLK88/p1572970070078500) and [Sentry alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7269/).

Investigation steps that led to us determining the code was to blame:
```ruby
# https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7269/
rails c> root_task = RootTask.find(257844)
rails c> puts root_task.appeal.structure_render(:id, :status, :created_at, :updated_at, :closed_at)
# Appeal 9710 [id, status, created_at, updated_at, closed_at]
# └── RootTask 257844, on_hold, 2019-07-02 14:17:35 UTC, 2019-07-02 14:17:36 UTC, (closed_at)
#     ├── TrackVeteranTask 257846, in_progress, 2019-07-02 14:17:36 UTC, 2019-07-05 19:20:12 UTC, (closed_at)
#     ├── DistributionTask 257847, completed, 2019-07-02 14:17:36 UTC, 2019-10-31 12:33:08 UTC, 2019-10-31 12:33:08 UTC
#     │   └── InformalHearingPresentationTask 257848, completed, 2019-07-02 14:17:36 UTC, 2019-10-23 11:47:11 UTC, 2019-10-23 11:47:11 UTC
#     │       └── InformalHearingPresentationTask 476192, completed, 2019-10-19 18:54:38 UTC, 2019-10-23 11:47:11 UTC, 2019-10-23 11:47:11 UTC
#     ├── JudgeAssignTask 497091, completed, 2019-10-31 12:33:08 UTC, 2019-11-05 15:55:02 UTC, 2019-11-05 15:55:02 UTC
#     └── JudgeDecisionReviewTask 504360, on_hold, 2019-11-05 15:55:02 UTC, 2019-11-05 15:55:02 UTC, (closed_at)
#         └── AttorneyTask 504361, assigned, 2019-11-05 15:55:02 UTC, 2019-11-05 15:55:02 UTC, (closed_at)
# JudgeAssignTask 497091 was closed at the point in time where the error was triggered.
# JudgeDecisionReviewTask and AttorneyTask were created then too.
# This is expected. Why did we throw this error? The RootTask is already on hold.
# Let's take a look at the code.
# Looks like problem with the code. We should not be sending ourselves this error when the RootTask is already on hold.
# Let's fix it and write a test.
```