### PR TITLE
increase postgres db to 9.6 in caseflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           - POSTGRES_USER: root
       # This is the circleci provided Postgres container. We can
       # configure it via environment variables.
-      - image: circleci/postgres:9.5
+      - image: circleci/postgres:9.6
         environment:
           - POSTGRES_USER: root
             POSTGRES_DB: caseflow_certification_test

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -30,7 +30,7 @@ services:
       - vacols-db-development
 
   appeals-postgres:
-    image: postgres:9.5
+    image: postgres:9.6
     container_name: appeals-db
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "6379:6379"
 
   appeals-postgres:
-    image: postgres:9.5
+    image: postgres:9.6
     container_name: appeals-db
     ports:
       - "5432:5432"


### PR DESCRIPTION
Upgrades to Postgres 9.6 latest
This will probably come in our security scan that we should be doing the latest 9.x this is the way to do it

### Description
Soon, we will get our db security scan, so before we get hit by it, I want to proactively upgrade our DB's to the latest Postgres 9 version, which this includes 9.6.16 in our local environments.
We will upgrade our infrastructure to 9.6.16 which is what is available to us.


### Testing Plan
We will do this change, that upgrades our CI, then we will continue with Preprod, then UAT and finally Prod.

### User Facing Changes
There shouldn't be any user facing changes.
