### PR TITLE
Set TZ to America/New_York for all jobs in UAT

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -34,11 +34,13 @@ class ApplicationJob < ActiveJob::Base
   end
 
   # Testing America/New_York TZ for all jobs in UAT.
-  around_perform do |job, block|
-    Time.use_zone("America/New_York") do
-      block.call
+  if !Rails.deploy_env?(:uat)
+    around_perform do |_job, block|
+      Time.use_zone("America/New_York") do
+        block.call
+      end
     end
-  end if Rails.current_env == :uat
+  end
 
   before_perform do |job|
     # setup debug context

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -33,6 +33,13 @@ class ApplicationJob < ActiveJob::Base
     end
   end
 
+  # Testing America/New_York TZ for all jobs in UAT.
+  around_perform do |job, block|
+    Time.use_zone("America/New_York") do
+      block.call
+    end
+  end if Rails.current_env == :uat
+
   before_perform do |job|
     # setup debug context
     Raven.tags_context(job: job.class.name, queue: job.queue_name)

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -36,7 +36,7 @@ class ApplicationJob < ActiveJob::Base
   # Testing America/New_York TZ for all jobs in UAT.
   if !Rails.deploy_env?(:uat)
     around_perform do |_job, block|
-      Time.use_zone("America/New_York") do
+      Time.use_zone(Rails.configuration.time_zone) do
         block.call
       end
     end


### PR DESCRIPTION
Related to #13187 #13156

### Description

Explicitly use EST timezone for all UAT jobs