### PR TITLE
Add logging to CreateConferenceJob

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -16,14 +16,20 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
     capture_exception(exception, extra: extra)
   end
 
-  def perform(hearing_id:, hearing_type:, email_type: :confirmation)
+  before_perform do |job|
+    kwargs = job.arguments.first
+    hearing_id = kwargs[:hearing_id]
+    email_type = kwargs[:email_type] || :confirmation
+
     Rails.logger.info(
       "Creating Pexip conference for hearing (#{hearing_id}) and sending #{email_type} email"
     )
     Rails.logger.info(
       "Timezones for #{self.class.name} are (zone: #{Time.zone.name}) (getlocal: #{Time.now.getlocal.zone})"
     )
+  end
 
+  def perform(hearing_id:, hearing_type:, email_type: :confirmation)
     set_virtual_hearing(hearing_id, hearing_type)
 
     virtual_hearing.establishment.attempted!

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -17,6 +17,13 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
   end
 
   def perform(hearing_id:, hearing_type:, email_type: :confirmation)
+    Rails.logger.info(
+      "Creating Pexip conference for hearing (#{hearing_id}) and sending #{email_type} email"
+    )
+    Rails.logger.info(
+      "Timezones for #{self.class.name} are (zone: #{Time.zone.name}) (getlocal: #{Time.now.getlocal.zone})"
+    )
+
     set_virtual_hearing(hearing_id, hearing_type)
 
     virtual_hearing.establishment.attempted!


### PR DESCRIPTION
Related to #13156  

### Description

Add some additional logging to confirm whether or not the timezone for a job is set to UTC or not.