### PR TITLE
Fix ETL bug with hash keys not being symbols

### DIFF
--- a/app/models/etl/appeal.rb
+++ b/app/models/etl/appeal.rb
@@ -20,8 +20,8 @@ class ETL::Appeal < ETL::Record
       aod = person&.advance_on_docket_motions&.last
 
       # avoid BGS call on sync for nil values
-      person_attributes = person&.attributes || {}
-      veteran_person_attributes = veteran&.person&.attributes || {}
+      person_attributes = (person&.attributes || {}).symbolize_keys
+      veteran_person_attributes = (veteran&.person&.attributes || {}).symbolize_keys
 
       target.appeal_id = original.id
       target.active_appeal = original.active?

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -30,6 +30,12 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
 
         expect(ETL::Appeal.count).to eq(13)
       end
+
+      it "populates person attributes" do
+        subject
+
+        expect(ETL::Appeal.first.veteran_dob).to_not be_nil
+      end
     end
 
     context "sync tomorrow" do


### PR DESCRIPTION
Discovered while doing some manual QA.