### PR TITLE
Do not allow children of timed hold tasks

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -24,6 +24,7 @@ class Task < ApplicationRecord
   validates :assigned_to, :appeal, :type, :status, presence: true
   validate :status_is_valid_on_create, on: :create
   validate :assignee_status_is_valid_on_create, on: :create
+  validate :parent_can_have_children
 
   before_create :set_assigned_at
   before_create :verify_org_task_unique
@@ -110,6 +111,10 @@ class Task < ApplicationRecord
     end
 
     def hide_from_queue_table_view
+      false
+    end
+
+    def cannot_have_children
       false
     end
 
@@ -670,6 +675,14 @@ class Task < ApplicationRecord
   def assignee_status_is_valid_on_create
     if parent&.child_must_have_active_assignee? && assigned_to.is_a?(User) && !assigned_to.active?
       fail Caseflow::Error::InvalidAssigneeStatusOnTaskCreate, assignee: assigned_to
+    end
+
+    true
+  end
+
+  def parent_can_have_children
+    if parent&.class&.cannot_have_children
+      fail Caseflow::Error::InvalidParentTask, message: "Child tasks cannot be created for #{parent.type}s"
     end
 
     true

--- a/app/models/tasks/timed_hold_task.rb
+++ b/app/models/tasks/timed_hold_task.rb
@@ -66,6 +66,10 @@ class TimedHoldTask < Task
     true
   end
 
+  def self.cannot_have_children
+    true
+  end
+
   private
 
   def verify_parent_task_presence

--- a/spec/models/queue_tabs/organization_on_hold_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/organization_on_hold_tasks_tab_spec.rb
@@ -44,9 +44,9 @@ describe OrganizationOnHoldTasksTab, :postgres do
       let!(:assignee_on_hold_tasks) { create_list(:ama_task, 3, :assigned, assigned_to: assignee) }
       let!(:on_hold_tasks_children) do
         assignee_on_hold_tasks.map do |task|
-          create(:ama_task, :on_hold, parent_id: task.id)
-          create(:timed_hold_task, :on_hold, parent_id: task.id)
-          task.update!(status: Constants.TASK_STATUSES.on_hold)
+          create(:ama_task, parent_id: task.id)
+          create(:timed_hold_task, parent_id: task.id)
+          task.descendants.each(&:on_hold!)
           task.children
         end.flatten
       end

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -223,4 +223,14 @@ describe TimedHoldTask, :postgres do
       expect(task.hide_from_task_snapshot).to eq(true)
     end
   end
+
+  describe "when attempting to create a child of a timed hold task" do
+    let(:child_task) { create(:task, parent: task) }
+
+    subject { child_task }
+
+    it "fails" do
+      expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask)
+    end
+  end
 end

--- a/spec/models/tasks/timed_hold_task_spec.rb
+++ b/spec/models/tasks/timed_hold_task_spec.rb
@@ -233,4 +233,14 @@ describe TimedHoldTask, :postgres do
       expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask)
     end
   end
+
+  describe "when attempting to adopt a child by a timed hold task" do
+    let!(:child_task) { create(:task) }
+
+    subject { child_task.update!(parent: task) }
+
+    it "fails" do
+      expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask)
+    end
+  end
 end


### PR DESCRIPTION
Resolves #12037

### Description
Disallowed the creation of children of timed hold tasks

### Acceptance Criteria
- [ ] Creation of children of TimedHoldTasks BANNED
- [ ] Adoption of children of TimedHoldTasks BANNED