### PR TITLE
Default AsyncableJobMessaging user to RequestStore current user

### DIFF
--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -36,7 +36,7 @@ class AsyncableJobsController < ApplicationController
 
   def add_note
     send_to_intake_user = ActiveRecord::Type::Boolean.new.deserialize(allowed_params[:send_to_intake_user])
-    messaging = AsyncableJobMessaging.new(job: job, current_user: current_user)
+    messaging = AsyncableJobMessaging.new(job: job, user: current_user)
     job_note = messaging.add_job_note(
       text: allowed_params[:note],
       send_to_intake_user: send_to_intake_user

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -121,12 +121,12 @@ class ClaimReview < DecisionReview
   # Cancel an unprocessed job, add a job note, and send a message to the job user's inbox.
   # Currently this only happens manually by an engineer, and requires a message explaining
   # why the job was cancelled and describing any additional action necessary.
-  def cancel_with_note!(current_user:, note:)
-    fail Caseflow::Error::ActionForbiddenError, message: "Acting user must be specified" unless current_user
+  def cancel_with_note!(user: RequestStore[:current_user], note:)
+    fail Caseflow::Error::ActionForbiddenError, message: "Acting user must be specified" unless user
     fail Caseflow::Error::ActionForbiddenError, message: "Processed job cannot be cancelled" if processed?
 
     cancel_establishment!
-    AsyncableJobMessaging.new(job: self, current_user: current_user).add_job_cancellation_note(text: note)
+    AsyncableJobMessaging.new(job: self, user: user).add_job_cancellation_note(text: note)
   end
 
   def invalid_modifiers

--- a/spec/services/asyncable_job_messaging_spec.rb
+++ b/spec/services/asyncable_job_messaging_spec.rb
@@ -6,7 +6,7 @@ describe AsyncableJobMessaging, :postgres do
     let(:job) { create(:higher_level_review, intake: create(:intake, user: owner)) }
     let(:user) { User.authenticate!(roles: ["Admin Intake"]) }
     let(:text) { "contents of a new job note" }
-    let(:messaging) { AsyncableJobMessaging.new(job: job, current_user: user) }
+    let(:messaging) { AsyncableJobMessaging.new(job: job, user: user) }
 
     subject { messaging.add_job_note(text: text, send_to_intake_user: send_to_intake_user) }
 
@@ -113,7 +113,7 @@ describe AsyncableJobMessaging, :postgres do
     let(:owner) { create(:default_user) }
     let(:job) { create(:higher_level_review, intake: create(:intake, user: owner)) }
     let(:user) { User.authenticate!(roles: ["Admin Intake"]) }
-    let(:messaging) { AsyncableJobMessaging.new(job: job, current_user: user) }
+    let(:messaging) { AsyncableJobMessaging.new(job: job, user: user) }
 
     subject { messaging.add_job_cancellation_note(text: "some reason") }
 


### PR DESCRIPTION
Connects #12947 

### Description
This PR every-so-slightly tidies up the way AsyncableJobMessaging detects the current user, to be in line with the rest of the codebase.

When I first wrote that class, I didn't realize that setting `RequestStore[:current_user]` was common practice for folks working in the Rails console. Now, instead of being forced to provide a user object, the engineer can do either

```
> ajm = AsyncableJobMessaging.new(job: some_job)
> ajm.add_job_note(text: "the note", send_to_intake_user: true)
```

or if they want to provide a user object other than what's in RequestStore,

```
> ajm = AsyncableJobMessaging.new(job: some_job, user: someone_else)
> ajm.add_job_note(text: "the note", send_to_intake_user: true)
```