### PR TITLE
Set statement_timeout longer for FK and index migrations

### DIFF
--- a/db/migrate/20191206024319_reference_legacy_issue_in_legacy_issue_optins.rb
+++ b/db/migrate/20191206024319_reference_legacy_issue_in_legacy_issue_optins.rb
@@ -2,7 +2,12 @@ class ReferenceLegacyIssueInLegacyIssueOptins < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
   def change
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 1800000" # 30 minutes
+
     add_reference :legacy_issue_optins, :legacy_issue, foreign_key: true, comment: "The legacy issue being opted in, which connects to the request issue", index: false
     add_index :legacy_issue_optins, :legacy_issue_id, algorithm: :concurrently
+
+  ensure
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
   end
 end


### PR DESCRIPTION
I am frankly puzzled why this is necessary given that the affected table only has 10k records in it and the index should finish quickly but taking this precaution in any case.