### PR TITLE
RootTask closes itself if all child tasks will be closed after_save

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -303,6 +303,14 @@ class Task < ApplicationRecord
     ["", ""]
   end
 
+  def post_dispatch_task?
+    dispatch_task = appeal.tasks.completed.find_by(type: [BvaDispatchTask.name, QualityReviewTask.name])
+
+    return false unless dispatch_task
+
+    created_at > dispatch_task.closed_at
+  end
+
   def children_attorney_tasks
     children.where(type: AttorneyTask.name)
   end

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -45,7 +45,7 @@ class RootTask < Task
   def update_children_status_after_closed
     transaction do
       # do not use update_all since that will avoid callbacks and we want versions history.
-      children.open.where(type: CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED).to_a.each(&:completed!)
+      children.open.where(type: CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED).find_each(&:completed!)
     end
   end
 

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -9,11 +9,19 @@ class RootTask < Task
   # Set assignee to the Bva organization automatically so we don't have to set it when we create RootTasks.
   after_initialize :set_assignee, if: -> { assigned_to_id.nil? }
 
+  CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED = [TrackVeteranTask.name].freeze
+
   def set_assignee
     self.assigned_to = Bva.singleton
   end
 
-  def when_child_task_completed(_child_task); end
+  def when_child_task_completed(child_task)
+    return unless child_task.post_dispatch_task?
+
+    if all_open_children_will_be_closed_after_closed?
+      completed!
+    end
+  end
 
   def self.creatable_tasks_types_when_on_hold
     [
@@ -35,7 +43,11 @@ class RootTask < Task
   end
 
   def update_children_status_after_closed
-    children.open.where(type: TrackVeteranTask.name).update_all(status: Constants.TASK_STATUSES.completed)
+    children.open.where(type: CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED).update_all(status: Constants.TASK_STATUSES.completed)
+  end
+
+  def all_open_children_will_be_closed_after_closed?
+    children.open.where.not(type: CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED).empty?
   end
 
   def hide_from_case_timeline

--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -43,7 +43,10 @@ class RootTask < Task
   end
 
   def update_children_status_after_closed
-    children.open.where(type: CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED).update_all(status: Constants.TASK_STATUSES.completed)
+    transaction do
+      # do not use update_all since that will avoid callbacks and we want versions history.
+      children.open.where(type: CHILD_TASK_TYPES_TO_CLOSE_AFTER_CLOSED).to_a.each(&:completed!)
+    end
   end
 
   def all_open_children_will_be_closed_after_closed?

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -504,6 +504,14 @@ FactoryBot.define do
       assigned_by { nil }
     end
 
+    factory :reconsideration_motion_mail_task, class: ReconsiderationMotionMailTask do
+      type { ReconsiderationMotionMailTask.name }
+      appeal { create(:appeal) }
+      parent { create(:root_task) }
+      assigned_to { MailTeam.singleton }
+      assigned_by { nil }
+    end
+
     factory :vacate_motion_mail_task, class: VacateMotionMailTask do
       type { VacateMotionMailTask.name }
       appeal { create(:appeal) }


### PR DESCRIPTION
Resolves #13133 

### Description
Use existing callbacks to allow RootTask to close itself when there are only auto-close-able child tasks remaining.

This applies primarily to tasks opened *after* a case has been dispatched.

Tested in production, the `.post_dispatch_task?` correctly identifies 28 of the 30 stuck appeals.
```ruby
stuck_appeals.select { |appeal| appeal.tasks.any? { |t| t.open? && t.post_dispatch_task? } }
```