### PR TITLE
Do not double count cancelled or child tasks when determining monthly limit for QR tasks

### DIFF
--- a/app/models/quality_review_case_selector.rb
+++ b/app/models/quality_review_case_selector.rb
@@ -14,7 +14,11 @@ class QualityReviewCaseSelector
     end
 
     def reached_monthly_limit_in_quality_reviews?
-      QualityReviewTask.created_this_month.size >= MONTHLY_LIMIT_OF_QUAILITY_REVIEWS
+      QualityReviewTask
+        .not_cancelled
+        .created_this_month
+        .where(assigned_to_type: Organization.name)
+        .size >= MONTHLY_LIMIT_OF_QUAILITY_REVIEWS
     end
   end
 end

--- a/spec/models/quality_review_case_selector_spec.rb
+++ b/spec/models/quality_review_case_selector_spec.rb
@@ -24,6 +24,8 @@ describe QualityReviewCaseSelector, :all_dbs do
     end
 
     context "after reaching the monthly limit" do
+      before { stub_const("QualityReviewCaseSelector::MONTHLY_LIMIT_OF_QUAILITY_REVIEWS", 5) }
+
       let!(:qr_tasks) { create_list(:qr_task, QualityReviewCaseSelector::MONTHLY_LIMIT_OF_QUAILITY_REVIEWS) }
 
       it "returns true" do

--- a/spec/models/quality_review_case_selector_spec.rb
+++ b/spec/models/quality_review_case_selector_spec.rb
@@ -31,10 +31,7 @@ describe QualityReviewCaseSelector, :all_dbs do
       end
 
       context "but some tasks are cancelled" do
-        before do
-          allow_any_instance_of(BvaDispatch).to receive(:next_assignee).and_return(false)
-          qr_tasks.last.update!(status: Constants.TASK_STATUSES.cancelled)
-        end
+        before { qr_tasks.last.update_columns(status: Constants.TASK_STATUSES.cancelled) }
 
         it "returns false" do
           expect(subject).to be(false)


### PR DESCRIPTION
Resolves issue where QR has stopped getting tasks at only 95.
References #13037

### Description
Stopped double counting tasks. We previously would count the child tasks as well.
```ruby
# This is the code that we check the limit against
QualityReviewTask.created_this_month.size
=> 168

# I wonder if this includes legacy appeals
QualityReviewTask.created_this_month.group(:appeal_type).count
=> {"Appeal"=>168}
# Nope

# I wonder if this includes user tasks?
QualityReviewTask.created_this_month.group(:assigned_to_type).count
=> {"Organization"=>77, "User"=>91}
# YEP
```

### Acceptance Criteria
- [ ] Cancelled QR tasks are not counted when calculating the monthly limit
- [ ] More then one QR task on an appeal are not counted when calculating the monthly limit