### PR TITLE
Update #scheduled_for_past? to work with older hearings

### DIFF
--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -185,7 +185,7 @@ class LegacyHearing < ApplicationRecord
   end
 
   def scheduled_for_past?
-    # FIXME: scheduled_for date is inconsistent in many places.
+    # FIXME: scheduled_for date is inconsistent in many places. (#13273)
     # scheduled_for should either pulled from VACOLS or from the associated hearing_day,
     # but some method exclusively use the value from VACOLS. The hearing_day association to
     # legacy hearings was added in #11741.

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -185,10 +185,12 @@ class LegacyHearing < ApplicationRecord
   end
 
   def scheduled_for_past?
-    # FIXME: scheduled_for date is inconsistent in many places. (#13273)
+    # FIXME: scheduled_for date is inconsistent in many places.
+    # (https://github.com/department-of-veterans-affairs/caseflow/issues/13273)
     # scheduled_for should either pulled from VACOLS or from the associated hearing_day,
     # but some method exclusively use the value from VACOLS. The hearing_day association to
     # legacy hearings was added in #11741.
+    # (https://github.com/department-of-veterans-affairs/caseflow/pull/11741)
     scheduled_date = if hearing_day_id_refers_to_vacols_row?
                        # Handles conversion of a VACOLS time (EST) to the timezone of the RO
                        time.local_time

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -184,9 +184,20 @@ class LegacyHearing < ApplicationRecord
     scheduled_for && !closed?
   end
 
-  # pulls scheduled_for from hearing day instead of VACOLS
   def scheduled_for_past?
-    hearing_day.scheduled_for < DateTime.yesterday.in_time_zone(regional_office_timezone)
+    # FIXME: scheduled_for date is inconsistent in many places.
+    # scheduled_for should either pulled from VACOLS or from the associated hearing_day,
+    # but some method exclusively use the value from VACOLS. The hearing_day association to
+    # legacy hearings was added in #11741.
+    scheduled_date = if hearing_day_id_refers_to_vacols_row?
+                       # Handles conversion of a VACOLS time (EST) to the timezone of the RO
+                       time.local_time
+                     else
+                       # Hearing Day scheduled_for is in the timezone of the RO
+                       hearing_day.scheduled_for
+                     end
+
+    scheduled_date < DateTime.yesterday.in_time_zone(regional_office_timezone)
   end
 
   def held_open?

--- a/spec/models/legacy_hearing_spec.rb
+++ b/spec/models/legacy_hearing_spec.rb
@@ -442,4 +442,48 @@ describe LegacyHearing, :all_dbs do
       end
     end
   end
+
+  context "#scheduled_for_past?" do
+    context "for a video hearing scheduled before 4/1/2019" do
+      let(:scheduled_for) do
+        Time.use_zone("America/New_York") { Time.zone.local(2018, 1, 1, 0, 0, 0) }
+      end
+
+      it "returns true" do
+        expect(hearing.scheduled_for_past?).to be(true)
+      end
+    end
+
+    context "for a video hearing scheduled after 4/1/2019" do
+      let(:hearing_day) do
+        create(
+          :hearing_day,
+          scheduled_for: scheduled_for,
+          regional_office: regional_office,
+          request_type: HearingDay::REQUEST_TYPES[:video]
+        )
+      end
+      let!(:hearing) { create(:legacy_hearing, hearing_day: hearing_day) }
+
+      context "before today" do
+        let(:scheduled_for) do
+          Time.use_zone("America/New_York") { Time.zone.local(2019, 8, 8, 0, 0, 0) }
+        end
+
+        it "returns true" do
+          expect(hearing.scheduled_for_past?).to be(true)
+        end
+      end
+
+      context "for tomorrow" do
+        let(:scheduled_for) do
+          Time.use_zone("America/New_York") { Time.zone.tomorrow }
+        end
+
+        it "returns false" do
+          expect(hearing.scheduled_for_past?).to be(false)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #13343 

### Description

Use `hearing_day_id_refers_to_vacols_row?` check to determine whether or not to use the VACOLS `scheduled_for` time, or Caseflow's `HearingDay` time.

#11741 Added the relationship to `HearingDay` that this depends on
#13273 Issue to fix the `scheduled_for` date for LegacyHearings more broadly

### Testing Plan

Follow up with support to make sure this fixes the issue in prod