### PR TITLE
Fix intake receipt_date logic for contestable issues

### DIFF
--- a/app/workflows/contestable_issue_generator.rb
+++ b/app/workflows/contestable_issue_generator.rb
@@ -32,7 +32,7 @@ class ContestableIssueGenerator
     return [] unless receipt_date
 
     rating_issues
-      .select { |issue| issue.profile_date && issue.profile_date.to_date < receipt_date }
+      .select { |issue| issue.profile_date && issue.profile_date.to_date <= receipt_date }
       .map { |rating_issue| ContestableIssue.from_rating_issue(rating_issue, review) }
   end
 
@@ -57,7 +57,7 @@ class ContestableIssueGenerator
     # so filter out any that are duplicates of a rating issue or that are not related to their parent rating.
     rating_decisions
       .select(&:contestable?)
-      .select { |rating_decision| rating_decision.profile_date && rating_decision.profile_date.to_date < receipt_date }
+      .select { |rating_decision| rating_decision.profile_date && rating_decision.profile_date.to_date <= receipt_date }
       .map { |rating_decision| ContestableIssue.from_rating_decision(rating_decision, review) }
   end
 

--- a/spec/workflows/contestable_issue_generator_spec.rb
+++ b/spec/workflows/contestable_issue_generator_spec.rb
@@ -29,6 +29,17 @@ describe "Contestable Issue Generator", :postgres do
     )
   end
 
+  let!(:today_rating) do
+    Generators::Rating.build(
+      participant_id: veteran.participant_id,
+      promulgation_date: review.receipt_date,
+      profile_date: review.receipt_date,
+      issues: [
+        { reference_id: "def456", decision_text: "Rating issue" }
+      ]
+    )
+  end
+
   let!(:review_decision_issue) do
     create(
       :decision_issue,
@@ -70,7 +81,7 @@ describe "Contestable Issue Generator", :postgres do
       after { FeatureToggle.disable!(:correct_claim_reviews) }
 
       it "returns decision issues from the same review" do
-        expect(subject.count).to eq(3)
+        expect(subject.count).to eq(4)
         expect(subject.select { |issue| issue.description == "review decision issue" }.empty?).to be false
       end
     end


### PR DESCRIPTION
It's ok to have a receipt date the same day as the rating promulgation date.

See https://dsva.slack.com/archives/CHX8FMP28/p1573572303228500