### PR TITLE
Cascade PrivacyActTask closure to FoiaColocatedTask

### DIFF
--- a/app/models/tasks/foia_colocated_task.rb
+++ b/app/models/tasks/foia_colocated_task.rb
@@ -36,6 +36,6 @@ class FoiaColocatedTask < ColocatedTask
   private
 
   def cascade_closure_from_child_task?(child_task)
-    child_task.is_a?(FoiaTask)
+    child_task.is_a?(FoiaTask) || child_task.is_a?(PrivacyActTask)
   end
 end


### PR DESCRIPTION
Related to #13266

### Description
Cascade PrivacyActTask closure to FoiaColocatedTask.

In #13266, for an active PrivacyActTask, "Move active PrivacyActTask under FoiaColocatedTask." However, closing the PrivacyActTask won't close its parent FoiaColocatedTask. To fix this, we will allow the automatic closure of FoiaColocatedTasks to extend to PrivacyActTasks.

[Slack](https://dsva.slack.com/archives/CJL810329/p1581720120293600?thread_ts=1581719235.292300&cid=CJL810329)

https://github.com/department-of-veterans-affairs/caseflow/issues/13266#issuecomment-586503812:
> Attorney's on hold tab is populated by [colocated tasks assigned by the attorney](https://github.com/department-of-veterans-affairs/caseflow/blob/e1e716f233c638dca81ee3064b3d58a9ccbedba4/app/models/queues/attorney_queue.rb#L12). If these privacy act tasks are not children of colocated tasks, they will not appear in the attorney's on hold tab


### Acceptance Criteria
- [ ] Code compiles correctly
