### PR TITLE
Missing denial draft alert applies to dismissed as well as denied disposition

### DIFF
--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -25,7 +25,7 @@ import { MTVTaskHeader } from './MTVTaskHeader';
 import TextField from '../../components/TextField';
 import { MTVIssueSelection } from './MTVIssueSelection';
 import StringUtil from '../../util/StringUtil';
-import { MissingDenialDraftAlert } from './MissingDenialDraftAlert';
+import { MissingDraftAlert } from './MissingDraftAlert';
 
 const vacateTypeText = (val) => {
   const opt = VACATE_TYPE_OPTIONS.find((i) => i.value === val);
@@ -141,7 +141,9 @@ export const MTVJudgeDisposition = ({
           />
         )}
 
-        {disposition && disposition === 'denied' && <MissingDenialDraftAlert to={returnToLitSupportLink} />}
+        {disposition && !isGrantType() && (
+          <MissingDraftAlert to={returnToLitSupportLink} disposition={disposition} />
+        )}
 
         {disposition && isGrantType() && (
           <RadioField

--- a/client/app/queue/mtv/MissingDraftAlert.jsx
+++ b/client/app/queue/mtv/MissingDraftAlert.jsx
@@ -3,16 +3,22 @@ import PropTypes from 'prop-types';
 import Alert from '../../components/Alert';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 
-export const MissingDenialDraftAlert = ({ to }) => (
+const dispositionStrings = {
+  denied: 'denial',
+  dismissed: 'dismissal'
+};
+
+export const MissingDraftAlert = ({ to, disposition = 'denied' }) => (
   <div style={{ maxWidth: '46rem',
     marginBottom: '1.5em' }}>
     <Alert type="warning" title="Please Note">
-      If you weren't provided the denial draft ruling letter, please <Link to={to}>return to the motions attorney</Link>
-      .
+      If you weren't provided the {dispositionStrings[disposition]} draft ruling letter, please{' '}
+      <Link to={to}>return to the motions attorney</Link>.
     </Alert>
   </div>
 );
 
-MissingDenialDraftAlert.propTypes = {
+MissingDraftAlert.propTypes = {
+  disposition: PropTypes.string,
   to: PropTypes.string.isRequired
 };


### PR DESCRIPTION
Connects #13243

### Description
Missing denial draft alert applies to dismissed as well as denied disposition

### Acceptance Criteria
- [ ] Show "Return to Motions Attorney" option when "dismiss" radio button is selected

