### PR TITLE
Update ruby-bgs to get access to common_security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "aasm", "4.11.0"
 gem "activerecord-import"
 gem "acts_as_tree"
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "136e263aafaf6512ad552ac67a4a8b26d1222f16"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "e8285d246b9123301f3516228c6c273d0fd8f900"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,8 +45,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 136e263aafaf6512ad552ac67a4a8b26d1222f16
-  ref: 136e263aafaf6512ad552ac67a4a8b26d1222f16
+  revision: e8285d246b9123301f3516228c6c273d0fd8f900
+  ref: e8285d246b9123301f3516228c6c273d0fd8f900
   specs:
     bgs (0.2)
       httpclient


### PR DESCRIPTION
### Description
Updates the ruby-bgs version so that we can get access to the new common_security service.

connects #10164