### PR TITLE
Fix same-station bypass FeatureToggle bug

### DIFF
--- a/app/models/validators/intake_start_validator.rb
+++ b/app/models/validators/intake_start_validator.rb
@@ -92,7 +92,7 @@ class IntakeStartValidator
     # BVA has indicated that station conflict policy doesn't apply to Appeals.
     # See https://github.com/department-of-veterans-affairs/caseflow/issues/13165
     # This bypass is behind the :allow_same_station_appeals feature toggle for now.
-    return true if FeatureToggle.enabled?(:allow_same_station_appeals) && intake.is_a?(AppealIntake)
+    return true if FeatureToggle.enabled?(:allow_same_station_appeals, user: intake.user) && intake.is_a?(AppealIntake)
 
     !bgs.station_conflict?(veteran_file_number, veteran.participant_id)
   end


### PR DESCRIPTION
Connects #13389

### Description
Fixes a bug where the `allow_same_station_appeals` FeatureToggle was only considered at a global scale (not for individual users or stations, as we are currently doing).