### PR TITLE
Aggregrate Geomatching Errors in Datadog

### DIFF
--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -41,7 +41,7 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
         break
       rescue StandardError => error
         # capture_exception(error: error, extra: { appeal_external_id: appeal.external_id })
-        record_geomatched_appeal(appeal.external_id, "error", error.message)
+        record_geomatched_appeal(appeal.external_id, "error", error.class.name)
       end
     end
   end
@@ -82,7 +82,7 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
     end
   end
 
-  def record_geomatched_appeal(appeal_external_id, status, message = nil)
+  def record_geomatched_appeal(appeal_external_id, status, error_name = nil)
     DataDogService.increment_counter(
       app_name: RequestStore[:application],
       metric_group: "job",
@@ -90,7 +90,7 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
       attrs: {
         status: status,
         appeal_external_id: appeal_external_id,
-        message: message
+        error_name: error_name
       }
     )
   end

--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -40,8 +40,8 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
         record_geomatched_appeal(appeal.external_id, "limit_error")
         break
       rescue StandardError => error
-        capture_exception(error: error, extra: { appeal_external_id: appeal.external_id })
-        record_geomatched_appeal(appeal.external_id, "error")
+        # capture_exception(error: error, extra: { appeal_external_id: appeal.external_id })
+        record_geomatched_appeal(appeal.external_id, "error", error.message)
       end
     end
   end
@@ -82,14 +82,15 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
     end
   end
 
-  def record_geomatched_appeal(appeal_external_id, status)
+  def record_geomatched_appeal(appeal_external_id, status, message = nil)
     DataDogService.increment_counter(
       app_name: RequestStore[:application],
       metric_group: "job",
       metric_name: "geomatched_appeals",
       attrs: {
         status: status,
-        appeal_external_id: appeal_external_id
+        appeal_external_id: appeal_external_id,
+        message: message
       }
     )
   end

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -168,7 +168,6 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
         it "records a geomatch error" do
           expect(subject).to receive(:record_geomatched_appeal)
             .with(legacy_appeal.external_id, "error")
-          expect(Raven).to receive(:capture_exception)
 
           subject.perform
         end

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -167,7 +167,7 @@ describe FetchHearingLocationsForVeteransJob, :all_dbs do
 
         it "records a geomatch error" do
           expect(subject).to receive(:record_geomatched_appeal)
-            .with(legacy_appeal.external_id, "error")
+            .with(legacy_appeal.external_id, "error", "StandardError")
 
           subject.perform
         end


### PR DESCRIPTION
send all geomatching errors to data dog and create a datadog alert if errors exceed X / hour