### PR TITLE
Async job CSV export

### DIFF
--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "date"
-
 class AsyncableJobsController < ApplicationController
   include PaginationConcern
 
@@ -18,7 +16,7 @@ class AsyncableJobsController < ApplicationController
       format.html
       format.csv do
         jobs_as_csv = AsyncableJobsReporter.new(jobs: jobs).as_csv
-        filename = Time.now.utc.strftime("async-jobs-%Y%m%d.csv")
+        filename = Time.zone.now.strftime("async-jobs-%Y%m%d.csv")
         send_data jobs_as_csv, filename: filename
       end
     end

--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "date"
+
 class AsyncableJobsController < ApplicationController
   include PaginationConcern
 
@@ -11,6 +13,14 @@ class AsyncableJobsController < ApplicationController
   def index
     if allowed_params[:asyncable_job_klass]
       @jobs = asyncable_job_klass.potentially_stuck.limit(page_size).offset(page_start)
+    end
+    respond_to do |format|
+      format.html
+      format.csv do
+        jobs_as_csv = AsyncableJobsReporter.new(jobs: jobs).as_csv
+        filename = Date.today.strftime("async-jobs-%Y%m%d.csv")
+        send_data jobs_as_csv, filename: filename
+      end
     end
   end
 

--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -18,7 +18,7 @@ class AsyncableJobsController < ApplicationController
       format.html
       format.csv do
         jobs_as_csv = AsyncableJobsReporter.new(jobs: jobs).as_csv
-        filename = Date.today.strftime("async-jobs-%Y%m%d.csv")
+        filename = Time.now.utc.strftime("async-jobs-%Y%m%d.csv")
         send_data jobs_as_csv, filename: filename
       end
     end

--- a/client/app/asyncableJobs/components/AsyncModelNav.jsx
+++ b/client/app/asyncableJobs/components/AsyncModelNav.jsx
@@ -37,9 +37,9 @@ export default class AsyncModelNav extends React.PureComponent {
 
     return <div>
       <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}
-      <div>
+      <div style={{ marginTop: '.5em' }}>
+        <a style={{ marginRight: '.5em' }} href="/jobs" className="cf-link-btn">All jobs</a>
         {this.modelNameLinks()}
-        <a style={{ float: 'right' }} href="/jobs" className="cf-link-btn">All jobs</a>
         <a style={{ float: 'right' }} href={`${currentPath}.csv`} className="cf-link-btn">Download as CSV</a>
       </div>
     </div>;

--- a/client/app/asyncableJobs/components/AsyncModelNav.jsx
+++ b/client/app/asyncableJobs/components/AsyncModelNav.jsx
@@ -31,13 +31,16 @@ export default class AsyncModelNav extends React.PureComponent {
   }
 
   render = () => {
+    const currentPath = this.props.asyncableJobKlass ?
+        `/asyncable_jobs/${this.props.asyncableJobKlass}/jobs` :
+        '/jobs';
 
     return <div>
       <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}
       <div>
         {this.modelNameLinks()}
         <a style={{ float: 'right' }} href="/jobs" className="cf-link-btn">All jobs</a>
-        <a style={{ float: 'right' }} href="/jobs.csv" className="cf-link-btn">Download as CSV</a>
+        <a style={{ float: 'right' }} href={`${currentPath}.csv`} className="cf-link-btn">Download as CSV</a>
       </div>
     </div>;
   }
@@ -45,5 +48,6 @@ export default class AsyncModelNav extends React.PureComponent {
 
 AsyncModelNav.propTypes = {
   models: PropTypes.array,
-  fetchedAt: PropTypes.string
+  fetchedAt: PropTypes.string,
+  asyncableJobKlass: PropTypes.string
 };

--- a/client/app/asyncableJobs/components/AsyncModelNav.jsx
+++ b/client/app/asyncableJobs/components/AsyncModelNav.jsx
@@ -37,6 +37,7 @@ export default class AsyncModelNav extends React.PureComponent {
       <div>
         {this.modelNameLinks()}
         <a style={{ float: 'right' }} href="/jobs" className="cf-link-btn">All jobs</a>
+        <a style={{ float: 'right' }} href="/jobs.csv" className="cf-link-btn">Download as CSV</a>
       </div>
     </div>;
   }

--- a/client/app/asyncableJobs/components/AsyncModelNav.jsx
+++ b/client/app/asyncableJobs/components/AsyncModelNav.jsx
@@ -32,8 +32,8 @@ export default class AsyncModelNav extends React.PureComponent {
 
   render = () => {
     const currentPath = this.props.asyncableJobKlass ?
-        `/asyncable_jobs/${this.props.asyncableJobKlass}/jobs` :
-        '/jobs';
+      `/asyncable_jobs/${this.props.asyncableJobKlass}/jobs` :
+      '/jobs';
 
     return <div>
       <strong>Last updated:</strong> {moment(this.props.fetchedAt).format(DATE_TIME_FORMAT)}

--- a/client/app/asyncableJobs/pages/JobsPage.jsx
+++ b/client/app/asyncableJobs/pages/JobsPage.jsx
@@ -40,7 +40,10 @@ class AsyncableJobsPage extends React.PureComponent {
     if (rowObjects.length === 0) {
       return <div>
         <h1>{`Success! There are no pending ${this.props.asyncableJobKlass} jobs.`}</h1>
-        <AsyncModelNav models={this.props.models} fetchedAt={this.props.fetchedAt} />
+        <AsyncModelNav
+          models={this.props.models}
+          fetchedAt={this.props.fetchedAt}
+          asyncableJobKlass={this.props.asyncableJobKlass} />
       </div>;
     }
 
@@ -112,7 +115,10 @@ class AsyncableJobsPage extends React.PureComponent {
 
     return <div className="cf-asyncable-jobs-table">
       <h1>{this.props.asyncableJobKlass} Jobs</h1>
-      <AsyncModelNav models={this.props.models} fetchedAt={this.props.fetchedAt} />
+      <AsyncModelNav
+        models={this.props.models}
+        fetchedAt={this.props.fetchedAt}
+        asyncableJobKlass={this.props.asyncableJobKlass} />
       <hr />
       <Table columns={columns} rowObjects={rowObjects} rowClassNames={rowClassNames} slowReRendersAreOk />
       <EasyPagination currentCases={rowObjects.length} pagination={this.props.pagination} />

--- a/spec/controllers/asyncable_jobs_controller_spec.rb
+++ b/spec/controllers/asyncable_jobs_controller_spec.rb
@@ -62,7 +62,7 @@ describe AsyncableJobsController, :postgres, type: :controller do
         get(:index, format: :csv)
 
         expect(response.status).to eq 200
-        expect(response.headers['Content-Type']).to include 'text/csv'
+        expect(response.headers["Content-Type"]).to include "text/csv"
         expect(response.body).to start_with("type,id,submitted,last_submitted,attempted_at,error,participant_id\n")
       end
     end

--- a/spec/controllers/asyncable_jobs_controller_spec.rb
+++ b/spec/controllers/asyncable_jobs_controller_spec.rb
@@ -57,6 +57,14 @@ describe AsyncableJobsController, :postgres, type: :controller do
 
         expect(response.status).to eq 200
       end
+
+      it "handles requests for CSV format" do
+        get(:index, format: :csv)
+
+        expect(response.status).to eq 200
+        expect(response.headers['Content-Type']).to include 'text/csv'
+        expect(response.body).to start_with("type,id,submitted,last_submitted,attempted_at,error,participant_id\n")
+      end
     end
 
     context "user is Admin Intake" do

--- a/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
+++ b/spec/feature/asyncable_jobs/asyncable_jobs_index_spec.rb
@@ -168,6 +168,12 @@ feature "Asyncable Jobs index", :postgres do
       expect(page).to have_current_path(manager_path(user_css_id: hlr_intake.user.css_id))
     end
 
+    it "links to CSV export" do
+      visit "/jobs"
+
+      expect(page).to have_content "Download as CSV"
+    end
+
     context "zero unprocessed jobs" do
       before do
         AsyncableJobs.new(page_size: 100).jobs.each(&:clear_error!).each(&:processed!)


### PR DESCRIPTION
Connects #12520

### Description
Adds
- a `Download as CSV` button on the `/jobs` page, and
- a CSV format responder for the `/jobs` endpoint. I went this route because the content (a list of async jobs) is the same as what `asyncable_jobs#index` already serves, and the only difference is in the content type, which ought to be handled with HTTP semantics.

Screenshots of the new jobs page layout as per design advice from @rutvigupta-design:

With many job types:
<img width="905" alt="Screen Shot 2019-11-07 at 12 50 05" src="https://user-images.githubusercontent.com/282869/68414140-99138100-015d-11ea-8c2f-1cd08e996568.png">

With a few job types:
<img width="905" alt="Screen Shot 2019-11-07 at 12 59 16" src="https://user-images.githubusercontent.com/282869/68414903-1a1f4800-015f-11ea-9eb4-82ecec088e0f.png">

Note: the many vs few job types UI was previously in place, and I tried not to change it when tweaking the layout to accommodate the new button. 

### Acceptance Criteria
- The `/jobs` page has a "Download as CSV" link, which when clicked returns a file named in the convention `async-jobs-YMD.csv`

### Testing Plan
1. Load the `/jobs` page, ideally with some jobs in the DB.
2. Click the `Download as CSV` button.
3. Verify that the CSV file has a `async-jobs-YMD.csv` name, and the expected contents.
4. New controller spec, new feature spec.