### PR TITLE
Danger warn on large table migration

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -74,15 +74,16 @@ KNOWN_LARGE_TABLES = %w[
   document_views
   hearing_views
   versions
-]
+].freeze
 
+large_table_migration_pattern = /(add_index|add_column) :(#{KNOWN_LARGE_TABLES.join('|')})/
 migrations_on_large_tables = git.diff.flat_map do |chunk|
   chunk.patch.lines.grep(/^\+\s*\w/).select do |added_line|
-    added_line.match?(/(add_index|add_column) :(#{KNOWN_LARGE_TABLES.join('|')})/)
+    added_line.match?(large_table_migration_pattern)
   end
 end
 
-if migrations_on_large_tables
+if migrations_on_large_tables.any?
   warn(
     "This PR contains DB migrations on large tables. Be sure to set connection statement_timeout accordingly."
   )

--- a/Dangerfile
+++ b/Dangerfile
@@ -61,3 +61,29 @@ if !new_specs.empty?
     "https://github.com/department-of-veterans-affairs/caseflow/wiki/Testing-Best-Practices#tests-that-write-to-the-db"
   )
 end
+
+# If we're performing a migration against a table that is known to be large, make sure
+# we've set connection timeouts appropriately.
+KNOWN_LARGE_TABLES = %w[
+  annotations
+  api_views
+  appeal_views
+  claims_folder_searches
+  documents
+  documents_tags
+  document_views
+  hearing_views
+  versions
+]
+
+migrations_on_large_tables = git.diff.flat_map do |chunk|
+  chunk.patch.lines.grep(/^\+\s*\w/).select do |added_line|
+    added_line.match?(/(add_index|add_column) :(#{KNOWN_LARGE_TABLES.join('|')})/)
+  end
+end
+
+if migrations_on_large_tables
+  warn(
+    "This PR contains DB migrations on large tables. Be sure to set connection statement_timeout accordingly."
+  )
+end

--- a/db/migrate/20191119192631_add_missing_appeal_indices.rb
+++ b/db/migrate/20191119192631_add_missing_appeal_indices.rb
@@ -3,7 +3,5 @@ class AddMissingAppealIndices < ActiveRecord::Migration[5.1]
 
   def change
     add_index :claims_folder_searches, [:appeal_id, :appeal_type], algorithm: :concurrently
-    # trigger warning
-    add_index :documents, [:foo]
   end
 end

--- a/db/migrate/20191119192631_add_missing_appeal_indices.rb
+++ b/db/migrate/20191119192631_add_missing_appeal_indices.rb
@@ -3,5 +3,7 @@ class AddMissingAppealIndices < ActiveRecord::Migration[5.1]
 
   def change
     add_index :claims_folder_searches, [:appeal_id, :appeal_type], algorithm: :concurrently
+    # trigger warning
+    add_index :documents, [:foo]
   end
 end


### PR DESCRIPTION
We've had multiple times recently when creating indices on large tables caused deployment failures due to connection timeouts. Try and prevent that my warning us about tables known to be large.

Pasting screenshot here (and removing the migration that triggered it).

<img width="659" alt="Screen Shot 2019-11-20 at 10 19 11 AM" src="https://user-images.githubusercontent.com/1205061/69256570-471c2380-0b7f-11ea-917a-44da0aa6b582.png">
