### PR TITLE
Return a nil end_product_code when request issue closed status is ineligible

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -215,6 +215,7 @@ class RequestIssue < ApplicationRecord
   end
 
   def end_product_code
+    return if ineligible?
     return if decision_review.processed_in_caseflow?
 
     EndProductCodeSelector.new(self).call

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -558,6 +558,14 @@ describe RequestIssue, :all_dbs do
       end
     end
 
+    context "when request issue is ineligible" do
+      let(:closed_status) { "ineligible" }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+
     context "when decision review is processed in caseflow" do
       it "calls EndProductCodeSelector" do
         expect_any_instance_of(EndProductCodeSelector).to receive(:call).once


### PR DESCRIPTION
### Description
Returns a `nil` `end_product_code` when the request issue's closed status is ineligible.

Addresses [this Sentry error](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7567/).