### PR TITLE
[WIP] Switch legacy issue data source

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -284,7 +284,7 @@ class Appeal < DecisionReview
       issue.benefit_type ||= issue.contested_benefit_type || issue.guess_benefit_type
       issue.veteran_participant_id = veteran.participant_id
       issue.save!
-      issue.handle_legacy_issues!
+      issue.create_legacy_issue!
     end
     request_issues.reload
   end

--- a/app/models/legacy_issue.rb
+++ b/app/models/legacy_issue.rb
@@ -4,5 +4,31 @@ class LegacyIssue < ApplicationRecord
   belongs_to :request_issue
   has_one :legacy_issue_optin
 
-  validates :request_issue, presence: true
+  validates :request_issue, :vacols_id, :vacols_sequence_id, presence: true
+  delegate :decision_review, to: :request_issue
+
+  def create_optin!
+    return unless request_issue.eligible?
+    return unless eligible_for_opt_in?
+
+    legacy_issue_optin.create!(
+      original_disposition_code: vacols_issue.disposition_id,
+      original_disposition_date: vacols_issue.disposition_date,
+      legacy_issue: self
+    )
+  end
+
+  def eligible_for_opt_in?
+    vacols_issue.eligible_for_opt_in? && legacy_appeal_eligible_for_opt_in?
+  end
+
+  def vacols_issue
+    @vacols_issue ||= AppealRepository.issues(vacols_id).find do |issue|
+      issue.vacols_sequence_id == vacols_sequence_id
+    end
+  end
+
+  def legacy_appeal_eligible_for_opt_in?
+    vacols_issue.legacy_appeal.eligible_for_soc_opt_in?(decision_review.receipt_date)
+  end
 end

--- a/app/models/legacy_issue.rb
+++ b/app/models/legacy_issue.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+##
+# Veterans may submit request issues on an AMA form that are already active issues on Legacy Appeals.  The user intaking the form tries to find matching legacy issues when adding a request issue, and if they find a match they connect the two.  One request issue can be connected to multiple legacy issues. If a match is found and the veteran did not select to opt their legacy issues into AMA, or the issue is not eligible to be opted into AMA, then the request issue is ineligible.  If it is eligible, an opt-in is created, which closes the issue in VACOLS so that it can continue to be processed only in AMA.
+
 class LegacyIssue < ApplicationRecord
   belongs_to :request_issue
   has_one :legacy_issue_optin

--- a/app/models/legacy_issue_optin.rb
+++ b/app/models/legacy_issue_optin.rb
@@ -8,7 +8,6 @@ class LegacyIssueOptin < ApplicationRecord
   VACOLS_DISPOSITION_CODE = "O" # oh not zero
   REMAND_DISPOSITION_CODES = %w[3 L].freeze
 
-  # delegate :vacols_id, :vacols_id=, :vacols_sequence_id, :vacols_sequence_id=, to: :request_issue
   delegate :vacols_id, :vacols_sequence_id, :request_issue, to: :legacy_issue
 
   class << self

--- a/app/models/legacy_issue_optin.rb
+++ b/app/models/legacy_issue_optin.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 class LegacyIssueOptin < ApplicationRecord
-  belongs_to :request_issue
+  self.ignored_columns = ["request_issue_id"]
+
   belongs_to :legacy_issue
 
   VACOLS_DISPOSITION_CODE = "O" # oh not zero
   REMAND_DISPOSITION_CODES = %w[3 L].freeze
 
   # delegate :vacols_id, :vacols_id=, :vacols_sequence_id, :vacols_sequence_id=, to: :request_issue
-  delegate :vacols_id, :vacols_sequence_id, to: :legacy_issue
+  delegate :vacols_id, :vacols_sequence_id, :request_issue, to: :legacy_issue
 
   class << self
     def related_remand_issues(vacols_id)

--- a/app/models/legacy_issue_optin.rb
+++ b/app/models/legacy_issue_optin.rb
@@ -7,7 +7,8 @@ class LegacyIssueOptin < ApplicationRecord
   VACOLS_DISPOSITION_CODE = "O" # oh not zero
   REMAND_DISPOSITION_CODES = %w[3 L].freeze
 
-  delegate :vacols_id, :vacols_id=, :vacols_sequence_id, :vacols_sequence_id=, to: :request_issue
+  # delegate :vacols_id, :vacols_id=, :vacols_sequence_id, :vacols_sequence_id=, to: :request_issue
+  delegate :vacols_id, :vacols_sequence_id, to: :legacy_issue
 
   class << self
     def related_remand_issues(vacols_id)

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -7,6 +7,8 @@
 
 # rubocop:disable Metrics/ClassLength
 class RequestIssue < ApplicationRecord
+  self.ignored_columns = ["vacols_id", "vacols_sequence_id"]
+
   include Asyncable
   include HasBusinessLine
   include DecisionSyncable
@@ -24,8 +26,8 @@ class RequestIssue < ApplicationRecord
   has_many :remand_reasons, through: :decision_issues
   has_many :duplicate_but_ineligible, class_name: "RequestIssue", foreign_key: "ineligible_due_to_id"
   has_many :hearing_issue_notes
-  has_one :legacy_issue_optin
   has_many :legacy_issues
+  has_many :legacy_issue_optins, through: :legacy_issues
   belongs_to :correction_request_issue, class_name: "RequestIssue", foreign_key: "corrected_by_request_issue_id"
   belongs_to :ineligible_due_to, class_name: "RequestIssue", foreign_key: "ineligible_due_to_id"
   belongs_to :contested_decision_issue, class_name: "DecisionIssue"
@@ -202,6 +204,7 @@ class RequestIssue < ApplicationRecord
   end
 
   delegate :veteran, to: :decision_review
+  attr_accessor :vacols_id, :vacols_sequence_id
 
   def create_for_claim_review!
     return unless decision_review.is_a?(ClaimReview)
@@ -292,7 +295,7 @@ class RequestIssue < ApplicationRecord
 
   def special_issues
     specials = []
-    specials << { code: "ASSOI", narrative: Constants.VACOLS_DISPOSITIONS_BY_ID.O } if legacy_issue_opted_in?
+    specials << { code: "ASSOI", narrative: Constants.VACOLS_DISPOSITIONS_BY_ID.O } if legacy_issues_opted_in?
     specials << { code: "SSR", narrative: "Same Station Review" } if decision_review.try(:same_office)
     return specials unless specials.empty?
   end
@@ -402,16 +405,8 @@ class RequestIssue < ApplicationRecord
     end_product_establishment.on_decision_issue_sync_processed
   end
 
-  def vacols_issue
-    return unless vacols_id && vacols_sequence_id
-
-    @vacols_issue ||= AppealRepository.issues(vacols_id).find do |issue|
-      issue.vacols_sequence_id == vacols_sequence_id
-    end
-  end
-
-  def legacy_issue_opted_in?
-    eligible? && vacols_id && vacols_sequence_id
+  def legacy_issues_opted_in?
+    eligible? && legacy_issues.any?
   end
 
   def close!(status:, closed_at_value: Time.zone.now)
@@ -437,7 +432,7 @@ class RequestIssue < ApplicationRecord
     return unless end_product_establishment&.reload&.status_canceled?
 
     close!(status: :end_product_canceled) do
-      legacy_issue_optin&.flag_for_rollback!
+      legacy_issue_optins.each(&:flag_for_rollback!)
     end
   end
 
@@ -451,7 +446,7 @@ class RequestIssue < ApplicationRecord
 
   def remove!
     close!(status: :removed) do
-      legacy_issue_optin&.flag_for_rollback!
+      legacy_issue_optins.each(&:flag_for_rollback!)
 
       # If the decision issue is not associated with any other request issue, also delete
       decision_issues.each(&:soft_delete_on_removed_request_issue)
@@ -576,17 +571,6 @@ class RequestIssue < ApplicationRecord
     legacy_issues.create!(
       vacols_id: vacols_id,
       vacols_sequence_id: vacols_sequence_id
-    )
-  end
-
-  def create_legacy_issue_optin!
-    return unless legacy_issue_opted_in?
-
-    LegacyIssueOptin.create!(
-      request_issue: self,
-      original_disposition_code: vacols_issue.disposition_id,
-      original_disposition_date: vacols_issue.disposition_date,
-      legacy_issue: legacy_issues.first
     )
   end
 
@@ -813,7 +797,7 @@ class RequestIssue < ApplicationRecord
 
   def check_for_legacy_issue_not_withdrawn!
     return unless eligible?
-    return unless vacols_id
+    return unless legacy_issues.any?
 
     if !decision_review.legacy_opt_in_approved
       self.ineligible_reason = :legacy_issue_not_withdrawn
@@ -822,16 +806,11 @@ class RequestIssue < ApplicationRecord
 
   def check_for_legacy_appeal_not_eligible!
     return unless eligible?
-    return unless vacols_id
-    return unless decision_review.serialized_legacy_appeals.any?
+    return unless legacy_issues.any?
 
-    unless vacols_issue.eligible_for_opt_in? && legacy_appeal_eligible_for_opt_in?
+    unless legacy_issues.any?(:eligible_for_opt_in?)
       self.ineligible_reason = :legacy_appeal_not_eligible
     end
-  end
-
-  def legacy_appeal_eligible_for_opt_in?
-    vacols_issue.legacy_appeal.eligible_for_soc_opt_in?(decision_review.receipt_date)
   end
 
   def check_for_active_request_issue_by_rating!

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -215,7 +215,7 @@ class RequestIssue < ApplicationRecord
     update!(end_product_establishment: epe) if epe
 
     RequestIssueCorrectionCleaner.new(self).remove_dta_request_issue! if correction?
-    handle_legacy_issues!
+    create_legacy_issue!
   end
 
   def end_product_code
@@ -558,21 +558,16 @@ class RequestIssue < ApplicationRecord
     duplicate_of_issue_in_active_review? ? ineligible_due_to.review_title : nil
   end
 
-  def handle_legacy_issues!
-    create_legacy_issue!
-    create_legacy_issue_optin!
-  end
-
-  private
-
   def create_legacy_issue!
     return unless vacols_id && vacols_sequence_id
 
     legacy_issues.create!(
       vacols_id: vacols_id,
       vacols_sequence_id: vacols_sequence_id
-    )
+    ).tap(&:create_optin!)
   end
+
+  private
 
   # When a request issue already has a rating in VBMS, prevent user from editing it.
   # LockedRatingError indicates that the matching rating issue could be locked,

--- a/app/services/legacy_optin_manager.rb
+++ b/app/services/legacy_optin_manager.rb
@@ -43,10 +43,6 @@ class LegacyOptinManager
   end
 
   def legacy_issue_opt_ins
-    request_issues_with_legacy_opt_ins.map(&:legacy_issue_optin)
-  end
-
-  def request_issues_with_legacy_opt_ins
-    decision_review.request_issues.select(&:legacy_issue_optin)
+    decision_review.request_issues.map(&:legacy_issue_optins).flatten
   end
 end

--- a/app/workflows/request_issue_closure.rb
+++ b/app/workflows/request_issue_closure.rb
@@ -9,7 +9,7 @@ class RequestIssueClosure < SimpleDelegator
 
     close!(status: :no_decision) do
       canceled!
-      legacy_issue_optin&.flag_for_rollback!
+      legacy_issue_optins.each(&:flag_for_rollback!)
     end
   end
 


### PR DESCRIPTION
connects #12615

### Description
Start using new legacy issues table for saving legacy issues connected to request issues, and running related object.
Start creating logic to support multiple legacy issue connections per request issue, to be completed in:
https://github.com/department-of-veterans-affairs/caseflow/issues/12693

### User Facing Changes
Backend only
 
### Documentation Updates
- [x] Topline File Descriptions Added or Updated as Needed

### Database Changes
N/A