### PR TITLE
Wrap cancel tree in transaction

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -533,12 +533,15 @@ class Task < ApplicationRecord
     # by avoiding callbacks, we aren't saving PaperTrail versions
     # Manually save the state before and after.
     tasks = Task.open.where(id: descendant_ids)
-    tasks.each { |task| task.paper_trail.save_with_version }
-    tasks.update_all(
-      status: Constants.TASK_STATUSES.cancelled,
-      closed_at: Time.zone.now
-    )
-    tasks.each { |task| task.reload.paper_trail.save_with_version }
+
+    transaction do
+      tasks.each { |task| task.paper_trail.save_with_version }
+      tasks.update_all(
+        status: Constants.TASK_STATUSES.cancelled,
+        closed_at: Time.zone.now
+      )
+      tasks.each { |task| task.reload.paper_trail.save_with_version }
+    end
   end
 
   def timeline_title


### PR DESCRIPTION
Extends #12617 
### Description
Wraps the cancel tree & the PaperTrails in a transaction.

### Acceptance Criteria
- [ ] tests pass