### PR TITLE
Include vet file numbers in async job labeling for Inbox

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -61,6 +61,10 @@ class ClaimReview < DecisionReview
     "/asyncable_jobs/#{self.class}/jobs/#{id}"
   end
 
+  def label
+    "#{self.class} #{id} (Veteran #{veteran_file_number})"
+  end
+
   def finalized_decision_issues_before_receipt_date
     return [] unless receipt_date
 

--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -256,5 +256,9 @@ module Asyncable
   def path
     "/asyncable_jobs/#{self.class}/jobs/#{id}"
   end
+
+  def label
+    "#{self.class} #{id}"
+  end
 end
 # rubocop:enable Metrics/ModuleLength

--- a/app/services/asyncable_job_messaging.rb
+++ b/app/services/asyncable_job_messaging.rb
@@ -17,7 +17,7 @@ class AsyncableJobMessaging
       job_note = JobNote.create!(job: job, user: current_user, note: text, send_to_intake_user: send_to_intake_user)
       if send_to_intake_user && job.asyncable_user
         message_text = <<-EOS.strip_heredoc
-          A new note has been added to your #{job.class} job.
+          A new note has been added to #{job.label}.
           <a href="#{job_note.path}">Click here</a> to view the note.
         EOS
         Message.create!(detail: job_note, text: message_text, user: job.asyncable_user, message_type: :job_note_added)
@@ -33,7 +33,7 @@ class AsyncableJobMessaging
       job_note = JobNote.create!(job: job, user: current_user, note: text, send_to_intake_user: send_to_intake_user)
       if send_to_intake_user
         message_text = <<-EOS.strip_heredoc
-          The job for processing <a href="#{job_note.path}">#{job.class} #{job.id}</a> has been cancelled.<br />
+          The job for processing <a href="#{job_note.path}">#{job.label}</a> has been cancelled.<br />
           No further action is necessary. Please see the job details page for more information on why this job has been cancelled.
         EOS
         Message.create!(detail: job_note, text: message_text, user: job.asyncable_user, message_type: :job_cancelled)
@@ -48,7 +48,7 @@ class AsyncableJobMessaging
 
     err = ERB::Util.html_escape(job.sanitized_error)
     message_text = <<-EOS.strip_heredoc
-      The job for <a href="#{job.path}">#{job.class} #{job.id}</a> was unable to complete because of an error: #{err}<br />
+      The job for <a href="#{job.path}">#{job.label}</a> was unable to complete because of an error: #{err}<br />
       No further action is necessary as the (IT) support team has been notified.
       You will receive a separate message in your inbox when the issue has resolved.
     EOS
@@ -65,7 +65,7 @@ class AsyncableJobMessaging
     return if job.messages.failing_job_succeeded.any?
 
     message_text = <<-EOS.strip_heredoc
-      <a href="#{job.path}">#{job.class} #{job.id}</a> has successfully been processed.
+      <a href="#{job.path}">#{job.label}</a> has successfully been processed.
       No further action is necessary. If you have opened a support ticket for this issue,
       you may inform them that it may be closed.
     EOS

--- a/spec/services/asyncable_job_messaging_spec.rb
+++ b/spec/services/asyncable_job_messaging_spec.rb
@@ -17,7 +17,7 @@ describe AsyncableJobMessaging, :postgres do
         message_count = owner.messages.count
         subject
         expect(owner.messages.count).to eq message_count + 1
-        expect(owner.messages.last.text).to match("A new note has been added to your HigherLevelReview job")
+        expect(owner.messages.last.text).to match("A new note has been added to HigherLevelReview")
         expect(owner.messages.last.text).to match(job.path)
         expect(owner.messages.last.message_type).to eq "job_note_added"
       end


### PR DESCRIPTION
Connects #12926 

### Description
As part of AMO's feedback on the async job messaging demo, in Inbox prose, labels for jobs will contain veteran file numbers.

Because there are several existing places (e.g. the `/jobs` index and specific job pages) where the job ID is already used, I chose to err on the side of extra information in the Inbox for the sake of consistency.

### User Facing Changes
Sample screenshot of an Inbox view with the new labels:
<img width="1089" alt="Screen Shot 2019-12-17 at 13 18 58" src="https://user-images.githubusercontent.com/282869/71023164-2ab4cd80-20d0-11ea-8afc-b1d301f74fb1.png">
No labeling outside of the Inbox has been changed.