### PR TITLE
Update ExternalApi::VBMSService#fetch_document_series_for to fallback to BGS claim ID 

### DIFF
--- a/app/services/external_api/vbms_document_series_for_appeal.rb
+++ b/app/services/external_api/vbms_document_series_for_appeal.rb
@@ -12,7 +12,7 @@ class ExternalApi::VbmsDocumentSeriesForAppeal < ExternalApi::VbmsRequestWithFil
       service = VBMS::Service::PagedDocuments.new(client: vbms_client)
 
       ExternalApi::VBMSService.call_and_log_service(
-        service: service, 
+        service: service,
         vbms_id: file_number_or_claim_number
       )&.[](:documents) || []
     else
@@ -21,7 +21,7 @@ class ExternalApi::VbmsDocumentSeriesForAppeal < ExternalApi::VbmsRequestWithFil
       ExternalApi::VBMSService.send_and_log_request(
         file_number_or_claim_number,
         request,
-        override_vbms_client = vbms_client
+        override_vbms_client: vbms_client
       )
     end
   end

--- a/app/services/external_api/vbms_document_series_for_appeal.rb
+++ b/app/services/external_api/vbms_document_series_for_appeal.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class ExternalApi::VbmsDocumentSeriesForAppeal < ExternalApi::VbmsRequestWithFileNumber
+  def fetch
+    get_and_retry
+  end
+
+  protected
+
+  def do_request(file_number_or_claim_number)
+    if FeatureToggle.enabled?(:vbms_pagination, user: RequestStore[:current_user])
+      service = VBMS::Service::PagedDocuments.new(client: vbms_client)
+
+      ExternalApi::VBMSService.call_and_log_service(
+        service: service, 
+        vbms_id: file_number_or_claim_number
+      )&.[](:documents) || []
+    else
+      request = VBMS::Requests::FindDocumentSeriesReference.new(file_number_or_claim_number)
+
+      ExternalApi::VBMSService.send_and_log_request(
+        file_number_or_claim_number,
+        request,
+        override_vbms_client = vbms_client
+      )
+    end
+  end
+end

--- a/app/services/external_api/vbms_document_series_for_appeal.rb
+++ b/app/services/external_api/vbms_document_series_for_appeal.rb
@@ -7,19 +7,19 @@ class ExternalApi::VbmsDocumentSeriesForAppeal < ExternalApi::VbmsRequestWithFil
 
   protected
 
-  def do_request(file_number_or_claim_number)
+  def do_request(ssn_or_claim_number)
     if FeatureToggle.enabled?(:vbms_pagination, user: RequestStore[:current_user])
       service = VBMS::Service::PagedDocuments.new(client: vbms_client)
 
       ExternalApi::VBMSService.call_and_log_service(
         service: service,
-        vbms_id: file_number_or_claim_number
+        vbms_id: ssn_or_claim_number
       )&.[](:documents) || []
     else
-      request = VBMS::Requests::FindDocumentSeriesReference.new(file_number_or_claim_number)
+      request = VBMS::Requests::FindDocumentSeriesReference.new(ssn_or_claim_number)
 
       ExternalApi::VBMSService.send_and_log_request(
-        file_number_or_claim_number,
+        ssn_or_claim_number,
         request,
         override_vbms_client: vbms_client
       )

--- a/app/services/external_api/vbms_document_series_for_appeal.rb
+++ b/app/services/external_api/vbms_document_series_for_appeal.rb
@@ -2,7 +2,7 @@
 
 class ExternalApi::VbmsDocumentSeriesForAppeal < ExternalApi::VbmsRequestWithFileNumber
   def fetch
-    get_and_retry
+    request_with_retry
   end
 
   protected

--- a/app/services/external_api/vbms_documents_for_appeal.rb
+++ b/app/services/external_api/vbms_documents_for_appeal.rb
@@ -14,8 +14,8 @@ class ExternalApi::VbmsDocumentsForAppeal < ExternalApi::VbmsRequestWithFileNumb
   def do_request(file_number_or_claim_number)
     if FeatureToggle.enabled?(:vbms_pagination, user: RequestStore[:current_user])
       ExternalApi::VBMSService.call_and_log_service(
-       service: vbms_paged_documents_service,
-       vbms_id: file_number_or_claim_number
+        service: vbms_paged_documents_service,
+        vbms_id: file_number_or_claim_number
       )&.[](:documents) || []
     else
       vbms_request = VBMS::Requests::FindDocumentVersionReference.new(file_number_or_claim_number)
@@ -35,7 +35,6 @@ class ExternalApi::VbmsDocumentsForAppeal < ExternalApi::VbmsRequestWithFileNumb
   def vbms_paged_documents_service
     @vbms_paged_documents_service ||= VBMS::Service::PagedDocuments.new(client: vbms_client)
   end
-
 
   def result_hash
     {

--- a/app/services/external_api/vbms_documents_for_appeal.rb
+++ b/app/services/external_api/vbms_documents_for_appeal.rb
@@ -11,19 +11,19 @@ class ExternalApi::VbmsDocumentsForAppeal < ExternalApi::VbmsRequestWithFileNumb
 
   protected
 
-  def do_request(file_number_or_claim_number)
+  def do_request(ssn_or_claim_number)
     if FeatureToggle.enabled?(:vbms_pagination, user: RequestStore[:current_user])
       ExternalApi::VBMSService.call_and_log_service(
         service: vbms_paged_documents_service,
-        vbms_id: file_number_or_claim_number
+        vbms_id: ssn_or_claim_number
       )&.[](:documents) || []
     else
-      vbms_request = VBMS::Requests::FindDocumentVersionReference.new(file_number_or_claim_number)
+      vbms_request = VBMS::Requests::FindDocumentVersionReference.new(ssn_or_claim_number)
 
       ExternalApi::VBMSRequest.new(
         client: vbms_client,
         request: vbms_request,
-        id: file_number_or_claim_number
+        id: ssn_or_claim_number
       ).call
     end
   end

--- a/app/services/external_api/vbms_documents_for_appeal.rb
+++ b/app/services/external_api/vbms_documents_for_appeal.rb
@@ -2,7 +2,7 @@
 
 class ExternalApi::VbmsDocumentsForAppeal < ExternalApi::VbmsRequestWithFileNumber
   def fetch
-    @documents = get_and_retry
+    @documents = request_with_retry
 
     Rails.logger.info("Document list length: #{documents.length}")
 

--- a/app/services/external_api/vbms_request_with_file_number.rb
+++ b/app/services/external_api/vbms_request_with_file_number.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-## 
+##
 # A request that requires the veteran's file number.
 # The file number for a veteran can be a claim ID (8-digit) or the veteran's
 # SSN (9-digit). This class wraps logic to retry the request for both the veteran's
 # SSN and the claim ID (if different).
-# 
+#
 
 class ExternalApi::VbmsRequestWithFileNumber
   def initialize(file_number:, vbms_client: init_vbms_client, bgs_client: init_bgs_client)

--- a/app/services/external_api/vbms_request_with_file_number.rb
+++ b/app/services/external_api/vbms_request_with_file_number.rb
@@ -21,7 +21,7 @@ class ExternalApi::VbmsRequestWithFileNumber
   attr_reader :file_number, :vbms_client, :bgs_client
 
   # Implement in subclass
-  def do_request(_file_number_or_claim_number); end
+  def do_request(_ssn_or_claim_number); end
 
   def request_with_retry
     DBService.release_db_connections

--- a/app/services/external_api/vbms_request_with_file_number.rb
+++ b/app/services/external_api/vbms_request_with_file_number.rb
@@ -23,7 +23,7 @@ class ExternalApi::VbmsRequestWithFileNumber
   # Implement in subclass
   def do_request(_file_number_or_claim_number); end
 
-  def get_and_retry
+  def request_with_retry
     DBService.release_db_connections
 
     begin

--- a/app/services/external_api/vbms_request_with_file_number.rb
+++ b/app/services/external_api/vbms_request_with_file_number.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+## 
+# A request that requires the veteran's file number.
+# The file number for a veteran can be a claim ID (8-digit) or the veteran's
+# SSN (9-digit). This class wraps logic to retry the request for both the veteran's
+# SSN and the claim ID (if different).
+# 
+
+class ExternalApi::VbmsRequestWithFileNumber
+  def initialize(file_number:, vbms_client: init_vbms_client, bgs_client: init_bgs_client)
+    @file_number = file_number
+    @vbms_client = vbms_client
+    @bgs_client = bgs_client
+  end
+
+  def fetch; end
+
+  protected
+
+  attr_reader :file_number, :vbms_client, :bgs_client
+
+  # Implement in subclass
+  def do_request(_file_number_or_claim_number); end
+
+  def get_and_retry
+    DBService.release_db_connections
+
+    begin
+      # Try with veteran's file number first
+      do_request(file_number)
+    rescue VBMS::FilenumberDoesNotExist
+      raise if bgs_claim_number_nil_or_same_as_veteran_file_number?
+
+      # Fallback to BGS claim number
+      do_request(bgs_claim_number)
+    end
+  end
+
+  private
+
+  def init_vbms_client
+    VBMS::Client.from_env_vars(
+      logger: VBMSCaseflowLogger.new,
+      env_name: ENV["CONNECT_VBMS_ENV"],
+      use_forward_proxy: FeatureToggle.enabled?(:vbms_forward_proxy)
+    )
+  end
+
+  def init_bgs_client
+    ExternalApi::BGSService.new
+  end
+
+  def bgs_claim_number_nil_or_same_as_veteran_file_number?
+    bgs_claim_number.nil? || bgs_claim_number == file_number
+  end
+
+  def bgs_claim_number
+    @bgs_claim_number ||= bgs_client.fetch_veteran_info(file_number)[:claim_number]
+  end
+end

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -35,19 +35,7 @@ class ExternalApi::VBMSService
   end
 
   def self.fetch_document_series_for(appeal)
-    DBService.release_db_connections
-
-    @vbms_client ||= init_vbms_client
-
-    veteran_file_number = appeal.veteran_file_number
-
-    if FeatureToggle.enabled?(:vbms_pagination, user: RequestStore[:current_user])
-      service = VBMS::Service::PagedDocuments.new(client: @vbms_client)
-      call_and_log_service(service: service, vbms_id: veteran_file_number)[:documents]
-    else
-      request = VBMS::Requests::FindDocumentSeriesReference.new(veteran_file_number)
-      send_and_log_request(veteran_file_number, request)
-    end
+    ExternalApi::VbmsDocumentSeriesForAppeal.new(file_number: appeal.veteran_file_number).fetch
   end
 
   def self.upload_document_to_vbms(appeal, uploadable_document)


### PR DESCRIPTION
Related to #10732 

### Description

  * Refactors retry logic to base class
  * Add `VbmsDocumentSeriesForAppeal` to retry VBMS call using BGS claim id
