### PR TITLE
APIv3 - HigherLevelReview#show to match up with specs

### DIFF
--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -968,7 +968,7 @@ paths:
                                       type: string
                                       enum: ["RequestIssue"]
                                     id:
-                                      type: integer
+                                      type: string
                           decisionIssues:
                             type: object
                             properties:
@@ -981,7 +981,7 @@ paths:
                                       type: string
                                       enum: ["DecisionIssue"]
                                     id:
-                                      type: integer
+                                      type: string
                   included:
                     type: array
                     items:
@@ -992,7 +992,7 @@ paths:
                               type: string
                               enum: ["DecisionIssue"]
                             id:
-                              type: integer
+                              type: string
                             attributes:
                               type: object
                               properties:
@@ -1016,7 +1016,7 @@ paths:
                               type: string
                               enum: ["RequestIssue"]
                             id:
-                              type: integer
+                              type: string
                             attributes:
                               type: object
                               properties:

--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -990,6 +990,37 @@ paths:
                           properties:
                             type:
                               type: string
+                              enum: ["Veteran"]
+                            id:
+                              type: string
+                              description: matches fileNumber
+                            attributes:
+                              type: object
+                              properties:
+                                firstName:
+                                  type: string
+                                  nullable: true
+                                middleName:
+                                  type: string
+                                  nullable: true
+                                lastName:
+                                  type: string
+                                  nullable: true
+                                nameSuffix:
+                                  type: string
+                                  nullable: true
+                                fileNumber:
+                                  type: string
+                                ssn:
+                                  type: string
+                                  nullable: true
+                                participantId:
+                                  type: string
+                                  nullable: true
+                        - type: object
+                          properties:
+                            type:
+                              type: string
                               enum: ["DecisionIssue"]
                             id:
                               type: string

--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -68,6 +68,7 @@ paths:
                         - sameOffice
                         - legacyOptInApproved
                         - benefitType
+                        - veteran
                       properties:
                         receiptDate:
                           type: string
@@ -80,52 +81,129 @@ paths:
                           type: boolean
                         benefitType:
                           $ref: "#/components/schemas/BenefitType"
-                    relationships:
-                      type: object
-                      required:
-                        - veteran
-                        # claimant (NOT required)
-                      properties:
                         veteran:
                           type: object
+                          description: >-
+                            The veteran whom this Higher-Level Review concerns.
+                            Use the field fileNumberOrSsn to identify the veteran.
+                            Optionally, you can update the veteran's current contact info using the other fields.
+                            If any of these fields are present: [addressLine1, addressLine2, city, stateProvinceCode, zipPostalCode, countryCode],
+                            all of these fields must be present: [addressLine1, addressLine2, city, stateProvinceCode, zipPostalCode].
+                            NOTE: countryCode can be left out, and it will be assumed to be "US".
+
                           required:
-                            - data
+                            - fileNumberOrSsn
                           properties:
-                            data:
-                              type: object
-                              required:
-                                - type
-                                - id
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [Veteran]
-                                id: # veteran_file_number
-                                  type: string
-                        claimant: # if claimant is not included, the veteran is the claimant (and their participantID is looked up)
+                            fileNumberOrSsn:
+                              type: string
+                              pattern: '^[0-9]{8,9}$'
+                              description: >-
+                                The veteran's file number or SSN.
+                                Example: "123456789"
+                                Format: 8 or 9 digit characters.
+                                Max length: 9 characters.
+                                Regex: /^[0-9]{8,9}$/
+                                Corresponds to both "1. VETERAN'S SOCIAL SECURITY NUMBER" and "2. VA FILE NUMBER" on form 20-0996.
+
+                            addressLine1:
+                              type: string
+                              description: >-
+                                Update a veteran's house number/name and street.
+                                Example: "123 Main St".
+                                Max length: 100 characters.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: No. & Street" on form 20-0996.
+
+                            addressLine2:
+                              type: string
+                              description: >-
+                                Update a veteran's apartment or unit number.
+                                Example: "Apt. 4".
+                                Max length: 100 characters.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: Apt./Unit Number" on form 20-0996.
+
+                            city:
+                              type: string
+                              description: >-
+                                Update a veteran's city.
+                                Example: "Kansas City".
+                                Max length: 100 characters.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: City" on form 20-0996.
+
+                            stateProvinceCode:
+                              type: string
+                              pattern: '^[a-z]{2}$'
+                              description: >-
+                                Update a veteran's state or province.
+                                Example: "CA".
+                                Max length: 2 characters.
+                                Regex: /^[a-z]{2}$/i
+                                Corresponds to "9. CURRENT MAILING ADDRESS: State/Province" on form 20-0996.
+
+                            countryCode:
+                              type: string
+                              pattern: '^[a-z]{2}$'
+                              description: >-
+                                Update a veteran's country.
+                                Example: "US".
+                                NOTE: If not specified, will assume "US".
+                                Max length: 2 characters.
+                                Regex: /^[a-z]{2}$/i
+                                Corresponds to "9. CURRENT MAILING ADDRESS: Country" on form 20-0996.
+
+                            zipPostalCode:
+                              type: string
+                              description: >-
+                                Update a veteran's zip or postal code.
+                                Example: "90210".
+                                NOTE: If countryCode is "US" or not specified, this field, if present, must be a 5 character string of digits.
+                                Corresponds to "9. CURRENT MAILING ADDRESS: Zip Code/Postal Code" on form 20-0996.
+
+                            phoneNumber:
+                              type: string
+                              pattern: '^[0-9]+$'
+                              description: >-
+                                Update a veteran's phone number (include area code).
+                                Example: "8446982311".
+                                Format: Include only digit characters. Include area code.
+                                Max length: 14 characters.
+                                Corresponds to "10. TELEPHONE NUMBER" on form 20-0996.
+
+                            phoneNumberCountryCode:
+                              type: string
+                              pattern: '^[0-9]+$'
+                              description: >-
+                                Update a veteran's phone number country code.
+                                Note: If not specified, will assume "1".
+                                Example: "20".
+                                Format: Include only digit characters.
+
+                            phoneNumberExt:
+                              type: string
+                              description: >-
+                                Update a veteran's phone number extension (if needed).
+                                Example: "123".
+                                Max length: 10 characters.
+
+                            emailAddress:
+                              type: string
+                              pattern: '^.+@.+\..+$'
+                              description: >-
+                                Update a veteran's email address.
+                                Example: "linda@example.com".
+                                Max length: 255 characters.
+                                Regex: /^.+@.+\..+$/i
+                                Corresponds to "11. E-MAIL ADDRESS" on form 20-0996.
+
+                        claimant:
                           type: object
                           required:
-                            - data
+                            - participantId
+                            - payeeCode
                           properties:
-                            data:
-                              type: object
-                              required:
-                                - type
-                                - id
-                                - meta
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [Claimant]
-                                id: # participantID
-                                  type: string
-                                meta:
-                                  type: object
-                                  required:
-                                    - payeeCode
-                                  properties:
-                                    payeeCode:
-                                      $ref: "#/components/schemas/PayeeCode"
+                            participantId:
+                              type: string
+                            payeeCode:
+                              $ref: "#/components/schemas/PayeeCode"
                 included:
                   type: array
                   items:
@@ -157,60 +235,32 @@ paths:
                           decisionText:
                             type: string
             examples:
-              pension:
-                value: {
-                  "data": {
-                    "type": "HigherLevelReview",
-                      "attributes": {
-                        "receiptDate": "2019-07-10",
-                        "informalConference": true,
-                        "sameOffice": false,
-                        "legacyOptInApproved": true,
-                        "benefitType": "pension"
-                      },
-                      "relationships": {
-                        "veteran": {
-                          "data": {
-                            "type": "Veteran",
-                            "id": "55555555"
-                          }
-                        },
-                        "claimant": {
-                          "data": {
-                            "type": "Claimant",
-                            "id": "44444444",
-                            "meta": {
-                              "payeeCode": "10"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "included": [
-                      {
-                        "type": "RequestIssue",
-                        "attributes": {
-                          "decisionText": "veteran status verified",
-                          "decisionDate": "2019-07-11",
-                          "category": "Eligibility | Veteran Status"
-                        }
-                      },
-                      {
-                        "type": "RequestIssue",
-                        "attributes": {
-                          "decisionIssueId": 22
-                        }
-                      },
-                      {
-                        "type": "RequestIssue",
-                        "attributes": {
-                          "ratingIssueId": "12345678",
-                          "legacyAppealId": "9876543210",
-                          "legacyAppealIssueId": 1
-                        }
-                      },
-                    ]
-                  }
+              compensation:
+                value:
+                  data:
+                    type: HigherLevelReview
+                    attributes:
+                      receiptDate: "2019-07-10"
+                      informalConference: true
+                      sameOffice: false
+                      legacyOptInApproved: true
+                      benefitType: compensation
+                      veteran:
+                        fileNumberOrSsn: "123456789"
+                        addressLine1: 123 Street St
+                        addressLine2: Apt 4
+                        city: Chicago
+                        stateProvinceCode: IL
+                        zipPostalCode: "60652"
+                        phoneNumber: "4432924565"
+                        emailAddress: someone@example.com
+                      claimant:
+                        participantId: "44444444"
+                        payeeCode: "10"
+                    included:
+                      - type: RequestIssue
+                        attributes:
+                          decisionIssueId: 205
       responses:
         '202':
           description: Accepted

--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -1022,6 +1022,32 @@ paths:
                           properties:
                             type:
                               type: string
+                              enum: ["Claimant"]
+                            id:
+                              type: string
+                            attributes:
+                              type: object
+                              properties:
+                                firstName:
+                                  type: string
+                                  nullable: true
+                                middleName:
+                                  type: string
+                                  nullable: true
+                                lastName:
+                                  type: string
+                                  nullable: true
+                                payeeCode:
+                                  allOf:
+                                    - $ref: "#/components/schemas/PayeeCode"
+                                    - nullable: true
+                                relationshipType:
+                                  type: string
+                                  nullable: true
+                        - type: object
+                          properties:
+                            type:
+                              type: string
                               enum: ["DecisionIssue"]
                             id:
                               type: string

--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -984,6 +984,7 @@ paths:
                                       type: string
                   included:
                     type: array
+                    description: Includes data for the Veteran, RequestIssues, and DecisionIssues.  When applicable, it will include the Claimant as well.
                     items:
                       anyOf:
                         - type: object

--- a/app/serializers/api/v3/higher_level_review_serializer.rb
+++ b/app/serializers/api/v3/higher_level_review_serializer.rb
@@ -15,19 +15,19 @@ class Api::V3::HigherLevelReviewSerializer
   # disable SymbolProc because these relationships aren't Rails relationships
   # rubocop:disable Style/SymbolProc
 
-  has_one :veteran do |higher_level_review|
+  has_one :veteran, record_type: 'Veteran' do |higher_level_review|
     higher_level_review.veteran
   end
 
-  has_one :claimant do |higher_level_review|
+  has_one :claimant, record_type: 'Claimant' do |higher_level_review|
     higher_level_review.claimants.first
   end
 
-  has_many :decision_issues do |higher_level_review|
+  has_many :decision_issues, record_type: 'DecisionIssue' do |higher_level_review|
     higher_level_review.fetch_all_decision_issues
   end
 
-  has_many :request_issues do |higher_level_review|
+  has_many :request_issues, record_type: 'RequestIssue' do |higher_level_review|
     higher_level_review.request_issues.includes(
       :decision_review, :contested_decision_issue
     ).active_or_ineligible_or_withdrawn

--- a/app/serializers/api/v3/higher_level_review_serializer.rb
+++ b/app/serializers/api/v3/higher_level_review_serializer.rb
@@ -15,19 +15,19 @@ class Api::V3::HigherLevelReviewSerializer
   # disable SymbolProc because these relationships aren't Rails relationships
   # rubocop:disable Style/SymbolProc
 
-  has_one :veteran, record_type: 'Veteran' do |higher_level_review|
+  has_one :veteran, record_type: "Veteran" do |higher_level_review|
     higher_level_review.veteran
   end
 
-  has_one :claimant, record_type: 'Claimant' do |higher_level_review|
+  has_one :claimant, record_type: "Claimant" do |higher_level_review|
     higher_level_review.claimants.first
   end
 
-  has_many :decision_issues, record_type: 'DecisionIssue' do |higher_level_review|
+  has_many :decision_issues, record_type: "DecisionIssue" do |higher_level_review|
     higher_level_review.fetch_all_decision_issues
   end
 
-  has_many :request_issues, record_type: 'RequestIssue' do |higher_level_review|
+  has_many :request_issues, record_type: "RequestIssue" do |higher_level_review|
     higher_level_review.request_issues.includes(
       :decision_review, :contested_decision_issue
     ).active_or_ineligible_or_withdrawn

--- a/spec/requests/api/v3/decision_review/higher_level_reviews_controller_spec.rb
+++ b/spec/requests/api/v3/decision_review/higher_level_reviews_controller_spec.rb
@@ -253,16 +253,19 @@ describe Api::V3::DecisionReview::HigherLevelReviewsController, :all_dbs, type: 
 
         it "should include the veteran" do
           expect(subject.dig("veteran", "data", "id")).to eq higher_level_review.veteran.id.to_s
+          expect(subject.dig("veteran", "data", "type")).to eq 'Veteran'
         end
 
         it "should include the claimant" do
           expect(subject.dig("claimant", "data", "id")).to eq higher_level_review.claimants.first.id.to_s
+          expect(subject.dig("claimant", "data", "type")).to eq 'Claimant'
         end
 
         it "should include request issues" do
           ri_relationships = subject["requestIssues"]["data"]
           expect(ri_relationships.count).to eq request_issues.count
           expect(ri_relationships.collect { |ri| ri["id"].to_i }).to include(*request_issues.collect(&:id))
+          expect(ri_relationships.collect { |ri| ri["type"] }.uniq).to eq ['RequestIssue']
         end
 
         it "should include decision issues" do
@@ -271,6 +274,7 @@ describe Api::V3::DecisionReview::HigherLevelReviewsController, :all_dbs, type: 
           di_relationships = subject["decisionIssues"]["data"]
           expect(di_relationships.count).to eq decision_issues.count
           expect(di_relationships.collect { |di| di["id"].to_i }).to include(*decision_issues.collect(&:id))
+          expect(di_relationships.collect { |di| di["type"] }.uniq).to eq ['DecisionIssue']
         end
       end
     end

--- a/spec/requests/api/v3/decision_review/higher_level_reviews_controller_spec.rb
+++ b/spec/requests/api/v3/decision_review/higher_level_reviews_controller_spec.rb
@@ -253,19 +253,19 @@ describe Api::V3::DecisionReview::HigherLevelReviewsController, :all_dbs, type: 
 
         it "should include the veteran" do
           expect(subject.dig("veteran", "data", "id")).to eq higher_level_review.veteran.id.to_s
-          expect(subject.dig("veteran", "data", "type")).to eq 'Veteran'
+          expect(subject.dig("veteran", "data", "type")).to eq "Veteran"
         end
 
         it "should include the claimant" do
           expect(subject.dig("claimant", "data", "id")).to eq higher_level_review.claimants.first.id.to_s
-          expect(subject.dig("claimant", "data", "type")).to eq 'Claimant'
+          expect(subject.dig("claimant", "data", "type")).to eq "Claimant"
         end
 
         it "should include request issues" do
           ri_relationships = subject["requestIssues"]["data"]
           expect(ri_relationships.count).to eq request_issues.count
           expect(ri_relationships.collect { |ri| ri["id"].to_i }).to include(*request_issues.collect(&:id))
-          expect(ri_relationships.collect { |ri| ri["type"] }.uniq).to eq ['RequestIssue']
+          expect(ri_relationships.collect { |ri| ri["type"] }.uniq).to eq ["RequestIssue"]
         end
 
         it "should include decision issues" do
@@ -274,7 +274,7 @@ describe Api::V3::DecisionReview::HigherLevelReviewsController, :all_dbs, type: 
           di_relationships = subject["decisionIssues"]["data"]
           expect(di_relationships.count).to eq decision_issues.count
           expect(di_relationships.collect { |di| di["id"].to_i }).to include(*decision_issues.collect(&:id))
-          expect(di_relationships.collect { |di| di["type"] }.uniq).to eq ['DecisionIssue']
+          expect(di_relationships.collect { |di| di["type"] }.uniq).to eq ["DecisionIssue"]
         end
       end
     end


### PR DESCRIPTION
Resolves #12719

### Description
* The relationships for a HigherLevelReview had to be updated to ensure the types were being set in upper-Camelcase.
* Specs for included values were missing and added to reflect API response