### PR TITLE
Fix a Higher-Level review test broken because of date

### DIFF
--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -656,7 +656,7 @@ feature "Higher-Level Review", :all_dbs do
     end
 
     context "Veteran has no ratings" do
-      let(:decision_date) { (receipt_date + 200.days).to_date.mdY }
+      let(:decision_date) { (receipt_date + 9000.days).to_date.mdY }
 
       scenario "the Add Issue modal skips directly to Nonrating Issue modal" do
         start_higher_level_review(veteran_no_ratings)


### PR DESCRIPTION
### Description

Today is 295 days after the AMA start date, which broke a test. The test will continue to fail because the date is no longer in the future!