### PR TITLE
Remove all references to GenericTask from the codebase.

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -15,7 +15,6 @@ class TasksController < ApplicationController
     ColocatedTask: ColocatedTask,
     EvidenceSubmissionWindowTask: EvidenceSubmissionWindowTask,
     FoiaTask: FoiaTask,
-    GenericTask: GenericTask,
     HearingAdminActionTask: HearingAdminActionTask,
     InformalHearingPresentationTask: InformalHearingPresentationTask,
     JudgeAddressMotionToVacateTask: JudgeAddressMotionToVacateTask,

--- a/app/models/tasks/generic_task.rb
+++ b/app/models/tasks/generic_task.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-## This model is in the process of being folded into the Task model.
-
-class GenericTask < Task
-end


### PR DESCRIPTION
Bumps #11607.  This PR represents some of the last work left to do in removing code referencing an outdated model, `GenericTask`.