### PR TITLE
BGS NoRatingsExistForVeteran error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "aasm", "4.11.0"
 gem "activerecord-import"
 gem "acts_as_tree"
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "85845c2d6a2c8190762d07a365e92972259e98b9"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "136e263aafaf6512ad552ac67a4a8b26d1222f16"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 85845c2d6a2c8190762d07a365e92972259e98b9
-  ref: 85845c2d6a2c8190762d07a365e92972259e98b9
+  revision: 136e263aafaf6512ad552ac67a4a8b26d1222f16
+  ref: 136e263aafaf6512ad552ac67a4a8b26d1222f16
   specs:
     bgs (0.2)
       httpclient

--- a/app/models/rating.rb
+++ b/app/models/rating.rb
@@ -138,7 +138,7 @@ class Rating
       end
 
       unsorted.sort_by(&:promulgation_date).reverse
-    rescue Savon::Error
+    rescue Savon::Error, BGS::ShareError
       []
     end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -314,7 +314,7 @@ class Fakes::BGSService
 
     # Simulate the error bgs throws if participant doesn't exist or doesn't have any ratings
     if ratings.blank?
-      fail Savon::Error, "java.lang.IndexOutOfBoundsException: Index: 0, Size: 0"
+      fail BGS::NoRatingsExistForVeteran, "No Ratings exist for this Veteran"
     end
 
     build_ratings_in_range(ratings, start_date, end_date)

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -418,5 +418,13 @@ describe Rating do
     it "returns rating objects for all ratings" do
       expect(subject.count).to eq(2)
     end
+
+    context "on NoRatingsExistForVeteran error" do
+      subject { Rating.fetch_all("FOOBAR") }
+
+      it "returns empty array" do
+        expect(subject.count).to eq(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Updates the BGS gem to use the new NoRatingsExistForVeteran exception, to mirror changes upstream.

https://dsva.slack.com/archives/CHX8FMP28/p1579008773084900

see also #12166 