### PR TITLE
Update judge email for virtual hearing when judge changes

### DIFF
--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -79,28 +79,28 @@ class BaseHearingUpdateForm
 
   def email_sent_flag(attr_key)
     attr_changed = virtual_hearing_attributes&.key?(:status) ||
-      virtual_hearing_attributes&.key?(attr_key) ||
-      scheduled_time_string.present? ||
-      (judge_id.present? && attr_key == :judge_email)
+                   virtual_hearing_attributes&.key?(attr_key) ||
+                   scheduled_time_string.present? ||
+                   (judge_id.present? && attr_key == :judge_email)
 
     !attr_changed
   end
 
   def virtual_hearing_updates
-      # The email sent flag should always be set to false if any changes are made.
-      emails_sent_updates = {
-        veteran_email_sent: email_sent_flag(:veteran_email),
-        judge_email_sent: email_sent_flag(:judge_email),
-        representative_email_sent: email_sent_flag(:representative_email)
-      }.reject { |_k, email_sent| email_sent == true }
+    # The email sent flag should always be set to false if any changes are made.
+    emails_sent_updates = {
+      veteran_email_sent: email_sent_flag(:veteran_email),
+      judge_email_sent: email_sent_flag(:judge_email),
+      representative_email_sent: email_sent_flag(:representative_email)
+    }.reject { |_k, email_sent| email_sent == true }
 
-      updates = (virtual_hearing_attributes || {}).compact.merge(emails_sent_updates)
+    updates = (virtual_hearing_attributes || {}).compact.merge(emails_sent_updates)
 
-      if judge_id.present?
-        updates[:judge_email] = hearing.judge&.email
-      end
+    if judge_id.present?
+      updates[:judge_email] = hearing.judge&.email
+    end
 
-      updates
+    updates
   end
 
   def virtual_hearing_created?

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -14,7 +14,7 @@ class BaseHearingUpdateForm
     ActiveRecord::Base.transaction do
       update_hearing
       add_update_hearing_alert if show_update_alert?
-      if virtual_hearing_form_or_hearing_time_was_updated?
+      if should_create_or_update_virtual_hearing?
         create_or_update_virtual_hearing
         hearing.reload
         start_async_job
@@ -49,7 +49,7 @@ class BaseHearingUpdateForm
     hearing_updated?
   end
 
-  def virtual_hearing_form_or_hearing_time_was_updated?
+  def should_create_or_update_virtual_hearing?
     !virtual_hearing_attributes.blank? || (hearing.virtual? && scheduled_time_string.present?)
   end
 

--- a/app/services/virtual_hearing_user_alert_builder.rb
+++ b/app/services/virtual_hearing_user_alert_builder.rb
@@ -56,8 +56,8 @@ class VirtualHearingUserAlertBuilder
 
   def only_emails_updated?
     email_changed = virtual_hearing_attributes.key?(:veteran_email) ||
-      virtual_hearing_attributes.key?(:representative_email) ||
-      virtual_hearing_attributes.key?(:judge_email)
+                    virtual_hearing_attributes.key?(:representative_email) ||
+                    virtual_hearing_attributes.key?(:judge_email)
 
     email_changed && !cancelled? && !changed_to_virtual
   end

--- a/app/services/virtual_hearing_user_alert_builder.rb
+++ b/app/services/virtual_hearing_user_alert_builder.rb
@@ -45,6 +45,8 @@ class VirtualHearingUserAlertBuilder
       copy["MESSAGES"]["TO_VETERAN"]
     elsif virtual_hearing_attributes.key?(:representative_email)
       copy["MESSAGES"]["TO_POA"]
+    elsif virtual_hearing_attributes.key?(:judge_email)
+      copy["MESSAGES"]["TO_VLJ"]
     end
   end
 
@@ -53,7 +55,10 @@ class VirtualHearingUserAlertBuilder
   end
 
   def only_emails_updated?
-    (virtual_hearing_attributes.key?(:veteran_email) || virtual_hearing_attributes.key?(:representative_email)) &&
-      !cancelled? && !changed_to_virtual
+    email_changed = virtual_hearing_attributes.key?(:veteran_email) ||
+      virtual_hearing_attributes.key?(:representative_email) ||
+      virtual_hearing_attributes.key?(:judge_email)
+
+    email_changed && !cancelled? && !changed_to_virtual
   end
 end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -652,7 +652,8 @@
       "MESSAGES": {
         "TO_VETERAN_AND_POA": "Emails to the Veteran and POA / Representative are in progress.",
         "TO_VETERAN": "Email to Veteran is in progress.",
-        "TO_POA": "Email to POA / Representative is in progress."
+        "TO_POA": "Email to POA / Representative is in progress.",
+        "TO_VLJ": "Email to VLJ is in progress."
       }
     },
     "HEARING_TIME_CHANGED": {

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe HearingsController, :all_dbs, type: :controller do
         response
       end
 
-      it "updates the judge's email on the virtual hearing", :aggregate_failures, focus: true do
+      it "updates the judge's email on the virtual hearing", :aggregate_failures do
         expect(subject.status).to eq(200)
 
         virtual_hearing.reload

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -209,6 +209,54 @@ RSpec.describe HearingsController, :all_dbs, type: :controller do
       end
     end
 
+    context "when updating the judge of an existing virtual hearing" do
+      let(:new_judge) { create(:user, station_id: User::BOARD_STATION_ID, email: "new_judge_email@caseflow.gov") }
+      let(:hearing) { create(:hearing, regional_office: "RO42") }
+      let!(:virtual_hearing) do
+        create(
+          :virtual_hearing,
+          hearing: hearing,
+          veteran_email: "existing_veteran_email@caseflow.gov",
+          veteran_email_sent: true,
+          judge_email: "existing_judge_email@caseflow.gov",
+          judge_email_sent: true,
+          representative_email: "existing_representative_email@caseflow.gov",
+          representative_email_sent: true
+        )
+      end
+
+      before do
+        # Stub out the job starting, so we can check to make sure the email
+        # sent flags are set properly.
+        allow(VirtualHearings::CreateConferenceJob).to receive(:perform_now)
+      end
+
+      subject do
+        patch_params = {
+          id: hearing.external_id,
+          hearing: {
+            judge_id: new_judge.id
+          }
+        }
+
+        patch :update, as: :json, params: patch_params
+        response
+      end
+
+      it "updates the judge's email on the virtual hearing", :aggregate_failures, focus: true do
+        expect(subject.status).to eq(200)
+
+        virtual_hearing.reload
+
+        expect(virtual_hearing.hearing.judge_id).to eq(new_judge.id)
+        expect(virtual_hearing.judge_email).to eq(new_judge.email)
+
+        expect(virtual_hearing.judge_email_sent).to eq(false)
+        expect(virtual_hearing.veteran_email_sent).to eq(true)
+        expect(virtual_hearing.representative_email_sent).to eq(true)
+      end
+    end
+
     context "when updating the AOD" do
       it "should return a 200 if empty aod" do
         params = {


### PR DESCRIPTION
Resolves #12969 

### Description

  * Updates the hearings controller route to send an email to only the judge if the judge is changed

    I don't think we would need to resend the email to the representative or the veteran because the email doesn't include any information about the judge.