### PR TITLE
import sqls

### DIFF
--- a/app/sql/looker/dashboards/AMA Appeals/AMA decisions by attorneys and judges.sql
+++ b/app/sql/looker/dashboards/AMA Appeals/AMA decisions by attorneys and judges.sql
@@ -1,0 +1,155 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/Appeals Status/api_views_created_unique.sql
+++ b/app/sql/looker/dashboards/Appeals Status/api_views_created_unique.sql
@@ -1,0 +1,20 @@
+-- raw sql results do not include filled-in values for 'api_views.created_month'
+-- NOT WORKING
+
+WITH legacy_veterans AS (SELECT 
+	legacy_appeals.vbms_id  AS vbms_id,
+	COUNT(*) AS count
+FROM public.legacy_appeals  AS legacy_appeals
+
+GROUP BY 1)
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', api_views.created_at ), 'YYYY-MM') AS "api_views.created_month",
+	COUNT(DISTINCT api_views.vbms_id ) AS "api_views.unique_veterans"
+FROM public.api_views  AS api_views
+LEFT JOIN public.api_keys  AS api_keys ON api_views.api_key_id = api_keys.id 
+LEFT JOIN legacy_veterans ON api_views.vbms_id = legacy_veterans.vbms_id 
+
+WHERE (api_views.created_at  >= TIMESTAMP '2018-03-21 11:00') AND ((api_views.created_at  < (DATEADD(month,0, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))) AND (api_keys.consumer_name = 'Vets.gov') AND (legacy_veterans.count > 0)
+GROUP BY DATE_TRUNC('month', api_views.created_at )
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Attorney and Judge productivity/AMA completed tasks and decisions signed by judges.sql
+++ b/app/sql/looker/dashboards/Attorney and Judge productivity/AMA completed tasks and decisions signed by judges.sql
@@ -1,0 +1,127 @@
+-- AMA completed tasks and decisions signed by judges
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 1 ELSE NULL END) AS "appeal_task_status.num_cases_signed_by_judge"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.judge_task_status = 'completed')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Attorney and Judge productivity/AMA completed tasks by attorneys.sql
+++ b/app/sql/looker/dashboards/Attorney and Judge productivity/AMA completed tasks by attorneys.sql
@@ -1,0 +1,127 @@
+-- AMA completed tasks by attorneys
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	COUNT(CASE WHEN (appeal_task_status.attorney_task_status = 'completed') THEN 1 ELSE NULL END) AS "appeal_task_status.attorney_completed_task_count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.attorney_task_status = 'completed')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Attorney and Judge productivity/Decision issues per judge.sql
+++ b/app/sql/looker/dashboards/Attorney and Judge productivity/Decision issues per judge.sql
@@ -1,0 +1,127 @@
+-- Decision issues per judge
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	((appeal_task_status.attorney_name IS NOT NULL AND LENGTH(appeal_task_status.attorney_name) <> 0 ) AND (appeal_task_status.attorney_name IS NOT NULL))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Attorney and Judge productivity/Decisions made by judges.sql
+++ b/app/sql/looker/dashboards/Attorney and Judge productivity/Decisions made by judges.sql
@@ -1,0 +1,128 @@
+-- Decisions made by judges
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(decision_documents.id ) AS "decision_documents.count",
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	((appeal_task_status.judge_name IS NOT NULL))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/DMS Replication Status/raw vacols issues count.sql
+++ b/app/sql/looker/dashboards/DMS Replication Status/raw vacols issues count.sql
@@ -1,0 +1,4 @@
+SELECT * FROM (SELECT
+	COUNT(*) AS "vacols_raw_issues.count"
+FROM VACOLS.ISSUES   vacols_raw_issues
+) WHERE ROWNUM <= 500

--- a/app/sql/looker/dashboards/DMS Replication Status/redshift vacols brieff count.sql
+++ b/app/sql/looker/dashboards/DMS Replication Status/redshift vacols brieff count.sql
@@ -1,0 +1,13 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	COUNT(*) AS "vacols_brieff.count"
+FROM vacols_brieff
+
+LIMIT 500

--- a/app/sql/looker/dashboards/DMS Replication Status/redshift vacols issues count.sql
+++ b/app/sql/looker/dashboards/DMS Replication Status/redshift vacols issues count.sql
@@ -1,0 +1,5 @@
+SELECT 
+	COUNT(*) AS "vacols_issues.total_count"
+FROM vacols.issues  AS vacols_issues
+
+LIMIT 500

--- a/app/sql/looker/dashboards/Dispatch Details/Completed Dispatch Tasks at ARC.sql
+++ b/app/sql/looker/dashboards/Dispatch Details/Completed Dispatch Tasks at ARC.sql
@@ -1,0 +1,13 @@
+-- raw sql results do not include filled-in values for 'dispatch_tasks.completed_week'
+
+
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', dispatch_tasks.completed_at ), 'YYYY-MM-DD') AS "dispatch_tasks.completed_week",
+	COUNT(*) AS "dispatch_tasks.count"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+WHERE 
+	(((dispatch_tasks.completed_at ) >= ((DATEADD(month,-8, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ))) AND (dispatch_tasks.completed_at ) < ((DATEADD(month,9, DATEADD(month,-8, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ) )))))
+GROUP BY DATE_TRUNC('week', dispatch_tasks.completed_at )
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/Dispatch Details/Current Pending Dispatch Tasks.sql
+++ b/app/sql/looker/dashboards/Dispatch Details/Current Pending Dispatch Tasks.sql
@@ -1,0 +1,10 @@
+SELECT 
+	dispatch_tasks.aasm_state  AS "dispatch_tasks.aasm_state",
+	COUNT(*) AS "dispatch_tasks.count"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+WHERE 
+	(dispatch_tasks.aasm_state  IN ('unassigned', 'unprepared'))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Dispatch Details/Dispatch Tasks Median Time to Complete (Week-over-week).sql
+++ b/app/sql/looker/dashboards/Dispatch Details/Dispatch Tasks Median Time to Complete (Week-over-week).sql
@@ -1,0 +1,8 @@
+SELECT 
+	dispatch_tasks.aasm_state  AS "dispatch_tasks.aasm_state",
+	COUNT(*) AS "dispatch_tasks.count"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Dispatch Details/Dispatch Tasks Stages Daily Details.sql
+++ b/app/sql/looker/dashboards/Dispatch Details/Dispatch Tasks Stages Daily Details.sql
@@ -1,0 +1,11 @@
+-- raw sql results do not include filled-in values for 'ramp_elections.established_month'
+
+
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', ramp_elections.established_at ), 'YYYY-MM') AS "ramp_elections.established_month",
+	COUNT(*) AS "ramp_elections.count"
+FROM public.ramp_elections  AS ramp_elections
+
+GROUP BY DATE_TRUNC('month', ramp_elections.established_at )
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Dispatch Details/Hearings Tasks with No Schedule Hearing Tasks.sql
+++ b/app/sql/looker/dashboards/Dispatch Details/Hearings Tasks with No Schedule Hearing Tasks.sql
@@ -1,0 +1,64 @@
+
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/HearingAdminAction > 6 months.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/HearingAdminAction > 6 months.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(month,-6, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type LIKE '%HearingAdminAction%')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/Hearings Tasks with No Schedule Hearing Tasks.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/Hearings Tasks with No Schedule Hearing Tasks.sql
@@ -1,0 +1,64 @@
+
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/Hearings- EvidenceWindowTask > 90 days.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/Hearings- EvidenceWindowTask > 90 days.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(day,-90, DATE_TRUNC('day',GETDATE()) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'EvidenceSubmissionWindowTask')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/Hearings- NoShowHearingTask > 25 days.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/Hearings- NoShowHearingTask > 25 days.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(day,-25, DATE_TRUNC('day',GETDATE()) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'NoShowHearingTask')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/Hearings- ScheduleHearingTasks > 1 year old.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/Hearings- ScheduleHearingTasks > 1 year old.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(year,-1, DATE_TRUNC('year', DATE_TRUNC('day',GETDATE())) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'ScheduleHearingTask')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/Hearings- TranscriptionTask > 6 months.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/Hearings- TranscriptionTask > 6 months.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(month,-6, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type LIKE '%TranscriptionTask%')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Hearings Metrics/More than One Open Hearing Tasks.sql
+++ b/app/sql/looker/dashboards/Hearings Metrics/More than One Open Hearing Tasks.sql
@@ -1,0 +1,79 @@
+WITH appeals_with_open_hearing_tasks AS (SELECT appeals.id AS id, uuid AS external_id, closest_regional_office, 'Appeal' AS appeal_type,
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = appeals.id AND child_tasks.appeal_type = appeal_type
+      AND type IN ('HearingTask', 'ScheduleHearingTask', 'DispositionTask', 'ChangeDispositionTask')
+      AND status IN ('assigned', 'on_hold', NULL)
+    ) AS "total_open_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'HearingTask'
+    ) AS "open_hearing_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'ScheduleHearingTask'
+    ) AS "open_schedule_hearing_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'HearingTask'
+    ) AS "open_disposition_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'ChangeDispositionTask'
+    ) AS "open_change_disposition_tasks"
+    FROM public.appeals WHERE total_open_tasks > 0
+    UNION
+    SELECT legacy_appeals.id AS id, vacols_id AS external_id, closest_regional_office, 'LegacyAppeal' AS appeal_type,
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = legacy_appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type IN ('HearingTask', 'ScheduleHearingTask', 'DispositionTask', 'ChangeDispositionTask')
+    ) AS "total_open_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = legacy_appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'HearingTask'
+    ) AS "open_hearing_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = legacy_appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'ScheduleHearingTask'
+    ) AS "open_schedule_hearing_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = legacy_appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'HearingTask'
+    ) AS "open_disposition_tasks",
+    (
+      SELECT count(child_tasks.id) FROM tasks AS child_tasks
+      WHERE child_tasks.appeal_id = legacy_appeals.id AND child_tasks.appeal_type = appeal_type
+      AND status IN ('assigned', 'on_hold', NULL)
+      AND type = 'ChangeDispositionTask'
+    ) AS "open_change_disposition_tasks"
+    FROM public.legacy_appeals WHERE total_open_tasks > 0
+             )
+SELECT 
+	appeals_with_open_hearing_tasks."appeal_type"  AS "appeals_with_open_hearing_tasks.appeal_type",
+	appeals_with_open_hearing_tasks."id"  AS "appeals_with_open_hearing_tasks.id",
+	appeals_with_open_hearing_tasks."open_hearing_tasks"  AS "appeals_with_open_hearing_tasks.open_hearing_tasks",
+	appeals_with_open_hearing_tasks."open_schedule_hearing_tasks"  AS "appeals_with_open_hearing_tasks.open_schedule_hearing_tasks",
+	appeals_with_open_hearing_tasks."open_disposition_tasks"  AS "appeals_with_open_hearing_tasks.open_disposition_tasks"
+FROM appeals_with_open_hearing_tasks
+
+WHERE 
+	(appeals_with_open_hearing_tasks."open_hearing_tasks"  > 1)
+GROUP BY 1,2,3,4,5
+ORDER BY 3 
+LIMIT 500

--- a/app/sql/looker/dashboards/Intake Stats/Ramp Elections Received.sql
+++ b/app/sql/looker/dashboards/Intake Stats/Ramp Elections Received.sql
@@ -1,0 +1,34 @@
+-- raw sql results do not include filled-in values for 'ramp_elections.receipt_month'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "ramp_elections.receipt_month") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "ramp_elections.receipt_month" ASC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "ramp_elections.option_selected" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	ramp_elections.option_selected  AS "ramp_elections.option_selected",
+	TO_CHAR(DATE_TRUNC('month', ramp_elections.receipt_date ), 'YYYY-MM') AS "ramp_elections.receipt_month",
+	COUNT(*) AS "ramp_elections.count"
+FROM public.ramp_elections  AS ramp_elections
+
+WHERE 
+	(ramp_elections.established_at  IS NOT NULL)
+GROUP BY 1,DATE_TRUNC('month', ramp_elections.receipt_date )) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the pivot row totals
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', ramp_elections.receipt_date ), 'YYYY-MM') AS "ramp_elections.receipt_month",
+	COUNT(*) AS "ramp_elections.count"
+FROM public.ramp_elections  AS ramp_elections
+
+WHERE 
+	(ramp_elections.established_at  IS NOT NULL)
+GROUP BY DATE_TRUNC('month', ramp_elections.receipt_date )
+ORDER BY 1 
+LIMIT 30000

--- a/app/sql/looker/dashboards/Intake Stats/Successful Intakes.sql
+++ b/app/sql/looker/dashboards/Intake Stats/Successful Intakes.sql
@@ -1,0 +1,34 @@
+-- raw sql results do not include filled-in values for 'intakes.completed_month'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "intakes.completed_month") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "intakes.completed_month" ASC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "intakes.type" DESC NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	intakes.type  AS "intakes.type",
+	TO_CHAR(DATE_TRUNC('month', intakes.completed_at ), 'YYYY-MM') AS "intakes.completed_month",
+	COUNT(*) AS "intakes.count"
+FROM public.intakes  AS intakes
+
+WHERE 
+	(intakes.completion_status = 'success')
+GROUP BY 1,DATE_TRUNC('month', intakes.completed_at )) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the pivot row totals
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', intakes.completed_at ), 'YYYY-MM') AS "intakes.completed_month",
+	COUNT(*) AS "intakes.count"
+FROM public.intakes  AS intakes
+
+WHERE 
+	(intakes.completion_status = 'success')
+GROUP BY DATE_TRUNC('month', intakes.completed_at )
+ORDER BY 1 
+LIMIT 30000

--- a/app/sql/looker/dashboards/Judge productivity/Judge Case Reviews.sql
+++ b/app/sql/looker/dashboards/Judge productivity/Judge Case Reviews.sql
@@ -1,0 +1,20 @@
+-- raw sql results do not include filled-in values for 'judge_case_reviews.created_week'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "judge_case_reviews.judge_id") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "judge_case_reviews.count" ELSE NULL END DESC NULLS LAST, "judge_case_reviews.count" DESC, z__pivot_col_rank, "judge_case_reviews.judge_id") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "judge_case_reviews.created_week" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	judge_case_reviews.judge_id  AS "judge_case_reviews.judge_id",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+
+GROUP BY DATE_TRUNC('week', judge_case_reviews.created_at ),2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/dashboards/Judge productivity/Judge productivity by judge per week.sql
+++ b/app/sql/looker/dashboards/Judge productivity/Judge productivity by judge per week.sql
@@ -1,0 +1,54 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "judge_case_reviews.judge_id","users.css_id","users.email","users.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "judge_case_reviews.judge_id" ASC, z__pivot_col_rank, "users.css_id", "users.email", "users.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "judge_case_reviews.created_week" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	judge_case_reviews.judge_id  AS "judge_case_reviews.judge_id",
+	users.css_id  AS "users.css_id",
+	users.email  AS "users.email",
+	users.full_name  AS "users.full_name",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY DATE_TRUNC('week', judge_case_reviews.created_at ),2,3,4,5) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY DATE_TRUNC('week', judge_case_reviews.created_at )
+ORDER BY 1 
+LIMIT 50
+
+-- sql for creating the pivot row totals
+SELECT 
+	judge_case_reviews.judge_id  AS "judge_case_reviews.judge_id",
+	users.css_id  AS "users.css_id",
+	users.email  AS "users.email",
+	users.full_name  AS "users.full_name",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY 1,2,3,4
+ORDER BY 1 
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+LIMIT 1

--- a/app/sql/looker/dashboards/New Dashboard/appeals.sql
+++ b/app/sql/looker/dashboards/New Dashboard/appeals.sql
@@ -1,0 +1,31 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "decision_documents.bva_decision_dispatched","decision_issues.disposition_date") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "appeals.count" ELSE NULL END DESC NULLS LAST, "appeals.count" DESC, z__pivot_col_rank, "decision_documents.bva_decision_dispatched", "decision_issues.disposition_date") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "decision_issues.disposition" NULLS LAST, "tasks.status" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	decision_issues.disposition  AS "decision_issues.disposition",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	decision_issues.disposition_date  AS "decision_issues.disposition_date",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE ((((decision_documents.decision_date ) >= ((DATE(DATEADD(month,-1, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))) AND (decision_documents.decision_date ) < ((DATE(DATEADD(month,2, DATEADD(month,-1, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ) ))))))) AND ((((decision_documents.decision_date ) >= ((DATE(DATE_TRUNC('year', DATE_TRUNC('day',GETDATE()))))) AND (decision_documents.decision_date ) < ((DATE(DATEADD(year,1, DATE_TRUNC('year', DATE_TRUNC('day',GETDATE())) )))))))
+GROUP BY 1,2,3,4) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/dashboards/Queue Metrics/AMA completed tasks by attorneys.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/AMA completed tasks by attorneys.sql
@@ -1,0 +1,125 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	COUNT(CASE WHEN (appeal_task_status.attorney_task_status = 'completed') THEN 1 ELSE NULL END) AS "appeal_task_status.attorney_completed_task_count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.attorney_task_status = 'completed')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Queue Metrics/AMA completed tasks by judges.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/AMA completed tasks by judges.sql
@@ -1,0 +1,124 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.judge_task_status = 'completed')
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/Queue Metrics/AMA decision progress by attorneys and judges.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/AMA decision progress by attorneys and judges.sql
@@ -1,0 +1,155 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/Queue Metrics/Attorney Case Reviews By Week.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/Attorney Case Reviews By Week.sql
@@ -1,0 +1,22 @@
+-- raw sql results do not include filled-in values for 'attorney_case_reviews.created_week'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "attorney_case_reviews.created_week") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "attorney_case_reviews.created_week" DESC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "attorney_case_reviews.document_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	attorney_case_reviews.document_type  AS "attorney_case_reviews.document_type",
+	TO_CHAR(DATE_TRUNC('week', attorney_case_reviews.created_at ), 'YYYY-MM-DD') AS "attorney_case_reviews.created_week",
+	COUNT(*) AS "attorney_case_reviews.count"
+FROM public.attorney_case_reviews  AS attorney_case_reviews
+
+WHERE 
+	(attorney_case_reviews.created_at  < (DATEADD(week,0, DATE_TRUNC('week', DATE_TRUNC('day',GETDATE())) )))
+GROUP BY 1,DATE_TRUNC('week', attorney_case_reviews.created_at )) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/dashboards/Queue Metrics/Attorney count by month.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/Attorney count by month.sql
@@ -1,0 +1,13 @@
+-- raw sql results do not include filled-in values for 'attorney_case_reviews.created_month'
+
+
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', attorney_case_reviews.created_at ), 'YYYY-MM') AS "attorney_case_reviews.created_month",
+	COUNT(*) AS "attorney_case_reviews.count",
+	COUNT(DISTINCT attorneys.id ) AS "attorneys.count"
+FROM public.attorney_case_reviews  AS attorney_case_reviews
+LEFT JOIN public.users  AS attorneys ON attorney_case_reviews.attorney_id = attorneys.id 
+
+GROUP BY DATE_TRUNC('month', attorney_case_reviews.created_at )
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Queue Metrics/Co-located tasks.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/Co-located tasks.sql
@@ -1,0 +1,19 @@
+SELECT 
+	tasks.action  AS "tasks.action",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+LIMIT 1

--- a/app/sql/looker/dashboards/Queue Metrics/Judge Case Reviews By Week.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/Judge Case Reviews By Week.sql
@@ -1,0 +1,13 @@
+-- raw sql results do not include filled-in values for 'judge_case_reviews.created_week'
+
+
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+
+WHERE 
+	(judge_case_reviews.created_at  < (DATEADD(week,0, DATE_TRUNC('week', DATE_TRUNC('day',GETDATE())) )))
+GROUP BY DATE_TRUNC('week', judge_case_reviews.created_at )
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/Queue Metrics/Judge count by month.sql
+++ b/app/sql/looker/dashboards/Queue Metrics/Judge count by month.sql
@@ -1,0 +1,13 @@
+-- raw sql results do not include filled-in values for 'judge_case_reviews.created_month'
+
+
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', judge_case_reviews.created_at ), 'YYYY-MM') AS "judge_case_reviews.created_month",
+	COUNT(*) AS "judge_case_reviews.count",
+	COUNT(DISTINCT users.id ) AS "users.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY DATE_TRUNC('month', judge_case_reviews.created_at )
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/dashboards/RAMP appeals pilot reports/RAMP Pilot Decision Progress.sql
+++ b/app/sql/looker/dashboards/RAMP appeals pilot reports/RAMP Pilot Decision Progress.sql
@@ -1,0 +1,273 @@
+-- raw sql results do not include filled-in values for 'appeal_task_status.decision_status'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+LIMIT 1

--- a/app/sql/looker/dashboards/RAMP appeals pilot reports/RAMP Refilings.sql
+++ b/app/sql/looker/dashboards/RAMP appeals pilot reports/RAMP Refilings.sql
@@ -1,0 +1,9 @@
+SELECT 
+	ramp_refilings.appeal_docket  AS "ramp_refilings.appeal_docket",
+	ramp_refilings.option_selected  AS "ramp_refilings.option_selected",
+	COUNT(*) AS "ramp_refilings.count"
+FROM public.ramp_refilings  AS ramp_refilings
+
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/dashboards/RAMP appeals pilot reports/RAMP appeals with completed BvaDispatch tasks.sql
+++ b/app/sql/looker/dashboards/RAMP appeals pilot reports/RAMP appeals with completed BvaDispatch tasks.sql
@@ -1,0 +1,31 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	appeals.docket_type  AS "appeals.docket_type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	request_issues.disposition  AS "request_issues.disposition",
+	remand_reasons.code  AS "remand_reasons.code",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+LEFT JOIN public.remand_reasons  AS remand_reasons ON request_issues.id = remand_reasons.request_issue_id
+
+WHERE (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_completed')) AND (tasks.type = 'BvaDispatchTask') AND (assigned_to_user.css_id <> 'VSCBPIET' OR assigned_to_user.css_id IS NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 4 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/ADC Validation.sql
+++ b/app/sql/looker/looks_sqls/ADC Validation.sql
@@ -1,0 +1,254 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	DATE(appeal_task_status.bva_dispatch_task_status_completed_date) AS "appeal_task_status.bva_dispatch_task_status_completed_at_date",
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 7 DESC
+LIMIT 20
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/ADP - Detail Report.sql
+++ b/app/sql/looker/looks_sqls/ADP - Detail Report.sql
@@ -1,0 +1,298 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+GROUP BY 1,2,3,4
+ORDER BY 1 
+LIMIT 20
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA - Task Status Summary by Lane.sql
+++ b/app/sql/looker/looks_sqls/AMA - Task Status Summary by Lane.sql
@@ -1,0 +1,557 @@
+-- raw sql results do not include filled-in values for 'appeal_task_status.decision_status'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeal_task_status.decision_status__sort_","appeal_task_status.decision_status") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "appeal_task_status.decision_status__sort_" ASC, z__pivot_col_rank, "appeal_task_status.decision_status") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 30000
+
+-- sql for creating the grand totals
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Appeals Average Days to Complete - By Docket By Month.sql
+++ b/app/sql/looker/looks_sqls/AMA Appeals Average Days to Complete - By Docket By Month.sql
@@ -1,0 +1,264 @@
+-- raw sql results do not include filled-in values for 'decision_documents.decision_month'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeals.docket_type") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "appeal_task_status.average_days_to_complete" ELSE NULL END DESC NULLS LAST, "appeal_task_status.average_days_to_complete" DESC, z__pivot_col_rank, "appeals.docket_type") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "decision_documents.decision_month" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', decision_documents.decision_date ), 'YYYY-MM') AS "decision_documents.decision_month",
+	appeals.docket_type  AS "appeals.docket_type",
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+GROUP BY DATE_TRUNC('month', decision_documents.decision_date ),2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', decision_documents.decision_date ), 'YYYY-MM') AS "decision_documents.decision_month",
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+GROUP BY DATE_TRUNC('month', decision_documents.decision_date )
+ORDER BY 1 
+LIMIT 50

--- a/app/sql/looker/looks_sqls/AMA Appeals Average Days to Complete - By Docket.sql
+++ b/app/sql/looker/looks_sqls/AMA Appeals Average Days to Complete - By Docket.sql
@@ -1,0 +1,249 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Appeals Established by Month.sql
+++ b/app/sql/looker/looks_sqls/AMA Appeals Established by Month.sql
@@ -1,0 +1,55 @@
+-- raw sql results do not include filled-in values for 'appeals.established_month'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeals.docket_type") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "appeals.docket_type" ASC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.established_month" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', appeals.established_at ), 'YYYY-MM') AS "appeals.established_month",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY DATE_TRUNC('month', appeals.established_at ),2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', appeals.established_at ), 'YYYY-MM') AS "appeals.established_month",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY DATE_TRUNC('month', appeals.established_at )
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 1 
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Appeals Including Dispatched Appeals.sql
+++ b/app/sql/looker/looks_sqls/AMA Appeals Including Dispatched Appeals.sql
@@ -1,0 +1,565 @@
+-- raw sql results do not include filled-in values for 'appeal_task_status.decision_status'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeal_task_status.decision_status__sort_","appeal_task_status.decision_status") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "appeal_task_status.decision_status__sort_" ASC, z__pivot_col_rank, "appeal_task_status.decision_status") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 30000
+
+-- sql for creating the grand totals
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Appeals Pending - Grand Total.sql
+++ b/app/sql/looker/looks_sqls/AMA Appeals Pending - Grand Total.sql
@@ -1,0 +1,292 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Appeals RO breakdown.sql
+++ b/app/sql/looker/looks_sqls/AMA Appeals RO breakdown.sql
@@ -1,0 +1,9 @@
+SELECT 
+	appeals.closest_regional_office  AS "appeals.closest_regional_office",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	((appeals.closest_regional_office IS NOT NULL))
+GROUP BY 1
+ORDER BY 1 

--- a/app/sql/looker/looks_sqls/AMA Case and Issue Disposition (Allowed, Denied, Remand).sql
+++ b/app/sql/looker/looks_sqls/AMA Case and Issue Disposition (Allowed, Denied, Remand).sql
@@ -1,0 +1,68 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "decision_documents.bva_decision_dispatched","appeals.docket_type") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "decision_documents.count" ELSE NULL END DESC NULLS LAST, "decision_documents.count" DESC, z__pivot_col_rank, "decision_documents.bva_decision_dispatched", "appeals.docket_type") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "decision_issues.disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	decision_issues.disposition  AS "decision_issues.disposition",
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT decision_documents.id ) AS "decision_documents.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE 
+	decision_documents.citation_number IS NOT NULL  
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	decision_issues.disposition  AS "decision_issues.disposition",
+	COUNT(DISTINCT decision_documents.id ) AS "decision_documents.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE 
+	decision_documents.citation_number IS NOT NULL  
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT decision_documents.id ) AS "decision_documents.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE 
+	decision_documents.citation_number IS NOT NULL  
+GROUP BY 1,2
+ORDER BY 3 DESC
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(DISTINCT decision_documents.id ) AS "decision_documents.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE 
+	decision_documents.citation_number IS NOT NULL  
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Decisions Dispatched.sql
+++ b/app/sql/looker/looks_sqls/AMA Decisions Dispatched.sql
@@ -1,0 +1,12 @@
+SELECT 
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	COUNT(decision_documents.id ) AS "decision_documents.count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE 
+	decision_documents.citation_number IS NOT NULL  
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA Intakes by Type.sql
+++ b/app/sql/looker/looks_sqls/AMA Intakes by Type.sql
@@ -1,0 +1,32 @@
+-- raw sql results do not include filled-in values for 'intakes.completed_month'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "intakes.completed_month") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "intakes.completed_month" DESC, CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "intakes.count" ELSE NULL END DESC NULLS LAST, "intakes.count" DESC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "intakes.type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	intakes.type  AS "intakes.type",
+	TO_CHAR(DATE_TRUNC('month', intakes.completed_at ), 'YYYY-MM') AS "intakes.completed_month",
+	COUNT(*) AS "intakes.count"
+FROM public.intakes  AS intakes
+
+WHERE ((((intakes.completed_at ) >= ((DATEADD(month,-2, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ))) AND (intakes.completed_at ) < ((DATEADD(month,3, DATEADD(month,-2, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ) )))))) AND (intakes.completion_status = 'success') AND ((intakes.type  IN ('HigherLevelReviewIntake', 'SupplementalClaimIntake', 'AppealIntake')))
+GROUP BY 1,DATE_TRUNC('month', intakes.completed_at )) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 5000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	intakes.type  AS "intakes.type",
+	COUNT(*) AS "intakes.count"
+FROM public.intakes  AS intakes
+
+WHERE ((((intakes.completed_at ) >= ((DATEADD(month,-2, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ))) AND (intakes.completed_at ) < ((DATEADD(month,3, DATEADD(month,-2, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ) )))))) AND (intakes.completion_status = 'success') AND ((intakes.type  IN ('HigherLevelReviewIntake', 'SupplementalClaimIntake', 'AppealIntake')))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 5000

--- a/app/sql/looker/looks_sqls/AMA Intakes by User Role.sql
+++ b/app/sql/looker/looks_sqls/AMA Intakes by User Role.sql
@@ -1,0 +1,20 @@
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', intakes.completed_at ), 'YYYY-MM') AS "intakes.completed_month",
+	users.roles  AS "users.roles",
+	COUNT(*) AS "intakes.count"
+FROM public.intakes  AS intakes
+LEFT JOIN public.users  AS users ON intakes.user_id = users.id 
+
+WHERE ((((intakes.completed_at ) >= ((DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())))) AND (intakes.completed_at ) < ((DATEADD(month,1, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))))) AND (intakes.completion_status = 'success') AND ((intakes.type  NOT IN ('RampElectionIntake', 'RampRefilingIntake') OR intakes.type IS NULL))
+GROUP BY DATE_TRUNC('month', intakes.completed_at ),2
+ORDER BY 1 DESC,3 DESC,2 
+LIMIT 5000
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(*) AS "intakes.count"
+FROM public.intakes  AS intakes
+LEFT JOIN public.users  AS users ON intakes.user_id = users.id 
+
+WHERE ((((intakes.completed_at ) >= ((DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())))) AND (intakes.completed_at ) < ((DATEADD(month,1, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))))) AND (intakes.completion_status = 'success') AND ((intakes.type  NOT IN ('RampElectionIntake', 'RampRefilingIntake') OR intakes.type IS NULL))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA Issues Dispatched.sql
+++ b/app/sql/looker/looks_sqls/AMA Issues Dispatched.sql
@@ -1,0 +1,137 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched')
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA appeal count.sql
+++ b/app/sql/looker/looks_sqls/AMA appeal count.sql
@@ -1,0 +1,19 @@
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/AMA appeals with finished QR tasks.sql
+++ b/app/sql/looker/looks_sqls/AMA appeals with finished QR tasks.sql
@@ -1,0 +1,32 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeals.veteran_file_number","appeals.receipt_date","assigned_to_user.css_id","tasks.status","appeals.docket_type") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "appeals.docket_type" ASC, "appeals.receipt_date" DESC, z__pivot_col_rank, "appeals.veteran_file_number", "assigned_to_user.css_id", "tasks.status") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "request_issues.disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	request_issues.disposition  AS "request_issues.disposition",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+
+WHERE (tasks.type = 'BvaDispatchTask') AND ((appeals.receipt_date  = DATE(DATE '2018-08-09') OR appeals.receipt_date  = DATE(DATE '2018-06-08') OR appeals.receipt_date  = DATE(DATE '2018-08-28') OR appeals.receipt_date  = DATE(DATE '2018-07-17') OR appeals.receipt_date  = DATE(DATE '2018-08-15')))
+GROUP BY 1,2,3,4,5,6) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/AMA cases by attorney - completed and signed by judge.sql
+++ b/app/sql/looker/looks_sqls/AMA cases by attorney - completed and signed by judge.sql
@@ -1,0 +1,125 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	COUNT(CASE WHEN appeal_task_status.attorney_task_status = 'completed'  THEN 1 ELSE NULL END) AS "appeal_task_status.num_cases_completed_by_attorney",
+	COUNT(CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 1 ELSE NULL END) AS "appeal_task_status.num_cases_signed_by_judge"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1
+ORDER BY 1 ,2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA cases completed by each attorney.sql
+++ b/app/sql/looker/looks_sqls/AMA cases completed by each attorney.sql
@@ -1,0 +1,124 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	COUNT(CASE WHEN appeal_task_status.attorney_task_status = 'completed'  THEN 1 ELSE NULL END) AS "appeal_task_status.num_cases_completed_by_attorney"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1
+ORDER BY 1 ,2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA cases judges and attorneys.sql
+++ b/app/sql/looker/looks_sqls/AMA cases judges and attorneys.sql
@@ -1,0 +1,129 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	appeal_task_status.judge_task_status AS "appeal_task_status.judge_task_status",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.attorney_task_status AS "appeal_task_status.attorney_task_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+ORDER BY 4 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA cases with finished QR tasks.sql
+++ b/app/sql/looker/looks_sqls/AMA cases with finished QR tasks.sql
@@ -1,0 +1,24 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.disposition  AS "request_issues.disposition",
+	remand_reasons.code  AS "remand_reasons.code",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+LEFT JOIN public.remand_reasons  AS remand_reasons ON request_issues.id = remand_reasons.request_issue_id
+
+WHERE (tasks.type = 'QualityReviewTask') AND ((appeals.receipt_date  = DATE(DATE '2018-08-09') OR appeals.receipt_date  = DATE(DATE '2018-06-08') OR appeals.receipt_date  = DATE(DATE '2018-08-28') OR appeals.receipt_date  = DATE(DATE '2018-07-17') OR appeals.receipt_date  = DATE(DATE '2018-08-15')))
+GROUP BY 1,2,3,4,5,6
+ORDER BY 4 ,2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA completed tasks and decisions signed by judges.sql
+++ b/app/sql/looker/looks_sqls/AMA completed tasks and decisions signed by judges.sql
@@ -1,0 +1,125 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 1 ELSE NULL END) AS "appeal_task_status.num_cases_signed_by_judge"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.judge_task_status = 'completed')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA completed tasks by attorneys.sql
+++ b/app/sql/looker/looks_sqls/AMA completed tasks by attorneys.sql
@@ -1,0 +1,125 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	COUNT(CASE WHEN (appeal_task_status.attorney_task_status = 'completed') THEN 1 ELSE NULL END) AS "appeal_task_status.attorney_completed_task_count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.attorney_task_status = 'completed')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA completed tasks by judges.sql
+++ b/app/sql/looker/looks_sqls/AMA completed tasks by judges.sql
@@ -1,0 +1,124 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.judge_task_status = 'completed')
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA decision progress by attorneys and judges -.sql
+++ b/app/sql/looker/looks_sqls/AMA decision progress by attorneys and judges -.sql
@@ -1,0 +1,156 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.attorney_task_status AS "appeal_task_status.attorney_task_status",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6,7
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA decision progress by attorneys and judges.sql
+++ b/app/sql/looker/looks_sqls/AMA decision progress by attorneys and judges.sql
@@ -1,0 +1,155 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA decisions by attorneys and judges.sql
+++ b/app/sql/looker/looks_sqls/AMA decisions by attorneys and judges.sql
@@ -1,0 +1,157 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	appeal_task_status.judge_task_status AS "appeal_task_status.judge_task_status",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.attorney_task_status AS "appeal_task_status.attorney_task_status",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6,7,8
+ORDER BY 6 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA decisions.sql
+++ b/app/sql/looker/looks_sqls/AMA decisions.sql
@@ -1,0 +1,19 @@
+SELECT 
+	appeals.id  AS "appeals.id",
+	tasks.type  AS "tasks.type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+
+WHERE 
+	(tasks.type  IN ('JudgeTask', 'AttorneyTask', 'BVADispatchTask'))
+GROUP BY 1,2,3
+ORDER BY 1 DESC,2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA issue remand reasons.sql
+++ b/app/sql/looker/looks_sqls/AMA issue remand reasons.sql
@@ -1,0 +1,12 @@
+SELECT 
+	remand_reasons.code  AS "remand_reasons.code",
+	request_issues.disposition  AS "request_issues.disposition",
+	COUNT(*) AS "remand_reasons.remand_reason_code_count"
+FROM public.remand_reasons  AS remand_reasons
+LEFT JOIN public.request_issues  AS request_issues ON remand_reasons.request_issue_id = request_issues.id
+
+WHERE 
+	(request_issues.disposition = 'remanded')
+GROUP BY 1,2
+ORDER BY 3 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/AMA, AttorneyTasks, Decision Dates.sql
+++ b/app/sql/looker/looks_sqls/AMA, AttorneyTasks, Decision Dates.sql
@@ -1,0 +1,22 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.decision_documents  AS decision_documents ON tasks.appeal_id = decision_documents.appeal_id
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1,2,3,4
+ORDER BY 4 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Alert - Caseflow Postgres DMS hasn't fetched recent data.sql
+++ b/app/sql/looker/looks_sqls/Alert - Caseflow Postgres DMS hasn't fetched recent data.sql
@@ -1,0 +1,10 @@
+SELECT 
+	TO_CHAR(users.efolder_documents_fetched_at , 'YYYY-MM-DD HH24:MI:SS') AS "users.efolder_documents_fetched_at_time"
+FROM public.reader_users  AS reader_users
+LEFT JOIN public.users  AS users ON reader_users.user_id = users.id 
+
+WHERE 
+	(((users.efolder_documents_fetched_at ) >= ((DATEADD(minute,-29, DATE_TRUNC('minute', GETDATE()) ))) AND (users.efolder_documents_fetched_at ) < ((DATEADD(minute,30, DATEADD(minute,-29, DATE_TRUNC('minute', GETDATE()) ) )))))
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Alert - In Progress AMA Appeals without any actions in the past 3 weeks.sql
+++ b/app/sql/looker/looks_sqls/Alert - In Progress AMA Appeals without any actions in the past 3 weeks.sql
@@ -1,0 +1,174 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	DATE(appeal_task_status.task_max_updated_at) AS "appeal_task_status.task_most_recently_updated_at_date"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE ((appeal_task_status.task_max_updated_at < (DATEADD(week,-3, DATE_TRUNC('week', DATE_TRUNC('day',GETDATE())) )))) AND ((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END NOT IN ('1. Not distributed', '7. Decision dispatched') OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+ORDER BY 5 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Alert - No New EstablishClaims Tasks Prepared in the past 24 hours.sql
+++ b/app/sql/looker/looks_sqls/Alert - No New EstablishClaims Tasks Prepared in the past 24 hours.sql
@@ -1,0 +1,10 @@
+SELECT 
+	TO_CHAR(dispatch_tasks.prepared_at , 'YYYY-MM-DD HH24:MI:SS') AS "dispatch_tasks.prepared_time",
+	dispatch_tasks.appeal_id  AS "dispatch_tasks.appeal_id"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+WHERE 
+	(((dispatch_tasks.prepared_at ) >= ((DATEADD(hour,-23, DATE_TRUNC('hour', GETDATE()) ))) AND (dispatch_tasks.prepared_at ) < ((DATEADD(hour,24, DATEADD(hour,-23, DATE_TRUNC('hour', GETDATE()) ) )))))
+GROUP BY 1,2
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Alert - Pending Decision Documents not uploaded to VBMS.sql
+++ b/app/sql/looker/looks_sqls/Alert - Pending Decision Documents not uploaded to VBMS.sql
@@ -1,0 +1,14 @@
+SELECT 
+	decision_documents.id  AS "decision_documents.id",
+	decision_documents.appeal_id  AS "decision_documents.appeal_id",
+	DATE(decision_documents.uploaded_to_vbms_at ) AS "decision_documents.uploaded_to_vbms_date",
+	DATE(decision_documents.submitted_at ) AS "decision_documents.submitted_date",
+	DATE(decision_documents.processed_at ) AS "decision_documents.processed_date",
+	DATE(decision_documents.attempted_at ) AS "decision_documents.attempted_date"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE ((decision_documents.submitted_at  < (DATEADD(day,-2, DATE_TRUNC('day',GETDATE()) )))) AND (decision_documents.processed_at  IS NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 3 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Alert - There are Pending Task Timers that haven't been completed.sql
+++ b/app/sql/looker/looks_sqls/Alert - There are Pending Task Timers that haven't been completed.sql
@@ -1,0 +1,14 @@
+SELECT 
+	task_timers.id  AS "task_timers.id",
+	DATE(task_timers.processed_at ) AS "task_timers.processed_date",
+	DATE(task_timers.submitted_at ) AS "task_timers.submitted_date",
+	DATE(task_timers.attempted_at ) AS "task_timers.attempted_date",
+	DATE(task_timers.created_at ) AS "task_timers.created_date"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN public.task_timers  AS task_timers ON task_timers.task_id =  tasks.id
+
+WHERE ((task_timers.created_at  < (DATEADD(day,-1, DATE_TRUNC('day',GETDATE()) )))) AND (task_timers.processed_at  IS NULL) AND ((task_timers.submitted_at  < (DATEADD(day,-2, DATE_TRUNC('day',GETDATE()) ))))
+GROUP BY 1,2,3,4,5
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Alert - VACOLS DMS is outdated.sql
+++ b/app/sql/looker/looks_sqls/Alert - VACOLS DMS is outdated.sql
@@ -1,0 +1,10 @@
+SELECT 
+	vacols_corres."STAFKEY"  AS "vacols_corres.stafkey",
+	vacols_corres."SNOTES"  AS "vacols_corres.snotes",
+	TO_CHAR(to_timestamp(vacols_corres."SNOTES", 'YYYY-MM-DD HH24:MI:SS'), 'YYYY-MM-DD HH24:MI:SS') AS "vacols_corres.snotes_date_time"
+FROM "VACOLS"."CORRES"  AS vacols_corres
+
+WHERE ((to_timestamp(vacols_corres."SNOTES", 'YYYY-MM-DD HH24:MI:SS') < (DATEADD(day,-1, DATE_TRUNC('day',GETDATE()) )))) AND (((vacols_corres."STAFKEY") = '3479B8F9'))
+GROUP BY 1,2,3
+ORDER BY 3 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Appeal Status by AMA Lane.sql
+++ b/app/sql/looker/looks_sqls/Appeal Status by AMA Lane.sql
@@ -1,0 +1,289 @@
+-- raw sql results do not include filled-in values for 'appeal_task_status.decision_status'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeal_task_status.decision_status__sort_","appeal_task_status.decision_status") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "appeal_task_status.decision_status__sort_" ASC, z__pivot_col_rank, "appeal_task_status.decision_status") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Appeals Dispositions FYTD.sql
+++ b/app/sql/looker/looks_sqls/Appeals Dispositions FYTD.sql
@@ -1,0 +1,270 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Appeals Dispositions Totals - Case and Issue Totals by Disposition Type (Allowed, Denied, Remanded).sql
+++ b/app/sql/looker/looks_sqls/Appeals Dispositions Totals - Case and Issue Totals by Disposition Type (Allowed, Denied, Remanded).sql
@@ -1,0 +1,302 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	request_issues.disposition  AS "request_issues.disposition",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3,4
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Appeals Dispositions by Month.sql
+++ b/app/sql/looker/looks_sqls/Appeals Dispositions by Month.sql
@@ -1,0 +1,276 @@
+-- raw sql results do not include filled-in values for 'decision_documents.decision_month'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	TO_CHAR(DATE_TRUNC('month', decision_documents.decision_date ), 'YYYY-MM') AS "decision_documents.decision_month",
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY DATE_TRUNC('month', decision_documents.decision_date )
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Appeals Pending Excluding Dispatched Appeals.sql
+++ b/app/sql/looker/looks_sqls/Appeals Pending Excluding Dispatched Appeals.sql
@@ -1,0 +1,654 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeal_task_status.decision_status__sort_","appeal_task_status.decision_status") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "appeal_task_status.decision_status__sort_" ASC, z__pivot_col_rank, "appeal_task_status.decision_status") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 30000
+
+-- sql for creating the grand totals
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Appeals Pending by Lane Graph.sql
+++ b/app/sql/looker/looks_sqls/Appeals Pending by Lane Graph.sql
@@ -1,0 +1,295 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) <> '7. Decision dispatched' OR (CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) IS NULL))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Appeals Task Status.sql
+++ b/app/sql/looker/looks_sqls/Appeals Task Status.sql
@@ -1,0 +1,130 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	appeal_task_status.judge_task_status AS "appeal_task_status.judge_task_status",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.attorney_task_status AS "appeal_task_status.attorney_task_status",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+GROUP BY 1,2,3,4,5,6
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Appellant with duplicate appeal, each on different dockets, same issues.sql
+++ b/app/sql/looker/looks_sqls/Appellant with duplicate appeal, each on different dockets, same issues.sql
@@ -1,0 +1,25 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	appeals.id  AS "appeals.id",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	tasks.type  AS "tasks.type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+
+WHERE ((tasks.type  IN ('JudgeTask', 'RootTask'))) AND (appeals.veteran_file_number = '20805856')
+GROUP BY 1,2,3,4,5,6,7
+ORDER BY 1 DESC
+LIMIT 750

--- a/app/sql/looker/looks_sqls/Assigned to Privacy Team.sql
+++ b/app/sql/looker/looks_sqls/Assigned to Privacy Team.sql
@@ -1,0 +1,48 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.action","tasks.instructions","assigned_to_organization.name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.action", "tasks.instructions", "assigned_to_organization.name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	assigned_to_organization.name  AS "assigned_to_organization.name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE 
+	(assigned_to_organization.name = 'Privacy Team')
+GROUP BY 1,2,3,4,5,6,7) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE 
+	(assigned_to_organization.name = 'Privacy Team')
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Attorneys assigned RAMP cases.sql
+++ b/app/sql/looker/looks_sqls/Attorneys assigned RAMP cases.sql
@@ -1,0 +1,72 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "assigned_to_user.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "assigned_to_user.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.type" NULLS LAST, "tasks.status" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.type  AS "tasks.type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.type  AS "tasks.type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Attorneys by SSC.sql
+++ b/app/sql/looker/looks_sqls/Attorneys by SSC.sql
@@ -1,0 +1,9 @@
+SELECT 
+	vacols_staff.smemgrp  AS "vacols_staff.smemgrp",
+	COUNT(*) AS "vacols_staff.count"
+FROM vacols.staff  AS vacols_staff
+
+WHERE (vacols_staff.sactive = 'A') AND (((vacols_staff.smemgrp IS NOT NULL) AND vacols_staff.smemgrp <> '1220'))
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/Attorneys with issues needing edits.sql
+++ b/app/sql/looker/looks_sqls/Attorneys with issues needing edits.sql
@@ -1,0 +1,15 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.email  AS "assigned_to_user.email",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+
+WHERE (tasks.type = 'AttorneyTask') AND ((appeals.veteran_file_number  IN ('609228688', '250453306', '24611658', '29174023', '20805856')))
+GROUP BY 1,2,3,4
+ORDER BY 5 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Average Days Processed for a decision overall.sql
+++ b/app/sql/looker/looks_sqls/Average Days Processed for a decision overall.sql
@@ -1,0 +1,11 @@
+WITH average_time_for_decision AS (SELECT AVG(DATEDIFF(days, appeals.established_at, decision_documents.decision_date)) as average_time_for_decision
+         from public.appeals as appeals
+         left outer join public.decision_documents as decision_documents on appeals.id = decision_documents.appeal_id
+      )
+SELECT 
+	average_time_for_decision.average_time_for_decision  AS "average_time_for_decision.average_time_for_decision"
+FROM average_time_for_decision
+
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Average Days Processed for a decision per year.sql
+++ b/app/sql/looker/looks_sqls/Average Days Processed for a decision per year.sql
@@ -1,0 +1,128 @@
+-- raw sql results do not include filled-in values for 'decision_documents.decision_year'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	DATE_PART(year, decision_documents.decision_date )::integer AS "decision_documents.decision_year",
+	(COALESCE(CAST( ( SUM(DISTINCT (CAST(FLOOR(COALESCE(DATEDIFF(days, appeals.established_at, decision_documents.decision_date),0)*(CAST(1000000 AS DOUBLE PRECISION)*1.0)) AS DECIMAL(38,0))) + CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0)) ) - SUM(DISTINCT CAST(STRTOL(LEFT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))* 1.0e8 + CAST(STRTOL(RIGHT(MD5(CAST(appeal_task_status.id  AS VARCHAR)),15),16) AS DECIMAL(38,0))) )  AS DOUBLE PRECISION) / CAST((CAST(1000000 AS DOUBLE PRECISION)) AS DOUBLE PRECISION), 0) / NULLIF(COUNT(DISTINCT CASE WHEN  DATEDIFF(days, appeals.established_at, decision_documents.decision_date) IS NOT NULL THEN appeal_task_status.id  ELSE NULL END), 0)) AS "appeal_task_status.average_days_to_complete"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NOT NULL) AND (appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Average Days Processing Test.sql
+++ b/app/sql/looker/looks_sqls/Average Days Processing Test.sql
@@ -1,0 +1,301 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeals.docket_type  AS "appeals.docket_type",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3,4,5
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Average Days pending for a decision per year.sql
+++ b/app/sql/looker/looks_sqls/Average Days pending for a decision per year.sql
@@ -1,0 +1,127 @@
+-- raw sql results do not include filled-in values for 'appeals.established_year'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	DATE_PART(year, appeals.established_at )::integer AS "appeals.established_year"
+FROM appeal_task_status
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeal_task_status.id 
+LEFT JOIN public.appeals  AS appeals ON appeal_task_status.id = appeals.id 
+
+WHERE (decision_documents.decision_date  IS NULL) AND (appeals.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/BVA Decision Progress.sql
+++ b/app/sql/looker/looks_sqls/BVA Decision Progress.sql
@@ -1,0 +1,277 @@
+-- raw sql results do not include filled-in values for 'appeal_task_status.decision_status'
+
+
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/BvaDispatchTasks and QualityReviewTasks missing a Decision issue.sql
+++ b/app/sql/looker/looks_sqls/BvaDispatchTasks and QualityReviewTasks missing a Decision issue.sql
@@ -1,0 +1,9 @@
+SELECT 
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+LEFT JOIN public.decision_issues  AS decision_issues ON tasks.appeal_id = decision_issues.decision_review_id
+
+WHERE ((tasks.type = 'BvaDispatchTask') OR (tasks.type = 'QualityReviewTask')) AND decision_issues.id IS NULL
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Case Distribution - Docket efficiency.sql
+++ b/app/sql/looker/looks_sqls/Case Distribution - Docket efficiency.sql
@@ -1,0 +1,35 @@
+WITH max_nonpriority_not_genpop_docket_index AS (select distinct d_id, coalesce, id, case_id from (select t.d_id, t.coalesce, m.id, m.case_id from(SELECT distributions.id as d_id, coalesce(max(distributed_cases.docket_index),0)
+           FROM public.distributions as distributions
+           LEFT OUTER JOIN public.distributed_cases as distributed_cases ON (distributed_cases.distribution_id = distributions.id
+           and distributed_cases.priority='false' and distributed_cases.genpop_query='not_genpop')
+           group by 1 order by 1) t LEFT OUTER JOIN distributed_cases m ON m.distribution_id = t.d_id AND t.coalesce = m.docket_index  order by d_id) )
+  ,  max_nonpriority_any_docket_index AS (select distinct d_id, coalesce, id, case_id from (select t.d_id, t.coalesce, m.id, m.case_id from(SELECT distributions.id as d_id, coalesce(max(distributed_cases.docket_index),0)
+           FROM public.distributions as distributions
+           LEFT OUTER JOIN public.distributed_cases as distributed_cases ON (distributed_cases.distribution_id = distributions.id
+           and distributed_cases.priority='false' and distributed_cases.genpop_query='any')
+           group by 1 order by 1) t LEFT OUTER JOIN distributed_cases m ON m.distribution_id = t.d_id AND t.coalesce = m.docket_index  order by d_id) )
+  ,  vacols_folder_not_genpop_cases AS (SELECT *,
+          (select count(*) into dcnt from vacols.assign where tsktknm = vf.ticknum and tskactcd in ('B', 'B1', 'B2')) +
+            (select count(*) into hcnt from vacols.hearsched where folder_nr = vf.ticknum and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y')) as AOD
+          from vacols.folder vf )
+  ,  vacols_folder_any_cases AS (SELECT *,
+          (select count(*) into dcnt from vacols.assign where tsktknm = vf.ticknum and tskactcd in ('B', 'B1', 'B2')) +
+            (select count(*) into hcnt from vacols.hearsched where folder_nr = vf.ticknum and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y')) as AOD
+          from vacols.folder vf )
+SELECT 
+	distributions.id  AS "distributions.id",
+	max_nonpriority_any_docket_index.coalesce AS "max_nonpriority_any_docket_index.docket_index",
+	max_nonpriority_not_genpop_docket_index.coalesce AS "max_nonpriority_not_genpop_docket_index.docket_index",
+	vacols_folder_not_genpop_cases.tinum  AS "vacols_folder_not_genpop_cases.tinum",
+	vacols_folder_any_cases.tinum  AS "vacols_folder_any_cases.tinum",
+	COUNT(CASE WHEN (distributed_cases.priority = 'false') AND (distributed_cases.genpop_query LIKE 'not_genpop') THEN 1 ELSE NULL END) AS "distributed_cases.not_genpop_non_priority_count"
+FROM public.distributions  AS distributions
+LEFT JOIN public.distributed_cases  AS distributed_cases ON distributions.id = distributed_cases.distribution_id 
+LEFT JOIN max_nonpriority_not_genpop_docket_index ON max_nonpriority_not_genpop_docket_index.d_id = distributions.id 
+LEFT JOIN max_nonpriority_any_docket_index ON max_nonpriority_any_docket_index.d_id = distributions.id 
+LEFT JOIN vacols_folder_not_genpop_cases ON max_nonpriority_not_genpop_docket_index.case_id = vacols_folder_not_genpop_cases.ticknum 
+LEFT JOIN vacols_folder_any_cases ON max_nonpriority_any_docket_index.case_id = vacols_folder_any_cases.ticknum 
+
+GROUP BY 1,2,3,4,5
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Cases with completed dispatch tasks.sql
+++ b/app/sql/looker/looks_sqls/Cases with completed dispatch tasks.sql
@@ -1,0 +1,28 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.contested_issue_description  AS "request_issues.contested_issue_description",
+	request_issues.disposition  AS "request_issues.disposition",
+	decision_issues.description  AS "decision_issues.description",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	remand_reasons.code  AS "remand_reasons.code",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+LEFT JOIN public.remand_reasons  AS remand_reasons ON request_issues.id = remand_reasons.request_issue_id
+LEFT JOIN public.decision_issues  AS decision_issues ON tasks.appeal_id = decision_issues.decision_review_id
+LEFT JOIN public.decision_documents  AS decision_documents ON tasks.appeal_id = decision_documents.appeal_id
+
+WHERE (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_completed')) AND (tasks.type = 'BvaDispatchTask') AND (assigned_to_user.css_id <> 'VSCBPIET' OR assigned_to_user.css_id IS NULL) AND ((((decision_documents.decision_date ) >= (DATE(DATE '2019-01-23')) AND (decision_documents.decision_date ) < (DATE(DATE '2019-02-19')))))
+GROUP BY 1,2,3,4,5,6,7,8
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Co-located pilot report.sql
+++ b/app/sql/looker/looks_sqls/Co-located pilot report.sql
@@ -1,0 +1,20 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.action") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.action") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	tasks.action  AS "tasks.action",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Co-located pilot.sql
+++ b/app/sql/looker/looks_sqls/Co-located pilot.sql
@@ -1,0 +1,41 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.action","tasks.instructions") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.action", "tasks.instructions") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1,2,3,4,5) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Co-located tasks.sql
+++ b/app/sql/looker/looks_sqls/Co-located tasks.sql
@@ -1,0 +1,48 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "legacy_appeals.vbms_id","appeals.veteran_file_number","tasks.instructions","tasks.appeal_id","tasks.created_date","tasks.status","tasks.action") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "tasks.created_date" DESC, z__pivot_col_rank, "legacy_appeals.vbms_id", "appeals.veteran_file_number", "tasks.instructions", "tasks.appeal_id", "tasks.status", "tasks.action") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" DESC NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	legacy_appeals.vbms_id  AS "legacy_appeals.vbms_id",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	tasks.instructions  AS "tasks.instructions",
+	tasks.appeal_id  AS "tasks.appeal_id",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.action  AS "tasks.action",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals  AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id AND tasks.appeal_type = 'LegacyAppeal'
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1,2,3,4,5,6,7,8) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals  AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id AND tasks.appeal_type = 'LegacyAppeal'
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Completed IHP tasks.sql
+++ b/app/sql/looker/looks_sqls/Completed IHP tasks.sql
@@ -1,0 +1,21 @@
+SELECT 
+	assigned_to_organization.name  AS "assigned_to_organization.name",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(tasks.assigned_at ) AS "tasks.assigned_date"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE 
+	(tasks.type = 'InformalHearingPresentationTask')
+GROUP BY 1,2,3,4
+ORDER BY 3 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Completed InformalHearingPresentationTask(s).sql
+++ b/app/sql/looker/looks_sqls/Completed InformalHearingPresentationTask(s).sql
@@ -1,0 +1,23 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	DATE(tasks.assigned_at ) AS "tasks.assigned_date",
+	CASE tasks.assigned_to_type
+          WHEN 'Organization' THEN assigned_to_organization.name
+          WHEN 'User' THEN assigned_to_user.full_name
+         END
+         AS "tasks.completed_by"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE (tasks.type = 'InformalHearingPresentationTask') AND ((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_completed')
+GROUP BY 1,2,3
+ORDER BY 2 DESC,3 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Completed Tasks - VLJ Support Staff.sql
+++ b/app/sql/looker/looks_sqls/Completed Tasks - VLJ Support Staff.sql
@@ -1,0 +1,55 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.action","tasks.instructions") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.action", "tasks.instructions") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_completed')) AND (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2,3,4,5,6) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 1000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_completed')) AND (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/Completed and On Hold Tasks - VLJ Support Staff.sql
+++ b/app/sql/looker/looks_sqls/Completed and On Hold Tasks - VLJ Support Staff.sql
@@ -1,0 +1,57 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.action","tasks.instructions") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.action", "tasks.instructions") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE ((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         IN ('3_completed', '3_on_hold'))) AND (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2,3,4,5,6) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 1000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE ((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         IN ('3_completed', '3_on_hold'))) AND (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/Count of AMA appeal decisions.sql
+++ b/app/sql/looker/looks_sqls/Count of AMA appeal decisions.sql
@@ -1,0 +1,19 @@
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE (decision_documents.citation_number IS NOT NULL) AND ((((decision_documents.decision_date ) >= (DATE(DATE '2019-06-01')) AND (decision_documents.decision_date ) < (DATE(DATE '2019-06-30')))))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE (decision_documents.citation_number IS NOT NULL) AND ((((decision_documents.decision_date ) >= (DATE(DATE '2019-06-01')) AND (decision_documents.decision_date ) < (DATE(DATE '2019-06-30')))))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Count of attorneys.sql
+++ b/app/sql/looker/looks_sqls/Count of attorneys.sql
@@ -1,0 +1,6 @@
+SELECT 
+	COUNT(*) AS "vacols_staff.count"
+FROM vacols.staff  AS vacols_staff
+
+WHERE (vacols_staff.sactive = 'A') AND ((vacols_staff.sattyid IS NOT NULL)) AND (vacols_staff.svlj <> 'J' OR vacols_staff.svlj IS NULL)
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Count of hearing dispositions.sql
+++ b/app/sql/looker/looks_sqls/Count of hearing dispositions.sql
@@ -1,0 +1,23 @@
+SELECT 
+	hearings.disposition  AS "hearings.disposition",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.hearings  AS hearings
+LEFT JOIN public.appeals  AS appeals ON hearings.appeal_id = appeals.id 
+LEFT JOIN public.hearing_days  AS hearing_days ON hearings.hearing_day_id = hearing_days.id 
+
+WHERE 
+	(((hearing_days.scheduled_for ) >= (DATE(DATE '2019-06-01')) AND (hearing_days.scheduled_for ) < (DATE(DATE '2019-06-30'))))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.hearings  AS hearings
+LEFT JOIN public.appeals  AS appeals ON hearings.appeal_id = appeals.id 
+LEFT JOIN public.hearing_days  AS hearing_days ON hearings.hearing_day_id = hearing_days.id 
+
+WHERE 
+	(((hearing_days.scheduled_for ) >= (DATE(DATE '2019-06-01')) AND (hearing_days.scheduled_for ) < (DATE(DATE '2019-06-30'))))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Count of legacy appeal decisions.sql
+++ b/app/sql/looker/looks_sqls/Count of legacy appeal decisions.sql
@@ -1,0 +1,14 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	COUNT(*) AS "vacols_brieff.count"
+FROM vacols_brieff
+
+WHERE ((vacols_brieff."BFDC"  IN ('1', '3', '4'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2019-06-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2019-06-30')))))
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Daily Case Distribution.sql
+++ b/app/sql/looker/looks_sqls/Daily Case Distribution.sql
@@ -1,0 +1,11 @@
+SELECT 
+	DATE(distributions.completed_at ) AS "distributions.completed_date",
+	COUNT(distributed_cases.id ) AS "distributed_cases.count"
+FROM public.distributions  AS distributions
+LEFT JOIN public.distributed_cases  AS distributed_cases ON distributions.id = distributed_cases.distribution_id 
+
+GROUP BY 1
+HAVING 
+	NOT (COUNT(distributed_cases.id ) IS NULL)
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Decision Hierarchy.sql
+++ b/app/sql/looker/looks_sqls/Decision Hierarchy.sql
@@ -1,0 +1,14 @@
+SELECT 
+	appeals.id  AS "appeals.id",
+	coalesce(MAX((case when request_issues.disposition = 'allowed' then 3
+            when request_issues.disposition = 'remanded' then 2
+            when request_issues.disposition = 'denied' then 1
+            end)), 0) AS "appeals.decision_hierarchy_max_points"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+
+WHERE 
+	((request_issues.disposition IS NOT NULL))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Decision Issues Disposition question.sql
+++ b/app/sql/looker/looks_sqls/Decision Issues Disposition question.sql
@@ -1,0 +1,13 @@
+SELECT 
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	appeals.uuid  AS "appeals.uuid",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	decision_issues.decision_review_type  AS "decision_issues.decision_review_type",
+	decision_issues.disposition  AS "decision_issues.disposition"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+
+WHERE ((((appeals.receipt_date ) >= (DATE(DATE '2018-08-06')) AND (appeals.receipt_date ) < (DATE(DATE '2018-12-05'))))) AND ((appeals.uuid  IN ('364bc6f9-1a1c-4e47-8938-821f9204b381', 'f12c115b-71b9-416a-af60-5493f66c65ae', '0137638d-a14b-4cbc-a6a1-ee5db13beb2a')))
+GROUP BY 1,2,3,4,5
+ORDER BY 3 DESC
+LIMIT 2000

--- a/app/sql/looker/looks_sqls/Decisions made by judge.sql
+++ b/app/sql/looker/looks_sqls/Decisions made by judge.sql
@@ -1,0 +1,125 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(decision_documents.id ) AS "decision_documents.count",
+	COUNT(CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 1 ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Dispatch Tasks Breakdown (2).sql
+++ b/app/sql/looker/looks_sqls/Dispatch Tasks Breakdown (2).sql
@@ -1,0 +1,8 @@
+SELECT 
+	dispatch_tasks.aasm_state  AS "dispatch_tasks.aasm_state",
+	COUNT(*) AS "dispatch_tasks.count"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Dispatch Tasks Breakdown when Unprepared is greater than 200.sql
+++ b/app/sql/looker/looks_sqls/Dispatch Tasks Breakdown when Unprepared is greater than 200.sql
@@ -1,0 +1,12 @@
+SELECT 
+	dispatch_tasks.aasm_state  AS "dispatch_tasks.aasm_state",
+	COUNT(*) AS "dispatch_tasks.count"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+WHERE 
+	(dispatch_tasks.aasm_state = 'unprepared')
+GROUP BY 1
+HAVING 
+	(COUNT(*) > 200)
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Dispatch Tasks Breakdown.sql
+++ b/app/sql/looker/looks_sqls/Dispatch Tasks Breakdown.sql
@@ -1,0 +1,8 @@
+SELECT 
+	dispatch_tasks.aasm_state  AS "dispatch_tasks.aasm_state",
+	COUNT(*) AS "dispatch_tasks.count"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Dispatch Tasks Median Time to Complete (Week-over-week).sql
+++ b/app/sql/looker/looks_sqls/Dispatch Tasks Median Time to Complete (Week-over-week).sql
@@ -1,0 +1,14 @@
+-- raw sql results do not include filled-in values for 'dispatch_tasks.completed_week'
+
+
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', dispatch_tasks.completed_at ), 'YYYY-MM-DD') AS "dispatch_tasks.completed_week",
+	MEDIAN(((DATE(dispatch_tasks.prepared_at )) - (DATE(dispatch_tasks.created_at )))) AS "dispatch_tasks.median_task_create_to_prepare_time",
+	MEDIAN(((DATE(dispatch_tasks.completed_at )) - (DATE(dispatch_tasks.prepared_at )))) AS "dispatch_tasks.median_task_prepare_to_complete_time"
+FROM public.dispatch_tasks  AS dispatch_tasks
+
+WHERE 
+	(((dispatch_tasks.completed_at ) >= ((DATEADD(month,-8, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ))) AND (dispatch_tasks.completed_at ) < ((DATEADD(month,9, DATEADD(month,-8, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) ) )))))
+GROUP BY DATE_TRUNC('week', dispatch_tasks.completed_at )
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Dispatched AMA decisions with issue count.sql
+++ b/app/sql/looker/looks_sqls/Dispatched AMA decisions with issue count.sql
@@ -1,0 +1,10 @@
+SELECT 
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE 
+	decision_documents.citation_number IS NOT NULL  
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Disposition breakdown by previous adjudication.sql
+++ b/app/sql/looker/looks_sqls/Disposition breakdown by previous adjudication.sql
@@ -1,0 +1,42 @@
+WITH request_issues_by_previous_adjudication AS (SELECT distinct request_issue.id AS request_issue_id, request_issue.disposition, election.option_selected
+      FROM ramp_issues refiling_issue, ramp_issues source_issue, ramp_elections election, ramp_refilings refiling, appeals appeal, request_issues request_issue
+      WHERE
+      refiling_issue.source_issue_id = source_issue.id AND
+      refiling_issue.review_type = 'RampRefiling' AND
+      refiling_issue.review_id = refiling.id AND
+      refiling.option_selected = 'appeal' AND
+      source_issue.review_type = 'RampElection' AND
+      source_issue.review_id = election.id AND
+      refiling.veteran_file_number = appeal.veteran_file_number AND
+      request_issue.review_request_id = appeal.id
+       )
+SELECT 
+	request_issues_by_previous_adjudication.option_selected  AS "request_issues_by_previous_adjudication.previous_adjudication",
+	request_issues_by_previous_adjudication.disposition  AS "request_issues_by_previous_adjudication.disposition",
+	COUNT(*) AS "request_issues_by_previous_adjudication.count"
+FROM public.request_issues  AS request_issues
+LEFT JOIN request_issues_by_previous_adjudication ON request_issues.id = request_issues_by_previous_adjudication.request_issue_id 
+
+GROUP BY 1,2
+ORDER BY 1 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH request_issues_by_previous_adjudication AS (SELECT distinct request_issue.id AS request_issue_id, request_issue.disposition, election.option_selected
+      FROM ramp_issues refiling_issue, ramp_issues source_issue, ramp_elections election, ramp_refilings refiling, appeals appeal, request_issues request_issue
+      WHERE
+      refiling_issue.source_issue_id = source_issue.id AND
+      refiling_issue.review_type = 'RampRefiling' AND
+      refiling_issue.review_id = refiling.id AND
+      refiling.option_selected = 'appeal' AND
+      source_issue.review_type = 'RampElection' AND
+      source_issue.review_id = election.id AND
+      refiling.veteran_file_number = appeal.veteran_file_number AND
+      request_issue.review_request_id = appeal.id
+       )
+SELECT 
+	COUNT(*) AS "request_issues_by_previous_adjudication.count"
+FROM public.request_issues  AS request_issues
+LEFT JOIN request_issues_by_previous_adjudication ON request_issues.id = request_issues_by_previous_adjudication.request_issue_id 
+
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Disposition of Appeals by Type Action Code.sql
+++ b/app/sql/looker/looks_sqls/Disposition of Appeals by Type Action Code.sql
@@ -1,0 +1,104 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_brieff.bfac_translated") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "vacols_brieff.action_decision_count" ELSE NULL END DESC NULLS LAST, "vacols_brieff.action_decision_count" DESC, z__pivot_col_rank, "vacols_brieff.bfac_translated") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_brieff.bfdc" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	vacols_brieff."BFDC"  AS "vacols_brieff.bfdc",
+	CASE
+        WHEN (vacols_brieff."BFAC") = 1 THEN 'Original'
+        WHEN (vacols_brieff."BFAC") = 2 THEN 'Supplemental'
+        WHEN (vacols_brieff."BFAC") = 3 THEN 'Post Remand'
+        WHEN (vacols_brieff."BFAC") = 4 THEN 'Reconsideration'
+        WHEN (vacols_brieff."BFAC") = 5 THEN 'Vacated'
+        WHEN (vacols_brieff."BFAC") = 6 THEN 'De Novo'
+        WHEN (vacols_brieff."BFAC") = 7 THEN 'Court Remand'
+        WHEN (vacols_brieff."BFAC") = 8 THEN 'Designation of Record'
+        WHEN (vacols_brieff."BFAC") = 9 THEN 'CUE'
+        ELSE (vacols_brieff."BFAC")
+      END
+       AS "vacols_brieff.bfac_translated",
+	COUNT(*) AS "vacols_brieff.action_decision_count"
+FROM vacols_brieff
+
+WHERE ((vacols_brieff."BFAC"  IN ('1', '2', '3', '4', '5', '6', '8', '9', '7'))) AND ((vacols_brieff."BFDC"  IN ('1', '2', '3', '4', '5', '6', '7', '8', '9'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-02')))))
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	vacols_brieff."BFDC"  AS "vacols_brieff.bfdc",
+	COUNT(*) AS "vacols_brieff.action_decision_count"
+FROM vacols_brieff
+
+WHERE ((vacols_brieff."BFAC"  IN ('1', '2', '3', '4', '5', '6', '8', '9', '7'))) AND ((vacols_brieff."BFDC"  IN ('1', '2', '3', '4', '5', '6', '7', '8', '9'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-02')))))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	CASE
+        WHEN (vacols_brieff."BFAC") = 1 THEN 'Original'
+        WHEN (vacols_brieff."BFAC") = 2 THEN 'Supplemental'
+        WHEN (vacols_brieff."BFAC") = 3 THEN 'Post Remand'
+        WHEN (vacols_brieff."BFAC") = 4 THEN 'Reconsideration'
+        WHEN (vacols_brieff."BFAC") = 5 THEN 'Vacated'
+        WHEN (vacols_brieff."BFAC") = 6 THEN 'De Novo'
+        WHEN (vacols_brieff."BFAC") = 7 THEN 'Court Remand'
+        WHEN (vacols_brieff."BFAC") = 8 THEN 'Designation of Record'
+        WHEN (vacols_brieff."BFAC") = 9 THEN 'CUE'
+        ELSE (vacols_brieff."BFAC")
+      END
+       AS "vacols_brieff.bfac_translated",
+	COUNT(*) AS "vacols_brieff.action_decision_count"
+FROM vacols_brieff
+
+WHERE ((vacols_brieff."BFAC"  IN ('1', '2', '3', '4', '5', '6', '8', '9', '7'))) AND ((vacols_brieff."BFDC"  IN ('1', '2', '3', '4', '5', '6', '7', '8', '9'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-02')))))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 30000
+
+-- sql for creating the grand totals
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	COUNT(*) AS "vacols_brieff.action_decision_count"
+FROM vacols_brieff
+
+WHERE ((vacols_brieff."BFAC"  IN ('1', '2', '3', '4', '5', '6', '8', '9', '7'))) AND ((vacols_brieff."BFDC"  IN ('1', '2', '3', '4', '5', '6', '7', '8', '9'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-02')))))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Duplicate TrackVeteranTasks.sql
+++ b/app/sql/looker/looks_sqls/Duplicate TrackVeteranTasks.sql
@@ -1,0 +1,15 @@
+SELECT 
+	tasks.appeal_type  AS "tasks.appeal_type",
+	tasks.appeal_id  AS "tasks.appeal_id",
+	tasks.type  AS "tasks.type",
+	tasks.assigned_to_type  AS "tasks.assigned_to_type",
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	tasks.action  AS "tasks.action"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.status  IN ('assigned', 'in_progress', 'on_hold'))) AND (tasks.assigned_to_type = 'Organization') AND (tasks.type = 'TrackVeteranTask')
+GROUP BY 1,2,3,4,5,6
+HAVING 
+	(COUNT(DISTINCT tasks.id ) > 1)
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/For Monday Standup v2 - Dispositions.sql
+++ b/app/sql/looker/looks_sqls/For Monday Standup v2 - Dispositions.sql
@@ -1,0 +1,271 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	decision_issues.description  AS "decision_issues.description",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	DATE(decision_documents.processed_at ) AS "decision_documents.processed_date",
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	veterans.id  AS "veterans.id",
+	veterans.file_number  AS "veterans.file_number",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (decision_documents.citation_number IS NOT NULL)
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14
+ORDER BY 9 DESC
+LIMIT 10
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (decision_documents.citation_number IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/For Monday Standup v2.sql
+++ b/app/sql/looker/looks_sqls/For Monday Standup v2.sql
@@ -1,0 +1,276 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	decision_issues.description  AS "decision_issues.description",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	DATE(decision_documents.processed_at ) AS "decision_documents.processed_date",
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	veterans.id  AS "veterans.id",
+	veterans.file_number  AS "veterans.file_number",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	decision_issues.decision_review_type  AS "decision_issues.decision_review_type",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count",
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15
+ORDER BY 9 DESC
+LIMIT 10
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count",
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/For Monday Standup.sql
+++ b/app/sql/looker/looks_sqls/For Monday Standup.sql
@@ -1,0 +1,275 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	decision_issues.description  AS "decision_issues.description",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	DATE(decision_documents.processed_at ) AS "decision_documents.processed_date",
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	veterans.id  AS "veterans.id",
+	veterans.file_number  AS "veterans.file_number",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count",
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14
+ORDER BY 9 DESC
+LIMIT 10
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count",
+	COUNT(DISTINCT CASE WHEN decision_documents.citation_number IS NOT NULL   THEN decision_documents.id  ELSE NULL END) AS "decision_documents.bva_decision_dispatched_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Grand, Denial, Remand totals by issues and docket.sql
+++ b/app/sql/looker/looks_sqls/Grand, Denial, Remand totals by issues and docket.sql
@@ -1,0 +1,18 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "request_issues.disposition") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "request_issues.appeal_request_issue_count" ELSE NULL END DESC NULLS LAST, "request_issues.appeal_request_issue_count" DESC, z__pivot_col_rank, "request_issues.disposition") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.disposition  AS "request_issues.disposition",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Grant, Denial and Remand totals by issue.sql
+++ b/app/sql/looker/looks_sqls/Grant, Denial and Remand totals by issue.sql
@@ -1,0 +1,19 @@
+SELECT 
+	request_issues.disposition  AS "request_issues.disposition",
+	COUNT(*) AS "request_issues.count"
+FROM public.request_issues  AS request_issues
+
+WHERE 
+	((request_issues.disposition IS NOT NULL))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(*) AS "request_issues.count"
+FROM public.request_issues  AS request_issues
+
+WHERE 
+	((request_issues.disposition IS NOT NULL))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Hearing Report Summary by Team_Member.sql
+++ b/app/sql/looker/looks_sqls/Hearing Report Summary by Team_Member.sql
@@ -1,0 +1,140 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_hearsched.team","vacols_hearsched.board_member","vacols_staff.snamef","vacols_staff.snamel") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=5 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=5 THEN "vacols_hearsched.hearing_result_count" ELSE NULL END DESC NULLS LAST, "vacols_hearsched.hearing_result_count" DESC, z__pivot_col_rank, "vacols_hearsched.team", "vacols_hearsched.board_member", "vacols_staff.snamef", "vacols_staff.snamel") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_hearsched.hearing_type" NULLS LAST, "vacols_hearsched.hearing_disp" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       AS "vacols_hearsched.hearing_type",
+	CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END
+       AS "vacols_hearsched.hearing_disp",
+	vacols_hearsched.team  AS "vacols_hearsched.team",
+	vacols_hearsched.board_member  AS "vacols_hearsched.board_member",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	COUNT(*) AS "vacols_hearsched.hearing_result_count"
+FROM vacols.hearsched  AS vacols_hearsched
+LEFT JOIN vacols.staff  AS vacols_staff ON vacols_hearsched.board_member = vacols_staff.sattyid 
+
+WHERE ((vacols_hearsched.board_member IS NOT NULL) AND (vacols_hearsched.board_member IS NOT NULL AND LENGTH(vacols_hearsched.board_member ) <> 0 )) AND ((((vacols_hearsched.hearing_date ) >= (TIMESTAMP '2017-10-01') AND (vacols_hearsched.hearing_date ) < (TIMESTAMP '2018-09-09')))) AND ((((CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END) IS NOT NULL))) AND ((CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       IN ('Video', 'Central', 'Travel')))
+GROUP BY 1,2,3,4,5,6) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       AS "vacols_hearsched.hearing_type",
+	CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END
+       AS "vacols_hearsched.hearing_disp",
+	COUNT(*) AS "vacols_hearsched.hearing_result_count"
+FROM vacols.hearsched  AS vacols_hearsched
+LEFT JOIN vacols.staff  AS vacols_staff ON vacols_hearsched.board_member = vacols_staff.sattyid 
+
+WHERE ((vacols_hearsched.board_member IS NOT NULL) AND (vacols_hearsched.board_member IS NOT NULL AND LENGTH(vacols_hearsched.board_member ) <> 0 )) AND ((((vacols_hearsched.hearing_date ) >= (TIMESTAMP '2017-10-01') AND (vacols_hearsched.hearing_date ) < (TIMESTAMP '2018-09-09')))) AND ((((CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END) IS NOT NULL))) AND ((CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       IN ('Video', 'Central', 'Travel')))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	vacols_hearsched.team  AS "vacols_hearsched.team",
+	vacols_hearsched.board_member  AS "vacols_hearsched.board_member",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	COUNT(*) AS "vacols_hearsched.hearing_result_count"
+FROM vacols.hearsched  AS vacols_hearsched
+LEFT JOIN vacols.staff  AS vacols_staff ON vacols_hearsched.board_member = vacols_staff.sattyid 
+
+WHERE ((vacols_hearsched.board_member IS NOT NULL) AND (vacols_hearsched.board_member IS NOT NULL AND LENGTH(vacols_hearsched.board_member ) <> 0 )) AND ((((vacols_hearsched.hearing_date ) >= (TIMESTAMP '2017-10-01') AND (vacols_hearsched.hearing_date ) < (TIMESTAMP '2018-09-09')))) AND ((((CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END) IS NOT NULL))) AND ((CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       IN ('Video', 'Central', 'Travel')))
+GROUP BY 1,2,3,4
+ORDER BY 5 DESC
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(*) AS "vacols_hearsched.hearing_result_count"
+FROM vacols.hearsched  AS vacols_hearsched
+LEFT JOIN vacols.staff  AS vacols_staff ON vacols_hearsched.board_member = vacols_staff.sattyid 
+
+WHERE ((vacols_hearsched.board_member IS NOT NULL) AND (vacols_hearsched.board_member IS NOT NULL AND LENGTH(vacols_hearsched.board_member ) <> 0 )) AND ((((vacols_hearsched.hearing_date ) >= (TIMESTAMP '2017-10-01') AND (vacols_hearsched.hearing_date ) < (TIMESTAMP '2018-09-09')))) AND ((((CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END) IS NOT NULL))) AND ((CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       IN ('Video', 'Central', 'Travel')))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/HearingAdminAction > 6 months.sql
+++ b/app/sql/looker/looks_sqls/HearingAdminAction > 6 months.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(month,-6, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type LIKE '%HearingAdminAction%')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings Report.sql
+++ b/app/sql/looker/looks_sqls/Hearings Report.sql
@@ -1,0 +1,50 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       AS "vacols_hearsched.hearing_type",
+	DATE(vacols_hearsched.hearing_date ) AS "vacols_hearsched.hearing_date",
+	CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END
+       AS "vacols_hearsched.hearing_disp",
+	vacols_hearsched.board_member  AS "vacols_hearsched.board_member",
+	vacols_hearsched.team  AS "vacols_hearsched.team",
+	DATE(vacols_brieff."BFD19" ) AS "vacols_brieff.bfd19_date",
+	vacols_brieff."BFREGOFF"  AS "vacols_brieff.bfregoff"
+FROM vacols.hearsched  AS vacols_hearsched
+LEFT JOIN vacols_brieff ON vacols_hearsched.folder_nr = (vacols_brieff."BFKEY") 
+
+WHERE ((((vacols_hearsched.hearing_date ) >= (TIMESTAMP '2017-01-01') AND (vacols_hearsched.hearing_date ) < (TIMESTAMP '2018-09-21')))) AND ((((CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END) IS NOT NULL))) AND ((CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       IN ('V', 'C', 'T')))
+GROUP BY 1,2,3,4,5,6,7
+ORDER BY 2 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (copy 2).sql
+++ b/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (copy 2).sql
@@ -1,0 +1,63 @@
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (copy 3).sql
+++ b/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (copy 3).sql
@@ -1,0 +1,63 @@
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (copy).sql
+++ b/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (copy).sql
@@ -1,0 +1,63 @@
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (moved from Andrew Lomax).sql
+++ b/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks (moved from Andrew Lomax).sql
@@ -1,0 +1,63 @@
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks.sql
+++ b/app/sql/looker/looks_sqls/Hearings Tasks with No Schedule Hearing Tasks.sql
@@ -1,0 +1,63 @@
+WITH hearing_tasks AS (SELECT
+  tasks.id AS "tasks.id",
+  tasks.type  AS "tasks.type",
+  tasks.appeal_id  AS "tasks.appeal_id",
+  tasks.appeal_type  AS "tasks.appeal_type",
+  tasks.status AS "tasks.status",
+  tasks.on_hold_duration AS "tasks.on_hold_duration",
+  tasks.placed_on_hold_at AS "tasks.placed_on_hold_at",
+  tasks.started_at AS "tasks.started_at",
+  hearing_task_associations.id AS "hearing_task_associations.id",
+  legacy_appeals.vacols_id AS "legacy_appeals.vacols_id",
+  legacy_appeals.vbms_id AS "legacy_appeals.vbms_id",
+  (case when tasks.appeal_type = 'Appeal' then appeals.uuid else legacy_appeals.vacols_id end) AS external_id,
+  (case when tasks.appeal_type = 'Appeal' then appeals.closest_regional_office else legacy_appeals.closest_regional_office end)
+    AS closest_regional_office,
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id
+  ) AS "count_of_child_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ScheduleHearingTask'
+  ) AS "schedule_hearing_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'DispositionTask'
+  ) AS "disposition_tasks",
+  (
+    SELECT count(child_tasks.id) FROM tasks AS child_tasks
+    WHERE child_tasks.parent_id = tasks.id AND
+    child_tasks.type = 'ChangeDispositionTask'
+  ) AS "change_disposition_tasks"
+FROM public.tasks AS tasks
+LEFT JOIN public.hearing_task_associations AS hearing_task_associations ON hearing_task_associations.hearing_task_id = tasks.id
+LEFT JOIN public.hearings AS hearings ON hearing_task_associations.hearing_id = hearings.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_hearings AS legacy_hearings ON hearing_task_associations.hearing_id = legacy_hearings.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+LEFT JOIN public.appeals AS appeals ON tasks.appeal_id = appeals.id
+  AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id
+  AND tasks.appeal_type = 'LegacyAppeal'
+WHERE
+  (tasks.type = 'HearingTask')
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 1 DESC
+       )
+SELECT 
+	hearing_tasks."tasks.appeal_id"  AS "hearing_tasks.tasks_appeal_id",
+	hearing_tasks.closest_regional_office  AS "hearing_tasks.closest_regional_office",
+	hearing_tasks."tasks.appeal_type"  AS "hearing_tasks.tasks_appeal_type",
+	hearing_tasks.count_of_child_tasks  AS "hearing_tasks.count_of_child_tasks",
+	hearing_tasks.disposition_tasks  AS "hearing_tasks.disposition_tasks",
+	hearing_tasks.schedule_hearing_tasks  AS "hearing_tasks.schedule_hearing_tasks"
+FROM hearing_tasks
+
+WHERE 
+	(hearing_tasks.schedule_hearing_tasks  = 0)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings: EvidenceWindowTask > 90 days.sql
+++ b/app/sql/looker/looks_sqls/Hearings: EvidenceWindowTask > 90 days.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(day,-90, DATE_TRUNC('day',GETDATE()) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'EvidenceSubmissionWindowTask')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings: NoShowHearingTask > 25 days.sql
+++ b/app/sql/looker/looks_sqls/Hearings: NoShowHearingTask > 25 days.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(day,-25, DATE_TRUNC('day',GETDATE()) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'NoShowHearingTask')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings: ScheduleHearingTasks > 1 year old.sql
+++ b/app/sql/looker/looks_sqls/Hearings: ScheduleHearingTasks > 1 year old.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(year,-1, DATE_TRUNC('year', DATE_TRUNC('day',GETDATE())) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'ScheduleHearingTask')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Hearings: TranscriptionTask > 6 months.sql
+++ b/app/sql/looker/looks_sqls/Hearings: TranscriptionTask > 6 months.sql
@@ -1,0 +1,22 @@
+SELECT 
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	tasks.type  AS "tasks.type",
+	tasks.appeal_id  AS "tasks.appeal_id"
+FROM public.tasks  AS tasks
+
+WHERE ((tasks.started_at  < (DATEADD(month,-6, DATE_TRUNC('month', DATE_TRUNC('day',GETDATE())) )))) AND (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) <> '3_completed' OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type LIKE '%TranscriptionTask%')
+GROUP BY 1,2,3
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Intakes by Vet ID.sql
+++ b/app/sql/looker/looks_sqls/Intakes by Vet ID.sql
@@ -1,0 +1,12 @@
+SELECT 
+	intakes.veteran_file_number  AS "intakes.veteran_file_number",
+	users.full_name  AS "users.full_name",
+	intakes.type  AS "intakes.type",
+	DATE(intakes.completed_at ) AS "intakes.completed_date"
+FROM public.intakes  AS intakes
+LEFT JOIN public.users  AS users ON intakes.user_id = users.id 
+
+WHERE (intakes.completion_status = 'success') AND (intakes.veteran_file_number = '102305870')
+GROUP BY 1,2,3,4
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Intern intakes.sql
+++ b/app/sql/looker/looks_sqls/Intern intakes.sql
@@ -1,0 +1,11 @@
+SELECT 
+	intakes.veteran_file_number  AS "intakes.veteran_file_number",
+	DATE(intakes.started_at ) AS "intakes.started_date",
+	users.full_name  AS "users.full_name"
+FROM public.intakes  AS intakes
+LEFT JOIN public.users  AS users ON intakes.user_id = users.id 
+
+WHERE (intakes.completion_status = 'success') AND ((users.full_name  IN ('CHRISTOPHER HARRIS', 'JESSICA HAMILTON', 'JOHN BARFIELD', 'MARIAM IBRAHIM', 'MATTHEW SOLANO', 'ROBIN BROWN', 'SHANTEL GRAYSON', 'TETYANA LEW')))
+GROUP BY 1,2,3
+ORDER BY 2 DESC
+LIMIT 2000

--- a/app/sql/looker/looks_sqls/Investigating double intakes by attorney tasks.sql
+++ b/app/sql/looker/looks_sqls/Investigating double intakes by attorney tasks.sql
@@ -1,0 +1,23 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	appeals.id  AS "appeals.id",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	tasks.type  AS "tasks.type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 DESC
+LIMIT 750

--- a/app/sql/looker/looks_sqls/Issue Dispositions - All Dockets.sql
+++ b/app/sql/looker/looks_sqls/Issue Dispositions - All Dockets.sql
@@ -1,0 +1,299 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issue Dispositions - Direct Review Docket.sql
+++ b/app/sql/looker/looks_sqls/Issue Dispositions - Direct Review Docket.sql
@@ -1,0 +1,302 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.disposition  AS "request_issues.disposition",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.docket_type = 'direct_review') AND (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3,4
+ORDER BY 4 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.docket_type = 'direct_review') AND (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issue Dispositions - Evidence Docket.sql
+++ b/app/sql/looker/looks_sqls/Issue Dispositions - Evidence Docket.sql
@@ -1,0 +1,302 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.disposition  AS "request_issues.disposition",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.docket_type = 'evidence_submission') AND (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3,4
+ORDER BY 4 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.docket_type = 'evidence_submission') AND (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issue Dispositions - Hearing Docket.sql
+++ b/app/sql/looker/looks_sqls/Issue Dispositions - Hearing Docket.sql
@@ -1,0 +1,302 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.disposition  AS "request_issues.disposition",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.docket_type = 'hearing') AND (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3,4
+ORDER BY 4 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.docket_type = 'hearing') AND (appeals.established_at  IS NOT NULL) AND (request_issues.disposition NOT LIKE '%stayed%' AND request_issues.disposition NOT LIKE '%withdrawn%' OR request_issues.disposition IS NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issue disposition report.sql
+++ b/app/sql/looker/looks_sqls/Issue disposition report.sql
@@ -1,0 +1,194 @@
+-- raw sql results do not include filled-in values for 'vacols_issues.issdcls_month'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_issues.issdcls_month") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "vacols_issues.issdcls_month" DESC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_issues.issdc" DESC NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       AS "vacols_issues.issdc",
+	TO_CHAR(DATE_TRUNC('month', vacols_issues.issdcls ), 'YYYY-MM') AS "vacols_issues.issdcls_month",
+	COUNT(*) AS "vacols_issues.issdc_count"
+FROM vacols.issues  AS vacols_issues
+
+WHERE (((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%1%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%2%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%3%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%4%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%5%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%6%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%7%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%8%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%9%')) AND ((((vacols_issues.issdcls ) >= (TIMESTAMP '2017-10-01') AND (vacols_issues.issdcls ) < (TIMESTAMP '2018-09-09'))))
+GROUP BY 1,DATE_TRUNC('month', vacols_issues.issdcls )) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       AS "vacols_issues.issdc",
+	COUNT(*) AS "vacols_issues.issdc_count"
+FROM vacols.issues  AS vacols_issues
+
+WHERE (((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%1%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%2%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%3%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%4%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%5%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%6%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%7%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%8%' OR (CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END) LIKE '%9%')) AND ((((vacols_issues.issdcls ) >= (TIMESTAMP '2017-10-01') AND (vacols_issues.issdcls ) < (TIMESTAMP '2018-09-09'))))
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Issues decided by lane and disposition.sql
+++ b/app/sql/looker/looks_sqls/Issues decided by lane and disposition.sql
@@ -1,0 +1,280 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	request_issues.disposition  AS "request_issues.disposition",
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2,3,4
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issues dispatched for AMA.sql
+++ b/app/sql/looker/looks_sqls/Issues dispatched for AMA.sql
@@ -1,0 +1,163 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	request_issues.id  AS "request_issues.id"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched')
+GROUP BY 1,2,3
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Issues per Case Test - exludes 0.sql
+++ b/app/sql/looker/looks_sqls/Issues per Case Test - exludes 0.sql
@@ -1,0 +1,313 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	appeals.docket_type  AS "appeals.docket_type",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	decision_documents.appeal_id  AS "decision_documents.appeal_id",
+	COUNT(DISTINCT decision_documents.id ) AS "decision_documents.count",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched')
+GROUP BY 1,2,3,4,5
+HAVING 
+	NOT (COUNT(DISTINCT decision_issues.id ) = 0)
+ORDER BY 4 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT decision_documents.id ) AS "decision_documents.count",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched')
+HAVING 
+	NOT (COUNT(DISTINCT decision_issues.id ) = 0)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issues per Judge.sql
+++ b/app/sql/looker/looks_sqls/Issues per Judge.sql
@@ -1,0 +1,146 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_brieff.bfmemid","vacols_staff.snamef","vacols_staff.snamel") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=7 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=7 THEN "vacols_issues.issdc_count" ELSE NULL END DESC NULLS LAST, "vacols_issues.issdc_count" DESC, z__pivot_col_rank, "vacols_brieff.bfmemid", "vacols_staff.snamef", "vacols_staff.snamel") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_issues.issdc" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       AS "vacols_issues.issdc",
+	vacols_brieff."BFMEMID"  AS "vacols_brieff.bfmemid",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	COUNT(*) AS "vacols_issues.issdc_count"
+FROM vacols.issues  AS vacols_issues
+LEFT JOIN vacols_brieff ON vacols_issues.isskey = (vacols_brieff."BFKEY") 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_brieff."BFMEMID") = vacols_staff.sattyid 
+
+WHERE ((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       IN ('Allowed', 'Remanded', 'Denied', 'Dismissed, Death', 'Dismissed, Withdrawn', 'Vacated'))) AND ((vacols_brieff."BFBOARD"  IN ('D1', 'D5'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-30')))))
+GROUP BY 1,2,3,4) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 1000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       AS "vacols_issues.issdc",
+	COUNT(*) AS "vacols_issues.issdc_count"
+FROM vacols.issues  AS vacols_issues
+LEFT JOIN vacols_brieff ON vacols_issues.isskey = (vacols_brieff."BFKEY") 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_brieff."BFMEMID") = vacols_staff.sattyid 
+
+WHERE ((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       IN ('Allowed', 'Remanded', 'Denied', 'Dismissed, Death', 'Dismissed, Withdrawn', 'Vacated'))) AND ((vacols_brieff."BFBOARD"  IN ('D1', 'D5'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-30')))))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 1000
+
+-- sql for creating the pivot row totals
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	vacols_brieff."BFMEMID"  AS "vacols_brieff.bfmemid",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	COUNT(*) AS "vacols_issues.issdc_count"
+FROM vacols.issues  AS vacols_issues
+LEFT JOIN vacols_brieff ON vacols_issues.isskey = (vacols_brieff."BFKEY") 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_brieff."BFMEMID") = vacols_staff.sattyid 
+
+WHERE ((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       IN ('Allowed', 'Remanded', 'Denied', 'Dismissed, Death', 'Dismissed, Withdrawn', 'Vacated'))) AND ((vacols_brieff."BFBOARD"  IN ('D1', 'D5'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-30')))))
+GROUP BY 1,2,3
+ORDER BY 4 DESC
+LIMIT 30000
+
+-- sql for creating the grand totals
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	COUNT(*) AS "vacols_issues.issdc_count"
+FROM vacols.issues  AS vacols_issues
+LEFT JOIN vacols_brieff ON vacols_issues.isskey = (vacols_brieff."BFKEY") 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_brieff."BFMEMID") = vacols_staff.sattyid 
+
+WHERE ((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       IN ('Allowed', 'Remanded', 'Denied', 'Dismissed, Death', 'Dismissed, Withdrawn', 'Vacated'))) AND ((vacols_brieff."BFBOARD"  IN ('D1', 'D5'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-30')))))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Issues.sql
+++ b/app/sql/looker/looks_sqls/Issues.sql
@@ -1,0 +1,70 @@
+WITH quota AS (SELECT
+        (select tasks.completed_at
+            FROM tasks AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as date_signed,
+        (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+        ) as attorney_id,
+        (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as judge_id,
+        (select vacols.staff.smemgrp
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as chief_group,
+        (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as status,
+        (select attorney_case_reviews.overtime
+          FROM attorney_case_reviews
+          INNER JOIN tasks on attorney_case_reviews.task_id = tasks.id
+          WHERE tasks.appeal_id = appeals.id
+          limit 1
+        ) as overtime,
+        appeals.id as id,
+        request_issues.disposition as disposition
+      FROM public.appeals as appeals
+      LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.review_request_id AND
+        request_issues.review_request_type = 'Appeal'
+      WHERE request_issues.disposition IS NOT NULL
+ORDER BY 1,2
+LIMIT 500
+ )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "quota.date_signed_date","quota.chief_group","quota.judge_id","quota.attorney_id","quota.id") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "quota.date_signed_date" DESC, z__pivot_col_rank, "quota.chief_group", "quota.judge_id", "quota.attorney_id", "quota.id") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "quota.disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	quota."disposition"  AS "quota.disposition",
+	DATE(quota."date_signed" ) AS "quota.date_signed_date",
+	quota."chief_group"  AS "quota.chief_group",
+	quota."judge_id"  AS "quota.judge_id",
+	quota."attorney_id"  AS "quota.attorney_id",
+	quota."id"  AS "quota.id",
+	COUNT(*) AS "quota.count"
+FROM quota
+
+WHERE 
+	(quota."date_signed"  IS NOT NULL)
+GROUP BY 1,2,3,4,5,6) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Judge Case Review locations by week.sql
+++ b/app/sql/looker/looks_sqls/Judge Case Review locations by week.sql
@@ -1,0 +1,20 @@
+-- raw sql results do not include filled-in values for 'judge_case_reviews.created_week'
+
+
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "judge_case_reviews.created_week") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "judge_case_reviews.created_week" DESC, CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "judge_case_reviews.count" ELSE NULL END DESC NULLS LAST, "judge_case_reviews.count" DESC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "judge_case_reviews.location" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	judge_case_reviews.location  AS "judge_case_reviews.location",
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+
+GROUP BY 1,DATE_TRUNC('week', judge_case_reviews.created_at )) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Judge Caseflow productivity by judge per week.sql
+++ b/app/sql/looker/looks_sqls/Judge Caseflow productivity by judge per week.sql
@@ -1,0 +1,58 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "judge_case_reviews.judge_id","users.css_id","users.email","users.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "judge_case_reviews.judge_id" ASC, z__pivot_col_rank, "users.css_id", "users.email", "users.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "judge_case_reviews.created_week" NULLS LAST, "judge_case_reviews.is_legacy" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	CASE WHEN strpos(judge_case_reviews.task_id, '-') > 0  THEN 'Yes' ELSE 'No' END
+ AS "judge_case_reviews.is_legacy",
+	judge_case_reviews.judge_id  AS "judge_case_reviews.judge_id",
+	users.css_id  AS "users.css_id",
+	users.email  AS "users.email",
+	users.full_name  AS "users.full_name",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY DATE_TRUNC('week', judge_case_reviews.created_at ),2,3,4,5,6) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', judge_case_reviews.created_at ), 'YYYY-MM-DD') AS "judge_case_reviews.created_week",
+	CASE WHEN strpos(judge_case_reviews.task_id, '-') > 0  THEN 'Yes' ELSE 'No' END
+ AS "judge_case_reviews.is_legacy",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY DATE_TRUNC('week', judge_case_reviews.created_at ),2
+ORDER BY 1 ,2 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	judge_case_reviews.judge_id  AS "judge_case_reviews.judge_id",
+	users.css_id  AS "users.css_id",
+	users.email  AS "users.email",
+	users.full_name  AS "users.full_name",
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY 1,2,3,4
+ORDER BY 1 
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(*) AS "judge_case_reviews.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Judge Status.sql
+++ b/app/sql/looker/looks_sqls/Judge Status.sql
@@ -1,0 +1,14 @@
+SELECT 
+	judge_case_reviews.judge_id  AS "judge_case_reviews.judge_id",
+	users.full_name  AS "users.full_name",
+	tasks.appeal_id  AS "tasks.appeal_id",
+	COUNT(*) AS "judge_case_reviews.count",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.judge_case_reviews  AS judge_case_reviews
+LEFT JOIN public.tasks  AS tasks ON judge_case_reviews.task_id = tasks.id 
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id 
+LEFT JOIN public.users  AS users ON judge_case_reviews.judge_id = users.id 
+
+GROUP BY 1,2,3
+ORDER BY 5 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Judge completed request issues by disposition.sql
+++ b/app/sql/looker/looks_sqls/Judge completed request issues by disposition.sql
@@ -1,0 +1,134 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeal_task_status.task_judge_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "request_issues.count" ELSE NULL END DESC NULLS LAST, "request_issues.count" DESC, z__pivot_col_rank, "appeal_task_status.task_judge_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "request_issues.disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	request_issues.disposition  AS "request_issues.disposition",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	COUNT(request_issues.id ) AS "request_issues.count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeal_task_status.judge_task_status = 'completed')
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/JudgeAssignTasks days waiting.sql
+++ b/app/sql/looker/looks_sqls/JudgeAssignTasks days waiting.sql
@@ -1,0 +1,25 @@
+SELECT 
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	DATE(tasks.assigned_at ) AS "tasks.assigned_date"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE ((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         NOT IN ('3_completed', '3_on_hold') OR (CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) IS NULL)) AND (tasks.type = 'JudgeAssignTask')
+GROUP BY 1,2,3
+ORDER BY 3 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Judges count of RAMP cases.sql
+++ b/app/sql/looker/looks_sqls/Judges count of RAMP cases.sql
@@ -1,0 +1,33 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "assigned_to_user.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "assigned_to_user.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.type  AS "tasks.type",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type  IN ('JudgeAssignTask', 'JudgeDecisionReviewTask'))
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.type  AS "tasks.type",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type  IN ('JudgeAssignTask', 'JudgeDecisionReviewTask'))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Judges who create attorney tasks.sql
+++ b/app/sql/looker/looks_sqls/Judges who create attorney tasks.sql
@@ -1,0 +1,11 @@
+SELECT 
+	assigned_by_user.full_name  AS "assigned_by_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_by_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_by_id = assigned_by_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/MPR Report Test.sql
+++ b/app/sql/looker/looks_sqls/MPR Report Test.sql
@@ -1,0 +1,26 @@
+WITH vacols_folder AS (SELECT *,
+    (select count(*) into dcnt from vacols.assign where tsktknm = vf.ticknum and tskactcd in ('B', 'B1', 'B2')) +
+      (select count(*) into hcnt from vacols.hearsched where folder_nr = vf.ticknum and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y')) as AOD
+    from vacols.folder vf )
+  ,  vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	DATE(vacols_brieff."BFD19" ) AS "vacols_brieff.bfd19_date",
+	DATE(vacols_brieff."BF41STAT" ) AS "vacols_brieff.bf41_stat_date",
+	DATE(vacols_brieff."BFDDEC" ) AS "vacols_brieff.bfddec_date",
+	DATE(vacols_folder.tidrecv ) AS "vacols_folder.tidrecv_date",
+	vacols_brieff."BFHA"  AS "vacols_brieff.bfha",
+	vacols_folder.AOD AS "vacols_folder.aod_cnt"
+FROM vacols_folder
+LEFT JOIN vacols_brieff ON (vacols_brieff."BFKEY") = vacols_folder.ticknum 
+
+WHERE (((vacols_brieff."BFAC") = '1')) AND ((vacols_brieff."BFDC"  IN ('1', '2', '3', '4', '5', '6', '7', '8', '9'))) AND ((((vacols_brieff."BFDDEC" ) >= ((DATE(DATEADD(day,-99, DATE_TRUNC('day',GETDATE()) )))) AND (vacols_brieff."BFDDEC" ) < ((DATE(DATEADD(day,100, DATEADD(day,-99, DATE_TRUNC('day',GETDATE()) ) )))))))
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Mail Task Type Counts.sql
+++ b/app/sql/looker/looks_sqls/Mail Task Type Counts.sql
@@ -1,0 +1,19 @@
+SELECT 
+	tasks.type  AS "tasks.type",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type  IN ('EvidenceOrArgumentMailTask', 'ClearAndUnmistakeableErrorMailTask', 'HearingRelatedMailTask'))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.type  IN ('EvidenceOrArgumentMailTask', 'ClearAndUnmistakeableErrorMailTask', 'HearingRelatedMailTask'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Mail Tasks Pilot.sql
+++ b/app/sql/looker/looks_sqls/Mail Tasks Pilot.sql
@@ -1,0 +1,50 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.instructions","assigned_to_organization.name","tasks.assigned_to_type","assigned_to_user.roles","tasks.type") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.instructions", "assigned_to_organization.name", "tasks.assigned_to_type", "assigned_to_user.roles", "tasks.type") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.instructions  AS "tasks.instructions",
+	assigned_to_organization.name  AS "assigned_to_organization.name",
+	tasks.assigned_to_type  AS "tasks.assigned_to_type",
+	assigned_to_user.roles  AS "assigned_to_user.roles",
+	tasks.type  AS "tasks.type",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE 
+	(tasks.type  IN ('EvidenceOrArgumentMailTask', 'ClearAndUnmistakeableErrorMailTask', 'HearingRelatedMailTask'))
+GROUP BY 1,2,3,4,5,6,7,8,9) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE 
+	(tasks.type  IN ('EvidenceOrArgumentMailTask', 'ClearAndUnmistakeableErrorMailTask', 'HearingRelatedMailTask'))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 50

--- a/app/sql/looker/looks_sqls/My Copy.sql
+++ b/app/sql/looker/looks_sqls/My Copy.sql
@@ -1,0 +1,12 @@
+WITH vacols_decass AS (select *, (select p.locdin from VACOLS.PRIORLOC p WHERE p.lockey=de.defolder AND p.locstto = '81' ORDER BY p.locdin DESC LIMIT 1) as distribution_date    from VACOLS.DECASS de )
+SELECT 
+	vacols_decass."DEFOLDER"  AS "vacols_decass.defolder",
+	DATE(vacols_decass."DEADTIM" ) AS "vacols_decass.deadtim_date",
+	COUNT(*) AS "vacols_decass.count"
+FROM vacols_decass
+
+GROUP BY 1,2
+HAVING 
+	(COUNT(*) > 2)
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Non-BVA User Appeal Intakes.sql
+++ b/app/sql/looker/looks_sqls/Non-BVA User Appeal Intakes.sql
@@ -1,0 +1,13 @@
+SELECT 
+	intakes.veteran_file_number  AS "intakes.veteran_file_number",
+	users.station_id  AS "users.station_id",
+	users.full_name  AS "users.full_name",
+	DATE(intakes.started_at ) AS "intakes.started_date",
+	intakes.completion_status  AS "intakes.completion_status"
+FROM public.intakes  AS intakes
+LEFT JOIN public.users  AS users ON intakes.user_id = users.id 
+
+WHERE (intakes.completion_status = 'success') AND (intakes.type = 'AppealIntake') AND (users.station_id <> '101' OR users.station_id IS NULL)
+GROUP BY 1,2,3,4,5
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Number of request and decision issues per case.sql
+++ b/app/sql/looker/looks_sqls/Number of request and decision issues per case.sql
@@ -1,0 +1,11 @@
+SELECT 
+	appeals.id  AS "appeals.id",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+
+GROUP BY 1
+ORDER BY 3 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/OT Test.sql
+++ b/app/sql/looker/looks_sqls/OT Test.sql
@@ -1,0 +1,155 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '00' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '01' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '02' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '03' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '04' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '05' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '06' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '07' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN '08' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN '09' 
+END AS "appeal_task_status.decision_status__sort_",
+	CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END AS "appeal_task_status.decision_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	COUNT(request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/OUTDATED VLJ Support Staff Report.sql
+++ b/app/sql/looker/looks_sqls/OUTDATED VLJ Support Staff Report.sql
@@ -1,0 +1,44 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.closed_date","tasks.action","tasks.instructions") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.closed_date", "tasks.action", "tasks.instructions") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(tasks.closed_at ) AS "tasks.closed_date",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2,3,4,5,6,7) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 1000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/On Hold Co-Located Tasks.sql
+++ b/app/sql/looker/looks_sqls/On Hold Co-Located Tasks.sql
@@ -1,0 +1,29 @@
+SELECT 
+	tasks.type  AS "tasks.type",
+	tasks.instructions  AS "tasks.instructions",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.appeal_id  AS "tasks.appeal_id",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	legacy_appeals.vbms_id  AS "legacy_appeals.vbms_id",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.legacy_appeals  AS legacy_appeals ON tasks.appeal_id = legacy_appeals.id AND tasks.appeal_type = 'LegacyAppeal'
+
+WHERE (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_on_hold')) AND (tasks.type = 'ColocatedTask')
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 100000

--- a/app/sql/looker/looks_sqls/Pending incomplete and uncanceled task timers.sql
+++ b/app/sql/looker/looks_sqls/Pending incomplete and uncanceled task timers.sql
@@ -1,0 +1,11 @@
+SELECT 
+	DATE(task_timers.created_at ) AS "task_timers.created_date",
+	task_timers.id  AS "task_timers.id",
+	DATE(task_timers.submitted_at ) AS "task_timers.submitted_date",
+	DATE(task_timers.attempted_at ) AS "task_timers.attempted_date",
+	task_timers.task_id  AS "task_timers.task_id"
+FROM public.task_timers  AS task_timers
+
+WHERE ((task_timers.created_at  < (DATEADD(day,-1, DATE_TRUNC('day',GETDATE()) )))) AND (task_timers.processed_at  IS NULL) AND (task_timers.canceled_at  IS NULL) AND ((task_timers.submitted_at  < (DATEADD(day,-2, DATE_TRUNC('day',GETDATE()) ))))
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Percentage of AMA reviews established within 7 days.sql
+++ b/app/sql/looker/looks_sqls/Percentage of AMA reviews established within 7 days.sql
@@ -1,0 +1,10 @@
+SELECT 
+	intakes.veteran_file_number  AS "intakes.veteran_file_number",
+	DATE(intakes.started_at ) AS "intakes.started_date",
+	DATE(intakes.completed_at ) AS "intakes.completed_date"
+FROM public.intakes  AS intakes
+
+WHERE ((((intakes.started_at ) >= (TIMESTAMP '2019-06-01') AND (intakes.started_at ) < (TIMESTAMP '2019-06-30')))) AND (intakes.type = 'AppealIntake')
+GROUP BY 1,2,3
+ORDER BY 2 DESC
+LIMIT 5000

--- a/app/sql/looker/looks_sqls/Percentage of priority cases for Case Distribution.sql
+++ b/app/sql/looker/looks_sqls/Percentage of priority cases for Case Distribution.sql
@@ -1,0 +1,14 @@
+SELECT 
+	distributions.id  AS "distributions.id",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	DATE(distributions.completed_at ) AS "distributions.completed_date",
+	COUNT(CASE WHEN (distributed_cases.priority = 'true') THEN 1 ELSE NULL END) AS "distributed_cases.judge_priority_count",
+	COUNT(distributed_cases.id ) AS "distributed_cases.count"
+FROM public.distributions  AS distributions
+LEFT JOIN public.distributed_cases  AS distributed_cases ON distributions.id = distributed_cases.distribution_id 
+LEFT JOIN vacols.staff  AS vacols_staff ON distributions.judge_id = vacols_staff.sattyid 
+
+GROUP BY 1,2,3,4
+ORDER BY 4 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Possible duplicate appeals.sql
+++ b/app/sql/looker/looks_sqls/Possible duplicate appeals.sql
@@ -1,0 +1,17 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "appeals.veteran_file_number") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "appeals.count" ELSE NULL END DESC NULLS LAST, "appeals.veteran_file_number" ASC, "appeals.count" DESC, z__pivot_col_rank) AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	COUNT(*) AS "appeals.count"
+FROM public.appeals  AS appeals
+
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Priority case inventory for Case distribution.sql
+++ b/app/sql/looker/looks_sqls/Priority case inventory for Case distribution.sql
@@ -1,0 +1,8 @@
+SELECT 
+	json_extract_path_text(distributions.statistics, 'priority_count')  AS "distributions.priority_case_count",
+	TO_CHAR(DATE_TRUNC('week', distributions.completed_at ), 'YYYY-MM-DD') AS "distributions.completed_week"
+FROM public.distributions  AS distributions
+
+GROUP BY 1,DATE_TRUNC('week', distributions.completed_at )
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Quota Test.sql
+++ b/app/sql/looker/looks_sqls/Quota Test.sql
@@ -1,0 +1,68 @@
+WITH quota AS (SELECT
+        (select tasks.completed_at
+            FROM tasks AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as date_signed,
+        (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+        ) as attorney_id,
+        (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as judge_id,
+        (select vacols.staff.smemgrp
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as chief_group,
+        (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+        ) as status,
+        (select attorney_case_reviews.overtime
+          FROM attorney_case_reviews
+          INNER JOIN tasks on attorney_case_reviews.task_id = tasks.id
+          WHERE tasks.appeal_id = appeals.id
+          limit 1
+        ) as overtime,
+        appeals.id as id,
+        request_issues.disposition as disposition
+      FROM public.appeals as appeals
+      LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.review_request_id AND
+        request_issues.review_request_type = 'Appeal'
+      WHERE request_issues.disposition IS NOT NULL
+ORDER BY 1,2
+LIMIT 500
+ )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "quota.chief_group","quota.judge_id","quota.attorney_id","quota.date_signed_date") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "quota.date_signed_date" DESC, z__pivot_col_rank, "quota.chief_group", "quota.judge_id", "quota.attorney_id") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "quota.disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	quota."disposition"  AS "quota.disposition",
+	quota."chief_group"  AS "quota.chief_group",
+	quota."judge_id"  AS "quota.judge_id",
+	quota."attorney_id"  AS "quota.attorney_id",
+	DATE(quota."date_signed" ) AS "quota.date_signed_date",
+	COUNT(*) AS "quota.count"
+FROM quota
+
+WHERE (quota."date_signed"  IS NOT NULL) AND ((((quota."disposition") IS NOT NULL)))
+GROUP BY 1,2,3,4,5) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/RAMP Refilings by Docket.sql
+++ b/app/sql/looker/looks_sqls/RAMP Refilings by Docket.sql
@@ -1,0 +1,20 @@
+SELECT 
+	ramp_refilings.appeal_docket  AS "ramp_refilings.appeal_docket",
+	ramp_refilings.option_selected  AS "ramp_refilings.option_selected",
+	COUNT(*) AS "ramp_refilings.count"
+FROM public.ramp_refilings  AS ramp_refilings
+
+WHERE 
+	(ramp_refilings.option_selected = 'appeal')
+GROUP BY 1,2
+ORDER BY 3 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(*) AS "ramp_refilings.count"
+FROM public.ramp_refilings  AS ramp_refilings
+
+WHERE 
+	(ramp_refilings.option_selected = 'appeal')
+LIMIT 1

--- a/app/sql/looker/looks_sqls/RAMP appeals by VSOs.sql
+++ b/app/sql/looker/looks_sqls/RAMP appeals by VSOs.sql
@@ -1,0 +1,56 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "assigned_to_organization.name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "appeals.count" ELSE NULL END DESC NULLS LAST, "appeals.count" DESC, z__pivot_col_rank, "assigned_to_organization.name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "appeals.docket_type" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	assigned_to_organization.name  AS "assigned_to_organization.name",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE (tasks.type = 'TrackVeteranTask') AND ((((appeals.established_at ) >= (TIMESTAMP '2018-10-01') AND (appeals.established_at ) < (TIMESTAMP '2019-02-19'))))
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE (tasks.type = 'TrackVeteranTask') AND ((((appeals.established_at ) >= (TIMESTAMP '2018-10-01') AND (appeals.established_at ) < (TIMESTAMP '2019-02-19'))))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	assigned_to_organization.name  AS "assigned_to_organization.name",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE (tasks.type = 'TrackVeteranTask') AND ((((appeals.established_at ) >= (TIMESTAMP '2018-10-01') AND (appeals.established_at ) < (TIMESTAMP '2019-02-19'))))
+GROUP BY 1
+ORDER BY 2 DESC
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.organizations  AS assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = assigned_to_organization.id 
+
+WHERE (tasks.type = 'TrackVeteranTask') AND ((((appeals.established_at ) >= (TIMESTAMP '2018-10-01') AND (appeals.established_at ) < (TIMESTAMP '2019-02-19'))))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Ramp Appeals Pilot - Attorney Task Breakdown.sql
+++ b/app/sql/looker/looks_sqls/Ramp Appeals Pilot - Attorney Task Breakdown.sql
@@ -1,0 +1,33 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.type","assigned_to_user.css_id","assigned_to_user.full_name","assigned_to_user.email","assigned_by_user.css_id","assigned_by_user.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "tasks.type" ASC, z__pivot_col_rank, "assigned_to_user.css_id", "assigned_to_user.full_name", "assigned_to_user.email", "assigned_by_user.css_id", "assigned_by_user.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.status" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.type  AS "tasks.type",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	assigned_to_user.email  AS "assigned_to_user.email",
+	assigned_by_user.css_id  AS "assigned_by_user.css_id",
+	assigned_by_user.full_name  AS "assigned_by_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+LEFT JOIN public.users  AS assigned_by_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_by_id = assigned_by_user.id 
+
+WHERE 
+	(tasks.type = 'AttorneyTask')
+GROUP BY 1,2,3,4,5,6,7) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Ramp Appeals Pilot - Judge Tasks Breakdown.sql
+++ b/app/sql/looker/looks_sqls/Ramp Appeals Pilot - Judge Tasks Breakdown.sql
@@ -1,0 +1,30 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.type","assigned_to_user.css_id","assigned_to_user.email","assigned_to_user.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "assigned_to_user.css_id" ASC, z__pivot_col_rank, "tasks.type", "assigned_to_user.email", "assigned_to_user.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.status" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.type  AS "tasks.type",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.email  AS "assigned_to_user.email",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'JudgeTask')
+GROUP BY 1,2,3,4,5) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/Ramp Elections by Date.sql
+++ b/app/sql/looker/looks_sqls/Ramp Elections by Date.sql
@@ -1,0 +1,13 @@
+-- raw sql results do not include filled-in values for 'ramp_elections.established_date'
+
+
+SELECT 
+	DATE(ramp_elections.established_at ) AS "ramp_elections.established_date",
+	COUNT(*) AS "ramp_elections.count"
+FROM public.ramp_elections  AS ramp_elections
+
+WHERE 
+	(ramp_elections.established_at  IS NOT NULL)
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Ramp Filing Numbers.sql
+++ b/app/sql/looker/looks_sqls/Ramp Filing Numbers.sql
@@ -1,0 +1,20 @@
+SELECT 
+	ramp_refilings.appeal_docket  AS "ramp_refilings.appeal_docket",
+	ramp_refilings.option_selected  AS "ramp_refilings.option_selected",
+	COUNT(*) AS "ramp_refilings.count"
+FROM public.ramp_refilings  AS ramp_refilings
+
+WHERE 
+	(ramp_refilings.receipt_date  < (DATE(DATE '2018-10-15')))
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(*) AS "ramp_refilings.count"
+FROM public.ramp_refilings  AS ramp_refilings
+
+WHERE 
+	(ramp_refilings.receipt_date  < (DATE(DATE '2018-10-15')))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Ramp Refilings Numbers.sql
+++ b/app/sql/looker/looks_sqls/Ramp Refilings Numbers.sql
@@ -1,0 +1,9 @@
+SELECT 
+	ramp_refilings.appeal_docket  AS "ramp_refilings.appeal_docket",
+	ramp_refilings.option_selected  AS "ramp_refilings.option_selected",
+	COUNT(*) AS "ramp_refilings.count"
+FROM public.ramp_refilings  AS ramp_refilings
+
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Ramp hearing requests .AOD.sql
+++ b/app/sql/looker/looks_sqls/Ramp hearing requests .AOD.sql
@@ -1,0 +1,13 @@
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	COUNT(DISTINCT CASE WHEN (advance_on_docket_motions.granted = 'true') THEN advance_on_docket_motions.id  ELSE NULL END) AS "advance_on_docket_motions.aod_count"
+FROM public.people  AS people
+LEFT JOIN public.claimants  AS claimants ON people.participant_id = claimants.participant_id 
+INNER JOIN public.advance_on_docket_motions  AS advance_on_docket_motions ON people.id = advance_on_docket_motions.person_id
+LEFT JOIN public.appeals  AS appeals ON claimants.decision_review_id = appeals.id AND claimants.decision_review_type = 'Appeal'
+
+WHERE 
+	(appeals.docket_type = 'hearing')
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Reader User Document Last Fetched Over Two Days ago.sql
+++ b/app/sql/looker/looks_sqls/Reader User Document Last Fetched Over Two Days ago.sql
@@ -1,0 +1,13 @@
+-- raw sql results do not include filled-in values for 'reader_users.documents_fetched_date'
+
+
+SELECT 
+	DATE(reader_users.documents_fetched_at ) AS "reader_users.documents_fetched_date",
+	COUNT(*) AS "reader_users.count"
+FROM public.reader_users  AS reader_users
+
+WHERE 
+	(reader_users.documents_fetched_at  < (DATEADD(day,-2, DATE_TRUNC('day',GETDATE()) )))
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Receipt date - Established date.sql
+++ b/app/sql/looker/looks_sqls/Receipt date - Established date.sql
@@ -1,0 +1,11 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	DATE(appeals.established_at ) AS "appeals.established_date"
+FROM public.appeals  AS appeals
+
+WHERE 
+	(((appeals.established_at ) >= (TIMESTAMP '2019-06-01') AND (appeals.established_at ) < (TIMESTAMP '2019-06-30')))
+GROUP BY 1,2,3
+ORDER BY 2 DESC
+LIMIT 5000

--- a/app/sql/looker/looks_sqls/Request issue disposition count per attorney.sql
+++ b/app/sql/looker/looks_sqls/Request issue disposition count per attorney.sql
@@ -1,0 +1,165 @@
+WITH dispositions AS (WITH appeal_task_status AS (SELECT *,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_status,
+          (select tasks.completed_at
+            FROM tasks AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_completion,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_name,
+          (select vacols.staff.smemgrp
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as chief_group
+          from public.appeals as appeals )
+SELECT
+  appeals.id  AS "appeals.id",
+  appeal_task_status.judge_task_completion  AS "appeal_task_status.judge_task_completion",
+  appeal_task_status.attorney_id AS "appeal_task_status.task_attorney_id",
+  appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+  appeal_task_status.judge_id AS "appeal_task_status.task_judge_id",
+  appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+  appeal_task_status.chief_group AS "appeal_task_status.chief_group",
+  CASE WHEN decisions.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decisions.bva_decision_dispatched",
+  request_issues.id as "request_issues.id",
+  request_issues.disposition as "request_issues.disposition"
+FROM public.appeals AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.review_request_id AND
+    request_issues.review_request_type = 'Appeal'
+LEFT JOIN public.decisions  AS decisions ON decisions.appeal_id = appeals.id
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id
+
+WHERE appeal_task_status.judge_task_status = 'completed'
+
+ORDER BY 2,1
+LIMIT 500
+ )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "dispositions.appeal_task_status_task_judge_name","dispositions.appeal_task_status_task_attorney_name","dispositions.appeal_task_status_task_attorney_id") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "dispositions.appeal_task_status_task_judge_name" DESC, z__pivot_col_rank, "dispositions.appeal_task_status_task_attorney_name", "dispositions.appeal_task_status_task_attorney_id") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "dispositions.request_issues_disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	dispositions."request_issues.disposition"  AS "dispositions.request_issues_disposition",
+	dispositions."appeal_task_status.task_judge_name"  AS "dispositions.appeal_task_status_task_judge_name",
+	dispositions."appeal_task_status.task_attorney_name"  AS "dispositions.appeal_task_status_task_attorney_name",
+	dispositions."appeal_task_status.task_attorney_id"  AS "dispositions.appeal_task_status_task_attorney_id",
+	COUNT(*) AS "dispositions.request_issues_disposition_count_per_attorney"
+FROM dispositions
+
+GROUP BY 1,2,3,4) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH dispositions AS (WITH appeal_task_status AS (SELECT *,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_status,
+          (select tasks.completed_at
+            FROM tasks AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_completion,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_name,
+          (select vacols.staff.smemgrp
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as chief_group
+          from public.appeals as appeals )
+SELECT
+  appeals.id  AS "appeals.id",
+  appeal_task_status.judge_task_completion  AS "appeal_task_status.judge_task_completion",
+  appeal_task_status.attorney_id AS "appeal_task_status.task_attorney_id",
+  appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+  appeal_task_status.judge_id AS "appeal_task_status.task_judge_id",
+  appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+  appeal_task_status.chief_group AS "appeal_task_status.chief_group",
+  CASE WHEN decisions.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decisions.bva_decision_dispatched",
+  request_issues.id as "request_issues.id",
+  request_issues.disposition as "request_issues.disposition"
+FROM public.appeals AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.review_request_id AND
+    request_issues.review_request_type = 'Appeal'
+LEFT JOIN public.decisions  AS decisions ON decisions.appeal_id = appeals.id
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id
+
+WHERE appeal_task_status.judge_task_status = 'completed'
+
+ORDER BY 2,1
+LIMIT 500
+ )
+SELECT 
+	dispositions."request_issues.disposition"  AS "dispositions.request_issues_disposition",
+	COUNT(*) AS "dispositions.request_issues_disposition_count_per_attorney"
+FROM dispositions
+
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Request issue disposition count per judge.sql
+++ b/app/sql/looker/looks_sqls/Request issue disposition count per judge.sql
@@ -1,0 +1,164 @@
+WITH dispositions AS (WITH appeal_task_status AS (SELECT *,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_status,
+          (select tasks.completed_at
+            FROM tasks AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_completion,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_name,
+          (select vacols.staff.smemgrp
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as chief_group
+          from public.appeals as appeals )
+SELECT
+  appeals.id  AS "appeals.id",
+  appeal_task_status.judge_task_completion  AS "appeal_task_status.judge_task_completion",
+  appeal_task_status.attorney_id AS "appeal_task_status.task_attorney_id",
+  appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+  appeal_task_status.judge_id AS "appeal_task_status.task_judge_id",
+  appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+  appeal_task_status.chief_group AS "appeal_task_status.chief_group",
+  CASE WHEN decisions.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decisions.bva_decision_dispatched",
+  request_issues.id as "request_issues.id",
+  request_issues.disposition as "request_issues.disposition"
+FROM public.appeals AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.review_request_id AND
+    request_issues.review_request_type = 'Appeal'
+LEFT JOIN public.decisions  AS decisions ON decisions.appeal_id = appeals.id
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id
+
+WHERE appeal_task_status.judge_task_status = 'completed'
+
+ORDER BY 2,1
+LIMIT 500
+ )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "dispositions.appeal_task_status_task_judge_id","dispositions.appeal_task_status_task_judge_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "dispositions.request_issues_disposition_count_per_attorney" ELSE NULL END DESC NULLS LAST, "dispositions.request_issues_disposition_count_per_attorney" DESC, z__pivot_col_rank, "dispositions.appeal_task_status_task_judge_id", "dispositions.appeal_task_status_task_judge_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "dispositions.request_issues_disposition" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	dispositions."request_issues.disposition"  AS "dispositions.request_issues_disposition",
+	dispositions."appeal_task_status.task_judge_id"  AS "dispositions.appeal_task_status_task_judge_id",
+	dispositions."appeal_task_status.task_judge_name"  AS "dispositions.appeal_task_status_task_judge_name",
+	COUNT(*) AS "dispositions.request_issues_disposition_count_per_attorney"
+FROM dispositions
+
+GROUP BY 1,2,3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+WITH dispositions AS (WITH appeal_task_status AS (SELECT *,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_status,
+          (select tasks.completed_at
+            FROM tasks AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_task_completion,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask'
+            limit 1
+          ) as attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as judge_name,
+          (select vacols.staff.smemgrp
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeTask'
+            limit 1
+          ) as chief_group
+          from public.appeals as appeals )
+SELECT
+  appeals.id  AS "appeals.id",
+  appeal_task_status.judge_task_completion  AS "appeal_task_status.judge_task_completion",
+  appeal_task_status.attorney_id AS "appeal_task_status.task_attorney_id",
+  appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+  appeal_task_status.judge_id AS "appeal_task_status.task_judge_id",
+  appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+  appeal_task_status.chief_group AS "appeal_task_status.chief_group",
+  CASE WHEN decisions.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decisions.bva_decision_dispatched",
+  request_issues.id as "request_issues.id",
+  request_issues.disposition as "request_issues.disposition"
+FROM public.appeals AS appeals
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.review_request_id AND
+    request_issues.review_request_type = 'Appeal'
+LEFT JOIN public.decisions  AS decisions ON decisions.appeal_id = appeals.id
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id
+
+WHERE appeal_task_status.judge_task_status = 'completed'
+
+ORDER BY 2,1
+LIMIT 500
+ )
+SELECT 
+	dispositions."request_issues.disposition"  AS "dispositions.request_issues_disposition",
+	COUNT(*) AS "dispositions.request_issues_disposition_count_per_attorney"
+FROM dispositions
+
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Status Inquiry.sql
+++ b/app/sql/looker/looks_sqls/Status Inquiry.sql
@@ -1,0 +1,31 @@
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	tasks.id  AS "tasks.id",
+	tasks.type  AS "tasks.type",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	DATE(tasks.assigned_at ) AS "tasks.assigned_date",
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	DATE(tasks.updated_at ) AS "tasks.updated_date",
+	task_assigned_to_organization.name  AS "task_assigned_to_organization.name",
+	task_assigned_to_user.css_id  AS "task_assigned_to_user.css_id",
+	task_assigned_by_user.css_id  AS "task_assigned_by_user.css_id"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN public.users  AS task_assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = task_assigned_to_user.id 
+LEFT JOIN public.users  AS task_assigned_by_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_by_id = task_assigned_by_user.id 
+LEFT JOIN public.organizations  AS task_assigned_to_organization ON tasks.assigned_to_type IN ('Organization', 'Vso') AND tasks.assigned_to_id = task_assigned_to_organization.id 
+
+WHERE 
+	(appeals.id  = 626)
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12
+ORDER BY 7 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Stayed RAMP appeals.sql
+++ b/app/sql/looker/looks_sqls/Stayed RAMP appeals.sql
@@ -1,0 +1,13 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	appeals.docket_type  AS "appeals.docket_type",
+	request_issues.disposition  AS "request_issues.disposition"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+
+WHERE 
+	(request_issues.disposition = 'stayed')
+GROUP BY 1,2,3
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Summary by Regional Office by AOJ.sql
+++ b/app/sql/looker/looks_sqls/Summary by Regional Office by AOJ.sql
@@ -1,0 +1,50 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       AS "vacols_hearsched.hearing_type",
+	DATE(vacols_hearsched.hearing_date ) AS "vacols_hearsched.hearing_date",
+	CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END
+       AS "vacols_hearsched.hearing_disp",
+	vacols_hearsched.team  AS "vacols_hearsched.team",
+	DATE(vacols_brieff."BFD19" ) AS "vacols_brieff.bfd19_date",
+	vacols_brieff."BFREGOFF"  AS "vacols_brieff.bfregoff",
+	vacols_hearsched.board_member  AS "vacols_hearsched.board_member"
+FROM vacols.hearsched  AS vacols_hearsched
+LEFT JOIN vacols_brieff ON vacols_hearsched.folder_nr = (vacols_brieff."BFKEY") 
+
+WHERE ((vacols_hearsched.board_member IS NOT NULL) AND (vacols_hearsched.board_member IS NOT NULL AND LENGTH(vacols_hearsched.board_member ) <> 0 )) AND ((((vacols_hearsched.hearing_date ) >= (TIMESTAMP '2017-04-01') AND (vacols_hearsched.hearing_date ) < (TIMESTAMP '2018-03-31')))) AND ((((CASE
+        WHEN vacols_hearsched.hearing_disp = 'C' THEN 'Canceled'
+        WHEN vacols_hearsched.hearing_disp = 'H' THEN 'Held'
+        WHEN vacols_hearsched.hearing_disp = 'N' THEN 'No Show'
+        WHEN vacols_hearsched.hearing_disp = 'P' THEN 'Postponed'
+        WHEN vacols_hearsched.hearing_disp = 'W' THEN 'Widthrawn'
+        ELSE vacols_hearsched.hearing_disp
+      END) IS NOT NULL))) AND ((CASE
+        WHEN vacols_hearsched.hearing_type = 'C' THEN 'Central'
+        WHEN vacols_hearsched.hearing_type = 'T' THEN 'Travel'
+        WHEN vacols_hearsched.hearing_type = 'V' THEN 'Video'
+        ELSE vacols_hearsched.hearing_type
+      END
+       IN ('V', 'C', 'T')))
+GROUP BY 1,2,3,4,5,6,7
+ORDER BY 7 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Sunil - test for Lowell.sql
+++ b/app/sql/looker/looks_sqls/Sunil - test for Lowell.sql
@@ -1,0 +1,9 @@
+SELECT 
+	tasks.appeal_type  AS "tasks.appeal_type"
+FROM public.tasks  AS tasks
+
+WHERE 
+	(tasks.assigned_to_type = 'Organization')
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/TEST - Issues Per Case - Dispatched Only.sql
+++ b/app/sql/looker/looks_sqls/TEST - Issues Per Case - Dispatched Only.sql
@@ -1,0 +1,278 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(decision_issues.id ) AS "decision_issues.count",
+	COUNT(decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND ((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END IN ('7. Decision dispatched', '6. Decision signed')))
+GROUP BY 1,2
+ORDER BY 3 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(decision_issues.id ) AS "decision_issues.count",
+	COUNT(decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND ((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END IN ('7. Decision dispatched', '6. Decision signed')))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/TEST - Issues Per Case 2.sql
+++ b/app/sql/looker/looks_sqls/TEST - Issues Per Case 2.sql
@@ -1,0 +1,26 @@
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(decision_issues.id ) AS "decision_issues.count",
+	COUNT(decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+GROUP BY 1,2
+ORDER BY 3 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(decision_issues.id ) AS "decision_issues.count",
+	COUNT(decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+
+WHERE 
+	(appeals.established_at  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/TEST - Issues Per Case 3.sql
+++ b/app/sql/looker/looks_sqls/TEST - Issues Per Case 3.sql
@@ -1,0 +1,294 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	decision_issues.disposition  AS "decision_issues.disposition",
+	decision_issues.decision_review_type  AS "decision_issues.decision_review_type",
+	decision_issues.description  AS "decision_issues.description",
+	DATE(appeals.receipt_date ) AS "appeals.receipt_date",
+	DATE(appeals.established_at ) AS "appeals.established_date",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	DATE(decision_documents.processed_at ) AS "decision_documents.processed_date",
+	CASE WHEN decision_documents.citation_number IS NOT NULL   THEN 'Yes' ELSE 'No' END
+ AS "decision_documents.bva_decision_dispatched",
+	veterans.id  AS "veterans.id",
+	veterans.file_number  AS "veterans.file_number",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13
+ORDER BY 10 DESC
+LIMIT 10
+
+-- sql for creating the total and/or determining pivot columns
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.veterans  AS veterans ON appeals.veteran_file_number = veterans.file_number 
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (((CASE
+WHEN appeal_task_status.judge_task_status is null  THEN '1. Not distributed' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress' or
+          (appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'on_hold')) and appeal_task_status.attorney_task_status is null THEN '2. Distributed to judge' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'assigned' THEN '3. Assigned to attorney' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.attorney_task_status = 'on_hold') and appeal_task_status.colocated_task_status = 'assigned' or appeal_task_status.colocated_task_status = 'in_progress' THEN '4. Assigned to colocated' 
+WHEN (appeal_task_status.judge_task_status = 'on_hold' or appeal_task_status.quality_review_task_status = 'on_hold') and appeal_task_status.attorney_task_status = 'in_progress' THEN '5. Decision in progress' 
+WHEN (appeal_task_status.judge_task_status = 'assigned' or appeal_task_status.judge_task_status = 'in_progress') and appeal_task_status.attorney_task_status = 'completed' THEN '6. Decision ready for signature' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and (appeal_task_status.bva_dispatch_task_status is null or appeal_task_status.bva_dispatch_task_status != 'completed') THEN '7. Decision signed' 
+WHEN appeal_task_status.judge_task_status = 'completed' and appeal_task_status.attorney_task_status = 'completed' and appeal_task_status.bva_dispatch_task_status = 'completed' THEN '8. Decision dispatched' 
+WHEN appeal_task_status.judge_task_status = 'on_hold' and appeal_task_status.attorney_task_status = 'on_hold' and appeal_task_status.colocated_task_status = 'on_hold' THEN 'ON HOLD' 
+WHEN appeal_task_status.judge_task_status = 'cancelled' or appeal_task_status.attorney_task_status = 'cancelled' THEN 'CANCELLED' 
+END) = '7. Decision dispatched'))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/TEST - Issues Per Case.sql
+++ b/app/sql/looker/looks_sqls/TEST - Issues Per Case.sql
@@ -1,0 +1,26 @@
+SELECT 
+	decision_issues.disposition  AS "decision_issues.disposition",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (decision_documents.decision_date  IS NOT NULL)
+GROUP BY 1,2
+HAVING (NOT (COUNT(DISTINCT appeals.id ) = 0)) AND (NOT (COUNT(DISTINCT decision_issues.id ) = 0))
+ORDER BY 2 DESC
+LIMIT 500
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	COUNT(DISTINCT appeals.id ) AS "appeals.count",
+	COUNT(DISTINCT decision_issues.id ) AS "decision_issues.appeal_decision_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.decision_issues  AS decision_issues ON appeals.id = decision_issues.decision_review_id AND decision_issues.decision_review_type = 'Appeal' 
+LEFT JOIN public.decision_documents  AS decision_documents ON decision_documents.appeal_id = appeals.id 
+
+WHERE (appeals.established_at  IS NOT NULL) AND (decision_documents.decision_date  IS NOT NULL)
+HAVING (NOT (COUNT(DISTINCT appeals.id ) = 0)) AND (NOT (COUNT(DISTINCT decision_issues.id ) = 0))
+LIMIT 1

--- a/app/sql/looker/looks_sqls/Task View for Del.sql
+++ b/app/sql/looker/looks_sqls/Task View for Del.sql
@@ -1,0 +1,136 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	appeal_task_status.judge_task_status AS "appeal_task_status.judge_task_status",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.attorney_task_status AS "appeal_task_status.attorney_task_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	tasks.type  AS "tasks.type",
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	DATE(tasks.updated_at ) AS "tasks.updated_date",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6,7,8,9,10
+ORDER BY 11 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Tasks Started Date.sql
+++ b/app/sql/looker/looks_sqls/Tasks Started Date.sql
@@ -1,0 +1,135 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	appeal_task_status.judge_name AS "appeal_task_status.task_judge_name",
+	appeal_task_status.judge_task_status AS "appeal_task_status.judge_task_status",
+	appeal_task_status.attorney_name AS "appeal_task_status.task_attorney_name",
+	appeal_task_status.attorney_task_status AS "appeal_task_status.attorney_task_status",
+	CASE WHEN appeal_task_status.judge_task_status = 'completed'  THEN 'Yes' ELSE 'No' END
+ AS "appeal_task_status.decision_signed_by_judge",
+	DATE(tasks.started_at ) AS "tasks.started_date",
+	DATE(tasks.updated_at ) AS "tasks.updated_date",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.appeal_request_issue_count"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN public.request_issues  AS request_issues ON appeals.id = request_issues.decision_review_id 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (NOT appeal_task_status.attorney_task_status IS NULL) OR (NOT appeal_task_status.judge_task_status IS NULL)
+GROUP BY 1,2,3,4,5,6,7,8,9
+ORDER BY 10 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Time from attorney to dispatch.sql
+++ b/app/sql/looker/looks_sqls/Time from attorney to dispatch.sql
@@ -1,0 +1,126 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	DATE(appeal_task_status.bva_dispatch_task_status_completed_date) AS "appeal_task_status.bva_dispatch_task_status_completed_at_date",
+	DATE(appeal_task_status.attorney_task_status_started_date) AS "appeal_task_status.attorney_task_status_started_at_date"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	appeal_task_status.judge_task_status = 'completed' 
+GROUP BY 1,2,3
+ORDER BY 2 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Time from judge reviewing to signing decision.sql
+++ b/app/sql/looker/looks_sqls/Time from judge reviewing to signing decision.sql
@@ -1,0 +1,133 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	DATE(appeal_task_status.judge_review_task_status_started_date) AS "appeal_task_status.judge_review_task_status_started_at_date",
+	DATE(appeal_task_status.judge_review_task_status_completed_date) AS "appeal_task_status.judge_review_task_status_completed_at_date",
+	(DATE(appeal_task_status.judge_review_task_status_completed_date)) - (DATE(appeal_task_status.judge_review_task_status_started_date)) AS "appeal_task_status.time_from_judge_reviewing_to_signing_complete"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE (((CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END) = '3_completed')) AND (tasks.type = 'JudgeDecisionReviewTask') AND (NOT ((DATE(appeal_task_status.judge_review_task_status_completed_date)) - (DATE(appeal_task_status.judge_review_task_status_started_date)) IS NULL))
+GROUP BY 1,2,3,4
+ORDER BY 4 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Time from signed decision to dispatch complete.sql
+++ b/app/sql/looker/looks_sqls/Time from signed decision to dispatch complete.sql
@@ -1,0 +1,127 @@
+WITH appeal_task_status AS (SELECT *,
+    (select max(tasks.updated_at)
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id
+            limit 1
+          ) as task_max_updated_at,
+          (select tasks.id
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_id,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND (tasks.type = 'AttorneyTask' or tasks.type = 'AttorneyRewriteTask') AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as attorney_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeAssignTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_assign_task_status_started_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status,
+          (select tasks.started_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_started_date,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'JudgeDecisionReviewTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as judge_review_task_status_completed_date,
+          (select tasks.status
+            FROM tasks  AS tasks
+              where tasks.appeal_id = appeals.id  AND tasks.type = 'ColocatedTask' AND tasks.appeal_type='Appeal'
+            order by tasks.closed_at desc
+            limit 1
+          ) as colocated_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'QualityReviewTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as quality_review_task_status,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as attorney_name,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'AttorneyTask' AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_attorney_id,
+          (select vacols.staff.sattyid
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            join vacols.staff on users.css_id = vacols.staff.sdomainid
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask')  AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as vacols_judge_id,
+          (select users.full_name
+            FROM tasks  AS tasks
+            join users on tasks.assigned_to_id = users.id
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_name,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type IN ('JudgeAssignTask', 'JudgeDecisionReviewTask') AND tasks.appeal_type='Appeal'
+            order by tasks.assigned_at desc
+            limit 1
+          ) as judge_task_status,
+          (select tasks.status
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status,
+          (select tasks.closed_at
+            FROM tasks  AS tasks
+            where tasks.appeal_id = appeals.id  AND tasks.type = 'BvaDispatchTask' AND tasks.appeal_type='Appeal'
+            limit 1
+          ) as bva_dispatch_task_status_completed_date
+          from public.appeals as appeals )
+SELECT 
+	appeal_task_status.id  AS "appeal_task_status.appeal_id",
+	(DATE(appeal_task_status.bva_dispatch_task_status_completed_date)) - (DATE(appeal_task_status.judge_review_task_status_completed_date)) AS "appeal_task_status.time_from_judge_signing_to_dispatch_complete",
+	DATE(appeal_task_status.judge_review_task_status_completed_date) AS "appeal_task_status.judge_review_task_status_completed_at_date",
+	DATE(appeal_task_status.bva_dispatch_task_status_completed_date) AS "appeal_task_status.bva_dispatch_task_status_completed_at_date"
+FROM public.appeals  AS appeals
+LEFT JOIN appeal_task_status ON appeal_task_status.id = appeals.id 
+
+WHERE 
+	(appeal_task_status.bva_dispatch_task_status_completed_date IS NOT NULL)
+GROUP BY 1,2,3,4
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Time to distribute a new priority case for Case Distribution.sql
+++ b/app/sql/looker/looks_sqls/Time to distribute a new priority case for Case Distribution.sql
@@ -1,0 +1,13 @@
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', distributions.completed_at ), 'YYYY-MM-DD') AS "distributions.completed_week",
+	AVG((DATEDIFF(days, DATE((DATE(distributed_cases.ready_at ))), (DATE(distributions.completed_at )))) ) AS "distributed_cases.average_priority_case_wait"
+FROM public.distributions  AS distributions
+LEFT JOIN public.distributed_cases  AS distributed_cases ON distributions.id = distributed_cases.distribution_id 
+
+WHERE 
+	(distributed_cases.priority = 'true')
+GROUP BY DATE_TRUNC('week', distributions.completed_at )
+HAVING 
+	NOT (AVG((DATEDIFF(days, DATE((DATE(distributed_cases.ready_at ))), (DATE(distributions.completed_at )))) ) IS NULL)
+ORDER BY 1 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/VACOLS issue query.sql
+++ b/app/sql/looker/looks_sqls/VACOLS issue query.sql
@@ -1,0 +1,40 @@
+WITH vacols_decass AS (select *, (select p.locdin from VACOLS.PRIORLOC p WHERE p.lockey=de.defolder AND p.locstto = '81' ORDER BY p.locdin DESC LIMIT 1) as distribution_date    from VACOLS.DECASS de )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_decass.decomp_week","vacols_decass.deprod") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "vacols_decass.decomp_week" DESC, z__pivot_col_rank, "vacols_decass.deprod") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_decass.deatty" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	vacols_decass."DEATTY"  AS "vacols_decass.deatty",
+	TO_CHAR(DATE_TRUNC('week', vacols_decass."DECOMP" ), 'YYYY-MM-DD') AS "vacols_decass.decomp_week",
+	vacols_decass."DEPROD"  AS "vacols_decass.deprod",
+	COUNT(*) AS "vacols_decass.defolder_count",
+	(case when
+            SUM(
+                case when
+                    vacols_issues.issdc = '5' OR
+                    vacols_issues.issdc = '6' OR
+                    vacols_issues.issdc = '8' OR
+                    vacols_issues.issdc = '9'
+                then 1 else null end
+            ) > 0
+        then 1 else 0 end
+          +
+          SUM(
+            case when
+                vacols_issues.issdc = '1' OR
+                vacols_issues.issdc = '3' OR
+                vacols_issues.issdc = '4'
+            then 1 else 0 end
+        )
+      ) AS "vacols_issues.case_issue_count"
+FROM vacols_decass
+LEFT JOIN vacols.issues  AS vacols_issues ON (vacols_decass."DEFOLDER") = vacols_issues.isskey 
+
+WHERE (((vacols_decass."DEATTY") = '1826')) AND ((((vacols_decass."DECOMP" ) >= (TIMESTAMP '2017-10-01') AND (vacols_decass."DECOMP" ) < (TIMESTAMP '2018-09-30')))) AND ((((vacols_decass."DEPROD") IS NOT NULL) AND (vacols_decass."DEPROD") NOT LIKE '%OT%'))
+GROUP BY 1,DATE_TRUNC('week', vacols_decass."DECOMP" ),3) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank

--- a/app/sql/looker/looks_sqls/VACOLS issue query2.sql
+++ b/app/sql/looker/looks_sqls/VACOLS issue query2.sql
@@ -1,0 +1,80 @@
+-- raw sql results do not include filled-in values for 'vacols_decass.decomp_week'
+
+
+WITH vacols_decass AS (select *, (select p.locdin from VACOLS.PRIORLOC p WHERE p.lockey=de.defolder AND p.locstto = '81' ORDER BY p.locdin DESC LIMIT 1) as distribution_date    from VACOLS.DECASS de )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_staff.snamef","vacols_staff.snamel","vacols_decass.deatty") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "vacols_decass.defolder_count" ELSE NULL END DESC NULLS LAST, "vacols_decass.defolder_count" DESC, z__pivot_col_rank, "vacols_staff.snamef", "vacols_staff.snamel", "vacols_decass.deatty") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_decass.decomp_week" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', vacols_decass."DECOMP" ), 'YYYY-MM-DD') AS "vacols_decass.decomp_week",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	vacols_decass."DEATTY"  AS "vacols_decass.deatty",
+	COUNT(*) AS "vacols_decass.defolder_count",
+	(case when
+            SUM(
+                case when
+                    vacols_issues.issdc = '5' OR
+                    vacols_issues.issdc = '6' OR
+                    vacols_issues.issdc = '8' OR
+                    vacols_issues.issdc = '9'
+                then 1 else null end
+            ) > 0
+        then 1 else 0 end
+          +
+          SUM(
+            case when
+                vacols_issues.issdc = '1' OR
+                vacols_issues.issdc = '3' OR
+                vacols_issues.issdc = '4'
+            then 1 else 0 end
+        )
+      ) AS "vacols_issues.case_issue_count"
+FROM vacols_decass
+LEFT JOIN vacols.issues  AS vacols_issues ON (vacols_decass."DEFOLDER") = vacols_issues.isskey 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_decass."DEATTY") = vacols_staff.sattyid 
+
+WHERE ((((vacols_decass."DECOMP" ) >= (TIMESTAMP '2017-10-01') AND (vacols_decass."DECOMP" ) < (TIMESTAMP '2018-09-30')))) AND ((((vacols_decass."DEPROD") IS NOT NULL) AND (vacols_decass."DEPROD") NOT LIKE '%OT%' AND vacols_decass."DEPROD"  NOT IN ('VHA', 'IME', 'REA'))) AND ((vacols_staff.sattyid  IN ('1826', '1258', '889', '1521')))
+GROUP BY DATE_TRUNC('week', vacols_decass."DECOMP" ),2,3,4) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the pivot row totals
+WITH vacols_decass AS (select *, (select p.locdin from VACOLS.PRIORLOC p WHERE p.lockey=de.defolder AND p.locstto = '81' ORDER BY p.locdin DESC LIMIT 1) as distribution_date    from VACOLS.DECASS de )
+SELECT 
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	vacols_decass."DEATTY"  AS "vacols_decass.deatty",
+	COUNT(*) AS "vacols_decass.defolder_count",
+	(case when
+            SUM(
+                case when
+                    vacols_issues.issdc = '5' OR
+                    vacols_issues.issdc = '6' OR
+                    vacols_issues.issdc = '8' OR
+                    vacols_issues.issdc = '9'
+                then 1 else null end
+            ) > 0
+        then 1 else 0 end
+          +
+          SUM(
+            case when
+                vacols_issues.issdc = '1' OR
+                vacols_issues.issdc = '3' OR
+                vacols_issues.issdc = '4'
+            then 1 else 0 end
+        )
+      ) AS "vacols_issues.case_issue_count"
+FROM vacols_decass
+LEFT JOIN vacols.issues  AS vacols_issues ON (vacols_decass."DEFOLDER") = vacols_issues.isskey 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_decass."DEATTY") = vacols_staff.sattyid 
+
+WHERE ((((vacols_decass."DECOMP" ) >= (TIMESTAMP '2017-10-01') AND (vacols_decass."DECOMP" ) < (TIMESTAMP '2018-09-30')))) AND ((((vacols_decass."DEPROD") IS NOT NULL) AND (vacols_decass."DEPROD") NOT LIKE '%OT%' AND vacols_decass."DEPROD"  NOT IN ('VHA', 'IME', 'REA'))) AND ((vacols_staff.sattyid  IN ('1826', '1258', '889', '1521')))
+GROUP BY 1,2,3
+ORDER BY 4 DESC
+LIMIT 30000

--- a/app/sql/looker/looks_sqls/VACOLS issue query3.sql
+++ b/app/sql/looker/looks_sqls/VACOLS issue query3.sql
@@ -1,0 +1,40 @@
+-- raw sql results do not include filled-in values for 'vacols_decass.decomp_week'
+
+
+WITH vacols_decass AS (select *, (select p.locdin from VACOLS.PRIORLOC p WHERE p.lockey=de.defolder AND p.locstto = '81' ORDER BY p.locdin DESC LIMIT 1) as distribution_date    from VACOLS.DECASS de )
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "vacols_staff.snamef","vacols_staff.snamel","vacols_decass.deatty") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "vacols_decass.defolder_count" ELSE NULL END DESC NULLS LAST, "vacols_decass.defolder_count" DESC, z__pivot_col_rank, "vacols_staff.snamef", "vacols_staff.snamel", "vacols_decass.deatty") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "vacols_decass.decomp_week" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	TO_CHAR(DATE_TRUNC('week', vacols_decass."DECOMP" ), 'YYYY-MM-DD') AS "vacols_decass.decomp_week",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	vacols_decass."DEATTY"  AS "vacols_decass.deatty",
+	COUNT(*) AS "vacols_decass.defolder_count"
+FROM vacols_decass
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_decass."DEATTY") = vacols_staff.sattyid 
+
+WHERE ((((vacols_decass."DECOMP" ) >= (TIMESTAMP '2018-10-01') AND (vacols_decass."DECOMP" ) < (TIMESTAMP '2018-10-08')))) AND ((((vacols_decass."DEPROD") IS NOT NULL))) AND ((vacols_staff.sattyid  IN ('1826', '1258', '889', '1337', '1521', '1977')))
+GROUP BY DATE_TRUNC('week', vacols_decass."DECOMP" ),2,3,4) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the pivot row totals
+WITH vacols_decass AS (select *, (select p.locdin from VACOLS.PRIORLOC p WHERE p.lockey=de.defolder AND p.locstto = '81' ORDER BY p.locdin DESC LIMIT 1) as distribution_date    from VACOLS.DECASS de )
+SELECT 
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	vacols_decass."DEATTY"  AS "vacols_decass.deatty",
+	COUNT(*) AS "vacols_decass.defolder_count"
+FROM vacols_decass
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_decass."DEATTY") = vacols_staff.sattyid 
+
+WHERE ((((vacols_decass."DECOMP" ) >= (TIMESTAMP '2018-10-01') AND (vacols_decass."DECOMP" ) < (TIMESTAMP '2018-10-08')))) AND ((((vacols_decass."DEPROD") IS NOT NULL))) AND ((vacols_staff.sattyid  IN ('1826', '1258', '889', '1337', '1521', '1977')))
+GROUP BY 1,2,3
+ORDER BY 4 DESC
+LIMIT 30000

--- a/app/sql/looker/looks_sqls/VACOLS playground.sql
+++ b/app/sql/looker/looks_sqls/VACOLS playground.sql
@@ -1,0 +1,51 @@
+WITH vacols_folder AS (SELECT *,
+    (select count(*) into dcnt from vacols.assign where tsktknm = vf.ticknum and tskactcd in ('B', 'B1', 'B2')) +
+      (select count(*) into hcnt from vacols.hearsched where folder_nr = vf.ticknum and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y')) as AOD
+    from vacols.folder vf )
+  ,  vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	DATE(vacols_brieff."BFD19" ) AS "vacols_brieff.bfd19_date",
+	DATE(vacols_brieff."BF41STAT" ) AS "vacols_brieff.bf41_stat_date",
+	DATE(vacols_folder.tidrecv ) AS "vacols_folder.tidrecv_date",
+	vacols_brieff."BFHA"  AS "vacols_brieff.bfha",
+	vacols_folder.AOD AS "vacols_folder.aod_cnt",
+	COUNT(DISTINCT vacols_brieff."BFKEY" ) AS "vacols_brieff.count",
+	COUNT(*) AS "vacols_folder.count"
+FROM vacols_folder
+LEFT JOIN vacols_brieff ON (vacols_brieff."BFKEY") = vacols_folder.ticknum 
+
+WHERE 
+	(vacols_brieff."BF41STAT"  IS NOT NULL)
+GROUP BY 1,2,3,4,5
+ORDER BY 1 DESC
+LIMIT 10
+
+-- sql for creating the total and/or determining pivot columns
+WITH vacols_folder AS (SELECT *,
+    (select count(*) into dcnt from vacols.assign where tsktknm = vf.ticknum and tskactcd in ('B', 'B1', 'B2')) +
+      (select count(*) into hcnt from vacols.hearsched where folder_nr = vf.ticknum and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y')) as AOD
+    from vacols.folder vf )
+  ,  vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	COUNT(DISTINCT vacols_brieff."BFKEY" ) AS "vacols_brieff.count",
+	COUNT(*) AS "vacols_folder.count"
+FROM vacols_folder
+LEFT JOIN vacols_brieff ON (vacols_brieff."BFKEY") = vacols_folder.ticknum 
+
+WHERE 
+	(vacols_brieff."BF41STAT"  IS NOT NULL)
+LIMIT 1

--- a/app/sql/looker/looks_sqls/VCL 19 Report.sql
+++ b/app/sql/looker/looks_sqls/VCL 19 Report.sql
@@ -1,0 +1,32 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	vacols_brieff."BFDC"  AS "vacols_brieff.bfdc",
+	vacols_brieff."BFHA"  AS "vacols_brieff.bfha",
+	vacols_brieff."BFAC"  AS "vacols_brieff.bfac",
+	CASE
+        WHEN (vacols_brieff."BFAC") = 1 THEN 'Original'
+        WHEN (vacols_brieff."BFAC") = 2 THEN 'Supplemental'
+        WHEN (vacols_brieff."BFAC") = 3 THEN 'Post Remand'
+        WHEN (vacols_brieff."BFAC") = 4 THEN 'Reconsideration'
+        WHEN (vacols_brieff."BFAC") = 5 THEN 'Vacated'
+        WHEN (vacols_brieff."BFAC") = 6 THEN 'De Novo'
+        WHEN (vacols_brieff."BFAC") = 7 THEN 'Court Remand'
+        WHEN (vacols_brieff."BFAC") = 8 THEN 'Designation of Record'
+        WHEN (vacols_brieff."BFAC") = 9 THEN 'CUE'
+        ELSE (vacols_brieff."BFAC")
+      END
+       AS "vacols_brieff.bfac_translated",
+	vacols_brieff."BFBOARD"  AS "vacols_brieff.bfboard",
+	vacols_brieff."BFREGOFF"  AS "vacols_brieff.bfregoff"
+FROM vacols_brieff
+
+GROUP BY 1,2,3,4,5,6
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/VEO Survey | Decisions issued.sql
+++ b/app/sql/looker/looks_sqls/VEO Survey | Decisions issued.sql
@@ -1,0 +1,15 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	DATE(decision_documents.decision_date ) AS "decision_documents.decision_date",
+	DATE(decision_documents.uploaded_to_vbms_at ) AS "decision_documents.uploaded_to_vbms_date"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.decision_documents  AS decision_documents ON tasks.appeal_id = decision_documents.appeal_id
+
+WHERE 
+	(((decision_documents.uploaded_to_vbms_at ) >= (TIMESTAMP '2019-06-17') AND (decision_documents.uploaded_to_vbms_at ) < (TIMESTAMP '2019-06-24')))
+GROUP BY 1,2,3,4,5
+ORDER BY 4 DESC
+LIMIT 2000

--- a/app/sql/looker/looks_sqls/VEO Survey | NOD establishments.sql
+++ b/app/sql/looker/looks_sqls/VEO Survey | NOD establishments.sql
@@ -1,0 +1,13 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	appeals.docket_type  AS "appeals.docket_type",
+	to_char((DATE(appeals.receipt_date )), 'yymmdd') || '-' || appeals.id  AS "appeals.docket_number",
+	DATE(appeals.established_at ) AS "appeals.established_date"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+
+WHERE 
+	(((appeals.established_at ) >= (TIMESTAMP '2019-06-01') AND (appeals.established_at ) < (TIMESTAMP '2019-06-30')))
+GROUP BY 1,2,3,4
+ORDER BY 4 DESC
+LIMIT 2000

--- a/app/sql/looker/looks_sqls/VLJ Support Branch Report - Copy of report.sql
+++ b/app/sql/looker/looks_sqls/VLJ Support Branch Report - Copy of report.sql
@@ -1,0 +1,44 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.closed_date","tasks.action","tasks.instructions") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.closed_date", "tasks.action", "tasks.instructions") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(tasks.closed_at ) AS "tasks.closed_date",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD', 'LAZETTE CLANTON', 'TIMOTHY OWENS', 'LOFRANDRA LEWIS', 'MALEKA GIOVINCO', 'MAURICE JONES', 'ANDRE JOHNSON') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2,3,4,5,6,7) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 1000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  = 23)) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD', 'LAZETTE CLANTON', 'TIMOTHY OWENS', 'LOFRANDRA LEWIS', 'MALEKA GIOVINCO', 'MAURICE JONES', 'ANDRE JOHNSON') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/VLJ Support Branch Report.sql
+++ b/app/sql/looker/looks_sqls/VLJ Support Branch Report.sql
@@ -1,0 +1,44 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.created_date","tasks.status","tasks.closed_date","tasks.action","tasks.instructions") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "tasks.created_date", "tasks.status", "tasks.closed_date", "tasks.action", "tasks.instructions") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.assigned_to_id" NULLS LAST, "assigned_to_user.full_name" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(tasks.closed_at ) AS "tasks.closed_date",
+	tasks.action  AS "tasks.action",
+	tasks.instructions  AS "tasks.instructions",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  IN (23,616))) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD', 'LAZETTE CLANTON', 'TIMOTHY OWENS', 'LOFRANDRA LEWIS', 'MALEKA GIOVINCO', 'MAURICE JONES', 'ANDRE JOHNSON', 'ROLANDUS BRANCH') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2,3,4,5,6,7) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 4000 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	tasks.assigned_to_id  AS "tasks.assigned_to_id",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND (NOT (assigned_to_user.id  IN (23,616))) AND ((assigned_to_user.full_name  NOT IN ('MARVOURNEEN DOLOR', 'EUGENE SCOTT', 'ANTOINETTE FORD', 'LAZETTE CLANTON', 'TIMOTHY OWENS', 'LOFRANDRA LEWIS', 'MALEKA GIOVINCO', 'MAURICE JONES', 'ANDRE JOHNSON', 'ROLANDUS BRANCH') OR assigned_to_user.full_name IS NULL))
+GROUP BY 1,2
+ORDER BY 1 ,2 
+LIMIT 4000

--- a/app/sql/looker/looks_sqls/VLJ Support Tasks with no completed date.sql
+++ b/app/sql/looker/looks_sqls/VLJ Support Tasks with no completed date.sql
@@ -1,0 +1,22 @@
+SELECT 
+	task_assigned_to_user.full_name  AS "task_assigned_to_user.full_name",
+	tasks.action  AS "tasks.action",
+	DATE(tasks.created_at ) AS "tasks.created_date",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.type  AS "tasks.type"
+FROM public.appeals  AS appeals
+LEFT JOIN public.tasks  AS tasks ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal' 
+LEFT JOIN public.users  AS task_assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = task_assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'ColocatedTask')
+GROUP BY 1,2,3,4,5
+ORDER BY 3 DESC
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/VLJ support tasks.sql
+++ b/app/sql/looker/looks_sqls/VLJ support tasks.sql
@@ -1,0 +1,45 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "assigned_to_user.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY CASE WHEN z__pivot_col_rank=1 THEN 1 ELSE 2 END, CASE WHEN z__pivot_col_rank=1 THEN "tasks.count" ELSE NULL END DESC NULLS LAST, "tasks.count" DESC, z__pivot_col_rank, "assigned_to_user.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.status" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND ((assigned_to_user.full_name IS NOT NULL))
+GROUP BY 1,2) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE (tasks.type = 'ColocatedTask') AND ((assigned_to_user.full_name IS NOT NULL))
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/VSO Generic Tasks.sql
+++ b/app/sql/looker/looks_sqls/VSO Generic Tasks.sql
@@ -1,0 +1,19 @@
+SELECT 
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	DATE(tasks.assigned_at ) AS "tasks.assigned_date"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+
+WHERE 
+	(tasks.type = 'GenericTask')
+GROUP BY 1,2,3
+ORDER BY 2 DESC
+LIMIT 500

--- a/app/sql/looker/looks_sqls/Veteran with extra issue.sql
+++ b/app/sql/looker/looks_sqls/Veteran with extra issue.sql
@@ -1,0 +1,13 @@
+SELECT 
+	appeals.id  AS "appeals.id",
+	appeals.veteran_file_number  AS "appeals.veteran_file_number",
+	COUNT(DISTINCT request_issues.id ) AS "request_issues.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.appeals  AS appeals ON tasks.appeal_id = appeals.id AND tasks.appeal_type = 'Appeal'
+LEFT JOIN public.request_issues  AS request_issues ON tasks.appeal_id = request_issues.decision_review_id
+
+WHERE 
+	(appeals.veteran_file_number = '437515307')
+GROUP BY 1,2
+ORDER BY 1 
+LIMIT 500

--- a/app/sql/looker/looks_sqls/issues per judge2.sql
+++ b/app/sql/looker/looks_sqls/issues per judge2.sql
@@ -1,0 +1,46 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       AS "vacols_issues.issdc",
+	vacols_issues.isscode  AS "vacols_issues.isscode",
+	vacols_issues.isslev2  AS "vacols_issues.isslev2",
+	vacols_issues.isslev3  AS "vacols_issues.isslev3",
+	vacols_issues.issdesc  AS "vacols_issues.issdesc",
+	vacols_brieff."BFKEY"  AS "vacols_brieff.bfkey",
+	DATE(vacols_brieff."BFDDEC" ) AS "vacols_brieff.bfddec_date",
+	vacols_brieff."BFMEMID"  AS "vacols_brieff.bfmemid",
+	vacols_staff.snamef  AS "vacols_staff.snamef",
+	vacols_staff.snamel  AS "vacols_staff.snamel",
+	vacols_issues.isslev1  AS "vacols_issues.isslev1"
+FROM vacols.issues  AS vacols_issues
+LEFT JOIN vacols_brieff ON vacols_issues.isskey = (vacols_brieff."BFKEY") 
+LEFT JOIN vacols.staff  AS vacols_staff ON (vacols_brieff."BFMEMID") = vacols_staff.sattyid 
+
+WHERE ((CASE
+        WHEN vacols_issues.issdc = '1' THEN 'Allowed'
+        WHEN vacols_issues.issdc = '3' THEN 'Remanded'
+        WHEN vacols_issues.issdc = '4' THEN 'Denied'
+        WHEN vacols_issues.issdc = '5' THEN 'Vacated'
+        WHEN vacols_issues.issdc = '6' THEN 'Dismissed, Withdrawn'
+        WHEN vacols_issues.issdc = '8' THEN 'Dismissed, Death'
+        ELSE vacols_issues.issdc
+      END
+       IN ('1', '2', '3', '4', '5', '6', '7', '8', '9'))) AND ((vacols_brieff."BFBOARD"  IN ('D1', 'D5'))) AND ((((vacols_brieff."BFDDEC" ) >= (DATE(DATE '2017-10-01')) AND (vacols_brieff."BFDDEC" ) < (DATE(DATE '2018-09-30')))))
+GROUP BY 1,2,3,4,5,6,7,8,9,10,11
+ORDER BY 7 DESC
+LIMIT 1000

--- a/app/sql/looker/looks_sqls/per Judge tasks.sql
+++ b/app/sql/looker/looks_sqls/per Judge tasks.sql
@@ -1,0 +1,76 @@
+SELECT * FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY z___min_rank) as z___pivot_row_rank, RANK() OVER (PARTITION BY z__pivot_col_rank ORDER BY z___min_rank) as z__pivot_col_ordering FROM (
+SELECT *, MIN(z___rank) OVER (PARTITION BY "tasks.type","assigned_to_user.css_id","assigned_to_user.email","assigned_to_user.full_name") as z___min_rank FROM (
+SELECT *, RANK() OVER (ORDER BY "assigned_to_user.css_id" ASC, z__pivot_col_rank, "tasks.type", "assigned_to_user.email", "assigned_to_user.full_name") AS z___rank FROM (
+SELECT *, DENSE_RANK() OVER (ORDER BY "tasks.status" NULLS LAST) AS z__pivot_col_rank FROM (
+SELECT 
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	tasks.type  AS "tasks.type",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.email  AS "assigned_to_user.email",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'JudgeTask')
+GROUP BY 1,2,3,4,5) ww
+) bb WHERE z__pivot_col_rank <= 16384
+) aa
+) xx
+) zz
+ WHERE z___pivot_row_rank <= 500 OR z__pivot_col_ordering = 1 ORDER BY z___pivot_row_rank
+
+-- sql for creating the total and/or determining pivot columns
+SELECT 
+	CASE tasks.status
+          WHEN 'assigned' THEN '1_assigned'
+          WHEN 'in_progress' THEN '2_viewed'
+          WHEN 'on_hold' THEN '3_on_hold'
+          WHEN 'completed' THEN '3_completed'
+          ELSE tasks.status
+         END
+         AS "tasks.status",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'JudgeTask')
+GROUP BY 1
+ORDER BY 1 
+LIMIT 500
+
+-- sql for creating the pivot row totals
+SELECT 
+	tasks.type  AS "tasks.type",
+	assigned_to_user.css_id  AS "assigned_to_user.css_id",
+	assigned_to_user.email  AS "assigned_to_user.email",
+	assigned_to_user.full_name  AS "assigned_to_user.full_name",
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'JudgeTask')
+GROUP BY 1,2,3,4
+ORDER BY 2 
+LIMIT 30000
+
+-- sql for creating the grand totals
+SELECT 
+	COUNT(DISTINCT tasks.id ) AS "tasks.count"
+FROM public.tasks  AS tasks
+LEFT JOIN public.users  AS assigned_to_user ON tasks.assigned_to_type = 'User' AND tasks.assigned_to_id = assigned_to_user.id 
+
+WHERE 
+	(tasks.type = 'JudgeTask')
+LIMIT 1

--- a/app/sql/looker/looks_sqls/vacols brieff count.sql
+++ b/app/sql/looker/looks_sqls/vacols brieff count.sql
@@ -1,0 +1,13 @@
+WITH vacols_brieff AS (select *, ((select count(*) into dcnt from vacols.assign
+            where tsktknm = bf.bfkey  and tskactcd in ('B', 'B1', 'B2')
+        ) +
+        (select count(*) into hcnt from vacols.hearsched where folder_nr = bf.bfkey
+          and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y'))
+        ) as aod_count
+         from vacols.brieff bf
+        )
+SELECT 
+	COUNT(*) AS "vacols_brieff.count"
+FROM vacols_brieff
+
+LIMIT 500


### PR DESCRIPTION
Resolves #12068

### Description
Since we are deprecating Looker, I found a way to automate and bring all the "Looks" aka SQL

I have created 2 folders:
`dashboards/*`
`looks_sqls/*`

The Dashboards are essentially *looks* grouped by. if you want to recreate a dashboard, you can just use the sql inside or get the queries accordingly.

### Code used
```
# config.ini
# API version is required
api_version=3.1
# Base URL for API. Do not include /api/* in the url
base_url=http://<looker ip or url for api>:19999
# API 3 client id
client_id=<get yours from the Looker Admin page>
# API 3 client secret
client_secret=<get yours from the Looker Admin page>
# Set to false if testing locally aganst self-signed certs. Otherwise leave True
```
```
# creationqueries.py
from looker_sdk import client, models, error
sdk = client.setup('config.ini')
looker_api_user = sdk.me()
looks_ids = list()

for look in sdk.all_looks(fields='id'):
	looks_ids.append(look.id)

for id in looks_ids:
	try:
		sql = sdk.run_look(id, 'sql')
		lookobj = sdk.look(id, fields='title')
		title = lookobj.title
		f = open("sqls/%s.sql"  % (title), "w+")
		f.write(sql)
		
	except:
		continue
	finally:
		f.close()

``