### PR TITLE
Fix null object error in Establish Claim

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -327,7 +327,7 @@ export class EstablishClaim extends React.Component {
         this.props.submitDecisionPageSuccess();
       },
       (error) => {
-        const errorMessage = CREATE_EP_ERRORS[error.response.body.error_code] || CREATE_EP_ERRORS.default;
+        const errorMessage = CREATE_EP_ERRORS[error.response.body?.error_code] || CREATE_EP_ERRORS.default;
 
         this.setState({
           loading: false


### PR DESCRIPTION
Connects #13405 

### Description
The `handleDecisionPageSubmit` function was returning an error when the `error` object was null.  Utilized optional chaining operator to check for existence of the error object to solve.
