### PR TITLE
increase default proxy buffer sizes

### DIFF
--- a/local/nginx/config/nginx/site-confs/default
+++ b/local/nginx/config/nginx/site-confs/default
@@ -59,6 +59,11 @@ server {
                 proxy_set_header Host $http_host;
                 proxy_redirect off;
                 proxy_pass http://rails_app;
+
+                # fix the 500s
+                proxy_buffer_size          128k;
+                proxy_buffers              4 256k;
+                proxy_busy_buffers_size    256k;
         }
 }
 


### PR DESCRIPTION
Demo was giving 500 in some pages, due to the amount of traffic we got from the JS passing and its default being only 4k.

That change increases Nginx’s proxy buffer from the default 4KB to 128KB, 
the nginx log showed
```
2019/12/18 21:39:59 [error] 410#410: *604 upstream sent too big header while reading response header from upstream, client: 74.96.204.56, server: , request: "GET /tasks?user_id=3&role=Judge HTTP/2.0", upstream: "http://192.168.96.6:3000/tasks?user_id=3&role=Judge", host: "caseflowdemo.com"
```

google search gave this resolution, from this website:
https://ma.ttias.be/nginx-proxy-upstream-sent-big-header-reading-response-header-upstream/