### PR TITLE
Past Hearing Type Field Not Editable for Past Hearings

### DIFF
--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -81,6 +81,7 @@ class HearingDetails extends React.Component {
         evidenceWindowWaived: hearing.evidenceWindowWaived || false,
         room: hearing.room,
         notes: hearing.notes,
+        scheduledForIsPast: hearing.scheduledForIsPast,
         // Transcription Request
         transcriptRequested: hearing.transcriptRequested,
         transcriptSentDate: DateUtil.formatDateStr(hearing.transcriptSentDate, 'YYYY-MM-DD', 'YYYY-MM-DD')

--- a/client/app/hearings/components/DetailsSections.jsx
+++ b/client/app/hearings/components/DetailsSections.jsx
@@ -31,6 +31,7 @@ class DetailsSections extends React.Component {
           requestType={requestType}
           isLegacy={isLegacy}
           hearing={hearing}
+          scheduledForIsPast={hearing.scheduledForIsPast}
           update={updateHearing}
           enableVirtualHearings={user.userCanScheduleVirtualHearings && requestType !== 'Central'}
           virtualHearing={virtualHearing}

--- a/client/app/hearings/components/details/DetailsInputs.jsx
+++ b/client/app/hearings/components/details/DetailsInputs.jsx
@@ -62,7 +62,7 @@ class DetailsInputs extends React.Component {
               requestType={requestType}
               updateVirtualHearing={updateVirtualHearing}
               openModal={openVirtualHearingModal}
-              readOnly={readOnly || (isVirtual && virtualHearing && !virtualHearing.jobCompleted)}
+              readOnly={hearing.scheduledForIsPast || (isVirtual && virtualHearing && !virtualHearing.jobCompleted)}
             />
             {this.renderVirtualHearingLinkSection()}
           </div>

--- a/client/app/hearings/components/details/DetailsInputs.jsx
+++ b/client/app/hearings/components/details/DetailsInputs.jsx
@@ -147,7 +147,8 @@ DetailsInputs.propTypes = {
     room: PropTypes.string,
     evidenceWindowWaived: PropTypes.bool,
     notes: PropTypes.string,
-    bvaPoc: PropTypes.string
+    bvaPoc: PropTypes.string,
+    scheduledForIsPast: PropTypes.bool
   }),
   update: PropTypes.func,
   readOnly: PropTypes.bool,


### PR DESCRIPTION
Resolves #13218 

Leaves the `HearingType` dropdown menu in the hearing details page as a disabled field.

_Past Virtual Hearing_
<img width="1416" alt="Screen Shot 2020-01-29 at 5 06 12 PM" src="https://user-images.githubusercontent.com/37313082/73401746-bae25700-42b9-11ea-9644-f6f56a3ffff7.png">

_Past Video Hearing_
<img width="979" alt="Screen Shot 2020-01-29 at 3 43 23 PM" src="https://user-images.githubusercontent.com/37313082/73401856-f846e480-42b9-11ea-8cee-3ce57380560b.png">
