### PR TITLE
Set Task.closed_at to nil if re-opening

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -672,6 +672,14 @@ class Task < ApplicationRecord
     return if will_save_change_to_attribute?(timestamp_to_update)
 
     self[timestamp_to_update] = Time.zone.now
+
+    nullify_closed_at_if_reopened if closed_at.present?
+  end
+
+  def nullify_closed_at_if_reopened
+    return unless self.class.open_statuses.include?(status_change_to_be_saved&.last)
+
+    self.closed_at = nil
   end
 
   def status_is_valid_on_create

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1362,6 +1362,20 @@ describe Task, :all_dbs do
         expect(task.started_at).to eq(two_weeks_ago)
       end
     end
+
+    context "when task is closed and is re-opened" do
+      let(:task) { create(:task, :cancelled) }
+
+      it "sets closed_at to nil" do
+        expect(task.cancelled?).to eq(true)
+        expect(task.closed_at).to_not be_nil
+
+        task.on_hold!
+
+        expect(task.on_hold?).to eq(true)
+        expect(task.closed_at).to be_nil
+      end
+    end
   end
 
   describe "task timer relationship" do

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -365,7 +365,7 @@ describe ColocatedTask, :all_dbs do
         # go back to in-progres - should reset date
         expect(colocated_admin_action.reload.started_at).to eq time5
         expect(colocated_admin_action.placed_on_hold_at).to eq time3
-        expect(colocated_admin_action.closed_at).to eq time6
+        expect(colocated_admin_action.closed_at).to be_nil
       end
     end
   end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -58,9 +58,9 @@ RSpec.configure do |config|
   end
 
   # ETL is never used in feature tests and there are only a few, so we tag those with :etl
-  # ETL db uses truncation strategy everywhere because syncing runs in a transaction.
+  # ETL db uses deletion strategy everywhere because syncing runs in a transaction.
   config.before(:each, :etl) do
-    DatabaseCleaner[:active_record, { connection: etl }].strategy = :truncation
+    DatabaseCleaner[:active_record, { connection: etl }].strategy = :deletion
   end
 
   config.before(:each, :etl, db_clean: :truncation) do


### PR DESCRIPTION
See https://dsva.slack.com/archives/CN3FQR4A1/p1579773865000300

### Description
When tasks are re-opened, their `closed_at` value should be re-set to null.