### PR TITLE
Show POA address on Case Details Page

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -59,7 +59,8 @@ class AppealsController < ApplicationController
     render json: {
       representative_type: appeal.representative_type,
       representative_name: appeal.representative_name,
-      representative_address: appeal.representative_address
+      representative_address: appeal.representative_address,
+      representative_email_address: appeal.representative_email_address
     }
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -276,7 +276,12 @@ class Appeal < DecisionReview
   def power_of_attorney
     claimants.first&.power_of_attorney
   end
-  delegate :representative_name, :representative_type, :representative_address, to: :power_of_attorney, allow_nil: true
+
+  delegate :representative_name,
+           :representative_type,
+           :representative_address,
+           :representative_email_address,
+           to: :power_of_attorney, allow_nil: true
 
   def power_of_attorneys
     claimants.map(&:power_of_attorney)

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -24,7 +24,12 @@ class Claimant < ApplicationRecord
   def power_of_attorney
     @power_of_attorney ||= BgsPowerOfAttorney.new(claimant_participant_id: participant_id)
   end
-  delegate :representative_name, :representative_type, :representative_address, to: :power_of_attorney
+
+  delegate :representative_name,
+           :representative_type,
+           :representative_address,
+           :representative_email_address,
+           to: :power_of_attorney
 
   def representative_participant_id
     power_of_attorney.participant_id
@@ -34,8 +39,22 @@ class Claimant < ApplicationRecord
     @person ||= Person.find_or_create_by(participant_id: participant_id)
   end
 
-  delegate :date_of_birth, :advanced_on_docket?, :name, :first_name, :last_name, :middle_name, to: :person
-  delegate :address, :address_line_1, :address_line_2, :address_line_3, :city, :country, :state, :zip,
+  delegate :date_of_birth,
+           :advanced_on_docket?,
+           :name,
+           :first_name,
+           :last_name,
+           :middle_name,
+           :email_address,
+           to: :person
+  delegate :address,
+           :address_line_1,
+           :address_line_2,
+           :address_line_3,
+           :city,
+           :country,
+           :state,
+           :zip,
            to: :bgs_address_service
 
   def fetch_bgs_record

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -250,10 +250,18 @@ class LegacyAppeal < ApplicationRecord
     (disposition == "Allowed" && issues.select(&:remanded?).any?) ? "Remanded" : disposition
   end
 
-  delegate :representative_name, :representative_type,
-           :representative_address, :representatives,
-           :representative_to_hash, :representative_participant_id,
-           :vacols_representatives, to: :legacy_appeal_representative
+  delegate :representative_name,
+           :representative_type,
+           :representative_address,
+           :representatives,
+           :representative_to_hash,
+           :representative_participant_id,
+           :vacols_representatives,
+           to: :legacy_appeal_representative
+
+  def representative_email_address
+    power_of_attorney.bgs_representative_email_address
+  end
 
   def legacy_appeal_representative
     @legacy_appeal_representative ||= LegacyAppealRepresentative.new(

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -37,7 +37,6 @@ class Person < ApplicationRecord
     FullName.new(first_name, "", last_name).formatted(:readable_short)
   end
 
-  # TODO: Should this be cached?
   def email_address
     bgs_person[:email_address]
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -37,6 +37,11 @@ class Person < ApplicationRecord
     FullName.new(first_name, "", last_name).formatted(:readable_short)
   end
 
+  # TODO: Should this be cached?
+  def email_address
+    bgs_person[:email_address]
+  end
+
   def stale_attributes?
     return false unless bgs_person
 

--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -16,6 +16,7 @@
 class PowerOfAttorney
   include ActiveModel::Model
   include AssociatedVacolsModel
+  include BgsService
 
   vacols_attr_accessor  :vacols_representative_type,
                         :vacols_representative_name,
@@ -29,7 +30,9 @@ class PowerOfAttorney
   delegate :representative_name,
            :representative_type,
            :representative_address,
-           :participant_id, to: :bgs_power_of_attorney, prefix: :bgs
+           :representative_email_address,
+           :participant_id,
+           to: :bgs_power_of_attorney, prefix: :bgs
 
   def update_vacols_rep_info!(appeal:, representative_type:, representative_name:, address:)
     repo = self.class.repository

--- a/app/services/bgs_power_of_attorney.rb
+++ b/app/services/bgs_power_of_attorney.rb
@@ -14,7 +14,14 @@ class BgsPowerOfAttorney
     @representative_address ||= load_bgs_address!
   end
 
+  delegate :email_address,
+           to: :person, prefix: :representative
+
   private
+
+  def person
+    @person ||= Person.find_or_create_by(participant_id: participant_id)
+  end
 
   def fetch_bgs_record
     if claimant_participant_id

--- a/app/services/bgs_power_of_attorney.rb
+++ b/app/services/bgs_power_of_attorney.rb
@@ -3,6 +3,7 @@
 class BgsPowerOfAttorney
   include ActiveModel::Model
   include AssociatedBgsRecord
+  include BgsService
 
   attr_accessor :file_number
   attr_accessor :claimant_participant_id
@@ -14,10 +15,6 @@ class BgsPowerOfAttorney
   end
 
   private
-
-  def bgs
-    BGSService.new
-  end
 
   def fetch_bgs_record
     if claimant_participant_id

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -83,7 +83,8 @@ class ExternalApi::BGSService
       last_name: bgs_info[:last_nm],
       middle_name: bgs_info[:middle_nm],
       name_suffix: bgs_info[:suffix_nm],
-      birth_date: bgs_info[:brthdy_dt]
+      birth_date: bgs_info[:brthdy_dt],
+      email_address: bgs_info[:email_addr]
     }
   end
 

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -45,6 +45,8 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
         <p><strong>{powerOfAttorney.representative_type}:</strong> {powerOfAttorney.representative_name}</p>
         {powerOfAttorney.representative_address &&
           <p><strong>Address:</strong> <Address address={powerOfAttorney.representative_address} /></p>}
+        {powerOfAttorney.representative_email_address &&
+          <p><strong>Email Address:</strong> {powerOfAttorney.representative_email_address}</p>}
         <p><em>{COPY.CASE_DETAILS_INCORRECT_POA}</em></p>
       </span>
       }

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -54,6 +55,19 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
     </React.Fragment>;
   }
 }
+
+PowerOfAttorneyDetail.propTypes = {
+  appealId: PropTypes.string,
+  error: PropTypes.object,
+  getAppealValue: PropTypes.func,
+  loading: PropTypes.bool,
+  powerOfAttorney: PropTypes.shape({
+    representative_type: PropTypes.string,
+    representative_name: PropTypes.string,
+    representative_address: PropTypes.object,
+    representative_email_address: PropTypes.string
+  })
+};
 
 const mapStateToProps = (state, ownProps) => {
   const loadingPowerOfAttorney = _.get(state.queue.loadingAppealDetail[ownProps.appealId], 'powerOfAttorney');

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -156,7 +156,8 @@ class Fakes::BGSService
         birth_date: "Sun, 05 Sep 1943 00:00:00 -0500",
         first_name: "Bob",
         middle_name: "Billy",
-        last_name: "Vance"
+        last_name: "Vance",
+        email_address: "bob.vance@caseflow.gov"
       }
     elsif participant_id == "1129318238"
       {
@@ -164,14 +165,24 @@ class Fakes::BGSService
         first_name: "Cathy",
         middle_name: "",
         last_name: "Smith",
-        name_suffix: "Jr."
+        name_suffix: "Jr.",
+        email_address: "cathy.smith@caseflow.gov"
+      }
+    elsif participant_id == "600153863"
+      {
+        birth_date: "Sat, 05 Sep 1998 00:00:00 -0500",
+        fist_name: "Clarence",
+        middle_name: "",
+        last_name: "Darrow",
+        email_address: "clarence.darrow@caseflow.gov"
       }
     else
       {
         birth_date: "Sat, 05 Sep 1998 00:00:00 -0500",
         first_name: "Tom",
         middle_name: "Edward",
-        last_name: "Brady"
+        last_name: "Brady",
+        email_address: "tom.brady@caseflow.gov"
       }
     end
   end


### PR DESCRIPTION
Resolves #12102 

### Description

  - Fetch POA email address from BGS person
  - Display POA email address on Case Details page

### Screenshots

![Screen Shot 2019-11-12 at 2 58 58 PM](https://user-images.githubusercontent.com/1298274/68711128-04e35880-0567-11ea-859c-16a24538c0b1.png)
