### PR TITLE
Hide inbox messages older than 120 days by default

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -13,4 +13,5 @@ class Message < ApplicationRecord
 
   scope :read, -> { where.not(read_at: nil) }
   scope :unread, -> { where(read_at: nil) }
+  scope :created_after, ->(datetime) { where("created_at > :datetime", datetime: datetime) }
 end

--- a/app/services/inbox_messages.rb
+++ b/app/services/inbox_messages.rb
@@ -1,21 +1,24 @@
 # frozen_string_literal: true
 
 class InboxMessages
-  def initialize(user:, page_size: 50, page: 1)
+  VISIBLE_DURATION = 120.days
+
+  def initialize(user:, page_size: 50, page: 1, created_after: VISIBLE_DURATION.ago)
     @user = user
     @page_size = page_size
     @page = page
+    @created_after = created_after
   end
 
   def total
-    user.messages.count
+    user.messages.created_after(created_after).count
   end
 
   def messages
-    user.messages.order(read_at: :desc, created_at: :desc).page(page).per(page_size)
+    user.messages.created_after(created_after).order(read_at: :desc, created_at: :desc).page(page).per(page_size)
   end
 
   private
 
-  attr_reader :user, :page_size, :page
+  attr_reader :user, :page_size, :page, :created_after
 end

--- a/client/app/inbox/pages/InboxPage.jsx
+++ b/client/app/inbox/pages/InboxPage.jsx
@@ -123,6 +123,9 @@ class InboxMessagesPage extends React.PureComponent {
     return <div className="cf-inbox-table">
       <h1>Inbox</h1>
       <hr />
+      <div>
+        Messages will remain in the intake box for 120 days. After such time, messages will be removed.
+      </div>
       <Table columns={columns} rowObjects={rowObjects} rowClassNames={rowClassNames} slowReRendersAreOk />
       <EasyPagination currentCases={rowObjects.length} pagination={this.props.pagination} />
     </div>;

--- a/spec/feature/inbox/inbox_spec.rb
+++ b/spec/feature/inbox/inbox_spec.rb
@@ -13,7 +13,7 @@ feature "Inbox", :postgres do
         user.messages << build(:message, text: "hello world")
         user.messages << build(:message, text: "message with <a href='/intake'>link</a>")
         user.messages << build(:message,
-                               created_at: DateTime.parse("2019-08-01T15:34:43-0500").in_time_zone,
+                               created_at: 1.month.ago,
                                text: "i have been read",
                                read_at: Time.zone.now)
       end
@@ -21,6 +21,7 @@ feature "Inbox", :postgres do
       it "show all messages and allows user to mark as read" do
         visit "/inbox"
 
+        expect(page).to have_content("Messages will remain in the intake box for 120 days")
         expect(page).to have_content("hello world")
         expect(page).to have_content("message with link")
         expect(page).to have_link("link")

--- a/spec/services/inbox_messages_spec.rb
+++ b/spec/services/inbox_messages_spec.rb
@@ -26,4 +26,16 @@ describe InboxMessages, :postgres do
       expect(inbox.messages.first).to_not eq(message)
     end
   end
+
+  describe "hiding older messages" do
+    before do
+      (0..200).step(25) { |age| create(:message, created_at: age.days.ago, user: user) }
+    end
+
+    it "hides messages older than the visible duration" do
+      inbox = described_class.new(user: user)
+      expect(inbox.total).to eq(5)
+      expect(inbox.messages.map(&:created_at)).to all(be > 120.days.ago)
+    end
+  end
 end


### PR DESCRIPTION
Connects #12926 

### Description
As per a request from AMO during the async messaging demo, the Inbox will not show messages older than 120 days. This PR hides older messages (and provides an easy way to change that duration or perhaps even control it from the frontend).

### Acceptance Criteria
- [x] Messages older than 120 days are hidden.
- [ ] Post this sentence on the main page of the inbox to alert the user:  `Messages will remain in the intake box for 120 days.  After such time, messages will be removed.`

### Testing Plan
1. Identify an inbox message in Postgres (seed data should create a few) and change its `created_at` to be more than 4 months ago.
1. Switch to the owner of that message, and visit `/inbox`.
1. Verify that the older message isn't present.
1. Updated inbox service tests and feature tests.

### User Facing Changes
Screenshot showing the new informational text:
<img width="1088" alt="Screen Shot 2019-12-12 at 21 23 08" src="https://user-images.githubusercontent.com/282869/70764831-be7c4780-1d26-11ea-8eac-83ce825bd1ec.png">
