### PR TITLE
Use request issues update user for establishment and cancellations

### DIFF
--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -10,7 +10,7 @@ class DecisionReviewProcessJob < CaseflowJob
     @decision_review = thing_to_establish
 
     # If establishment is for a RequestIssuesUpdate, use the user on the update
-    establishment_user = decision_review.try(:user) || User.system_user
+    @establishment_user = decision_review.try(:user) || User.system_user
 
     # restore whatever the user was when we finish, in case we are not running async (as during tests)
     current_user = RequestStore.store[:current_user]
@@ -37,7 +37,7 @@ class DecisionReviewProcessJob < CaseflowJob
 
   private
 
-  attr_reader :decision_review
+  attr_reader :decision_review, :establishment_user
 
   def ok_to_ping_sentry?
     decision_review.sort_by_last_submitted_at > (Time.zone.now - 4.hours)

--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -9,9 +9,12 @@ class DecisionReviewProcessJob < CaseflowJob
   def perform(thing_to_establish)
     @decision_review = thing_to_establish
 
+    # If establishment is for a RequestIssuesUpdate, use the user on the update
+    establishment_user = decision_review.try(:user) || User.system_user
+
     # restore whatever the user was when we finish, in case we are not running async (as during tests)
     current_user = RequestStore.store[:current_user]
-    RequestStore.store[:current_user] = User.system_user
+    RequestStore.store[:current_user] = establishment_user
 
     return_value = nil
 

--- a/spec/jobs/decision_review_process_job_spec.rb
+++ b/spec/jobs/decision_review_process_job_spec.rb
@@ -23,30 +23,30 @@ describe DecisionReviewProcessJob do
     allow(Raven).to receive(:extra_context)
   end
 
-  let(:claim_review) { AClaimReview.new }
+  let(:establishment_subject) { AClaimReview.new }
 
   let(:vbms_error) do
     VBMS::HTTPError.new("500", "More EPs more problems")
   end
 
-  subject { DecisionReviewProcessJob.perform_now(claim_review) }
+  subject { DecisionReviewProcessJob.perform_now(establishment_subject) }
 
   it "saves Exception messages and logs error" do
     capture_raven_log
-    allow(claim_review).to receive(:establish!).and_raise(vbms_error)
+    allow(establishment_subject).to receive(:establish!).and_raise(vbms_error)
 
     subject
 
-    expect(claim_review.error).to eq(vbms_error.inspect)
+    expect(establishment_subject.error).to eq(vbms_error.inspect)
     expect(@raven_called).to eq(true)
     expect(Raven).to have_received(:extra_context).with(id: 123, class: "AClaimReview")
   end
 
   it "ignores error on success" do
-    allow(claim_review).to receive(:establish!).and_return(true)
+    allow(establishment_subject).to receive(:establish!).and_return(true)
 
     expect(subject).to eq(true)
-    expect(claim_review.error).to be_nil
+    expect(establishment_subject.error).to be_nil
   end
 
   context "transient VBMS error" do
@@ -56,24 +56,42 @@ describe DecisionReviewProcessJob do
 
     it "does not alert Sentry" do
       capture_raven_log
-      allow(claim_review).to receive(:establish!).and_raise(vbms_error)
+      allow(establishment_subject).to receive(:establish!).and_raise(vbms_error)
 
       subject
 
-      expect(claim_review.error).to eq(vbms_error.inspect)
+      expect(establishment_subject.error).to eq(vbms_error.inspect)
       expect(@raven_called).to be_falsey
     end
   end
 
   context "job is retried after 4 hours" do
     it "does not send error to sentry" do
-      allow(claim_review).to receive(:sort_by_last_submitted_at) { 4.hours.ago }
-      allow(claim_review).to receive(:establish!).and_raise(vbms_error)
+      allow(establishment_subject).to receive(:sort_by_last_submitted_at) { 4.hours.ago }
+      allow(establishment_subject).to receive(:establish!).and_raise(vbms_error)
       capture_raven_log
 
       subject
 
       expect(@raven_called).to be_falsey
+    end
+  end
+
+  context ".establishment_user" do
+    subject { DecisionReviewProcessJob.new() }
+
+    it "sets the user to the system user for establishment" do
+      subject.perform(establishment_subject)
+      expect(subject.send(:establishment_user)).to eq(User.system_user)
+    end
+
+    context "when the establishment subject is a request issues update" do
+      let(:establishment_subject) { create(:request_issues_update) }
+
+      it "sets the user to the request issue update's user for establishment" do
+        subject.perform(establishment_subject)
+        expect(subject.send(:establishment_user)).to eq(establishment_subject.user)
+      end
     end
   end
 

--- a/spec/jobs/decision_review_process_job_spec.rb
+++ b/spec/jobs/decision_review_process_job_spec.rb
@@ -78,7 +78,7 @@ describe DecisionReviewProcessJob do
   end
 
   context ".establishment_user" do
-    subject { DecisionReviewProcessJob.new() }
+    subject { DecisionReviewProcessJob.new }
 
     it "sets the user to the system user for establishment" do
       subject.perform(establishment_subject)

--- a/spec/jobs/decision_review_process_job_spec.rb
+++ b/spec/jobs/decision_review_process_job_spec.rb
@@ -91,7 +91,7 @@ describe DecisionReviewProcessJob do
       let(:establishment_subject) { create(:request_issues_update) }
 
       before do
-        allow(establishment_subject).to receive(:establish!).and_wrap_original { @current_user = RequestStore[:current_user] }
+        allow(establishment_subject).to receive(:establish!) { @current_user = RequestStore[:current_user] }
       end
 
       it "sets the user to the request issue update's user for establishment" do


### PR DESCRIPTION
### Description
When a user edits the issues on a claim, they can add and remove issues.  This can subsequently result in adding or removing end products.  These establishments or cancellations should be associated to the user who performed the update.

Currently, the user is manually being set to the system user. This PR sets the user to the RequestIssuesUpdate user, if a RequestIssuesUpdate is the source of the DecisionReviewProcess job.

Please note: This is the first (small change), of what may be many changes with respect to stopping from using the system user. This specific request is for EP cancellations, so the user has been updated for RequestIssuesUpdates only in this PR. More time and investigation is necessary before making additional changes, such as automatically generated decision reviews, EPs established from intakes, or whatever else BGS brings to our attention.