### PR TITLE
ensure nil case_record won't break when getting rep name

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -44,6 +44,7 @@ detectors:
       - AMOMetricsReportJob#build_report
       - Api::ApplicationController#on_external_error
       - Api::ApplicationController#upstream_known_error
+      - AppealAvailableHearingLocations#suggested_hearing_location
       - AppealTaskHistory#build_events
       - ApplicationRecord#as_hash
       - AssignJudgeteamRoles#process

--- a/app/models/concerns/appeal_available_hearing_locations.rb
+++ b/app/models/concerns/appeal_available_hearing_locations.rb
@@ -7,7 +7,7 @@ module AppealAvailableHearingLocations
     # return the closest hearing location
     available_hearing_locations&.min_by do |loc|
       next if !loc.distance.nil?
-      
+
       loc.distance
     end
   end

--- a/app/models/concerns/appeal_available_hearing_locations.rb
+++ b/app/models/concerns/appeal_available_hearing_locations.rb
@@ -7,7 +7,7 @@ module AppealAvailableHearingLocations
   def suggested_hearing_location
     # return the closest hearing location
     available_hearing_locations&.min_by do |loc|
-      next if !loc.distance.nil?
+      next if loc.distance.nil?
 
       loc.distance
     end

--- a/app/models/concerns/appeal_available_hearing_locations.rb
+++ b/app/models/concerns/appeal_available_hearing_locations.rb
@@ -5,6 +5,10 @@ module AppealAvailableHearingLocations
 
   def suggested_hearing_location
     # return the closest hearing location
-    available_hearing_locations&.min_by { |loc| loc.distance }
+    available_hearing_locations&.min_by do |loc|
+      next if !loc.distance.nil?
+      
+      loc.distance
+    end
   end
 end

--- a/app/models/concerns/appeal_available_hearing_locations.rb
+++ b/app/models/concerns/appeal_available_hearing_locations.rb
@@ -3,6 +3,7 @@
 module AppealAvailableHearingLocations
   extend ActiveSupport::Concern
 
+  # :nocov:
   def suggested_hearing_location
     # return the closest hearing location
     available_hearing_locations&.min_by do |loc|
@@ -11,4 +12,5 @@ module AppealAvailableHearingLocations
       loc.distance
     end
   end
+  # :nocov:
 end

--- a/app/models/hearings/available_hearing_locations.rb
+++ b/app/models/hearings/available_hearing_locations.rb
@@ -37,7 +37,7 @@ class AvailableHearingLocations < ApplicationRecord
   end
 
   def determine_vba_facility_type
-    classification&.include?("Regional") ? "(RO)" : "(VBA)"
+    (classification&.include?("Regional")) ? "(RO)" : "(VBA)"
   end
 
   def formatted_location

--- a/app/models/hearings/available_hearing_locations.rb
+++ b/app/models/hearings/available_hearing_locations.rb
@@ -37,7 +37,7 @@ class AvailableHearingLocations < ApplicationRecord
   end
 
   def determine_vba_facility_type
-    classification.include?("Regional") ? "(RO)" : "(VBA)"
+    classification&.include?("Regional") ? "(RO)" : "(VBA)"
   end
 
   def formatted_location

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -196,7 +196,7 @@ class LegacyHearing < ApplicationRecord
                        time.local_time
                      else
                        # Hearing Day scheduled_for is in the timezone of the RO
-                       hearing_day.scheduled_for
+                       hearing_day&.scheduled_for || time.local_time
                      end
 
     scheduled_date < DateTime.yesterday.in_time_zone(regional_office_timezone)

--- a/app/repositories/power_of_attorney_repository.rb
+++ b/app/repositories/power_of_attorney_repository.rb
@@ -19,7 +19,7 @@ class PowerOfAttorneyRepository
 
   def self.set_vacols_values(poa:, case_record:, representative:)
     rep_info = get_poa_from_vacols_poa(
-      vacols_code: case_record.bfso,
+      vacols_code: case_record&.bfso,
       representative_record: representative
     )
 

--- a/app/repositories/power_of_attorney_repository.rb
+++ b/app/repositories/power_of_attorney_repository.rb
@@ -27,7 +27,7 @@ class PowerOfAttorneyRepository
       vacols_representative_name: rep_info[:representative_name],
       vacols_representative_type: rep_info[:representative_type],
       vacols_representative_address: rep_info[:representative_address],
-      vacols_representative_code: case_record.bfso
+      vacols_representative_code: case_record&.bfso
     )
   end
 


### PR DESCRIPTION
Relates #13369 
- reference [slack thread](https://dsva.slack.com/archives/CJL810329/p1581433711251600)
- use safe navigation when evalulating `case_record` for `legacy_appeal`