### PR TITLE
Add message type column to messages db schema

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,7 +8,7 @@ class Message < ApplicationRecord
     job_note_added: "job_note_added",
     job_failing: "job_failing",
     failing_job_succeeded: "failing_job_succeeded",
-    job_canceled: "job_canceled"
+    job_cancelled: "job_cancelled"
   }
 
   scope :read, -> { where.not(read_at: nil) }

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,6 +4,13 @@ class Message < ApplicationRecord
   belongs_to :user
   belongs_to :detail, polymorphic: true
 
+  enum message_type: {
+    job_note_added: "job_note_added",
+    job_failing: "job_failing",
+    failing_job_succeeded: "failing_job_succeeded",
+    job_canceled: "job_canceled"
+  }
+
   scope :read, -> { where.not(read_at: nil) }
   scope :unread, -> { where(read_at: nil) }
 end

--- a/db/migrate/20191118163855_add_message_type_to_messages.rb
+++ b/db/migrate/20191118163855_add_message_type_to_messages.rb
@@ -1,0 +1,12 @@
+class AddMessageTypeToMessages < ActiveRecord::Migration[5.1]
+  def up
+    add_column :messages, :message_type, :string, comment: "The type of event that caused this message to be created"
+    safety_assured do
+      execute "UPDATE messages SET message_type='job_note_added' WHERE text LIKE 'A new note has been added %'"
+    end
+  end
+
+  def down
+    remove_column :messages, :message_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191113160247) do
+ActiveRecord::Schema.define(version: 20191118163855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -798,6 +798,7 @@ ActiveRecord::Schema.define(version: 20191113160247) do
     t.datetime "created_at", null: false
     t.integer "detail_id", comment: "ID of the related object"
     t.string "detail_type", comment: "Model name of the related object"
+    t.string "message_type", comment: "The type of event that caused this message to be created"
     t.datetime "read_at", comment: "When the message was read"
     t.string "text", comment: "The message"
     t.datetime "updated_at", null: false


### PR DESCRIPTION
Connects #12689 

### Description
As part of #12689 (if a job fails after 24 hours, message the user once) this PR is a schema change proposal to add a `message_type` column to the `messages` table. Some benefits of adding this column would be:
- Primary benefit: Easy to check whether a job has triggered any `job_failing` messages yet -- compared to inspecting the text, or doing timestamp math with assumptions
- Easy to regenerate message prose, in case we make any changes to the English (see discussion in #12707) and want them to be retroactive
- Easy to implement inbox filtering by message type, since we'd like Caseflow Inbox to be useful for non-job-related messaging

As a taste of things to come (see various acceptance criteria in #11907) I am also proposing a set of `message_type` enum values, and welcoming thoughts on better enum values or even a better alternative to all this.

### Schema Changes
* [x] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
