### PR TITLE
Choose correct claimant and payee code for board grant effectuations

### DIFF
--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -130,12 +130,9 @@ class BoardGrantEffectuation < ApplicationRecord
     )
   end
 
-  # the end product establishment for board grant effectuations is created here
-  # decision_document.appeal.claimaints
-  # decision_document.appeal.veteran_is_not_claimant
   def build_end_product_establishment
     EndProductEstablishment.create!(
-      source: decision_document, # the decision document is connected to an appeal, and the appeal has the claimant
+      source: decision_document,
       veteran_file_number: veteran.file_number,
       claim_date: decision_document.decision_date,
       claimant_participant_id: claimaint_participant_id,

--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -151,15 +151,11 @@ class BoardGrantEffectuation < ApplicationRecord
   def claimant_payee_code
     claimant = appeal&.claimants&.first
 
-    payee_code = if claimant&.payee_code.present?
-                   claimant.payee_code
-                 elsif appeal&.veteran_is_not_claimant
-                   veteran&.relationships&.find do |relationship|
-                     relationship.participant_id == claimant.participant_id
-                   end&.default_payee_code
-                 end
-
-    payee_code || EndProduct::DEFAULT_PAYEE_CODE
+    if claimant&.payee_code.present?
+      claimant.payee_code
+    elsif appeal&.veteran_is_not_claimant
+      veteran&.relationship_with_participant_id(claimant.participant_id)&.default_payee_code
+    end || EndProduct::DEFAULT_PAYEE_CODE
   end
 
   def end_product_code

--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -152,15 +152,15 @@ class BoardGrantEffectuation < ApplicationRecord
     claimant = decision_document&.appeal&.claimants&.first
     veteran = decision_document&.appeal&.veteran
 
-    if claimant&.payee_code.present?
-      claimant.payee_code
-    elsif decision_document&.appeal&.veteran_is_not_claimant
-      veteran&.relationships&.find do |relationship|
-        relationship.participant_id == claimant.participant_id
-      end&.default_payee_code
-    else
-      "00"
-    end
+    payee_code = if claimant&.payee_code.present?
+                   claimant.payee_code
+                 elsif decision_document&.appeal&.veteran_is_not_claimant
+                   veteran&.relationships&.find do |relationship|
+                     relationship.participant_id == claimant.participant_id
+                   end&.default_payee_code
+                 end
+
+    payee_code || EndProduct::DEFAULT_PAYEE_CODE
   end
 
   def end_product_code

--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -145,16 +145,15 @@ class BoardGrantEffectuation < ApplicationRecord
   end
 
   def claimaint_participant_id
-    decision_document&.appeal&.claimants&.first&.participant_id
+    appeal&.claimants&.first&.participant_id
   end
 
   def claimant_payee_code
-    claimant = decision_document&.appeal&.claimants&.first
-    veteran = decision_document&.appeal&.veteran
+    claimant = appeal&.claimants&.first
 
     payee_code = if claimant&.payee_code.present?
                    claimant.payee_code
-                 elsif decision_document&.appeal&.veteran_is_not_claimant
+                 elsif appeal&.veteran_is_not_claimant
                    veteran&.relationships&.find do |relationship|
                      relationship.participant_id == claimant.participant_id
                    end&.default_payee_code

--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -158,7 +158,7 @@ class BoardGrantEffectuation < ApplicationRecord
     if claimant&.payee_code.present?
       claimant.payee_code
     elsif decision_document&.appeal&.veteran_is_not_claimant
-      veteran&.fetch_relationships&.find do |relationship|
+      veteran&.relationships&.find do |relationship|
         relationship.participant_id == claimant.participant_id
       end&.default_payee_code
     else

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -29,11 +29,14 @@ class Relationship
     }
   end
 
-  private
-
+  # this method chooses the default payee code for a specific veteran relationship;
+  # it's currently used to choose a default payee code for the front-end payee_code
+  # selector
   def default_payee_code
     previous_claim_payee_code || payee_code_by_relationship_type
   end
+
+  private
 
   def previous_claim_payee_code
     @previous_claim_payee_code ||= latest_end_product.try(:payee_code)

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -29,9 +29,6 @@ class Relationship
     }
   end
 
-  # this method chooses the default payee code for a specific veteran relationship;
-  # it's currently used to choose a default payee code for the front-end payee_code
-  # selector
   def default_payee_code
     previous_claim_payee_code || payee_code_by_relationship_type
   end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -148,6 +148,12 @@ class Veteran < ApplicationRecord
     @relationships ||= fetch_relationships
   end
 
+  def relationship_with_participant_id(match_id = nil)
+    relationships&.find do |relationship|
+      relationship.participant_id == match_id
+    end
+  end
+
   def incident_flash?
     bgs_record.is_a?(Hash) && bgs_record[:block_cadd_ind] == "S"
   end
@@ -377,11 +383,10 @@ class Veteran < ApplicationRecord
   end
 
   def fetch_relationships
-    relationships = bgs.find_all_relationships(
-      participant_id: participant_id
-    )
-    relationships_array = Array.wrap(relationships)
-    relationships_array.map { |relationship_hash| Relationship.from_bgs_hash(self, relationship_hash) }
+    relationship_hashes = Array.wrap(bgs.find_all_relationships(participant_id: participant_id))
+    relationship_hashes.map do |relationship_hash|
+      Relationship.from_bgs_hash(self, relationship_hash)
+    end
   end
 
   def period_of_service(service_attributes)

--- a/spec/models/board_grant_effectuation_spec.rb
+++ b/spec/models/board_grant_effectuation_spec.rb
@@ -163,11 +163,15 @@ describe BoardGrantEffectuation, :postgres do
 
         before do
           allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(
-            first_name: "Josephine",
-            gender: gender,
-            last_name: "Clark",
-            ptcpnt_id: claimant_participant_id,
-            relationship_type: relationship_type
+            [
+              {
+                first_name: "Josephine",
+                gender: gender,
+                last_name: "Clark",
+                ptcpnt_id: claimant_participant_id,
+                relationship_type: relationship_type
+              }
+            ]
           )
         end
 

--- a/spec/models/board_grant_effectuation_spec.rb
+++ b/spec/models/board_grant_effectuation_spec.rb
@@ -8,8 +8,12 @@ describe BoardGrantEffectuation, :postgres do
     Timecop.freeze(Time.utc(2020, 1, 1, 19, 0, 0))
   end
 
+  let(:claimant_participant_id) { "2019110801" }
+  let(:claimant_payee_code) { "50" }
+  let(:claimant) { create(:claimant, participant_id: claimant_participant_id, payee_code: claimant_payee_code) }
+  let(:appeal) { create(:appeal, claimants: [claimant]) }
+  let(:decision_document) { create(:decision_document, appeal: appeal) }
   let!(:veteran) { decision_document.appeal.veteran }
-  let(:decision_document) { create(:decision_document) }
   let(:contention_reference_id) { nil }
   let(:board_grant_effectuation) do
     BoardGrantEffectuation.create(
@@ -126,6 +130,13 @@ describe BoardGrantEffectuation, :postgres do
       is_expected.to have_attributes(
         appeal_id: decision_document.appeal.id,
         decision_document_id: decision_document.id
+      )
+    end
+
+    it "has the correct claimant participant id and payee code" do
+      expect(subject.end_product_establishment). to have_attributes(
+        claimant_participant_id: claimant_participant_id,
+        payee_code: claimant_payee_code
       )
     end
 

--- a/spec/models/board_grant_effectuation_spec.rb
+++ b/spec/models/board_grant_effectuation_spec.rb
@@ -13,7 +13,9 @@ describe BoardGrantEffectuation, :postgres do
   let(:veteran_is_not_claimant) { nil }
   let(:claimant) { create(:claimant, participant_id: claimant_participant_id, payee_code: claimant_payee_code) }
   let(:veteran) { create(:veteran) }
-  let(:appeal) { create(:appeal, veteran: veteran, claimants: [claimant], veteran_is_not_claimant: veteran_is_not_claimant) }
+  let(:appeal) do
+    create(:appeal, veteran: veteran, claimants: [claimant], veteran_is_not_claimant: veteran_is_not_claimant)
+  end
   let(:decision_document) { create(:decision_document, appeal: appeal) }
   let(:contention_reference_id) { nil }
   let(:board_grant_effectuation) do

--- a/spec/models/board_grant_effectuation_spec.rb
+++ b/spec/models/board_grant_effectuation_spec.rb
@@ -214,6 +214,16 @@ describe BoardGrantEffectuation, :postgres do
             end
           end
         end
+
+        context "no relationship matches the claimant's participant_id" do
+          let(:claimant_participant_id) { "2019111101" }
+
+          it "is created with a payee code of 00" do
+            expect(subject.end_product_establishment).to have_attributes(
+              payee_code: "00"
+            )
+          end
+        end
       end
     end
 

--- a/spec/models/decision_document_spec.rb
+++ b/spec/models/decision_document_spec.rb
@@ -11,8 +11,10 @@ describe DecisionDocument, :postgres do
   end
 
   let(:veteran) { create(:veteran) }
+  let(:claimant_participant_id) { "2019111203" }
+  let(:claimant) { create(:claimant, participant_id: claimant_participant_id) }
   let(:appeal) do
-    create(:appeal, number_of_claimants: 1, veteran_file_number: veteran.file_number)
+    create(:appeal, claimants: [claimant], veteran_file_number: veteran.file_number)
   end
 
   let(:decision_document) do
@@ -243,7 +245,7 @@ describe DecisionDocument, :postgres do
               end_product_code: "030BGR",
               gulf_war_registry: false,
               suppress_acknowledgement_letter: false,
-              claimant_participant_id: nil, # decision_document.appeal.veteran.participant_id
+              claimant_participant_id: claimant_participant_id,
               limited_poa_code: nil,
               limited_poa_access: nil
             },

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -370,6 +370,35 @@ describe Veteran, :all_dbs do
     end
   end
 
+  context "#relationship_with_participant_id" do
+    let(:relationship_participant_id) { "2019111201" }
+    let(:other_participant_id) { "2019111202" }
+
+    before do
+      allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(
+        [
+          {
+            first_name: "Ilse",
+            last_name: "Cerveny",
+            ptcpnt_id: other_participant_id
+          },
+          {
+            first_name: "Josephine",
+            last_name: "Clark",
+            ptcpnt_id: relationship_participant_id
+          }
+        ]
+      )
+    end
+
+    subject { veteran.relationship_with_participant_id(relationship_participant_id) }
+
+    it "returns the matching relationship" do
+      expect(subject).to_not be_nil
+      expect(subject.participant_id).to eq relationship_participant_id
+    end
+  end
+
   context "#periods_of_service" do
     subject { veteran.periods_of_service }
 


### PR DESCRIPTION
Connects #12447

### Description
Choose the correct `claimant_participant_id` and `payee_code` when creating a board grant effectuation end product.