### PR TITLE
Fix completed date sort

### DIFF
--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -252,6 +252,6 @@ export const taskCompletedDateColumn = () => {
     name: QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name,
     valueFunction: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null,
     backendCanSort: true,
-    getSortValue: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null
+    getSortValue: (task) => task.closedAt ? new Date(task.closedAt) : null
   };
 };


### PR DESCRIPTION
Resolves #13140

### Description
Fixes value returned for sorting by closed at date

### Acceptance Criteria
- [ ] Can sort by Date Completed

### Testing Plan
1. The queue of a user that has completed tasks
2. Check that sorting by Date Completed works

### User Facing Changes
![ezgif-7-ed5994c2f353](https://user-images.githubusercontent.com/45575454/72559090-09333700-3872-11ea-8e4b-b774de19fb3b.gif)