### PR TITLE
Set Up Container Component for MTV Checkout Workflows

### DIFF
--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -76,8 +76,9 @@ import { FlashAlerts } from '../nonComp/components/Alerts';
 import AddressMotionToVacateView from './mtv/AddressMotionToVacateView';
 import ReviewMotionToVacateView from './mtv/ReviewMotionToVacateView';
 import { PulacCerulloReminderModal } from './pulacCerullo/PulacCerulloReminderModal';
-import { ReturnToLitSupportModal } from './mtv/ReturnToLitSupportModal';
-import { returnToLitSupport } from './mtv/mtvActions';
+// import { ReturnToLitSupportModal } from './mtv/ReturnToLitSupportModal';
+// import { returnToLitSupport } from './mtv/mtvActions';
+import { motionToVacateRoutes } from './mtv/motionToVacateRoutes';
 
 class QueueApp extends React.PureComponent {
   componentDidMount = () => {
@@ -234,20 +235,20 @@ class QueueApp extends React.PureComponent {
 
   routedAssignToPulacCerullo = (props) => <AssignToView isTeamAssign assigneeAlreadySelected {...props.match.params} />;
 
-  routedReturnToLitSupport = (props) => {
-    const { taskId } = props.match.params;
+  // routedReturnToLitSupport = (props) => {
+  //   const { taskId } = props.match.params;
 
-    return (
-      <ReturnToLitSupportModal
-        {...props.match.params}
-        onCancel={() => props.history.goBack()}
-        onSubmit={({ instructions }) => {
-          this.props.returnToLitSupport({ instructions,
-            task_id: taskId }, props);
-        }}
-      />
-    );
-  };
+  //   return (
+  //     <ReturnToLitSupportModal
+  //       {...props.match.params}
+  //       onCancel={() => props.history.goBack()}
+  //       onSubmit={({ instructions }) => {
+  //         this.props.returnToLitSupport({ instructions,
+  //           task_id: taskId }, props);
+  //       }}
+  //     />
+  //   );
+  // };
 
   routedReassignToUser = (props) => <AssignToView isReassignAction {...props.match.params} />;
 
@@ -545,7 +546,9 @@ class QueueApp extends React.PureComponent {
               title="Assign to Pulac-Cerullo | Caseflow"
               render={this.routedAssignToPulacCerullo}
             />
-            <PageRoute
+            {motionToVacateRoutes.page}
+            {motionToVacateRoutes.modal}
+            {/* <PageRoute
               path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.ADDRESS_MOTION_TO_VACATE.value}`}
               title="Address Motion to Vacate | Caseflow"
               render={this.routedAddressMotionToVacate}
@@ -559,7 +562,7 @@ class QueueApp extends React.PureComponent {
               ].join('/')}
               title="Return to Litigation Support | Caseflow"
               render={this.routedReturnToLitSupport}
-            />
+            /> */}
             <PageRoute
               exact
               path={`/queue/appeals/:appealId/tasks/:taskId/${
@@ -666,7 +669,7 @@ QueueApp.propTypes = {
   flash: PropTypes.array,
   reviewActionType: PropTypes.string,
   userCanViewHearingSchedule: PropTypes.bool,
-  returnToLitSupport: PropTypes.func
+  // returnToLitSupport: PropTypes.func
 };
 
 const mapStateToProps = (state) => ({
@@ -682,7 +685,7 @@ const mapDispatchToProps = (dispatch) =>
       setUserIsVsoEmployee,
       setFeedbackUrl,
       setOrganizations,
-      returnToLitSupport
+      // returnToLitSupport
     },
     dispatch
   );

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -73,11 +73,8 @@ import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
 import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
 import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
 import { FlashAlerts } from '../nonComp/components/Alerts';
-// import AddressMotionToVacateView from './mtv/AddressMotionToVacateView';
-// import ReviewMotionToVacateView from './mtv/ReviewMotionToVacateView';
+
 import { PulacCerulloReminderModal } from './pulacCerullo/PulacCerulloReminderModal';
-// import { ReturnToLitSupportModal } from './mtv/ReturnToLitSupportModal';
-// import { returnToLitSupport } from './mtv/mtvActions';
 import { motionToVacateRoutes } from './mtv/motionToVacateRoutes';
 
 class QueueApp extends React.PureComponent {
@@ -215,10 +212,6 @@ class QueueApp extends React.PureComponent {
 
   routedAssignToUser = (props) => <AssignToView {...props.match.params} />;
 
-  // routedSendMotionToVacateToJudge = () => <ReviewMotionToVacateView />;
-
-  // routedAddressMotionToVacate = (props) => <AddressMotionToVacateView {...props.match.params} />;
-
   routedPulacCerulloReminder = (props) => {
     const { appealId, taskId } = props.match.params;
     const pulacRoute = `/queue/appeals/${appealId}/tasks/${taskId}/${TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.value}`;
@@ -234,21 +227,6 @@ class QueueApp extends React.PureComponent {
   };
 
   routedAssignToPulacCerullo = (props) => <AssignToView isTeamAssign assigneeAlreadySelected {...props.match.params} />;
-
-  // routedReturnToLitSupport = (props) => {
-  //   const { taskId } = props.match.params;
-
-  //   return (
-  //     <ReturnToLitSupportModal
-  //       {...props.match.params}
-  //       onCancel={() => props.history.goBack()}
-  //       onSubmit={({ instructions }) => {
-  //         this.props.returnToLitSupport({ instructions,
-  //           task_id: taskId }, props);
-  //       }}
-  //     />
-  //   );
-  // };
 
   routedReassignToUser = (props) => <AssignToView isReassignAction {...props.match.params} />;
 
@@ -546,23 +524,10 @@ class QueueApp extends React.PureComponent {
               title="Assign to Pulac-Cerullo | Caseflow"
               render={this.routedAssignToPulacCerullo}
             />
+
             {motionToVacateRoutes.page}
             {motionToVacateRoutes.modal}
-            {/* <PageRoute
-              path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.ADDRESS_MOTION_TO_VACATE.value}`}
-              title="Address Motion to Vacate | Caseflow"
-              render={this.routedAddressMotionToVacate}
-            />
-            <PageRoute
-              exact
-              path={[
-                '/queue/appeals/:appealId/tasks/:taskId',
-                TASK_ACTIONS.ADDRESS_MOTION_TO_VACATE.value,
-                TASK_ACTIONS.JUDGE_RETURN_TO_LIT_SUPPORT.value
-              ].join('/')}
-              title="Return to Litigation Support | Caseflow"
-              render={this.routedReturnToLitSupport}
-            /> */}
+
             <PageRoute
               exact
               path={`/queue/appeals/:appealId/tasks/:taskId/${
@@ -668,8 +633,7 @@ QueueApp.propTypes = {
   applicationUrls: PropTypes.array,
   flash: PropTypes.array,
   reviewActionType: PropTypes.string,
-  userCanViewHearingSchedule: PropTypes.bool,
-  // returnToLitSupport: PropTypes.func
+  userCanViewHearingSchedule: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({
@@ -684,8 +648,7 @@ const mapDispatchToProps = (dispatch) =>
       setUserCssId,
       setUserIsVsoEmployee,
       setFeedbackUrl,
-      setOrganizations,
-      // returnToLitSupport
+      setOrganizations
     },
     dispatch
   );

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -73,8 +73,8 @@ import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
 import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
 import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
 import { FlashAlerts } from '../nonComp/components/Alerts';
-import AddressMotionToVacateView from './mtv/AddressMotionToVacateView';
-import ReviewMotionToVacateView from './mtv/ReviewMotionToVacateView';
+// import AddressMotionToVacateView from './mtv/AddressMotionToVacateView';
+// import ReviewMotionToVacateView from './mtv/ReviewMotionToVacateView';
 import { PulacCerulloReminderModal } from './pulacCerullo/PulacCerulloReminderModal';
 // import { ReturnToLitSupportModal } from './mtv/ReturnToLitSupportModal';
 // import { returnToLitSupport } from './mtv/mtvActions';
@@ -215,9 +215,9 @@ class QueueApp extends React.PureComponent {
 
   routedAssignToUser = (props) => <AssignToView {...props.match.params} />;
 
-  routedSendMotionToVacateToJudge = () => <ReviewMotionToVacateView />;
+  // routedSendMotionToVacateToJudge = () => <ReviewMotionToVacateView />;
 
-  routedAddressMotionToVacate = (props) => <AddressMotionToVacateView {...props.match.params} />;
+  // routedAddressMotionToVacate = (props) => <AddressMotionToVacateView {...props.match.params} />;
 
   routedPulacCerulloReminder = (props) => {
     const { appealId, taskId } = props.match.params;
@@ -444,10 +444,10 @@ class QueueApp extends React.PureComponent {
               path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.SPECIAL_CASE_MOVEMENT.value}`}
               render={this.routedAssignToUser}
             />
-            <Route
+            {/* <Route
               path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.SEND_MOTION_TO_VACATE_TO_JUDGE.value}`}
               render={this.routedSendMotionToVacateToJudge}
-            />
+            /> */}
             <PageRoute
               exact
               path="/queue/appeals/:appealId"

--- a/client/app/queue/mtv/AddressMotionToVacateView.jsx
+++ b/client/app/queue/mtv/AddressMotionToVacateView.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { withRouter } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { useRouteMatch, useParams, useHistory } from 'react-router-dom';
 
 import { taskById, appealWithDetailSelector } from '../selectors';
 import { MTVJudgeDisposition } from './MTVJudgeDisposition';
@@ -11,10 +9,17 @@ import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS.jso
 import { submitMTVJudgeDecision } from './mtvActions';
 import { taskActionData } from '../utils';
 
-export const AddressMotionToVacateView = (props) => {
-  const { task, appeal } = props;
+export const AddressMotionToVacateView = () => {
+  const { taskId, appealId } = useParams();
+  const match = useRouteMatch();
+  const history = useHistory();
+  const dispatch = useDispatch();
 
-  const { selected, options } = taskActionData(props);
+  const task = useSelector((state) => taskById(state, { taskId }));
+  const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
+
+  const { selected, options } = taskActionData({ task,
+    match });
 
   const attyOptions = options.map(({ value, label }) => ({
     label: label + (selected && value === selected.id ? ' (Orig. Attorney)' : ''),
@@ -22,7 +27,7 @@ export const AddressMotionToVacateView = (props) => {
   }));
 
   const handleSubmit = (result) => {
-    props.submitMTVJudgeDecision(result, props);
+    dispatch(submitMTVJudgeDecision(result, { history }));
   };
 
   return (
@@ -32,40 +37,9 @@ export const AddressMotionToVacateView = (props) => {
       selectedAttorney={selected}
       appeal={appeal}
       onSubmit={handleSubmit}
-      returnToLitSupportLink={`${props.match.url}/${JUDGE_RETURN_TO_LIT_SUPPORT.value}`}
+      returnToLitSupportLink={`${match.url}/${JUDGE_RETURN_TO_LIT_SUPPORT.value}`}
     />
   );
 };
 
-AddressMotionToVacateView.propTypes = {
-  task: PropTypes.object,
-  appeal: PropTypes.object,
-  submitMTVJudgeDecision: PropTypes.func,
-  match: PropTypes.shape({
-    url: PropTypes.string
-  })
-};
-
-const mapStateToProps = (state, { match }) => {
-  const { taskId, appealId } = match.params;
-
-  return {
-    task: taskById(state, { taskId }),
-    appeal: appealWithDetailSelector(state, { appealId })
-  };
-};
-
-const mapDispatchToProps = (dispatch) =>
-  bindActionCreators(
-    {
-      submitMTVJudgeDecision
-    },
-    dispatch
-  );
-
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(AddressMotionToVacateView)
-);
+export default AddressMotionToVacateView;

--- a/client/app/queue/mtv/AddressMotionToVacateView.jsx
+++ b/client/app/queue/mtv/AddressMotionToVacateView.jsx
@@ -5,7 +5,7 @@ import { useRouteMatch, useParams, useHistory } from 'react-router-dom';
 
 import { taskById, appealWithDetailSelector } from '../selectors';
 import { MTVJudgeDisposition } from './MTVJudgeDisposition';
-import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS.json';
+import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS';
 import { submitMTVJudgeDecision } from './mtvActions';
 import { taskActionData } from '../utils';
 

--- a/client/app/queue/mtv/MotionToVacateContext.js
+++ b/client/app/queue/mtv/MotionToVacateContext.js
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+const defaultState = {};
+
+// This pattern allows us to access a shared object state using familiar functions
+// Components that consume this context can simply use this syntax:
+// const [state, setState] = useContext(MotionToVacateContext);
+// setState({...state, foo: 'bar'});
+export const MotionToVacateContext = React.createContext([{}, () => null]);
+
+export const MotionToVacateContextProvider = ({ initialState = { ...defaultState }, children }) => {
+  const [state, setState] = useState(initialState);
+
+  return <MotionToVacateContext.Provider value={[state, setState]}>{children}</MotionToVacateContext.Provider>;
+};
+MotionToVacateContextProvider.propTypes = {
+  initialState: PropTypes.object,
+  children: PropTypes.element
+};

--- a/client/app/queue/mtv/MotionToVacateFlowContainer.jsx
+++ b/client/app/queue/mtv/MotionToVacateFlowContainer.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { useParams, useRouteMatch, Switch, Route } from 'react-router';
+import { taskById, appealWithDetailSelector } from '../selectors';
+import { MotionToVacateContextProvider } from './MotionToVacateContext';
+
+export const MotionToVacateFlowContainer = () => {
+  const { path } = useRouteMatch();
+  const { taskId, appealId } = useParams();
+  const task = useSelector((state) => taskById(state, { taskId }));
+  const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
+
+  return (
+    <React.Fragment>
+      <MotionToVacateContextProvider>
+        {/* MTV Progress Bar (#13319) Here */}
+
+        <Switch>
+          <Route path={`${path}/draft_decision/vacatures`}>
+            {/* Insert component from #13007 here */}
+            {/* <ReviewVacatedDecisionIssuesView appeal={appeal} /> */}
+            <></>
+          </Route>
+          <Route path={`${path}/draft_decision/add_decisions`}>
+            {/* Insert component from #13071 here */}
+            {/* <AddDecisionsView appeal={appeal} /> */}
+            <></>
+          </Route>
+        </Switch>
+      </MotionToVacateContextProvider>
+    </React.Fragment>
+  );
+};

--- a/client/app/queue/mtv/MotionToVacateFlowContainer.jsx
+++ b/client/app/queue/mtv/MotionToVacateFlowContainer.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { useParams, useRouteMatch, Switch, Route } from 'react-router';
 import { taskById, appealWithDetailSelector } from '../selectors';
@@ -11,18 +10,22 @@ export const MotionToVacateFlowContainer = () => {
   const task = useSelector((state) => taskById(state, { taskId }));
   const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
 
+  // For linter while things are stubbed — remove once used
+  (() => ({ task,
+    appeal }))();
+
   return (
     <React.Fragment>
       <MotionToVacateContextProvider>
         {/* MTV Progress Bar (#13319) Here */}
 
         <Switch>
-          <Route path={`${path}/draft_decision/vacatures`}>
+          <Route path={`${path}/review_vacatures`}>
             {/* Insert component from #13007 here */}
             {/* <ReviewVacatedDecisionIssuesView appeal={appeal} /> */}
             <></>
           </Route>
-          <Route path={`${path}/draft_decision/add_decisions`}>
+          <Route path={`${path}/add_decisions`}>
             {/* Insert component from #13071 here */}
             {/* <AddDecisionsView appeal={appeal} /> */}
             <></>

--- a/client/app/queue/mtv/motionToVacateRoutes.js
+++ b/client/app/queue/mtv/motionToVacateRoutes.js
@@ -8,6 +8,7 @@ import { AddressMotionToVacateView } from './AddressMotionToVacateView';
 import { ReturnToLitSupportModal } from './ReturnToLitSupportModal';
 import { useDispatch } from 'react-redux';
 import { returnToLitSupport } from './mtvActions';
+import { MotionToVacateFlowContainer } from './MotionToVacateFlowContainer';
 
 const RoutedReturnToLitSupport = (props) => {
   const { taskId } = useParams();
@@ -28,6 +29,12 @@ const PageRoutes = [
     path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.ADDRESS_MOTION_TO_VACATE.value}`}
     title="Address Motion to Vacate | Caseflow"
     component={AddressMotionToVacateView}
+  />,
+
+  // This route handles the remaining checkout flow
+  <Route
+    path="/queue/appeals/:appealId/tasks/:taskId/motion_to_vacate_checkout"
+    component={MotionToVacateFlowContainer}
   />
 ];
 
@@ -42,6 +49,7 @@ const ModalRoutes = [
     title="Return to Litigation Support | Caseflow"
     component={RoutedReturnToLitSupport}
   />,
+
   <Route
     path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.SEND_MOTION_TO_VACATE_TO_JUDGE.value}`}
     component={ReviewMotionToVacateView}

--- a/client/app/queue/mtv/motionToVacateRoutes.js
+++ b/client/app/queue/mtv/motionToVacateRoutes.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Route, useParams, useHistory } from 'react-router';
+import PageRoute from '../../components/PageRoute';
+
+import TASK_ACTIONS from '../../../constants/TASK_ACTIONS.json';
+import { ReviewMotionToVacateView } from './ReviewMotionToVacateView';
+import { AddressMotionToVacateView } from './AddressMotionToVacateView';
+import { ReturnToLitSupportModal } from './ReturnToLitSupportModal';
+import { useDispatch } from 'react-redux';
+import { returnToLitSupport } from './mtvActions';
+
+const RoutedReturnToLitSupport = (props) => {
+  const { taskId } = useParams();
+  const { goBack } = useHistory();
+  const dispatch = useDispatch();
+
+  return (
+    <ReturnToLitSupportModal
+      onCancel={() => goBack()}
+      onSubmit={({ instructions }) => dispatch(returnToLitSupport({ instructions,
+        task_id: taskId }, props))}
+    />
+  );
+};
+
+const PageRoutes = [
+  <PageRoute
+    path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.ADDRESS_MOTION_TO_VACATE.value}`}
+    title="Address Motion to Vacate | Caseflow"
+    component={AddressMotionToVacateView}
+  />
+];
+
+const ModalRoutes = [
+  <PageRoute
+    exact
+    path={[
+      '/queue/appeals/:appealId/tasks/:taskId',
+      TASK_ACTIONS.ADDRESS_MOTION_TO_VACATE.value,
+      TASK_ACTIONS.JUDGE_RETURN_TO_LIT_SUPPORT.value
+    ].join('/')}
+    title="Return to Litigation Support | Caseflow"
+    component={RoutedReturnToLitSupport}
+  />,
+  <Route
+    path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.SEND_MOTION_TO_VACATE_TO_JUDGE.value}`}
+    component={ReviewMotionToVacateView}
+  />
+];
+
+export const motionToVacateRoutes = {
+  page: PageRoutes,
+  modal: ModalRoutes
+};

--- a/client/app/queue/mtv/motionToVacateRoutes.js
+++ b/client/app/queue/mtv/motionToVacateRoutes.js
@@ -3,7 +3,7 @@ import { Route, useParams, useHistory } from 'react-router';
 import PageRoute from '../../components/PageRoute';
 
 import TASK_ACTIONS from '../../../constants/TASK_ACTIONS.json';
-import { ReviewMotionToVacateView } from './ReviewMotionToVacateView';
+import ReviewMotionToVacateView from './ReviewMotionToVacateView';
 import { AddressMotionToVacateView } from './AddressMotionToVacateView';
 import { ReturnToLitSupportModal } from './ReturnToLitSupportModal';
 import { useDispatch } from 'react-redux';


### PR DESCRIPTION
Connects #13318

### Description
This does multiple things:
- refactors `QueueApp` to break out MTV routes into their own file
- creates MotionToVacateContext for data handling as part of MTV checkout flow
- creates MotionToVacateFlowContainer that will serve as a container for the MTV checkout flows

### Acceptance Criteria
- [ ] Code compiles correctly

