### PR TITLE
Batch assign ama tasks in one request

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -230,7 +230,7 @@
   "ASSIGN_WIDGET_NO_TASK_DETAIL": "Please select a task.",
   "ASSIGN_WIDGET_SUCCESS": "%(verb)s %(numCases)s %(casePlural)s",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_TITLE": "Error assigning tasks",
-  "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL": "One or more tasks couldn't be assigned. Reassign tasks to a judge on the case deatils screen",
+  "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL": "One or more tasks couldn't be assigned. Reassign tasks to a judge on the case details screen",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL_MODAL_LINK": "Please assign tasks to an attorney from your assign page.",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL_MODAL": " Reassign tasks to a judge in the action dropdown",
   "ASSIGN_WIDGET_LOADING": "Loading...",

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -455,11 +455,7 @@ export const initialAssignTasksToUser = ({
     };
   });
 
-  const paramsArray = legacyParams.concat(amaParams);
-
-  debugger;
-
-  return Promise.all(paramsArray.map((params) => {
+  return Promise.all(legacyParams.concat(amaParams).map((params) => {
     const { requestParams, url } = params;
 
     return ApiUtil.post(url, requestParams).

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -406,7 +406,7 @@ const dispatchOldTasks = (dispatch, oldTasks, resp) => {
     dispatch(onReceiveAmaTasks(resp.tasks.data));
   } else {
     // For das deprecation, legacy_task_controller#create returns tasks, not a task
-    const tasks = [resp.task.data].flat();
+    const tasks = resp.tasks ? resp.tasks.data : [resp.task.data];
     const allTasks = prepareAllTasksForStore(tasks);
 
     dispatch(onReceiveTasks({

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -429,31 +429,27 @@ export const initialAssignTasksToUser = ({
     url: '/judge_assign_tasks',
     requestParams: {
       data: {
-        tasks: amaTasks.map((oldTask) => {
-          return {
-            external_id: oldTask.externalAppealId,
-            parent_id: oldTask.taskId,
-            assigned_to_id: assigneeId
-          };
-        })
+        tasks: amaTasks.map((oldTask) => ({
+          external_id: oldTask.externalAppealId,
+          parent_id: oldTask.taskId,
+          assigned_to_id: assigneeId
+        }))
       }
     }
   };
 
-  const legacyParams = legacyTasks.map((oldTask) => {
-    return {
-      url: '/legacy_tasks',
-      requestParams: {
-        data: {
-          tasks: {
-            assigned_to_id: assigneeId,
-            type: 'JudgeCaseAssignmentToAttorney',
-            appeal_id: oldTask.appealId
-          }
+  const legacyParams = legacyTasks.map((oldTask) => ({
+    url: '/legacy_tasks',
+    requestParams: {
+      data: {
+        tasks: {
+          assigned_to_id: assigneeId,
+          type: 'JudgeCaseAssignmentToAttorney',
+          appeal_id: oldTask.appealId
         }
       }
-    };
-  });
+    }
+  }));
 
   const paramsArray = amaParams.requestParams.data.tasks.length ? legacyParams.concat(amaParams) : legacyParams;
 

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -400,16 +400,13 @@ export const bulkAssignTasks =
   });
 
 // isInitial is only used for das deprecation
-const dispatchOldTasks = (dispatch, oldTasks, resp, isInitial = false) => {
+const dispatchOldTasks = (dispatch, oldTasks, resp) => {
   // Ama request is batched
   if (Array.isArray(oldTasks) || oldTasks.appealType === 'Appeal') {
     dispatch(onReceiveAmaTasks(resp.tasks.data));
   } else {
     // For das deprecation, legacy_task_controller#create returns tasks, not a task
-    const tasks = isInitial && (oldTasks.appealType === 'LegacyAppeal' && !oldTasks.isLegacy) ?
-      resp.tasks.data :
-      [resp.task.data];
-
+    const tasks = [resp.task.data].flat();
     const allTasks = prepareAllTasksForStore(tasks);
 
     dispatch(onReceiveTasks({
@@ -461,7 +458,7 @@ export const initialAssignTasksToUser = ({
       then((resp) => {
         const assignedTasks = requestParams.data.tasks;
 
-        dispatchOldTasks(dispatch, assignedTasks, resp, true);
+        dispatchOldTasks(dispatch, assignedTasks, resp);
 
         [assignedTasks].flat().forEach((oldTask) => {
           dispatch(setSelectionOfTaskOfUser({

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -424,6 +424,7 @@ export const initialAssignTasksToUser = ({
 
   const amaParams = {
     url: '/judge_assign_tasks',
+    taskIds: amaTasks.map((oldTask) => oldTask.uniqueId),
     requestParams: {
       data: {
         tasks: amaTasks.map((oldTask) => ({
@@ -437,6 +438,7 @@ export const initialAssignTasksToUser = ({
 
   const legacyParams = legacyTasks.map((oldTask) => ({
     url: '/legacy_tasks',
+    taskIds: [oldTask.uniqueId],
     requestParams: {
       data: {
         tasks: {
@@ -451,20 +453,18 @@ export const initialAssignTasksToUser = ({
   const paramsArray = amaParams.requestParams.data.tasks.length ? legacyParams.concat(amaParams) : legacyParams;
 
   return Promise.all(paramsArray.map((params) => {
-    const { requestParams, url } = params;
+    const { requestParams, url, taskIds } = params;
 
     return ApiUtil.post(url, requestParams).
       then((resp) => resp.body).
       then((resp) => {
-        const assignedTasks = requestParams.data.tasks;
+        dispatchOldTasks(dispatch, requestParams.data.tasks, resp);
 
-        dispatchOldTasks(dispatch, assignedTasks, resp);
-
-        [assignedTasks].flat().forEach((oldTask) => {
+        taskIds.forEach((taskId) => {
           dispatch(setSelectionOfTaskOfUser({
             userId: previousAssigneeId,
-            taskId: oldTask.uniqueId,
-            selected: false
+            selected: false,
+            taskId
           }));
 
           dispatch(incrementTaskCountForAttorney({

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
   end
 
   context "Can move appeals between attorneys" do
-    scenario "submits draft decision" do
+    fscenario "submits draft decision" do
       judge_task_one = create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, appeal: appeal_one)
       judge_task_two = create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, appeal: appeal_two)
 
@@ -206,7 +206,7 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
     end
   end
 
-  describe "Assigning a legacy appeal to an attorney from the case details page" do
+  fdescribe "Assigning a legacy appeal to an attorney from the case details page" do
     let!(:vacols_case) { create(:case, staff: vacols_user_one) }
     let!(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
     let!(:decass) { create(:decass, defolder: vacols_case.bfkey) }

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
   end
 
   context "Can move appeals between attorneys" do
-    fscenario "submits draft decision" do
+    scenario "submits draft decision" do
       judge_task_one = create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, appeal: appeal_one)
       judge_task_two = create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, appeal: appeal_two)
 
@@ -206,7 +206,7 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
     end
   end
 
-  fdescribe "Assigning a legacy appeal to an attorney from the case details page" do
+  describe "Assigning a legacy appeal to an attorney from the case details page" do
     let!(:vacols_case) { create(:case, staff: vacols_user_one) }
     let!(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
     let!(:decass) { create(:decass, defolder: vacols_case.bfkey) }


### PR DESCRIPTION
~Random thought that may solve inconsistent request store tasks on the front end that may have given users the ability to create multiple assign requests~ Resolves #13086

### Description
The judge assign tasks controller was always able to handle multiple task assignments, but for some reason we only would send a request for each task. This PR batch assigns ama tasks to only receive and set the new tasks in the redux store once.

### Acceptance Criteria
- [ ] All tests still pass
- [ ] One request for all AMA task assignments is sent to the back end

### Testing Plan
1. Sign in as BVAAAAAABSHIRE and go to http://localhost:3000/queue/3/assign
1. Select multiple legacy appeals and ama appeals and assign them to an attorney
1. Confirm
   1. Button says "Assign 0 cases"
   1. We still send 1 request per each legacy appeal
   1. We send 1 request for _all_ the selected ama appeals
   1. Case numbers are still correctly updated in the attorney headers
   1. Assigned cases load correctly in the attorney assigned table (http://localhost:3000/queue/3/assign/<attorney_id>)
   1. Throw in a refresh for good measure to confirm numbers and tasks are all in their correct places