### PR TITLE
Detect claims that get changed to a 400 and close the request issues

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -389,7 +389,7 @@ class EndProductEstablishment < ApplicationRecord
 
   def close_request_issues_with_no_decision!
     return unless status_cleared?
-    return unless result.claim_type_code =~ /^400/
+    return unless result.claim_type_code.include?("400")
 
     request_issues.each { |ri| RequestIssueClosure.new(ri).with_no_decision! }
   end

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -488,7 +488,7 @@ describe RequestIssue, :all_dbs do
         let(:disposition) { "DTA Error" }
 
         it "includes an array of the contention reference IDs from the decision issues request issues" do
-          expect(subject).to eq([101, 121])
+          expect(subject).to match_array([101, 121])
         end
       end
     end

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -42,7 +42,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
     end
 
     context "sync tomorrow" do
-      subject { described_class.new(since: Time.zone.tomorrow).call }
+      subject { described_class.new(since: Time.zone.now + 1.day).call }
 
       it "does not sync" do
         subject


### PR DESCRIPTION
### Description
If a Caseflow EP gets changed to a 400 EP, automatically close the request issues.
