### PR TITLE
Tie JudgeTeam status to its Judges status

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -342,12 +342,12 @@ class User < ApplicationRecord
 
   def user_reactivation
     # We do not automatically re-add organization membership for reactivated users
-    JudgeTeam.for_judge(self)&.update!(status: Constants.USER_STATUSES.active, status_updated_at: Time.zone.now)
+    JudgeTeam.for_judge(self)&.active!
   end
 
   def user_inactivation
     remove_user_from_auto_assign_orgs
-    JudgeTeam.for_judge(self)&.update!(status: Constants.USER_STATUSES.inactive, status_updated_at: Time.zone.now)
+    JudgeTeam.for_judge(self)&.inactive!
   end
 
   def remove_user_from_auto_assign_orgs

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,7 +288,12 @@ class User < ApplicationRecord
 
   def update_status!(new_status)
     transaction do
-      remove_user_from_auto_assign_orgs if new_status.eql?(Constants.USER_STATUSES.inactive)
+      if new_status.eql?(Constants.USER_STATUSES.inactive)
+        user_inactivation
+      elsif new_status.eql?(Constants.USER_STATUSES.active)
+        user_reactivation
+      end
+
       update!(status: new_status, status_updated_at: Time.zone.now)
     end
   end
@@ -334,6 +339,16 @@ class User < ApplicationRecord
   end
 
   private
+
+  def user_reactivation
+    # We do not automatically re-add organization membership for reactivated users
+    JudgeTeam.for_judge(self)&.update!(status: Constants.USER_STATUSES.active, status_updated_at: Time.zone.now)
+  end
+
+  def user_inactivation
+    remove_user_from_auto_assign_orgs
+    JudgeTeam.for_judge(self)&.update!(status: Constants.USER_STATUSES.inactive, status_updated_at: Time.zone.now)
+  end
 
   def remove_user_from_auto_assign_orgs
     auto_assign_orgs = organizations.select(&:automatically_assign_to_member?)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -661,6 +661,30 @@ describe User, :all_dbs do
         expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s
       end
 
+      context "when the user is a judge with a JudgeTeam" do
+        let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
+        let(:user) { judge_team.judge }
+
+        context "when marking the user inactive" do
+          it "marks their JudgeTeam as inactive" do
+            expect(subject).to eq true
+            expect(judge_team.reload.status).to eq status
+          end
+        end
+
+        context "when making an inactive user active" do
+          let(:status) { Constants.USER_STATUSES.active }
+
+          before { user.update_status!(Constants.USER_STATUSES.inactive) }
+
+          it "marks their JudgeTeam as active" do
+            expect(judge_team.reload.status).to eq Constants.USER_STATUSES.inactive
+            expect(subject).to eq true
+            expect(judge_team.reload.status).to eq status
+          end
+        end
+      end
+
       context "when the user is a member of an org that automatically assigns tasks" do
         before do
           create(:organization).add_user(user)


### PR DESCRIPTION
Resolves #12942 

### Description
When a user with a Judge team status is changed to `active`/`inactive`, their JudgeTeam's status is updated as well.

### Acceptance Criteria
- [ ] A JudgeTeam's status always matches the status of its associated Judge user 

### Testing Plan
1. Confirm counts & find an active JudgeTeam
  ```
  irb> JudgeTeam.unscoped.inactive.count
  => 0
  irb> JudgeTeam.count
  => 8
  irb> judge_team = JudgeTeam.active.first
  => #<JudgeTeam:0x000055e28689aa58
   id: 18,
   status: "active",
   status_updated_at: nil
  ...>
  ```
2. Update the status of the Judge User for that JudgeTeam to inactive
  ```
  irb> judge_team.judge.update_status!(Constants.USER_STATUSES.inactive)
  => true
  ```
3. Confirm User and JudgeTeam status are both `inactive` & the counts updated
  ```
  irb> judge_team.reload.status
  => "inactive"
  irb> judge_team.judge.status
  => "inactive"
  irb> JudgeTeam.unscoped.inactive.count
  => 1
  irb> JudgeTeam.count
  => 7
  ```
4. Update the status of the Judge User for that JudgeTeam back to active
  ```
  irb> judge_team.judge.update_status!(Constants.USER_STATUSES.active)
  => true
  ```
3. Confirm User and JudgeTeam status are both `active` again & the counts updated
  ```
  irb> judge_team.reload.status
  => "active"
  irb> judge_team.judge.status
  => "active"
  irb> JudgeTeam.unscoped.inactive.count
  => 0
  irb> JudgeTeam.count
  => 8
  ```

### User Facing Changes
None
 
