### PR TITLE
Disable trailing comma in literal rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -142,3 +142,6 @@ Lint/UriEscapeUnescape:
 
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
+
+Style/TrailingCommaInLiteral:
+  Enabled: false


### PR DESCRIPTION
Disabling this rubocop rule across caseflow repos, which did not allow the use of trailing commas in literals.
See https://github.com/department-of-veterans-affairs/caseflow-efolder/pull/1144
