### PR TITLE
Use stream_docket_number for docket number in SQL code

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -32,6 +32,7 @@ class Appeal < DecisionReview
   }
 
   before_save :set_stream_docket_number_and_stream_type
+  after_save :set_stream_docket_number_from_new_id
 
   with_options on: :intake_review do
     validates :receipt_date, :docket_type, presence: { message: "blank" }
@@ -435,6 +436,14 @@ class Appeal < DecisionReview
       self.stream_docket_number ||= docket_number
     end
     self.stream_type ||= type
+  end
+
+  # If the new ID from a save! was all we needed to determine the docket_number,
+  # immediately do a second save! so the database record is accurate.
+  def set_stream_docket_number_from_new_id
+    if stream_docket_number.nil? && receipt_date
+      save!(stream_docket_number: docket_number)
+    end
   end
 
   def maybe_create_translation_task

--- a/app/sql/ama-cases.sql
+++ b/app/sql/ama-cases.sql
@@ -449,12 +449,7 @@ SELECT
           FROM
             public.appeals AS appeals
       ) SELECT
-          to_char (
-            (
-              DATE( appeal_task_status.receipt_date )
-            )
-            ,'yymmdd'
-          ) || '-' || appeal_task_status.id AS "docket_number"
+          appeal_task_status.stream_docket_number AS "docket_number"
           ,appeal_task_status. *
           ,CASE
             WHEN appeal_task_status.distribution_task_status IN (

--- a/app/sql/ama-tasks.sql
+++ b/app/sql/ama-tasks.sql
@@ -414,12 +414,7 @@ SELECT
           FROM
             PUBLIC.appeals AS appeals
       ) SELECT
-          to_char (
-            (
-              DATE( appeal_task_status.receipt_date )
-            )
-            ,'yymmdd'
-          ) || '-' || appeal_task_status.id AS "docket_number"
+          appeal_task_status.stream_docket_number AS "docket_number"
           ,appeal_task_status. *
           ,CASE
             WHEN appeal_task_status.distribution_task_status IN (

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -17,6 +17,11 @@ FactoryBot.define do
       Fakes::VBMSService.document_records[appeal.veteran_file_number] = evaluator.documents
     end
 
+    # Appeal's after_save interferes with explicit updated_at values
+    after(:create) do |appeal, evaluator|
+      appeal.touch(time: evaluator.updated_at) if evaluator.try(:updated_at)
+    end
+
     after(:create) do |appeal, _evaluator|
       appeal.request_issues.each do |issue|
         issue.decision_review = appeal

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -385,17 +385,25 @@ describe Appeal, :all_dbs do
   end
 
   context "#set_stream_docket_number_and_stream_type" do
+    let(:appeal) { Appeal.new(veteran_file_number: "1234") }
+    let(:receipt_date) { Time.new("2020", "01", "24").utc }
+
     it "persists an accurate value for stream_docket_number to the database" do
-      appeal = Appeal.new(veteran_file_number: "1234")
       appeal.save!
       expect(appeal.stream_docket_number).to be_nil
-      appeal.receipt_date = Time.new("2020", "01", "24").utc
+      appeal.receipt_date = receipt_date
       expect(appeal.docket_number).to eq("200124-#{appeal.id}")
       appeal.save!
       expect(appeal.stream_docket_number).to eq("200124-#{appeal.id}")
       appeal.stream_docket_number = "something else"
       appeal.save!
       expect(Appeal.where(stream_docket_number: "something else").count).to eq(1)
+    end
+
+    it "persists a non-NULL value for stream_docket_number as soon as possible" do
+      appeal.receipt_date = receipt_date
+      appeal.save!
+      expect(Appeal.where(stream_docket_number: "200124-#{appeal.id}").count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Connects #13211

### Description
Epilogue in a series of PRs (previously: #13241 #13258 #13280) to support appeal streams by storing the docket number and type in the DB.

Now that `stream_docket_number` is created and accurately populated for all existing and future appeals, the SQL code no longer needs to mirror the old Rails code in computing docket numbers on the fly.

One broad question: we do want this diff, right? Assuming Tableau wants accurate docket numbers once MTV appeals land.

And one very narrow concern:

An Appeal that's been saved just once, with a receipt_date and a PG-generated ID, will have a logical docket number but not a `stream_docket_number`, since Rails can't know the ID pre-save. Rails-side, this isn't any worse than before, but this simplified SQL query would now see a NULL.

In practice, it's not currently a problem since the appeal is created by `IntakesController#create` and receipt_date lands later in `#review`. Should we protect against the hypothetical bug, though? Either by revisiting this SQL code, or making Rails do a double-save.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. All tests in `spec/sql/` still passing.