### PR TITLE
Support Webpack Resolving JSON Files w/o Extension

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -3,9 +3,7 @@ module.exports = {
     browser: true,
     mocha: true
   },
-  extends: [
-    '@department-of-veterans-affairs/eslint-config-appeals'
-  ],
+  extends: ['@department-of-veterans-affairs/eslint-config-appeals'],
   rules: {
     'prefer-const': 'off',
     'max-statements': 'off',
@@ -14,7 +12,12 @@ module.exports = {
   },
   settings: {
     react: {
-      version: '16.2'
+      version: '16.12'
+    },
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.jsx', '.json']
+      }
     }
   },
   globals: {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -16,7 +16,7 @@ const config = {
     new webpack.EnvironmentPlugin({ NODE_ENV: 'development' })
   ]),
   resolve: {
-    extensions: ['.js', '.jsx'],
+    extensions: ['.js', '.jsx', '.json'],
     alias: {
       // This does not actually appear to be necessary, but it does silence
       // a warning from superagent-no-cache.


### PR DESCRIPTION
Connects #13348

### Description
This updates Webpack config to allow resolving `.json` files w/o the extension. It also updates eslint rules to allow those imports to pass linting.

```js
// This still works
import COPY from '../COPY.json';

// But now so does this
import COPY from '../COPY';
```