### PR TITLE
Add virtual_hearings_establishment table

### DIFF
--- a/db/migrate/20191113160247_create_virtual_hearing_establishments.rb
+++ b/db/migrate/20191113160247_create_virtual_hearing_establishments.rb
@@ -1,0 +1,15 @@
+class CreateVirtualHearingEstablishments < ActiveRecord::Migration[5.1]
+  def change
+    create_table :virtual_hearing_establishments do |t|
+      t.belongs_to :virtual_hearing, null: false, comment: "Virtual Hearing the conference is being established for."
+      t.datetime :last_submitted_at, comment: "Async timestamp for most recent job start."
+      t.datetime :submitted_at, comment: "Async timestamp for initial job start."
+      t.datetime :attempted_at, comment: "Async timestamp for most recent attempt to run."
+      t.datetime :processed_at, comment: "Timestamp for when the virtual hearing was successfully processed."
+      t.datetime :canceled_at, comment: "Timestamp when job was abandoned."
+      t.string :error, comment: "Async any error message from most recent failed attempt to run."
+      t.datetime "created_at", null: false, comment: "Automatic timestamp when row was created."
+      t.datetime "updated_at", null: false, comment: "Timestamp when record was last updated."
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191106153923) do
+ActiveRecord::Schema.define(version: 20191113160247) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1218,6 +1218,19 @@ ActiveRecord::Schema.define(version: 20191106153923) do
     t.index ["file_number"], name: "index_veterans_on_file_number", unique: true
     t.index ["participant_id"], name: "index_veterans_on_participant_id"
     t.index ["ssn"], name: "index_veterans_on_ssn"
+  end
+
+  create_table "virtual_hearing_establishments", force: :cascade do |t|
+    t.datetime "attempted_at", comment: "Async timestamp for most recent attempt to run."
+    t.datetime "canceled_at", comment: "Timestamp when job was abandoned."
+    t.datetime "created_at", null: false, comment: "Automatic timestamp when row was created."
+    t.string "error", comment: "Async any error message from most recent failed attempt to run."
+    t.datetime "last_submitted_at", comment: "Async timestamp for most recent job start."
+    t.datetime "processed_at", comment: "Timestamp for when the virtual hearing was successfully processed."
+    t.datetime "submitted_at", comment: "Async timestamp for initial job start."
+    t.datetime "updated_at", null: false, comment: "Timestamp when record was last updated."
+    t.bigint "virtual_hearing_id", null: false, comment: "Virtual Hearing the conference is being established for."
+    t.index ["virtual_hearing_id"], name: "index_virtual_hearing_establishments_on_virtual_hearing_id"
   end
 
   create_table "virtual_hearings", force: :cascade do |t|


### PR DESCRIPTION
Schema changes for #12696

### Description

We are adding the `Asyncable` concern to a virtual hearing using a related model similar to what is being done for `TaskTimer`. There's some overlap of naming and status tracking that would makes it confusing to implement the necessary columns on the `VirtualHearing` model directly.

A follow up PR will follow with the implementation of the model.

*Schema Changes Only*

* [x] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
