### PR TITLE
make the switch product link accessible as a expanding/collapsing button

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -28,7 +28,7 @@
     "client/node_modules"
   ],
   "dependencies": {
-    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#3ef2bfb",
+    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#8071c37",
     "@fortawesome/fontawesome-free": "^5.3.1",
     "babel-core": "^6.18.2",
     "babel-loader": "^7.1.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -68,9 +68,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#3ef2bfb":
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#6c44e03":
   version "2.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#3ef2bfb1ef50d68984fdc27cc263e58be1611b88"
+  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#6c44e03b0f297f3fb053b072401313e0d48db818"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -68,9 +68,9 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#6c44e03":
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#8071c37":
   version "2.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#6c44e03b0f297f3fb053b072401313e0d48db818"
+  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#8071c37fb643879d15d59fb8a4a3e5d02946a5d4"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"

--- a/spec/feature/help_spec.rb
+++ b/spec/feature/help_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.feature "Help" do
+  before do
+    User.authenticate!
+  end
+
   scenario "user goes to the help page" do
     visit "/help"
     expect(page).to have_content("Caseflow Help")


### PR DESCRIPTION
Connects #12124

### Description
Includes [the commit of `caseflow-frontend-toolkit`](https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit/commit/8071c37fb643879d15d59fb8a4a3e5d02946a5d4) that makes the switch product link (and other links using the `DropdownMenu` component) accessible as an expanding/collapsing button with a menu and menu items.