### PR TITLE
CsvToS3Exporter service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,17 @@ jobs:
             ~/project/ci-bin/capture-log "bundle exec rake spec:setup_vacols"
 
       - run:
+          name: Install dependencies
+          command: |
+            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+            sudo apt-get update
+            sudo apt-get install google-chrome-stable
+            bundle exec rake webdrivers:chromedriver:remove
+            bundle exec rake webdrivers:chromedriver:update
+            sudo apt-get install postgresql-client
+
+      - run:
           name: RSpec
           command: |
             mkdir -p ~/test-results/rspec

--- a/.reek.yml
+++ b/.reek.yml
@@ -11,6 +11,7 @@ detectors:
   BooleanParameter:
     exclude:
       - AsyncableJobsReporter#initialize
+      - CsvToS3Exporter#initialize
       - HearingRepository#slot_new_hearing
       - LegacyDocket#distribute_appeals
       - Veteran
@@ -86,6 +87,7 @@ detectors:
   LongParameterList:
     exclude:
       - Address#initialize
+      - CsvToS3Exporter#initialize
       - ExternalApi::VBMSService#self.create_contentions!
       - LegacyDocket#new_distributed_case
       - Api::V3::DecisionReview::ContestableIssueFinder#initialize
@@ -117,6 +119,7 @@ detectors:
   TooManyInstanceVariables:
     exclude:
       - AmaAppealDispatch
+      - CsvToS3Exporter
       - DuplicateUserTask
       - LegacyAppealDispatch
       - Address

--- a/app/services/csv_to_s3_exporter.rb
+++ b/app/services/csv_to_s3_exporter.rb
@@ -13,6 +13,8 @@ class CsvToS3Exporter
     @region = region
     @compress = compress
     @test = test
+
+    set_psql_url
   end
   # rubocop:enable Metrics/ParameterLists
 
@@ -63,13 +65,13 @@ class CsvToS3Exporter
     @tmp_file ||= Tempfile.new(csv_file).path # wrap in Tempfile so it cleans itself up
   end
 
-  def psql_url
+  def set_psql_url
     conf = ActiveRecord::Base.connection_config
-    "postgres://#{conf[:username]}:#{conf[:password]}@#{conf[:host]}/#{conf[:database]}"
+    ENV["POSTGRES_URL"] ||= "postgres://#{conf[:username]}:#{conf[:password]}@#{conf[:host]}/#{conf[:database]}"
   end
 
   def csv_cmd
-    "psql #{psql_url} -c '\\copy #{table} to #{tmp_file} with (format csv, header, force_quote *)'"
+    "psql \$POSTGRES_URL -c '\\copy #{table} to #{tmp_file} with (format csv, header, force_quote *)'"
   end
 
   def bucket_target

--- a/app/services/csv_to_s3_exporter.rb
+++ b/app/services/csv_to_s3_exporter.rb
@@ -75,7 +75,7 @@ class CsvToS3Exporter
   end
 
   def bucket_target
-    "s3://#{bucket}/#{csv_file}"
+    "s3://#{bucket}/#{date}/#{csv_file}"
   end
 
   def s3_cp_cmd

--- a/app/services/csv_to_s3_exporter.rb
+++ b/app/services/csv_to_s3_exporter.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+# Export a psql table to a csv file in an S3 bucket
+
+require "English"
+
+class CsvToS3Exporter
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(table:, bucket:, region: "us-gov-west-1", date: Time.zone.today.iso8601, compress: true, test: false)
+    @date = date
+    @table = table
+    @bucket = bucket
+    @region = region
+    @compress = compress
+    @test = test
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  def call
+    called_at = Time.zone.now
+    rows = run(csv_cmd)
+    rows_copied = rows.tr("COPY ", "").to_i
+    line_count = run("wc -l #{tmp_file}")
+    unless (rows_copied + 1) == line_count.strip.to_i
+      fail "CSV appears truncated. Expected #{rows_copied} but found #{line_count.strip}"
+    end
+
+    checksum = run(checksum_cmd)
+    run(s3_cp_cmd)
+    meta = { rows: rows_copied, time: called_at.iso8601, checksum: checksum.strip.gsub(/ .*/, "") }
+    run(s3_cp_meta_cmd(meta))
+    meta
+  end
+
+  private
+
+  attr_reader :table, :bucket, :date, :compress, :region, :test
+
+  def run(cmd)
+    Rails.logger.info(cmd)
+    output = `#{cmd}`
+
+    if $CHILD_STATUS != 0
+      fail "#{cmd} failed: #{$CHILD_STATUS} #{$ERROR_INFO}"
+    end
+
+    output
+  end
+
+  def test?
+    !!test
+  end
+
+  def compress?
+    !!compress
+  end
+
+  def csv_file
+    "#{date}-caseflow-#{table}.csv"
+  end
+
+  def tmp_file
+    @tmp_file ||= Tempfile.new(csv_file).path # wrap in Tempfile so it cleans itself up
+  end
+
+  def psql_url
+    conf = ActiveRecord::Base.connection_config
+    "postgres://#{conf[:username]}:#{conf[:password]}@#{conf[:host]}/#{conf[:database]}"
+  end
+
+  def csv_cmd
+    "psql #{psql_url} -c '\\copy #{table} to #{tmp_file} with (format csv, header, force_quote *)'"
+  end
+
+  def bucket_target
+    "s3://#{bucket}/#{csv_file}"
+  end
+
+  def s3_cp_cmd
+    return "cp #{tmp_file} #{test}" if test?
+
+    if compress?
+      "gzip -c #{tmp_file} | aws --region #{region} s3 cp - #{bucket_target}.gz"
+    else
+      "aws --region #{region} s3 cp #{tmp_file} #{bucket_target}"
+    end
+  end
+
+  def s3_cp_meta_cmd(meta)
+    meta_json = meta.to_json
+
+    return "echo '#{meta_json}' > #{test}.meta" if test?
+
+    "echo '#{meta_json}' | aws --region #{region} s3 cp - #{bucket_target}.meta"
+  end
+
+  def checksum_cmd
+    "sha256sum #{tmp_file}"
+  end
+end

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -496,7 +496,7 @@ RSpec.feature "Reader", :all_dbs do
       add_comment("A")
 
       click_on "Edit"
-      find("#editCommentBox-2").send_keys(:backspace)
+      find("#editCommentBox-2").send_keys(:delete)
       click_on "Save"
 
       # Delete modal should appear

--- a/spec/services/csv_to_s3_exporter_spec.rb
+++ b/spec/services/csv_to_s3_exporter_spec.rb
@@ -5,15 +5,15 @@ describe CsvToS3Exporter do
     after do
       File.unlink(temp_file)
       File.unlink(meta_file)
-      fail "failed to clean up #{temp_file}" if File.exists?(temp_file)
-      fail "failed to clean up #{meta_file}" if File.exists?(meta_file)
+      fail "failed to clean up #{temp_file}" if File.exist?(temp_file)
+      fail "failed to clean up #{meta_file}" if File.exist?(meta_file)
     end
 
     let(:temp_file) { Tempfile.new.path }
     let(:meta_file) { "#{temp_file}.meta" }
     let(:today) { Time.zone.today.iso8601 }
 
-    subject { described_class.new(test: temp_file, table: "appeals", bucket: "ignored" ).call }
+    subject { described_class.new(test: temp_file, table: "appeals", bucket: "ignored").call }
 
     it "writes csv and meta files" do
       create(:appeal)
@@ -21,8 +21,8 @@ describe CsvToS3Exporter do
       meta = subject
 
       expect(meta[:rows]).to eq(1)
-      expect(File.exists?(temp_file)).to eq(true)
-      expect(File.exists?(meta_file)).to eq(true)
+      expect(File.exist?(temp_file)).to eq(true)
+      expect(File.exist?(meta_file)).to eq(true)
 
       meta_contents = File.read(meta_file)
       expect(JSON.parse(meta_contents, symbolize_names: true)).to eq(meta)

--- a/spec/services/csv_to_s3_exporter_spec.rb
+++ b/spec/services/csv_to_s3_exporter_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 describe CsvToS3Exporter do
-  describe "#call", skip_db_cleaner: true do # skip cleaner so our data is available to psql CLI
+  describe "#call", db_clean: :truncation do # explicit cleaner strategy so psql client sees transactions.
     after do
-      DatabaseCleaner.clean
       File.unlink(temp_file) if File.exist?(temp_file)
       File.unlink(meta_file) if File.exist?(meta_file)
       fail "failed to clean up #{temp_file}" if File.exist?(temp_file)

--- a/spec/services/csv_to_s3_exporter_spec.rb
+++ b/spec/services/csv_to_s3_exporter_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe CsvToS3Exporter do
+  subject { described_class.new(test: temp_file, table: "appeals", bucket: "ignored") }
+
   describe "#call", db_clean: :truncation do # explicit cleaner strategy so psql client sees transactions.
     after do
       File.unlink(temp_file) if File.exist?(temp_file)
@@ -13,12 +15,10 @@ describe CsvToS3Exporter do
     let(:meta_file) { "#{temp_file}.meta" }
     let(:today) { Time.zone.today.iso8601 }
 
-    subject { described_class.new(test: temp_file, table: "appeals", bucket: "ignored").call }
+    let!(:appeal) { create(:appeal) }
 
     it "writes csv and meta files" do
-      create(:appeal)
-
-      meta = subject
+      meta = subject.call
 
       expect(meta[:rows]).to eq(1)
       expect(File.exist?(temp_file)).to eq(true)
@@ -26,6 +26,51 @@ describe CsvToS3Exporter do
 
       meta_contents = File.read(meta_file)
       expect(JSON.parse(meta_contents, symbolize_names: true)).to eq(meta)
+    end
+
+    context "external shell commands missing or exit with non-zero" do
+      it "raises error" do
+        allow(subject).to receive(:run).and_call_original
+        allow(subject).to receive(:run).with(/wc -l /).and_wrap_original do |m|
+          m.call("false")
+        end
+
+        expect { subject.call }.to raise_error(CsvToS3Exporter::ShellError)
+      end
+    end
+
+    context "line count mismatch" do
+      it "raises CsvError" do
+        allow(subject).to receive(:run).and_call_original
+        allow(subject).to receive(:run).with(/wc -l /) { "123" }
+
+        expect { subject.call }.to raise_error(CsvToS3Exporter::CsvError)
+      end
+    end
+
+    context "with live aws s3 cp" do
+      before do
+        allow(subject).to receive(:run).and_call_original
+        allow(subject).to receive(:run).with(/aws --region/) { true }
+      end
+
+      subject { described_class.new(table: "appeals", bucket: "bucket-name", date: "the-date") }
+
+      it "receives expected bucket path" do
+        expect(subject).to receive(:run).with(/s3:\/\/bucket-name\/the-date\/the-date-caseflow-appeals.csv.gz/)
+
+        subject.call
+      end
+
+      context "with compress:false" do
+        subject { described_class.new(table: "appeals", bucket: "bucket-name", date: "the-date", compress: false) }
+
+        it "does not compress" do
+          expect(subject).to receive(:run).with(/s3:\/\/bucket-name\/the-date\/the-date-caseflow-appeals.csv/)
+
+          subject.call
+        end
+      end
     end
   end
 end

--- a/spec/services/csv_to_s3_exporter_spec.rb
+++ b/spec/services/csv_to_s3_exporter_spec.rb
@@ -4,8 +4,8 @@ describe CsvToS3Exporter do
   describe "#call", skip_db_cleaner: true do # skip cleaner so our data is available to psql CLI
     after do
       DatabaseCleaner.clean
-      File.unlink(temp_file)
-      File.unlink(meta_file)
+      File.unlink(temp_file) if File.exist?(temp_file)
+      File.unlink(meta_file) if File.exist?(meta_file)
       fail "failed to clean up #{temp_file}" if File.exist?(temp_file)
       fail "failed to clean up #{meta_file}" if File.exist?(meta_file)
     end

--- a/spec/services/csv_to_s3_exporter_spec.rb
+++ b/spec/services/csv_to_s3_exporter_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe CsvToS3Exporter do
+  describe "#call", skip_db_cleaner: true do # skip cleaner so our data is available to psql CLI
+    after do
+      File.unlink(temp_file)
+      File.unlink(meta_file)
+      fail "failed to clean up #{temp_file}" if File.exists?(temp_file)
+      fail "failed to clean up #{meta_file}" if File.exists?(meta_file)
+    end
+
+    let(:temp_file) { Tempfile.new.path }
+    let(:meta_file) { "#{temp_file}.meta" }
+    let(:today) { Time.zone.today.iso8601 }
+
+    subject { described_class.new(test: temp_file, table: "appeals", bucket: "ignored" ).call }
+
+    it "writes csv and meta files" do
+      create(:appeal)
+
+      meta = subject
+
+      expect(meta[:rows]).to eq(1)
+      expect(File.exists?(temp_file)).to eq(true)
+      expect(File.exists?(meta_file)).to eq(true)
+
+      meta_contents = File.read(meta_file)
+      expect(JSON.parse(meta_contents, symbolize_names: true)).to eq(meta)
+    end
+  end
+end

--- a/spec/services/csv_to_s3_exporter_spec.rb
+++ b/spec/services/csv_to_s3_exporter_spec.rb
@@ -3,13 +3,14 @@
 describe CsvToS3Exporter do
   describe "#call", skip_db_cleaner: true do # skip cleaner so our data is available to psql CLI
     after do
+      DatabaseCleaner.clean
       File.unlink(temp_file)
       File.unlink(meta_file)
       fail "failed to clean up #{temp_file}" if File.exist?(temp_file)
       fail "failed to clean up #{meta_file}" if File.exist?(meta_file)
     end
 
-    let(:temp_file) { Tempfile.new.path }
+    let(:temp_file) { File.join(Rails.root, "tmp", "appeals-to-s3.csv") }
     let(:meta_file) { "#{temp_file}.meta" }
     let(:today) { Time.zone.today.iso8601 }
 

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -46,15 +46,19 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each) do
-    DatabaseCleaner[:active_record, { connection: vacols }].start
-    DatabaseCleaner[:active_record, { connection: caseflow }].start
+  config.before(:each) do |example|
+    unless example.metadata[:skip_db_cleaner]
+      DatabaseCleaner[:active_record, { connection: vacols }].start
+      DatabaseCleaner[:active_record, { connection: caseflow }].start
+    end
   end
 
-  config.append_after(:each) do
-    DatabaseCleaner[:active_record, { connection: vacols }].clean
-    DatabaseCleaner[:active_record, { connection: caseflow }].clean
-    clean_application!
+  config.append_after(:each) do |example|
+    unless example.metadata[:skip_db_cleaner]
+      DatabaseCleaner[:active_record, { connection: vacols }].clean
+      DatabaseCleaner[:active_record, { connection: caseflow }].clean
+      clean_application!
+    end
   end
 
   # ETL is never used in feature tests and there are only a few, so we tag those with :etl
@@ -68,12 +72,12 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :etl) do
-    puts "DatabaseCleaner.start ETL"
+    Rails.logger.info("DatabaseCleaner.start ETL")
     DatabaseCleaner[:active_record, { connection: etl }].start
   end
 
   config.append_after(:each, :etl) do
     DatabaseCleaner[:active_record, { connection: etl }].clean
-    puts "DatabaseCleaner.clean ETL"
+    Rails.logger.info("DatabaseCleaner.clean ETL")
   end
 end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -46,19 +46,15 @@ RSpec.configure do |config|
     end
   end
 
-  config.before(:each) do |example|
-    unless example.metadata[:skip_db_cleaner]
-      DatabaseCleaner[:active_record, { connection: vacols }].start
-      DatabaseCleaner[:active_record, { connection: caseflow }].start
-    end
+  config.before(:each) do
+    DatabaseCleaner[:active_record, { connection: vacols }].start
+    DatabaseCleaner[:active_record, { connection: caseflow }].start
   end
 
-  config.append_after(:each) do |example|
-    unless example.metadata[:skip_db_cleaner]
-      DatabaseCleaner[:active_record, { connection: vacols }].clean
-      DatabaseCleaner[:active_record, { connection: caseflow }].clean
-      clean_application!
-    end
+  config.append_after(:each) do
+    DatabaseCleaner[:active_record, { connection: vacols }].clean
+    DatabaseCleaner[:active_record, { connection: caseflow }].clean
+    clean_application!
   end
 
   # ETL is never used in feature tests and there are only a few, so we tag those with :etl


### PR DESCRIPTION
connects #12697 

### Description
Service class to:

* export a single postgresql table to a csv file,
* verify its contents,
* write it to S3 bucket

### Testing Plan
1. In UAT, set AWS credentials as env vars for the appropriate Data Lake bucket. Credentials are currently in 1Password.
1. In UAT, run the exporter for a single table from the console.

### Documentation Updates
- [x] Topline File Descriptions Added or Updated as Needed

### Example

From Rails console:

```
[1] pry(main)> e = CsvToS3Exporter.new(test: "/tmp/appeals.csv", table: 'appeals', bucket: 'foo')
=> #<CsvToS3Exporter:0x00007feaabe4aa28
 @bucket="foo",
 @compress=true,
 @date="2020-01-22",
 @region="us-gov-west-1",
 @table="appeals",
 @test="/tmp/appeals.csv">
[2] pry(main)> e.call
psql $POSTGRES_URL -c '\copy appeals to /var/folders/vy/cpsrccmx7x3g1j9vv8rxm58m0000gn/T/2020-01-22-caseflow-appeals.csv20200122-16147-1npg7s2 with (format csv, header, force_quote *)'
wc -l /var/folders/vy/cpsrccmx7x3g1j9vv8rxm58m0000gn/T/2020-01-22-caseflow-appeals.csv20200122-16147-1npg7s2
sha256sum /var/folders/vy/cpsrccmx7x3g1j9vv8rxm58m0000gn/T/2020-01-22-caseflow-appeals.csv20200122-16147-1npg7s2
cp /var/folders/vy/cpsrccmx7x3g1j9vv8rxm58m0000gn/T/2020-01-22-caseflow-appeals.csv20200122-16147-1npg7s2 /tmp/appeals.csv
echo '{"rows":278,"time":"2020-01-22T23:08:56Z","checksum":"5d5eb2685df9829ea3e94c4389a1fa1da67501381f0e27f4ad613250ac6e0343"}' > /tmp/appeals.csv.meta
=> {:rows=>278, :time=>"2020-01-22T23:08:56Z", :checksum=>"5d5eb2685df9829ea3e94c4389a1fa1da67501381f0e27f4ad613250ac6e0343"}
```