### PR TITLE
handle null receipt_date in serializer

### DIFF
--- a/app/serializers/intake/decision_review_serializer.rb
+++ b/app/serializers/intake/decision_review_serializer.rb
@@ -40,7 +40,7 @@ class Intake::DecisionReviewSerializer
   end
 
   attribute :receipt_date do |object|
-    object.receipt_date.to_formatted_s(:json_date)
+    object.receipt_date&.to_formatted_s(:json_date)
   end
 
   attribute :veteran do |object|


### PR DESCRIPTION
https://dsva.slack.com/archives/CHX8FMP28/p1581101209245800

and in Sentry:

https://dsva.slack.com/archives/CCB97HZJL/p1581100502056400

### Description

Handle null `receipt_date` instead of erroring