### PR TITLE
Message user when a job succeeds after 24 hours

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -111,6 +111,11 @@ class ClaimReview < DecisionReview
     processed!
   end
 
+  def processed!
+    super
+    AsyncableJobMessaging.new(job: self).handle_job_success
+  end
+
   def update_error!(err)
     super
     AsyncableJobMessaging.new(job: self).handle_job_failure

--- a/app/services/asyncable_job_messaging.rb
+++ b/app/services/asyncable_job_messaging.rb
@@ -42,6 +42,21 @@ class AsyncableJobMessaging
     )
   end
 
+  def handle_job_success
+    return unless messaging_enabled_for_job_attempt?
+    return if job.messages.failing_job_succeeded.any?
+
+    message_text = <<-EOS.strip_heredoc
+      <a href="#{job.path}">#{job.class} #{job.id}</a> has successfully been processed. No further action is necessary. If you have opened a support ticket for this issue, you may inform them that it may be closed.
+    EOS
+    Message.create!(
+      detail: job,
+      text: message_text,
+      user: job.asyncable_user,
+      message_type: "failing_job_succeeded"
+    )
+  end
+
   private
 
   def messaging_enabled_for_job_attempt?

--- a/app/services/asyncable_job_messaging.rb
+++ b/app/services/asyncable_job_messaging.rb
@@ -47,7 +47,9 @@ class AsyncableJobMessaging
     return if job.messages.failing_job_succeeded.any?
 
     message_text = <<-EOS.strip_heredoc
-      <a href="#{job.path}">#{job.class} #{job.id}</a> has successfully been processed. No further action is necessary. If you have opened a support ticket for this issue, you may inform them that it may be closed.
+      <a href="#{job.path}">#{job.class} #{job.id}</a> has successfully been processed.
+      No further action is necessary. If you have opened a support ticket for this issue,
+      you may inform them that it may be closed.
     EOS
     Message.create!(
       detail: job,

--- a/spec/services/asyncable_job_messaging_spec.rb
+++ b/spec/services/asyncable_job_messaging_spec.rb
@@ -78,4 +78,34 @@ describe AsyncableJobMessaging, :postgres do
       end
     end
   end
+
+  describe "#handle_job_success" do
+    let(:owner) { create(:default_user) }
+    let(:job) { create(:higher_level_review, :requires_processing, intake: create(:intake, user: owner)) }
+    let(:messaging) { AsyncableJobMessaging.new(job: job) }
+
+    subject { messaging.handle_job_success }
+
+    context "when a success happens within 24 hours" do
+      it "doesn't send a message to the job owner" do
+        message_count = owner.messages.count
+        subject
+        expect(owner.messages.count).to eq message_count
+      end
+    end
+
+    context "when a success happens after 24 hours of failure" do
+      it "sends a message to the job owner" do
+        job
+        messaging.handle_job_failure
+        Timecop.travel(Time.zone.now.tomorrow)
+        messaging.handle_job_failure
+        message_count = owner.messages.count
+        subject
+        expect(owner.messages.count).to eq message_count + 1
+        expect(owner.messages.last.text).to match("has successfully been processed")
+        expect(owner.messages.last.text).to match(job.path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #12670 

### Description
Message the user when a job succeeds more than 24 hours after it was submitted.

### Acceptance Criteria
- [ ] When an asyncable job gets successfully processed more than 24 hours after it was submitted, automatically send the user a message to their inbox.
- [ ] Include a link to the job detail page where the user can see when the job got processed and the notes on that job.

### Testing Plan
1. Create an HLR or SC, submitted more than 24 hours in the past (use a factory or existing test to help, see item 5 or 6 below)
2. `pry> hlr.processed!`
3. Load `/inbox` as the user who owns this job
4. Verify that a success message landed in the inbox.
5. Added test for job messaging service class
6. Added inbox feature test

### User Facing Changes
<img width="968" alt="Screen Shot 2019-11-25 at 10 13 16" src="https://user-images.githubusercontent.com/282869/69552348-4cf17a80-0f6c-11ea-8d26-bd582ca7abb7.png">
Sample job success message

### Notes
This mirrors the implementation of #12767, which overrides an `Asyncable` lifecycle method in `ClaimReview` to also trigger a call to the job messaging service class.