### PR TITLE
Reconsider what we consider to be on hold on the front end

### DIFF
--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -513,11 +513,6 @@ export const taskHasNewDocuments = (task, newDocsForAppeal) => {
 };
 
 export const taskIsOnHold = (task) => {
-  if (task.onHoldDuration && task.placedOnHoldAt) {
-    return moment().startOf('day').
-      diff(moment(task.placedOnHoldAt), 'days') < task.onHoldDuration;
-  }
-
   return task.status === TASK_STATUSES.on_hold;
 };
 
@@ -527,7 +522,7 @@ export const taskHasCompletedHold = (task) => {
       diff(moment(task.placedOnHoldAt), 'days') >= task.onHoldDuration;
   }
 
-  return task.status === TASK_STATUSES.on_hold;
+  return taskIsOnHold(task);
 };
 
 export const taskIsActive = (task) => ![TASK_STATUSES.completed, TASK_STATUSES.cancelled].includes(task.status);

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -399,7 +399,8 @@ describe('ColocatedTaskListView', () => {
         id: '1',
         cssIdAssignee: 'BVALSPORER',
         placedOnHoldAt: moment().subtract(2, 'days'),
-        onHoldDuration: 30
+        onHoldDuration: 30,
+        status: 'on_hold'
       });
       const taskNotAssigned = amaTaskWith({
         ...task,

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -248,7 +248,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
 
     scenario "Schedule Veteran for a video hearing with admin actions that can be put on hold and completed" do
       # Do the first part of the test in the past so we can wait for our hold to complete.
-      Timecop.travel(20.days.ago) do
+      Timecop.travel(17.days.ago) do
         visit "hearings/schedule/assign"
         expect(page).to have_content("Regional Office")
         click_dropdown(text: "Denver")
@@ -286,6 +286,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       end
 
       # Refresh the page in the present, and the hold should be completed.
+      TaskTimerJob.perform_now
       visit "/queue"
       click_on "Bob Smith"
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -663,7 +663,7 @@ RSpec.feature "Case details", :all_dbs do
       User.authenticate!(user: colocated_user)
     end
 
-    context "on hold task", skip: "flaky test" do
+    context "on hold task" do
       let!(:on_hold_task) do
         create(
           :colocated_task,


### PR DESCRIPTION
Any task with a status on hold should be in the on hold tab