### PR TITLE
Add message for editing a non-established claim review

### DIFF
--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -4,7 +4,6 @@ class ClaimReviewController < ApplicationController
   before_action :verify_access, :react_routed, :set_application
 
   EDIT_ERRORS = {
-    "ClaimReview::NotYetProcessed" => COPY::CLAIM_REVIEW_NOT_YET_PROCESSED_ERROR,
     "RequestIssue::MissingDecisionDate" => COPY::CLAIM_REVIEW_EDIT_ERROR_MISSING_DECISION_DATE,
     "StandardError" => COPY::CLAIM_REVIEW_EDIT_ERROR_DEFAULT
   }.freeze

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -24,7 +24,6 @@ class ClaimReview < DecisionReview
   self.abstract_class = true
 
   class NoEndProductsRequired < StandardError; end
-  class NotYetProcessed < StandardError; end
 
   class << self
     def find_by_uuid_or_reference_id!(claim_id)

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -52,13 +52,13 @@ class ClaimReview < DecisionReview
   end
 
   def validate_prior_to_edit
-    fail NotYetProcessed unless processed?
+    if processed?
+      # force sync on initial edit call so that we have latest EP status.
+      # This helps prevent us editing something that recently closed upstream.
+      sync_end_product_establishments!
 
-    # force sync on initial edit call so that we have latest EP status.
-    # This helps prevent us editing something that recently closed upstream.
-    sync_end_product_establishments!
-
-    verify_contentions
+      verify_contentions
+    end
 
     # this will raise any errors for missing data
     ui_hash

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -45,10 +45,15 @@ class ClaimReview < DecisionReview
     super.merge(
       asyncJobUrl: async_job_url,
       benefitType: benefit_type,
-      payeeCode: payee_code,
-      hasClearedRatingEp: cleared_rating_ep?,
-      hasClearedNonratingEp: cleared_nonrating_ep?
-    )
+      payeeCode: payee_code
+    ).tap do |hash|
+      if processed?
+        hash.update(
+          hasClearedRatingEp: cleared_rating_ep?,
+          hasClearedNonratingEp: cleared_nonrating_ep?
+        )
+      end
+    end
   end
 
   def validate_prior_to_edit

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -44,6 +44,7 @@ export const PAGE_PATHS = {
   FINISH: '/finish',
   ADD_ISSUES: '/add_issues',
   COMPLETED: '/completed',
+  NOT_EDITABLE: '/not_editable',
   CANCEL_ISSUES: '/cancel',
   CONFIRMATION: '/confirmation',
   CLEARED_EPS: '/cleared_eps',

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -92,10 +92,11 @@ class AddIssuesPage extends React.Component {
   };
 
   willRedirect(intakeData, hasClearedEp) {
-    const { formType, featureToggles } = this.props;
+    const { formType, editPage, processedAt, featureToggles } = this.props;
     const { correctClaimReviews } = featureToggles;
 
     return (
+      (editPage && !processedAt) ||
       !formType ||
       intakeData.isOutcoded ||
       (hasClearedEp && !correctClaimReviews)
@@ -103,9 +104,11 @@ class AddIssuesPage extends React.Component {
   }
 
   redirect(intakeData, hasClearedEp) {
-    const { formType } = this.props;
+    const { formType, editPage, processedAt } = this.props;
 
-    if (!formType) {
+    if (editPage && !processedAt) {
+      return <Redirect to={PAGE_PATHS.NOT_EDITABLE} />;
+    } else if (!formType) {
       return <Redirect to={PAGE_PATHS.BEGIN} />;
     } else if (hasClearedEp) {
       return <Redirect to={PAGE_PATHS.CLEARED_EPS} />;

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -91,25 +91,31 @@ class AddIssuesPage extends React.Component {
     this.props.setIssueWithdrawalDate(value);
   };
 
+  editingClaimReview() {
+    const { formType, editPage } = this.props;
+
+    return (formType === 'higher_level_review' || formType === 'supplemental_claim') && editPage;
+  }
+
   willRedirect(intakeData, hasClearedEp) {
-    const { formType, editPage, processedAt, featureToggles } = this.props;
+    const { formType, processedAt, featureToggles } = this.props;
     const { correctClaimReviews } = featureToggles;
 
     return (
-      (editPage && !processedAt) ||
       !formType ||
+      (this.editingClaimReview() && !processedAt) ||
       intakeData.isOutcoded ||
       (hasClearedEp && !correctClaimReviews)
     );
   }
 
   redirect(intakeData, hasClearedEp) {
-    const { formType, editPage, processedAt } = this.props;
+    const { formType, processedAt } = this.props;
 
-    if (editPage && !processedAt) {
-      return <Redirect to={PAGE_PATHS.NOT_EDITABLE} />;
-    } else if (!formType) {
+    if (!formType) {
       return <Redirect to={PAGE_PATHS.BEGIN} />;
+    } else if (this.editingClaimReview() && !processedAt) {
+      return <Redirect to={PAGE_PATHS.NOT_EDITABLE} />;
     } else if (hasClearedEp) {
       return <Redirect to={PAGE_PATHS.CLEARED_EPS} />;
     } else if (intakeData.isOutcoded) {

--- a/client/app/intakeEdit/IntakeEditFrame.jsx
+++ b/client/app/intakeEdit/IntakeEditFrame.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import NavigationBar from '../components/NavigationBar';
 import Footer from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Footer';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Redirect } from 'react-router-dom';
 import PageRoute from '../components/PageRoute';
 import AppFrame from '../components/AppFrame';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
+import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import { LOGO_COLORS } from '../constants/AppConstants';
 import { PAGE_PATHS } from '../intake/constants';
 import { EditAddIssuesPage } from '../intake/pages/addIssues';
@@ -27,6 +28,16 @@ export default class IntakeEditFrame extends React.PureComponent {
 
   displayConfirmationMessage = (details) => {
     return `${details.veteran.name}'s claim review has been successfully edited. You can close this window.`;
+  }
+
+  displayNotEditableMessage = (details) => {
+    const { asyncJobUrl } = this.props.serverIntake;
+
+    return <React.Fragment>
+      The review has not yet been established in VBMS.
+      Check the <Link href={asyncJobUrl}>job page</Link> for details.
+      You may try to edit the review again once it has been established.
+    </React.Fragment>;
   }
 
   displayCanceledMessage = (details) => {
@@ -81,6 +92,13 @@ export default class IntakeEditFrame extends React.PureComponent {
                   path={PAGE_PATHS.BEGIN}
                   title="Edit Claim Issues | Caseflow Intake"
                   component={EditAddIssuesPage} />
+                <PageRoute
+                  exact
+                  path={PAGE_PATHS.NOT_EDITABLE}
+                  title="Edit Claim Issues | Caseflow Intake"
+                  component={() => {
+                    return <Message title="Review not editable" displayMessage={this.displayNotEditableMessage} />;
+                  }} />
                 <PageRoute
                   exact
                   path={PAGE_PATHS.CANCEL_ISSUES}

--- a/client/app/intakeEdit/IntakeEditFrame.jsx
+++ b/client/app/intakeEdit/IntakeEditFrame.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import NavigationBar from '../components/NavigationBar';
 import Footer from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Footer';
-import { BrowserRouter, Route, Redirect } from 'react-router-dom';
+import { BrowserRouter, Route } from 'react-router-dom';
 import PageRoute from '../components/PageRoute';
 import AppFrame from '../components/AppFrame';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
@@ -30,7 +30,7 @@ export default class IntakeEditFrame extends React.PureComponent {
     return `${details.veteran.name}'s claim review has been successfully edited. You can close this window.`;
   }
 
-  displayNotEditableMessage = (details) => {
+  displayNotEditableMessage = () => {
     const { asyncJobUrl } = this.props.serverIntake;
 
     return <React.Fragment>
@@ -154,6 +154,7 @@ IntakeEditFrame.propTypes = {
     veteran: PropTypes.object,
     formType: PropTypes.string,
     editIssuesUrl: PropTypes.string,
+    asyncJobUrl: PropTypes.string,
     hasClearedNonratingEp: PropTypes.bool,
     hasClearedRatingEp: PropTypes.bool
   }),

--- a/client/app/intakeEdit/IntakeEditFrame.jsx
+++ b/client/app/intakeEdit/IntakeEditFrame.jsx
@@ -34,8 +34,8 @@ export default class IntakeEditFrame extends React.PureComponent {
     const { asyncJobUrl } = this.props.serverIntake;
 
     return <React.Fragment>
-      The review has not yet been established in VBMS.
-      Check the <Link href={asyncJobUrl}>job page</Link> for details.
+      Review not yet established in VBMS.
+      Check <Link href={asyncJobUrl}>the job page</Link> for details.
       You may try to edit the review again once it has been established.
     </React.Fragment>;
   }

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -736,6 +736,8 @@ feature "Higher Level Review Edit issues", :all_dbs do
         visit "#{url_path}/#{decision_review.uuid}/edit"
 
         expect(page).to have_content("Review not yet established in VBMS. Check the job page for details.")
+        expect(page).not_to have_content("Something went wrong")
+        expect(page).not_to have_content("There was an error")
         expect(page).to have_link("the job page")
 
         click_link "the job page"

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -735,9 +735,8 @@ feature "Higher Level Review Edit issues", :all_dbs do
       it "disallows editing" do
         visit "#{url_path}/#{decision_review.uuid}/edit"
 
+        expect(page).to have_content("Review not editable")
         expect(page).to have_content("Review not yet established in VBMS. Check the job page for details.")
-        expect(page).not_to have_content("Something went wrong")
-        expect(page).not_to have_content("There was an error")
         expect(page).to have_link("the job page")
 
         click_link "the job page"

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -690,6 +690,8 @@ feature "Supplemental Claim Edit issues", :all_dbs do
         visit "#{url_path}/#{decision_review.uuid}/edit"
 
         expect(page).to have_content("Review not yet established in VBMS. Check the job page for details.")
+        expect(page).not_to have_content("Something went wrong")
+        expect(page).not_to have_content("There was an error")
         expect(page).to have_link("the job page")
 
         click_link "the job page"

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -689,9 +689,8 @@ feature "Supplemental Claim Edit issues", :all_dbs do
       it "disallows editing" do
         visit "#{url_path}/#{decision_review.uuid}/edit"
 
+        expect(page).to have_content("Review not editable")
         expect(page).to have_content("Review not yet established in VBMS. Check the job page for details.")
-        expect(page).not_to have_content("Something went wrong")
-        expect(page).not_to have_content("There was an error")
         expect(page).to have_link("the job page")
 
         click_link "the job page"

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -205,9 +205,7 @@ feature "NonComp Dispositions Task Page", :postgres do
 
       scenario "goes back to intake" do
         visit dispositions_url
-        click_on "Edit Issues"
-
-        expect(page).to have_current_path(decision_review.reload.caseflow_only_edit_issues_url)
+        expect(page).to have_link("Edit Issues", href: decision_review.reload.caseflow_only_edit_issues_url)
       end
     end
   end


### PR DESCRIPTION
Connects #12210 

### Description
When a user attempts to edit a ClaimReview (HigherLevelReview or SupplementalClaim) that has not been established yet, display an informative message instead of the current error message.

#### Notes:
With guidance from @jcq I took this opportunity to shift the backend/frontend responsibilities here a bit. Instead of letting `#validate_prior_to_edit` raise an exception and triggering Rails to render an error, the ClaimReview ui_hash is now usable before job processing finishes. This allows the frontend to decide how to render the edit page pre-establishment, with a few consequences:
- The frontend now makes use of the `asyncJobUrl` (which was already in the ui_hash) to assemble the friendly message.
- The frontend uses a new `/edit/not_editable` route in a style that's consistent with the other edit-page states.
- The backend has to be a little more careful about what fields to include in the ui_hash, pre- or post-establishment. This part I don't particularly love, and it shows in the diff for `claim_review.rb`.

### Acceptance Criteria
- [x] When a review is not yet established, if the user navigates to the edit screen they are directed to a message page instead of the error page.
- [x] The intake page for adding issues is not impacted
- [x] The edit page for appeals is not impacted

### Testing Plan
1. With a seeded database, get the UUID of an HLR without an `establishment_processed_at` (using Postgres or ActiveRecord), visit `/higher_level_reviews/<UUID>/edit`, and verify that the new messaging is shown.
1. Update feature tests to verify that the new informational page doesn't have any unexpected error messaging.
1. Existing feature tests already thoroughly exercise the add/edit-issue UI for new intakes, and for existing appeals.

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

Screenshot of new messaging:
<img width="1096" alt="Screen Shot 2019-12-10 at 16 04 20" src="https://user-images.githubusercontent.com/282869/70568904-d86f2c00-1b66-11ea-8f85-4c36ca934114.png">
