### PR TITLE
rep email can be empty

### DIFF
--- a/client/app/hearings/components/VirtualHearingModal.jsx
+++ b/client/app/hearings/components/VirtualHearingModal.jsx
@@ -180,11 +180,7 @@ class VirtualHearingModal extends React.Component {
       this.setState({ vetEmailError: INVALID_EMAIL_FORMAT });
       isValid = false;
     }
-    if (_.isEmpty(virtualHearing.representativeEmail)) {
-      this.setState({ repEmailError: INVALID_EMAIL_FORMAT });
-      isValid = false;
-    }
-
+    
     return isValid;
   }
 

--- a/client/app/hearings/components/VirtualHearingModal.jsx
+++ b/client/app/hearings/components/VirtualHearingModal.jsx
@@ -180,7 +180,7 @@ class VirtualHearingModal extends React.Component {
       this.setState({ vetEmailError: INVALID_EMAIL_FORMAT });
       isValid = false;
     }
-    
+
     return isValid;
   }
 


### PR DESCRIPTION
relates to #12750

### Description
- since we're not requiring users to enter rep email, it can be empty