### PR TITLE
Allow `AddressMotionToVacateTask` to Appear in Judge Queue

### DIFF
--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -291,7 +291,8 @@ export const judgeDecisionReviewTasksSelector = createSelector(
     // eslint-disable-next-line no-undefined
     return [null, undefined, COPY.JUDGE_DECISION_REVIEW_TASK_LABEL,
       COPY.JUDGE_QUALITY_REVIEW_TASK_LABEL,
-      COPY.JUDGE_DISPATCH_RETURN_TASK_LABEL].includes(task.label);
+      COPY.JUDGE_DISPATCH_RETURN_TASK_LABEL,
+      COPY.JUDGE_ADDRESS_MOTION_TO_VACATE_TASK_LABEL].includes(task.label);
   })
 );
 

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -283,7 +283,8 @@ export const judgeDecisionReviewTasksSelector = createSelector(
     if (task.appealType === 'Appeal') {
       return ([COPY.JUDGE_DECISION_REVIEW_TASK_LABEL,
         COPY.JUDGE_QUALITY_REVIEW_TASK_LABEL,
-        COPY.JUDGE_DISPATCH_RETURN_TASK_LABEL].includes(task.label)) &&
+        COPY.JUDGE_DISPATCH_RETURN_TASK_LABEL,
+        COPY.JUDGE_ADDRESS_MOTION_TO_VACATE_TASK_LABEL].includes(task.label)) &&
         (task.status === TASK_STATUSES.in_progress || task.status === TASK_STATUSES.assigned);
     }
 

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -164,7 +164,11 @@ RSpec.feature "Motion to vacate", :all_dbs do
              instructions: ["Initial instructions"])
     end
     let!(:judge_address_motion_to_vacate_task) do
-      create(:judge_address_motion_to_vacate_task, appeal: appeal, assigned_to: judge, assigned_at: DateTime.now, parent: vacate_motion_mail_task)
+      create(:judge_address_motion_to_vacate_task,
+             appeal: appeal,
+             assigned_to: judge,
+             assigned_at: Time.zone.now,
+             parent: vacate_motion_mail_task)
     end
     let!(:atty_option_txt) { "#{drafting_attorney.full_name} (Orig. Attorney)" }
     let!(:judge_notes) { "Here's why I made my decision..." }

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -164,7 +164,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
              instructions: ["Initial instructions"])
     end
     let!(:judge_address_motion_to_vacate_task) do
-      create(:judge_address_motion_to_vacate_task, appeal: appeal, assigned_to: judge, parent: vacate_motion_mail_task)
+      create(:judge_address_motion_to_vacate_task, appeal: appeal, assigned_to: judge, assigned_at: DateTime.now, parent: vacate_motion_mail_task)
     end
     let!(:atty_option_txt) { "#{drafting_attorney.full_name} (Orig. Attorney)" }
     let!(:judge_notes) { "Here's why I made my decision..." }
@@ -181,6 +181,12 @@ RSpec.feature "Motion to vacate", :all_dbs do
     end
 
     after { FeatureToggle.disable!(:review_motion_to_vacate) }
+
+    it "task shows up in judge's queue" do
+      User.authenticate!(user: judge)
+      visit "/queue"
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MOTION_TO_VACATE_TASK_LABEL)
+    end
 
     it "judge grants motion to vacate (vacate & readjudication)" do
       address_motion_to_vacate(user: judge, appeal: appeal, judge_task: judge_address_motion_to_vacate_task)


### PR DESCRIPTION
Connects #13198

### Description
Updated whitelist in `judgeDecisionReviewTasksSelector` to allow `AddressMotionToVacateTask` to appear in judge queue.

### Acceptance Criteria
- [ ] `AddressMotionToVacateTask` shows up in queue for assigned judge

