### PR TITLE
Include error message in ACD docket number error

### DIFF
--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -236,7 +236,7 @@ class VACOLS::CaseDocket < VACOLS::Record
   end
 
   def self.distribute_nonpriority_appeals(judge, genpop, range, limit, dry_run = false)
-    fail DocketNumberCentennialLoop if Time.zone.now.year >= 2030
+    fail(DocketNumberCentennialLoop, COPY::MAX_LEGACY_DOCKET_NUMBER_ERROR_MESSAGE) if Time.zone.now.year >= 2030
 
     # Docket numbers begin with the two digit year. The Board of Veterans Appeals was created in 1930.
     # Although there are no new legacy appeals after 2019, an old appeal can be reopened through a finding

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -287,6 +287,8 @@
   "SPECIAL_CASE_MOVEMENT_MODAL_TITLE": "Special Case Movement",
   "SPECIAL_CASE_MOVEMENT_MODAL_DETAIL": "This action overrides the normal case distribution process and immediately assigns the appeal to the judge selected.",
   "SPECIAL_CASE_MOVEMENT_MODAL_SELECTOR_PLACEHOLDER": "Select a judge",
+  
+  "MAX_LEGACY_DOCKET_NUMBER_ERROR_MESSAGE": "Docket numbers begin with the two digit year. The Board of Veterans Appeals was created in 1930. Although there are no new legacy appeals after 2019, an old appeal can be reopened through a finding of clear and unmistakable error, which would result in a brand new docket number being assigned. An updated docket number format will need to be in place for legacy appeals by 2030 in order to ensure that docket numbers are sorted correctly.",
 
   "CANCEL_TASK_MODAL_TITLE": "Cancel task",
   "CANCEL_TASK_MODAL_DETAIL": "Cancelling this task will return it to %s",


### PR DESCRIPTION
The code comment two lines below this error explains why we are throwing this error. This PR includes that comment in the error itself to be more resilient to code changes in the future that may cause the code comment to drift away from the place where we are throwing the error.