### PR TITLE
Add index to document_views.user_id

### DIFF
--- a/db/migrate/20191219155741_add_user_id_index_document_views.rb
+++ b/db/migrate/20191219155741_add_user_id_index_document_views.rb
@@ -1,0 +1,13 @@
+class AddUserIdIndexDocumentViews < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 1800000" # 30 minutes
+
+    add_index :document_views, :user_id, algorithm: :concurrently
+
+  ensure
+    # always restore the timeout value
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191218211421) do
+ActiveRecord::Schema.define(version: 20191219155741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -415,6 +415,7 @@ ActiveRecord::Schema.define(version: 20191218211421) do
     t.datetime "updated_at"
     t.integer "user_id", null: false
     t.index ["document_id", "user_id"], name: "index_document_views_on_document_id_and_user_id", unique: true
+    t.index ["user_id"], name: "index_document_views_on_user_id"
   end
 
   create_table "documents", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
We have a unique index on `document_id, user_id` but not one just on `user_id`.

`SELECT COUNT(*) FROM "document_views" WHERE "document_views"."user_id" = ?` will timeout after 30 seconds.

This new index may (or may not) help that performance but it's a start.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [ ] #appeals-schema notified with summary and link to this PR
