### PR TITLE
switch to conventional VA headers

### DIFF
--- a/app/controllers/api/docs/v3/decision_reviews.yaml
+++ b/app/controllers/api/docs/v3/decision_reviews.yaml
@@ -1007,13 +1007,13 @@ paths:
       tags:
         - Issues
       parameters:
-        - name: ssn
+        - name: X-VA-SSN
           in: header
           required: true
           description: The SSN of the veteran.
           schema:
             type : string
-        - name: receiptDate
+        - name: X-VA-Receipt-Date
           in: header
           required: true
           description: (yyyy-mm-dd) In order to determine contestability of issues, the receipt date of a hypothetical Decision Review must be supplied.

--- a/app/controllers/api/v3/decision_review/contestable_issues_controller.rb
+++ b/app/controllers/api/v3/decision_review/contestable_issues_controller.rb
@@ -30,7 +30,7 @@ class Api::V3::DecisionReview::ContestableIssuesController < Api::V3::BaseContro
   end
 
   def set_veteran_from_header
-    @veteran = VeteranFinder.find_best_match(request.headers["ssn"])
+    @veteran = VeteranFinder.find_best_match(request.headers["X-VA-SSN"])
     unless @veteran
       render_error(
         status: 404,
@@ -41,7 +41,7 @@ class Api::V3::DecisionReview::ContestableIssuesController < Api::V3::BaseContro
   end
 
   def set_receipt_date_from_header
-    @receipt_date = Date.iso8601(request.headers["receiptDate"])
+    @receipt_date = Date.iso8601(request.headers["X-VA-Receipt-Date"])
     if invalid_receipt_date? # veteran must be set before using this helper
       render_bad_receipt_date
     end

--- a/spec/requests/api/v3/decision_review/contestable_issues_controller_spec.rb
+++ b/spec/requests/api/v3/decision_review/contestable_issues_controller_spec.rb
@@ -25,8 +25,8 @@ describe Api::V3::DecisionReview::ContestableIssuesController, :postgres, type: 
         "/api/v3/decision_review/contestable_issues",
         headers: {
           "Authorization" => "Token #{api_key}",
-          "ssn" => ssn,
-          "receiptDate" => date || receipt_date
+          "X-VA-SSN" => ssn,
+          "X-VA-Receipt-Date" => date || receipt_date
         }
       )
     end


### PR DESCRIPTION
To be in-line with other VA APIs, switch to `X-VA-` prefixed headers.
Only affects ContestableIssues endpoint:
```
        ssn -> X-VA-SSN
receiptDate -> X-VA-Receipt-Date
```