### PR TITLE
remove inactive users from all orgs except judges from JudgeTeams

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -275,7 +275,7 @@ class User < ApplicationRecord
 
   def selectable_organizations
     orgs = organizations.select(&:selectable_in_queue?)
-    judge_team_judges = (JudgeTeam.for_judge(self) || judge_in_vacols?) ? [self] : []
+    judge_team_judges = judge? ? [self] : []
     judge_team_judges |= administered_judge_teams.map(&:judge) if FeatureToggle.enabled?(:judge_admin_scm)
 
     judge_team_judges.each do |judge|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -362,9 +362,9 @@ class User < ApplicationRecord
 
   def remove_user_from_orgs
     removal_orgs = organizations
-    removal_orgs = removal_orgs.reject { |org| org.is_a?(JudgeTeam) && org.judge == self } if judge?
-    removal_orgs.each do |organization|
-      OrganizationsUser.remove_user_from_organization(self, organization)
+    my_judge_team = JudgeTeam.for_judge(self)
+    removal_orgs.each do |org|
+      OrganizationsUser.remove_user_from_organization(self, org) unless org == my_judge_team
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -289,7 +289,7 @@ class User < ApplicationRecord
   end
 
   def judge?
-    JudgeTeam.for_judge(self) || judge_in_vacols?
+    !!JudgeTeam.for_judge(self) || judge_in_vacols?
   end
 
   def update_status!(new_status)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,7 +288,7 @@ class User < ApplicationRecord
     orgs
   end
 
-  def is_judge?
+  def judge?
     if FeatureToggle.enabled?(:use_judge_team_role)
       JudgeTeam.for_judge(self) || judge_in_vacols?
     else
@@ -366,7 +366,7 @@ class User < ApplicationRecord
 
   def remove_user_from_orgs
     removal_orgs = organizations
-    removal_orgs = removal_orgs.reject { |org| org.is_a?(JudgeTeam) } if is_judge?
+    removal_orgs = removal_orgs.reject { |org| org.is_a?(JudgeTeam) } if judge?
     removal_orgs.each do |organization|
       OrganizationsUser.remove_user_from_organization(self, organization)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -289,11 +289,7 @@ class User < ApplicationRecord
   end
 
   def judge?
-    if FeatureToggle.enabled?(:use_judge_team_role)
-      JudgeTeam.for_judge(self) || judge_in_vacols?
-    else
-      judge_in_vacols?
-    end
+    JudgeTeam.for_judge(self) || judge_in_vacols?
   end
 
   def update_status!(new_status)
@@ -366,7 +362,7 @@ class User < ApplicationRecord
 
   def remove_user_from_orgs
     removal_orgs = organizations
-    removal_orgs = removal_orgs.reject { |org| org.is_a?(JudgeTeam) } if judge?
+    removal_orgs = removal_orgs.reject { |org| org.is_a?(JudgeTeam) && org.judge == self } if judge?
     removal_orgs.each do |organization|
       OrganizationsUser.remove_user_from_organization(self, organization)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -754,6 +754,7 @@ describe User, :all_dbs do
           end
 
           it "removes admin from all organizations, including JudgeTeam" do
+            expect(judge_team.judge).not_to eq user
             expect(judge_team.admins).to include user
             expect(user.organizations.size).to eq 3
             expect(user.selectable_organizations.length).to eq 2

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -757,9 +757,7 @@ describe User, :all_dbs do
             expect(judge_team.judge).not_to eq user
             expect(judge_team.admins).to include user
             expect(user.organizations.size).to eq 3
-            puts FeatureToggle.enabled?(:judge_admin_scm)
-            expect(user.selectable_organizations.length).to eq 3 if FeatureToggle.enabled?(:judge_admin_scm)
-            expect(user.selectable_organizations.length).to eq 2 if not FeatureToggle.enabled?(:judge_admin_scm)
+            expect(user.selectable_organizations.length).to eq 2
             expect(subject).to eq true
             expect(user.reload.status).to eq status
             expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -757,7 +757,9 @@ describe User, :all_dbs do
             expect(judge_team.judge).not_to eq user
             expect(judge_team.admins).to include user
             expect(user.organizations.size).to eq 3
-            expect(user.selectable_organizations.length).to eq 2
+            puts FeatureToggle.enabled?(:judge_admin_scm)
+            expect(user.selectable_organizations.length).to eq 3 if FeatureToggle.enabled?(:judge_admin_scm)
+            expect(user.selectable_organizations.length).to eq 2 if not FeatureToggle.enabled?(:judge_admin_scm)
             expect(subject).to eq true
             expect(user.reload.status).to eq status
             expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -728,12 +728,9 @@ describe User, :all_dbs do
 
       context "when the user is a member of many orgs" do
         let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
-        # Colocated is an org that auto-assigns tasks (ie, it overrides next_assignee)
         let(:other_orgs) { [Colocated.singleton, create(:organization)] }
 
-        before do
-          other_orgs.each { |org| org.add_user(user) }
-        end
+        before { other_orgs.each { |org| org.add_user(user) } }
 
         context "when marking the user inactive" do
           before { judge_team.add_user(user) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -747,7 +747,10 @@ describe User, :all_dbs do
         end
 
         context "when marking the admin inactive" do
-          before { OrganizationsUser.make_user_admin(user, judge_team) }
+          before do
+            OrganizationsUser.make_user_admin(user, judge_team)
+            allow(user).to receive(:judge_in_vacols?).and_return(false)
+          end
 
           it "removes admin from all organizations, including JudgeTeam" do
             expect(judge_team.admins).to include user

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -703,7 +703,7 @@ describe User, :all_dbs do
         let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
         let(:user) { judge_team.judge }
 
-        before { allow(user).to receive(:judge?).and_return(true) }
+        before { allow(user).to receive(:judge_in_vacols?).and_return(true) }
 
         context "when marking the user inactive" do
           it "marks their JudgeTeam as inactive" do
@@ -763,7 +763,7 @@ describe User, :all_dbs do
 
         context "when marking the judge inactive" do
           let(:judge_team) { JudgeTeam.create_for_judge(user) }
-          before { allow(user).to receive(:judge?).and_return(true) }
+          before { allow(user).to receive(:judge_in_vacols?).and_return(true) }
 
           it "removes judge from all orgs except their own JudgeTeam" do
             expect(user.judge?)
@@ -775,12 +775,13 @@ describe User, :all_dbs do
             expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s
             expect(judge_team.judge).to eq user
             expect(user.organizations.size).to eq 0 # 0 since judge_team is inactive
-            expect(user.selectable_organizations.length).to eq 0
+            # Every judge in vacols should be able to see their assign page, even if they don't have a judge team
+            expect(user.selectable_organizations.length).to eq 1
           end
 
           context "when judge is a non-JudgeTeamLead in another JudgeTeam" do
             let(:judge_team2) { JudgeTeam.create_for_judge(create(:user)) }
-            before { allow(user).to receive(:judge?).and_return(true) }
+            before { allow(user).to receive(:judge_in_vacols?).and_return(true) }
             before { judge_team2.add_user(user) }
 
             it "removes judge from all orgs (including JudgeTeams) except their own JudgeTeam" do
@@ -793,7 +794,8 @@ describe User, :all_dbs do
               expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s
               expect(judge_team.judge).to eq user
               expect(user.organizations.size).to eq 0 # 0 since judge_team is inactive
-              expect(user.selectable_organizations.length).to eq 0
+              # Every judge in vacols should be able to see their assign page, even if they don't have a judge team
+              expect(user.selectable_organizations.length).to eq 1
             end
           end
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -703,7 +703,7 @@ describe User, :all_dbs do
         let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
         let(:user) { judge_team.judge }
 
-        before { allow(user).to receive(:is_judge?).and_return(true) }
+        before { allow(user).to receive(:judge?).and_return(true) }
 
         context "when marking the user inactive" do
           it "marks their JudgeTeam as inactive" do
@@ -773,18 +773,17 @@ describe User, :all_dbs do
         end
 
         context "when marking the judge inactive" do
-          # let(:judge_team) { JudgeTeam.create_for_judge(user) }
-          let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
-          let(:user) { judge_team.judge }
+          let(:judge_team) { JudgeTeam.create_for_judge(user) }
           before do
-            allow(user).to receive(:is_judge?).and_return(true)
+            allow(user).to receive(:judge?).and_return(true)
             other_orgs.each do |org|
               org.add_user(user)
             end
           end
 
           it "removes judge from all orgs except JudgeTeam" do
-            expect(user.is_judge?)
+            expect(user.judge?)
+            expect(judge_team.judge).to eq user
             expect(user.organizations.size).to eq 3
             expect(user.selectable_organizations.length).to eq 3
             expect(user.update_status!(status)).to eq true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -728,7 +728,7 @@ describe User, :all_dbs do
       end
 
       context "when the user is a member of many orgs" do
-        let(:judge_team) { create(:judge_team, :has_judge_team_lead_as_admin) }
+        let(:judge_team) { JudgeTeam.create_for_judge(create(:user)) }
         let(:other_orgs) { [Colocated.singleton, create(:organization)] }
 
         before { other_orgs.each { |org| org.add_user(user) } }


### PR DESCRIPTION
Resolves #12940 

### Description
Remove a user from their organizations when they are marked inactive, except do not remove judges from their JudgeTeam (they are marked inactive #12942).

Changes:
```diff
-    remove_user_from_auto_assign_orgs
+    remove_user_from_orgs
```

### Acceptance Criteria
- [x] Code compiles correctly and tests pass

