### PR TITLE
include child task id in error message

### DIFF
--- a/app/models/tasks/root_task.rb
+++ b/app/models/tasks/root_task.rb
@@ -38,7 +38,8 @@ class RootTask < Task
     if active?
       update!(status: :on_hold)
     elsif !self.class.creatable_tasks_types_when_on_hold.include?(child_task.type) && !on_hold?
-      Raven.capture_message("Created child task for RootTask #{id} but did not update RootTask status")
+      Raven.capture_message("Created child task #{child_task&.id} for RootTask #{id} " \
+        "but did not update RootTask status")
     end
   end
 


### PR DESCRIPTION
Related to #13278

### Description
Can't tell which child task was created and instigating Sentry alerts mentioned in #13278.

This PR adds the child_task.id in the error message.

See https://github.com/department-of-veterans-affairs/caseflow/issues/13278#issuecomment-579513879

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Check for Sentry alert msgs for child task id
