### PR TITLE
implement sort fix with role & tabIndex

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,7 +360,7 @@ GEM
       pry (~> 0.10)
     psych (3.1.0)
     public_suffix (3.1.1)
-    puma (3.12.1)
+    puma (3.12.2)
     rack (2.0.7)
     rack-contrib (2.1.0)
       rack (~> 2.0)

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -83,7 +83,7 @@ const HeaderRow = (props) => {
             COLORS.PRIMARY :
             COLORS.GREY_LIGHT;
 
-          sortIcon = <span {...iconStyle} aria-label={`Sort by ${column.header}`}
+          sortIcon = <span {...iconStyle} aria-label={`Sort by ${column.header}`} role="button" tabIndex="0"
             onClick={() => props.setSortOrder(column.name)}>
             <DoubleArrow topColor={topColor} bottomColor={botColor} />
           </span>;


### PR DESCRIPTION
Partially addresses #12126

### Description
These changes allow both VoiceOver and JAWS to identify & interact with the sort functionality utilizing the keyboard.  

A secondary aspect to the original ticket was to implement a fix for keyboard functionality with the filter menu.  Voiceover functionality with this was pre-existing however a fix for integration with JAWS has not been identified or implemented.

