### PR TITLE
Remove modern recordkeeping, always use promulgation date as decision date

### DIFF
--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -70,6 +70,8 @@ class RatingDecision
   def contestable?
     return true if rating_issue?
 
+    return false unless disability_date
+
     date_near_promulgation_date?(disability_date.to_date) || date_near_profile_date?(disability_date.to_date)
   end
 

--- a/app/models/rating_decision.rb
+++ b/app/models/rating_decision.rb
@@ -71,12 +71,7 @@ class RatingDecision
   end
 
   def contestable?
-    return false if rating_issue?
-
-    # TODO
-    #return false unless disability_date
-
-    true
+    !rating_issue?
   end
 
   def rating_issue?

--- a/app/workflows/contestable_issue_generator.rb
+++ b/app/workflows/contestable_issue_generator.rb
@@ -57,7 +57,6 @@ class ContestableIssueGenerator
     # so filter out any that are duplicates of a rating issue or that are not related to their parent rating.
     rating_decisions
       .select(&:contestable?)
-      .reject(&:rating_issue?)
       .select { |rating_decision| rating_decision.profile_date && rating_decision.profile_date.to_date < receipt_date }
       .map { |rating_decision| ContestableIssue.from_rating_decision(rating_decision, review) }
   end

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -33,6 +33,7 @@ feature "Intake Add Issues Page", :all_dbs do
           diagnostic_text: "Broken arm",
           diagnostic_type: "Bone",
           disability_id: "123",
+          disability_date: promulgation_date - 3.days,
           type_name: "Not Service Connected"
         }
       ]

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -186,10 +186,16 @@ describe RatingDecision do
           it { is_expected.to eq(true) }
         end
 
-        context "promulgation date and original_denial_date are not close" do
-          let(:original_denial_date) { promulgation_date + 6.months }
+        context "promulgation date, profile date and disability_date are not close" do
+          let(:disability_date) { promulgation_date + 6.months }
 
           it { is_expected.to eq(false) }
+        end
+
+        context "profile date and disability date are close, promulgation date is not close" do
+          let(:promulgation_date) { disability_date + 6.months }
+
+          it { is_expected.to eq(true) }
         end
 
         context "profile date is near original_denial_date but not promulgation date" do
@@ -208,6 +214,26 @@ describe RatingDecision do
       end
     end
 
+    describe "#effective_date" do
+      context "decision is not a rating issue" do
+        let(:rating_issue_reference_id) { nil }
+        let(:original_denial_date) { Time.zone.today }
+        let(:begin_date) { Time.zone.tomorrow }
+
+        it "prefers the original_denial_date as the oldest date" do
+          expect(subject.effective_date).to eq(original_denial_date)
+        end
+
+        context "original_denial_date is nil" do
+          let(:original_denial_date) { nil }
+
+          it "defaults to begin_date" do
+            expect(subject.effective_date).to eq(begin_date)
+          end
+        end
+      end
+    end
+
     describe "#decision_date" do
       context "decision is a rating issue" do
         let(:rating_issue_reference_id) { "123" }
@@ -222,16 +248,8 @@ describe RatingDecision do
         let(:original_denial_date) { Time.zone.today }
         let(:begin_date) { Time.zone.tomorrow }
 
-        it "prefers the original_denial_date as the oldest date" do
-          expect(subject.decision_date).to eq(original_denial_date)
-        end
-
-        context "original_denial_date is nil" do
-          let(:original_denial_date) { nil }
-
-          it "defaults to begin_date" do
-            expect(subject.decision_date).to eq(begin_date)
-          end
+        it "uses the promulgation_date" do
+          expect(subject.decision_date).to eq(promulgation_date)
         end
       end
     end

--- a/spec/models/rating_decision_spec.rb
+++ b/spec/models/rating_decision_spec.rb
@@ -176,7 +176,7 @@ describe RatingDecision do
       subject { described_class.from_bgs_disability(rating, bgs_record).contestable? }
 
       context "rating_issue? is true" do
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
 
       context "rating_issue? is false" do
@@ -189,7 +189,7 @@ describe RatingDecision do
         context "promulgation date, profile date and disability_date are not close" do
           let(:disability_date) { promulgation_date + 6.months }
 
-          it { is_expected.to eq(false) }
+          it { is_expected.to eq(true) }
         end
 
         context "profile date and disability date are close, promulgation date is not close" do

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -719,6 +719,7 @@ module IntakeHelpers
           diagnostic_text: "Right arm broken",
           diagnostic_type: "Bone",
           disability_id: "123",
+          disability_date: receipt_date - 5.years - 2.days,
           type_name: "Not Service Connected"
         }
       ]


### PR DESCRIPTION
connects #11840

See https://dsva.slack.com/archives/C754H751T/p1572906326036300?thread_ts=1572904848.036200&cid=C754H751T

### Description
Continue refining the definition of `contestable?` rating decision to be more inclusive. We now include all rating decisions where the disability date is near the promulgation or profile date, and ignore the arbitrary "modern recordkeeping" definition implemented earlier.

The goal is to increase the number of rating decisions visible on the Add Issues screen during Intake.