### PR TITLE
Add missing Person model to ETL sync

### DIFF
--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -10,6 +10,7 @@ class ETL::Builder
     DecisionIssue
     Organization
     OrganizationsUser
+    Person
     Task
     User
   ].freeze

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -32,7 +32,7 @@ describe ETL::Builder, :etl, :all_dbs do
 
         # use .to_s comparison since Rails.cache does not store .milliseconds
         expect(builder.last_built.to_s).to eq(Time.zone.now.to_s)
-        expect(built).to eq(75)
+        expect(built).to eq(88)
       end
 
       hour_from_now = Time.zone.now + 1.hour
@@ -61,10 +61,11 @@ describe ETL::Builder, :etl, :all_dbs do
 
         built = subject
 
-        expect(built).to eq(75)
+        expect(built).to eq(88)
         expect(ETL::Task.count).to eq(31)
         expect(ETL::Appeal.count).to eq(13)
         expect(ETL::User.all.count).to eq(23)
+        expect(ETL::Person.all.count).to eq(13)
         expect(ETL::OrganizationsUser.all.count).to eq(3)
         expect(ETL::Organization.all.count).to eq(5)
       end
@@ -80,10 +81,11 @@ describe ETL::Builder, :etl, :all_dbs do
 
         built = subject
 
-        expect(built).to eq(72)
+        expect(built).to eq(85)
         expect(ETL::Task.count).to eq(31)
         expect(ETL::Appeal.count).to eq(13)
         expect(ETL::User.all.count).to eq(22)
+        expect(ETL::Person.all.count).to eq(13)
         expect(ETL::OrganizationsUser.all.count).to eq(2)
         expect(ETL::Organization.all.count).to eq(4)
       end


### PR DESCRIPTION
As reported by @rajinderbhanot we were missing data from the `people` table.