### PR TITLE
don't start async job if virtual hearing cancelled

### DIFF
--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -57,8 +57,13 @@ class BaseHearingUpdateForm
     !virtual_hearing_created? && scheduled_time_string.present?
   end
 
+  def start_async_job?
+    (hearing.virtual_hearing.pending? || !hearing.virtual_hearing.all_emails_sent?) &&
+      !hearing.virtual_hearing.cancelled?
+  end
+
   def start_async_job
-    if hearing.virtual_hearing.status == "pending" || !hearing.virtual_hearing.all_emails_sent?
+    if start_async_job?
       hearing.virtual_hearing.establishment.submit_for_processing!
       VirtualHearings::CreateConferenceJob.perform_now(
         hearing_id: hearing.id,

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -204,7 +204,6 @@ RSpec.describe HearingsController, :all_dbs, type: :controller do
           expect(subject.status).to eq(200)
           virtual_hearing.reload
           expect(virtual_hearing.cancelled?).to eq(true)
-          expect(virtual_hearing.all_emails_sent?).to eq(true)
         end
       end
     end


### PR DESCRIPTION
Resolves #12971

### Description
- do not start async job is virtual hearing has been switched back to video