### PR TITLE
Turn on config.force_ssl for links when FORCE_ENV env var set

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,6 +34,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.force_ssl = ENV.fetch('FORCE_SSL', false)
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/docker-bin/env.sh
+++ b/docker-bin/env.sh
@@ -2,6 +2,7 @@
 
 # env vars required to run the appeals-app docker container on caseflowdemo
 
+export FORCE_SSL=true
 export POSTGRES_HOST=appeals-db
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
Now that our demo site has a SSL cert, let's require it.