### PR TITLE
Fix intake dev data

### DIFF
--- a/app/services/duplicate_veteran_participant_id_finder.rb
+++ b/app/services/duplicate_veteran_participant_id_finder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DuplicateVeteranParticipantIDFinder
+  include BgsService
+
   BGS_SSN_FIELD_NAMES = [
     :ssn,
     :soc_sec_number,
@@ -16,7 +18,7 @@ class DuplicateVeteranParticipantIDFinder
   # find and return duplicate participant IDs
   def call
     ssns = ([ssn] + BGS_SSN_FIELD_NAMES.map { |field_name| bgs_record[field_name] }).compact.uniq
-    ([participant_id] + ssns.map { |ssn| BGSService.new.client.people.find_by_ssn(ssn)[:ptcpnt_id] }).compact.uniq
+    ([participant_id] + ssns.map { |ssn| bgs.fetch_person_info_by_ssn(ssn)[:ptcpnt_id] }).compact.uniq
   end
 
   private

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -88,6 +88,19 @@ class ExternalApi::BGSService
     }
   end
 
+  def fetch_person_info_by_ssn(ssn)
+    DBService.release_db_connections
+
+    @people_by_ssn[ssn] ||=
+      MetricsService.record("BGS: fetch person by ssn: #{ssn}",
+                            service: :bgs,
+                            name: "people.find_by_ssn") do
+        client.people.find_by_ssn(ssn)
+      end
+
+    @people_by_ssn[ssn]
+  end
+
   def fetch_file_number_by_ssn(ssn)
     DBService.release_db_connections
 

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -97,8 +97,6 @@ class ExternalApi::BGSService
                             name: "people.find_by_ssn") do
         client.people.find_by_ssn(ssn)
       end
-
-    @people_by_ssn[ssn]
   end
 
   def fetch_file_number_by_ssn(ssn)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191203005255) do
+ActiveRecord::Schema.define(version: 20191203004132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191203004132) do
+ActiveRecord::Schema.define(version: 20191203005255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -285,6 +285,18 @@ class Fakes::BGSService
     default_claimant_info
   end
 
+  def fetch_person_info_by_ssn(ssn)
+    return if ssn_not_found
+
+    self.class.veteran_store.all_veteran_file_numbers.each do |file_number|
+      record = get_veteran_record(file_number)
+      if record[:ssn].to_s == ssn.to_s
+        return record
+      end
+    end
+    nil # i.e. not found
+  end
+
   def fetch_file_number_by_ssn(ssn)
     return if ssn_not_found
 


### PR DESCRIPTION
### Description
Dev data for intake has been broken. This is because we added use of a BGS service that was not available in Fakes::BGSService because we were calling it directly from the bgs code in ruby-bgs.

This adds the method to our BGS service (real and fake).