### PR TITLE
Serialize appeal stream information for vacate-type appeals

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -97,6 +97,12 @@ class Appeal < DecisionReview
     end
   end
 
+  def vacate_type
+    return nil unless vacate?
+
+    post_decision_motion&.vacate_type
+  end
+
   # Returns the most directly responsible party for an appeal when it is at the Board,
   # mirroring Legacy Appeals' location code in VACOLS
   def assigned_to_location
@@ -459,5 +465,11 @@ class Appeal < DecisionReview
   ensure
     distribution_task = tasks.open.find_by(type: DistributionTask.name)
     TranslationTask.create_from_parent(distribution_task) if STATE_CODES_REQUIRING_TRANSLATION_TASK.include?(state_code)
+  end
+
+  # Non-vacate Appeals are not expected to have a PDM, but this method makes a
+  # best-effort attempt in either situation, and returns nil if none is found.
+  def post_decision_motion
+    PostDecisionMotion.where(task: tasks).first
   end
 end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -470,6 +470,6 @@ class Appeal < DecisionReview
   # Non-vacate Appeals are not expected to have a PDM, but this method makes a
   # best-effort attempt in either situation, and returns nil if none is found.
   def post_decision_motion
-    PostDecisionMotion.where(task: tasks).first
+    PostDecisionMotion.find_by(task: tasks)
   end
 end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -98,8 +98,6 @@ class Appeal < DecisionReview
   end
 
   def vacate_type
-    return nil unless vacate?
-
     post_decision_motion&.vacate_type
   end
 

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -79,6 +79,7 @@ class WorkQueue::AppealSerializer
   attribute :external_id, &:uuid
 
   attribute :type
+  attribute :vacate_type
   attribute :aod, &:advanced_on_docket?
   attribute :docket_name
   attribute :docket_number

--- a/app/serializers/intake/appeal_serializer.rb
+++ b/app/serializers/intake/appeal_serializer.rb
@@ -9,6 +9,4 @@ class Intake::AppealSerializer < Intake::DecisionReviewSerializer
   attribute :form_type do
     "appeal"
   end
-  attribute :type
-  attribute :vacate_type, if: proc { |appeal| appeal.vacate? }
 end

--- a/app/serializers/intake/appeal_serializer.rb
+++ b/app/serializers/intake/appeal_serializer.rb
@@ -9,4 +9,6 @@ class Intake::AppealSerializer < Intake::DecisionReviewSerializer
   attribute :form_type do
     "appeal"
   end
+  attribute :type
+  attribute :vacate_type, if: Proc.new { |appeal| appeal.vacate? }
 end

--- a/app/serializers/intake/appeal_serializer.rb
+++ b/app/serializers/intake/appeal_serializer.rb
@@ -10,5 +10,5 @@ class Intake::AppealSerializer < Intake::DecisionReviewSerializer
     "appeal"
   end
   attribute :type
-  attribute :vacate_type, if: Proc.new { |appeal| appeal.vacate? }
+  attribute :vacate_type, if: proc { |appeal| appeal.vacate? }
 end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -196,12 +196,14 @@ FactoryBot.define do
           appeal: appeal,
           parent: appeal.root_task,
           assigned_at: evaluator.active_task_assigned_at,
-          assigned_to: evaluator.associated_judge)
+          assigned_to: evaluator.associated_judge
+        )
         params = {
           disposition: "granted",
           vacate_type: "straight_vacate",
           instructions: "some instructions",
-          assigned_to_id: task.assigned_to.id}
+          assigned_to_id: task.assigned_to.id
+        }
         PostDecisionMotionUpdater.new(task, params).process
       end
     end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -189,7 +189,7 @@ FactoryBot.define do
     end
 
     trait :straight_vacated do
-      stream_type { "Vacate" }
+      stream_type { "vacate" }
 
       after(:create) do |appeal, evaluator|
         task = JudgeAddressMotionToVacateTask.create!(

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -187,5 +187,23 @@ FactoryBot.define do
         ).call
       end
     end
+
+    trait :straight_vacated do
+      stream_type { "Vacate" }
+
+      after(:create) do |appeal, evaluator|
+        task = JudgeAddressMotionToVacateTask.create!(
+          appeal: appeal,
+          parent: appeal.root_task,
+          assigned_at: evaluator.active_task_assigned_at,
+          assigned_to: evaluator.associated_judge)
+        params = {
+          disposition: "granted",
+          vacate_type: "straight_vacate",
+          instructions: "some instructions",
+          assigned_to_id: task.assigned_to.id}
+        PostDecisionMotionUpdater.new(task, params).process
+      end
+    end
   end
 end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -931,4 +931,24 @@ describe Appeal, :all_dbs do
       end
     end
   end
+
+  describe "#vacate_type" do
+    subject { appeal.vacate_type }
+
+    context "Appeal is a vacatur and has a post-decision motion" do
+      let(:appeal) { create(:appeal, :straight_vacated) }
+
+      it "returns the post-decision motion's vacate type" do
+        expect(subject).to eq "straight_vacate"
+      end
+    end
+
+    context "Appeal is not a vacatur" do
+      let(:appeal) { create(:appeal) }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #13333 

### Description
This PR adds `type` and `vacate_type` fields to the Appeal serializer, so that the frontend can show the appropriate UI for MTV-related appeal streams.

### Acceptance Criteria
- [ ] Appeal serializer includes `type`
- [ ] Appeal serializer includes `vacate_type` when stream type is `Vacate`

### Testing Plan
- Added test for `vacate_type` when appeal is vacate and non-vacate
  - Added `:straight_vacated` trait to appeal factorybot, to help with this and future MTV tests