### PR TITLE
remove updated_at indices on large tables

### DIFF
--- a/db/migrate/20191114210706_add_updated_at_indices.rb
+++ b/db/migrate/20191114210706_add_updated_at_indices.rb
@@ -4,11 +4,8 @@ class AddUpdatedAtIndices < ActiveRecord::Migration[5.1]
   def change
     add_index :advance_on_docket_motions, :updated_at, algorithm: :concurrently
     add_index :allocations, :updated_at, algorithm: :concurrently
-    add_index :annotations, :updated_at, algorithm: :concurrently
     add_index :api_keys, :updated_at, algorithm: :concurrently
-    add_index :api_views, :updated_at, algorithm: :concurrently
     add_index :appeal_series, :updated_at, algorithm: :concurrently
-    add_index :appeal_views, :updated_at, algorithm: :concurrently
     add_index :appeals, :updated_at, algorithm: :concurrently
     add_index :attorney_case_reviews, :updated_at, algorithm: :concurrently
     add_index :available_hearing_locations, :updated_at, algorithm: :concurrently
@@ -27,7 +24,6 @@ class AddUpdatedAtIndices < ActiveRecord::Migration[5.1]
     add_index :distributions, :updated_at, algorithm: :concurrently
     add_index :docket_snapshots, :updated_at, algorithm: :concurrently
     add_index :docket_tracers, :updated_at, algorithm: :concurrently
-    add_index :document_views, :updated_at, algorithm: :concurrently
     add_index :documents, :updated_at, algorithm: :concurrently
     add_index :documents_tags, :updated_at, algorithm: :concurrently
     add_index :end_product_code_updates, :updated_at, algorithm: :concurrently
@@ -38,7 +34,6 @@ class AddUpdatedAtIndices < ActiveRecord::Migration[5.1]
     add_index :hearing_issue_notes, :updated_at, algorithm: :concurrently
     add_index :hearing_locations, :updated_at, algorithm: :concurrently
     add_index :hearing_task_associations, :updated_at, algorithm: :concurrently
-    add_index :hearing_views, :updated_at, algorithm: :concurrently
     add_index :hearings, :updated_at, algorithm: :concurrently
     add_index :higher_level_reviews, :updated_at, algorithm: :concurrently
     add_index :intakes, :updated_at, algorithm: :concurrently

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,7 +49,6 @@ ActiveRecord::Schema.define(version: 20191118163855) do
     t.integer "x"
     t.integer "y"
     t.index ["document_id"], name: "index_annotations_on_document_id"
-    t.index ["updated_at"], name: "index_annotations_on_updated_at"
     t.index ["user_id"], name: "index_annotations_on_user_id"
   end
 
@@ -69,7 +68,6 @@ ActiveRecord::Schema.define(version: 20191118163855) do
     t.string "source"
     t.datetime "updated_at"
     t.string "vbms_id"
-    t.index ["updated_at"], name: "index_api_views_on_updated_at"
   end
 
   create_table "appeal_series", id: :serial, force: :cascade do |t|
@@ -88,7 +86,6 @@ ActiveRecord::Schema.define(version: 20191118163855) do
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
     t.index ["appeal_type", "appeal_id", "user_id"], name: "index_appeal_views_on_appeal_type_and_appeal_id_and_user_id", unique: true
-    t.index ["updated_at"], name: "index_appeal_views_on_updated_at"
   end
 
   create_table "appeals", force: :cascade, comment: "Decision reviews intaken for AMA appeals to the board (also known as a notice of disagreement)." do |t|
@@ -414,7 +411,6 @@ ActiveRecord::Schema.define(version: 20191118163855) do
     t.datetime "updated_at"
     t.integer "user_id", null: false
     t.index ["document_id", "user_id"], name: "index_document_views_on_document_id_and_user_id", unique: true
-    t.index ["updated_at"], name: "index_document_views_on_updated_at"
   end
 
   create_table "documents", id: :serial, force: :cascade do |t|
@@ -651,7 +647,6 @@ ActiveRecord::Schema.define(version: 20191118163855) do
     t.datetime "updated_at"
     t.integer "user_id", null: false
     t.index ["hearing_id", "user_id", "hearing_type"], name: "index_hearing_views_on_hearing_id_and_user_id_and_hearing_type", unique: true
-    t.index ["updated_at"], name: "index_hearing_views_on_updated_at"
   end
 
   create_table "hearings", force: :cascade do |t|


### PR DESCRIPTION
Production deployment failing because large tables are causing index creation to time out.

We don't actually need these indices so removing them so migration can run.