### PR TITLE
Pass task type instead of generic Task when assigning tasks to organizations. 

### DIFF
--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -13,7 +13,7 @@ class TaskActionRepository
       {
         selected: nil,
         options: organizations,
-        type: Task.name
+        type: task.type
       }
     end
 


### PR DESCRIPTION
Closes #12486. 