### PR TITLE
Migration timeout

### DIFF
--- a/db/migrate/20191119192631_add_missing_appeal_indices.rb
+++ b/db/migrate/20191119192631_add_missing_appeal_indices.rb
@@ -4,5 +4,7 @@ class AddMissingAppealIndices < ActiveRecord::Migration[5.1]
   def change
     ActiveRecord::Base.connection.execute "SET statement_timeout = 1800000" # 30 minutes
     add_index :claims_folder_searches, [:appeal_id, :appeal_type], algorithm: :concurrently
+  ensure
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
   end
 end

--- a/db/migrate/20191119192631_add_missing_appeal_indices.rb
+++ b/db/migrate/20191119192631_add_missing_appeal_indices.rb
@@ -2,6 +2,7 @@ class AddMissingAppealIndices < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
   def change
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 1800000" # 30 minutes
     add_index :claims_folder_searches, [:appeal_id, :appeal_type], algorithm: :concurrently
   end
 end


### PR DESCRIPTION
For large tables, set timeout longer during index creation.