### PR TITLE
Upgrade brakeman dependency from 4.6.1 to 4.7.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
-    brakeman (4.6.1)
+    brakeman (4.7.1)
     builder (3.2.3)
     bullet (6.0.1)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
### Description

Upgrade `brakeman` from 4.6.1 too 4.7.1. 

Mostly bug fixes and refactors from 4.6.1 to 4.7.1 from what I could tell. There was a change for which HAML templates are supported, but I don't think are using HAML templates anywhere:

> Haml 3.x and 4.x are no longer supported, although in general Haml is mostly backwards-compatible.
