### PR TITLE
Decouple UpcomingHearingDays from AssignHearingTabs

### DIFF
--- a/client/app/components/TableFilter.jsx
+++ b/client/app/components/TableFilter.jsx
@@ -41,8 +41,9 @@ const iconStyle = css(
  *     user readable text
  *   - @label {string} used for the aria-label on the icon,
  *   - @valueName {string} used as the name for the dropdown filter.
- *   - @valueTransform {function(any)} function that takes the value of the
- *     column, and transforms it into a string.
+ *   - @valueTransform {function(any, any)} function that takes the value of the
+ *     column, and transforms it into a string. The row is passed in as a second
+ *     argument.
  */
 
 class TableFilter extends React.PureComponent {
@@ -52,10 +53,10 @@ class TableFilter extends React.PureComponent {
     this.state = { open: false };
   }
 
-  transformColumnValue = (columnValue) => {
+  transformColumnValue = (columnValue, row) => {
     const { valueTransform } = this.props;
 
-    return valueTransform ? valueTransform(columnValue) : columnValue;
+    return valueTransform ? valueTransform(columnValue, row) : columnValue;
   }
 
   filterDropdownOptions = (tableDataByRow, columnName) => {
@@ -72,7 +73,7 @@ class TableFilter extends React.PureComponent {
 
     const countByColumnName = _.countBy(
       tableDataByRow,
-      (row) => this.transformColumnValue(_.get(row, columnName))
+      (row) => this.transformColumnValue(_.get(row, columnName), row)
     );
     const uniqueOptions = [];
 

--- a/client/app/hearings/components/assignHearings/AssignHearingsFields.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsFields.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import _ from 'lodash';
+
 import { getTime, getTimeInDifferentTimeZone } from '../../../util/DateUtil';
 import DocketTypeBadge from '../../../components/DocketTypeBadge';
-import _ from 'lodash';
 
 export const HearingTime = ({ hearing, isCentralOffice }) => {
   const { date, regionalOfficeTimezone } = hearing;

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -1,13 +1,7 @@
 import React from 'react';
-import { css } from 'glamor';
-import QueueTable from '../../../queue/QueueTable';
 import PropTypes from 'prop-types';
-
-const tableNumberStyling = css({
-  '& tr > td:first-child': {
-    paddingRight: 0
-  }
-});
+import QueueTable from '../../../queue/QueueTable';
+import { tableNumberStyling } from './styles';
 
 class AssignHearingsTable extends React.Component {
 

--- a/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
@@ -6,7 +6,6 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import LEGACY_APPEAL_TYPES_BY_ID from '../../../../constants/LEGACY_APPEAL_TYPES_BY_ID.json';
 
-import { sortHearings } from '../../utils';
 import COPY from '../../../../COPY.json';
 import AssignHearingsTable from './AssignHearingsTable';
 import UpcomingHearingsTable from './UpcomingHearingsTable';
@@ -22,15 +21,6 @@ import PowerOfAttorneyDetail from '../../../queue/PowerOfAttorneyDetail';
 const UPCOMING_HEARINGS_TAB_NAME = 'upcomingHearings';
 const AMA_APPEALS_TAB_NAME = 'amaAppeals';
 const LEGACY_APPEALS_TAB_NAME = 'legacyAppeals';
-
-const NoUpcomingHearingDayMessage = () => (
-  <StatusMessage
-    title={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_HEADER}
-    type="alert"
-    messageText={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_MESSAGE}
-    wrapInAppSegment={false}
-  />
-);
 
 const AvailableVeteransTable = ({ rows, columns, selectedHearingDay, style = {} }) => {
   if (_.isNil(selectedHearingDay)) {

--- a/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
@@ -13,18 +13,14 @@ import TabWindow from '../../../components/TabWindow';
 import { renderAppealType } from '../../../queue/utils';
 import StatusMessage from '../../../components/StatusMessage';
 import { getFacilityType } from '../../../components/DataDropdowns/AppealHearingLocations';
+import { NoUpcomingHearingDayMessage } from './Messages';
 import { getIndexOfDocketLine, docketCutoffLineStyle } from './AssignHearingsDocketLine';
 import { AppealDocketTag, SuggestedHearingLocation, CaseDetailsInformation } from './AssignHearingsFields';
-
 import PowerOfAttorneyDetail from '../../../queue/PowerOfAttorneyDetail';
-
-const UPCOMING_HEARINGS_TAB_NAME = 'upcomingHearings';
-const AMA_APPEALS_TAB_NAME = 'amaAppeals';
-const LEGACY_APPEALS_TAB_NAME = 'legacyAppeals';
 
 const AvailableVeteransTable = ({ rows, columns, selectedHearingDay, style = {} }) => {
   if (_.isNil(selectedHearingDay)) {
-    return <div><NoUpcomingHearingDayMessage /></div>;
+    return <NoUpcomingHearingDayMessage />;
   }
 
   if (_.isEmpty(rows)) {
@@ -115,7 +111,7 @@ export class AssignHearingsTabs extends React.Component {
     }));
   };
 
-  tabWindowColumns = (tab) => {
+  tabWindowColumns = () => {
     // Remove `displayPowerOfAttorneyColumn` when pagination lands (#11757)
     const { selectedRegionalOffice, selectedHearingDay, displayPowerOfAttorneyColumn } = this.props;
 
@@ -247,7 +243,7 @@ export class AssignHearingsTabs extends React.Component {
             label: 'Legacy Veterans Waiting',
             page: <AvailableVeteransTable
               rows={legacyRows}
-              columns={this.tabWindowColumns(LEGACY_APPEALS_TAB_NAME)}
+              columns={this.tabWindowColumns()}
               selectedHearingDay={selectedHearingDay}
             />
           },
@@ -256,7 +252,7 @@ export class AssignHearingsTabs extends React.Component {
             page: <AvailableVeteransTable
               style={this.amaDocketCutoffLineStyle(amaAppeals)}
               rows={amaRows}
-              columns={this.tabWindowColumns(AMA_APPEALS_TAB_NAME)}
+              columns={this.tabWindowColumns()}
               selectedHearingDay={selectedHearingDay}
             />
           }

--- a/client/app/hearings/components/assignHearings/Messages.jsx
+++ b/client/app/hearings/components/assignHearings/Messages.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import StatusMessage from '../../../components/StatusMessage';
 import COPY from '../../../../COPY.json';
 

--- a/client/app/hearings/components/assignHearings/Messages.jsx
+++ b/client/app/hearings/components/assignHearings/Messages.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import StatusMessage from '../../../components/StatusMessage';
 import COPY from '../../../../COPY.json';
+import StatusMessage from '../../../components/StatusMessage';
 
 export const NoUpcomingHearingDayMessage = () => (
   <div>

--- a/client/app/hearings/components/assignHearings/Messages.jsx
+++ b/client/app/hearings/components/assignHearings/Messages.jsx
@@ -1,0 +1,13 @@
+import StatusMessage from '../../../components/StatusMessage';
+import COPY from '../../../../COPY.json';
+
+export const NoUpcomingHearingDayMessage = () => (
+  <div>
+    <StatusMessage
+      title={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_HEADER}
+      type="alert"
+      messageText={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_MESSAGE}
+      wrapInAppSegment={false}
+    />
+  </div>
+);

--- a/client/app/hearings/components/assignHearings/Messages.jsx
+++ b/client/app/hearings/components/assignHearings/Messages.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import COPY from '../../../../COPY.json';
 import StatusMessage from '../../../components/StatusMessage';
 

--- a/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
@@ -4,10 +4,11 @@ import moment from 'moment';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 
-import COPY from '../../../../COPY.json';
 import { renderAppealType } from '../../../queue/utils';
 import { HearingTime, HearingDocketTag, HearingAppellantName } from './AssignHearingsFields';
+import { NoUpcomingHearingDayMessage } from './Messages';
 import QueueTable from '../../../queue/QueueTable';
+import { tableNumberStyling } from './styles';
 
 export default class UpcomingHearingsTable extends React.PureComponent {
 
@@ -30,7 +31,7 @@ export default class UpcomingHearingsTable extends React.PureComponent {
         align: 'left',
         // Since this column isn't tied to anything in the input row, _value will
         // always be undefined.
-        valueFunction: (_value, rowId) => rowId + 1
+        valueFunction: (_value, rowId) => <span>{rowId + 1}.</span>
       },
       {
         header: 'Case Details',
@@ -87,16 +88,7 @@ export default class UpcomingHearingsTable extends React.PureComponent {
     const { hearings, selectedHearingDay } = this.props;
 
     if (_.isNil(selectedHearingDay)) {
-      return (
-        <div>
-          <StatusMessage
-            title={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_HEADER}
-            type="alert"
-            messageText={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_MESSAGE}
-            wrapInAppSegment={false}
-          />
-        </div>
-      );
+      return <NoUpcomingHearingDayMessage />;
     }
 
     return (
@@ -108,6 +100,8 @@ export default class UpcomingHearingsTable extends React.PureComponent {
           columns={this.getColumns()}
           rowObjects={Object.values(hearings)}
           slowReRendersAreOk
+          summary="upcoming-hearings"
+          bodyStyling={tableNumberStyling}
         />
       </div>
     );

--- a/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
@@ -36,7 +36,6 @@ export default class UpcomingHearingsTable extends React.PureComponent {
       {
         header: 'Case Details',
         align: 'left',
-        valueName: 'caseDetails',
         valueFunction: (row) => (
           <Link
             name={row.appealExternalId}
@@ -48,7 +47,6 @@ export default class UpcomingHearingsTable extends React.PureComponent {
       {
         header: 'Type(s)',
         align: 'left',
-        valueName: 'type',
         valueFunction: (row) => renderAppealType({
           caseType: row.appealType,
           isAdvancedOnDocket: row.aod
@@ -57,7 +55,6 @@ export default class UpcomingHearingsTable extends React.PureComponent {
       {
         header: 'Docket Number',
         align: 'left',
-        valueName: 'docketNumber',
         valueFunction: (row) => <HearingDocketTag hearing={row} />
       },
       {
@@ -74,7 +71,6 @@ export default class UpcomingHearingsTable extends React.PureComponent {
       {
         header: 'Time',
         align: 'left',
-        columnName: 'time',
         valueFunction: (row) => (
           <HearingTime hearing={row} isCentralOffice={this.isCentralOffice()} />
         )

--- a/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
+import moment from 'moment';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+
+import { renderAppealType } from '../../../queue/utils';
+import { HearingTime, HearingDocketTag, HearingAppellantName } from './AssignHearingsFields';
+import QueueTable from '../../../queue/QueueTable';
+
+export default class UpcomingHearingsTable extends React.PureComponent {
+
+  isCentralOffice = () => {
+    return this.props.selectedRegionalOffice === 'C';
+  }
+
+  getLinkToAppeal = (appealExternalId) => {
+    const { selectedHearingDay, selectedRegionalOffice } = this.props;
+    const date = moment(selectedHearingDay.scheduledFor).format('YYYY-MM-DD');
+    const qry = `?hearingDate=${date}&regionalOffice=${selectedRegionalOffice}`;
+
+    return `/queue/appeals/${appealExternalId}/${qry}`;
+  }
+
+  getColumns = () => {
+    const { selectedHearingDay, selectedRegionalOffice } = this.props;
+    const columns = [
+      {
+        header: '',
+        align: 'left',
+        valueFunction: (_, rowId) => rowId + 1
+      },
+      {
+        header: 'Case Details',
+        align: 'left',
+        valueName: 'caseDetails',
+        valueFunction: (row) => (
+          <Link
+            name={row.appealExternalId}
+            href={this.getLinkToAppeal(row.appealExternalId)}>
+            <HearingAppellantName hearing={row} />
+          </Link>
+        )
+      },
+      {
+        header: 'Type(s)',
+        align: 'left',
+        valueName: 'type',
+        valueFunction: (row) => renderAppealType({
+          caseType: row.appealType,
+          isAdvancedOnDocket: row.aod
+        })
+      },
+      {
+        header: 'Docket Number',
+        align: 'left',
+        valueName: 'docketNumber',
+        valueFunction: (row) => <HearingDocketTag hearing={row} />
+      },
+      {
+        name: 'Hearing Location',
+        header: 'Hearing Location',
+        align: 'left',
+        columnName: 'readableLocation',
+        valueName: 'readableLocation',
+        label: 'Filter by location',
+        anyFiltersAreSet: true,
+        enableFilter: true,
+        enableFilterTextTransform: false
+      },
+      {
+        header: 'Time',
+        align: 'left',
+        columnName: 'time',
+        valueFunction: (row) => (
+          <HearingTime hearing={row} isCentralOffice={this.isCentralOffice()} />
+        )
+      }
+    ];
+
+    return columns;
+  }
+
+  render() {
+    const { hearings, selectedHearingDay } = this.props;
+
+    if (_.isNil(selectedHearingDay)) {
+      return <div><NoUpcomingHearingDayMessage /></div>;
+    }
+
+    return (
+      <div>
+        <Link to={`/schedule/docket/${selectedHearingDay.id}`}>
+          {`View the Daily Docket for ${moment(selectedHearingDay.scheduledFor).format('M/DD/YYYY')}` }
+        </Link>
+        <QueueTable
+          columns={this.getColumns()}
+          rowObjects={Object.values(hearings)}
+          slowReRendersAreOk
+        />
+      </div>
+    );
+  }
+}
+
+UpcomingHearingsTable.propTypes = {
+  hearings: PropTypes.object,
+  selectedHearingDay: PropTypes.shape({
+    id: PropTypes.number,
+    scheduledFor: PropTypes.string
+  }),
+  selectedRegionalOffice: PropTypes.string
+};

--- a/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/UpcomingHearingsTable.jsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 
+import COPY from '../../../../COPY.json';
 import { renderAppealType } from '../../../queue/utils';
 import { HearingTime, HearingDocketTag, HearingAppellantName } from './AssignHearingsFields';
 import QueueTable from '../../../queue/QueueTable';
@@ -23,12 +24,13 @@ export default class UpcomingHearingsTable extends React.PureComponent {
   }
 
   getColumns = () => {
-    const { selectedHearingDay, selectedRegionalOffice } = this.props;
     const columns = [
       {
         header: '',
         align: 'left',
-        valueFunction: (_, rowId) => rowId + 1
+        // Since this column isn't tied to anything in the input row, _value will
+        // always be undefined.
+        valueFunction: (_value, rowId) => rowId + 1
       },
       {
         header: 'Case Details',
@@ -85,7 +87,16 @@ export default class UpcomingHearingsTable extends React.PureComponent {
     const { hearings, selectedHearingDay } = this.props;
 
     if (_.isNil(selectedHearingDay)) {
-      return <div><NoUpcomingHearingDayMessage /></div>;
+      return (
+        <div>
+          <StatusMessage
+            title={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_HEADER}
+            type="alert"
+            messageText={COPY.ASSIGN_HEARINGS_TABS_NO_HEARING_DAY_MESSAGE}
+            wrapInAppSegment={false}
+          />
+        </div>
+      );
     }
 
     return (

--- a/client/app/hearings/components/assignHearings/styles.jsx
+++ b/client/app/hearings/components/assignHearings/styles.jsx
@@ -1,0 +1,7 @@
+import { css } from 'glamor';
+
+export const tableNumberStyling = css({
+  '& tr > td:first-child': {
+    paddingRight: 0
+  }
+});

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
@@ -104,7 +104,7 @@ PowerOfAttorneyDetail.defaultProps = {
 const mapStateToProps = (state, ownProps) => {
   const loadingPowerOfAttorney = _.get(state.queue.loadingAppealDetail[ownProps.appealId], 'powerOfAttorney');
 
-  if (!loadingPowerOfAttorney) {
+  if (_.isUndefined(loadingPowerOfAttorney) || loadingPowerOfAttorney.loading) {
     return { loading: true };
   }
 
@@ -116,8 +116,8 @@ const mapStateToProps = (state, ownProps) => {
 
   return {
     powerOfAttorney: appeal.powerOfAttorney,
-    loading: loadingPowerOfAttorney ? loadingPowerOfAttorney.loading : null,
-    error: loadingPowerOfAttorney ? loadingPowerOfAttorney.error : null
+    loading: null,
+    error: loadingPowerOfAttorney.error
   };
 };
 

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -29,8 +29,9 @@ import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
  *     an argument and returns the value of the cell for that column.
  *   - @valueName {string} if valueFunction is not defined, cell value will use
  *     valueName to pull that attribute from the rowObject.
- *   - @filterValueTransform {function(any)} function that takes the value of the
- *     column, and transforms it into a string for filtering.
+ *   - @filterValueTransform {function(any, any)} function that takes the value of the
+ *     column, and transforms it into a string for filtering. The row is passed in as
+ *     a second argument.
  *   - @filterOptions {array[object]} array of value - displayText pairs to override the
  *     generated filter values and counts in <TableFilter>
  *   - @enableFilterTextTransform {boolean} when true, filter text that gets displayed
@@ -320,7 +321,7 @@ export default class QueueTable extends React.PureComponent {
           let cellValue = _.get(row, columnName);
 
           if (columnConfig && columnConfig.filterValueTransform) {
-            cellValue = columnConfig.filterValueTransform(cellValue);
+            cellValue = columnConfig.filterValueTransform(cellValue, row);
           }
 
           if (_.isNil(cellValue)) {


### PR DESCRIPTION
Prerequisite to #11757 

### Description

  * Moves `UpcomingHearingsTable` to a separate component, which doesn't use `AssignHearingTable`
  * Fix bug in `PowerOfAttorneyDetail` where the component thought it was constantly being loaded
  * Pass the current row to the `filterValueTransform`. This acts as context, and can optionally be handled

I'm making this change because it is not necessary to paginate `UpcomingHearingsTable`. The data that powers the `UpcomingHearingsTable` is bounded by the number of hearings for a given day (usually fewer than 20). `UpcomingHearingsTable` leverages `AssignHearingsTable`, and the plan right now is to add pagination to just `AssignHearingsTable`. It doesn't make sense to make `AssignHearingsTable` flexible enough to handle both cases...and I think it's probably just better to separate them at this point.
