### PR TITLE
Fix AssignWidget to prevent TypeError when in a modal

### DIFF
--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -46,11 +46,7 @@ class AssignWidget extends React.PureComponent {
       return false;
     }
 
-    if (selectedAssignee !== OTHER) {
-      return true;
-    }
-
-    if (!selectedAssigneeSecondary) {
+    if (selectedAssignee == OTHER && !selectedAssigneeSecondary) {
       this.props.showErrorMessage(
         { title: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_TITLE,
           detail: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_DETAIL });
@@ -66,7 +62,7 @@ class AssignWidget extends React.PureComponent {
     this.props.resetSuccessMessages();
     this.props.resetErrorMessages();
 
-    if(this.props.isModal) {
+    if (this.props.isModal) {
       // QueueFlowModal will call validateForm
     } else {
       if(!this.validateForm()) {
@@ -76,9 +72,9 @@ class AssignWidget extends React.PureComponent {
 
     if (selectedAssignee == OTHER) {
       return this.assignTasks(selectedTasks, selectedAssigneeSecondary);
-    } else {
-      return this.assignTasks(selectedTasks, selectedAssignee);
     }
+
+    return this.assignTasks(selectedTasks, selectedAssignee);
   }
 
   assignTasks = (selectedTasks, assigneeId) => {
@@ -207,9 +203,9 @@ class AssignWidget extends React.PureComponent {
         }
       </div>
     </React.Fragment>;
+
     return this.props.isModal ? <QueueFlowModal title={COPY.ASSIGN_WIDGET_MODAL_TITLE}
-                                                submit={this.submit}
-                                                validateForm={this.validateForm}>
+      submit={this.submit} validateForm={this.validateForm}>
       {Widget}
     </QueueFlowModal> : Widget;
   }

--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -28,18 +28,14 @@ import QueueFlowModal from './QueueFlowModal';
 const OTHER = 'OTHER';
 
 class AssignWidget extends React.PureComponent {
-  submit = () => {
+  validateForm = () => {
     const { selectedAssignee, selectedAssigneeSecondary, selectedTasks } = this.props;
-
-    this.props.resetSuccessMessages();
-    this.props.resetErrorMessages();
-
     if (!selectedAssignee) {
       this.props.showErrorMessage(
         { title: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_TITLE,
           detail: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_DETAIL });
 
-      return;
+      return false;
     }
 
     if (selectedTasks.length === 0) {
@@ -47,11 +43,11 @@ class AssignWidget extends React.PureComponent {
         { title: COPY.ASSIGN_WIDGET_NO_TASK_TITLE,
           detail: COPY.ASSIGN_WIDGET_NO_TASK_DETAIL });
 
-      return;
+      return false;
     }
 
     if (selectedAssignee !== OTHER) {
-      return this.assignTasks(selectedTasks, selectedAssignee);
+      return true;
     }
 
     if (!selectedAssigneeSecondary) {
@@ -59,10 +55,30 @@ class AssignWidget extends React.PureComponent {
         { title: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_TITLE,
           detail: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_DETAIL });
 
-      return;
+      return false;
     }
 
-    return this.assignTasks(selectedTasks, selectedAssigneeSecondary);
+    return true;
+  }
+
+  submit = () => {
+    const { selectedAssignee, selectedAssigneeSecondary, selectedTasks } = this.props;
+    this.props.resetSuccessMessages();
+    this.props.resetErrorMessages();
+
+    if(this.props.isModal) {
+      // QueueFlowModal will call validateForm
+    } else {
+      if(!this.validateForm()) {
+        return;
+      }
+    }
+
+    if (selectedAssignee == OTHER) {
+      return this.assignTasks(selectedTasks, selectedAssigneeSecondary);
+    } else {
+      return this.assignTasks(selectedTasks, selectedAssignee);
+    }
   }
 
   assignTasks = (selectedTasks, assigneeId) => {
@@ -191,8 +207,9 @@ class AssignWidget extends React.PureComponent {
         }
       </div>
     </React.Fragment>;
-
-    return this.props.isModal ? <QueueFlowModal title={COPY.ASSIGN_WIDGET_MODAL_TITLE} submit={this.submit}>
+    return this.props.isModal ? <QueueFlowModal title={COPY.ASSIGN_WIDGET_MODAL_TITLE}
+                                                submit={this.submit}
+                                                validateForm={this.validateForm}>
       {Widget}
     </QueueFlowModal> : Widget;
   }

--- a/client/app/queue/components/AssignWidget.jsx
+++ b/client/app/queue/components/AssignWidget.jsx
@@ -30,6 +30,7 @@ const OTHER = 'OTHER';
 class AssignWidget extends React.PureComponent {
   validateForm = () => {
     const { selectedAssignee, selectedAssigneeSecondary, selectedTasks } = this.props;
+
     if (!selectedAssignee) {
       this.props.showErrorMessage(
         { title: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_TITLE,
@@ -46,7 +47,7 @@ class AssignWidget extends React.PureComponent {
       return false;
     }
 
-    if (selectedAssignee == OTHER && !selectedAssigneeSecondary) {
+    if (selectedAssignee === OTHER && !selectedAssigneeSecondary) {
       this.props.showErrorMessage(
         { title: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_TITLE,
           detail: COPY.ASSIGN_WIDGET_NO_ASSIGNEE_DETAIL });
@@ -59,18 +60,17 @@ class AssignWidget extends React.PureComponent {
 
   submit = () => {
     const { selectedAssignee, selectedAssigneeSecondary, selectedTasks } = this.props;
+
     this.props.resetSuccessMessages();
     this.props.resetErrorMessages();
 
     if (this.props.isModal) {
       // QueueFlowModal will call validateForm
-    } else {
-      if(!this.validateForm()) {
-        return;
-      }
+    } else if (!this.validateForm()) {
+      return;
     }
 
-    if (selectedAssignee == OTHER) {
+    if (selectedAssignee === OTHER) {
       return this.assignTasks(selectedTasks, selectedAssigneeSecondary);
     }
 

--- a/client/app/queue/components/QueueFlowModal.jsx
+++ b/client/app/queue/components/QueueFlowModal.jsx
@@ -41,7 +41,8 @@ class QueueFlowModal extends React.PureComponent {
     this.props.highlightInvalidFormItems(false);
     this.setState({ loading: true });
 
-    this.props.submit().then(() => {
+    const promise=this.props.submit()
+    promise && promise.then(() => {
       this.setState({ loading: false });
       if (!this.props.error) {
         this.closeHandler();
@@ -99,7 +100,7 @@ QueueFlowModal.propTypes = {
   title: PropTypes.string,
   button: PropTypes.string,
   pathAfterSubmit: PropTypes.string,
-  submit: PropTypes.func,
+  submit: PropTypes.func, // should return a promise on which .then() can be called
   success: PropTypes.object,
   validateForm: PropTypes.func,
   reloadPageAfterSubmit: PropTypes.bool

--- a/client/app/queue/components/QueueFlowModal.jsx
+++ b/client/app/queue/components/QueueFlowModal.jsx
@@ -41,8 +41,7 @@ class QueueFlowModal extends React.PureComponent {
     this.props.highlightInvalidFormItems(false);
     this.setState({ loading: true });
 
-    const promise=this.props.submit()
-    promise && promise.then(() => {
+    this.props.submit().then(() => {
       this.setState({ loading: false });
       if (!this.props.error) {
         this.closeHandler();
@@ -100,7 +99,8 @@ QueueFlowModal.propTypes = {
   title: PropTypes.string,
   button: PropTypes.string,
   pathAfterSubmit: PropTypes.string,
-  submit: PropTypes.func, // should return a promise on which .then() can be called
+  // submit should return a promise on which .then() can be called
+  submit: PropTypes.func,
   success: PropTypes.object,
   validateForm: PropTypes.func,
   reloadPageAfterSubmit: PropTypes.bool


### PR DESCRIPTION
Resolves  #10632

### Description
Fixes `AssignWidget` to prevent TypeError when in a `QueueFlowModal`.
* Extracted validation into `validateForm`, which is passed to `QueueFlowModal` (which rely on it to return true before calling `submit`).
* When `AssignWidget` is not in a modal, it has to call `validateForm` itself.

### Acceptance Criteria
- [x] No TypeError in the console of the Case Details page upon user error
- [x] AssignWidget performs validation in the Case Assignment page

### Testing Plan
1. Log in as a judge with cases to assign (e.g., BVAAABSHIRE)
2. Go to http://localhost:3000/queue/3/assign
3. Open the Developer Tools to see the console. Clear the console log messages.
4. Assign cases to users by clicking "Assign N cases". Cause each of these user errors:
  * not selecting a user
  * not selecting a case
  * selecting "Other" and not selecting any attorney
5. Appropriate error messages should appear on the page. No errors should appear in the Developer Tools' console.
6. Make sure case assignment still works.
7. Go to a Case Details page by selecting one of the cases.
8. Clear the console log messages.
9. Choose "Assign to attorney". Cause user errors like step 4 above. No TypeErrors or errors associated with the modal should appear in the Developer Tools' console.
10. Make sure case assignment still works.

