### PR TITLE
Remove PUSHGATEWAY_HEALTHCHECK

### DIFF
--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -7,24 +7,10 @@ class HealthChecksController < ActionController::Base
   protect_from_forgery with: :exception
   newrelic_ignore_apdex
 
-  def initialize
-    @pushgateway = Caseflow::PushgatewayService.new
-  end
-
-  def healthy?
-    # Check health of sidecar services
-    if ENV.include? "ENABLE_PUSHGATEWAY_HEALTHCHECK"
-      @pushgateway.healthy?
-    else
-      true
-    end
-  end
-
   def show
-    healthy = healthy?
     body = {
-      healthy: healthy
+      healthy: true
     }.merge(Rails.application.config.build_version || {})
-    render(json: body, status: healthy ? :ok : :service_unavailable)
+    render(json: body, status: :ok)
   end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
     auth_token: ENV["GOVDELIVERY_TOKEN"],
     api_root: "https://#{ENV["GOVDELIVERY_SERVER"]}"
   }
-  
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
@@ -50,7 +50,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  # Allow health check to pushgateway
-  ENV["ENABLE_PUSHGATEWAY_HEALTHCHECK"] = "true"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -79,8 +79,5 @@ Rails.application.configure do
   ENV["FULL_GRANT_IDS"] = "VACOLS123,VACOLS234,VACOLS345,VACOLS456"
   ENV["PARTIAL_AND_REMAND_IDS"] = "VACOLS321,VACOLS432,VACOLS543,VACOLS654"
 
-  # Allow health check to pushgateway
-  ENV["ENABLE_PUSHGATEWAY_HEALTHCHECK"] = "true"
-
   config.active_job.queue_adapter = :test
 end

--- a/spec/requests/health_checks_spec.rb
+++ b/spec/requests/health_checks_spec.rb
@@ -6,21 +6,7 @@ describe "Health Check API" do
       Rails.application.config.build_version = { deployed_at: "the best day ever" }
     end
 
-    it "should fail health check when pushgateway is offline" do
-      allow_any_instance_of(Caseflow::PushgatewayService).to receive(:healthy?) { false }
-
-      get "/health-check"
-
-      expect(response).to have_http_status(503)
-
-      json = JSON.parse(response.body)
-      expect(json["healthy"]).to eq(false)
-      expect(json["deployed_at"]).to eq("the best day ever")
-    end
-
-    it "should pass health check when pushgateway is online" do
-      allow_any_instance_of(Caseflow::PushgatewayService).to receive(:healthy?) { true }
-
+    it "should pass health check" do
       get "/health-check"
 
       expect(response).to be_success


### PR DESCRIPTION
Remove PUSHGATEWAY_HEALTHCHECK since we no longer have Prometheus sidecar

Resolves https://github.com/department-of-veterans-affairs/appeals-deployment/issues/2369

### Description
PushGateway was removed when we removed Prometheus

