### PR TITLE
Persist stream docket number and type to new database columns

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -30,6 +30,8 @@ class Appeal < DecisionReview
     "De Novo": "De Novo"
   }
 
+  before_save :set_stream_fields
+
   with_options on: :intake_review do
     validates :receipt_date, :docket_type, presence: { message: "blank" }
     validate :validate_receipt_date
@@ -297,7 +299,7 @@ class Appeal < DecisionReview
 
   def docket_number
     return stream_docket_number if stream_docket_number
-    return "Missing Docket Number" unless receipt_date
+    return "Missing Docket Number" unless receipt_date && id.present?
 
     "#{receipt_date.strftime('%y%m%d')}-#{id}"
   end
@@ -422,6 +424,13 @@ class Appeal < DecisionReview
   end
 
   private
+
+  def set_stream_fields
+    if receipt_date && id.present?
+      self.stream_docket_number ||= docket_number
+    end
+    self.stream_type ||= type
+  end
 
   def maybe_create_translation_task
     veteran_state_code = veteran&.state

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -30,7 +30,7 @@ class Appeal < DecisionReview
     "De Novo": "De Novo"
   }
 
-  before_save :set_stream_fields
+  before_save :set_stream_docket_number_and_stream_type
 
   with_options on: :intake_review do
     validates :receipt_date, :docket_type, presence: { message: "blank" }
@@ -425,7 +425,7 @@ class Appeal < DecisionReview
 
   private
 
-  def set_stream_fields
+  def set_stream_docket_number_and_stream_type
     if receipt_date && persisted?
       self.stream_docket_number ||= docket_number
     end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -299,7 +299,7 @@ class Appeal < DecisionReview
 
   def docket_number
     return stream_docket_number if stream_docket_number
-    return "Missing Docket Number" unless receipt_date && id.present?
+    return "Missing Docket Number" unless receipt_date && persisted?
 
     "#{receipt_date.strftime('%y%m%d')}-#{id}"
   end
@@ -426,7 +426,7 @@ class Appeal < DecisionReview
   private
 
   def set_stream_fields
-    if receipt_date && id.present?
+    if receipt_date && persisted?
       self.stream_docket_number ||= docket_number
     end
     self.stream_type ||= type

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -321,7 +321,7 @@ describe Appeal, :all_dbs do
     end
   end
 
-  context "#set_stream_fields" do
+  context "#set_stream_docket_number_and_stream_type" do
     it "persists an accurate value for stream_docket_number to the database" do
       appeal = Appeal.new(veteran_file_number: "1234")
       appeal.save!

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -302,10 +302,10 @@ describe Appeal, :all_dbs do
   context "#docket_number" do
     context "when receipt_date is defined" do
       let(:appeal) do
-        create(:appeal, receipt_date: Time.new("2018", "04", "05").utc)
+        create(:appeal, id: 1234, receipt_date: Time.new("2018", "04", "05").utc)
       end
 
-      it "returns a docket number if receipt_date is defined" do
+      it "returns a docket number if id and receipt_date are defined" do
         expect(appeal.docket_number).to eq("180405-#{appeal.id}")
       end
     end
@@ -318,6 +318,21 @@ describe Appeal, :all_dbs do
       it "returns Missing Docket Number" do
         expect(appeal.docket_number).to eq("Missing Docket Number")
       end
+    end
+  end
+
+  context "#set_stream_fields" do
+    it "persists an accurate value for stream_docket_number to the database" do
+      appeal = Appeal.new(veteran_file_number: "1234")
+      appeal.save!
+      expect(appeal.stream_docket_number).to be_nil
+      appeal.receipt_date = Time.new("2020", "01", "24").utc
+      expect(appeal.docket_number).to eq("200124-#{appeal.id}")
+      appeal.save!
+      expect(appeal.stream_docket_number).to eq("200124-#{appeal.id}")
+      appeal.stream_docket_number = "something else"
+      appeal.save!
+      expect(Appeal.where(stream_docket_number: "something else").count).to eq(1)
     end
   end
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -302,7 +302,7 @@ describe Appeal, :all_dbs do
   context "#docket_number" do
     context "when receipt_date is defined" do
       let(:appeal) do
-        create(:appeal, id: 1234, receipt_date: Time.new("2018", "04", "05").utc)
+        create(:appeal, receipt_date: Time.new("2018", "04", "05").utc)
       end
 
       it "returns a docket number if id and receipt_date are defined" do


### PR DESCRIPTION
Connects #13211 

### Description
Second in a series of PRs (first: #13241) to support appeal streams by storing the docket number and type in the DB.

This PR adds a `before_save` hook to Appeal which persists accurate values for docket number and type to the DB. After this PR, the DB fields will be populated for new and touched appeals, including MTV appeal when they land.

N.B.: with docket number, there's a tension in the fact that a non-nil stored value overrides the computed value, which in turn overrides a nil stored value — possible if the Appeal is new or only recently got its `id` or `receipt_date` — and this has some subtle order-of-operations implications. 

I've added a test for edge cases, even though the happy path for appeal creation is pretty well-behaved. Other tests are somewhat less well-behaved.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Added a model test, to stress-test the order-of-operations subtleties mentioned above.