### PR TITLE
ETL Build tables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ jobs:
       - image: circleci/postgres:9.6
         environment:
           - POSTGRES_USER: root
+            POSTGRES_PASSWORD: password
             POSTGRES_DB: caseflow_certification_test
 
       # This is our homespun VACOLS container. An oracle db with some special sauce.

--- a/.reek.yml
+++ b/.reek.yml
@@ -82,6 +82,7 @@ detectors:
       - Task
       - CaseflowJob
       - Api::V3::DecisionReview::HigherLevelReviewIntakeProcessor
+      - ETL::Syncer
       - User
   IrresponsibleModule:
     enabled: false

--- a/app/jobs/etl_builder_job.rb
+++ b/app/jobs/etl_builder_job.rb
@@ -18,12 +18,12 @@ class ETLBuilderJob < CaseflowJob
   private
 
   def build_etl
-    built = ETL::Builder.new.incremental
+    etl_build = ETL::Builder.new.incremental
 
     datadog_report_runtime(metric_group_name: DATADOG_NAME)
 
     msg = "ETL failed to sync any records"
 
-    slack_service.send_notification(msg, self.class.to_s, SLACK_CHANNEL) if built == 0
+    slack_service.send_notification(msg, self.class.to_s, SLACK_CHANNEL) if etl_build.built == 0
   end
 end

--- a/app/models/etl/build.rb
+++ b/app/models/etl/build.rb
@@ -22,4 +22,8 @@ class ETL::Build < ETL::Record
     etl_build_tables.each { |ebt| built += ebt.rows_built }
     built
   end
+
+  def build_for(table_name)
+    etl_build_tables.find { |ebt| ebt.table_name == table_name }
+  end
 end

--- a/app/models/etl/build.rb
+++ b/app/models/etl/build.rb
@@ -5,5 +5,21 @@
 class ETL::Build < ETL::Record
   self.table_name = "etl_builds"
 
+  enum status: {
+    running: "running",
+    complete: "complete",
+    error: "error"
+  }
+
   has_many :etl_build_tables, class_name: "ETL::BuildTable", foreign_key: "etl_build_id"
+
+  def tables
+    etl_build_tables.pluck(:table_name).compact
+  end
+
+  def built
+    built = 0
+    etl_build_tables.each { |ebt| built += ebt.rows_built }
+    built
+  end
 end

--- a/app/models/etl/build.rb
+++ b/app/models/etl/build.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# metadata about an ETL build
+
+class ETL::Build < ETL::Record
+  self.table_name = "etl_builds"
+
+  has_many :etl_build_tables, class_name: "ETL::BuildTable", foreign_key: "etl_build_id"
+end

--- a/app/models/etl/build_table.rb
+++ b/app/models/etl/build_table.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# metadata about an ETL build per table
+
+class ETL::BuildTable < ETL::Record
+  self.table_name = "etl_build_tables"
+
+  belongs_to :etl_build, class_name: "ETL::Build"
+end

--- a/app/models/etl/build_table.rb
+++ b/app/models/etl/build_table.rb
@@ -5,5 +5,15 @@
 class ETL::BuildTable < ETL::Record
   self.table_name = "etl_build_tables"
 
+  enum status: {
+    running: "running",
+    complete: "complete",
+    error: "error"
+  }
+
   belongs_to :etl_build, class_name: "ETL::Build"
+
+  def rows_built
+    (rows_inserted || 0) + (rows_updated || 0) - (rows_deleted || 0)
+  end
 end

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -76,7 +76,9 @@ class ETL::Builder
   end
 
   def checkmark
-    Rails.cache.write(CHECKPOINT_KEY, Time.zone.now.to_s)
+    now = Time.zone.now.to_s
+    Rails.logger.info("ETL::Builder.checkmark #{now}")
+    Rails.cache.write(CHECKPOINT_KEY, now)
   end
 
   def post_build_steps

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -25,7 +25,6 @@ class ETL::Builder
 
   def incremental
     checkmark
-    create_build_record
     syncer_klasses.each do |klass|
       klass.new(since: since).call(build_record)
     end
@@ -35,8 +34,7 @@ class ETL::Builder
 
   def full
     checkmark
-    create_build_record
-    syncer_klasses.each { |klass| klass.new.call }
+    syncer_klasses.each { |klass| klass.new.call(build_record) }
     post_build_steps
     update_build_record
   end
@@ -51,8 +49,8 @@ class ETL::Builder
 
   private
 
-  def create_build_record
-    @build_record = ETL::Build.create(started_at: Time.zone.now, status: :running)
+  def build_record
+    @build_record ||= ETL::Build.create(started_at: Time.zone.now, status: :running)
   end
 
   def update_build_record

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -21,7 +21,7 @@ class ETL::Builder
     @since = since
   end
 
-  attr_reader :since, :build_record
+  attr_reader :since
 
   def incremental
     checkmark
@@ -47,11 +47,11 @@ class ETL::Builder
     Time.zone.parse(checkpoint)
   end
 
-  private
-
   def build_record
     @build_record ||= ETL::Build.create(started_at: Time.zone.now, status: :running)
   end
+
+  private
 
   def update_build_record
     build_record.update!(finished_at: Time.zone.now, status: :complete)

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -54,7 +54,12 @@ class ETL::Builder
   private
 
   def update_build_record
-    build_record.update!(finished_at: Time.zone.now, status: :complete)
+    status = build_record.reload.etl_build_tables.any?(&:error?) ? :error : :complete
+    comments = nil
+    if status == :error
+      comments = build_record.etl_build_tables.error.map(&:comments).join("\n")
+    end
+    build_record.update!(finished_at: Time.zone.now, status: status, comments: comments)
     build_record
   end
 

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -30,6 +30,9 @@ class ETL::Builder
     end
     post_build_steps
     update_build_record
+  rescue StandardError => error
+    update_build_record
+    raise error
   end
 
   def full
@@ -37,6 +40,9 @@ class ETL::Builder
     syncer_klasses.each { |klass| klass.new.call(build_record) }
     post_build_steps
     update_build_record
+  rescue StandardError => error
+    update_build_record
+    raise error
   end
 
   def built

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -52,6 +52,8 @@ class ETL::Syncer
         status: :error,
         finished_at: Time.zone.now
       )
+      # re-raise so sentry and parent build record know.
+      raise error
     end
     build_record
   end

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -20,7 +20,7 @@ class ETL::Syncer
     rejected = 0
     instances_needing_update.find_in_batches.with_index do |originals, batch|
       Rails.logger.debug("Starting batch #{batch} for #{target_class}")
-      create_build_record(etl_build) # create inside the loop so we reflect what we actually update
+      build_record(etl_build) # create inside the loop so we reflect what we actually update
       target_class.transaction do
         possible = originals.length
         saved = 0
@@ -76,7 +76,7 @@ class ETL::Syncer
 
   attr_reader :since, :build_record
 
-  def create_build_record(etl_build)
+  def build_record(etl_build)
     @build_record ||= ETL::BuildTable.create(
       etl_build: etl_build,
       table_name: target_class.table_name,

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -18,9 +18,9 @@ class ETL::Syncer
     inserted = 0
     updated = 0
     rejected = 0
-    create_build_record(etl_build)
     instances_needing_update.find_in_batches.with_index do |originals, batch|
       Rails.logger.debug("Starting batch #{batch} for #{target_class}")
+      create_build_record(etl_build) # create inside the loop so we reflect what we actually update
       target_class.transaction do
         possible = originals.length
         saved = 0
@@ -75,7 +75,7 @@ class ETL::Syncer
   attr_reader :since, :build_record
 
   def create_build_record(etl_build)
-    @build_record = ETL::BuildTable.create(
+    @build_record ||= ETL::BuildTable.create(
       etl_build: etl_build,
       table_name: target_class.table_name,
       started_at: Time.zone.now,

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -74,9 +74,11 @@ class ETL::Syncer
 
   private
 
-  attr_reader :since, :build_record
+  attr_reader :since
 
-  def build_record(etl_build)
+  def build_record(etl_build = nil)
+    return if etl_build.nil? && @build_record.nil?
+
     @build_record ||= ETL::BuildTable.create(
       etl_build: etl_build,
       table_name: target_class.table_name,

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -13,6 +13,7 @@ class ETL::Syncer
   end
 
   # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def call(etl_build)
     inserted = 0
     updated = 0
@@ -55,6 +56,7 @@ class ETL::Syncer
     build_record
   end
   # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   def origin_class
     fail "Must override abstract method origin_class"

--- a/db/etl/migrate/20200212205344_add_etl_build_tables.rb
+++ b/db/etl/migrate/20200212205344_add_etl_build_tables.rb
@@ -1,0 +1,41 @@
+class AddEtlBuildTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :etl_builds, comment: "ETL build metadata for each job" do |t|
+      t.datetime "started_at", comment: "Build start time (usually identical to created_at)"
+      t.datetime "finished_at", comment: "Build end time"
+      t.string "status", comment: "Enum value: running, complete, error"
+      t.string "comments", comment: "Ad hoc comments (e.g. error message)"
+      t.datetime "created_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+      t.datetime "updated_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+
+      t.index ["status"]
+      t.index ["created_at"]
+      t.index ["updated_at"]
+      t.index ["started_at"]
+      t.index ["finished_at"]
+    end
+
+    create_table :etl_build_tables, comment: "ETL table metadata, one for each table per-build" do |t|
+      t.bigint "etl_build_id", null: false, comment: "PK of the etl_build"
+      t.datetime "started_at", comment: "Build start time (usually identical to created_at)"
+      t.datetime "finished_at", comment: "Build end time"
+      t.string "table_name", comment: "Name of the ETL table"
+      t.string "status", comment: "Enum value: running, complete, error"
+      t.string "comments", comment: "Ad hoc comments (e.g. error message)"
+      t.bigint "rows_inserted", comment: "Number of new rows"
+      t.bigint "rows_updated", comment: "Number of rows changed"
+      t.bigint "rows_deleted", comment: "Number of rows deleted"
+      t.bigint "rows_rejected", comment: "Number of rows skipped"
+      t.datetime "created_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+      t.datetime "updated_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+
+      t.index ["etl_build_id"]
+      t.index ["table_name"]
+      t.index ["status"]
+      t.index ["created_at"]
+      t.index ["updated_at"]
+      t.index ["started_at"]
+      t.index ["finished_at"]
+    end
+  end
+end

--- a/db/etl/migrate/20200212205344_add_etl_build_tables.rb
+++ b/db/etl/migrate/20200212205344_add_etl_build_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddEtlBuildTables < ActiveRecord::Migration[5.2]
   def change
     create_table :etl_builds, comment: "ETL build metadata for each job" do |t|

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_21_221718) do
+ActiveRecord::Schema.define(version: 2020_02_12_205344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,6 +149,42 @@ ActiveRecord::Schema.define(version: 2020_01_21_221718) do
     t.index ["updated_at"], name: "index_decision_issues_on_updated_at"
   end
 
+  create_table "etl_build_tables", comment: "ETL table metadata, one for each table per-build", force: :cascade do |t|
+    t.string "comments", comment: "Ad hoc comments (e.g. error message)"
+    t.datetime "created_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+    t.bigint "etl_build_id", null: false, comment: "PK of the etl_build"
+    t.datetime "finished_at", comment: "Build end time"
+    t.bigint "rows_deleted", comment: "Number of rows deleted"
+    t.bigint "rows_inserted", comment: "Number of new rows"
+    t.bigint "rows_rejected", comment: "Number of rows skipped"
+    t.bigint "rows_updated", comment: "Number of rows changed"
+    t.datetime "started_at", comment: "Build start time (usually identical to created_at)"
+    t.string "status", comment: "Enum value: running, complete, error"
+    t.string "table_name", comment: "Name of the ETL table"
+    t.datetime "updated_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+    t.index ["created_at"], name: "index_etl_build_tables_on_created_at"
+    t.index ["etl_build_id"], name: "index_etl_build_tables_on_etl_build_id"
+    t.index ["finished_at"], name: "index_etl_build_tables_on_finished_at"
+    t.index ["started_at"], name: "index_etl_build_tables_on_started_at"
+    t.index ["status"], name: "index_etl_build_tables_on_status"
+    t.index ["table_name"], name: "index_etl_build_tables_on_table_name"
+    t.index ["updated_at"], name: "index_etl_build_tables_on_updated_at"
+  end
+
+  create_table "etl_builds", comment: "ETL build metadata for each job", force: :cascade do |t|
+    t.string "comments", comment: "Ad hoc comments (e.g. error message)"
+    t.datetime "created_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+    t.datetime "finished_at", comment: "Build end time"
+    t.datetime "started_at", comment: "Build start time (usually identical to created_at)"
+    t.string "status", comment: "Enum value: running, complete, error"
+    t.datetime "updated_at", null: false, comment: "Default created_at/updated_at for the ETL record"
+    t.index ["created_at"], name: "index_etl_builds_on_created_at"
+    t.index ["finished_at"], name: "index_etl_builds_on_finished_at"
+    t.index ["started_at"], name: "index_etl_builds_on_started_at"
+    t.index ["status"], name: "index_etl_builds_on_status"
+    t.index ["updated_at"], name: "index_etl_builds_on_updated_at"
+  end
+
   create_table "organizations", comment: "Copy of Organizations table", force: :cascade do |t|
     t.datetime "created_at"
     t.string "name"
@@ -180,7 +216,7 @@ ActiveRecord::Schema.define(version: 2020_01_21_221718) do
   create_table "people", comment: "Copy of People table", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date_of_birth"
-    t.string "email_address"
+    t.string "email_address", comment: "Person email address, cached from BGS"
     t.string "first_name", limit: 50, comment: "Person first name, cached from BGS"
     t.string "last_name", limit: 50, comment: "Person last name, cached from BGS"
     t.string "middle_name", limit: 50, comment: "Person middle name, cached from BGS"

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -48,9 +48,9 @@ FactoryBot.define do
 
     transient do
       associated_attorney do
-        judge = User.find_or_create_by(css_id: "BVAAABSHIRE", station_id: 101)
+        judge = User.find_or_create_by(css_id: "BVAAABSHIRE", full_name: "BVAAABSHIRE", station_id: 101)
         judge_team = JudgeTeam.for_judge(judge) || JudgeTeam.create_for_judge(judge)
-        attorney = User.find_or_create_by(css_id: "BVAEERDMAN", station_id: 101)
+        attorney = User.find_or_create_by(css_id: "BVAEERDMAN", full_name: "BVAEERDMAN", station_id: 101)
         judge_team.add_user(attorney)
         create(:staff, :attorney_role, sdomainid: attorney.css_id)
 
@@ -60,7 +60,7 @@ FactoryBot.define do
 
     transient do
       associated_judge do
-        judge = User.find_or_create_by(css_id: "BVAAABSHIRE", station_id: 101)
+        judge = User.find_or_create_by(css_id: "BVAAABSHIRE", full_name: "BVAAABSHIRE", station_id: 101)
         JudgeTeam.for_judge(judge) || JudgeTeam.create_for_judge(judge)
         create(:staff, :judge_role, sdomainid: judge.css_id)
 

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -77,7 +77,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
       end
 
       it "syncs" do
-        subject # no error proves the test passes
+        expect { subject }.to_not raise_error
 
         expect(ETL::Appeal.count).to eq(14)
       end

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -57,9 +57,11 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
       let!(:appeal) { create(:appeal, established_at: nil) }
 
       it "skips non-established Appeals" do
-        subject
+        etl_build_table = subject
 
         expect(ETL::Appeal.count).to eq(13)
+        expect(etl_build_table.rows_rejected).to eq(0) # not part of .filter so we can't know about it.
+        expect(etl_build_table.rows_inserted).to eq(13)
       end
     end
 
@@ -75,7 +77,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
       end
 
       it "syncs" do
-        subject
+        subject # no error proves the test passes
 
         expect(ETL::Appeal.count).to eq(14)
       end

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -5,6 +5,8 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
 
   include_context "AMA Tableau SQL"
 
+  let(:etl_build) { ETL::Build.create }
+
   describe "#origin_class" do
     subject { described_class.new.origin_class }
 
@@ -18,7 +20,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
   end
 
   describe "#call" do
-    subject { described_class.new.call }
+    subject { described_class.new.call(etl_build) }
 
     before do
       expect(ETL::Appeal.count).to eq(0)
@@ -42,7 +44,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
     end
 
     context "sync tomorrow" do
-      subject { described_class.new(since: Time.zone.now + 1.day).call }
+      subject { described_class.new(since: Time.zone.now + 1.day).call(etl_build) }
 
       it "does not sync" do
         subject

--- a/spec/services/etl/attorney_case_review_syncer_spec.rb
+++ b/spec/services/etl/attorney_case_review_syncer_spec.rb
@@ -11,6 +11,8 @@ describe ETL::AttorneyCaseReviewSyncer, :etl, :all_dbs do
     create(:attorney_case_review, attorney: attorney, reviewing_judge: judge, task_id: task_id)
   end
 
+  let(:etl_build) { ETL::Build.create }
+
   # rubocop:disable Metrics/AbcSize
   def expect_denormalized_users(etl_acr)
     expect(etl_acr.attorney_css_id).to eq(attorney.css_id)
@@ -27,7 +29,7 @@ describe ETL::AttorneyCaseReviewSyncer, :etl, :all_dbs do
       CachedUser.sync_from_vacols
     end
 
-    subject { described_class.new.call }
+    subject { described_class.new.call(etl_build) }
 
     context "LegacyAppeal" do
       let(:task_id) { "#{appeal.vacols_id}-2019-12-17" }

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -24,11 +24,11 @@ describe ETL::Builder, :etl, :all_dbs do
 
   describe "#last_built" do
     it "returns timestamp of last build" do
-      # start first build with 1 second delay so we don't bump up against
+      # start first build with small delay so we don't bump up against
       # a rounding error on the fixtures created via "AMA Tableau SQL"
-      first_build_time = Time.zone.now.round + 1.second
+      first_build_time = Time.zone.now.round + 5.seconds
 
-      Timecop.freeze(first_build_time) do
+      Timecop.travel(first_build_time) do
         # perform first full build
         builder = described_class.new
         build = builder.full

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -160,7 +160,7 @@ describe ETL::Builder, :etl, :all_dbs do
 
   describe "error handling" do
     before do
-      allow(ETL::Appeal).to receive(:merge_original_attributes_to_target) { raise error }
+      allow(ETL::Appeal).to receive(:merge_original_attributes_to_target) { fail error }
     end
 
     subject { described_class.new }

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -99,28 +99,30 @@ describe ETL::Builder, :etl, :all_dbs do
 
     context "BVA status distribution" do
       it "syncs all records" do
-        described_class::ETL_KLASSES.each { |klass| expect("ETL::#{klass}".constantize.all.count).to eq(0) }
+        Timecop.freeze(Time.zone.now.round) do
+          described_class::ETL_KLASSES.each { |klass| expect("ETL::#{klass}".constantize.all.count).to eq(0) }
 
-        expect(ETL::Appeal.count).to eq(0)
+          expect(ETL::Appeal.count).to eq(0)
 
-        build = subject
+          build = subject
 
-        expect(build).to be_a(ETL::Build)
-        expect(build).to be_complete
-        expect(build.finished_at).to eq(Time.zone.now)
-        expect(build.built).to eq(88)
-        expect(build.tables).to include("appeals", "people", "tasks", "users", "organizations")
-        expect(build.build_for("appeals").rows_inserted).to eq(13)
-        expect(build.build_for("appeals").rows_updated).to eq(0)
-        expect(build.build_for("users").rows_updated).to eq(0)
-        expect(build.build_for("users").rows_inserted).to eq(23)
+          expect(build).to be_a(ETL::Build)
+          expect(build).to be_complete
+          expect(build.finished_at).to eq(Time.zone.now)
+          expect(build.built).to eq(88)
+          expect(build.tables).to include("appeals", "people", "tasks", "users", "organizations")
+          expect(build.build_for("appeals").rows_inserted).to eq(13)
+          expect(build.build_for("appeals").rows_updated).to eq(0)
+          expect(build.build_for("users").rows_updated).to eq(0)
+          expect(build.build_for("users").rows_inserted).to eq(23)
 
-        expect(ETL::Task.count).to eq(31)
-        expect(ETL::Appeal.count).to eq(13)
-        expect(ETL::User.all.count).to eq(23)
-        expect(ETL::Person.all.count).to eq(13)
-        expect(ETL::OrganizationsUser.all.count).to eq(3)
-        expect(ETL::Organization.all.count).to eq(5)
+          expect(ETL::Task.count).to eq(31)
+          expect(ETL::Appeal.count).to eq(13)
+          expect(ETL::User.all.count).to eq(23)
+          expect(ETL::Person.all.count).to eq(13)
+          expect(ETL::OrganizationsUser.all.count).to eq(3)
+          expect(ETL::Organization.all.count).to eq(5)
+        end
       end
     end
   end
@@ -130,26 +132,28 @@ describe ETL::Builder, :etl, :all_dbs do
 
     context "BVA status distribution" do
       it "syncs only records that have changed" do
-        described_class::ETL_KLASSES.each { |klass| expect("ETL::#{klass}".constantize.all.count).to eq(0) }
+        Timecop.freeze(Time.zone.now.round) do
+          described_class::ETL_KLASSES.each { |klass| expect("ETL::#{klass}".constantize.all.count).to eq(0) }
 
-        build = subject
+          build = subject
 
-        expect(build).to be_a(ETL::Build)
-        expect(build).to be_complete
-        expect(build.finished_at).to eq(Time.zone.now)
-        expect(build.built).to eq(85)
-        expect(build.tables).to include("appeals", "people", "tasks", "users", "organizations")
-        expect(build.build_for("appeals").rows_inserted).to eq(13)
-        expect(build.build_for("appeals").rows_updated).to eq(0)
-        expect(build.build_for("users").rows_inserted).to eq(22)
-        expect(build.build_for("users").rows_rejected).to eq(0)
+          expect(build).to be_a(ETL::Build)
+          expect(build).to be_complete
+          expect(build.finished_at).to eq(Time.zone.now)
+          expect(build.built).to eq(85)
+          expect(build.tables).to include("appeals", "people", "tasks", "users", "organizations")
+          expect(build.build_for("appeals").rows_inserted).to eq(13)
+          expect(build.build_for("appeals").rows_updated).to eq(0)
+          expect(build.build_for("users").rows_inserted).to eq(22)
+          expect(build.build_for("users").rows_rejected).to eq(0)
 
-        expect(ETL::Task.count).to eq(31)
-        expect(ETL::Appeal.count).to eq(13)
-        expect(ETL::User.all.count).to eq(22)
-        expect(ETL::Person.all.count).to eq(13)
-        expect(ETL::OrganizationsUser.all.count).to eq(2)
-        expect(ETL::Organization.all.count).to eq(4)
+          expect(ETL::Task.count).to eq(31)
+          expect(ETL::Appeal.count).to eq(13)
+          expect(ETL::User.all.count).to eq(22)
+          expect(ETL::Person.all.count).to eq(13)
+          expect(ETL::OrganizationsUser.all.count).to eq(2)
+          expect(ETL::Organization.all.count).to eq(4)
+        end
       end
     end
   end

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -157,4 +157,24 @@ describe ETL::Builder, :etl, :all_dbs do
       end
     end
   end
+
+  describe "error handling" do
+    before do
+      allow(ETL::Appeal).to receive(:merge_original_attributes_to_target) { raise error }
+    end
+
+    subject { described_class.new.full }
+
+    let(:error) { StandardError.new("oops!") }
+
+    it "captures error string and sets status" do
+      build = subject
+
+      expect(build).to be_error
+      expect(build.comments).to eq("oops!")
+      expect(build.build_for("appeals")).to be_error
+      expect(build.build_for("appeals").comments).to eq("oops!")
+      expect(build.build_for("tasks")).to be_complete
+    end
+  end
 end

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -17,16 +17,9 @@ describe ETL::Builder, :etl, :all_dbs do
   let(:user) { create(:user) }
 
   before do
-    @safe_mode_started_on = Timecop.safe_mode?
-    Timecop.safe_mode = true # must use blocks
-
     Timecop.travel(3.days.ago.round) do
       CachedUser.sync_from_vacols
     end
-  end
-
-  after do
-    Timecop.safe_mode = false if @safe_mode_started_on
   end
 
   describe "#last_built" do

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -23,8 +23,6 @@ describe ETL::Builder, :etl, :all_dbs do
     Timecop.travel(3.days.ago.round) do
       CachedUser.sync_from_vacols
     end
-
-    #Timecop.freeze(Time.zone.now)
   end
 
   after do

--- a/spec/services/etl/builder_spec.rb
+++ b/spec/services/etl/builder_spec.rb
@@ -163,18 +163,21 @@ describe ETL::Builder, :etl, :all_dbs do
       allow(ETL::Appeal).to receive(:merge_original_attributes_to_target) { raise error }
     end
 
-    subject { described_class.new.full }
+    subject { described_class.new }
 
     let(:error) { StandardError.new("oops!") }
 
     it "captures error string and sets status" do
-      build = subject
+      builder = subject
 
+      expect { builder.full }.to raise_error(error)
+
+      build = builder.build_record
       expect(build).to be_error
       expect(build.comments).to eq("oops!")
       expect(build.build_for("appeals")).to be_error
       expect(build.build_for("appeals").comments).to eq("oops!")
-      expect(build.build_for("tasks")).to be_complete
+      expect(build.build_for("tasks")).to be_nil # we did not finish
     end
   end
 end

--- a/spec/services/etl/decision_issue_syncer_spec.rb
+++ b/spec/services/etl/decision_issue_syncer_spec.rb
@@ -2,9 +2,10 @@
 
 describe ETL::DecisionIssueSyncer, :etl, :all_dbs do
   let!(:decision_issue) { create(:decision_issue) }
+  let(:etl_build) { ETL::Build.create }
 
   describe "#call" do
-    subject { described_class.new.call }
+    subject { described_class.new.call(etl_build) }
 
     context "one decision issue" do
       it "syncs attributes" do

--- a/spec/services/etl/organization_syncer_spec.rb
+++ b/spec/services/etl/organization_syncer_spec.rb
@@ -4,9 +4,10 @@ describe ETL::OrganizationSyncer, :etl do
   describe "#call" do
     let!(:org1) { create(:organization, updated_at: 3.days.ago.round) }
     let!(:org2) { create(:organization) }
+    let(:etl_build) { ETL::Build.create }
 
     context "2 org records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       it "syncs 1 record" do
         expect(ETL::Organization.all.count).to eq(0)
@@ -19,7 +20,7 @@ describe ETL::OrganizationSyncer, :etl do
     end
 
     context "2 org records, full sync" do
-      subject { described_class.new.call }
+      subject { described_class.new.call(etl_build) }
 
       it "syncs all records" do
         expect(ETL::Organization.all.count).to eq(0)
@@ -31,10 +32,10 @@ describe ETL::OrganizationSyncer, :etl do
     end
 
     context "origin Org record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       before do
-        described_class.new.call
+        described_class.new.call(etl_build)
       end
 
       let(:new_name) { "foobar" }

--- a/spec/services/etl/organizations_user_syncer_spec.rb
+++ b/spec/services/etl/organizations_user_syncer_spec.rb
@@ -7,9 +7,10 @@ describe ETL::OrganizationsUserSyncer, :etl do
     let(:org1) { create(:organization) }
     let(:org2) { create(:organization) }
     let(:user) { create(:user) }
+    let(:etl_build) { ETL::Build.create }
 
     context "2 org_user records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       it "syncs 1 record" do
         expect(ETL::OrganizationsUser.all.count).to eq(0)
@@ -22,7 +23,7 @@ describe ETL::OrganizationsUserSyncer, :etl do
     end
 
     context "2 org records, full sync" do
-      subject { described_class.new.call }
+      subject { described_class.new.call(etl_build) }
 
       it "syncs all records" do
         expect(ETL::OrganizationsUser.all.count).to eq(0)
@@ -34,10 +35,10 @@ describe ETL::OrganizationsUserSyncer, :etl do
     end
 
     context "origin record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       before do
-        described_class.new.call
+        described_class.new.call(etl_build)
       end
 
       let(:new_admin) { true }

--- a/spec/services/etl/person_syncer_spec.rb
+++ b/spec/services/etl/person_syncer_spec.rb
@@ -4,9 +4,10 @@ describe ETL::PersonSyncer, :etl do
   describe "#call" do
     let!(:person1) { create(:person, updated_at: 3.days.ago.round) }
     let!(:person2) { create(:person) }
+    let(:etl_build) { ETL::Build.create }
 
     context "2 person records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       it "syncs 1 record" do
         expect(ETL::Person.all.count).to eq(0)
@@ -19,7 +20,7 @@ describe ETL::PersonSyncer, :etl do
     end
 
     context "2 person records, full sync" do
-      subject { described_class.new.call }
+      subject { described_class.new.call(etl_build) }
 
       it "syncs all records" do
         expect(ETL::Person.all.count).to eq(0)
@@ -31,10 +32,10 @@ describe ETL::PersonSyncer, :etl do
     end
 
     context "origin Person record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       before do
-        described_class.new.call
+        described_class.new.call(etl_build)
       end
 
       let(:new_last_name) { "foobar" }

--- a/spec/services/etl/syncer_spec.rb
+++ b/spec/services/etl/syncer_spec.rb
@@ -30,18 +30,22 @@ describe ETL::Syncer, :etl do
     before do
       dummy_target = double("dummy")
       allow(dummy_target).to receive(:save!) { @dummy_saved = true }
+      allow(dummy_target).to receive(:persisted?) { true }
       allow(DummyEtlClass).to receive(:sync_with_original) { dummy_target }
     end
+
+    let(:etl_build) { ETL::Build.create }
 
     context "one stale origin class instance needing sync" do
       let!(:user) { create(:user) }
 
-      subject { MySyncer.new.call }
+      subject { MySyncer.new.call(etl_build) }
 
       it "saves a new target class instance" do
         subject
         expect(DummyEtlClass).to have_received(:sync_with_original).once
         expect(@dummy_saved).to eq(true)
+        expect(etl_build.built).to eq(1)
       end
     end
   end

--- a/spec/services/etl/task_syncer_spec.rb
+++ b/spec/services/etl/task_syncer_spec.rb
@@ -14,6 +14,7 @@ describe ETL::TaskSyncer, :etl, :all_dbs do
       it "has expected distribution" do
         subject
 
+        expect(Task.count).to eq(31)
         expect(ETL::Task.count).to eq(31)
       end
     end
@@ -25,9 +26,13 @@ describe ETL::TaskSyncer, :etl, :all_dbs do
       end
 
       it "skips orphans" do
-        subject
+        etl_build_table = subject
 
+        expect(Task.count).to eq(32)
         expect(ETL::Task.count).to eq(31)
+        expect(etl_build_table).to be_complete
+        expect(etl_build_table.rows_rejected).to eq(1)
+        expect(etl_build_table.rows_updated).to eq(31)
       end
     end
   end

--- a/spec/services/etl/task_syncer_spec.rb
+++ b/spec/services/etl/task_syncer_spec.rb
@@ -32,7 +32,8 @@ describe ETL::TaskSyncer, :etl, :all_dbs do
         expect(ETL::Task.count).to eq(31)
         expect(etl_build_table).to be_complete
         expect(etl_build_table.rows_rejected).to eq(1)
-        expect(etl_build_table.rows_updated).to eq(31)
+        expect(etl_build_table.rows_inserted).to eq(31)
+        expect(etl_build_table.rows_updated).to eq(0)
       end
     end
   end

--- a/spec/services/etl/task_syncer_spec.rb
+++ b/spec/services/etl/task_syncer_spec.rb
@@ -5,8 +5,10 @@ describe ETL::TaskSyncer, :etl, :all_dbs do
 
   include_context "AMA Tableau SQL"
 
+  let(:etl_build) { ETL::Build.create }
+
   describe "#call" do
-    subject { described_class.new.call }
+    subject { described_class.new.call(etl_build) }
 
     context "BVA status distribution" do
       it "has expected distribution" do

--- a/spec/services/etl/user_syncer_spec.rb
+++ b/spec/services/etl/user_syncer_spec.rb
@@ -7,6 +7,7 @@ describe ETL::UserSyncer, :etl do
     let!(:user1) { create(:user, css_id: vacols_user1.sdomainid) }
     let!(:user2) { create(:user, css_id: vacols_user2.sdomainid, updated_at: 3.days.ago.round) }
     let!(:user3) { create(:user) }
+    let(:etl_build) { ETL::Build.create }
 
     before do
       Timecop.travel(3.days.ago.round) do
@@ -15,7 +16,7 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "3 User records, 2 needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       it "syncs 2 records" do
         expect(ETL::User.all.count).to eq(0)
@@ -30,10 +31,10 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "VACOLS attribute changes" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       before do
-        described_class.new.call
+        described_class.new.call(etl_build)
         user2.vacols_user.svlj = "J"
         user2.vacols_user.save!
       end
@@ -49,7 +50,7 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "3 User records, full sync" do
-      subject { described_class.new.call }
+      subject { described_class.new.call(etl_build) }
 
       it "syncs all records" do
         expect(ETL::User.all.count).to eq(0)
@@ -61,10 +62,10 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "origin User record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call }
+      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
 
       before do
-        described_class.new.call
+        described_class.new.call(etl_build)
       end
 
       let(:new_name) { "foobar" }


### PR DESCRIPTION
connects #13074 

### Description
Adds new tables to track metadata about ETL builds, mostly timings and number of rows touched.


### Documentation Updates
- [x] Topline File Descriptions Added or Updated as Needed

### Database Changes
*Only for Schema Changes*

* [x] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] #appeals-schema notified with summary and link to this PR
