### PR TITLE
 508 compliance for tab window

### DIFF
--- a/client/app/components/TabWindow.jsx
+++ b/client/app/components/TabWindow.jsx
@@ -78,6 +78,7 @@ export default class TabWindow extends React.Component {
                 onClick={this.onTabClick(i)}
                 aria-label={this.getTabHeader(tab)}
                 disabled={Boolean(tab.disable)}
+                role="tab"
               >
                 <span>
                   {this.getTabHeaderWithSVG(tab)}


### PR DESCRIPTION
Connects #12137 

I figured changing it the root component would be the best option for all tabs to have a role.

To test this change, activate voice control on your computer and tab through assigned, on hold and completed.

<img width="1276" alt="Screen Shot 2019-11-06 at 5 50 36 PM" src="https://user-images.githubusercontent.com/23080951/68346140-59975700-00c1-11ea-809d-545df47b4caf.png">
<img width="1277" alt="Screen Shot 2019-11-06 at 5 51 24 PM" src="https://user-images.githubusercontent.com/23080951/68346222-92cfc700-00c1-11ea-9055-c8ff5a1abb75.png">

