### PR TITLE
Update inactive users page copy

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -448,7 +448,7 @@
   "USER_MANAGEMENT_ACTIVE_SUCCESS_TITLE": "Successfully made %s ACTIVE",
   "USER_MANAGEMENT_INACTIVE_SUCCESS_TITLE": "Successfully made %s INACTIVE",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s can now be assigned new tasks and will need to be added to organizations via the team management page",
-  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations they were a member of. They will not be assigned any new tasks. If this was a mistake, mark the user ACTIVE and add them to organizations on the team management page",
+  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations to which they belonged. They will no longer be assigned new tasks. If this was a mistake, mark the user ACTIVE and add them back to the proper organizations on those organizations' team management pages",
   "USER_MANAGEMENT_USER_SEARCH_ERROR_TITLE": "Error searching for user",
 
   "LOOKUP_PARTICIPANT_ID_MODAL_TITLE": "Look Up Participant ID",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -441,14 +441,14 @@
 
   "USER_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow user management",
   "USER_MANAGEMENT_STATUS_PAGE_TITLE": "Caseflow user status management",
-  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Making a user inactive will remove them from any organization that automatically assigns tasks to team members.",
+  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Making a user inactive will remove them from organizations they are a member of. Inactive users cannot be assigned new tasks.",
   "USER_MANAGEMENT_STATUS_CHANGE_ERROR_TITLE": "Failed to modify user status",
   "USER_MANAGEMENT_GIVE_USER_ACTIVE_STATUS_BUTTON_TEXT": "Make user active",
   "USER_MANAGEMENT_GIVE_USER_INACTIVE_STATUS_BUTTON_TEXT": "Make user inactive",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_TITLE": "Successfully made %s ACTIVE",
   "USER_MANAGEMENT_INACTIVE_SUCCESS_TITLE": "Successfully made %s INACTIVE",
-  "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s will need to be added to organizations that automatically assign tasks to team members via the team management page",
-  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations that automatically assign tasks to team members. If this was a mistake, mark the user ACTIVE and add them to their organizations on the team management page",
+  "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s can now be assigned new tasks and will need to be added to organizations via the team management page",
+  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations they were a member of. They will not be assigned any new tasks. If this was a mistake, mark the user ACTIVE and add them to organizations on the team management page",
   "USER_MANAGEMENT_USER_SEARCH_ERROR_TITLE": "Error searching for user",
 
   "LOOKUP_PARTICIPANT_ID_MODAL_TITLE": "Look Up Participant ID",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -441,14 +441,14 @@
 
   "USER_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow user management",
   "USER_MANAGEMENT_STATUS_PAGE_TITLE": "Caseflow user status management",
-  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Marking a user inactive will remove them from all organizations to which they currently belong. Once marked inactive, a user cannot be assigned new tasks.",
+  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Marking a user inactive will remove them from all organizations they are a member of. Once marked inactive, a user cannot be assigned new tasks.",
   "USER_MANAGEMENT_STATUS_CHANGE_ERROR_TITLE": "Failed to modify user status",
   "USER_MANAGEMENT_GIVE_USER_ACTIVE_STATUS_BUTTON_TEXT": "Make user active",
   "USER_MANAGEMENT_GIVE_USER_INACTIVE_STATUS_BUTTON_TEXT": "Make user inactive",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_TITLE": "Successfully made %s ACTIVE",
   "USER_MANAGEMENT_INACTIVE_SUCCESS_TITLE": "Successfully made %s INACTIVE",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s can now be assigned new tasks and will need to be added to organizations via the team management page",
-  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations to which they belonged. They will no longer be assigned new tasks. If this was a mistake, mark the user ACTIVE and add them back to the proper organizations on those organizations' team management pages",
+  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations they were a member of. They will no longer be assigned new tasks. If this was a mistake, mark the user ACTIVE and add them back to the proper organizations on those organizations' team management pages",
   "USER_MANAGEMENT_USER_SEARCH_ERROR_TITLE": "Error searching for user",
 
   "LOOKUP_PARTICIPANT_ID_MODAL_TITLE": "Look Up Participant ID",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -441,7 +441,7 @@
 
   "USER_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow user management",
   "USER_MANAGEMENT_STATUS_PAGE_TITLE": "Caseflow user status management",
-  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Making a user inactive will remove them from organizations they are a member of. Inactive users cannot be assigned new tasks.",
+  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Marking a user inactive will remove them from all organizations to which they currently belong. Once marked inactive, a user cannot be assigned new tasks.",
   "USER_MANAGEMENT_STATUS_CHANGE_ERROR_TITLE": "Failed to modify user status",
   "USER_MANAGEMENT_GIVE_USER_ACTIVE_STATUS_BUTTON_TEXT": "Make user active",
   "USER_MANAGEMENT_GIVE_USER_INACTIVE_STATUS_BUTTON_TEXT": "Make user inactive",


### PR DESCRIPTION
### Description
Updates the copy on the inactive users page to reflect updates to code

### ⛔️ Blocked By
- [x] #13172
- [x] Design modifications/approval

### User Facing Changes
#### After marking ACTIVE
<img width="947" alt="Screen Shot 2020-01-17 at 6 10 21 PM" src="https://user-images.githubusercontent.com/45575454/72652569-4fad9200-3955-11ea-8359-d11aebfc08a2.png">

#### After marking INACTIVE
![Screen Shot 2020-01-17 at 12 25 32 PM](https://user-images.githubusercontent.com/45575454/72652621-82f02100-3955-11ea-8115-7458307954e1.png)

### Testing
1. Sign in as TEAM_ADMIN
1. Go to /user_management via the user's dropdown
![Screen Shot 2020-01-17 at 12 55 51 PM](https://user-images.githubusercontent.com/45575454/72634514-bbc5d100-3928-11ea-9ef2-552d1b58dc61.png)
1. Search for a user by their css id (I used BVAIWIZA in dev but any should work)
1. Toggle the user's status to see the alerts