### PR TITLE
Add inbox messaging for when a job is manually cancelled

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -121,6 +121,17 @@ class ClaimReview < DecisionReview
     AsyncableJobMessaging.new(job: self).handle_job_failure
   end
 
+  # Cancel an unprocessed job, add a job note, and send a message to the job user's inbox.
+  # Currently this only happens manually by an engineer, and requires a message explaining
+  # why the job was cancelled and describing any additional action necessary.
+  def cancel_with_note!(current_user:, note:)
+    fail Caseflow::Error::ActionForbiddenError, message: "Acting user must be specified" unless current_user
+    fail Caseflow::Error::ActionForbiddenError, message: "Processed job cannot be cancelled" if processed?
+
+    canceled!
+    AsyncableJobMessaging.new(job: self, current_user: current_user).add_job_cancellation_note(text: note)
+  end
+
   def invalid_modifiers
     end_product_establishments.map(&:modifier).reject(&:nil?)
   end

--- a/app/models/job_note.rb
+++ b/app/models/job_note.rb
@@ -15,4 +15,8 @@ class JobNote < ApplicationRecord
       sent_to_intake_user: send_to_intake_user
     }
   end
+
+  def path
+    "#{job.path}#job-note-#{id}"
+  end
 end


### PR DESCRIPTION
Connects #12672 

### Description
Added a method called "cancel_job_with_note!" that cancels an asyncable job and sends a job note to the users inbox with a message, indicating whether further action is necessary.

### Acceptance Criteria
- [x] The message should automatically include a link to the job detail page where the user can see job details and notes
- [x] The message should be from the current user (the user canceling the job)
- [x] Please add a comment above the method instructing the user to add a message explaining why the job was canceled, and describing any additional action necessary
- [x] Please add a process note to this ticket, with instructions on using the new method when canceling an asyncable job: #12276
- [x] Include a screenshot in the Github issue of the message about cancellation

### Testing Plan
1. The cancellation itself must be done in Rails console:
```
pry> job = HigherLevelReview.find(SOME_ID)
pry> user = User.find(SOME_ADMIN_USERID)
pry> job.cancel_with_note!(current_user: user, note: "some reason")
```
2. As the job's asyncable user, visit `/inbox` and verify that a message was sent.
3. Click on the link in the message to visit the job, and verify that a job note was added.

### User Facing Changes

Sample inbox message notifying the asyncable user of the cancellation:
<img width="832" alt="Screen Shot 2019-12-03 at 17 49 48" src="https://user-images.githubusercontent.com/282869/70098381-c7b83680-15f9-11ea-8b1c-1c837f8bdc55.png">

Sample job note appended to the job:
<img width="409" alt="Screen Shot 2019-12-03 at 17 49 02" src="https://user-images.githubusercontent.com/282869/70098321-a1929680-15f9-11ea-9394-b0f333f76c74.png">
 
### Documentation Updates
- [ ] Comment added to the new method, describing what circumstances a job may be cancelled (manually by engineer) and what's required (the canceller's user object, and sufficient description of the reason).