### PR TITLE
Always warn on new index w/o statement_timeout

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -88,3 +88,21 @@ if migrations_on_large_tables.any?
     "This PR contains DB migrations on large tables. Be sure to set connection statement_timeout accordingly."
   )
 end
+
+contains_new_index = git.diff.flat_map do |chunk|
+  chunk.patch.lines.grep(/^\+\s*\w/).select do |added_line|
+    added_line.match?(/add_index/)
+  end
+end
+
+contains_statement_timeout = git.diff.flat_map do |chunk|
+  chunk.patch.lines.grep(/^\+\s*\w/).select do |added_line|
+    added_line.match?(/statement_timeout/)
+  end
+end
+
+if contains_new_index.any? && contains_statement_timeout.none?
+  warn(
+    "This PR contains DB migrations without extending statement_timeout. It may fail in production."
+  )
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -49,19 +49,6 @@ if !result.empty?
   )
 end
 
-# Remind folks to tag new specs appropriately if they require the DB
-new_specs = git.added_files.grep(/.*_spec\.rb/)
-
-if !new_specs.empty?
-  warn(
-    "This PR adds one or more new specs. If the specs use the DB, see if " \
-    "you can rewrite them so they don't use the DB, such as by using `build_stubbed`. " \
-    "If they must use the DB, please remember to add the appropriate require statements " \
-    "and either the `:postgres` or `:all_dbs` tags, as documented in our Wiki: " \
-    "https://github.com/department-of-veterans-affairs/caseflow/wiki/Testing-Best-Practices#tests-that-write-to-the-db"
-  )
-end
-
 # If we're performing a migration against a table that is known to be large, make sure
 # we've set connection timeouts appropriately.
 KNOWN_LARGE_TABLES = %w[


### PR DESCRIPTION
Adds danger rule to always require statement_timeout on new index creation.