### PR TITLE
Update hearing serializer to return RO zip code, facility id, and address

### DIFF
--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -47,6 +47,18 @@ class RegionalOffice
     location_hash[:label]
   end
 
+  def facility_id
+    location_hash[:facility_locator_id]
+  end
+
+  def address
+    facility_location_hash["address_1"]
+  end
+
+  def zip_code
+    facility_location_hash["zip"]
+  end
+
   def to_h
     location_hash.merge(key: key)
   end
@@ -59,17 +71,20 @@ class RegionalOffice
     !!location_hash[:city]
   end
 
-  def self.city_state_by_key(ro_key)
-    regional_office = CITIES[ro_key]
-    if regional_office
-      "#{regional_office[:city]}, #{regional_office[:state]}"
-    end
-  end
-
   private
 
   def location_hash
     @location_hash ||= compute_location_hash
+  end
+
+  def facility_location_hash
+    if facility_id.present?
+      addr = Constants::REGIONAL_OFFICE_FACILITY_ADDRESS[facility_id]
+
+      return addr if addr.present?
+    end
+
+    {}
   end
 
   def compute_location_hash
@@ -90,6 +105,21 @@ class RegionalOffice
       fail NotFoundError unless result.valid?
 
       result
+    end
+
+    def all
+      Enumerator.new do |iter|
+        CITIES.each_key { |ro_key| iter << RegionalOffice.new(ro_key) }
+        SATELLITE_OFFICES.each_key { |ro_key| iter << RegionalOffice.new(ro_key) }
+      end
+    end
+
+    def city_state_by_key(ro_key)
+      regional_office = RegionalOffice.find!(ro_key)
+
+      "#{regional_office.city}, #{regional_office.state}"
+    rescue NotFoundError
+      nil
     end
 
     def ros_with_hearings

--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -51,7 +51,7 @@ class RegionalOffice
     location_hash[:facility_locator_id]
   end
 
-  def address
+  def street_address
     facility_location_hash["address_1"]
   end
 

--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -4,26 +4,14 @@ class Api::V2::HearingSerializer
   include FastJsonapi::ObjectSerializer
 
   attribute :address do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.street_address
-    else
-      hearing.regional_office.address
-    end
+    (hearing.hearing_location || hearing.regional_office).street_address
   end
   attribute :city do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.city
-    else
-      hearing.regional_office.city
-    end
+    (hearing.hearing_location || hearing.regional_office).city
   end
   attribute :appeal, &:appeal_external_id
   attribute :facility_id do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.facility_id
-    else
-      hearing.regional_office.facility_id
-    end
+    (hearing.hearing_location || hearing.regional_office).facility_id
   end
   attribute :first_name, &:veteran_first_name
   attribute :last_name, &:veteran_last_name
@@ -31,11 +19,7 @@ class Api::V2::HearingSerializer
     hearing.appeal.veteran.participant_id
   end
   attribute :hearing_location do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.name
-    else
-      hearing.regional_office.name
-    end
+    (hearing.hearing_location || hearing.regional_office).name
   end
   attribute :is_virtual, &:virtual?
   attribute :room do |hearing|
@@ -46,24 +30,12 @@ class Api::V2::HearingSerializer
     hearing.appeal.veteran_ssn
   end
   attribute :state do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.state
-    else
-      hearing.regional_office.state
-    end
+    (hearing.hearing_location || hearing.regional_office).state
   end
   attribute :timezone do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.timezone
-    else
-      hearing.regional_office.timezone
-    end
+    (hearing.hearing_location || hearing.regional_office).timezone
   end
   attribute :zip_code do |hearing|
-    if hearing.hearing_location.present?
-      hearing.hearing_location.zip_code
-    else
-      hearing.regional_office.zip_code
-    end
+    (hearing.hearing_location || hearing.regional_office).zip_code
   end
 end

--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -4,14 +4,26 @@ class Api::V2::HearingSerializer
   include FastJsonapi::ObjectSerializer
 
   attribute :address do |hearing|
-    hearing.hearing_location&.street_address
+    if hearing.hearing_location.present?
+      hearing.hearing_location.street_address
+    else
+      hearing.regional_office.address
+    end
   end
   attribute :city do |hearing|
-    hearing.hearing_location&.city || hearing.regional_office.city
+    if hearing.hearing_location.present?
+      hearing.hearing_location.city
+    else
+      hearing.regional_office.city
+    end
   end
   attribute :appeal, &:appeal_external_id
   attribute :facility_id do |hearing|
-    hearing.hearing_location&.facility_id
+    if hearing.hearing_location.present?
+      hearing.hearing_location.facility_id
+    else
+      hearing.regional_office.facility_id
+    end
   end
   attribute :first_name, &:veteran_first_name
   attribute :last_name, &:veteran_last_name
@@ -19,7 +31,11 @@ class Api::V2::HearingSerializer
     hearing.appeal.veteran.participant_id
   end
   attribute :hearing_location do |hearing|
-    hearing.hearing_location&.name || hearing.regional_office.name
+    if hearing.hearing_location.present?
+      hearing.hearing_location.name
+    else
+      hearing.regional_office.name
+    end
   end
   attribute :is_virtual, &:virtual?
   attribute :room do |hearing|
@@ -30,12 +46,24 @@ class Api::V2::HearingSerializer
     hearing.appeal.veteran_ssn
   end
   attribute :state do |hearing|
-    hearing.hearing_location&.state || hearing.regional_office.state
+    if hearing.hearing_location.present?
+      hearing.hearing_location.state
+    else
+      hearing.regional_office.state
+    end
   end
   attribute :timezone do |hearing|
-    hearing.hearing_location&.timezone || hearing.regional_office.timezone
+    if hearing.hearing_location.present?
+      hearing.hearing_location.timezone
+    else
+      hearing.regional_office.timezone
+    end
   end
   attribute :zip_code do |hearing|
-    hearing.hearing_location&.zip_code
+    if hearing.hearing_location.present?
+      hearing.hearing_location.zip_code
+    else
+      hearing.regional_office.zip_code
+    end
   end
 end

--- a/spec/controllers/api/v2/hearings_controller_spec.rb
+++ b/spec/controllers/api/v2/hearings_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
 
             first_location = response_body["hearings"][0]["hearing_location"]
             expect(first_location).to eq("Board of Veterans' Appeals CO Office")
-          
+
             expected_times = hearings.map(&:scheduled_for)
             scheduled_times = response_body["hearings"].map { |hearing| hearing["scheduled_for"] }
 

--- a/spec/controllers/api/v2/hearings_controller_spec.rb
+++ b/spec/controllers/api/v2/hearings_controller_spec.rb
@@ -113,10 +113,7 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
 
             first_location = response_body["hearings"][0]["hearing_location"]
             expect(first_location).to eq("Board of Veterans' Appeals CO Office")
-          end
-
-          it do
-            response_body = JSON.parse(subject.body)
+          
             expected_times = hearings.map(&:scheduled_for)
             scheduled_times = response_body["hearings"].map { |hearing| hearing["scheduled_for"] }
 
@@ -179,11 +176,13 @@ RSpec.describe Api::V2::HearingsController, :all_dbs, type: :controller do
           response
         end
 
-        it { expect(subject.status).to eq 200 }
-        it { expect(JSON.parse(subject.body)).to have_key("hearings") }
-        it { expect(JSON.parse(subject.body)["hearings"].size).to eq 2 }
-        it do
-          json_hearings = JSON.parse(subject.body)["hearings"]
+        it "returns a 200 and response has expected attributes and values", :aggregate_failures do
+          expect(subject.status).to eq 200
+          response_body = JSON.parse(subject.body)
+          expect(response_body).to have_key("hearings")
+
+          json_hearings = response_body["hearings"]
+          expect(json_hearings.size).to eq 2
           expect(json_hearings.map { |hearing| hearing["scheduled_for"] }).to all(start_with("2019-08-08"))
         end
       end

--- a/spec/models/regional_office_spec.rb
+++ b/spec/models/regional_office_spec.rb
@@ -99,13 +99,13 @@ describe RegionalOffice do
     it "RO87 has nil address" do
       ro = RegionalOffice.find!("RO87")
 
-      expect(ro.address).to eq nil
+      expect(ro.street_address).to eq nil
     end
 
     it "RO46 has correct address" do
       ro = RegionalOffice.find!("RO46")
 
-      expect(ro.address).to eq "915 Second Avenue"
+      expect(ro.street_address).to eq "915 Second Avenue"
     end
   end
 

--- a/spec/models/regional_office_spec.rb
+++ b/spec/models/regional_office_spec.rb
@@ -52,4 +52,68 @@ describe RegionalOffice do
       expect(subject.last).to have_attributes(key: "RO71", city: "Pittsburgh Foreign Cases")
     end
   end
+
+  context ".city_state_by_key" do
+    let(:key) { "RO01" }
+
+    subject { RegionalOffice.city_state_by_key(key) }
+
+    context "invalid key" do
+      let(:key) { "RO10000" }
+
+      it "is nil" do
+        expect(subject).to eq nil
+      end
+    end
+
+    context "valid key" do
+      it "returns the correct city and state" do
+        expect(subject).to eq "Boston, MA"
+      end
+    end
+  end
+
+  context ".valid?" do
+    RegionalOffice.all.each do |ro|
+      it "regional office (#{ro.key}) is valid?" do
+        expect(ro.valid?).to eq true
+      end
+    end
+  end
+
+  context ".facility_id" do
+    RegionalOffice.all.each do |ro|
+      it "regional office (#{ro.key}) does not throw when facility id is called" do
+        expect { ro.facility_id }.not_to raise_error
+      end
+    end
+  end
+
+  context ".address" do
+    RegionalOffice.all.each do |ro|
+      it "regional office (#{ro.key}) does not throw when address is called" do
+        expect { ro.address }.not_to raise_error
+      end
+    end
+
+    it "RO87 has nil address" do
+      ro = RegionalOffice.find!("RO87")
+
+      expect(ro.address).to eq nil
+    end
+
+    it "RO46 has correct address" do
+      ro = RegionalOffice.find!("RO46")
+
+      expect(ro.address).to eq "915 Second Avenue"
+    end
+  end
+
+  context ".zip_code" do
+    RegionalOffice.all.each do |ro|
+      it "regional office (#{ro.key}) does not throw when zip_code is called" do
+        expect { ro.zip_code }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/models/regional_office_spec.rb
+++ b/spec/models/regional_office_spec.rb
@@ -89,10 +89,10 @@ describe RegionalOffice do
     end
   end
 
-  context ".address" do
+  context ".street_address" do
     RegionalOffice.all.each do |ro|
-      it "regional office (#{ro.key}) does not throw when address is called" do
-        expect { ro.address }.not_to raise_error
+      it "regional office (#{ro.key}) does not throw when street_address is called" do
+        expect { ro.street_address }.not_to raise_error
       end
     end
 

--- a/spec/serializers/api/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/v2/hearing_serializer_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe Api::V2::HearingSerializer do
+  let(:hearing_day) do
+    build(
+      :hearing_day,
+      regional_office: "RO01",
+      request_type: HearingDay::REQUEST_TYPES[:video]
+    )
+  end
+
+  subject do
+    Api::V2::HearingSerializer.new(hearing).serializable_hash[:data][:attributes]
+  end
+
+  context "hearing with no location" do
+    let(:hearing) do
+      build(
+        :hearing,
+        hearing_day: hearing_day,
+        hearing_location: nil
+      )
+    end
+
+    it "has expected attributes after serialization", :aggregate_failures do
+      expect(subject[:city]).to eq "Boston"
+      expect(subject[:state]).to eq "MA"
+      expect(subject[:hearing_location]).to eq "Boston regional office"
+      expect(subject[:timezone]).to eq "America/New_York"
+      expect(subject[:zip_code]).to eq "02203"
+      expect(subject[:address]).to eq "15 New Sudbury Street"
+    end
+  end
+
+  context "hearing with alternate location" do
+    let(:hearing) do
+      build(
+        :hearing,
+        hearing_day: hearing_day,
+        regional_office: "RO15"
+      )
+    end
+
+    it "has expected attributes after serialization", :aggregate_failures do
+      expect(subject[:city]).to eq "Huntington"
+      expect(subject[:state]).to eq "WV"
+      expect(subject[:hearing_location]).to eq "Huntington regional office"
+      expect(subject[:timezone]).to eq "America/Kentucky/Louisville"
+      expect(subject[:zip_code]).to eq "25701"
+      expect(subject[:address]).to eq "640 4th Avenue"
+    end
+  end
+end


### PR DESCRIPTION
# Description

  * Add `zip_code`, `facility_id` and `street_address` attributes to `RegionalOffice`. These are populated if a corresponding facility entry exists for the RO's `facility_id`
  * Add tests around `Api::V2::HearingSerializer` and new `RegionalOffice` methods
  * Update `Api::V2::HearingSerializer` to use only fields from the hearing location OR regional office, not mixing the two