### PR TITLE
Upstream Error | Do not fetch contentions for canceled EP to prevent FileNumberNotFoundForClaimID error

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -195,15 +195,14 @@ class EndProductEstablishment < ApplicationRecord
     # load contentions now, in case "source" needs them.
     # this VBMS call is slow and will cause the transaction below
     # to timeout in some cases.
-    contentions
+    contentions unless status_canceled?
 
     transaction do
       update!(
         synced_status: result.status_type_code,
         last_synced_at: Time.zone.now
       )
-      sync_source!
-      handle_canceled_ep!
+      status_canceled? ? handle_canceled_ep! : sync_source!
       close_request_issues_with_no_decision!
     end
 

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -195,7 +195,7 @@ class EndProductEstablishment < ApplicationRecord
     # load contentions now, in case "source" needs them.
     # this VBMS call is slow and will cause the transaction below
     # to timeout in some cases.
-    contentions unless status_canceled?
+    contentions unless result.status_type_code == EndProduct::STATUSES.key("Canceled")
 
     transaction do
       update!(

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -890,11 +890,13 @@ describe EndProductEstablishment, :postgres do
       end
 
       context "when the end product is canceled" do
-        let(:status_type_code) { "CAN" }
+        before { allow(Fakes::VBMSService).to receive(:fetch_contentions).and_call_original }
+        let(:status_type_code) { EndProduct::STATUSES.key("Canceled") }
 
-        it "closes request issues and cancels establishment" do
+        it "closes request issues, cancels establishment, and doesn't fetch contentions" do
           subject
 
+          expect(Fakes::VBMSService).to_not have_received(:fetch_contentions)
           expect(end_product_establishment.reload.synced_status).to eq("CAN")
           expect(end_product_establishment.source.canceled?).to be true
           expect(request_issues.first.reload.closed_at).to eq(Time.zone.now)


### PR DESCRIPTION
connects #11787

### Description
Some EPs get canceled before contentions have been created. In this case, when we try to sync them, fetching the contentions fails, returning the FileNumberNotFoundForClaimId error.

This PR does not try to fetch the contentions or sync the source if the EP has been cancelled, instead just updating the status and closing the request issues.