### PR TITLE
Flakey date bug fixed in specs

### DIFF
--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -3,11 +3,11 @@
 describe Appeal, :all_dbs do
   include IntakeHelpers
 
-  let!(:appeal) { create(:appeal) }
-
   before do
     Timecop.freeze(Time.utc(2019, 1, 1, 12, 0, 0))
   end
+
+  let!(:appeal) { create(:appeal) } # must be *after* Timecop.freeze
 
   context "includes PrintsTaskTree concern" do
     context "#structure" do


### PR DESCRIPTION
We should be wary of `let!(:foo)` outside of any `context` scoping, particularly at the start of a file. That means the factory will *always* be instantiated.

In this case, we need to define the `before` block before anything else, so that the time is frozen before any factories are called.