### PR TITLE
Update error message for duplicate veteran records

### DIFF
--- a/client/app/intake/pages/search.jsx
+++ b/client/app/intake/pages/search.jsx
@@ -94,12 +94,9 @@ class Search extends React.PureComponent {
       veteran_has_duplicate_records_in_corpdb: {
         title: 'Duplicate veteran records',
         body: <React.Fragment key="alert-error-body">
-          {'This Veteran has a duplicate record in CorpDB. Please submit an incident in '}
-          { YourITLink }
-          {' requesting that the duplicate record be removed. Include the veteran\'s first ' +
-              'initial, last name, the last 4 digits of their file number or SSN, and the ' +
-              `following participant IDs: [${searchErrorData.pids}]. The ticket should be ` +
-              'routed to the PHI SME Compensation Corporate Records Group'}
+          {'This Veteran has a duplicate record in the Corporate database (CorpDB). Please ' +
+              'follow your locally established procedures for addressing duplicate records ' +
+              'to the assigned point-of-contact of the regional office.'}
         </React.Fragment>
       },
       veteran_not_accessible: {

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -286,8 +286,7 @@ feature "Intake", :all_dbs do
         click_on "Search"
 
         expect(page).to have_current_path("/intake/search")
-        expect(page).to have_content("This Veteran has a duplicate record in CorpDB")
-        expect(page).to have_content("[#{participant_id1}, #{participant_id2}]")
+        expect(page).to have_content("This Veteran has a duplicate record in the Corporate database")
       end
     end
 


### PR DESCRIPTION
Connects #13240 

### Description
Update the message shown to intake users when they encounter a duplicate veteran record error.

### Acceptance Criteria
- [ ] As an Intake user, when I encounter error associated to a veteran having a duplicate record, show alert with updated copy below.

### Testing Plan
1. Force `IntakeStartValidator#validate_veteran` to always set the `:veteran_has_duplicate_records_in_corpdb` error, and attempt to start an intake with any veteran ID.

### User Facing Changes

Screenshot of new error message:
<img width="642" alt="Screen Shot 2020-02-12 at 14 19 56" src="https://user-images.githubusercontent.com/282869/74369470-6b188b00-4da3-11ea-9fa0-ffb71791ebd4.png">
