### PR TITLE
Add missing ep codes for 930 corrections on HLR DTA PMC supplemental claims

### DIFF
--- a/app/workflows/end_product_code_selector.rb
+++ b/app/workflows/end_product_code_selector.rb
@@ -94,6 +94,10 @@ class EndProductCodeSelector
             appeal: {
               rating: "930AMARRCPMC",
               nonrating: "930ARNRCPMC"
+            },
+            higher_level_review: {
+              rating: "930AHDERPMC",
+              nonrating: "930AHDENRPMC"
             }
           }
         }
@@ -136,6 +140,10 @@ class EndProductCodeSelector
             appeal: {
               rating: "930ARRCLQPMC",
               nonrating: "930ARNRCLPMC"
+            },
+            higher_level_review: {
+              rating: "930AHDERLPMC",
+              nonrating: "930AHDENLPMC"
             }
           }
         }
@@ -178,6 +186,10 @@ class EndProductCodeSelector
             appeal: {
               rating: "930ARRCNQPMC",
               nonrating: "930ARNRCNPMC"
+            },
+            higher_level_review: {
+              rating: "930AHDERNPMC",
+              nonrating: "930AHDENNPMC"
             }
           }
         }

--- a/spec/workflows/end_product_code_selector_spec.rb
+++ b/spec/workflows/end_product_code_selector_spec.rb
@@ -69,7 +69,13 @@ EP_CODES = [
   %w[930ARNRCNQE 930 national_quality_error dta compensation nonrating appeal],
   %w[930ARNRCPMC 930 control dta pension nonrating appeal],
   %w[930ARRCLQPMC 930 local_quality_error dta pension rating appeal],
-  %w[930ARRCNQPMC 930 national_quality_error dta pension rating appeal]
+  %w[930ARRCNQPMC 930 national_quality_error dta pension rating appeal],
+  %w[930AHDENLPMC 930 local_quality_error dta pension nonrating higher_level_review],
+  %w[930AHDENNPMC 930 national_quality_error dta pension nonrating higher_level_review],
+  %w[930AHDENRPMC 930 control dta pension nonrating higher_level_review],
+  %w[930AHDERPMC 930 control dta pension rating higher_level_review],
+  %w[930AHDERLPMC 930 local_quality_error dta pension rating higher_level_review],
+  %w[930AHDERNPMC 930 national_quality_error dta pension rating higher_level_review]
 ].freeze
 
 describe "Request Issue Correction Cleaner", :postgres do


### PR DESCRIPTION
connects #12989

### Description
We've been missing 6 EP codes since 930s got deployed, for corrections on DTA supplemental claims from pension higher level reviews.  Those just got added to VBMS in the December coordinated install, so adding them into the codebase.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. Tested end product code selector to select the right codes

### User Facing Changes
N/A
 
### Documentation Updates
Added EP codes to spreadsheet in Foxtrot folder