### PR TITLE
(Partial) Global Removal of '.json' Extension from Imports

### DIFF
--- a/client/app/components/DataDropdowns/constants.js
+++ b/client/app/components/DataDropdowns/constants.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import HEARING_ROOMS_LIST from '../../../constants/HEARING_ROOMS_LIST.json';
+import HEARING_ROOMS_LIST from '../../../constants/HEARING_ROOMS_LIST';
 
 export const HEARING_ROOM_OPTIONS = [
   {

--- a/client/app/components/FilterSummary.jsx
+++ b/client/app/components/FilterSummary.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const ALTERNATE_COLUMN_NAMES = {
   'appeal.caseType': 'Case Type',

--- a/client/app/components/LoadingDataDisplay.jsx
+++ b/client/app/components/LoadingDataDisplay.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LoadingScreen from './LoadingScreen';
 import StatusMessage from './StatusMessage';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const PROMISE_RESULTS = {
   SUCCESS: 'SUCCESS',

--- a/client/app/components/TableFilter.jsx
+++ b/client/app/components/TableFilter.jsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { sprintf } from 'sprintf-js';
 
 import { css, hover } from 'glamor';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import FilterIcon from './FilterIcon';
 import QueueDropdownFilter from '../queue/QueueDropdownFilter';
 import FilterOption from './FilterOption';

--- a/client/app/hearings/components/BuildSchedule.jsx
+++ b/client/app/hearings/components/BuildSchedule.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import { css } from 'glamor';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import Table from '../../components/Table';
 import { formatDateStr } from '../../util/DateUtil';
 import Button from '../../components/Button';

--- a/client/app/hearings/components/BuildScheduleUpload.jsx
+++ b/client/app/hearings/components/BuildScheduleUpload.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import _ from 'lodash';
@@ -36,16 +36,16 @@ const inlineFormStyling = css({
 
 export default class BuildScheduleUpload extends React.Component {
 
-  getErrorMessage = (errors) => {
-    return <div className="usa-input-error">We have found the following errors with your upload. Please
-      check the file and dates and try again.
+  getErrorMessage = (errors) => (
+    <div className="usa-input-error">
+      We have found the following errors with your upload. Please check the file and dates and try again.
       <ul>
         {_.map(errors.replace('Validation failed: ', '').split(', '), (error, i) => {
           return <li key={i}>{error}</li>;
         })}
       </ul>
-    </div>;
-  };
+    </div>
+  );
 
   getRoCoDisplay = () => {
     return <div>{ SPREADSHEET_TYPES.RoSchedulePeriod.display }

--- a/client/app/hearings/components/ReviewAssignments.jsx
+++ b/client/app/hearings/components/ReviewAssignments.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { css } from 'glamor';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import Alert from '../../components/Alert';
@@ -92,7 +92,7 @@ export default class ReviewAssignments extends React.Component {
 
     if (this.props.schedulePeriodError) {
       let message = <span>Please confirm the information in the spreadsheet is valid and
-        <Link to="/schedule/build/upload"> try again</Link>. If the issue persists, please
+      <Link to="/schedule/build/upload"> try again</Link>. If the issue persists, please
         contact the Caseflow team via the VA Enterprise Service Desk at 855-673-4357
         or by creating a ticket
         via <a href="https://yourit.va.gov" target="_blank" rel="noopener noreferrer">YourIT</a>.
@@ -103,7 +103,7 @@ export default class ReviewAssignments extends React.Component {
           message = <span>You have allocated too many hearing days to the {spErrorDetails.details.ro_key},
           the maximum number of allocations is {spErrorDetails.details.max_allocation}.<br></br>
           Please check your spreadsheet and upload the file again using the "Go back" link below.<br></br>
-            <Link to="/schedule/build/upload"> Go back</Link>
+          <Link to="/schedule/build/upload"> Go back</Link>
           </span>;
         } else if (this.props.spErrorDetails.type === SPREADSHEET_TYPES.JudgeSchedulePeriod.value) {
           title = 'We were unable to assign judges to the schedule.';

--- a/client/app/hearings/components/VirtualHearingModal.jsx
+++ b/client/app/hearings/components/VirtualHearingModal.jsx
@@ -5,7 +5,7 @@ import Button from '../../components/Button';
 import Modal from '../../components/Modal';
 import TextField from '../../components/TextField';
 import moment from 'moment-timezone';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import _ from 'lodash';
 
 const getCentralOfficeTime = (hearing) => {

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -8,7 +8,7 @@ import moment from 'moment';
 import { COLORS } from '../../../constants/AppConstants';
 import AssignHearingsTabs from './AssignHearingsTabs';
 import StatusMessage from '../../../components/StatusMessage';
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 
 const sectionNavigationListStyling = css({
   '& > li': {

--- a/client/app/hearings/components/assignHearings/AssignHearingsDocketLine.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsDocketLine.jsx
@@ -2,7 +2,7 @@ import { css } from 'glamor';
 import _ from 'lodash';
 import moment from 'moment';
 
-import LEGACY_APPEAL_TYPES_BY_ID from '../../../../constants/LEGACY_APPEAL_TYPES_BY_ID.json';
+import LEGACY_APPEAL_TYPES_BY_ID from '../../../../constants/LEGACY_APPEAL_TYPES_BY_ID';
 
 export const docketCutoffLineStyle = (_index, scheduledForText) => {
   const isEmpty = _index < 0;

--- a/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
@@ -4,9 +4,9 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 import moment from 'moment';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import LEGACY_APPEAL_TYPES_BY_ID from '../../../../constants/LEGACY_APPEAL_TYPES_BY_ID.json';
+import LEGACY_APPEAL_TYPES_BY_ID from '../../../../constants/LEGACY_APPEAL_TYPES_BY_ID';
 
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 import AssignHearingsTable from './AssignHearingsTable';
 import UpcomingHearingsTable from './UpcomingHearingsTable';
 import TabWindow from '../../../components/TabWindow';

--- a/client/app/hearings/components/assignHearings/Messages.jsx
+++ b/client/app/hearings/components/assignHearings/Messages.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 import StatusMessage from '../../../components/StatusMessage';
 
 export const NoUpcomingHearingDayMessage = () => (

--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -14,7 +14,7 @@ import DailyDocketEditLinks from './DailyDocketEditLinks';
 import { isPreviouslyScheduledHearing } from '../../utils';
 import { navigateToPrintPage } from '../../../util/PrintUtil';
 import { encodeQueryParams } from '../../../util/QueryParamsUtil';
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 import UserAlerts from '../../../components/UserAlerts';
 
 const alertStyling = css({

--- a/client/app/hearings/components/dailyDocket/DailyDocketModals.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketModals.jsx
@@ -3,11 +3,11 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { sprintf } from 'sprintf-js';
 
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Modal from '../../../components/Modal';
 import Button from '../../../components/Button';
-import HEARING_DISPOSITION_TYPE_TO_LABEL_MAP from '../../../../constants/HEARING_DISPOSITION_TYPE_TO_LABEL_MAP.json';
+import HEARING_DISPOSITION_TYPE_TO_LABEL_MAP from '../../../../constants/HEARING_DISPOSITION_TYPE_TO_LABEL_MAP';
 
 export const RemoveHearingModal = ({ onCancelRemoveHearingDay, deleteHearingDay, dailyDocket }) => (
   <div>

--- a/client/app/hearings/components/dailyDocket/DailyDocketPrinted.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketPrinted.jsx
@@ -9,8 +9,8 @@ import { getDisplayTime } from './DailyDocketRowDisplayText';
 import { isPreviouslyScheduledHearing, sortHearings } from '../../utils';
 import { getDate } from '../../../util/DateUtil';
 import { openPrintDialogue } from '../../../util/PrintUtil';
-import AOD_CODE_TO_LABEL_MAP from '../../../../constants/AOD_CODE_TO_LABEL_MAP.json';
-import HEARING_DISPOSITION_TYPE_TO_LABEL_MAP from '../../../../constants/HEARING_DISPOSITION_TYPE_TO_LABEL_MAP.json';
+import AOD_CODE_TO_LABEL_MAP from '../../../../constants/AOD_CODE_TO_LABEL_MAP';
+import HEARING_DISPOSITION_TYPE_TO_LABEL_MAP from '../../../../constants/HEARING_DISPOSITION_TYPE_TO_LABEL_MAP';
 
 export class DailyDocketPrinted extends React.Component {
 

--- a/client/app/hearings/components/dailyDocket/DailyDocketRowDisplayText.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRowDisplayText.jsx
@@ -5,7 +5,7 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 import DocketTypeBadge from '../../../components/DocketTypeBadge';
 
 import { PreppedCheckbox } from './DailyDocketRowInputs';
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 
 import moment from 'moment-timezone';
 

--- a/client/app/hearings/components/dailyDocket/DailyDocketRowInputs.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRowInputs.jsx
@@ -15,7 +15,7 @@ import VirtualHearingLink from '../VirtualHearingLink';
 
 import { DISPOSITION_OPTIONS } from '../../constants';
 import { COLORS } from '../../../constants/AppConstants';
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 
 const staticSpacing = css({ marginTop: '5px' });
 

--- a/client/app/hearings/components/details/DetailsInputs.jsx
+++ b/client/app/hearings/components/details/DetailsInputs.jsx
@@ -14,7 +14,7 @@ import VirtualHearingLink from '../VirtualHearingLink';
 import HearingTypeDropdown from './HearingTypeDropdown';
 import TextField from '../../../components/TextField';
 import { COLORS } from '../../../constants/AppConstants';
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 
 class DetailsInputs extends React.Component {
   renderVirtualHearingLinkSection() {

--- a/client/app/hearings/components/hearingWorksheet/HearingWorksheetPrinted.jsx
+++ b/client/app/hearings/components/hearingWorksheet/HearingWorksheetPrinted.jsx
@@ -7,7 +7,7 @@ import WorksheetFooter from './WorksheetFooter';
 import WorksheetHeader from './WorksheetHeader';
 import HearingWorksheetPreImpressions from './HearingWorksheetPreImpressions';
 import { getWorksheetTitle } from './HearingWorksheet';
-import BENEFIT_TYPES from '../../../../constants/BENEFIT_TYPES.json';
+import BENEFIT_TYPES from '../../../../constants/BENEFIT_TYPES';
 import { filterCurrentIssues, filterIssuesOnAppeal } from '../../utils';
 import { formatDateStr, formatArrayOfDateStrings } from '../../../util/DateUtil';
 import { formatNameShort } from '../../../util/FormatUtil';

--- a/client/app/hearings/containers/AssignHearingsContainer.jsx
+++ b/client/app/hearings/containers/AssignHearingsContainer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import _ from 'lodash';
 import { css } from 'glamor';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';

--- a/client/app/hearings/containers/ListScheduleContainer.jsx
+++ b/client/app/hearings/containers/ListScheduleContainer.jsx
@@ -25,7 +25,7 @@ import { bindActionCreators } from 'redux';
 import { css } from 'glamor';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import Alert from '../../components/Alert';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import {
   formatDateStr,
   getMinutesToMilliseconds

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -1,4 +1,4 @@
-import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES.json';
+import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES';
 import moment from 'moment-timezone';
 import _ from 'lodash';
 

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -3,8 +3,8 @@
 import _ from 'lodash';
 import React from 'react';
 
-import INELIGIBLE_REQUEST_ISSUES from '../../../constants/INELIGIBLE_REQUEST_ISSUES.json';
-import COPY from '../../../COPY.json';
+import INELIGIBLE_REQUEST_ISSUES from '../../../constants/INELIGIBLE_REQUEST_ISSUES';
+import COPY from '../../../COPY';
 
 import { legacyIssue } from '../util/issues';
 import { formatDateStr } from '../../util/DateUtil';

--- a/client/app/intake/components/CorrectionTypeModal.jsx
+++ b/client/app/intake/components/CorrectionTypeModal.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import Modal from '../../components/Modal';
 import RadioField from '../../components/RadioField';
-import { INTAKE_CORRECTION_TYPE_MODAL_TITLE, INTAKE_CORRECTION_TYPE_MODAL_COPY } from '../../../COPY.json';
+import { INTAKE_CORRECTION_TYPE_MODAL_TITLE, INTAKE_CORRECTION_TYPE_MODAL_COPY } from '../../../COPY';
 import { CORRECTION_TYPE_OPTIONS } from '../constants';
 
 class CorrectionTypeModal extends React.Component {

--- a/client/app/intake/components/IssueList.jsx
+++ b/client/app/intake/components/IssueList.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import { FORM_TYPES } from '../constants';
 import AddedIssue from './AddedIssue';
 import Button from '../../components/Button';

--- a/client/app/intake/components/LegacyOptInApproved.jsx
+++ b/client/app/intake/components/LegacyOptInApproved.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import RadioField from '../../components/RadioField';
-import { INTAKE_LEGACY_OPT_IN_MESSAGE } from '../../../COPY.json';
+import { INTAKE_LEGACY_OPT_IN_MESSAGE } from '../../../COPY';
 import PropTypes from 'prop-types';
 
 const radioOptions = [

--- a/client/app/intake/components/NonratingRequestIssueModal.jsx
+++ b/client/app/intake/components/NonratingRequestIssueModal.jsx
@@ -10,7 +10,7 @@ import RadioField from '../../components/RadioField';
 import SearchableDropdown from '../../components/SearchableDropdown';
 import TextField from '../../components/TextField';
 import DateSelector from '../../components/DateSelector';
-import ISSUE_CATEGORIES from '../../../constants/ISSUE_CATEGORIES.json';
+import ISSUE_CATEGORIES from '../../../constants/ISSUE_CATEGORIES';
 import { validateDateNotInFuture, isTimely } from '../util/issues';
 import { formatDateStr } from '../../util/DateUtil';
 

--- a/client/app/intake/components/UnidentifiedIssueAlert.jsx
+++ b/client/app/intake/components/UnidentifiedIssueAlert.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Alert from '../../components/Alert';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 class UnidentifiedIssueAlert extends React.Component {
   render() {

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -1,5 +1,5 @@
-import INTAKE_FORM_NAMES from '../../constants/INTAKE_FORM_NAMES.json';
-import INTAKE_FORM_NAMES_SHORT from '../../constants/INTAKE_FORM_NAMES_SHORT.json';
+import INTAKE_FORM_NAMES from '../../constants/INTAKE_FORM_NAMES';
+import INTAKE_FORM_NAMES_SHORT from '../../constants/INTAKE_FORM_NAMES_SHORT';
 
 export const FORM_TYPES = {
   APPEAL: {
@@ -23,7 +23,7 @@ export const FORM_TYPES = {
     category: 'decisionReview',
     formName: 'supplementalClaim'
   },
-   RAMP_REFILING: {
+  RAMP_REFILING: {
     key: 'ramp_refiling',
     name: INTAKE_FORM_NAMES.ramp_refiling,
     category: 'ramp',
@@ -65,7 +65,7 @@ export const CORRECTION_TYPE_OPTIONS = [
     displayText: 'Local Quality Error' },
   { value: 'national_quality_error',
     displayText: 'National Quality Error' }
-]
+];
 
 export const BOOLEAN_RADIO_OPTIONS_DISABLED_FALSE = [
   { value: 'false',

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -36,7 +36,7 @@ import {
   toggleLegacyOptInModal,
   toggleCorrectionTypeModal
 } from '../actions/addIssues';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 class AddIssuesPage extends React.Component {
   constructor(props) {

--- a/client/app/intake/pages/decisionReviewEditCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewEditCompleted.jsx
@@ -10,7 +10,7 @@ import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 import IneligibleIssuesList from '../components/IneligibleIssuesList';
 import SmallLoader from '../../components/SmallLoader';
 import { LOGO_COLORS } from '../../constants/AppConstants';
-import END_PRODUCT_CODES from '../../../constants/END_PRODUCT_CODES.json';
+import END_PRODUCT_CODES from '../../../constants/END_PRODUCT_CODES';
 
 const leadMessageList = ({ veteran, formName, requestIssues, addedIssues, detailEditUrl }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -11,7 +11,7 @@ import { legacyIssue } from '../util/issues';
 import IneligibleIssuesList from '../components/IneligibleIssuesList';
 import SmallLoader from '../../components/SmallLoader';
 import { LOGO_COLORS } from '../../constants/AppConstants';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 
 const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, detailEditUrl, completedReview }) => {

--- a/client/app/intake/pages/rampRefiling/review.jsx
+++ b/client/app/intake/pages/rampRefiling/review.jsx
@@ -13,7 +13,7 @@ import { setReceiptDate, setOptionSelected } from '../../actions/intake';
 import { toggleIneligibleError } from '../../util';
 import { getIntakeStatus } from '../../selectors';
 import ErrorAlert from '../../components/ErrorAlert';
-import COPY from '../../../../COPY.json';
+import COPY from '../../../../COPY';
 import PropTypes from 'prop-types';
 
 class Review extends React.PureComponent {

--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -13,7 +13,7 @@ import { invalidVeteranInstructions } from '../components/ErrorAlert';
 import { PAGE_PATHS, INTAKE_STATES, REQUEST_STATE } from '../constants';
 import { getIntakeStatus } from '../selectors';
 import _ from 'lodash';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 const steps = [
   <span>

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { REVIEW_OPTIONS } from '../constants';
-import DATES from '../../../constants/DATES.json';
+import DATES from '../../../constants/DATES';
 import { formatDateStr } from '../../util/DateUtil';
 
 export const getBlankOptionError = (responseErrorCodes, field) => (

--- a/client/app/queue/AddColocatedTaskView.jsx
+++ b/client/app/queue/AddColocatedTaskView.jsx
@@ -24,7 +24,7 @@ import {
   marginBottom,
   marginTop
 } from './constants';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import Button from '../components/Button';
 
 import { taskActionData, prepareAllTasksForStore } from './utils';

--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -37,9 +37,9 @@ import {
   fullWidth,
   ISSUE_DESCRIPTION_MAX_LENGTH
 } from './constants';
-import COPY from '../../COPY.json';
-import ISSUE_INFO from '../../constants/ISSUE_INFO.json';
-import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json';
+import COPY from '../../COPY';
+import ISSUE_INFO from '../../constants/ISSUE_INFO';
+import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS';
 import QueueFlowPage from './components/QueueFlowPage';
 
 const marginTop = css({ marginTop: '5rem' });

--- a/client/app/queue/AppellantDetail.jsx
+++ b/client/app/queue/AppellantDetail.jsx
@@ -6,7 +6,7 @@ import _ from 'lodash';
 import BareList from '../components/BareList';
 import { boldText } from './constants';
 import Address from './components/Address';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const detailListStyling = css({
   paddingLeft: 0,

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { sprintf } from 'sprintf-js';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 import { taskById, appealWithDetailSelector } from './selectors';
 

--- a/client/app/queue/CaseDetailsLink.jsx
+++ b/client/app/queue/CaseDetailsLink.jsx
@@ -6,8 +6,8 @@ import { css } from 'glamor';
 
 import { onReceiveAmaTasks } from './QueueActions';
 import ApiUtil from '../util/ApiUtil';
-import COPY from '../../COPY.json';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import COPY from '../../COPY';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import { subHeadTextStyle } from './constants';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 

--- a/client/app/queue/CaseDetailsLoadingScreen.jsx
+++ b/client/app/queue/CaseDetailsLoadingScreen.jsx
@@ -6,8 +6,8 @@ import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
 import { prepareAppealForStore, prepareAllTasksForStore } from './utils';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
-import COPY from '../../COPY.json';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
+import COPY from '../../COPY';
 import PropTypes from 'prop-types';
 
 import { onReceiveAppealDetails, onReceiveTasks, setAttorneysOfJudge, fetchAllAttorneys } from './QueueActions';

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -13,7 +13,7 @@ import {
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import Tooltip from '../components/Tooltip';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import StringUtil from '../util/StringUtil';
 import { DateString } from '../util/DateUtil';
 import { showVeteranCaseList } from './uiReducer/uiActions';

--- a/client/app/queue/CaseListSearch.jsx
+++ b/client/app/queue/CaseListSearch.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import PropTypes from 'prop-types';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 import { clearCaseListSearch, appealsSearch, setCaseListSearch } from './CaseList/CaseListActions';
 

--- a/client/app/queue/CaseListView.jsx
+++ b/client/app/queue/CaseListView.jsx
@@ -29,7 +29,7 @@ import {
   claimReviewsByCaseflowVeteranId
 } from './selectors';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const horizontalRuleStyling = css({
   border: 0,

--- a/client/app/queue/CaseTitleDetails.jsx
+++ b/client/app/queue/CaseTitleDetails.jsx
@@ -16,7 +16,7 @@ import ReaderLink from './ReaderLink';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import { pencilSymbol } from '../components/RenderFunctions';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import { COLORS } from '../constants/AppConstants';
 import { renderLegacyAppealType } from './utils';
 

--- a/client/app/queue/ChangeHearingDispositionModal.jsx
+++ b/client/app/queue/ChangeHearingDispositionModal.jsx
@@ -6,9 +6,9 @@ import { withRouter } from 'react-router-dom';
 import _ from 'lodash';
 import moment from 'moment';
 
-import COPY from '../../COPY.json';
-import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES.json';
-import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
+import COPY from '../../COPY';
+import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES';
+import TASK_STATUSES from '../../constants/TASK_STATUSES';
 
 import {
   taskById,

--- a/client/app/queue/ChangeTaskTypeModal.jsx
+++ b/client/app/queue/ChangeTaskTypeModal.jsx
@@ -17,7 +17,7 @@ import {
   taskById
 } from './selectors';
 import { marginTop } from './constants';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 import { taskActionData } from './utils';
 import QueueFlowModal from './components/QueueFlowModal';

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -24,7 +24,7 @@ import {
   fullWidth,
   marginBottom
 } from './constants';
-import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
+import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 
 import Alert from '../components/Alert';
 import TabWindow from '../components/TabWindow';

--- a/client/app/queue/CreateChangeHearingDispositionTaskModal.jsx
+++ b/client/app/queue/CreateChangeHearingDispositionTaskModal.jsx
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { sprintf } from 'sprintf-js';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 import {
   taskById,

--- a/client/app/queue/CreateMailTaskDialog.jsx
+++ b/client/app/queue/CreateMailTaskDialog.jsx
@@ -5,7 +5,7 @@ import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { sprintf } from 'sprintf-js';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import { onReceiveAmaTasks } from './QueueActions';
 import SearchableDropdown from '../components/SearchableDropdown';
 import TextareaField from '../components/TextareaField';

--- a/client/app/queue/LegacySelectDispositionsView.jsx
+++ b/client/app/queue/LegacySelectDispositionsView.jsx
@@ -26,7 +26,7 @@ import {
   VACOLS_DISPOSITIONS,
   ISSUE_DISPOSITIONS
 } from './constants';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import { getUndecidedIssues } from './utils';
 import QueueFlowPage from './components/QueueFlowPage';
 

--- a/client/app/queue/LookupParticipantIdModal.jsx
+++ b/client/app/queue/LookupParticipantIdModal.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ApiUtil from '../util/ApiUtil';
 import Button from '../components/Button';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import PropTypes from 'prop-types';
 import SearchableDropdown from '../components/SearchableDropdown';

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -25,7 +25,7 @@ import {
 import { tasksWithAppealsFromRawTasks } from './utils';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
 import { fullWidth } from './constants';
-import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
+import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 
 const containerStyles = css({
   position: 'relative'

--- a/client/app/queue/OrganizationUsers.jsx
+++ b/client/app/queue/OrganizationUsers.jsx
@@ -12,7 +12,7 @@ import Button from '../components/Button';
 import SearchableDropdown from '../components/SearchableDropdown';
 
 import { LOGO_COLORS } from '../constants/AppConstants';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 
 const userStyle = css({ margin: '2rem 0 3rem',

--- a/client/app/queue/OtherReviewsTable.jsx
+++ b/client/app/queue/OtherReviewsTable.jsx
@@ -8,8 +8,8 @@ import { css } from 'glamor';
 import Table from '../components/Table';
 import { clearCaseListSearch } from './CaseList/CaseListActions';
 
-import COPY from '../../COPY.json';
-import CLAIM_REVIEW_TEXT from '../../constants/CLAIM_REVIEW_TEXT.json';
+import COPY from '../../COPY';
+import CLAIM_REVIEW_TEXT from '../../constants/CLAIM_REVIEW_TEXT';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import { DateString } from '../util/DateUtil';
 

--- a/client/app/queue/PostponeHearingTaskModal.jsx
+++ b/client/app/queue/PostponeHearingTaskModal.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { onReceiveAmaTasks } from './QueueActions';
 import QueueFlowModal from './components/QueueFlowModal';
 import { requestSave } from './uiReducer/uiActions';
-import TASK_ACTIONS from '../../constants/TASK_ACTIONS.json';
+import TASK_ACTIONS from '../../constants/TASK_ACTIONS';
 import { taskById } from './selectors';
 import { withRouter } from 'react-router-dom';
 

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import { getAppealValue } from './QueueActions';
 import { appealWithDetailSelector } from './selectors';
 import Address from './components/Address';

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -67,11 +67,11 @@ import UserManagement from './UserManagement';
 
 import { LOGO_COLORS } from '../constants/AppConstants';
 import { PAGE_TITLES } from './constants';
-import COPY from '../../COPY.json';
-import TASK_ACTIONS from '../../constants/TASK_ACTIONS.json';
-import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
-import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
+import COPY from '../../COPY';
+import TASK_ACTIONS from '../../constants/TASK_ACTIONS';
+import TASK_STATUSES from '../../constants/TASK_STATUSES';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
+import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES';
 import { FlashAlerts } from '../nonComp/components/Alerts';
 import AddressMotionToVacateView from './mtv/AddressMotionToVacateView';
 import ReviewMotionToVacateView from './mtv/ReviewMotionToVacateView';

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -7,7 +7,7 @@ import { bindActionCreators } from 'redux';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import { LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import { getMinutesToMilliseconds } from '../util/DateUtil';
 import { associateTasksWithAppeals } from './utils';
 
@@ -18,7 +18,7 @@ import {
   fetchAmaTasksOfUser
 } from './QueueActions';
 import { setUserId } from './uiReducer/uiActions';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 
 class QueueLoadingScreen extends React.PureComponent {
   maybeLoadAmaQueue = () => {

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -14,7 +14,7 @@ import { COLORS, LOGO_COLORS } from '../constants/AppConstants';
 import ApiUtil from '../util/ApiUtil';
 import LoadingScreen from '../components/LoadingScreen';
 import { tasksWithAppealsFromRawTasks } from './utils';
-import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG.json';
+import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 
 /**
  * This component can be used to easily build tables.

--- a/client/app/queue/SelectRemandReasonsView.jsx
+++ b/client/app/queue/SelectRemandReasonsView.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { css } from 'glamor';
 import { sprintf } from 'sprintf-js';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 import IssueRemandReasonsOptions from './components/IssueRemandReasonsOptions';
 import {
@@ -17,7 +17,7 @@ import {
   ISSUE_DISPOSITIONS,
   PAGE_TITLES
 } from './constants';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES.json';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import QueueFlowPage from './components/QueueFlowPage';
 const subHeadStyling = css({ marginBottom: '2rem' });
 const smallBottomMargin = css({ marginBottom: '1rem' });

--- a/client/app/queue/TaskSnapshot.jsx
+++ b/client/app/queue/TaskSnapshot.jsx
@@ -5,7 +5,7 @@ import { appealWithDetailSelector, taskSnapshotTasksForAppeal } from './selector
 import { css } from 'glamor';
 import AddNewTaskButton from './components/AddNewTaskButton';
 import TaskRows from './components/TaskRows';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import { sectionSegmentStyling, sectionHeadingStyling, anchorJumpLinkStyling } from './StickyNavContentArea';
 import { PulacCerulloReminderAlert } from './pulacCerullo/PulacCerulloReminderAlert';
 

--- a/client/app/queue/TeamManagement.jsx
+++ b/client/app/queue/TeamManagement.jsx
@@ -2,7 +2,7 @@ import Alert from '../components/Alert';
 import ApiUtil from '../util/ApiUtil';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Button from '../components/Button';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import LoadingDataDisplay from '../components/LoadingDataDisplay';
 import PropTypes from 'prop-types';

--- a/client/app/queue/UserManagement.jsx
+++ b/client/app/queue/UserManagement.jsx
@@ -8,8 +8,8 @@ import ApiUtil from '../util/ApiUtil';
 import Alert from '../components/Alert';
 import Button from '../components/Button';
 
-import COPY from '../../COPY.json';
-import USER_STATUSES from '../../constants/USER_STATUSES.json';
+import COPY from '../../COPY';
+import USER_STATUSES from '../../constants/USER_STATUSES';
 import TextField from '../components/TextField';
 
 const buttonPaddingStyle = css({ margin: '0 1rem' });

--- a/client/app/queue/VeteranCasesView.jsx
+++ b/client/app/queue/VeteranCasesView.jsx
@@ -14,7 +14,7 @@ import { onReceiveAppealDetails } from './QueueActions';
 import { appealsByCaseflowVeteranId } from './selectors';
 import { prepareAppealForStore } from './utils';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const containerStyling = css({
   backgroundColor: COLORS.GREY_BACKGROUND,

--- a/client/app/queue/caseEvaluation/EvaluateDecisionView.jsx
+++ b/client/app/queue/caseEvaluation/EvaluateDecisionView.jsx
@@ -20,9 +20,9 @@ import { requestSave } from '../uiReducer/uiActions';
 import { buildCaseReviewPayload } from '../utils';
 import { taskById } from '../selectors';
 
-import COPY from '../../../COPY.json';
-import JUDGE_CASE_REVIEW_OPTIONS from '../../../constants/JUDGE_CASE_REVIEW_OPTIONS.json';
-import DECISION_TYPES from '../../../constants/APPEAL_DECISION_TYPES.json';
+import COPY from '../../../COPY';
+import JUDGE_CASE_REVIEW_OPTIONS from '../../../constants/JUDGE_CASE_REVIEW_OPTIONS';
+import DECISION_TYPES from '../../../constants/APPEAL_DECISION_TYPES';
 import {
   marginBottom,
   marginTop,

--- a/client/app/queue/caseEvaluation/JudgeCaseQuality.jsx
+++ b/client/app/queue/caseEvaluation/JudgeCaseQuality.jsx
@@ -7,8 +7,8 @@ import RadioField from '../../components/RadioField';
 import CheckboxGroup from '../../components/CheckboxGroup';
 import Alert from '../../components/Alert';
 import { css } from 'glamor';
-import COPY from '../../../COPY.json';
-import JUDGE_CASE_REVIEW_OPTIONS from '../../../constants/JUDGE_CASE_REVIEW_OPTIONS.json';
+import COPY from '../../../COPY';
+import JUDGE_CASE_REVIEW_OPTIONS from '../../../constants/JUDGE_CASE_REVIEW_OPTIONS';
 import {
   headerStyling,
   errorStylingNoTopMargin,

--- a/client/app/queue/components/ActionsDropdown.jsx
+++ b/client/app/queue/components/ActionsDropdown.jsx
@@ -14,7 +14,7 @@ import {
 import {
   dropdownStyling
 } from '../constants';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 class ActionsDropdown extends React.PureComponent {
   changeRoute = (option) => {

--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -20,7 +20,7 @@ import Button from '../../components/Button';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import _ from 'lodash';
 import pluralize from 'pluralize';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import { sprintf } from 'sprintf-js';
 import { fullWidth } from '../constants';
 import QueueFlowModal from './QueueFlowModal';

--- a/client/app/queue/components/CancelTaskModal.jsx
+++ b/client/app/queue/components/CancelTaskModal.jsx
@@ -14,7 +14,7 @@ import {
   requestPatch
 } from '../uiReducer/uiActions';
 import { taskActionData } from '../utils';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import QueueFlowModal from './QueueFlowModal';
 
 class CancelTaskModal extends React.Component {

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router-dom';
 import { sprintf } from 'sprintf-js';
 import TextareaField from '../../components/TextareaField';
 import { ATTORNEY_COMMENTS_MAX_LENGTH, marginTop } from '../constants';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 import { taskById, appealWithDetailSelector } from '../selectors';
 import { onReceiveAmaTasks } from '../QueueActions';

--- a/client/app/queue/components/DispatchSuccessDetail.jsx
+++ b/client/app/queue/components/DispatchSuccessDetail.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 const DispatchSuccessDetail = (props) => {
   const { task, feedbackUrl } = props;

--- a/client/app/queue/components/EndHoldModal.jsx
+++ b/client/app/queue/components/EndHoldModal.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { onReceiveAmaTasks } from '../QueueActions';
 import QueueFlowModal from './QueueFlowModal';
 import { requestSave } from '../uiReducer/uiActions';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import { taskById } from '../selectors';
 import { withRouter } from 'react-router-dom';
 

--- a/client/app/queue/components/IssueRemandReasonsOptions.jsx
+++ b/client/app/queue/components/IssueRemandReasonsOptions.jsx
@@ -6,8 +6,8 @@ import { css } from 'glamor';
 import { formatDateStr } from '../../util/DateUtil';
 import scrollToComponent from 'react-scroll-to-component';
 
-import BENEFIT_TYPES from '../../../constants/BENEFIT_TYPES.json';
-import COPY from '../../../COPY.json';
+import BENEFIT_TYPES from '../../../constants/BENEFIT_TYPES';
+import COPY from '../../../COPY';
 import Checkbox from '../../components/Checkbox';
 import CheckboxGroup from '../../components/CheckboxGroup';
 import RadioField from '../../components/RadioField';

--- a/client/app/queue/components/LegacyIssueListItem.jsx
+++ b/client/app/queue/components/LegacyIssueListItem.jsx
@@ -9,8 +9,8 @@ import {
   getIssueDiagnosticCodeLabel
 } from '../utils';
 import { boldText } from '../constants';
-import ISSUE_INFO from '../../../constants/ISSUE_INFO.json';
-import VACOLS_DISPOSITIONS_BY_ID from '../../../constants/VACOLS_DISPOSITIONS_BY_ID.json';
+import ISSUE_INFO from '../../../constants/ISSUE_INFO';
+import VACOLS_DISPOSITIONS_BY_ID from '../../../constants/VACOLS_DISPOSITIONS_BY_ID';
 
 const minimalLeftPadding = css({ paddingLeft: '0.5rem' });
 const noteMarginTop = css({ marginTop: '1.5rem' });

--- a/client/app/queue/components/PostponeHearingModal.jsx
+++ b/client/app/queue/components/PostponeHearingModal.jsx
@@ -15,7 +15,7 @@ import {
 } from '../uiReducer/uiActions';
 import QueueFlowModal from './QueueFlowModal';
 import { taskActionData, prepareAppealForStore } from '../utils';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 
 import RadioField from '../../components/RadioField';
 import AssignHearingForm from '../../hearings/components/modalForms/AssignHearingForm';

--- a/client/app/queue/components/QueueFlowModal.jsx
+++ b/client/app/queue/components/QueueFlowModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Modal from '../../components/Modal';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';

--- a/client/app/queue/components/QueueOrganizationDropdown.jsx
+++ b/client/app/queue/components/QueueOrganizationDropdown.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { sprintf } from 'sprintf-js';
 
 import QueueSelectorDropdown from './QueueSelectorDropdown';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 export default class QueueOrganizationDropdown extends React.Component {
   render = () => {

--- a/client/app/queue/components/QueueSelectorDropdown.jsx
+++ b/client/app/queue/components/QueueSelectorDropdown.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { css } from 'glamor';
 
 import DropdownButton from '../../components/DropdownButton';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 // NOTE: parent container needs to be given 'position: relative'
 const style = css({

--- a/client/app/queue/components/StartHoldModal.jsx
+++ b/client/app/queue/components/StartHoldModal.jsx
@@ -8,8 +8,8 @@ import { requestSave } from '../uiReducer/uiActions';
 import SearchableDropdown from '../../components/SearchableDropdown';
 import TextField from '../../components/TextField';
 import TextareaField from '../../components/TextareaField';
-import COPY from '../../../COPY.json';
-import TASK_ACTIONS from '../../../constants/TASK_ACTIONS.json';
+import COPY from '../../../COPY';
+import TASK_ACTIONS from '../../../constants/TASK_ACTIONS';
 import { sprintf } from 'sprintf-js';
 import {
   appealWithDetailSelector,

--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import Button from '../../components/Button';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import { GrayDot, GreenCheckmark, CancelIcon } from '../../components/RenderFunctions';
 import { COLORS } from '../../constants/AppConstants';
 import { taskIsOnHold, sortTaskList } from '../utils';
@@ -11,7 +11,7 @@ import StringUtil from '../../util/StringUtil';
 import CaseDetailsDescriptionList from '../components/CaseDetailsDescriptionList';
 import ActionsDropdown from '../components/ActionsDropdown';
 import OnHoldLabel from '../components/OnHoldLabel';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import DecisionDateTimeLine from '../components/DecisionDateTimeLine';
 
 export const grayLineStyling = css({

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -22,8 +22,8 @@ import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regi
 
 import { setSelectionOfTaskOfUser } from '../QueueActions';
 import { hasDASRecord } from '../utils';
-import COPY from '../../../COPY.json';
-import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG.json';
+import COPY from '../../../COPY';
+import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG';
 
 export class TaskTableUnconnected extends React.PureComponent {
   getKeyForRow = (rowNumber, object) => object.uniqueId

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -12,10 +12,10 @@ import OnHoldLabel, { numDaysOnHold } from './OnHoldLabel';
 import { taskHasCompletedHold, hasDASRecord, collapseColumn, regionalOfficeCity, renderAppealType } from '../utils';
 import { DateString } from '../../util/DateUtil';
 
-import COPY from '../../../COPY.json';
-import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG.json';
-import DOCKET_NAME_FILTERS from '../../../constants/DOCKET_NAME_FILTERS.json';
-import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS.json';
+import COPY from '../../../COPY';
+import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG';
+import DOCKET_NAME_FILTERS from '../../../constants/DOCKET_NAME_FILTERS';
+import CO_LOCATED_ADMIN_ACTIONS from '../../../constants/CO_LOCATED_ADMIN_ACTIONS';
 
 import {
   CATEGORIES,

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -2,15 +2,15 @@
 /* eslint-disable max-lines */
 import { css } from 'glamor';
 import _ from 'lodash';
-import VACOLS_DISPOSITIONS_BY_ID from '../../constants/VACOLS_DISPOSITIONS_BY_ID.json';
-import ISSUE_DISPOSITIONS_BY_ID from '../../constants/ISSUE_DISPOSITIONS_BY_ID.json';
-import LEGACY_REMAND_REASONS_BY_ID from '../../constants/LEGACY_ACTIVE_REMAND_REASONS_BY_ID.json';
-import REMAND_REASONS_BY_ID from '../../constants/AMA_REMAND_REASONS_BY_ID.json';
+import VACOLS_DISPOSITIONS_BY_ID from '../../constants/VACOLS_DISPOSITIONS_BY_ID';
+import ISSUE_DISPOSITIONS_BY_ID from '../../constants/ISSUE_DISPOSITIONS_BY_ID';
+import LEGACY_REMAND_REASONS_BY_ID from '../../constants/LEGACY_ACTIVE_REMAND_REASONS_BY_ID';
+import REMAND_REASONS_BY_ID from '../../constants/AMA_REMAND_REASONS_BY_ID';
 import StringUtil from '../util/StringUtil';
 import { COLORS as COMMON_COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
-import COPY from '../../COPY.json';
-import VACOLS_COLUMN_MAX_LENGTHS from '../../constants/VACOLS_COLUMN_MAX_LENGTHS.json';
-import LEGACY_APPEAL_TYPES_BY_ID from '../../constants/LEGACY_APPEAL_TYPES_BY_ID.json';
+import COPY from '../../COPY';
+import VACOLS_COLUMN_MAX_LENGTHS from '../../constants/VACOLS_COLUMN_MAX_LENGTHS';
+import LEGACY_APPEAL_TYPES_BY_ID from '../../constants/LEGACY_APPEAL_TYPES_BY_ID';
 
 export const COLORS = {
   QUEUE_LOGO_PRIMARY: '#11598D',

--- a/client/app/queue/mtv/AddressMotionToVacateView.jsx
+++ b/client/app/queue/mtv/AddressMotionToVacateView.jsx
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 
 import { taskById, appealWithDetailSelector } from '../selectors';
 import { MTVJudgeDisposition } from './MTVJudgeDisposition';
-import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS.json';
+import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS';
 import { submitMTVJudgeDecision } from './mtvActions';
 import { taskActionData } from '../utils';
 

--- a/client/app/queue/mtv/MTVDispositionSelection.jsx
+++ b/client/app/queue/mtv/MTVDispositionSelection.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import RadioField from '../../components/RadioField';
 
-import { DISPOSITION_OPTIONS, PARTIAL_GRANT_OPTION } from '../../../constants/MOTION_TO_VACATE.json';
+import { DISPOSITION_OPTIONS, PARTIAL_GRANT_OPTION } from '../../../constants/MOTION_TO_VACATE';
 
 // In certain cases (judge view) we want to include a "partial grant" option
 const [grant, ...rest] = DISPOSITION_OPTIONS;

--- a/client/app/queue/mtv/MTVIssueSelection.jsx
+++ b/client/app/queue/mtv/MTVIssueSelection.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import CheckboxGroup from '../../components/CheckboxGroup';
-import { JUDGE_ADDRESS_MTV_ISSUE_SELECTION_LABEL } from '../../../COPY.json';
+import { JUDGE_ADDRESS_MTV_ISSUE_SELECTION_LABEL } from '../../../COPY';
 
 const getDisplayOptions = (issues) => {
   // CheckboxGroup expects options with id (string) & label

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -14,9 +14,9 @@ import {
   JUDGE_ADDRESS_MTV_HYPERLINK_LABEL,
   JUDGE_ADDRESS_MTV_DISPOSITION_NOTES_LABEL,
   JUDGE_ADDRESS_MTV_ASSIGN_ATTORNEY_LABEL
-} from '../../../COPY.json';
-import { DISPOSITION_TEXT, VACATE_TYPE_OPTIONS } from '../../../constants/MOTION_TO_VACATE.json';
-import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS.json';
+} from '../../../COPY';
+import { DISPOSITION_TEXT, VACATE_TYPE_OPTIONS } from '../../../constants/MOTION_TO_VACATE';
+import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS';
 import SearchableDropdown from '../../components/SearchableDropdown';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Button from '../../components/Button';

--- a/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
+++ b/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
@@ -10,7 +10,7 @@ import {
   MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL,
   MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_LABEL,
   MOTIONS_ATTORNEY_REVIEW_MTV_ASSIGN_JUDGE_LABEL
-} from '../../../COPY.json';
+} from '../../../COPY';
 import { MTVDispositionSelection } from './MTVDispositionSelection';
 import TextareaField from '../../components/TextareaField';
 import SearchableDropdown from '../../components/SearchableDropdown';
@@ -19,7 +19,7 @@ import Button from '../../components/Button';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import { css } from 'glamor';
 import { MTVTaskHeader } from './MTVTaskHeader';
-import { DISPOSITION_TEXT } from '../../../constants/MOTION_TO_VACATE.json';
+import { DISPOSITION_TEXT } from '../../../constants/MOTION_TO_VACATE';
 import { sprintf } from 'sprintf-js';
 
 const formatReviewAttyInstructions = ({ disposition, hyperlink, instructions }) => {

--- a/client/app/queue/mtv/ReturnToLitSupportModal.jsx
+++ b/client/app/queue/mtv/ReturnToLitSupportModal.jsx
@@ -8,7 +8,7 @@ import {
   RETURN_TO_LIT_SUPPORT_MODAL_INSTRUCTIONS_LABEL,
   RETURN_TO_LIT_SUPPORT_MODAL_DEFAULT_INSTRUCTIONS,
   MODAL_CANCEL_BUTTON
-} from '../../../COPY.json';
+} from '../../../COPY';
 import TextareaField from '../../components/TextareaField';
 import StringUtil from '../../util/StringUtil';
 

--- a/client/app/queue/pulacCerullo/PulacCerulloReminderModal.jsx
+++ b/client/app/queue/pulacCerullo/PulacCerulloReminderModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import Modal from '../../components/Modal';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import RadioField from '../../components/RadioField';
 import { CavcLinkInfo } from './CavcLinkInfo';
 

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -5,9 +5,9 @@ import {
   taskIsOnHold
 } from './utils';
 
-import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
+import TASK_STATUSES from '../../constants/TASK_STATUSES';
 
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 export const selectedTasksSelector = (state, userId) => {
   return _.map(

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -10,13 +10,13 @@ import {
   LEGACY_APPEAL_TYPES
 } from './constants';
 
-import ISSUE_INFO from '../../constants/ISSUE_INFO.json';
-import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json';
-import UNDECIDED_VACOLS_DISPOSITIONS_BY_ID from '../../constants/UNDECIDED_VACOLS_DISPOSITIONS_BY_ID.json';
-import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES.json';
-import TASK_STATUSES from '../../constants/TASK_STATUSES.json';
-import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMATION.json';
-import COPY from '../../COPY.json';
+import ISSUE_INFO from '../../constants/ISSUE_INFO';
+import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS';
+import UNDECIDED_VACOLS_DISPOSITIONS_BY_ID from '../../constants/UNDECIDED_VACOLS_DISPOSITIONS_BY_ID';
+import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES';
+import TASK_STATUSES from '../../constants/TASK_STATUSES';
+import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMATION';
+import COPY from '../../COPY';
 import { formatDateStrUtc } from '../util/DateUtil';
 
 /**


### PR DESCRIPTION
### Description
This is a follow-up to the PR (#13347) that allows importing of JSON files w/o using the extension (this matches Webpack defaults, and makes JSON import syntax match that for JS/JSX imports). That PR also included an update to eslint config to allow for those, but in doing so it *prohibited* the '.json' extensions, which will trigger linting warnings on any modified files that include them. 

This PR does a global removal of the '.json' extension from all imports in files that *don't already have other linting errors*. This avoids triggering those same linting warnings with a PR designed to fix them. :P

