### PR TITLE
unset session pg_user_id if user not found

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -69,6 +69,8 @@ detectors:
       - TaskTimerJob
       - UpdateCachedAppealsAttributesJob#assignees_for_vacols_id
       - UserReporter#report_user_related_records
+      - User#current_case_assignments_with_views
+      - User#appeal_has_task_assigned_to_user?
       - VeteranAttributeCacher
       - WarmBgsCachesJob
       - ExternalApi::PexipService#send_pexip_request
@@ -78,6 +80,7 @@ detectors:
       - Task
       - CaseflowJob
       - Api::V3::DecisionReview::HigherLevelReviewIntakeProcessor
+      - User
   IrresponsibleModule:
     enabled: false
   LongParameterList:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ApplicationRecord
   def regional_office
     upcase = ->(str) { str ? str.upcase : str }
 
-    ro_is_ambiguous_from_station_office? ? upcase.call(@regional_office) : station_offices
+    ro_is_ambiguous_from_station_office? ? upcase.call(regional_office) : station_offices
   end
 
   def users_regional_office
@@ -416,13 +416,7 @@ class User < ApplicationRecord
       end
       user = user_by_id || find_by_css_id(css_id)
 
-      attrs = {
-        station_id: user_session["station_id"],
-        full_name: user_session["name"],
-        email: user_session["email"],
-        roles: user_session["roles"],
-        regional_office: session[:regional_office]
-      }
+      attrs = attrs_from_session(user_session)
 
       user ||= create!(attrs.merge(css_id: css_id.upcase))
       user.update!(attrs.merge(last_login_at: Time.zone.now))
@@ -463,6 +457,16 @@ class User < ApplicationRecord
     end
 
     private
+
+    def attrs_from_session(user_session)
+      {
+        station_id: user_session["station_id"],
+        full_name: user_session["name"],
+        email: user_session["email"],
+        roles: user_session["roles"],
+        regional_office: session[:regional_office]
+      }
+    end
 
     def prod_system_user
       find_or_initialize_by(station_id: "283", css_id: "CSFLOW")

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -410,16 +410,14 @@ class User < ApplicationRecord
 
       pg_user_id = user_session["pg_user_id"]
       css_id = user_session["id"]
-      station_id = user_session["station_id"]
       user_by_id = find_by(id: pg_user_id)
       if !user_by_id && pg_user_id
         session["user"]["pg_user_id"] = nil
-        pg_user_id = nil
       end
       user = user_by_id || find_by_css_id(css_id)
 
       attrs = {
-        station_id: station_id,
+        station_id: user_session["station_id"],
         full_name: user_session["name"],
         email: user_session["email"],
         roles: user_session["roles"],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -410,10 +410,10 @@ class User < ApplicationRecord
 
       pg_user_id = user_session["pg_user_id"]
       css_id = user_session["id"]
-      user_by_id = find_by_pg_user_id!(pg_user_id)
+      user_by_id = find_by_pg_user_id!(pg_user_id, session)
       user = user_by_id || find_by_css_id(css_id)
 
-      attrs = attrs_from_session(user_session)
+      attrs = attrs_from_session(session, user_session)
 
       user ||= create!(attrs.merge(css_id: css_id.upcase))
       user.update!(attrs.merge(last_login_at: Time.zone.now))
@@ -455,14 +455,15 @@ class User < ApplicationRecord
 
     private
 
-    def find_by_pg_user_id!(pg_user_id)
+    def find_by_pg_user_id!(pg_user_id, session)
       user_by_id = find_by(id: pg_user_id)
       if !user_by_id && pg_user_id
         session["user"]["pg_user_id"] = nil
       end
+      user_by_id
     end
 
-    def attrs_from_session(user_session)
+    def attrs_from_session(session, user_session)
       {
         station_id: user_session["station_id"],
         full_name: user_session["name"],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,7 +47,7 @@ class User < ApplicationRecord
   def regional_office
     upcase = ->(str) { str ? str.upcase : str }
 
-    ro_is_ambiguous_from_station_office? ? upcase.call(regional_office) : station_offices
+    ro_is_ambiguous_from_station_office? ? upcase.call(@regional_office) : station_offices
   end
 
   def users_regional_office
@@ -410,10 +410,7 @@ class User < ApplicationRecord
 
       pg_user_id = user_session["pg_user_id"]
       css_id = user_session["id"]
-      user_by_id = find_by(id: pg_user_id)
-      if !user_by_id && pg_user_id
-        session["user"]["pg_user_id"] = nil
-      end
+      user_by_id = find_by_pg_user_id!(pg_user_id)
       user = user_by_id || find_by_css_id(css_id)
 
       attrs = attrs_from_session(user_session)
@@ -457,6 +454,13 @@ class User < ApplicationRecord
     end
 
     private
+
+    def find_by_pg_user_id!(pg_user_id)
+      user_by_id = find_by(id: pg_user_id)
+      if !user_by_id && pg_user_id
+        session["user"]["pg_user_id"] = nil
+      end
+    end
 
     def attrs_from_session(user_session)
       {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -411,7 +411,12 @@ class User < ApplicationRecord
       pg_user_id = user_session["pg_user_id"]
       css_id = user_session["id"]
       station_id = user_session["station_id"]
-      user = pg_user_id ? find_by(id: pg_user_id) : find_by_css_id(css_id)
+      user_by_id = find_by(id: pg_user_id)
+      if !user_by_id && pg_user_id
+        session["user"]["pg_user_id"] = nil
+        pg_user_id = nil
+      end
+      user = user_by_id || find_by_css_id(css_id)
 
       attrs = {
         station_id: station_id,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -484,6 +484,14 @@ describe User, :all_dbs do
         session["user"]["pg_user_id"] = user.id
         expect(subject).to eq user
       end
+
+      it "resets pg_user_id when it is not found" do
+        user = create(:user, css_id: css_id)
+        expect(User).to receive(:find_by_css_id).and_call_original
+        session["user"]["pg_user_id"] = user.id + 1000 # integer not found
+        expect(subject).to eq user
+        expect(session["user"]["pg_user_id"]).to eq user.id
+      end
     end
 
     context "returns nil when no user in session" do


### PR DESCRIPTION
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7634/

### Description
If a Rails session `pg_user_id` is stale and no longer points at a valid User row, unset the session variable.