### PR TITLE
Fix inactive judge team error and selectable_orgs flake

### DIFF
--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -23,7 +23,7 @@ class JudgeTeam < Organization
     end
 
     def use_judge_team_roles?
-      FeatureToggle.enabled?(:use_judge_team_role)
+      FeatureToggle.enabled?(:judge_admin_scm)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -262,7 +262,7 @@ class User < ApplicationRecord
   end
 
   def administered_teams
-    organizations_users.select(&:admin?).map(&:organization)
+    organizations_users.select(&:admin?).map(&:organization).compact
   end
 
   def administered_judge_teams

--- a/spec/models/organizations/judge_team_spec.rb
+++ b/spec/models/organizations/judge_team_spec.rb
@@ -118,8 +118,8 @@ describe JudgeTeam, :postgres do
   end
 
   describe "feature use_judge_team_roles activated" do
-    before { FeatureToggle.enable!(:use_judge_team_role) }
-    after { FeatureToggle.disable!(:use_judge_team_role) }
+    before { FeatureToggle.enable!(:judge_admin_scm) }
+    after { FeatureToggle.disable!(:judge_admin_scm) }
 
     describe ".create_for_judge" do
       subject { JudgeTeam.create_for_judge(judge) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -319,10 +319,9 @@ describe User, :all_dbs do
 
     context "when the user is a judge team admin" do
       let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
-      let(:judge) { judge_team.judge }
+      let!(:judge) { judge_team.judge }
 
       before do
-        OrganizationsUser.make_user_admin(judge, judge_team)
         OrganizationsUser.make_user_admin(user, judge_team)
       end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -318,8 +318,8 @@ describe User, :all_dbs do
     end
 
     context "when the user is a judge team admin" do
-      let(:judge) { create(:user) }
-      let!(:judge_team) { create(:judge_team) }
+      let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
+      let(:judge) { judge_team.judge }
 
       before do
         OrganizationsUser.make_user_admin(judge, judge_team)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -323,6 +323,8 @@ describe User, :all_dbs do
 
       before do
         OrganizationsUser.make_user_admin(user, judge_team)
+        allow(JudgeTeam).to receive(:for_judge).with(user).and_return(nil)
+        allow(user).to receive(:judge_in_vacols?).and_return(false)
       end
 
       it "does not return assigned cases link for judge" do


### PR DESCRIPTION
Resolves error seen by judges when their team is made inactive.

### Description
When grabbing or users and mapping to the related organization, inactive teams are returned as `nil` causing an error when the name of the org is [queried](https://github.com/department-of-veterans-affairs/caseflow/blob/e21282bd6a16402c20171a6f7f23f29cf360cfdf/app/controllers/application_controller.rb#L41).

### Acceptance Criteria
- [ ] No errors when a users team is made inactive

### Testing Plan
1. Make a user's team they admin inactive
```ruby
user = User.find_by(css_id: "BVAAABSHIRE")
JudgeTeam.for_judge(user).inactive!
```
2. Navigate to that user's queue
3. Ensure no errors
