### PR TITLE
Tweak copy for a few async message types

### DIFF
--- a/app/services/asyncable_job_messaging.rb
+++ b/app/services/asyncable_job_messaging.rb
@@ -33,7 +33,8 @@ class AsyncableJobMessaging
       job_note = JobNote.create!(job: job, user: current_user, note: text, send_to_intake_user: send_to_intake_user)
       if send_to_intake_user
         message_text = <<-EOS.strip_heredoc
-          The job for processing <a href="#{job_note.path}">#{job.class} #{job.id}</a> has been cancelled.
+          The job for processing <a href="#{job_note.path}">#{job.class} #{job.id}</a> has been cancelled.<br />
+          No further action is necessary. Please see the job details page for more information on why this job has been cancelled.
         EOS
         Message.create!(detail: job_note, text: message_text, user: job.asyncable_user, message_type: :job_cancelled)
       end
@@ -47,7 +48,9 @@ class AsyncableJobMessaging
 
     err = ERB::Util.html_escape(job.sanitized_error)
     message_text = <<-EOS.strip_heredoc
-      The job for <a href="#{job.path}">#{job.class} #{job.id}</a> was unable to complete because of an error: #{err}
+      The job for <a href="#{job.path}">#{job.class} #{job.id}</a> was unable to complete because of an error: #{err}<br />
+      No further action is necessary as the (IT) support team has been notified.
+      You will receive a separate message in your inbox when the issue has resolved.
     EOS
     Message.create!(
       detail: job,


### PR DESCRIPTION
Connects #12926 

As per AMO's feedback on async job messaging, a few message types are getting slightly fleshed out.

### Designs
Sample screenshot of what the new language will look like, in the inbox:
<img width="1085" alt="Screen Shot 2019-12-16 at 16 57 10" src="https://user-images.githubusercontent.com/282869/70946420-27183c80-2025-11ea-8996-6afce12a5ab7.png">
