### PR TITLE
Create AMA Appeals ready for Distribution with known Vet File Numbers

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -667,6 +667,23 @@ class SeedDB
       )
     end
 
+    # Create AMA tasks ready for distribution
+    (1..30).each do |num|
+      vet_file_number = "3213213%02d" % num
+      FactoryBot.create(
+        :appeal,
+        :ready_for_distribution,
+        number_of_claimants: 1,
+        active_task_assigned_at: Time.zone.now,
+        veteran_file_number: vet_file_number,
+        docket_type: Constants.AMA_DOCKETS.direct_review,
+        closest_regional_office: "RO17",
+        request_issues: FactoryBot.create_list(
+          :request_issue, 2, :nonrating, notes: notes
+        )
+      )
+    end
+
     LegacyAppeal.create(vacols_id: "2096907", vbms_id: "228081153S")
     LegacyAppeal.create(vacols_id: "2226048", vbms_id: "213912991S")
     LegacyAppeal.create(vacols_id: "2249056", vbms_id: "608428712S")


### PR DESCRIPTION
Resolves #12597 

### Description
Adds 30 AMA cases to the seed data with known veteran file numbers (`321321301`-`321321330`) that are ready to be distributed. These can be used to test/demo Special Case Movement.

![Peek 2019-11-05 15-37](https://user-images.githubusercontent.com/6129479/68244709-6180c980-ffe3-11e9-9c6c-9657d7390db3.gif)

### Acceptance Criteria
- [ ] Seed data creates AMA cases with a reliable set of Veteran File Numbers

### Testing Plan
1. Become a special case movement team member (BVA
2. Search for a Veteran File Number `321321301`..`321321330`
3. Special Case Movement is available on the case.
