### PR TITLE
Hyperlink in MTVJudgeDisposition only required for "dismissed"

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -144,7 +144,7 @@
   "JUDGE_ADDRESS_MTV_DESCRIPTION": "Determine how you would like to address this motion to vacate.\n\nIf you are granting all issues for vacatur or a partial vacatur for this motion, you will then assign this case to an attorney on your team.\n\nIf you are choosing to deny or dismiss this motion, it will be automatically returned to the original Motions Attorney on the case. If they are no longer active, it will be placed in the Litigation Support team queue for reassignment.",
   "JUDGE_ADDRESS_MTV_DISPOSITION_SELECT_LABEL": "How will you address this motion to vacate?",
   "JUDGE_ADDRESS_MTV_VACATE_TYPE_LABEL": "What type of vacate?",
-  "JUDGE_ADDRESS_MTV_HYPERLINK_LABEL": "Insert hyperlink to signed denial document",
+  "JUDGE_ADDRESS_MTV_HYPERLINK_LABEL": "Insert hyperlink to signed %s document",
   "JUDGE_ADDRESS_MTV_DISPOSITION_NOTES_LABEL": "Provide context and instructions on which issues you will be granting",
   "JUDGE_ADDRESS_MTV_ASSIGN_ATTORNEY_LABEL": "Assign to decisions attorney",
   "JUDGE_ADDRESS_MTV_ISSUE_SELECTION_LABEL": "Which issues would you like to vacate?",

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -26,6 +26,7 @@ import TextField from '../../components/TextField';
 import { MTVIssueSelection } from './MTVIssueSelection';
 import StringUtil from '../../util/StringUtil';
 import { MissingDraftAlert } from './MissingDraftAlert';
+import { sprintf } from 'sprintf-js';
 
 const vacateTypeText = (val) => {
   const opt = VACATE_TYPE_OPTIONS.find((i) => i.value === val);
@@ -53,6 +54,11 @@ const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }
 };
 
 const grantTypes = ['granted', 'partial'];
+
+const dispositionStrings = {
+  denied: 'denial',
+  dismissed: 'dismissal'
+};
 
 export const MTVJudgeDisposition = ({
   attorneys,
@@ -108,7 +114,7 @@ export const MTVJudgeDisposition = ({
       !instructions ||
       (isGrantType() && !vacateType) ||
       (disposition === 'partial' && !issueIds.length) ||
-      (!isGrantType() && !hyperlink)
+      (disposition === 'dismissed' && !hyperlink)
     );
   };
 
@@ -141,9 +147,7 @@ export const MTVJudgeDisposition = ({
           />
         )}
 
-        {disposition && !isGrantType() && (
-          <MissingDraftAlert to={returnToLitSupportLink} disposition={disposition} />
-        )}
+        {disposition && !isGrantType() && <MissingDraftAlert to={returnToLitSupportLink} disposition={disposition} />}
 
         {disposition && isGrantType() && (
           <RadioField
@@ -160,10 +164,10 @@ export const MTVJudgeDisposition = ({
         {disposition && !isGrantType() && (
           <TextField
             name="hyperlink"
-            label={JUDGE_ADDRESS_MTV_HYPERLINK_LABEL}
+            label={sprintf(JUDGE_ADDRESS_MTV_HYPERLINK_LABEL, dispositionStrings[disposition])}
             value={hyperlink}
             onChange={(val) => setHyperlink(val)}
-            required
+            required={disposition === 'dismissed'}
             className={['mtv-review-hyperlink']}
           />
         )}


### PR DESCRIPTION
Connects #13236

### Description
This makes the `hyperlink` field optional for `denied` disposition; it's only required for `dismissed`.

### Acceptance Criteria
- [ ] `hyperlink` field is required only for `dismissed` disposition
