### PR TITLE
Bugfix: allow ratings with zero issues if non-zero decisions

### DIFF
--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -17,7 +17,7 @@ class DecisionReview < ApplicationRecord
   has_one :intake, as: :detail
 
   cache_attribute :cached_serialized_ratings, cache_key: :ratings_cache_key, expires_in: 1.day do
-    ratings_with_issues.map(&:serialize)
+    ratings_with_issues_or_decisions.map(&:serialize)
   end
 
   delegate :contestable_issues, to: :contestable_issue_generator
@@ -366,10 +366,10 @@ class DecisionReview < ApplicationRecord
     @active_matchable_legacy_appeals ||= matchable_legacy_appeals.select(&:active?)
   end
 
-  def ratings_with_issues
+  def ratings_with_issues_or_decisions
     return [] unless veteran
 
-    veteran.ratings.reject { |rating| rating.issues.empty? }
+    veteran.ratings.reject { |rating| rating.issues.empty? && rating.decisions.empty? }
 
     # return empty list when there are no ratings
   rescue Rating::BackfilledRatingError, Rating::LockedRatingError => error

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -319,16 +319,32 @@ describe ClaimReview, :postgres do
     let(:ratings) do
       [
         Generators::Rating.build(promulgation_date: Time.zone.today - 30),
+        Generators::Rating.build(promulgation_date: Time.zone.today - 60, issues: [], decisions: decisions),
         Generators::Rating.build(promulgation_date: Time.zone.today - 400)
       ]
     end
 
+    let(:decisions) do
+      [
+        { decision_text: "not service connected for bad knee" }
+      ]
+    end
+
     before do
+      FeatureToggle.enable!(:contestable_rating_decisions)
       allow(subject.veteran).to receive(:ratings).and_return(ratings)
+    end
+
+    after do
+      FeatureToggle.disable!(:contestable_rating_decisions)
     end
 
     subject do
       create(:higher_level_review, veteran_file_number: veteran_file_number, receipt_date: Time.zone.today)
+    end
+
+    it "filters out ratings with zero decisions and zero issues" do
+      expect(subject.serialized_ratings.count).to eq(3)
     end
 
     it "calculates timely flag" do


### PR DESCRIPTION
See https://dsva.slack.com/archives/CHX8FMP28/p1577482241130800

### Description
The Add Issues screen had been ignoring any Ratings with zero Rating Issues. Since we now include Rating Decisions as well, only filter out Ratings that have both zero Rating Issues and zero Rating Decisions. A non-zero count for either one will mean the Rating is included.