### PR TITLE
Add member_of_organization method to User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -288,6 +288,10 @@ class User < ApplicationRecord
     orgs
   end
 
+  def member_of_organization?(org)
+    organizations.pluck(:id).include?(org&.id)
+  end
+
   def judge?
     !!JudgeTeam.for_judge(self) || judge_in_vacols?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -289,7 +289,7 @@ class User < ApplicationRecord
   end
 
   def member_of_organization?(org)
-    organizations.pluck(:id).include?(org&.id)
+    organizations.include?(org)
   end
 
   def judge?

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -349,11 +349,18 @@ describe User, :all_dbs do
     end
   end
 
-  context "#member_of_organization?" do
+  fcontext "#member_of_organization?" do
     let(:org) { create(:organization) }
     let(:user) { create(:user) }
 
     subject { user.member_of_organization?(org) }
+
+    context "when the organization does not exist" do
+      let(:org) { nil }
+      it "returns false" do
+        expect(subject).to eq(false)
+      end
+    end
 
     context "when the current user is not a member of the organization" do
       it "returns false" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -349,7 +349,7 @@ describe User, :all_dbs do
     end
   end
 
-  fcontext "#member_of_organization?" do
+  context "#member_of_organization?" do
     let(:org) { create(:organization) }
     let(:user) { create(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -349,6 +349,26 @@ describe User, :all_dbs do
     end
   end
 
+  context "#member_of_organization?" do
+    let(:org) { create(:organization) }
+    let(:user) { create(:user) }
+
+    subject { user.member_of_organization?(org) }
+
+    context "when the current user is not a member of the organization" do
+      it "returns false" do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context "when the user is a member of the organization" do
+      before { org.add_user(user) }
+      it "returns true" do
+        expect(subject).to eq(true)
+      end
+    end
+  end
+
   context "#when BGS data is setup" do
     let(:participant_id) { "123456" }
     let(:vso_participant_id) { "123456" }


### PR DESCRIPTION
### Description
The User model was lacking a method to check if a user was a member of a particular organization.

