### PR TITLE
Revert "Fix race condition for remand supplemental claims"

### DIFF
--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -276,8 +276,8 @@ class ClaimReview < DecisionReview
   end
 
   def create_decision_review_task!
-    return if tasks.open.any? { |task| task.is_a?(DecisionReviewTask) }
-    return if request_issues.active.empty?
+    return if tasks.any? { |task| task.is_a?(DecisionReviewTask) } # TODO: more specific check?
+    return if request_issues.active.blank?
 
     DecisionReviewTask.create!(appeal: self, assigned_at: Time.zone.now, assigned_to: business_line)
   end

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -230,7 +230,7 @@ class DecisionReview < ApplicationRecord
       delay = rsc.receipt_date.future? ? (rsc.receipt_date + PROCESS_DELAY_VBMS_OFFSET_HOURS.hours).utc : 0
       rsc.submit_for_processing!(delay: delay)
 
-      unless rsc.receipt_date.future?
+      unless rsc.processed? || rsc.receipt_date.future?
         rsc.start_processing_job!
       end
     end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -296,10 +296,10 @@ class EndProductEstablishment < ApplicationRecord
     end
   end
 
-  def on_decision_issue_sync_processed
-    return unless request_issues.all? { |issue| issue.closed? || issue.processed? }
-
-    source.on_decision_issues_sync_processed
+  def on_decision_issue_sync_processed(processing_request_issue)
+    if decision_issues_sync_complete?(processing_request_issue)
+      source.on_decision_issues_sync_processed
+    end
   end
 
   def status
@@ -358,6 +358,11 @@ class EndProductEstablishment < ApplicationRecord
 
   def all_contention_records
     source.all_contention_records(self)
+  end
+
+  def decision_issues_sync_complete?(processing_request_issue)
+    other_request_issues = request_issues.all.reject { |i| i.id == processing_request_issue.id }
+    other_request_issues.all? { |i| i.closed? || i.processed? }
   end
 
   def potential_decision_ratings

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -394,12 +394,11 @@ class RequestIssue < ApplicationRecord
     transaction do
       return unless create_decision_issues
 
+      end_product_establishment.on_decision_issue_sync_processed(self)
       clear_error!
       close_decided_issue!
       processed!
     end
-
-    end_product_establishment.on_decision_issue_sync_processed
   end
 
   def vacols_issue

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -130,6 +130,69 @@ describe Appeal, :all_dbs do
     end
   end
 
+  context "#create_remand_supplemental_claims!" do
+    before { setup_prior_claim_with_payee_code(appeal, veteran) }
+
+    let(:veteran) { create(:veteran) }
+    let(:appeal) do
+      create(:appeal, number_of_claimants: 1, veteran_file_number: veteran.file_number)
+    end
+
+    subject { appeal.create_remand_supplemental_claims! }
+
+    let!(:remanded_decision_issue) do
+      create(
+        :decision_issue,
+        decision_review: appeal,
+        disposition: "remanded",
+        benefit_type: "compensation",
+        caseflow_decision_date: decision_date
+      )
+    end
+
+    let!(:remanded_decision_issue_processed_in_caseflow) do
+      create(
+        :decision_issue, decision_review: appeal, disposition: "remanded", benefit_type: "nca",
+                         caseflow_decision_date: decision_date
+      )
+    end
+
+    let(:decision_date) { 10.days.ago }
+    let!(:decision_document) { create(:decision_document, decision_date: decision_date, appeal: appeal) }
+
+    let!(:not_remanded_decision_issue) { create(:decision_issue, decision_review: appeal) }
+
+    it "creates supplemental claim, request issues, and starts processing" do
+      subject
+
+      remanded_supplemental_claims = SupplementalClaim.where(decision_review_remanded: appeal)
+
+      expect(remanded_supplemental_claims.count).to eq(2)
+
+      vbms_remand = remanded_supplemental_claims.find_by(benefit_type: "compensation")
+      expect(vbms_remand).to have_attributes(
+        receipt_date: decision_date.to_date
+      )
+      expect(vbms_remand.request_issues.count).to eq(1)
+      expect(vbms_remand.request_issues.first).to have_attributes(
+        contested_decision_issue: remanded_decision_issue
+      )
+      expect(vbms_remand.end_product_establishments.first).to be_committed
+      expect(vbms_remand.tasks).to be_empty
+
+      caseflow_remand = remanded_supplemental_claims.find_by(benefit_type: "nca")
+      expect(caseflow_remand).to have_attributes(
+        receipt_date: decision_date.to_date
+      )
+      expect(caseflow_remand.request_issues.count).to eq(1)
+      expect(caseflow_remand.request_issues.first).to have_attributes(
+        contested_decision_issue: remanded_decision_issue_processed_in_caseflow
+      )
+      expect(caseflow_remand.end_product_establishments).to be_empty
+      expect(caseflow_remand.tasks.first).to have_attributes(assigned_to: BusinessLine.find_by(url: "nca"))
+    end
+  end
+
   context "#document_fetcher" do
     let(:veteran_file_number) { "64205050" }
     let(:appeal) do

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -421,22 +421,6 @@ describe ClaimReview, :postgres do
         it "does nothing" do
           expect { subject }.to_not change(DecisionReviewTask, :count)
         end
-
-        context "when the existing task is not open" do
-          it "creates a decision review task" do
-            drt = DecisionReviewTask.last
-            drt.completed!
-
-            expect { subject }.to change(DecisionReviewTask, :count).by(1)
-
-            expect(DecisionReviewTask.last).to have_attributes(
-              appeal: claim_review,
-              assigned_at: Time.zone.now,
-              assigned_to: BusinessLine.find_by(url: "vha"),
-              status: "assigned"
-            )
-          end
-        end
       end
 
       context "when the review only has ineligible issues" do

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1542,6 +1542,19 @@ describe RequestIssue, :all_dbs do
                 expect(rating_request_issue.closed_status).to eq("decided")
               end
             end
+
+            context "when syncing the end_product_establishment fails" do
+              before do
+                allow(end_product_establishment).to receive(
+                  :on_decision_issue_sync_processed
+                ).and_raise("DTA 040 failed")
+              end
+
+              it "does not processs" do
+                expect { subject }.to raise_error("DTA 040 failed")
+                expect(rating_request_issue.processed?).to eq(false)
+              end
+            end
           end
 
           context "when no matching rating issues exist" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -754,10 +754,15 @@ describe User, :all_dbs do
           end
 
           it "removes admin from all organizations, including JudgeTeam" do
-            expect(judge_team.judge).not_to eq user if FeatureToggle.enabled?(:judge_admin_scm)
+            if FeatureToggle.enabled?(:judge_admin_scm)
+              expect(judge_team.judge).not_to eq user
+              expect(user.selectable_organizations.length).to eq 3
+            else
+              expect(user.selectable_organizations.length).to eq 2
+            end
+
             expect(judge_team.admins).to include user
             expect(user.organizations.size).to eq 3
-            expect(user.selectable_organizations.length).to eq 2
             expect(subject).to eq true
             expect(user.reload.status).to eq status
             expect(user.status_updated_at.to_s).to eq Time.zone.now.to_s


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow#13061

The reverted PR is causing duplicate EPs to be created.