### PR TITLE
v3 api - update spec - receive contact info when intaking HLRs

### DIFF
--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -162,16 +162,25 @@ paths:
                               type: string
                               pattern: '^[0-9]+$'
                               description: >-
-                                Update a veteran's phone number.
-                                Example: "18446982311".
-                                Format: Include only digit characters. Include both country code and area code.
+                                Update a veteran's phone number (include area code).
+                                Example: "8446982311".
+                                Format: Include only digit characters. Include area code.
                                 Max length: 14 characters.
                                 Corresponds to "10. TELEPHONE NUMBER" on form 20-0996.
+
+                            phoneNumberCountryCode:
+                              type: string
+                              pattern: '^[0-9]+$'
+                              description: >-
+                                Update a veteran's phone number country code.
+                                Note: If not specified, will assume "1".
+                                Example: "20".
+                                Format: Include only digit characters.
 
                             phoneNumberExt:
                               type: string
                               description: >-
-                                Update a veteran's phone number extension.
+                                Update a veteran's phone number extension (if needed).
                                 Example: "123".
                                 Max length: 10 characters.
 
@@ -243,7 +252,7 @@ paths:
                         city: Chicago
                         stateProvinceCode: IL
                         zipPostalCode: "60652"
-                        phoneNumber: "14432924565"
+                        phoneNumber: "4432924565"
                         emailAddress: someone@example.com
                       claimant:
                         participantId: "44444444"

--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -68,6 +68,7 @@ paths:
                         - sameOffice
                         - legacyOptInApproved
                         - benefitType
+                        - veteran
                       properties:
                         receiptDate:
                           type: string
@@ -80,6 +81,68 @@ paths:
                           type: boolean
                         benefitType:
                           $ref: "#/components/schemas/BenefitType"
+                        veteran:
+                          type: object
+                          required:
+                            - fileNumberOrSsn
+                          properties:
+                            fileNumberOrSsn:
+                              type: string
+                            currentMailingAddress:
+                              type: object
+                              properties:
+                                addressLine1:
+                                  type: string
+                                addressLine2:
+                                  type: string
+                                addressLine3:
+                                  type: string
+                                addressPOU:
+                                  type: string
+                                  enum: ["RESIDENCE/CHOICE","CORRESPONDENCE"]
+                                city:
+                                  type: string
+                                internationalPostalCode:
+                                  type: string
+                                country:
+                                  type: object
+                                  properties:
+                                    code:
+                                      type: string
+                                    name:
+                                      type: string
+                                stateProvince:
+                                  type: object
+                                  properties:
+                                    code:
+                                      type: string
+                                    name:
+                                      type: string
+                                zipCode5:
+                                  type: string
+                                zipCode4:
+                                  type: string
+                            primaryPhoneNumber:
+                              type: object
+                              properties:
+                                number:
+                                  type: string
+                                extension:
+                                  type: string
+                                countryCode:
+                                  type: string
+                            email:
+                              type: string
+                        claimant:
+                          type: object
+                          required:
+                            - participantId
+                            - payeeCode
+                          properties:
+                            participantId:
+                              type: string
+                            payeeCode:
+                              $ref: "#/components/schemas/PayeeCode"
                     relationships:
                       type: object
                       required:
@@ -161,27 +224,34 @@ paths:
                 value: {
                   "data": {
                     "type": "HigherLevelReview",
-                      "attributes": {
-                        "receiptDate": "2019-07-10",
-                        "informalConference": true,
-                        "sameOffice": false,
-                        "legacyOptInApproved": true,
-                        "benefitType": "pension"
-                      },
-                      "relationships": {
-                        "veteran": {
-                          "data": {
-                            "type": "Veteran",
-                            "id": "55555555"
-                          }
+                    "attributes": {
+                      "receiptDate": "2019-07-10",
+                      "informalConference": true,
+                      "sameOffice": false,
+                      "legacyOptInApproved": true,
+                      "benefitType": "pension",
+                      "veteran": {
+                        "fileNumberOrSsn": "123456789",
+                        "currentMailingAddress": {
+                          "addressLine1": "123 Street St",
+                          "addressLine2": "Apt 4",
+                          "city": "Cityville",
+                          "stateProvince": {
+                            "code": "OR"
+                          },
+                          "zipCode5": "39383"
                         },
-                        "claimant": {
-                          "data": {
-                            "type": "Claimant",
-                            "id": "44444444",
-                            "meta": {
-                              "payeeCode": "10"
-                            }
+                        "primaryPhoneNumber": {
+                          "number": "8005551870"
+                        },
+                        "email": "myemail@example.com"
+                      },
+                      "claimant": {
+                        "data": {
+                          "type": "Claimant",
+                          "id": "44444444",
+                          "meta": {
+                            "payeeCode": "10"
                           }
                         }
                       }
@@ -211,6 +281,7 @@ paths:
                       },
                     ]
                   }
+                }
       responses:
         '202':
           description: Accepted

--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -83,56 +83,108 @@ paths:
                           $ref: "#/components/schemas/BenefitType"
                         veteran:
                           type: object
+                          description: >-
+                            The veteran whom this Higher-Level Review concerns.
+                            Use the field fileNumberOrSsn to identify the veteran.
+                            Optionally, you can update the veteran's current contact info using the other fields.
+                            If any of these fields are present: [addressLine1, addressLine2, city, stateProvinceCode, zipPostalCode, countryCode],
+                            all of these fields must be present: [addressLine1, addressLine2, city, stateProvinceCode, zipPostalCode].
+                            NOTE: countryCode can be left out, and it will be assumed to be "US".
+
                           required:
                             - fileNumberOrSsn
                           properties:
                             fileNumberOrSsn:
                               type: string
-                            currentMailingAddress:
-                              type: object
-                              properties:
-                                addressLine1:
-                                  type: string
-                                addressLine2:
-                                  type: string
-                                addressLine3:
-                                  type: string
-                                addressPOU:
-                                  type: string
-                                  enum: ["RESIDENCE/CHOICE","CORRESPONDENCE"]
-                                city:
-                                  type: string
-                                internationalPostalCode:
-                                  type: string
-                                country:
-                                  type: object
-                                  properties:
-                                    code:
-                                      type: string
-                                    name:
-                                      type: string
-                                stateProvince:
-                                  type: object
-                                  properties:
-                                    code:
-                                      type: string
-                                    name:
-                                      type: string
-                                zipCode5:
-                                  type: string
-                                zipCode4:
-                                  type: string
-                            primaryPhoneNumber:
-                              type: object
-                              properties:
-                                number:
-                                  type: string
-                                extension:
-                                  type: string
-                                countryCode:
-                                  type: string
-                            email:
+                              pattern: '^[0-9]{8,9}$'
+                              description: >-
+                                The veteran's file number or SSN.
+                                Example: "123456789"
+                                Format: 8 or 9 digit characters.
+                                Max length: 9 characters.
+                                Regex: /^[0-9]{8,9}$/
+                                Corresponds to both "1. VETERAN'S SOCIAL SECURITY NUMBER" and "2. VA FILE NUMBER" on form 20-0996.
+
+                            addressLine1:
                               type: string
+                              description: >-
+                                Update a veteran's house number/name and street.
+                                Example: "123 Main St".
+                                Max length: 100 characters.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: No. & Street" on form 20-0996.
+
+                            addressLine2:
+                              type: string
+                              description: >-
+                                Update a veteran's apartment or unit number.
+                                Example: "Apt. 4".
+                                Max length: 100 characters.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: Apt./Unit Number" on form 20-0996.
+
+                            city:
+                              type: string
+                              description: >-
+                                Update a veteran's city.
+                                Example: "Kansas City".
+                                Max length: 100 characters.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: City" on form 20-0996.
+
+                            stateProvinceCode:
+                              type: string
+                              pattern: '^[a-z]{2}$'
+                              description: >-
+                                Update a veteran's state or province.
+                                Example: "CA".
+                                Max length: 2 characters.
+                                Regex: /^[a-z]{2}$/i
+                                Corresponds to "9. CURRENT MAILING ADDRESS: State/Province" on form 20-0996.
+
+                            countryCode:
+                              type: string
+                              pattern: '^[a-z]{2}$'
+                              description: >-
+                                Update a veteran's country.
+                                Example: "US".
+                                NOTE: If not specified, will assume "US".
+                                Max length: 2 characters.
+                                Regex: /^[a-z]{2}$/i
+                                Corresponds to "9. CURRENT MAILING ADDRESS: Country" on form 20-0996.
+
+                            zipPostalCode:
+                              type: string
+                              description: >-
+                                Update a veteran's zip or postal code.
+                                Example: "90210".
+                                NOTE: If countryCode is "US" or not specified, this field, if present, must be a 5 character string of digits.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: Zip Code/Postal Code" on form 20-0996.
+
+                            phoneNumber:
+                              type: string
+                              pattern: '^[0-9]+$'
+                              description: >-
+                                Update a veteran's phone number.
+                                Example: "18446982311".
+                                Format: Include only digit characters. Include both country code and area code.
+                                Max length: 14 characters.
+                                Corresponds to "10. TELEPHONE NUMBER" on form 20-0996.
+
+                            phoneNumberExt:
+                              type: string
+                              description: >-
+                                Update a veteran's phone number extension.
+                                Example: "123".
+                                Max length: 10 characters.
+
+                            emailAddress:
+                              type: string
+                              pattern: '^.+@.+\..+$'
+                              description: >-
+                                Update a veteran's email address.
+                                Example: "linda@example.com".
+                                Max length: 255 characters.
+                                Regex: /^.+@.+\..+$/i
+                                Corresponds to "11. E-MAIL ADDRESS" on form 20-0996.
+
                         claimant:
                           type: object
                           required:
@@ -143,52 +195,6 @@ paths:
                               type: string
                             payeeCode:
                               $ref: "#/components/schemas/PayeeCode"
-                    relationships:
-                      type: object
-                      required:
-                        - veteran
-                        # claimant (NOT required)
-                      properties:
-                        veteran:
-                          type: object
-                          required:
-                            - data
-                          properties:
-                            data:
-                              type: object
-                              required:
-                                - type
-                                - id
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [Veteran]
-                                id: # veteran_file_number
-                                  type: string
-                        claimant: # if claimant is not included, the veteran is the claimant (and their participantID is looked up)
-                          type: object
-                          required:
-                            - data
-                          properties:
-                            data:
-                              type: object
-                              required:
-                                - type
-                                - id
-                                - meta
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [Claimant]
-                                id: # participantID
-                                  type: string
-                                meta:
-                                  type: object
-                                  required:
-                                    - payeeCode
-                                  properties:
-                                    payeeCode:
-                                      $ref: "#/components/schemas/PayeeCode"
                 included:
                   type: array
                   items:
@@ -220,68 +226,32 @@ paths:
                           decisionText:
                             type: string
             examples:
-              pension:
-                value: {
-                  "data": {
-                    "type": "HigherLevelReview",
-                    "attributes": {
-                      "receiptDate": "2019-07-10",
-                      "informalConference": true,
-                      "sameOffice": false,
-                      "legacyOptInApproved": true,
-                      "benefitType": "pension",
-                      "veteran": {
-                        "fileNumberOrSsn": "123456789",
-                        "currentMailingAddress": {
-                          "addressLine1": "123 Street St",
-                          "addressLine2": "Apt 4",
-                          "city": "Cityville",
-                          "stateProvince": {
-                            "code": "OR"
-                          },
-                          "zipCode5": "39383"
-                        },
-                        "primaryPhoneNumber": {
-                          "number": "8005551870"
-                        },
-                        "email": "myemail@example.com"
-                      },
-                      "claimant": {
-                        "data": {
-                          "type": "Claimant",
-                          "id": "44444444",
-                          "meta": {
-                            "payeeCode": "10"
-                          }
-                        }
-                      }
-                    },
-                    "included": [
-                      {
-                        "type": "RequestIssue",
-                        "attributes": {
-                          "decisionText": "veteran status verified",
-                          "decisionDate": "2019-07-11",
-                          "category": "Eligibility | Veteran Status"
-                        }
-                      },
-                      {
-                        "type": "RequestIssue",
-                        "attributes": {
-                          "decisionIssueId": 22
-                        }
-                      },
-                      {
-                        "type": "RequestIssue",
-                        "attributes": {
-                          "ratingIssueId": "12345678",
-                          "legacyAppealId": "9876543210",
-                          "legacyAppealIssueId": 1
-                        }
-                      },
-                    ]
-                  }
-                }
+              compensation:
+                value:
+                  data:
+                    type: HigherLevelReview
+                    attributes:
+                      receiptDate: "2019-07-10"
+                      informalConference: true
+                      sameOffice: false
+                      legacyOptInApproved: true
+                      benefitType: compensation
+                      veteran:
+                        fileNumberOrSsn: "123456789"
+                        addressLine1: 123 Street St
+                        addressLine2: Apt 4
+                        city: Chicago
+                        stateProvinceCode: IL
+                        zipPostalCode: "60652"
+                        phoneNumber: "14432924565"
+                        emailAddress: someone@example.com
+                      claimant:
+                        participantId: "44444444"
+                        payeeCode: "10"
+                    included:
+                      - type: RequestIssue
+                        attributes:
+                          decisionIssueId: 205
       responses:
         '202':
           description: Accepted


### PR DESCRIPTION
**no code changes**

_the easiest way to view this new version of the spec:_
paste the contents of
https://raw.githubusercontent.com/department-of-veterans-affairs/caseflow/cd470c763d27558fe968a789e78383c319cde426/app/controllers/api/docs/v3/decision_reviews.yaml

into http://editor.swagger.io/

example json:
```
{
  "data": {
    "type": "HigherLevelReview",
    "attributes": {
      "receiptDate": "2019-07-10",
      "informalConference": true,
      "sameOffice": false,
      "legacyOptInApproved": true,
      "benefitType": "compensation",
      "veteran": {
        "fileNumberOrSsn": "123456789",
        "addressLine1": "123 Street St",
        "addressLine2": "Apt 4",
        "city": "Chicago",
        "stateProvinceCode": "IL",
        "zipPostalCode": "60652",
        "phoneNumber": "4432924565",
        "emailAddress": "someone@example.com"
      },
      "claimant": {
        "participantId": "44444444",
        "payeeCode": "10"
      }
    },
    "included": [
      {
        "type": "RequestIssue",
        "attributes": {
          "decisionIssueId": 205
        }
      }
    ]
  }
}
```

resolves https://github.com/department-of-veterans-affairs/caseflow/issues/12705

>[Form 20-0996](https://www.va.gov/decision-reviews/forms/higher-level-review-20-0996.pdf) has a section for updating a veteran's contact info. Currently, our only decision review creation endpoint, _create a higher_level_review_, does not support this. 

I considered a few different sources when designing this:
[Form 20-0996](https://www.va.gov/decision-reviews/forms/higher-level-review-20-0996.pdf)
[The Benefits API](https://developer.va.gov/explore/benefits/docs/claims)
[Vet360 endpoints](https://app.swaggerhub.com/apis-docs/annaswims/va-gov_api/1.0.0#/profile/postVet360EmailAddress) (va.gov API /v0/profile)
and the [Address Validation API](https://developer.va.gov/explore/verification/docs/address_validation)

At this moment, we're going to receive this contact info solely for generating a _filled-out_ pdf of 20-0996, but, in the future, we'll use it to update the veteran's address in vet360.
My original design leaned very closely to how va.gov's profile endpoints / the benefits api works. In discussing this with @erluti, I'm erring on the side of replicating 20-0996. It's nearly field for field similar to the paper form, but I did decide to add a phoneNumberExt field in accordance with how vet360 takes in phone numbers. My design is a compromise --the goal was to keep it simple and not too nested.

*NOTE:*
I'm also introducing another change.
To be more [JSON:API-y](https://jsonapi.org/format/) I've moved `veteran` and `claimant` out of `relationships` and into `attributes`. 1) there's currently no plan and we don't foresee a plan to create endpoints that would allow one to manipulate veteran or claimant records --using the `relationships` field seem misleading in this respect. 2) with the contact info changes, this endpoint will be performing multiple actions with one request (creating a HLR, and updating vet360 with new contact info), something JSON:API is not well-suited to do. Doing multiple things at once is already a perversion of JSON:API, and doing it within `relationships` seemed even worse.