### PR TITLE
Do not raise FilenumberDoesNotExist during document prefetch

### DIFF
--- a/app/workflows/fetch_documents_for_reader_job.rb
+++ b/app/workflows/fetch_documents_for_reader_job.rb
@@ -10,6 +10,11 @@ class FetchDocumentsForReaderJob
   def process
     setup_debug_context
     appeals.each { |appeal| fetch_for_appeal(appeal) }
+  rescue VBMS::FilenumberDoesNotExist => error
+    # there is nothing actionable here, since it reflects data changes on the VBMS side.
+    # we do not want to retry since it will never work.
+    log_error
+    return
   rescue StandardError => error
     log_error
     # raising an exception here triggers a retry through shoryuken

--- a/app/workflows/fetch_documents_for_reader_job.rb
+++ b/app/workflows/fetch_documents_for_reader_job.rb
@@ -13,8 +13,8 @@ class FetchDocumentsForReaderJob
   rescue VBMS::FilenumberDoesNotExist => error
     # there is nothing actionable here, since it reflects data changes on the VBMS side.
     # we do not want to retry since it will never work.
+    Rails.logger.error error
     log_error
-    return
   rescue StandardError => error
     log_error
     # raising an exception here triggers a retry through shoryuken

--- a/spec/jobs/fetch_documents_for_reader_user_spec.rb
+++ b/spec/jobs/fetch_documents_for_reader_user_spec.rb
@@ -113,6 +113,17 @@ describe FetchDocumentsForReaderUserJob, :all_dbs do
       end
     end
 
+    context "when efolder does not recognize the veteran file number" do
+      before do
+        allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
+          .and_raise(VBMS::FilenumberDoesNotExist.new(500, "error"))
+      end
+
+      it "does not raise error" do
+        expect { FetchDocumentsForReaderUserJob.perform_now(user) }.not_to raise_error
+      end
+    end
+
     context "when HTTP Timeout occurs" do
       it "job raises an error" do
         allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)

--- a/spec/workflows/fetch_documents_for_reader_spec.rb
+++ b/spec/workflows/fetch_documents_for_reader_spec.rb
@@ -88,45 +88,45 @@ describe FetchDocumentsForReaderJob, :all_dbs do
           msg = "<faultstring>Womp Womp.</faultstring>"
           expect(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
             .and_raise(Caseflow::Error::DocumentRetrievalError.new(code: 502, message: msg)).once
-  
+
           expect { subject }.not_to raise_error
         end
       end
-  
+
       context "when efolder returns 403" do
         it "job does not raise an error" do
           allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
             .and_raise(Caseflow::Error::EfolderAccessForbidden.new(code: 401, message: "error"))
-  
+
           expect { subject }.not_to raise_error
         end
       end
-  
+
       context "when efolder returns 400" do
         it "job does not raise an error" do
           allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
             .and_raise(Caseflow::Error::ClientRequestError.new(code: 400, message: "error"))
-  
+
           expect { subject }.not_to raise_error
         end
       end
-  
+
       context "when efolder does not recognize the veteran file number" do
         before do
           allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
             .and_raise(VBMS::FilenumberDoesNotExist.new(500, "error"))
         end
-  
+
         it "does not raise error" do
           expect { subject }.not_to raise_error
         end
       end
-  
+
       context "when HTTP Timeout occurs" do
         it "job raises an error" do
           allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
             .and_raise(HTTPClient::KeepAliveDisconnected.new("You lose."))
-  
+
           expect { subject }.to raise_error(HTTPClient::KeepAliveDisconnected)
         end
       end

--- a/spec/workflows/fetch_documents_for_reader_spec.rb
+++ b/spec/workflows/fetch_documents_for_reader_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "faker"
+
+describe FetchDocumentsForReaderJob, :all_dbs do
+  describe "#process" do
+    let(:user) { create(:user) }
+    let(:document) { create(:document) }
+
+    let(:appeal) do
+      create(
+        :legacy_appeal,
+        vacols_case: create(:case, documents: [document], staff: create(:staff, sdomainid: user.css_id))
+      )
+    end
+
+    let(:doc_struct) do
+      {
+        documents: [document]
+      }
+    end
+
+    subject { described_class.new(user: user, appeals: [appeal]).process }
+
+    context "when a reader user with 1 legacy appeal is provided" do
+      it "retrieves the appeal document" do
+        expect(EFolderService).to receive(:fetch_documents_for).with(appeal, anything).and_return(doc_struct).once
+
+        subject
+      end
+    end
+
+    context "when a reader user with 1 ama appeal is provided" do
+      let(:appeal) do
+        create(
+          :appeal,
+          documents: [document]
+        )
+      end
+      let!(:task) do
+        create(
+          :ama_attorney_task,
+          :in_progress,
+          assigned_to: user,
+          appeal: appeal
+        )
+      end
+
+      it "retrieves the appeal document" do
+        expect(EFolderService).to receive(:fetch_documents_for).with(appeal, anything).and_return(doc_struct).once
+
+        subject
+      end
+    end
+
+    context "when an attorney with a colocated task is provided" do
+      let!(:vacols_atty) do
+        create(
+          :staff,
+          :attorney_role,
+          sdomainid: user.css_id
+        )
+      end
+      let(:appeal) do
+        create(
+          :appeal,
+          documents: [document]
+        )
+      end
+      let!(:task) do
+        create(
+          :colocated_task,
+          assigned_to: create(:user),
+          assigned_by: user,
+          appeal: appeal
+        )
+      end
+      it "retrieves the appeal document" do
+        expect(EFolderService).to receive(:fetch_documents_for).with(appeal, anything).and_return(doc_struct).once
+
+        subject
+      end
+    end
+
+    context "exception handling" do
+      context "when eFolder exception is thrown" do
+        it "does not raise an error" do
+          msg = "<faultstring>Womp Womp.</faultstring>"
+          expect(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
+            .and_raise(Caseflow::Error::DocumentRetrievalError.new(code: 502, message: msg)).once
+  
+          expect { subject }.not_to raise_error
+        end
+      end
+  
+      context "when efolder returns 403" do
+        it "job does not raise an error" do
+          allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
+            .and_raise(Caseflow::Error::EfolderAccessForbidden.new(code: 401, message: "error"))
+  
+          expect { subject }.not_to raise_error
+        end
+      end
+  
+      context "when efolder returns 400" do
+        it "job does not raise an error" do
+          allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
+            .and_raise(Caseflow::Error::ClientRequestError.new(code: 400, message: "error"))
+  
+          expect { subject }.not_to raise_error
+        end
+      end
+  
+      context "when efolder does not recognize the veteran file number" do
+        before do
+          allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
+            .and_raise(VBMS::FilenumberDoesNotExist.new(500, "error"))
+        end
+  
+        it "does not raise error" do
+          expect { subject }.not_to raise_error
+        end
+      end
+  
+      context "when HTTP Timeout occurs" do
+        it "job raises an error" do
+          allow(EFolderService).to receive(:fetch_documents_for).with(appeal, anything)
+            .and_raise(HTTPClient::KeepAliveDisconnected.new("You lose."))
+  
+          expect { subject }.to raise_error(HTTPClient::KeepAliveDisconnected)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Should silence some non-actionable Sentry alerts in the #appeals-reader channel.