### PR TITLE
Fix bug where fake veterans not autobuilt in caseflowdemo

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -41,7 +41,7 @@ class Fakes::BGSService
     end
 
     def veteran_records_created?
-      veteran_store.all_keys.any?
+      veteran_store.all_veteran_file_numbers.include?("872958715") # known file_number from local/vacols//bgs_setup.csv
     end
 
     def all_grants


### PR DESCRIPTION
Resolves #12862

## Description

Fixes the naive assumption in development that any veteran in the local fake store means all the fakes have been built.