### PR TITLE
Fix hearing disposition change job spec flakey test

### DIFF
--- a/app/jobs/hearing_disposition_change_job.rb
+++ b/app/jobs/hearing_disposition_change_job.rb
@@ -91,7 +91,10 @@ class HearingDispositionChangeJob < CaseflowJob
   end
 
   def lock_hearing_days
-    HearingDay.where("scheduled_for < ?", 1.day.ago).where(lock: [false, nil]).update_all(lock: true)
+    HearingDay
+      .where("scheduled_for < ?", 1.day.ago.to_date)
+      .where(lock: [false, nil])
+      .update_all(lock: true)
   end
 
   def log_info(start_time, task_count_for, error_count, hearing_ids, err = nil)


### PR DESCRIPTION
### Description

@yoomlam [reported a flake in the `hearing_disposition_change_job_spec` that only happened at night](https://dsva.slack.com/archives/C2ZAMLK88/p1573047479092200).

I was able to reproduce the issue using `Timecop` to set the time equal to what it would have been when the tests ran:

```
before do
  Timecop.freeze(Time.utc(2019, 11, 6, 4, 55, 0))
end
```

I traced this down to an issue with the SQL that is getting generated by Rails. The job looks for hearing days from a day ago, and the query that gets issued looks like this:

```sql
SELECT "hearing_days".* FROM "hearing_days" WHERE "hearing_days"."deleted_at" IS NULL AND (scheduled_for < '2019-11-05 04:55:00')
```

The field is simply stored as a date string in the database:

```
> HearingDay.where("scheduled_for < ?", 1.day.ago).last.attributes_before_type_cast
=> {"id"=>3,
 "bva_poc"=>nil,
 "created_at"=>"2019-11-06 04:55:00",
 "created_by_id"=>6,
 "deleted_at"=>nil,
 "judge_id"=>nil,
 "lock"=>true,
 "notes"=>nil,
 "regional_office"=>nil,
 "request_type"=>"C",
 "room"=>"2",
 "scheduled_for"=>"2019-11-04",
 "updated_at"=>"2019-11-06 04:55:00",
 "updated_by_id"=>7}
```

Updating the query to look for a date instead of a date time fixed the issue:

```sql
SELECT "hearing_days".* FROM "hearing_days" WHERE "hearing_days"."deleted_at" IS NULL AND (scheduled_for < '2019-11-04')
```