### PR TITLE
Do not call method on possible nil

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -226,7 +226,7 @@ class AppealsController < ApplicationController
   end
 
   def access_error_message
-    appeal.veteran.multiple_phone_numbers? ? COPY::DUPLICATE_PHONE_NUMBER_TITLE : COPY::ACCESS_DENIED_TITLE
+    (appeal.veteran&.multiple_phone_numbers?) ? COPY::DUPLICATE_PHONE_NUMBER_TITLE : COPY::ACCESS_DENIED_TITLE
   end
 
   def docket_number?(search)


### PR DESCRIPTION
Resolves [this sentry alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7522)

### Description
Fixes error thrown when the veteran on an appeal is nil