### PR TITLE
Add missing index, skip some Appeal associations for updated_since

### DIFF
--- a/app/queries/appeals_updated_since_query.rb
+++ b/app/queries/appeals_updated_since_query.rb
@@ -14,10 +14,17 @@ class AppealsUpdatedSinceQuery
 
   private
 
+  SKIP_ASSOCIATIONS = %w[
+    appeal_views
+    claims_folder_searches
+    request_decision_issues
+    request_issues_updates
+  ].freeze
+
   attr_reader :since_date
 
   def association_names
-    @association_names ||= Appeal.reflections.keys
+    @association_names ||= Appeal.reflections.keys.reject { |key| SKIP_ASSOCIATIONS.include?(key) }
   end
 
   def build_query

--- a/db/migrate/20191119192631_add_missing_appeal_indices.rb
+++ b/db/migrate/20191119192631_add_missing_appeal_indices.rb
@@ -1,0 +1,7 @@
+class AddMissingAppealIndices < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :claims_folder_searches, [:appeal_id, :appeal_type], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191118163855) do
+ActiveRecord::Schema.define(version: 20191119192631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -293,6 +293,7 @@ ActiveRecord::Schema.define(version: 20191118163855) do
     t.string "query"
     t.datetime "updated_at"
     t.integer "user_id"
+    t.index ["appeal_id", "appeal_type"], name: "index_claims_folder_searches_on_appeal_id_and_appeal_type"
     t.index ["updated_at"], name: "index_claims_folder_searches_on_updated_at"
     t.index ["user_id"], name: "index_claims_folder_searches_on_user_id"
   end


### PR DESCRIPTION
connects #12659 

### Description
Based on actual performance in production, skip some unnecessary associated tables for Appeals-updated-since query.

### Database Changes
*Only for Schema Changes*

* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
