### PR TITLE
search for appeal with both ssn and file_number

### DIFF
--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -12,7 +12,7 @@ class AppealFinder
       find_appeals_for_vso_user(veterans: veterans)
     else
       self.class.find_appeals_with_file_numbers(
-        veterans.map(&:file_number)
+        [veterans.map(&:file_number), veterans.map(&:ssn)].flatten.compact.uniq
       )
     end
   end

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
         end
       end
 
+      context "when request header contains Veteran file number but appeal is associated with veteran ssn", focus: true do
+        let!(:veteran) { create(:veteran, ssn: ssn) }
+
+        it "returns valid response with one appeal" do
+          binding.pry
+          request.headers["HTTP_CASE_SEARCH"] = veteran.file_number
+          get :index, params: options
+          response_body = JSON.parse(response.body)
+          expect(response.status).to eq 200
+          expect(response_body["appeals"].size).to eq 1
+        end
+      end
+
       context "when request header contains existing Veteran ID with no associated appeals" do
         let!(:veteran_without_associated_appeals) { create(:veteran) }
 

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -37,11 +37,10 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
         end
       end
 
-      context "when request header contains Veteran file number but appeal is associated with veteran ssn", focus: true do
+      context "when request header contains Veteran file number but appeal is associated with veteran ssn" do
         let!(:veteran) { create(:veteran, ssn: ssn) }
 
         it "returns valid response with one appeal" do
-          binding.pry
           request.headers["HTTP_CASE_SEARCH"] = veteran.file_number
           get :index, params: options
           response_body = JSON.parse(response.body)

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -38,9 +38,10 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
       end
 
       context "when request header contains Veteran file number but appeal is associated with veteran ssn" do
-        let!(:veteran) { create(:veteran, ssn: ssn) }
+        let!(:veteran) { create(:veteran, file_number: "000000000", ssn: ssn) }
 
         it "returns valid response with one appeal" do
+          appeal
           request.headers["HTTP_CASE_SEARCH"] = veteran.file_number
           get :index, params: options
           response_body = JSON.parse(response.body)

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -415,7 +415,7 @@ RSpec.feature "Search", :all_dbs do
     end
 
     context "when appeal is associated with ssn not file number" do
-      let!(:veteran) { create(:veteran, ssn: Generators::Random.unique_ssn) }
+      let!(:veteran) { create(:veteran, file_number: "00000000", ssn: Generators::Random.unique_ssn) }
       let!(:legacy_appeal) do
         create(
           :legacy_appeal,

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -413,6 +413,23 @@ RSpec.feature "Search", :all_dbs do
         expect(page).to have_content(COPY::IS_PAPER_CASE)
       end
     end
+
+    context "when appeal is associated with ssn not file number" do
+      let!(:veteran) { create(:veteran, ssn: Generators::Random.unique_ssn) }
+      let!(:legacy_appeal) do
+        create(
+          :legacy_appeal,
+          vacols_case: create(:case, bfcorlid: "#{veteran.ssn}S")
+        )
+      end
+      scenario "found one appeal" do
+        visit "/search"
+        fill_in "searchBarEmptyList", with: veteran.file_number
+        click_on "Search"
+
+        expect(page).to have_content("1 case found for")
+      end
+    end
   end
 
   context "queue case search for appeals using docket number" do


### PR DESCRIPTION
### Description
- related to issue is appeals-batteam https://dsva.slack.com/archives/CHX8FMP28/p1575986812109200
- AppealFinder now looks for veteran case using both ssn and file_number
- write tests