### PR TITLE
Rubaiyat/integrate caseflow with virtual hearings

### DIFF
--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -14,7 +14,7 @@ class BaseHearingUpdateForm
     ActiveRecord::Base.transaction do
       update_hearing
 
-      if !virtual_hearing_attributes.nil?
+      if !virtual_hearing_attributes.blank?
         create_or_update_virtual_hearing
         # TODO: Start the job to create the Pexip conference here?
       end

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -39,7 +39,7 @@ class BaseHearingUpdateForm
     # TODO: All of this is not atomic :(. Revisit later, since Rails 6 offers an upsert.
     virtual_hearing = VirtualHearing.not_cancelled.find_or_create_by!(hearing: hearing) do |new_virtual_hearing|
       new_virtual_hearing.veteran_email = virtual_hearing_attributes[:veteran_email]
-      new_virtual_hearing.judge_email = virtual_hearing_attributes[:judge_email]
+      new_virtual_hearing.judge_email = hearing.judge.email
       new_virtual_hearing.representative_email = virtual_hearing_attributes[:representative_email]
       created = true
     end

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -71,6 +71,11 @@ class HearingSerializer
   attribute :veteran_gender, if: for_full
   attribute :veteran_last_name
   attribute :virtual, &:virtual?
+  attribute :virtual_hearing do |object|
+    if object.virtual?
+      VirtualHearingSerializer.new(object.virtual_hearing).serializable_hash[:data][:attributes]
+    end
+  end
   attribute :witness
   attribute :worksheet_issues
 end

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -70,7 +70,7 @@ class HearingSerializer
   attribute :veteran_first_name
   attribute :veteran_gender, if: for_full
   attribute :veteran_last_name
-  attribute :virtual, &:virtual?
+  attribute :is_virtual, &:virtual?
   attribute :virtual_hearing do |object|
     if object.virtual?
       VirtualHearingSerializer.new(object.virtual_hearing).serializable_hash[:data][:attributes]

--- a/app/serializers/hearings/legacy_hearing_serializer.rb
+++ b/app/serializers/hearings/legacy_hearing_serializer.rb
@@ -67,7 +67,7 @@ class LegacyHearingSerializer
       hearing_view.user_id == params[:current_user_id]
     end
   end
-  attribute :virtual, &:virtual?
+  attribute :is_virtual, &:virtual?
   attribute :virtual_hearing do |object|
     if object.virtual?
       VirtualHearingSerializer.new(object.virtual_hearing).serializable_hash[:data][:attributes]

--- a/app/serializers/hearings/legacy_hearing_serializer.rb
+++ b/app/serializers/hearings/legacy_hearing_serializer.rb
@@ -68,5 +68,10 @@ class LegacyHearingSerializer
     end
   end
   attribute :virtual, &:virtual?
+  attribute :virtual_hearing do |object|
+    if object.virtual?
+      VirtualHearingSerializer.new(object.virtual_hearing).serializable_hash[:data][:attributes]
+    end
+  end
   attribute :witness
 end

--- a/app/serializers/hearings/virtual_hearing_serializer.rb
+++ b/app/serializers/hearings/virtual_hearing_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class VirtualHearingSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attribute :veteran_email
+  attribute :representative_email
+  attribute :status
+end

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -110,7 +110,7 @@ class HearingDetails extends React.Component {
   }
 
   submit = () => {
-    const { hearing: { externalId }, hearingDetailsForm, transcriptionDetailsForm, virtualHearingForm} = this.props;
+    const { hearing: { externalId }, hearingDetailsForm, transcriptionDetailsForm, virtualHearingForm } = this.props;
     const { updated } = this.state;
 
     if (!updated) {

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -89,7 +89,7 @@ class HearingDetails extends React.Component {
       this.props.onChangeFormData(VIRTUAL_HEARING_FORM_NAME, {
         veteranEmail: virtualHearing.veteranEmail,
         representativeEmail: virtualHearing.representativeEmail,
-        active: virtualHearing.active
+        status: virtualHearing.status
       });
     }
   }
@@ -110,7 +110,7 @@ class HearingDetails extends React.Component {
   }
 
   submit = () => {
-    const { hearing: { externalId }, hearingDetailsForm, transcriptionDetailsForm } = this.props;
+    const { hearing: { externalId }, hearingDetailsForm, transcriptionDetailsForm, virtualHearingForm} = this.props;
     const { updated } = this.state;
 
     if (!updated) {
@@ -122,6 +122,9 @@ class HearingDetails extends React.Component {
         ...hearingDetailsForm,
         transcription_attributes: {
           ...transcriptionDetailsForm
+        },
+        virtual_hearing_attributes: {
+          ...virtualHearingForm
         }
       }
     };

--- a/client/app/hearings/components/DetailsSections.jsx
+++ b/client/app/hearings/components/DetailsSections.jsx
@@ -100,7 +100,7 @@ DetailsSections.propTypes = {
     virtualHearing: PropTypes.shape({
       veteranEmail: PropTypes.string,
       representativeEmail: PropTypes.string,
-      active: PropTypes.bool
+      status: PropTypes.string
     })
   }),
   disabled: PropTypes.bool,

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -51,7 +51,7 @@ const inputSpacing = css({
   }
 });
 
-class HearingActions extends React.Component {
+class DailyDocketRow extends React.Component {
   constructor(props) {
     super(props);
 
@@ -89,6 +89,16 @@ class HearingActions extends React.Component {
       }
     });
   }
+
+  updateVirtualHearing = (values) => {
+    this.update({
+      virtualHearing: {
+        ...(this.props.hearing.virtualHearing || {}),
+        ...values
+      }
+    });
+  }
+
   openVirtualHearingModal = () => {
     this.setState({ virtualHearingModalActive: true });
   }
@@ -98,6 +108,7 @@ class HearingActions extends React.Component {
 
   cancelUpdate = () => {
     this.props.update(this.state.initialState);
+    this.prop.updateAodMotion(this.state.initialState.aodMotion)
     this.setState({
       edited: false,
       invalid: {
@@ -256,7 +267,7 @@ class HearingActions extends React.Component {
         {this.getRightColumn()}
       </div>
       {/* This is where the modal for the edit virtual hearing modal is supposed to appear*/}
-      {(user.userCanScheduleVirtualHearings && this.state.virtualHearingModalActive) &&
+      {(user.userCanScheduleVirtualHearings && this.state.virtualHearingModalActive && hearing.isVirtual) &&
         <VirtualHearingModal hearing={hearing}
           timeWasEdited={this.state.initialState.scheduledTimeString !== _.get(hearing, 'scheduledTimeString')}
           virtualHearing={hearing.virtualHearing || {}} reset={() => {
@@ -264,6 +275,7 @@ class HearingActions extends React.Component {
             this.closeVirtualHearingModal()
             ;
           }} user={user}
+          update={this.updateVirtualHearing}
           submit={() => {
             this.saveHearing();
             this.closeVirtualHearingModal();
@@ -284,7 +296,7 @@ class HearingActions extends React.Component {
   }
 }
 
-HearingActions.propTypes = {
+DailyDocketRow.propTypes = {
   index: PropTypes.number,
   hearingId: PropTypes.string,
   update: PropTypes.func,
@@ -318,5 +330,5 @@ const mapDispatchToProps = (dispatch, props) => bindActionCreators({
   update: (values) => onUpdateDocketHearing(props.hearingId, values)
 }, dispatch);
 
-export default connect(mapStateToProps, mapDispatchToProps)(HearingActions);
+export default connect(mapStateToProps, mapDispatchToProps)(DailyDocketRow);
 

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -108,7 +108,7 @@ class DailyDocketRow extends React.Component {
 
   cancelUpdate = () => {
     this.props.update(this.state.initialState);
-    this.prop.updateAodMotion(this.state.initialState.aodMotion)
+    this.prop.updateAodMotion(this.state.initialState.aodMotion);
     this.setState({
       edited: false,
       invalid: {
@@ -307,7 +307,8 @@ DailyDocketRow.propTypes = {
   hearing: PropTypes.shape({
     docketName: PropTypes.string,
     advanceOnDocketMotion: PropTypes.object,
-    virtualHearing: PropTypes.object
+    virtualHearing: PropTypes.object,
+    isVirtual: PropTypes.bool
   }),
   user: PropTypes.shape({
     userCanAssignHearingSchedule: PropTypes.bool,

--- a/client/app/hearings/components/details/DetailsInputs.jsx
+++ b/client/app/hearings/components/details/DetailsInputs.jsx
@@ -34,11 +34,11 @@ const DetailsInputs = ({
         ]}
         value={(virtualHearing && virtualHearing.status !== "cancelled") || false}
         onChange={(option) => {
-          let status;
           if ((virtualHearing && virtualHearing.status !== "cancelled") || option.value) {
             openModal();
-            status = "cancelled"
           }
+
+          let status = option.value? "cancelled": null
           
           updateVirtualHearing({ status: status });
         }}

--- a/client/app/hearings/components/details/DetailsInputs.jsx
+++ b/client/app/hearings/components/details/DetailsInputs.jsx
@@ -32,12 +32,15 @@ const DetailsInputs = ({
             label: 'Virtual'
           }
         ]}
-        value={(virtualHearing && virtualHearing.active) || false}
+        value={(virtualHearing && virtualHearing.status !== "cancelled") || false}
         onChange={(option) => {
-          if ((virtualHearing && virtualHearing.active) || option.value) {
+          let status;
+          if ((virtualHearing && virtualHearing.status !== "cancelled") || option.value) {
             openModal();
+            status = "cancelled"
           }
-          updateVirtualHearing({ active: option.value });
+          
+          updateVirtualHearing({ status: status });
         }}
       />}
     </div>
@@ -103,7 +106,7 @@ DetailsInputs.propTypes = {
   openModal: PropTypes.func,
   updateVirtualHearing: PropTypes.func,
   virtualHearing: PropTypes.shape({
-    active: PropTypes.bool
+    status: PropTypes.string
   }),
   enableVirtualHearings: PropTypes.bool
 };

--- a/client/app/hearings/components/details/DetailsInputs.jsx
+++ b/client/app/hearings/components/details/DetailsInputs.jsx
@@ -32,15 +32,15 @@ const DetailsInputs = ({
             label: 'Virtual'
           }
         ]}
-        value={(virtualHearing && virtualHearing.status !== "cancelled") || false}
+        value={(virtualHearing && virtualHearing.status !== 'cancelled') || false}
         onChange={(option) => {
-          if ((virtualHearing && virtualHearing.status !== "cancelled") || option.value) {
+          if ((virtualHearing && virtualHearing.status !== 'cancelled') || option.value) {
             openModal();
           }
 
-          let status = option.value? "cancelled": null
-          
-          updateVirtualHearing({ status: status });
+          let status = option.value ? 'cancelled' : null;
+
+          updateVirtualHearing({ status });
         }}
       />}
     </div>

--- a/client/app/hearings/containers/DailyDocketContainer.jsx
+++ b/client/app/hearings/containers/DailyDocketContainer.jsx
@@ -98,6 +98,18 @@ export class DailyDocketContainer extends React.Component {
     });
   };
 
+  formatVirtualHearing = (hearing) => {
+    if (!virtualHearing.isVirtual){
+      return {};
+    }
+
+    return _.omitBy({
+      veteran_email: hearing.virtualHearing.veteranEmail,
+      representative_email: hearing.virtualHearing.representativeEmail,
+      status: hearing.virtualHearing.status
+    }, _.isNil);
+  }
+  
   formatHearing = (hearing) => {
     const amaHearingValues = hearing.docketName === 'hearing' ? {
       evidence_window_waived: hearing.evidenceWindowWaived
@@ -108,11 +120,14 @@ export class DailyDocketContainer extends React.Component {
       hold_open: hearing.holdOpen
     } : {};
 
+    const virtualHearing = formatVirtualHearing(hearing.virtualHearing)
+
     return _.omitBy({
       disposition: hearing.disposition,
       transcript_requested: hearing.transcriptRequested,
       notes: hearing.notes,
       hearing_location_attributes: hearing.location ? ApiUtil.convertToSnakeCase(hearing.location) : null,
+      virtual_hearing_attributes: virtualHearing ? ApiUtil.convertToSnakeCase(virtualHearing) : null,
       scheduled_time_string: hearing.scheduledTimeString,
       prepped: hearing.prepped,
       ...legacyValues,

--- a/client/app/hearings/containers/DailyDocketContainer.jsx
+++ b/client/app/hearings/containers/DailyDocketContainer.jsx
@@ -97,7 +97,7 @@ export class DailyDocketContainer extends React.Component {
       this.loadHearingDetails(resp.hearingDay.hearings);
     });
   };
-  
+
   formatHearing = (hearing) => {
     const amaHearingValues = hearing.docketName === 'hearing' ? {
       evidence_window_waived: hearing.evidenceWindowWaived
@@ -137,7 +137,7 @@ export class DailyDocketContainer extends React.Component {
   }
 
   formatVirtualHearing = (hearing) => {
-    if (!hearing.isVirtual){
+    if (!hearing.isVirtual) {
       return {};
     }
 

--- a/client/app/hearings/containers/DailyDocketContainer.jsx
+++ b/client/app/hearings/containers/DailyDocketContainer.jsx
@@ -97,18 +97,6 @@ export class DailyDocketContainer extends React.Component {
       this.loadHearingDetails(resp.hearingDay.hearings);
     });
   };
-
-  formatVirtualHearing = (hearing) => {
-    if (!virtualHearing.isVirtual){
-      return {};
-    }
-
-    return _.omitBy({
-      veteran_email: hearing.virtualHearing.veteranEmail,
-      representative_email: hearing.virtualHearing.representativeEmail,
-      status: hearing.virtualHearing.status
-    }, _.isNil);
-  }
   
   formatHearing = (hearing) => {
     const amaHearingValues = hearing.docketName === 'hearing' ? {
@@ -120,7 +108,7 @@ export class DailyDocketContainer extends React.Component {
       hold_open: hearing.holdOpen
     } : {};
 
-    const virtualHearing = formatVirtualHearing(hearing.virtualHearing)
+    const virtualHearing = this.formatVirtualHearing(hearing);
 
     return _.omitBy({
       disposition: hearing.disposition,
@@ -145,6 +133,18 @@ export class DailyDocketContainer extends React.Component {
       granted: hearing.advanceOnDocketMotion.granted,
       person_id: hearing.claimantId || hearing.advanceOnDocketMotion.personId,
       user_id: hearing.advanceOnDocketMotion.userId
+    }, _.isNil);
+  }
+
+  formatVirtualHearing = (hearing) => {
+    if (!hearing.isVirtual){
+      return {};
+    }
+
+    return _.omitBy({
+      veteran_email: hearing.virtualHearing.veteranEmail,
+      representative_email: hearing.virtualHearing.representativeEmail,
+      status: hearing.virtualHearing.status
     }, _.isNil);
   }
 

--- a/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
+++ b/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
@@ -92,26 +92,31 @@ RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
       end
 
       let!(:current_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
-      let(:hearing) { create(:hearing, regional_office: "RO06") }
+      let!(:hearing) { create(:hearing, :with_tasks, regional_office: "RO06") }
       let!(:virtual_hearing) { create( :virtual_hearing, hearing: hearing) }
 
       scenario "User can select Virtual Hearing time" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+        hearing.reload
         choose("hearingTime1_other", allow_label_click: true)
         click_dropdown(name: "optionalHearingTime1", index: 1)
         expect(page).to have_content("Change to Virtual Hearing")
         expect(page).to have_content("Change and Send Email")
       end
+
       scenario "Virtual Hearing time has been updated" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
+        hearing.reload
         choose("hearingTime1_other", allow_label_click: true)
         click_dropdown(name: "optionalHearingTime1", index: 2)
         fill_in "vet-email", with: "newEmail@testingEmail.com"
         click_button("Change and Send Email")
         expect(page).to have_content("You have successfully updated")
+
         virtual_hearing.reload
         expect(virtual_hearing.veteran_email).to eq("newEmail@testingEmail.com")
       end
+
       scenario "Changes to Virtual Hearing have been cancelled" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
         choose("hearingTime1_other", allow_label_click: true)

--- a/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
+++ b/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
 
       let!(:current_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
       let!(:hearing) { create(:hearing, :with_tasks, regional_office: "RO06") }
-      let!(:virtual_hearing) { create( :virtual_hearing, hearing: hearing) }
+      let!(:virtual_hearing) { create(:virtual_hearing, hearing: hearing) }
 
       scenario "User can select Virtual Hearing time" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s

--- a/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
+++ b/spec/feature/hearings/daily_docket/hearing_prep_spec.rb
@@ -92,25 +92,30 @@ RSpec.feature "Hearing Schedule Daily Docket for Hearing Prep", :all_dbs do
       end
 
       let!(:current_user) { User.authenticate!(css_id: "BVAYELLOW", roles: ["Edit HearSched", "Build HearSched"]) }
-      let!(:hearing) { create(:hearing, :with_tasks, hearing_day: hearing_day) }
-      let!(:hearing_day) { create(:hearing_day, judge: current_user) }
+      let(:hearing) { create(:hearing, regional_office: "RO06") }
+      let!(:virtual_hearing) { create( :virtual_hearing, hearing: hearing) }
 
       scenario "User can select Virtual Hearing time" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
         choose("hearingTime1_other", allow_label_click: true)
-        click_dropdown(name: "optionalHearingTime1", index: 3)
-        click_button("Change and Send Email")
-        expect(page).to have_content("You have successfully updated")
+        click_dropdown(name: "optionalHearingTime1", index: 1)
+        expect(page).to have_content("Change to Virtual Hearing")
+        expect(page).to have_content("Change and Send Email")
       end
       scenario "Virtual Hearing time has been updated" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
-        choose("hearingTime1_13:00", allow_label_click: true)
+        choose("hearingTime1_other", allow_label_click: true)
+        click_dropdown(name: "optionalHearingTime1", index: 2)
+        fill_in "vet-email", with: "newEmail@testingEmail.com"
         click_button("Change and Send Email")
         expect(page).to have_content("You have successfully updated")
+        virtual_hearing.reload
+        expect(virtual_hearing.veteran_email).to eq("newEmail@testingEmail.com")
       end
       scenario "Changes to Virtual Hearing have been cancelled" do
         visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
-        choose("hearingTime1_09:00", allow_label_click: true)
+        choose("hearingTime1_other", allow_label_click: true)
+        click_dropdown(name: "optionalHearingTime1", index: 3)
         click_button("Change-to-Virtual-Hearing-button-id-close")
       end
     end

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Hearing Schedule Daily Docket", :all_dbs do
       fill_in "vet-email", with: "email@testingEmail.com"
       fill_in "rep-email", with: "email@testingEmail.com"
       click_button("Change and Send Email")
-      
+
       expect(page).to have_content("Hearing Successfully Updated")
 
       legacy_hearing.reload

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -62,7 +62,8 @@ RSpec.feature "Hearing Schedule Daily Docket", :all_dbs do
       User.authenticate!(user: user)
       FeatureToggle.enable!(:schedule_virtual_hearings)
     end
-    let!(:legacy_hearing) { create(:legacy_hearing) }
+    let!(:legacy_hearing) { create(:legacy_hearing, regional_office: "RO06") }
+    let!(:virtual_hearing) { create( :virtual_hearing, hearing: legacy_hearing) }
 
     scenario "User can edit Judge and change virtual hearings" do
       visit "hearings/" + legacy_hearing.external_id.to_s + "/details"
@@ -81,6 +82,12 @@ RSpec.feature "Hearing Schedule Daily Docket", :all_dbs do
       click_button("Change and Send Email")
 
       expect(page).to have_content("Hearing Successfully Updated")
+
+      virtual_hearing.reload
+      expect(VirtualHearing.count).to eq(1)
+      expect(virtual_hearing.hearing).to eq(legacy_hearing)
+      expect(virtual_hearing.veteran_email).to eq("email@testingEmail.com")
+      expect(virtual_hearing.representative_email).to eq("email@testingEmail.com")
     end
 
     scenario "User can select judge, hearing room, hearing coordinator, and add notes" do

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -62,8 +62,9 @@ RSpec.feature "Hearing Schedule Daily Docket", :all_dbs do
       User.authenticate!(user: user)
       FeatureToggle.enable!(:schedule_virtual_hearings)
     end
-    let!(:legacy_hearing) { create(:legacy_hearing, regional_office: "RO06") }
-    let!(:virtual_hearing) { create( :virtual_hearing, hearing: legacy_hearing) }
+
+    let!(:judge) { create(:user, station_id: User::BOARD_STATION_ID, email: "judge@testingEmail.com") }
+    let!(:legacy_hearing) { create(:legacy_hearing, :with_tasks, user: judge, regional_office: "RO06") }
 
     scenario "User can edit Judge and change virtual hearings" do
       visit "hearings/" + legacy_hearing.external_id.to_s + "/details"
@@ -80,14 +81,15 @@ RSpec.feature "Hearing Schedule Daily Docket", :all_dbs do
       fill_in "vet-email", with: "email@testingEmail.com"
       fill_in "rep-email", with: "email@testingEmail.com"
       click_button("Change and Send Email")
-
+      
       expect(page).to have_content("Hearing Successfully Updated")
 
-      virtual_hearing.reload
+      legacy_hearing.reload
       expect(VirtualHearing.count).to eq(1)
-      expect(virtual_hearing.hearing).to eq(legacy_hearing)
-      expect(virtual_hearing.veteran_email).to eq("email@testingEmail.com")
-      expect(virtual_hearing.representative_email).to eq("email@testingEmail.com")
+      expect(legacy_hearing.virtual?).to eq(true)
+      expect(legacy_hearing.virtual_hearing.status).to eq("pending")
+      expect(legacy_hearing.virtual_hearing.veteran_email).to eq("email@testingEmail.com")
+      expect(legacy_hearing.virtual_hearing.representative_email).to eq("email@testingEmail.com")
     end
 
     scenario "User can select judge, hearing room, hearing coordinator, and add notes" do
@@ -100,7 +102,6 @@ RSpec.feature "Hearing Schedule Daily Docket", :all_dbs do
       fill_in "Notes", with: generate_words(10)
 
       click_button("Save")
-
       expect(page).to have_content("Hearing Successfully Updated")
     end
 


### PR DESCRIPTION
Resolves #12334
Relates to #12519
### Description
- integrate changes on hearing details page with backend, sends patch request to hearings_controller
- integrate changes on daily docket row with backed, sends patch request to hearings_controller
- modify tests on hearing_prep_spec.rb and hearing_details_spec.rb