### PR TITLE
Remove line in flakey test

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -754,6 +754,7 @@ describe User, :all_dbs do
           end
 
           it "removes admin from all organizations, including JudgeTeam" do
+            expect(judge_team.judge).not_to eq user if FeatureToggle.enabled?(:judge_admin_scm)
             expect(judge_team.admins).to include user
             expect(user.organizations.size).to eq 3
             expect(user.selectable_organizations.length).to eq 2

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -754,7 +754,6 @@ describe User, :all_dbs do
           end
 
           it "removes admin from all organizations, including JudgeTeam" do
-            expect(judge_team.judge).not_to eq user
             expect(judge_team.admins).to include user
             expect(user.organizations.size).to eq 3
             expect(user.selectable_organizations.length).to eq 2


### PR DESCRIPTION
## Description

Fixes a flakey test that is failing because it depends on order. 

https://github.com/department-of-veterans-affairs/caseflow/blob/4aa4bbaf437a2a8fb0e8e26e085aa649f1cc99e7/app/models/organizations/judge_team.rb#L44

`admins` seems to be returning a random order. The next line in the modified test, checks if the user is an admin -- so there's an expectation that `user` could be returned as a judge.

I think it would be better to define the logic for which admin is judge if there are multiples, but for now, removing this line seems fine.