### PR TITLE
Fix NoMethodError: undefined method user_represents_claimant_not_veteran for Appeal

### DIFF
--- a/app/models/concerns/appeal_concern.rb
+++ b/app/models/concerns/appeal_concern.rb
@@ -45,12 +45,6 @@ module AppealConcern
     end
   end
 
-  def user_represents_claimant_not_veteran
-    return false unless FeatureToggle.enabled?(:vso_claimant_representative)
-
-    appellant_is_not_veteran && representatives.any? { |rep| rep.user_has_access?(current_user) }
-  end
-
   private
 
   # TODO: this is named "veteran_name_object" to avoid name collision, refactor


### PR DESCRIPTION
Resolves #13314

### Description
Don't call a function that doesn't exist!