### PR TITLE
Associate PostDecisionMotion with appeal rather than task

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -23,6 +23,7 @@ class Appeal < DecisionReview
   has_many :remand_supplemental_claims, as: :decision_review_remanded, class_name: "SupplementalClaim"
 
   has_one :special_issue_list
+  has_one :post_decision_motion
   has_many :record_synced_by_job, as: :record
 
   enum stream_type: {
@@ -98,6 +99,8 @@ class Appeal < DecisionReview
   end
 
   def vacate_type
+    return nil unless vacate?
+
     post_decision_motion&.vacate_type
   end
 
@@ -463,11 +466,5 @@ class Appeal < DecisionReview
   ensure
     distribution_task = tasks.open.find_by(type: DistributionTask.name)
     TranslationTask.create_from_parent(distribution_task) if STATE_CODES_REQUIRING_TRANSLATION_TASK.include?(state_code)
-  end
-
-  # Non-vacate Appeals are not expected to have a PDM, but this method makes a
-  # best-effort attempt in either situation, and returns nil if none is found.
-  def post_decision_motion
-    PostDecisionMotion.find_by(task: tasks)
   end
 end

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class PostDecisionMotion < ApplicationRecord
-  belongs_to :task, optional: false
+  self.ignored_columns = ["task_id"]
+
+  belongs_to :appeal, optional: false
 
   validates :disposition, presence: true
   validate :vacate_type_is_present_if_granted

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 class PostDecisionMotion < ApplicationRecord
-  self.ignored_columns = ["task_id"]
-
-  belongs_to :appeal, optional: false
+  belongs_to :appeal
+  belongs_to :task, optional: false
 
   validates :disposition, presence: true
   validate :vacate_type_is_present_if_granted

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -7,6 +7,8 @@
 class PostDecisionMotionUpdater
   include ActiveModel::Model
 
+  class InvalidMotionUpdaterArguments < StandardError; end
+
   attr_reader :task, :params, :disposition, :instructions
 
   def initialize(task, params)
@@ -16,20 +18,24 @@ class PostDecisionMotionUpdater
     @instructions = @params[:instructions]
   end
 
-  delegate :appeal, to: :task
+  delegate :appeal, to: :task, prefix: "original"
 
   def process
     ActiveRecord::Base.transaction do
-      return unless post_decision_motion
+      if post_decision_motion
+        handle_denial_or_dismissal
+        handle_grant
+      end
 
-      handle_denial_or_dismissal
-      handle_grant
-
-      return if errors.messages.any?
+      raise InvalidMotionUpdaterArguments if errors.messages.any?
 
       task.update(status: Constants.TASK_STATUSES.completed)
       post_decision_motion
     end
+  rescue InvalidMotionUpdaterArguments
+    # Slightly leaky abstraction: vacate_stream may have already been created and
+    # committed to DB before we realize the transaction should be rolled back.
+    @vacate_stream&.destroy!
   end
 
   private
@@ -38,9 +44,23 @@ class PostDecisionMotionUpdater
     @post_decision_motion ||= create_motion
   end
 
+  def vacate_stream
+    return nil unless grant_type?
+
+    @vacate_stream ||= original_appeal.create_stream(:vacate)
+  end
+
+  def appeal
+    if denied_or_dismissed?
+      original_appeal
+    elsif grant_type?
+      vacate_stream
+    end
+  end
+
   def create_motion
     motion = PostDecisionMotion.new(
-      task: task,
+      appeal: appeal,
       disposition: disposition,
       vacate_type: params[:vacate_type]
     )
@@ -49,7 +69,7 @@ class PostDecisionMotionUpdater
       motion.vacated_decision_issue_ids = params[:vacated_decision_issue_ids]
     elsif disposition == "granted"
       # For full grant, auto populate all decision issue IDs
-      motion.vacated_decision_issue_ids = appeal.decision_issues.map(&:id)
+      motion.vacated_decision_issue_ids = original_appeal.decision_issues.map(&:id)
     end
 
     unless motion.valid?
@@ -85,7 +105,6 @@ class PostDecisionMotionUpdater
   def handle_grant
     return unless grant_type?
 
-    vacate_stream = appeal.create_stream(:vacate)
     create_new_stream_tasks(vacate_stream)
     post_decision_motion.create_request_issues_for_vacatur
     post_decision_motion.create_vacated_decision_issues

--- a/app/workflows/post_decision_motion_updater.rb
+++ b/app/workflows/post_decision_motion_updater.rb
@@ -22,12 +22,8 @@ class PostDecisionMotionUpdater
 
   def process
     ActiveRecord::Base.transaction do
-      if post_decision_motion
-        handle_denial_or_dismissal
-        handle_grant
-      end
-
-      raise InvalidMotionUpdaterArguments if errors.messages.any?
+      create_new_models
+      fail InvalidMotionUpdaterArguments if errors.messages.any?
 
       task.update(status: Constants.TASK_STATUSES.completed)
       post_decision_motion
@@ -35,7 +31,7 @@ class PostDecisionMotionUpdater
   rescue InvalidMotionUpdaterArguments
     # Slightly leaky abstraction: vacate_stream may have already been created and
     # committed to DB before we realize the transaction should be rolled back.
-    @vacate_stream&.destroy!
+    vacate_stream&.destroy!
   end
 
   private
@@ -50,17 +46,17 @@ class PostDecisionMotionUpdater
     @vacate_stream ||= original_appeal.create_stream(:vacate)
   end
 
-  def appeal
-    if denied_or_dismissed?
-      original_appeal
-    elsif grant_type?
-      vacate_stream
+  def create_new_models
+    if post_decision_motion
+      handle_denial_or_dismissal
+      handle_grant
     end
   end
 
   def create_motion
     motion = PostDecisionMotion.new(
-      appeal: appeal,
+      appeal: vacate_stream,
+      task: task,
       disposition: disposition,
       vacate_type: params[:vacate_type]
     )
@@ -93,8 +89,7 @@ class PostDecisionMotionUpdater
       return
     end
 
-    new_task = create_new_task(abstract_task)
-
+    new_task = create_denial_or_dismissal_task(abstract_task)
     unless new_task.valid?
       errors.messages.merge!(new_task.errors.messages)
       return
@@ -112,15 +107,15 @@ class PostDecisionMotionUpdater
 
   def create_abstract_task
     AbstractMotionToVacateTask.new(
-      appeal: appeal,
+      appeal: original_appeal,
       parent: task.parent,
       assigned_to: judge_user
     )
   end
 
-  def create_new_task(parent)
+  def create_denial_or_dismissal_task(parent)
     task_class.new(
-      appeal: appeal,
+      appeal: original_appeal,
       parent: parent,
       assigned_by: judge_user,
       assigned_to: attorney_user,

--- a/db/migrate/20200206161309_link_motions_to_appeals.rb
+++ b/db/migrate/20200206161309_link_motions_to_appeals.rb
@@ -1,42 +1,10 @@
 class LinkMotionsToAppeals < ActiveRecord::Migration[5.1]
   def up
-    # Index creation and task_id removal will be a separate Caseflow::Migration
     add_reference :post_decision_motions, :appeal, foreign_key: true, index: false
-    safety_assured do
-      execute <<-EOS.strip_heredoc
-        UPDATE post_decision_motions SET appeal_id = (
-          SELECT appeals.id FROM appeals
-            WHERE (
-                (stream_type = 'Original' AND disposition IN ('denied', 'dismissed')) OR
-                (stream_type = 'Vacate' AND disposition IN ('granted', 'partially_granted'))
-              ) AND
-              appeals.stream_docket_number = (
-                SELECT appeals.stream_docket_number
-                  FROM tasks JOIN appeals ON tasks.appeal_id = appeals.id
-                  WHERE tasks.id = post_decision_motions.task_id
-            )
-            LIMIT 1
-        )
-      EOS
-    end
   end
 
   def down
     safety_assured do
-      execute <<-EOS.strip_heredoc
-        UPDATE post_decision_motions SET task_id = (
-          SELECT tasks.id
-            FROM tasks JOIN appeals ON tasks.appeal_id = appeals.id
-            WHERE
-              tasks.type = 'JudgeAddressMotionToVacateTask' AND
-              appeals.stream_type = 'Original' AND
-              appeals.stream_docket_number = (
-                SELECT appeals.stream_docket_number FROM appeals
-                  WHERE appeals.id = post_decision_motions.appeal_id
-              )
-            LIMIT 1
-        )
-      EOS
       remove_reference :post_decision_motions, :appeal, foreign_key: true
     end
   end

--- a/db/migrate/20200206161309_link_motions_to_appeals.rb
+++ b/db/migrate/20200206161309_link_motions_to_appeals.rb
@@ -1,0 +1,43 @@
+class LinkMotionsToAppeals < ActiveRecord::Migration[5.1]
+  def up
+    # Index creation and task_id removal will be a separate Caseflow::Migration
+    add_reference :post_decision_motions, :appeal, foreign_key: true, index: false
+    safety_assured do
+      execute <<-EOS.strip_heredoc
+        UPDATE post_decision_motions SET appeal_id = (
+          SELECT appeals.id FROM appeals
+            WHERE (
+                (stream_type = 'Original' AND disposition IN ('denied', 'dismissed')) OR
+                (stream_type = 'Vacate' AND disposition IN ('granted', 'partially_granted'))
+              ) AND
+              appeals.stream_docket_number = (
+                SELECT appeals.stream_docket_number
+                  FROM tasks JOIN appeals ON tasks.appeal_id = appeals.id
+                  WHERE tasks.id = post_decision_motions.task_id
+            )
+            LIMIT 1
+        )
+      EOS
+    end
+  end
+
+  def down
+    safety_assured do
+      execute <<-EOS.strip_heredoc
+        UPDATE post_decision_motions SET task_id = (
+          SELECT tasks.id
+            FROM tasks JOIN appeals ON tasks.appeal_id = appeals.id
+            WHERE
+              tasks.type = 'JudgeAddressMotionToVacateTask' AND
+              appeals.stream_type = 'Original' AND
+              appeals.stream_docket_number = (
+                SELECT appeals.stream_docket_number FROM appeals
+                  WHERE appeals.id = post_decision_motions.appeal_id
+              )
+            LIMIT 1
+        )
+      EOS
+      remove_reference :post_decision_motions, :appeal, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_153700) do
+ActiveRecord::Schema.define(version: 2020_02_06_161309) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -906,7 +906,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_153700) do
   create_table "people", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date_of_birth"
-    t.string "email_address"
+    t.string "email_address", comment: "Person email address, cached from BGS"
     t.string "first_name", comment: "Person first name, cached from BGS"
     t.string "last_name", comment: "Person last name, cached from BGS"
     t.string "middle_name", comment: "Person middle name, cached from BGS"
@@ -918,6 +918,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_153700) do
   end
 
   create_table "post_decision_motions", comment: "Stores the disposition and associated task of post-decisional motions handled by the Litigation Support Team: Motion for Reconsideration, Motion to Vacate, and Clear and Unmistakeable Error.", force: :cascade do |t|
+    t.bigint "appeal_id"
     t.datetime "created_at", null: false
     t.string "disposition", comment: "Possible options are Grant, Deny, Withdraw, and Dismiss"
     t.bigint "task_id"
@@ -1402,6 +1403,7 @@ ActiveRecord::Schema.define(version: 2020_01_28_153700) do
   add_foreign_key "legacy_hearings", "users", column: "updated_by_id"
   add_foreign_key "legacy_issue_optins", "legacy_issues"
   add_foreign_key "organizations_users", "users"
+  add_foreign_key "post_decision_motions", "appeals"
   add_foreign_key "post_decision_motions", "tasks"
   add_foreign_key "ramp_closed_appeals", "ramp_elections"
   add_foreign_key "ramp_election_rollbacks", "users"

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -52,6 +52,7 @@ FactoryBot.define do
         judge_team = JudgeTeam.for_judge(judge) || JudgeTeam.create_for_judge(judge)
         attorney = User.find_or_create_by(css_id: "BVAEERDMAN", station_id: 101)
         judge_team.add_user(attorney)
+        create(:staff, :attorney_role, sdomainid: attorney.css_id)
 
         attorney
       end
@@ -61,6 +62,7 @@ FactoryBot.define do
       associated_judge do
         judge = User.find_or_create_by(css_id: "BVAAABSHIRE", station_id: 101)
         JudgeTeam.for_judge(judge) || JudgeTeam.create_for_judge(judge)
+        create(:staff, :judge_role, sdomainid: judge.css_id)
 
         judge
       end
@@ -188,23 +190,17 @@ FactoryBot.define do
       end
     end
 
-    trait :straight_vacated do
-      stream_type { "vacate" }
-
+    trait :with_straight_vacate_stream do
       after(:create) do |appeal, evaluator|
-        task = JudgeAddressMotionToVacateTask.create!(
-          appeal: appeal,
-          parent: appeal.root_task,
-          assigned_at: evaluator.active_task_assigned_at,
-          assigned_to: evaluator.associated_judge
-        )
+        mail_task = create(:vacate_motion_mail_task, appeal: appeal, parent: appeal.root_task, assigned_to: evaluator.associated_judge)
+        addr_task = create(:judge_address_motion_to_vacate_task, appeal: appeal, parent: mail_task, assigned_to: evaluator.associated_judge)
         params = {
           disposition: "granted",
           vacate_type: "straight_vacate",
           instructions: "some instructions",
-          assigned_to_id: task.assigned_to.id
+          assigned_to_id: evaluator.associated_attorney.id
         }
-        PostDecisionMotionUpdater.new(task, params).process
+        PostDecisionMotionUpdater.new(addr_task, params).process
       end
     end
   end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -192,8 +192,18 @@ FactoryBot.define do
 
     trait :with_straight_vacate_stream do
       after(:create) do |appeal, evaluator|
-        mail_task = create(:vacate_motion_mail_task, appeal: appeal, parent: appeal.root_task, assigned_to: evaluator.associated_judge)
-        addr_task = create(:judge_address_motion_to_vacate_task, appeal: appeal, parent: mail_task, assigned_to: evaluator.associated_judge)
+        mail_task = create(
+          :vacate_motion_mail_task,
+          appeal: appeal,
+          parent: appeal.root_task,
+          assigned_to: evaluator.associated_judge
+        )
+        addr_task = create(
+          :judge_address_motion_to_vacate_task,
+          appeal: appeal,
+          parent: mail_task,
+          assigned_to: evaluator.associated_judge
+        )
         params = {
           disposition: "granted",
           vacate_type: "straight_vacate",

--- a/spec/factories/post_decision_motions.rb
+++ b/spec/factories/post_decision_motions.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :post_decision_motion do
-    task { create(:judge_address_motion_to_vacate_task) }
+    appeal { create(:appeal) }
     disposition { "granted" }
     vacate_type { "straight_vacate" }
 
     before(:create) do |post_decision_motion|
-      appeal = post_decision_motion.task.appeal
-      return unless appeal.reload.decision_issues.empty?
+      appeal = post_decision_motion.appeal
+      next unless appeal.reload.decision_issues.empty?
 
       3.times do |idx|
         create(

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -936,7 +936,8 @@ describe Appeal, :all_dbs do
     subject { appeal.vacate_type }
 
     context "Appeal is a vacatur and has a post-decision motion" do
-      let(:appeal) { create(:appeal, :straight_vacated) }
+      let(:original) { create(:appeal, :with_straight_vacate_stream) }
+      let(:appeal) { Appeal.vacate.find_by(stream_docket_number: original.docket_number) }
 
       it "returns the post-decision motion's vacate type" do
         expect(subject).to eq "straight_vacate"

--- a/spec/models/post_decision_motion_spec.rb
+++ b/spec/models/post_decision_motion_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe PostDecisionMotion, type: :model do
     create(
       :post_decision_motion,
       appeal: appeal,
+      task: task,
       disposition: disposition,
       vacate_type: vacate_type,
       vacated_decision_issue_ids: vacated_decision_issue_ids

--- a/spec/models/post_decision_motion_spec.rb
+++ b/spec/models/post_decision_motion_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PostDecisionMotion, type: :model do
   let(:post_decision_motion) do
     create(
       :post_decision_motion,
-      task: task,
+      appeal: appeal,
       disposition: disposition,
       vacate_type: vacate_type,
       vacated_decision_issue_ids: vacated_decision_issue_ids

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -245,6 +245,9 @@ describe PostDecisionMotionUpdater, :all_dbs do
     )
 
     expect(attorney_task).to_not be_nil
+
+    motion = PostDecisionMotion.first
+    expect(motion.appeal).to eq(vacate_stream)
   end
 
   def verify_decision_issues_created

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -104,10 +104,12 @@ describe PostDecisionMotionUpdater, :all_dbs do
         let(:vacate_type) { "vacate_and_de_novo" }
         let(:assigned_to_id) { nil }
 
-        it "should not create an attorney task" do
+        it "should not create a motion, vacate stream, or attorney task" do
           subject.process
           expect(subject.errors[:assigned_to].first).to eq "can't be blank"
           expect(task.reload.status).to eq Constants.TASK_STATUSES.in_progress
+          expect(Appeal.vacate.count).to eq 0
+          expect(PostDecisionMotion.count).to eq 0
           expect(AbstractMotionToVacateTask.count).to eq 0
         end
       end
@@ -116,10 +118,12 @@ describe PostDecisionMotionUpdater, :all_dbs do
         let(:vacate_type) { nil }
         let(:assigned_to_id) { attorney.id }
 
-        it "should not create an attorney task" do
+        it "should not create a motion, vacate stream, or attorney task" do
           subject.process
           expect(subject.errors[:vacate_type].first).to eq "is required for granted disposition"
           expect(task.reload.status).to eq Constants.TASK_STATUSES.in_progress
+          expect(Appeal.vacate.count).to eq 0
+          expect(PostDecisionMotion.count).to eq 0
           expect(AbstractMotionToVacateTask.count).to eq 0
         end
       end


### PR DESCRIPTION
Connects #13355 

### Description
This PR adds an `appeal_id` column to the PostDecisionMotion table and model. The logic surrounding the relationship between appeals/tasks and PDMs is cleaned up accordingly.

### Acceptance Criteria
- [ ] Add `post_decision_motions.appeal_id`
- [ ] For motions to vacate, the associated appeal should be the "Vacate" stream
- ~~Rails migrate suggested removing post_decision_motions.task_id in a separate migration.~~ We decided not to remove it after all.

### Testing Plan
1. Updated tests to match new association, and corrected the factory for appeals with a vacate stream
2. Manually tested migrate, rollback, and re-migrate for 4 PDMs, one with each disposition.

### Database Changes
*Only for Schema Changes*

* [ ] #appeals-schema notified with summary and link to this PR
