### PR TITLE
Only assignee can act on JudgeTasks

### DIFF
--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -19,6 +19,10 @@ class JudgeTask < Task
     ].flatten
   end
 
+  def actions_allowable?(user)
+    super && assigned_to == user
+  end
+
   # :nocov:
   def additional_available_actions(_user)
     fail Caseflow::Error::MustImplementInSubclass

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -11,16 +11,17 @@
 
 class JudgeTask < Task
   def available_actions(user)
-    [
-      Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
-      Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-      Constants.TASK_ACTIONS.REASSIGN_TO_JUDGE.to_h,
-      additional_available_actions(user)
-    ].flatten
-  end
-
-  def actions_allowable?(user)
-    super && assigned_to == user
+    # Only the current assignee of a judge task should have actions available to them on the judge task.
+    if assigned_to == user
+      [
+        Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
+        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
+        Constants.TASK_ACTIONS.REASSIGN_TO_JUDGE.to_h,
+        additional_available_actions(user)
+      ].flatten
+    else
+      []
+    end
   end
 
   # :nocov:

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -22,6 +22,13 @@ describe JudgeTask, :all_dbs do
 
     subject { subject_task.available_actions_unwrapper(user) }
 
+    context "the task is not assigned to the current user" do
+      let(:user) { judge2 }
+      it "should return an empty array" do
+        expect(subject).to eq([])
+      end
+    end
+
     context "the task is assigned to the current user" do
       context "in the assign phase" do
         it "should return the assignment action" do


### PR DESCRIPTION
Reverts change made in PR #12549 that allowed anyone to act on `JudgeTask`s. This PR still ensures that `on_hold` `JudgeTask`s are unable to be acted upon. [Related Slack thread](https://dsva.slack.com/archives/CJL810329/p1574691024052000).