### PR TITLE
Split caseflowdemo env vars into separate file for easier sourcing

### DIFF
--- a/docker-bin/env.sh
+++ b/docker-bin/env.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# env vars required to run the appeals-app docker container on caseflowdemo
+
+export POSTGRES_HOST=appeals-db
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=postgres
+export RAILS_ENV=development
+export NLS_LANG=AMERICAN_AMERICA.US7ASCII
+export REDIS_URL_CACHE=redis://appeals-redis:6379/0/cache/
+export REDIS_URL_SIDEKIQ=redis://appeals-redis:6379
+# envs to make development work in docker without affecting other devs
+export DOCKERIZED=true
+export DEMO_PORT=1521
+export DEMO_DB="(DESCRIPTION=
+    (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=VACOLS_DB-development)(PORT=1521)))(RECV_TIMEOUT=120)(SEND_TIMEOUT=5)(CONNECT_DATA=(SID=BVAP)))"
+
+
+export PATH=/.yarn/bin:/.config/yarn/global/node_modules/.bin:/usr/local/bundle/bin:/usr/local/bundle/gems/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/oracle/instantclient_12_2
+
+export LD_LIBRARY_PATH=/opt/oracle/instantclient_12_2
+export ORACLE_HOME=/opt/oracle/instantclient_12_2

--- a/docker-bin/startup.sh
+++ b/docker-bin/startup.sh
@@ -1,24 +1,9 @@
 #!/bin/bash
 
-# Variables for application
-export POSTGRES_HOST=appeals-db
-export POSTGRES_USER=postgres
-export POSTGRES_PASSWORD=postgres
-export RAILS_ENV=development
-export NLS_LANG=AMERICAN_AMERICA.US7ASCII
-export REDIS_URL_CACHE=redis://appeals-redis:6379/0/cache/
-export REDIS_URL_SIDEKIQ=redis://appeals-redis:6379
-# envs to make development work in docker without affecting other devs
-export DOCKERIZED=true
-export DEMO_PORT=1521
-export DEMO_DB="(DESCRIPTION=
-    (ADDRESS_LIST=(ADDRESS=(PROTOCOL=tcp)(HOST=VACOLS_DB-development)(PORT=1521)))(RECV_TIMEOUT=120)(SEND_TIMEOUT=5)(CONNECT_DATA=(SID=BVAP)))"
-    
+THIS_SCRIPT_DIR=$(dirname $0)
 
-export PATH=/.yarn/bin:/.config/yarn/global/node_modules/.bin:/usr/local/bundle/bin:/usr/local/bundle/gems/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/oracle/instantclient_12_2
-
-export LD_LIBRARY_PATH=/opt/oracle/instantclient_12_2
-export ORACLE_HOME=/opt/oracle/instantclient_12_2
+# Set variables for application
+source $THIS_SCRIPT_DIR/env.sh
 
 echo "Waiting for FACOLS to properly start up - 4 minutes"
 sleep 240


### PR DESCRIPTION
Should make it easier to SSM into the caseflowdemo docker instance interactively.