### PR TITLE
Update default error message in LoadingDataDisplay

### DIFF
--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -18,6 +18,7 @@ export class DocumentsCheck extends React.Component {
   // TODO: updating state in UNSAFE_componentWillMount is
   // sometimes thought of as an anti-pattern.
   // is there a better way to do this?
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     this.props.updateProgressBar();
   }

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -56,13 +56,13 @@ export class DocumentsCheck extends React.Component {
         <p>If the document status is marked
           with an <NotFoundIcon />, try checking:</p>
         <ul>The <strong>document type</strong> in VBMS to make sure it's
-          <a href="/certification/help#mismatched-documents"> labeled correctly.</a></ul>
+        <a href="/certification/help#mismatched-documents"> labeled correctly.</a></ul>
         <ul>The <strong>document date</strong> in VBMS. NOD and Form 9 dates must match their VACOLS dates.
         SOC and SSOC dates are considered matching if the VBMS date is the same as the VACOLS date,
         or if the VBMS date is 4 days or fewer before the VACOLS date.
-          <a href="/certification/help#cannot-find-documents"> Learn more about document dates.</a> </ul>
+        <a href="/certification/help#cannot-find-documents"> Learn more about document dates.</a> </ul>
         <p>Once you've made corrections,&nbsp;
-          <a href={`/certifications/${match.params.vacols_id}/check_documents`}>refresh this page.</a></p>
+        <a href={`/certifications/${match.params.vacols_id}/check_documents`}>refresh this page.</a></p>
         <p>If you can't find the document, <a href="#"
           onClick={toggleCancellationModal}>cancel this certification.</a></p>
       </div>;

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -130,5 +130,7 @@ DocumentsCheck.propTypes = {
   form9: PropTypes.object,
   ssocs: PropTypes.arrayOf(PropTypes.object),
   documentsMatch: PropTypes.bool,
-  match: PropTypes.object
+  match: PropTypes.object,
+  updateProgressBar: PropTypes.func,
+  toggleCancellationModal: PropTypes.func
 };

--- a/client/app/certification/DocumentsCheck.jsx
+++ b/client/app/certification/DocumentsCheck.jsx
@@ -12,6 +12,7 @@ import NotFoundIcon from '../components/NotFoundIcon';
 import * as certificationActions from './actions/Certification';
 import Header from './Header';
 import CertificationProgressBar from './CertificationProgressBar';
+import WindowUtil from '../util/WindowUtil';
 
 export class DocumentsCheck extends React.Component {
   // TODO: updating state in UNSAFE_componentWillMount is
@@ -41,10 +42,6 @@ export class DocumentsCheck extends React.Component {
       match,
       toggleCancellationModal
     } = this.props;
-
-    let reloadPage = () => {
-      window.location.reload();
-    };
 
     if (certificationStatus === 'data_missing') {
       return <NotReady />;
@@ -92,7 +89,7 @@ export class DocumentsCheck extends React.Component {
           `/certifications/${match.params.vacols_id}/confirm_case_details` :
           ''
         }
-        onClickContinue={documentsMatch ? null : reloadPage} />
+        onClickContinue={documentsMatch ? null : WindowUtil.reloadWithPOST} />
     </div>;
   }
 }

--- a/client/app/components/LoadingDataDisplay.jsx
+++ b/client/app/components/LoadingDataDisplay.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LoadingScreen from './LoadingScreen';
 import StatusMessage from './StatusMessage';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const PROMISE_RESULTS = {
   SUCCESS: 'SUCCESS',
@@ -24,6 +24,12 @@ const itemNotFoundTitle = { title: 'Information cannot be found' };
 const itemNotFoundMsg = <div>
         We could not find the information you were looking for.<br />
         Please return to the previous page, check the information provided, and try again.</div>;
+
+const DEFAULT_UNKNOWN_ERROR_MSG = (
+  <div>
+    An unknown error occured.
+  </div>
+);
 
 class LoadingDataDisplay extends React.PureComponent {
   constructor() {
@@ -150,10 +156,7 @@ LoadingDataDisplay.propTypes = {
   children: PropTypes.node,
   createLoadPromise: PropTypes.func.isRequired,
   errorComponent: PropTypes.func,
-  failStatusMessageChildren: PropTypes.oneOfType([
-    PropTypes.element,
-    PropTypes.object
-  ]),
+  failStatusMessageChildren: PropTypes.node,
   failStatusMessageProps: PropTypes.object,
   loadingComponent: PropTypes.func,
   loadingComponentProps: PropTypes.object,
@@ -170,7 +173,7 @@ LoadingDataDisplay.defaultProps = {
   errorComponent: StatusMessage,
   loadingComponentProps: {},
   failStatusMessageProps: {},
-  failStatusMessageChildren: {}
+  failStatusMessageChildren: DEFAULT_UNKNOWN_ERROR_MSG
 };
 
 export default LoadingDataDisplay;

--- a/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
@@ -8,6 +8,7 @@ import Alert from '../../components/Alert';
 import { formatDateStr } from '../../util/DateUtil';
 import ApiUtil from '../../util/ApiUtil';
 import * as Constants from '../../establishClaim/constants';
+import WindowUtil from '../../util/WindowUtil';
 
 export class AssociatePage extends React.Component {
 
@@ -90,7 +91,7 @@ export class AssociatePage extends React.Component {
     return ApiUtil.post(
       `/dispatch/establish-claim/${id}/assign-existing-end-product`,
       { data }).then(() => {
-      window.location.reload();
+      WindowUtil.reloadWithPOST();
       this.setState({
         epLoading: null
       });

--- a/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
@@ -206,7 +206,8 @@ AssociatePage.propTypes = {
   backToDecisionReviewText: PropTypes.string.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   hasAvailableModifers: PropTypes.bool.isRequired,
-  task: PropTypes.object.isRequired
+  task: PropTypes.object.isRequired,
+  loading: PropTypes.bool
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimAssociateEP.jsx
@@ -21,6 +21,7 @@ export class AssociatePage extends React.Component {
     };
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount() {
     if (!this.props.endProducts.length) {
       this.props.history.goBack();

--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -21,6 +21,7 @@ import moment from 'moment';
 
 import { LIST_SCHEDULE_VIEWS, VIDEO_HEARING } from '../constants';
 import DropdownButton from '../../components/DropdownButton';
+import WindowUtil from '../../util/WindowUtil';
 
 const downloadButtonStyling = css({
   marginTop: '60px'
@@ -92,6 +93,11 @@ SwitchViewDropdown.propTypes = { onSwitchView: PropTypes.func };
 
 class ListTable extends React.Component {
   render() {
+    const failStatusMessageChildren = <div>
+      It looks like Caseflow was unable to load the hearing schedule.<br />
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
+    </div>;
+
     return (
       <LoadingDataDisplay
         createLoadPromise={this.props.onApply}
@@ -101,7 +107,9 @@ class ListTable extends React.Component {
         }}
         failStatusMessageProps={{
           title: 'Unable to load the hearing schedule.'
-        }}>
+        }}
+        failStatusMessageChildren={failStatusMessageChildren}
+      >
         {this.props.user.userCanBuildHearingSchedule && <div style={{ marginBottom: 25 }}>
           <Button linkStyling
             onClick={this.props.openModal}>

--- a/client/app/queue/CaseDetailsLoadingScreen.jsx
+++ b/client/app/queue/CaseDetailsLoadingScreen.jsx
@@ -7,8 +7,8 @@ import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
 import WindowUtil from '../util/WindowUtil';
 import { prepareAppealForStore, prepareAllTasksForStore } from './utils';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
-import COPY from '../../COPY.json';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
+import COPY from '../../COPY';
 import PropTypes from 'prop-types';
 
 import { onReceiveAppealDetails, onReceiveTasks, setAttorneysOfJudge, fetchAllAttorneys } from './QueueActions';

--- a/client/app/queue/CaseDetailsLoadingScreen.jsx
+++ b/client/app/queue/CaseDetailsLoadingScreen.jsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
+import WindowUtil from '../util/WindowUtil';
 import { prepareAppealForStore, prepareAllTasksForStore } from './utils';
 import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
 import COPY from '../../COPY.json';
@@ -68,12 +69,10 @@ class CaseDetailLoadingScreen extends React.PureComponent {
     this.maybeLoadJudgeData()
   ]);
 
-  reload = () => window.location.reload();
-
   render = () => {
     const failStatusMessageChildren = <div>
       It looks like Caseflow was unable to load this case.<br />
-      Please <a onClick={this.reload}>refresh the page</a> and try again.
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
     </div>;
 
     const loadingDataDisplay = <LoadingDataDisplay

--- a/client/app/queue/CaseListView.jsx
+++ b/client/app/queue/CaseListView.jsx
@@ -30,7 +30,7 @@ import {
   claimReviewsByCaseflowVeteranId
 } from './selectors';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const horizontalRuleStyling = css({
   border: 0,

--- a/client/app/queue/CaseListView.jsx
+++ b/client/app/queue/CaseListView.jsx
@@ -10,6 +10,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 
 import ApiUtil from '../util/ApiUtil';
+import WindowUtil from '../util/WindowUtil';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import {
   COLORS,
@@ -102,7 +103,7 @@ class CaseListView extends React.PureComponent {
   render() {
     const failStatusMessageChildren = <div>
       Caseflow was unable to load cases.<br />
-      Please <a onClick={this.reload}>refresh the page</a> and try again.
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
     </div>;
 
     return <AppSegment filledBackground>

--- a/client/app/queue/OrganizationQueueLoadingScreen.jsx
+++ b/client/app/queue/OrganizationQueueLoadingScreen.jsx
@@ -17,10 +17,9 @@ import {
 import {
   setActiveOrganization
 } from './uiReducer/uiActions';
+import WindowUtil from '../util/WindowUtil';
 
 class OrganizationQueueLoadingScreen extends React.PureComponent {
-  reload = () => window.location.reload();
-
   createOrgQueueLoadPromise = () => {
     const requestOptions = {
       timeout: { response: getMinutesToMilliseconds(5) }
@@ -50,7 +49,7 @@ class OrganizationQueueLoadingScreen extends React.PureComponent {
   render = () => {
     const failStatusMessageChildren = <div>
       It looks like Caseflow was unable to load your cases.<br />
-      Please <a onClick={this.reload}>refresh the page</a> and try again.
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
     </div>;
 
     const loadingDataDisplay = <LoadingDataDisplay

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -7,7 +7,7 @@ import { bindActionCreators } from 'redux';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import { getMinutesToMilliseconds } from '../util/DateUtil';
 import { associateTasksWithAppeals } from './utils';
 
@@ -18,7 +18,7 @@ import {
   fetchAmaTasksOfUser
 } from './QueueActions';
 import { setUserId } from './uiReducer/uiActions';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import WindowUtil from '../util/WindowUtil';
 
 class QueueLoadingScreen extends React.PureComponent {

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -19,6 +19,7 @@ import {
 } from './QueueActions';
 import { setUserId } from './uiReducer/uiActions';
 import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import WindowUtil from '../util/WindowUtil';
 
 class QueueLoadingScreen extends React.PureComponent {
   maybeLoadAmaQueue = () => {
@@ -102,12 +103,10 @@ class QueueLoadingScreen extends React.PureComponent {
     this.maybeLoadJudgeData()
   ]);
 
-  reload = () => window.location.reload();
-
   render = () => {
     const failStatusMessageChildren = <div>
       It looks like Caseflow was unable to load your cases.<br />
-      Please <a onClick={this.reload}>refresh the page</a> and try again.
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
     </div>;
 
     const loadingDataDisplay = <LoadingDataDisplay

--- a/client/app/queue/SpecialIssueLoadingScreen.jsx
+++ b/client/app/queue/SpecialIssueLoadingScreen.jsx
@@ -9,6 +9,7 @@ import ApiUtil from '../util/ApiUtil';
 import { getMinutesToMilliseconds } from '../util/DateUtil';
 
 import { setSpecialIssues } from './QueueActions';
+import WindowUtil from '../util/WindowUtil';
 
 class SpecialIssueLoadingScreen extends React.PureComponent {
 
@@ -28,12 +29,10 @@ class SpecialIssueLoadingScreen extends React.PureComponent {
     );
   }
 
-  reload = () => window.location.reload();
-
   render = () => {
     const failStatusMessageChildren = <div>
       It looks like Caseflow was unable to load this case's special issues<br />
-      Please <a onClick={this.reload}>refresh the page</a> and try again.
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
     </div>;
 
     const loadingDataDisplay = <LoadingDataDisplay

--- a/client/app/queue/VeteranCasesView.jsx
+++ b/client/app/queue/VeteranCasesView.jsx
@@ -15,6 +15,7 @@ import { appealsByCaseflowVeteranId } from './selectors';
 import { prepareAppealForStore } from './utils';
 
 import COPY from '../../COPY.json';
+import WindowUtil from '../util/WindowUtil';
 
 const containerStyling = css({
   backgroundColor: COLORS.GREY_BACKGROUND,
@@ -69,7 +70,7 @@ class VeteranCasesView extends React.PureComponent {
 
     const failStatusMessageChildren = <div>
       Caseflow was unable to load cases.<br />
-      Please <a onClick={this.reload}>refresh the page</a> and try again.
+      Please <a onClick={WindowUtil.reloadWithPOST}>refresh the page</a> and try again.
     </div>;
 
     return <LoadingDataDisplay

--- a/client/app/queue/VeteranCasesView.jsx
+++ b/client/app/queue/VeteranCasesView.jsx
@@ -14,7 +14,7 @@ import { onReceiveAppealDetails } from './QueueActions';
 import { appealsByCaseflowVeteranId } from './selectors';
 import { prepareAppealForStore } from './utils';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import WindowUtil from '../util/WindowUtil';
 
 const containerStyling = css({

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router-dom';
@@ -63,18 +64,20 @@ class BulkAssignModal extends React.PureComponent {
     this.props.bulkAssignTasks(this.state.modal);
 
     const {
-      taskType: task_type,
-      numberOfTasks: task_count,
-      assignedUser: assigned_to_id,
-      regionalOffice: regional_office
+      taskType,
+      numberOfTasks,
+      assignedUser,
+      regionalOffice
     } = this.state.modal;
 
-    const data = { bulk_task_assignment: {
-      organization_url: this.organizationUrl(),
-      regional_office,
-      assigned_to_id,
-      task_type,
-      task_count }
+    const data = {
+      bulk_task_assignment: {
+        organization_url: this.organizationUrl(),
+        regional_office: regionalOffice,
+        assigned_to_id: assignedUser,
+        task_type: taskType,
+        task_count: numberOfTasks
+      }
     };
 
     return ApiUtil.post('/bulk_task_assignments', { data }).then(() => {
@@ -217,6 +220,13 @@ class BulkAssignModal extends React.PureComponent {
   }
   ;
 }
+
+BulkAssignModal.propTypes = {
+  bulkAssignTasks: PropTypes.func,
+  highlightFormItems: PropTypes.bool,
+  history: PropTypes.object,
+  location: PropTypes.object
+};
 
 const mapStateToProps = (state) => {
   const {

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -12,7 +12,7 @@ import { bulkAssignTasks } from '../QueueActions';
 import { setActiveOrganization } from '../uiReducer/uiActions';
 import LoadingScreen from '../../components/LoadingScreen';
 import { LOGO_COLORS } from '../../constants/AppConstants';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import WindowUtil from '../../util/WindowUtil';
 
 const BULK_ASSIGN_ISSUE_COUNT = [5, 10, 20, 30, 40, 50];

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -13,6 +13,7 @@ import { setActiveOrganization } from '../uiReducer/uiActions';
 import LoadingScreen from '../../components/LoadingScreen';
 import { LOGO_COLORS } from '../../constants/AppConstants';
 import COPY from '../../../COPY.json';
+import WindowUtil from '../../util/WindowUtil';
 
 const BULK_ASSIGN_ISSUE_COUNT = [5, 10, 20, 30, 40, 50];
 
@@ -78,7 +79,7 @@ class BulkAssignModal extends React.PureComponent {
 
     return ApiUtil.post('/bulk_task_assignments', { data }).then(() => {
       this.props.history.push(`/organizations/${this.organizationUrl()}`);
-      window.location.reload();
+      WindowUtil.reloadWithPOST();
     }).
       catch(() => {
         // handle the error

--- a/client/app/util/WindowUtil.js
+++ b/client/app/util/WindowUtil.js
@@ -1,5 +1,11 @@
 export default {
   reloadPage() {
     window.location.href = window.location.pathname + window.location.search;
+  },
+
+  // Does a reload with POST data.
+  reloadWithPOST() {
+    // https://stackoverflow.com/questions/41020403/reload-a-page-with-location-href-or-window-location-reloadtrue
+    window.location.reload()
   }
 };


### PR DESCRIPTION
Resolves #11336

### Description

Reproduced the error locally by updating the API to return a 504

<img width="621" alt="Screen Shot 2020-02-05 at 11 46 40 AM" src="https://user-images.githubusercontent.com/1298274/73871004-04332900-481b-11ea-8e86-2bba8092d52b.png">

#### Changes

  * Update the default `LoadingDataDisplay` failure message component to be a React component instead of an Object
  * Refactor `this.reload` / `window.location.reload` to a utility function in various places
  * Changes for linter

### Screenshots

<img width="1256" alt="Screen Shot 2020-02-05 at 1 25 11 PM" src="https://user-images.githubusercontent.com/1298274/73870984-fda4b180-481a-11ea-8a51-f1898bdf9f37.png">
