### PR TITLE
UI Bug Fix: Add line-height to usa-alert-text

### DIFF
--- a/client/app/styles/react/_alerts.scss
+++ b/client/app/styles/react/_alerts.scss
@@ -22,4 +22,8 @@
       font-size: 2rem;
     }
   }
+
+  .usa-alert-text {
+    line-height: 1.5;
+  }
 }


### PR DESCRIPTION
Connects #12456

### Description
Added `line-height: 1.5` to `.usa-alert-text`

### Acceptance Criteria
- [ ] Spacing for main alert text matches that of [USWDS](https://v1.designsystem.digital.gov/components/alerts/)
