### PR TITLE
Upgrade nokogiri to 1.10.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,9 @@ gem "moment_timezone-rails"
 gem "newrelic_rpm"
 # nokogiri versions before 1.10.4 are vulnerable to CVE-2019-5477.
 # https://github.com/sparklemotion/nokogiri/issues/1915
-gem "nokogiri", "~> 1.10.4"
+# nokogiri 1.10.4 is vulnerable to CVE-2019-13117, CVE-2019-13118, CVE-2019-18197.
+# https://github.com/sparklemotion/nokogiri/issues/1943
+gem "nokogiri", "~> 1.10.5"
 gem "paper_trail", "8.1.2"
 # Used to speed up reporting
 gem "parallel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
     newrelic_rpm (6.5.0.357)
     nio4r (2.3.1)
     no_proxy_fix (0.1.2)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     notiffany (0.1.1)
@@ -599,7 +599,7 @@ DEPENDENCIES
   meta_request
   moment_timezone-rails
   newrelic_rpm
-  nokogiri (~> 1.10.4)
+  nokogiri (~> 1.10.5)
   paper_trail (= 8.1.2)
   parallel
   paranoia (~> 2.2)


### PR DESCRIPTION
Resolves a security warning:

```
Name: nokogiri
Version: 1.10.4
Advisory: CVE-2019-13117
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1943
Title: Nokogiri gem, via libxslt, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.10.5
```

### Description

Upgrades `nokogiri` to 1.10.5, which updates the included `libxml` dependency that contained a couple of vulnerabilities. I wouldn't expect any breakages

See: https://github.com/sparklemotion/nokogiri/issues/1943