### PR TITLE
Fix test flakes

### DIFF
--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -43,11 +43,11 @@ class TaskSorter
   def order_clause
     case column.name
     when Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name
-      task_type_order_clause
+      Arel.sql(task_type_order_clause)
     when Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNER.name
-      assigner_order_clause
+      Arel.sql(assigner_order_clause)
     else
-      default_order_clause
+      Arel.sql(default_order_clause)
     end
   end
 

--- a/app/repositories/judge_repository.rb
+++ b/app/repositories/judge_repository.rb
@@ -3,7 +3,7 @@
 class JudgeRepository
   # :nocov:
   def self.find_all_judges
-    css_ids = judge_records.where.not(sdomainid: nil).pluck("UPPER(sdomainid)")
+    css_ids = judge_records.where.not(sdomainid: nil).pluck(:sdomainid).map(&:upcase)
 
     User.batch_find_by_css_id_or_create_with_default_station_id(css_ids)
   end

--- a/spec/models/concerns/task_tree_render_module_spec.rb
+++ b/spec/models/concerns/task_tree_render_module_spec.rb
@@ -1,32 +1,29 @@
 # frozen_string_literal: true
 
 describe TaskTreeRenderModule do
-  before { skip("Trying to get tests to pass") }
-  before(:all) do
-    @appeal = create(:appeal, :with_post_intake_tasks)
-    root = @appeal.root_task
-    create(:ama_judge_task, appeal: @appeal, parent: root, created_at: 1.day.ago)
-    create(:ama_attorney_task, parent: root, appeal: @appeal)
-    create(:ama_attorney_task, appeal: @appeal)
-  end
+  let(:appeal) { create(:appeal, :with_post_intake_tasks) }
+  let(:root_task) { appeal.root_task }
+  let!(:ama_judge_task) { create(:ama_judge_task, appeal: appeal, parent: root_task, created_at: 1.day.ago.round) }
+  let!(:ama_attorney_task) { create(:ama_attorney_task, parent: root_task, appeal: appeal) }
+  let!(:ama_attorney_task_no_parent) { create(:ama_attorney_task, appeal: appeal) }
 
   context "#tree is called on an appeal" do
     it "returns all tasks for the appeal" do
-      rows_hash, metadata = @appeal.tree_hash
+      rows_hash, metadata = appeal.tree_hash
       expect(rows_hash.count).to eq 1
-      expect(metadata.rows.count).to eq @appeal.tasks.count
-      expect(@appeal.tree.lines.count).to eq @appeal.tasks.count + 3
+      expect(metadata.rows.count).to eq appeal.tasks.count
+      expect(appeal.tree.lines.count).to eq appeal.tasks.count + 3
     end
 
     it "returns only specified attributes" do
-      _rows_hash, metadata = @appeal.tree_hash(:id, :status)
+      _rows_hash, metadata = appeal.tree_hash(:id, :status)
       expect(metadata.col_metadata.values.pluck(:label)).to eq %w[ID STATUS]
     end
 
     it "returns dereferenced column chain '[:assigned_to, :type]'" do
-      _rows_hash, metadata = @appeal.tree_hash(:id, [:assigned_to, :type])
+      _rows_hash, metadata = appeal.tree_hash(:id, [:assigned_to, :type])
       expect(metadata.col_metadata.values.pluck(:label)).to eq ["ID", "[:ASSIGNED_TO, :TYPE]"]
-      @appeal.tasks.each do |tsk|
+      appeal.tasks.each do |tsk|
         if tsk.assigned_to&.is_a?(Organization)
           expect(metadata.rows[tsk]["[:assigned_to, :type]"]).to eq tsk.assigned_to.type
         else
@@ -38,18 +35,18 @@ describe TaskTreeRenderModule do
     it "uses specified column labels" do
       atts = [:id, :status, :assigned_to_type, :parent_id, [:assigned_to, :type], :created_at]
       col_labels = ["\#", "Status", "AssignToType", "P_ID", "ASGN_TO", "Created"]
-      _rows_hash, metadata = @appeal.tree_hash(*atts, col_labels: col_labels)
+      _rows_hash, metadata = appeal.tree_hash(*atts, col_labels: col_labels)
 
       expect(metadata.col_metadata.values.pluck(:label)).to eq col_labels
     end
 
     it "returns column values that result from calling the specified lambda" do
-      @appeal.global_renderer.config.value_funcs_hash["ASGN_TO.TYPE"] = ->(task) { task.assigned_to.type }
-      @appeal.global_renderer.config.value_funcs_hash[:ASGN_TO_CSSID] = ->(task) { task.assigned_to.css_id }
+      appeal.global_renderer.config.value_funcs_hash["ASGN_TO.TYPE"] = ->(task) { task.assigned_to.type }
+      appeal.global_renderer.config.value_funcs_hash[:ASGN_TO_CSSID] = ->(task) { task.assigned_to.css_id }
 
-      error_char = @appeal.global_renderer.config.func_error_char
-      _rows_hash, metadata = @appeal.tree_hash(:id, :status, :assigned_to_type, "ASGN_TO.TYPE", :ASGN_BY, :ASGN_TO)
-      @appeal.tasks.each do |tsk|
+      error_char = appeal.global_renderer.config.func_error_char
+      _rows_hash, metadata = appeal.tree_hash(:id, :status, :assigned_to_type, "ASGN_TO.TYPE", :ASGN_BY, :ASGN_TO)
+      appeal.tasks.each do |tsk|
         expect(metadata.rows[tsk]["ASGN_TO.TYPE"]).to eq tsk.assigned_to&.type if tsk.assigned_to.is_a?(Organization)
         expect(metadata.rows[tsk]["ASGN_TO.TYPE"]).to eq error_char if tsk.assigned_to.is_a?(User)
       end
@@ -58,31 +55,31 @@ describe TaskTreeRenderModule do
 
   context "#tree is called on a task" do
     def check_for_highlight(metadata, task_to_highlight)
-      highlight_char = @appeal.global_renderer.config.highlight_char
+      highlight_char = appeal.global_renderer.config.highlight_char
       expect(metadata.rows[task_to_highlight][" "]).to eq highlight_char
 
-      @appeal.tasks.each do |tsk|
+      appeal.tasks.each do |tsk|
         expect(metadata.rows[tsk][" "]).to eq " " unless tsk == task_to_highlight
       end
     end
 
     it "highlights self task with an asterisk" do
-      task_to_highlight = @appeal.tasks.sample
+      task_to_highlight = appeal.tasks.sample # TODO: do we need .sample ?
       _rows_hash, metadata = task_to_highlight.tree_hash(" ", :id, :status)
       check_for_highlight(metadata, task_to_highlight)
     end
 
     it "highlights specified task with an asterisk, even if no columns are specified" do
-      task_to_highlight = @appeal.tasks.sample
-      _rows_hash, metadata = @appeal.root_task.tree_hash(highlight: task_to_highlight.id)
+      task_to_highlight = appeal.tasks.sample
+      _rows_hash, metadata = appeal.root_task.tree_hash(highlight: task_to_highlight.id)
       check_for_highlight(metadata, task_to_highlight)
     end
 
     it "highlights specified task with an asterisk, even if highlight column is not specified" do
-      task_to_highlight = @appeal.tasks.sample
-      @appeal.global_renderer.config.default_atts = [:id, :status, :CLO_DATE, :CRE_TIME]
+      task_to_highlight = appeal.tasks.sample
+      appeal.global_renderer.config.default_atts = [:id, :status, :CLO_DATE, :CRE_TIME]
 
-      _rows_hash, metadata = @appeal.root_task.tree_hash(highlight: task_to_highlight.id)
+      _rows_hash, metadata = appeal.root_task.tree_hash(highlight: task_to_highlight.id)
       check_for_highlight(metadata, task_to_highlight)
     end
   end
@@ -107,12 +104,12 @@ describe TaskTreeRenderModule do
     end
 
     it "prints all tasks" do
-      num_lines = @appeal.tasks.count + 1
-      expect((tree1 @appeal).lines.count).to eq num_lines
-      expect((tree2 @appeal, :id, :status).lines.count).to eq num_lines
+      num_lines = appeal.tasks.count + 1
+      expect((tree1 appeal).lines.count).to eq num_lines
+      expect((tree2 appeal, :id, :status).lines.count).to eq num_lines
     end
     it "should raise error" do
-      expect { tree2 @appeal, :id, :status, renderer: "any value" }.to raise_error(RuntimeError)
+      expect { tree2 appeal, :id, :status, renderer: "any value" }.to raise_error(RuntimeError)
     end
   end
 end

--- a/spec/models/concerns/task_tree_render_module_spec.rb
+++ b/spec/models/concerns/task_tree_render_module_spec.rb
@@ -64,7 +64,7 @@ describe TaskTreeRenderModule do
     end
 
     it "highlights self task with an asterisk" do
-      task_to_highlight = appeal.tasks.sample # TODO: do we need .sample ?
+      task_to_highlight = appeal.tasks.sample
       _rows_hash, metadata = task_to_highlight.tree_hash(" ", :id, :status)
       check_for_highlight(metadata, task_to_highlight)
     end

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -8,16 +8,16 @@ describe ETL::Builder, :etl, :all_dbs do
   let!(:vacols_user1) { create(:staff, :judge_role) }
   let!(:vacols_user2) { create(:staff, :attorney_judge_role) }
   let!(:user1) { create(:user, css_id: vacols_user1.sdomainid) }
-  let!(:user2) { create(:user, css_id: vacols_user2.sdomainid, updated_at: 3.days.ago) }
+  let!(:user2) { create(:user, css_id: vacols_user2.sdomainid, updated_at: 3.days.ago.round) }
   let!(:user3) { create(:user) }
-  let!(:org1) { create(:organization, updated_at: 3.days.ago) }
+  let!(:org1) { create(:organization, updated_at: 3.days.ago.round) }
   let!(:org2) { create(:organization) }
   let!(:org_user1) { create(:organizations_user, user: user, organization: org1) }
-  let!(:org_user2) { create(:organizations_user, user: user, organization: org2, updated_at: 3.days.ago) }
+  let!(:org_user2) { create(:organizations_user, user: user, organization: org2, updated_at: 3.days.ago.round) }
   let(:user) { create(:user) }
 
   before do
-    Timecop.travel(3.days.ago) do
+    Timecop.travel(3.days.ago.round) do
       CachedUser.sync_from_vacols
     end
 
@@ -60,14 +60,14 @@ describe ETL::Builder, :etl, :all_dbs do
 
       # change dob for one active
       ETL::Appeal.active.where(aod_due_to_dob: false)
-        .where("claimant_dob > ?", 76.years.ago).first
-        .update(claimant_dob: 76.years.ago)
+        .where("claimant_dob > ?", 76.years.ago.round).first
+        .update(claimant_dob: 76.years.ago.round)
 
       # and for one inactive
       ETL::Appeal.where(aod_due_to_dob: false)
         .where(active_appeal: false)
-        .where("claimant_dob > ?", 76.years.ago).first
-        .update(claimant_dob: 76.years.ago)
+        .where("claimant_dob > ?", 76.years.ago.round).first
+        .update(claimant_dob: 76.years.ago.round)
 
       builder = described_class.new(since: Time.zone.now + 1.day)
       built = builder.incremental
@@ -97,7 +97,7 @@ describe ETL::Builder, :etl, :all_dbs do
   end
 
   describe "#incremental" do
-    subject { described_class.new(since: 2.days.ago).incremental }
+    subject { described_class.new(since: 2.days.ago.round).incremental }
 
     context "BVA status distribution" do
       it "syncs only records that have changed" do

--- a/spec/services/etl/organization_syncer_spec.rb
+++ b/spec/services/etl/organization_syncer_spec.rb
@@ -2,11 +2,11 @@
 
 describe ETL::OrganizationSyncer, :etl do
   describe "#call" do
-    let!(:org1) { create(:organization, updated_at: 3.days.ago) }
+    let!(:org1) { create(:organization, updated_at: 3.days.ago.round) }
     let!(:org2) { create(:organization) }
 
     context "2 org records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       it "syncs 1 record" do
         expect(ETL::Organization.all.count).to eq(0)
@@ -31,7 +31,7 @@ describe ETL::OrganizationSyncer, :etl do
     end
 
     context "origin Org record changes" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       before do
         described_class.new.call

--- a/spec/services/etl/organizations_user_syncer_spec.rb
+++ b/spec/services/etl/organizations_user_syncer_spec.rb
@@ -3,13 +3,13 @@
 describe ETL::OrganizationsUserSyncer, :etl do
   describe "#call" do
     let!(:org_user1) { create(:organizations_user, user: user, organization: org1) }
-    let!(:org_user2) { create(:organizations_user, user: user, organization: org2, updated_at: 3.days.ago) }
+    let!(:org_user2) { create(:organizations_user, user: user, organization: org2, updated_at: 3.days.ago.round) }
     let(:org1) { create(:organization) }
     let(:org2) { create(:organization) }
     let(:user) { create(:user) }
 
     context "2 org_user records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       it "syncs 1 record" do
         expect(ETL::OrganizationsUser.all.count).to eq(0)
@@ -34,7 +34,7 @@ describe ETL::OrganizationsUserSyncer, :etl do
     end
 
     context "origin record changes" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       before do
         described_class.new.call

--- a/spec/services/etl/person_syncer_spec.rb
+++ b/spec/services/etl/person_syncer_spec.rb
@@ -2,11 +2,11 @@
 
 describe ETL::PersonSyncer, :etl do
   describe "#call" do
-    let!(:person1) { create(:person, updated_at: 3.days.ago) }
+    let!(:person1) { create(:person, updated_at: 3.days.ago.round) }
     let!(:person2) { create(:person) }
 
     context "2 person records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       it "syncs 1 record" do
         expect(ETL::Person.all.count).to eq(0)
@@ -31,7 +31,7 @@ describe ETL::PersonSyncer, :etl do
     end
 
     context "origin Person record changes" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       before do
         described_class.new.call

--- a/spec/services/etl/user_syncer_spec.rb
+++ b/spec/services/etl/user_syncer_spec.rb
@@ -5,17 +5,17 @@ describe ETL::UserSyncer, :etl do
     let!(:vacols_user1) { create(:staff, :judge_role) }
     let!(:vacols_user2) { create(:staff, :attorney_judge_role) }
     let!(:user1) { create(:user, css_id: vacols_user1.sdomainid) }
-    let!(:user2) { create(:user, css_id: vacols_user2.sdomainid, updated_at: 3.days.ago) }
+    let!(:user2) { create(:user, css_id: vacols_user2.sdomainid, updated_at: 3.days.ago.round) }
     let!(:user3) { create(:user) }
 
     before do
-      Timecop.travel(3.days.ago) do
+      Timecop.travel(3.days.ago.round) do
         CachedUser.sync_from_vacols
       end
     end
 
     context "3 User records, 2 needing sync" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       it "syncs 2 records" do
         expect(ETL::User.all.count).to eq(0)
@@ -30,7 +30,7 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "VACOLS attribute changes" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       before do
         described_class.new.call
@@ -61,7 +61,7 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "origin User record changes" do
-      subject { described_class.new(since: 2.days.ago).call }
+      subject { described_class.new(since: 2.days.ago.round).call }
 
       before do
         described_class.new.call

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -68,12 +68,12 @@ RSpec.configure do |config|
   end
 
   config.before(:each, :etl) do
-    puts "DatabaseCleaner.start ETL"
+    Rails.logger.info("DatabaseCleaner.start ETL")
     DatabaseCleaner[:active_record, { connection: etl }].start
   end
 
   config.append_after(:each, :etl) do
     DatabaseCleaner[:active_record, { connection: etl }].clean
-    puts "DatabaseCleaner.clean ETL"
+    Rails.logger.info("DatabaseCleaner.clean ETL")
   end
 end


### PR DESCRIPTION
Try addressing flakey tests via:

* better datetime precision[0]
* avoid `before(:all)` except in global rspec config

[0] Idea via https://www.toptal.com/ruby-on-rails/timestamp-truncation-rails-activerecord-tale