### PR TITLE
Ignore CSRF for Histogram route

### DIFF
--- a/app/controllers/metrics/v1/histogram_controller.rb
+++ b/app/controllers/metrics/v1/histogram_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Metrics::V1::HistogramController < ApplicationController
+  protect_from_forgery with: :null_session
+
   def create
     histograms.each do |metric|
       DataDogService.histogram(


### PR DESCRIPTION
### Description

Resolves a recurring CSRF error in reader. It seems to be related to the CSRF token expiring. There isn't a huge impact to disabling the check here because the route just passes the request to Datadog.

For context, see:

https://dsva.slack.com/archives/CHX8FMP28/p1580835101178000