### PR TITLE
Test showing timezone bug

### DIFF
--- a/app/helpers/vacols_helper.rb
+++ b/app/helpers/vacols_helper.rb
@@ -46,12 +46,12 @@ module VacolsHelper
   end
 
   def self.day_only_str(date_time)
-    Time.zone = "Eastern Time (US & Canada)"
-
-    Time.zone.local(
-      date_time.year,
-      date_time.month,
-      date_time.day
-    ).strftime("%Y-%m-%d")
+    Time.use_zone("America/New_York") do
+      Time.zone.local(
+        date_time.year,
+        date_time.month,
+        date_time.day
+      ).strftime("%Y-%m-%d")
+    end
   end
 end

--- a/app/models/vacols/record.rb
+++ b/app/models/vacols/record.rb
@@ -15,15 +15,16 @@ class VACOLS::Record < ApplicationRecord
   end
 
   def self.rounded_current_time
-    Time.zone = "Eastern Time (US & Canada)"
-    current_time = Time.zone.now
+    Time.use_zone("America/New_York") do
+      current_time = Time.zone.now
 
-    # Round off hours, minutes, and seconds
-    Time.zone.local(
-      current_time.year,
-      current_time.month,
-      current_time.day
-    )
+      # Round off hours, minutes, and seconds
+      Time.zone.local(
+        current_time.year,
+        current_time.month,
+        current_time.day
+      )
+    end
   end
 
   def self.current_user_slogid


### PR DESCRIPTION
See #13156, #13187

### Description

This PR has a test that shows the extent of the time zone bug described in #13156. The bug seems to be caused by this line, where the controllers sets the global timezone for the current request:

https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/controllers/application_controller.rb#L209-L212

I'm not sure if this bug would ever come up in a realistic scenario, but it shows that the hearings code has an underlying assumption that the person viewing the hearing must have the same timezone as the person who scheduled the hearing.

The bug is as follows:

  1. Hearing coordinator in the East Coast schedules a hearing for `8:30`
  2. Request goes to the server, and application controller sets the global `Time.zone` to `EST`
  3. ActiveRecord thinks `8:30` is an `EST` time, and it applies the 5 hour offset. The time gets saved as `13:30` (UTC)

      ```
        "scheduled_time"=>2000-01-01 13:30:00 UTC,
      ```
  4. User from west coast goes to look at the hearing schedule.
  5. Request goes to the server, and application controller sets the global `Time.zone` to `PST`
  6. Request goes to database, ActiveRecord converts `13:30` to `PST` time, which ends up being `5:30`
  7. Timezone gets changed to RO timezone
  8. `scheduled_time_string` in JSON is `5:30` which is wrong, since it was scheduled for `8:30`
  9. `scheduled_for` is `2:30 PST`, which is `5:30 EST`


