### PR TITLE
Remove Whitespace in Virtual Hearing Link

### DIFF
--- a/client/app/hearings/components/VirtualHearingLink.jsx
+++ b/client/app/hearings/components/VirtualHearingLink.jsx
@@ -38,9 +38,11 @@ class VirtualHearingLink extends React.PureComponent {
       return null;
     }
 
+    const href = this.getUrl();
+
     return (
       <Link
-        href={this.getUrl()}
+        href={href}
         target={newWindow ? '_blank' : '_self'}
         disabled={!virtualHearing.jobCompleted}
       >

--- a/client/app/hearings/components/VirtualHearingLink.jsx
+++ b/client/app/hearings/components/VirtualHearingLink.jsx
@@ -1,6 +1,7 @@
 import { css } from 'glamor';
 import React from 'react';
 import PropTypes from 'prop-types';
+import querystring from 'querystring';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import { COLORS } from '../../constants/AppConstants';
 import { ExternalLink } from '../../components/RenderFunctions';
@@ -16,22 +17,30 @@ class VirtualHearingLink extends React.PureComponent {
     return role === 'host' ? virtualHearing.hostPin : virtualHearing.guestPin;
   }
 
+  getUrl() {
+    const { role, virtualHearing } = this.props;
+    const qs = querystring.stringify(
+      {
+        conference: virtualHearing.alias,
+        pin: this.getPin(),
+        join: 1,
+        role
+      }
+    );
+
+    return `https://${virtualHearing.clientHost}/webapp/?${qs}`;
+  }
+
   render() {
-    const { isVirtual, newWindow, role, showFullLink, virtualHearing } = this.props;
+    const { isVirtual, newWindow, showFullLink, virtualHearing } = this.props;
 
     if (!isVirtual) {
       return null;
     }
 
-    const href = `https://${virtualHearing.clientHost}/webapp/\
-      ?conference=${virtualHearing.alias}\
-      &pin=${this.getPin()}\
-      &join=1\
-      &role=${role}`;
-
     return (
       <Link
-        href={href}
+        href={this.getUrl()}
         target={newWindow ? '_blank' : '_self'}
         disabled={!virtualHearing.jobCompleted}
       >


### PR DESCRIPTION
Resolves #12966

### Description

  * Use `querystring` library to build Pexip URL (removes whitespace from the generated URL)

### User Facing Changes

<img width="599" alt="Screen Shot 2019-12-18 at 11 34 23 AM" src="https://user-images.githubusercontent.com/1298274/71104790-601df180-218a-11ea-84fb-dfa00faa6e5a.png">

_The `href` changed_