### PR TITLE
Always enable database_cleaner

### DIFF
--- a/spec/feature/queue/special_case_movement_task_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "support/vacols_database_cleaner"
-require "support/database_cleaner"
 require "rails_helper"
 
 RSpec.feature "SpecialCaseMovementTask", :all_dbs do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -25,7 +25,7 @@ require "timeout"
 # require only the support files necessary.
 #
 Dir[Rails.root.join("spec/support/**/*.rb")].each do |file|
-  excluded_files = %w[database_cleaner.rb vacols_database_cleaner.rb]
+  excluded_files = %w[vacols_database_cleaner.rb]
   require file unless excluded_files.include?(file.split("/").last)
 end
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -9,15 +9,15 @@ RSpec.configure do |config|
     DatabaseCleaner[:active_record, { connection: Rails.env.to_s.to_sym }].clean_with(:truncation)
   end
 
-  config.before(:each, :postgres) do
+  config.before(:each) do
     DatabaseCleaner[:active_record, { connection: Rails.env.to_s.to_sym }].strategy = :transaction
   end
 
-  config.before(:each, :postgres, db_clean: :truncation) do
+  config.before(:each, db_clean: :truncation) do
     DatabaseCleaner[:active_record, { connection: Rails.env.to_s.to_sym }].strategy = :truncation
   end
 
-  config.before(:each, :postgres, type: :feature) do
+  config.before(:each, type: :feature) do
     # :rack_test driver's Rack app under test shares database connection
     # with the specs, so continue to use transaction strategy for speed.
     driver_shares_db_connection_with_specs = Capybara.current_driver == :rack_test
@@ -31,11 +31,11 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each, :postgres) do
+  config.before(:each) do
     DatabaseCleaner[:active_record, { connection: Rails.env.to_s.to_sym }].start
   end
 
-  config.append_after(:each, :postgres) do
+  config.append_after(:each) do
     DatabaseCleaner[:active_record, { connection: Rails.env.to_s.to_sym }].clean
     clean_application!
   end


### PR DESCRIPTION
Reverts part of 7e95cc5faeb08e9484b38bc3b0a1b5ae2002697a to proactively address flakey tests.