### PR TITLE
Allow certain MailTasks to be created off closed RootTasks

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -15,13 +15,21 @@ class RootTask < Task
 
   def when_child_task_completed(_child_task); end
 
+  def self.creatable_tasks_types_when_on_hold
+    [
+      # Expect mail to be received for dispatched or cancelled appeals.
+      ReturnedUndeliverableCorrespondenceMailTask.name,
+      # Expect TrackVeteranTasks to occasionally be created for closed RootTasks because of timing complications
+      # described in https://github.com/department-of-veterans-affairs/caseflow/issues/12574#issuecomment-549463832
+      TrackVeteranTask.name
+    ]
+  end
+
   # Do not change the status of closed or on_hold RootTasks when child tasks are created for them.
   def when_child_task_created(child_task)
     if active?
       update!(status: :on_hold)
-    elsif !child_task.is_a?(TrackVeteranTask) && !on_hold?
-      # Expect TrackVeteranTasks to occasionally be created for closed RootTasks because of timing complications
-      # described in https://github.com/department-of-veterans-affairs/caseflow/issues/12574#issuecomment-549463832
+    elsif !self.class.creatable_tasks_types_when_on_hold.include?(child_task.type) && !on_hold?
       Raven.capture_message("Created child task for RootTask #{id} but did not update RootTask status")
     end
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -376,6 +376,13 @@ FactoryBot.define do
       parent { create(:appeal_withdrawal_mail_task, appeal: appeal) }
     end
 
+    factory :returned_undeliverable_correspondence_mail_task, class: ReturnedUndeliverableCorrespondenceMailTask do
+      type { ReturnedUndeliverableCorrespondenceMailTask.name }
+      appeal { create(:appeal) }
+      assigned_to { BvaDispatch.singleton }
+      parent { create(:root_task, appeal: appeal) }
+    end
+
     factory :no_show_hearing_task, class: NoShowHearingTask do
       type { NoShowHearingTask.name }
       appeal { create(:appeal) }

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -148,6 +148,18 @@ describe RootTask, :postgres do
           expect(Raven).to have_received(:capture_message).exactly(0).times
         end
       end
+
+      context "when the child task is a ReturnedUndeliverableCorrespondenceMailTask" do
+        let(:task_factory) { :returned_undeliverable_correspondence_mail_task }
+
+        # Automatic task assignment requires there to be members of the BVA dispatch team.
+        before { BvaDispatch.singleton.add_user(create(:user)) }
+
+        it "does not send a message to Sentry" do
+          subject
+          expect(Raven).to have_received(:capture_message).exactly(0).times
+        end
+      end
     end
 
     context "when the RootTask is on_hold" do


### PR DESCRIPTION
Related to the discussion on a Sentry alert [captured in Slack](https://dsva.slack.com/archives/CLRTL92TW/p1573137212057100).