### PR TITLE
Move has_many job_notes from subclasses into Asyncable

### DIFF
--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -12,7 +12,6 @@ class BoardGrantEffectuation < ApplicationRecord
   belongs_to :granted_decision_issue, class_name: "DecisionIssue"
   belongs_to :decision_document
   belongs_to :end_product_establishment
-  has_many :job_notes, as: :job
 
   validates :granted_decision_issue, presence: true
   before_save :hydrate_from_granted_decision_issue, on: :create

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -14,6 +14,10 @@ module Asyncable
 
   include RunAsyncable
 
+  included do
+    has_many :job_notes, as: :job
+  end
+
   # class methods to scope queries based on class-defined columns
   # we expect 5 column types:
   #  * last_submitted_at : when the job is eligible to run (can be reset to restart the job)

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -10,7 +10,6 @@ class DecisionDocument < ApplicationRecord
   belongs_to :appeal, polymorphic: true
   has_many :end_product_establishments, as: :source
   has_many :effectuations, class_name: "BoardGrantEffectuation"
-  has_many :job_notes, as: :job
 
   validates :citation_number, format: { with: /\AA?\d{8}\Z/i }
 

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -15,7 +15,6 @@ class DecisionReview < ApplicationRecord
   has_many :tasks, as: :appeal, dependent: :destroy
   has_many :request_issues_updates, as: :review, dependent: :destroy
   has_one :intake, as: :detail
-  has_many :job_notes, as: :job
 
   cache_attribute :cached_serialized_ratings, cache_key: :ratings_cache_key, expires_in: 1.day do
     ratings_with_issues.map(&:serialize)

--- a/app/models/hearings/virtual_hearing_establishment.rb
+++ b/app/models/hearings/virtual_hearing_establishment.rb
@@ -7,7 +7,6 @@ class VirtualHearingEstablishment < ApplicationRecord
   include Asyncable
 
   belongs_to :virtual_hearing
-  has_many :job_notes, as: :job
 
   # :nocov:
   # Implements Asyncable

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -24,7 +24,6 @@ class RequestIssue < ApplicationRecord
   has_many :remand_reasons, through: :decision_issues
   has_many :duplicate_but_ineligible, class_name: "RequestIssue", foreign_key: "ineligible_due_to_id"
   has_many :hearing_issue_notes
-  has_many :job_notes, as: :job
   has_one :legacy_issue_optin
   belongs_to :correction_request_issue, class_name: "RequestIssue", foreign_key: "corrected_by_request_issue_id"
   belongs_to :ineligible_due_to, class_name: "RequestIssue", foreign_key: "ineligible_due_to_id"

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -8,7 +8,6 @@ class RequestIssuesUpdate < ApplicationRecord
 
   belongs_to :user
   belongs_to :review, polymorphic: true
-  has_many :job_notes, as: :job
 
   attr_writer :request_issues_data
   attr_reader :error_code

--- a/spec/models/concerns/asyncable_spec.rb
+++ b/spec/models/concerns/asyncable_spec.rb
@@ -3,6 +3,9 @@
 describe Asyncable do
   class TestAsyncable
     include ActiveModel::Model
+
+    # make Asyncable's has_many association(s) a no-op for these tests
+    def self.has_many(*); end
     include Asyncable
 
     attr_accessor :submitted_at, :attempted_at, :processed_at, :canceled_at


### PR DESCRIPTION
### Description
Minor refactor to move the job notes association from various Asyncable subclasses, into the Asyncable concern. This has no impact on how job/job-notes are stored, since job notes already `belong_to` polymorphic jobs.

This was a pretty straightforward change (once I figured out the correct machinery to use) but I'm curious if seasoned Ruby folks think it's a good way to go?

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. All tests still passing