### PR TITLE
attempting to fix flake for Hschallhorn/inactive-users-copy 

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -448,7 +448,7 @@
   "USER_MANAGEMENT_ACTIVE_SUCCESS_TITLE": "Successfully made %s ACTIVE",
   "USER_MANAGEMENT_INACTIVE_SUCCESS_TITLE": "Successfully made %s INACTIVE",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s can now be assigned new tasks and will need to be added to organizations via the team management page",
-  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations they were a member of. They will not be assigned any new tasks. If this was a mistake, mark the user ACTIVE and add them to organizations on the team management page",
+  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations to which they belonged. They will no longer be assigned new tasks. If this was a mistake, mark the user ACTIVE and add them back to the proper organizations on those organizations' team management pages",
   "USER_MANAGEMENT_USER_SEARCH_ERROR_TITLE": "Error searching for user",
 
   "LOOKUP_PARTICIPANT_ID_MODAL_TITLE": "Look Up Participant ID",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -441,14 +441,14 @@
 
   "USER_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow user management",
   "USER_MANAGEMENT_STATUS_PAGE_TITLE": "Caseflow user status management",
-  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Making a user inactive will remove them from any organization that automatically assigns tasks to team members.",
+  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Making a user inactive will remove them from organizations they are a member of. Inactive users cannot be assigned new tasks.",
   "USER_MANAGEMENT_STATUS_CHANGE_ERROR_TITLE": "Failed to modify user status",
   "USER_MANAGEMENT_GIVE_USER_ACTIVE_STATUS_BUTTON_TEXT": "Make user active",
   "USER_MANAGEMENT_GIVE_USER_INACTIVE_STATUS_BUTTON_TEXT": "Make user inactive",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_TITLE": "Successfully made %s ACTIVE",
   "USER_MANAGEMENT_INACTIVE_SUCCESS_TITLE": "Successfully made %s INACTIVE",
-  "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s will need to be added to organizations that automatically assign tasks to team members via the team management page",
-  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations that automatically assign tasks to team members. If this was a mistake, mark the user ACTIVE and add them to their organizations on the team management page",
+  "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s can now be assigned new tasks and will need to be added to organizations via the team management page",
+  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations they were a member of. They will not be assigned any new tasks. If this was a mistake, mark the user ACTIVE and add them to organizations on the team management page",
   "USER_MANAGEMENT_USER_SEARCH_ERROR_TITLE": "Error searching for user",
 
   "LOOKUP_PARTICIPANT_ID_MODAL_TITLE": "Look Up Participant ID",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -441,14 +441,14 @@
 
   "USER_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow user management",
   "USER_MANAGEMENT_STATUS_PAGE_TITLE": "Caseflow user status management",
-  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Marking a user inactive will remove them from all organizations to which they currently belong. Once marked inactive, a user cannot be assigned new tasks.",
+  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Marking a user inactive will remove them from all organizations they are a member of. Once marked inactive, a user cannot be assigned new tasks.",
   "USER_MANAGEMENT_STATUS_CHANGE_ERROR_TITLE": "Failed to modify user status",
   "USER_MANAGEMENT_GIVE_USER_ACTIVE_STATUS_BUTTON_TEXT": "Make user active",
   "USER_MANAGEMENT_GIVE_USER_INACTIVE_STATUS_BUTTON_TEXT": "Make user inactive",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_TITLE": "Successfully made %s ACTIVE",
   "USER_MANAGEMENT_INACTIVE_SUCCESS_TITLE": "Successfully made %s INACTIVE",
   "USER_MANAGEMENT_ACTIVE_SUCCESS_BODY": "%s can now be assigned new tasks and will need to be added to organizations via the team management page",
-  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations to which they belonged. They will no longer be assigned new tasks. If this was a mistake, mark the user ACTIVE and add them back to the proper organizations on those organizations' team management pages",
+  "USER_MANAGEMENT_INACTIVE_SUCCESS_BODY": "%s has been removed from organizations they were a member of. They will no longer be assigned new tasks. If this was a mistake, mark the user ACTIVE and add them back to the proper organizations on those organizations' team management pages",
   "USER_MANAGEMENT_USER_SEARCH_ERROR_TITLE": "Error searching for user",
 
   "LOOKUP_PARTICIPANT_ID_MODAL_TITLE": "Look Up Participant ID",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -441,7 +441,7 @@
 
   "USER_MANAGEMENT_PAGE_DROPDOWN_LINK": "Caseflow user management",
   "USER_MANAGEMENT_STATUS_PAGE_TITLE": "Caseflow user status management",
-  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Making a user inactive will remove them from organizations they are a member of. Inactive users cannot be assigned new tasks.",
+  "USER_MANAGEMENT_PAGE_DESCRIPTION": "Marking a user inactive will remove them from all organizations to which they currently belong. Once marked inactive, a user cannot be assigned new tasks.",
   "USER_MANAGEMENT_STATUS_CHANGE_ERROR_TITLE": "Failed to modify user status",
   "USER_MANAGEMENT_GIVE_USER_ACTIVE_STATUS_BUTTON_TEXT": "Make user active",
   "USER_MANAGEMENT_GIVE_USER_INACTIVE_STATUS_BUTTON_TEXT": "Make user inactive",

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -748,6 +748,7 @@ describe User, :all_dbs do
         end
 
         context "when marking the admin inactive" do
+          let(:judge_team) { JudgeTeam.create_for_judge(create(:user)) }
           before do
             OrganizationsUser.make_user_admin(user, judge_team)
             allow(user).to receive(:judge_in_vacols?).and_return(false)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -691,6 +691,7 @@ describe User, :all_dbs do
       end
     end
 
+    ensure_stable do
     context "with a valid status" do
       let(:status) { Constants.USER_STATUSES.inactive }
 
@@ -820,6 +821,7 @@ describe User, :all_dbs do
           end
         end
       end
+    end
     end
   end
 end


### PR DESCRIPTION

### Description
attempting to fix flake for Hschallhorn/inactive-users-copy 

```
1) User when the status is updated with a valid status when the user is a member of many orgs when marking the admin inactive removes admin from all organizations, including JudgeTeam
     Failure/Error: expect(judge_team.judge).not_to eq user
       expected: value != #<User id: 83, created_at: "2020-01-18 00:00:07", css_id: "CSS_ID2142", efolder_documents_fetched_at:...nil, station_id: "101", status: "active", status_updated_at: nil, updated_at: "2020-01-18 00:00:07">
            got: #<User id: 83, created_at: "2020-01-18 00:00:07", css_id: "CSS_ID2142", efolder_documents_fetched_at:...nil, station_id: "101", status: "active", status_updated_at: nil, updated_at: "2020-01-18 00:00:07">
       (compared using ==)
       Diff:
       @@ -1,4 +1,4 @@
       -#<User:0x00007f09ad989230
       +#<User:0x00007f09ad7b52d8
         id: 83,
         created_at: Fri, 17 Jan 2020 19:00:07 EST -05:00,
         css_id: "CSS_ID2142",
     # ./spec/models/user_spec.rb:757:in `block (6 levels) in <top (required)>'
```
### Acceptance Criteria
- [ ] Code compiles correctly

