### PR TITLE
Skip same-station conflict check when intaking appeals

### DIFF
--- a/app/models/validators/intake_start_validator.rb
+++ b/app/models/validators/intake_start_validator.rb
@@ -86,6 +86,11 @@ class IntakeStartValidator
   def user_may_modify_veteran_file?
     return true if intake.user == User.api_user
 
-    BGSService.new.may_modify?(veteran_file_number, veteran.participant_id)
+    bgs = BGSService.new
+    return false unless bgs.can_access?(veteran_file_number)
+
+    # BVA has indicated that station conflict policy doesn't apply to Appeals.
+    # See https://github.com/department-of-veterans-affairs/caseflow/issues/13165
+    intake.is_a?(AppealIntake) || !bgs.station_conflict?(veteran_file_number, veteran.participant_id)
   end
 end

--- a/app/models/validators/intake_start_validator.rb
+++ b/app/models/validators/intake_start_validator.rb
@@ -91,6 +91,9 @@ class IntakeStartValidator
 
     # BVA has indicated that station conflict policy doesn't apply to Appeals.
     # See https://github.com/department-of-veterans-affairs/caseflow/issues/13165
-    intake.is_a?(AppealIntake) || !bgs.station_conflict?(veteran_file_number, veteran.participant_id)
+    # This bypass is behind the :allow_same_station_appeals feature toggle for now.
+    return true if FeatureToggle.enabled?(:allow_same_station_appeals) && intake.is_a?(AppealIntake)
+
+    !bgs.station_conflict?(veteran_file_number, veteran.participant_id)
   end
 end

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -190,20 +190,18 @@ class ExternalApi::BGSService
     end
   end
 
-  # can_access? reflects whether a user may read a veteran's records.
-  # may_modify? reflects whether a user may establish a new claim.
-  def may_modify?(vbms_id, veteran_participant_id)
-    return false unless can_access?(vbms_id)
-
+  # station_conflict? performs a few checks to determine if the current user
+  # has a same-station conflict with the veteran in question
+  def station_conflict?(vbms_id, veteran_participant_id)
     # sometimes find_flashes works
     begin
       client.claimants.find_flashes(vbms_id)
     rescue BGS::ShareError
-      return false
+      return true
     end
 
     # sometimes the station conflict logic works
-    !ExternalApi::BgsVeteranStationUserConflict.new(
+    ExternalApi::BgsVeteranStationUserConflict.new(
       veteran_participant_id: veteran_participant_id,
       client: client
     ).conflict?

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -188,10 +188,8 @@ class Fakes::BGSService
   end
   # rubocop:enable Metrics/MethodLength
 
-  def may_modify?(vbms_id, _veteran_participant_id)
-    return false unless can_access?(vbms_id)
-
-    !(self.class.inaccessible_appeal_vbms_ids || []).include?(vbms_id)
+  def station_conflict?(vbms_id, _veteran_participant_id)
+    (self.class.inaccessible_appeal_vbms_ids || []).include?(vbms_id)
   end
 
   def can_access?(vbms_id)

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe IntakesController, :postgres do
     context "veteran in BGS but user may not modify" do
       before do
         Generators::Veteran.build(file_number: file_number, first_name: "Ed", last_name: "Merica")
-        allow_any_instance_of(Fakes::BGSService).to receive(:may_modify?).and_return(false)
+        allow_any_instance_of(Fakes::BGSService).to receive(:station_conflict?).and_return(true)
       end
 
       let(:file_number) { "999887777" }

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -202,7 +202,7 @@ feature "Intake", :all_dbs do
 
     context "Veteran is an employee at the same station as the User" do
       before do
-        allow_any_instance_of(Fakes::BGSService).to receive(:may_modify?).and_return(false)
+        allow_any_instance_of(Fakes::BGSService).to receive(:station_conflict?).and_return(true)
       end
 
       scenario "Search for a Veteran that the user may not modify" do

--- a/spec/models/validators/intake_start_validator_spec.rb
+++ b/spec/models/validators/intake_start_validator_spec.rb
@@ -6,9 +6,11 @@ describe IntakeStartValidator, :postgres do
 
     let(:veteran) { create(:veteran) }
 
+    let(:review) { HigherLevelReview.new }
+
     let(:intake) do
       # IntakeStartValidator expects an uncommitted intake (hence new)
-      Intake.new(veteran_file_number: veteran.file_number, user: user)
+      HigherLevelReviewIntake.new(veteran_file_number: veteran.file_number, detail: review, user: user)
     end
 
     let(:validator) do
@@ -21,13 +23,24 @@ describe IntakeStartValidator, :postgres do
     end
 
     it "sets no error_code when BGS allows modification" do
-      allow_any_instance_of(BGSService).to receive(:may_modify?) { true }
+      allow_any_instance_of(BGSService).to receive(:station_conflict?) { false }
       expect(validate_error_code).to be nil
     end
 
-    it "sets error_code \"veteran_not_modifiable\" when BGS does not allow modification" do
-      allow_any_instance_of(BGSService).to receive(:may_modify?) { false }
+    it "sets error_code \"veteran_not_modifiable\" when BGS shows a station conflict" do
+      allow_any_instance_of(BGSService).to receive(:station_conflict?) { true }
       expect(validate_error_code).to eq "veteran_not_modifiable"
+    end
+
+    context "intaking an Appeal" do
+      let(:intake) do
+        AppealIntake.new(veteran_file_number: veteran.file_number, detail: review, user: user)
+      end
+
+      it "sets no error_code even if BGS shows a station conflict" do
+        allow_any_instance_of(BGSService).to receive(:station_conflict?) { true }
+        expect(validate_error_code).to be nil
+      end
     end
 
     context "user is api_user" do

--- a/spec/models/validators/intake_start_validator_spec.rb
+++ b/spec/models/validators/intake_start_validator_spec.rb
@@ -36,10 +36,21 @@ describe IntakeStartValidator, :postgres do
       let(:intake) do
         AppealIntake.new(veteran_file_number: veteran.file_number, detail: review, user: user)
       end
+      subject { validate_error_code }
 
-      it "sets no error_code even if BGS shows a station conflict" do
+      it "sets an error_code if BGS shows a station conflict" do
         allow_any_instance_of(BGSService).to receive(:station_conflict?) { true }
-        expect(validate_error_code).to be nil
+        is_expected.to eq "veteran_not_modifiable"
+      end
+
+      context "appeals bypass same station check" do
+        before { FeatureToggle.enable!(:allow_same_station_appeals) }
+        after { FeatureToggle.disable!(:allow_same_station_appeals) }
+
+        it "sets no error_code even if BGS shows a station conflict" do
+          allow_any_instance_of(BGSService).to receive(:station_conflict?) { true }
+          is_expected.to be nil
+        end
       end
     end
 

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -137,8 +137,8 @@ describe ExternalApi::BGSService do
     end
   end
 
-  describe "#may_modify?" do
-    subject { bgs.may_modify?(vbms_id, veteran.participant_id) }
+  describe "#station_conflict?" do
+    subject { bgs.station_conflict?(vbms_id, veteran.participant_id) }
 
     before do
       allow(bgs_client).to receive(:people).and_return(bgs_people_service)
@@ -159,8 +159,8 @@ describe ExternalApi::BGSService do
         { ptcpnt_id: veteran.participant_id }
       end
 
-      it "returns true" do
-        expect(subject).to be_truthy
+      it "returns false" do
+        expect(subject).to be_falsey
       end
     end
 
@@ -172,8 +172,8 @@ describe ExternalApi::BGSService do
         }
       end
 
-      it "returns false" do
-        expect(subject).to be_falsey
+      it "returns true" do
+        expect(subject).to be_truthy
       end
     end
 
@@ -193,8 +193,8 @@ describe ExternalApi::BGSService do
         }
       end
 
-      it "returns true" do
-        expect(subject).to be_truthy
+      it "returns false" do
+        expect(subject).to be_falsey
       end
     end
 
@@ -203,8 +203,8 @@ describe ExternalApi::BGSService do
         allow(bgs_claimants_service).to receive(:find_flashes) { fail BGS::ShareError, "no access" }
       end
 
-      it "returns false" do
-        expect(subject).to be_falsey
+      it "returns true" do
+        expect(subject).to be_truthy
       end
     end
 
@@ -224,8 +224,8 @@ describe ExternalApi::BGSService do
         }
       end
 
-      it "returns false" do
-        expect(subject).to be_falsey
+      it "returns true" do
+        expect(subject).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Connects #13165 

### Description
This PR disables the same-station conflict check when intaking appeals, as requested by the Board. Some decisions I made:

- Doing the check for appeals up in the models/validators layer, rather than the BGSService layer. This felt like application logic that our library code for external dependencies shouldn't have to worry about.
- Replacing `may_modify?` with `station_conflict?` and adjusting the logic accordingly. This makes the method name clearly describe what it's trying to detect. I felt that `may_modify?` was coupling station conflicts with sensitivity levels, and conflating these with the desired end effect (preventing failed establishments).

Happy to hear what folks' thoughts are on this small refactor; I'm still getting to understand the division of labor between Caseflow app logic, BGSService, and BGS itself.

### Acceptance Criteria
- [ ] Same-station conflict check remains in place for ClaimReviews
- [ ] Same-station conflict check is skipped for Appeals

### Testing Plan
1. All `may_modify?` tests updated to use `station_conflict?`
2. New validator test to check that appeals bypass the conflict check
