### PR TITLE
Search User name in autocomplete, fix zero match bug

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,9 +5,9 @@ class UsersController < ApplicationController
 
   def index
     return filter_by_role if params[:role]
-    return filter_by_css_id if params[:css_id]
+    return filter_by_css_id_or_name if params[:css_id]
 
-    render json: {}, status: 200
+    render json: {}, status: :ok
   end
 
   def search_by_css_id
@@ -54,9 +54,10 @@ class UsersController < ApplicationController
     end
   end
 
-  def filter_by_css_id
-    finder = UserFinder.new(css_id: css_id)
-    users = finder.users
+  def filter_by_css_id_or_name
+    # the param name is css_id for convenience but we are more generous in what we search.
+    finder = UserFinder.new(css_id: css_id, name: css_id)
+    users = finder.users || []
     if params[:exclude_org]
       org = Organization.find_by_name_or_url(params[:exclude_org])
       users -= org.users

--- a/spec/services/user_finder_spec.rb
+++ b/spec/services/user_finder_spec.rb
@@ -9,19 +9,38 @@ describe UserFinder, :all_dbs do
       create(:staff, :judge_role, sdomainid: judge.css_id)
     end
   end
-  let!(:user) { create(:user, css_id: "foobar") }
+  let!(:user) { create(:user, full_name: "Jill Smith", css_id: "foobar") }
   let(:css_id) {}
   let(:role) {}
+  let(:name) {}
   let(:organization) {}
 
   describe "#users" do
-    subject { described_class.new(css_id: css_id, role: role, organization: organization).users.to_a }
+    subject { described_class.new(css_id: css_id, name: name, role: role, organization: organization).users.to_a }
 
     context "css_id" do
       let(:css_id) { judge.css_id[0..2] } # first 3 characters
 
       it "finds by fuzzy css_id" do
         expect(subject).to eq([judge])
+      end
+    end
+
+    context "name" do
+      context "last name first" do
+        let(:name) { "smiTH, jIll" }
+
+        it "finds case-insensitive without regard to name order" do
+          expect(subject).to eq([user])
+        end
+      end
+
+      context "first name first" do
+        let(:name) { "jill SMITH" }
+
+        it "finds case-insensitive without regard to name order" do
+          expect(subject).to eq([user])
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #12536 

### Description
Looking at production logs, it is clear our users search for other users by name as well as CSS id. So support that expectation where possible.

In addition, there was a bug where zero matches were causing a 500 error due to nil object.