### PR TITLE
Fail if attempting to close hearing task not in caseflow

### DIFF
--- a/app/models/concerns/appeal_concern.rb
+++ b/app/models/concerns/appeal_concern.rb
@@ -45,6 +45,10 @@ module AppealConcern
     end
   end
 
+  def in_caseflow_location?
+    is_a?(Appeal) || location_code == LegacyAppeal::LOCATION_CODES[:caseflow]
+  end
+
   private
 
   # TODO: this is named "veteran_name_object" to avoid name collision, refactor

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -94,10 +94,6 @@ class HearingTask < Task
     true
   end
 
-  def send_alert_of_attempted_location_move
-    capture_exception(HearingTaskNotCompletable.new, extra: { task_id: id, location_code: appeal.location_code })
-  end
-
   def set_assignee
     self.assigned_to = Bva.singleton
   end

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -521,7 +521,7 @@ describe AssignHearingDispositionTask, :all_dbs do
       end
 
       context "the appeal is a legacy appeal" do
-        let(:vacols_case) { create(:case, bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing]) }
+        let!(:vacols_case) { create(:case, bfcurloc: LegacyAppeal::LOCATION_CODES[:caseflow]) }
         let(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
         let(:hearing) { create(:legacy_hearing, appeal: appeal, disposition: disposition) }
         let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.cancelled }
@@ -538,6 +538,13 @@ describe AssignHearingDispositionTask, :all_dbs do
             expect(disposition_task.reload.completed?).to be_truthy
             expect(hearing_task.reload.completed?).to be_truthy
             expect(vacols_case.reload.bfcurloc).to eq(LegacyAppeal::LOCATION_CODES[:transcription])
+          end
+
+          context "but the case is not in CASEFLOW location" do
+            let!(:vacols_case) { create(:case, bfcurloc: LegacyAppeal::LOCATION_CODES[:case_storage]) }
+            it "fails" do
+              expect { subject }.to raise_error(HearingTask::HearingTaskNotCompletable)
+            end
           end
         end
       end


### PR DESCRIPTION
related to #12215: Cases that mysteriously move locations after the case is resolve. Maybe as a result of duplicate hearing tasks or maybe because a location is moved manually in VACOLS with the expectation that it will no longer be worked in Caseflow. 

Since we only move locations in hearings on the Hearing Task, fail when we attempt to move an appeal that is not currently in Caseflow