### PR TITLE
only set timezone to Rails.configuration.time_zone when in uat

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -34,7 +34,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   # Testing America/New_York TZ for all jobs in UAT.
-  if !Rails.deploy_env?(:uat)
+  if Rails.deploy_env?(:uat)
     around_perform do |_job, block|
       Time.use_zone(Rails.configuration.time_zone) do
         block.call

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -34,6 +34,7 @@ class ApplicationJob < ActiveJob::Base
   end
 
   # Testing America/New_York TZ for all jobs in UAT.
+  # :nocov:
   if Rails.deploy_env?(:uat)
     around_perform do |_job, block|
       Time.use_zone(Rails.configuration.time_zone) do
@@ -41,6 +42,7 @@ class ApplicationJob < ActiveJob::Base
       end
     end
   end
+  # :nocov:
 
   before_perform do |job|
     # setup debug context


### PR DESCRIPTION
Connects #13156 

### Description
Set the timezone to `Rails.configuration.time_zone` around job performance _only_ in the uat deploy env, as originally intended in PR #13302.
