### PR TITLE
Add docket_number and stream_type columns to Appeals table

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -24,6 +24,12 @@ class Appeal < DecisionReview
   has_one :special_issue_list
   has_many :record_synced_by_job, as: :record
 
+  enum stream_type: {
+    "Original": "Original",
+    "Vacate": "Vacate",
+    "De Novo": "De Novo"
+  }
+
   with_options on: :intake_review do
     validates :receipt_date, :docket_type, presence: { message: "blank" }
     validate :validate_receipt_date

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -72,7 +72,7 @@ class Appeal < DecisionReview
   end
 
   def type
-    "Original"
+    stream_type || "Original"
   end
 
   # Returns the most directly responsible party for an appeal when it is at the Board,
@@ -290,9 +290,7 @@ class Appeal < DecisionReview
   end
 
   def docket_number
-    return "Missing Docket Number" unless receipt_date
-
-    "#{receipt_date.strftime('%y%m%d')}-#{id}"
+    super || (receipt_date ? "#{receipt_date.strftime('%y%m%d')}-#{id}" : "Missing Docket Number")
   end
 
   # Currently AMA only supports one claimant per decision review

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -296,7 +296,10 @@ class Appeal < DecisionReview
   end
 
   def docket_number
-    super || (receipt_date ? "#{receipt_date.strftime('%y%m%d')}-#{id}" : "Missing Docket Number")
+    return stream_docket_number if stream_docket_number
+    return "Missing Docket Number" unless receipt_date
+
+    "#{receipt_date.strftime('%y%m%d')}-#{id}"
   end
 
   # Currently AMA only supports one claimant per decision review

--- a/db/migrate/20200123200907_add_multiple_appeal_streams.rb
+++ b/db/migrate/20200123200907_add_multiple_appeal_streams.rb
@@ -1,0 +1,6 @@
+class AddMultipleAppealStreams < ActiveRecord::Migration[5.1]
+  def change
+    add_column :appeals, :docket_number, :string, comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
+    add_column :appeals, :stream_type, :string, comment: "When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
+  end
+end

--- a/db/migrate/20200123200907_add_multiple_appeal_streams.rb
+++ b/db/migrate/20200123200907_add_multiple_appeal_streams.rb
@@ -1,6 +1,6 @@
 class AddMultipleAppealStreams < ActiveRecord::Migration[5.1]
   def change
-    add_column :appeals, :docket_number, :string, comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
+    add_column :appeals, :stream_docket_number, :string, comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
     add_column :appeals, :stream_type, :string, comment: "When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200102193042) do
+ActiveRecord::Schema.define(version: 20200123200907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 20200102193042) do
   create_table "appeals", force: :cascade, comment: "Decision reviews intaken for AMA appeals to the board (also known as a notice of disagreement)." do |t|
     t.string "closest_regional_office", comment: "The code for the regional office closest to the Veteran on the appeal."
     t.datetime "created_at"
+    t.string "docket_number", comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
     t.date "docket_range_date", comment: "Date that appeal was added to hearing docket range."
     t.string "docket_type", comment: "The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
     t.datetime "established_at", comment: "Timestamp for when the appeal has successfully been intaken into Caseflow by the user."
@@ -103,6 +104,7 @@ ActiveRecord::Schema.define(version: 20200102193042) do
     t.boolean "legacy_opt_in_approved", comment: "Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review."
     t.string "poa_participant_id", comment: "Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
     t.date "receipt_date", comment: "Receipt date of the appeal form. Used to determine which issues are within the timeliness window to be appealed. Only issues decided prior to the receipt date will show up as contestable issues."
+    t.string "stream_type", comment: "When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
     t.date "target_decision_date", comment: "If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
     t.datetime "updated_at"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false, comment: "The universally unique identifier for the appeal, which can be used to navigate to appeals/appeal_uuid. This allows a single ID to determine an appeal whether it is a legacy appeal or an AMA appeal."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,6 @@ ActiveRecord::Schema.define(version: 20200123200907) do
   create_table "appeals", force: :cascade, comment: "Decision reviews intaken for AMA appeals to the board (also known as a notice of disagreement)." do |t|
     t.string "closest_regional_office", comment: "The code for the regional office closest to the Veteran on the appeal."
     t.datetime "created_at"
-    t.string "docket_number", comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
     t.date "docket_range_date", comment: "Date that appeal was added to hearing docket range."
     t.string "docket_type", comment: "The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
     t.datetime "established_at", comment: "Timestamp for when the appeal has successfully been intaken into Caseflow by the user."
@@ -104,6 +103,7 @@ ActiveRecord::Schema.define(version: 20200123200907) do
     t.boolean "legacy_opt_in_approved", comment: "Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review."
     t.string "poa_participant_id", comment: "Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
     t.date "receipt_date", comment: "Receipt date of the appeal form. Used to determine which issues are within the timeliness window to be appealed. Only issues decided prior to the receipt date will show up as contestable issues."
+    t.string "stream_docket_number", comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
     t.string "stream_type", comment: "When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
     t.date "target_decision_date", comment: "If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
     t.datetime "updated_at"


### PR DESCRIPTION
Connects #13211 

### Description
This is the first of multiple PRs for adding (MTV-required) support for multiple appeal streams with the same docket number. Previously, each appeal had a unique docket number and a type of `Original`. Going forward, the MTV flow will create a new appeal with the same docket number as the original, but with type `Vacate`.

This PR just adds the two DB columns and updates the `Appeal` model to use the values of those columns when not nil, or fall back on the existing behavior of hard-coded ephemeral values.

Future work:
- Update existing appeal-creation code to persist values to DB
- Backfill these two columns for all existing appeals
- After backfilling, remove the logic that supplies default values when DB values are nil

Note:
ActiveRecord is not happy about a DB column named `type`, so I named it `stream_type` (`docket_type` is used for a different purpose). We may want to consider changing the Appeal model's method name anyway, for the sake of consistency and because "type" is quite generic.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `appeals` table contains new columns
- [ ] `Appeal#docket_number` and `#type` use existing behavior when new columns are nil
- [ ] `Appeal#docket_number` and `#type` use values in new columns when they're not nil

### Testing Plan
1. Tested in Rails console:
```
> a = Appeal.first
> a.docket_number
=> "191208-1"
> a.type
=> "Original"
> a = Appeal.new(docket_number: "foo", stream_type: "Vacate")  # or use psql to insert
> a.docket_number
=> "foo"
> a.type
=> "Vacate"
```

### Database Changes
*Only for Schema Changes*

* [x] Column comments updated
* [x] #appeals-schema notified with summary and link to this PR
