### PR TITLE
ETL appeals sort column

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -269,7 +269,7 @@ class Appeal < DecisionReview
   end
 
   def status
-    BVAAppealStatus.new(appeal: self)
+    @status ||= BVAAppealStatus.new(appeal: self)
   end
 
   def previously_selected_for_quality_review

--- a/app/models/etl/appeal.rb
+++ b/app/models/etl/appeal.rb
@@ -36,6 +36,7 @@ class ETL::Appeal < ETL::Record
       target.claimant_payee_code = claimant&.payee_code
       target.claimant_person_id = person&.id
       target.closest_regional_office = original.closest_regional_office
+      target.decision_status_sort_key = original.status.to_i
       target.docket_number = original.docket_number
       target.docket_range_date = original.docket_range_date
       target.docket_type = original.docket_type

--- a/app/services/bva_appeal_status.rb
+++ b/app/services/bva_appeal_status.rb
@@ -5,6 +5,21 @@
 class BVAAppealStatus
   attr_reader :status
 
+  SORT_KEYS = {
+    not_distributed: 1,
+    distributed_to_judge: 2,
+    assigned_to_attorney: 3,
+    assigned_to_colocated: 4,
+    in_progress: 5,
+    ready_for_signature: 6,
+    signed: 7,
+    dispatched: 8,
+    cancelled: 10,
+    misc: 11,
+    on_hold: 9,
+    unknown: 12
+  }.freeze
+
   DEFINITIONS = {
     not_distributed: "1. Not distributed",
     distributed_to_judge: "2. Distributed to judge",
@@ -57,6 +72,10 @@ class BVAAppealStatus
 
   def to_s
     DEFINITIONS[status]
+  end
+
+  def to_i
+    SORT_KEYS[status]
   end
 
   def as_json(_args)

--- a/db/etl/migrate/20191209162326_add_appeal_status_sort.rb
+++ b/db/etl/migrate/20191209162326_add_appeal_status_sort.rb
@@ -2,7 +2,7 @@ class AddAppealStatusSort < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
   def change
-    add_column :appeals, :decision_status_sort_key, :integer, null: false
+    add_column :appeals, :decision_status_sort_key, :integer, null: false, comment: "Integer for sorting status in display order"
     add_index :appeals, :decision_status_sort_key, algorithm: :concurrently
   end
 end

--- a/db/etl/migrate/20191209162326_add_appeal_status_sort.rb
+++ b/db/etl/migrate/20191209162326_add_appeal_status_sort.rb
@@ -1,0 +1,8 @@
+class AddAppealStatusSort < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :appeals, :decision_status_sort_key, :integer, null: false
+    add_index :appeals, :decision_status_sort_key, algorithm: :concurrently
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191126203511) do
+ActiveRecord::Schema.define(version: 20191209162326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20191126203511) do
     t.bigint "claimant_person_id", comment: "people.id"
     t.string "closest_regional_office", limit: 20, comment: "The code for the regional office closest to the Veteran on the appeal."
     t.datetime "created_at", null: false, comment: "Creation timestamp for the ETL record"
+    t.integer "decision_status_sort_key", null: false
     t.string "docket_number", limit: 50, null: false, comment: "Docket number"
     t.date "docket_range_date", comment: "Date that appeal was added to hearing docket range."
     t.string "docket_type", limit: 50, null: false, comment: "Docket type"
@@ -63,6 +64,7 @@ ActiveRecord::Schema.define(version: 20191126203511) do
     t.index ["claimant_participant_id"], name: "index_appeals_on_claimant_participant_id"
     t.index ["claimant_person_id"], name: "index_appeals_on_claimant_person_id"
     t.index ["created_at"], name: "index_appeals_on_created_at"
+    t.index ["decision_status_sort_key"], name: "index_appeals_on_decision_status_sort_key"
     t.index ["docket_type"], name: "index_appeals_on_docket_type"
     t.index ["poa_participant_id"], name: "index_appeals_on_poa_participant_id"
     t.index ["receipt_date"], name: "index_appeals_on_receipt_date"

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 20191209162326) do
     t.bigint "claimant_person_id", comment: "people.id"
     t.string "closest_regional_office", limit: 20, comment: "The code for the regional office closest to the Veteran on the appeal."
     t.datetime "created_at", null: false, comment: "Creation timestamp for the ETL record"
-    t.integer "decision_status_sort_key", null: false
+    t.integer "decision_status_sort_key", null: false, comment: "Integer for sorting status in display order"
     t.string "docket_number", limit: 50, null: false, comment: "Docket number"
     t.date "docket_range_date", comment: "Date that appeal was added to hearing docket range."
     t.string "docket_type", limit: 50, null: false, comment: "Docket type"

--- a/spec/services/bva_appeal_status_spec.rb
+++ b/spec/services/bva_appeal_status_spec.rb
@@ -9,16 +9,19 @@ describe BVAAppealStatus, :all_dbs do
     let(:sql_status) do
       result = execute_sql("ama-cases")
       result.map do |r|
-        [r["id"], r["appeal_task_status.decision_status"]]
+        [r["id"], [r["appeal_task_status.decision_status"], r["appeal_task_status.decision_status__sort_"]]]
       end.to_h
     end
 
     it "computes like SQL does" do
-      sql_status.each do |appeal_id, status|
+      sql_status.each do |appeal_id, pair|
+        status = pair.first
+        sort_key = pair.last
         appeal = Appeal.find(appeal_id)
         appeal_status = described_class.new(appeal: appeal)
 
         expect(appeal_status.to_s).to eq(status)
+        expect(appeal_status.to_i).to eq(sort_key.to_i + 1) # our sort keys are 1-based
       end
     end
   end


### PR DESCRIPTION
Resolves #12907 

### Description
Add `appeal.decision_status_sort_key` integer column to ETL appeals. This makes sorting by decision status consistent with Tableau reporting order.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
