### PR TITLE
Retry BGS ignorable errors

### DIFF
--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -99,6 +99,8 @@ class UpdateAppellantRepresentationJob < CaseflowJob
     Rails.logger.info(msg)
     Rails.logger.info(err.backtrace.join("\n"))
 
+    Raven.capture_exception(err)
+
     slack_service.send_notification(msg)
 
     datadog_report_runtime(metric_group_name: METRIC_GROUP_NAME)

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -201,6 +201,8 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     Rails.logger.info(msg)
     Rails.logger.info(err.backtrace.join("\n"))
 
+    Raven.capture_exception(err)
+
     slack_service.send_notification(msg)
 
     datadog_report_runtime(metric_group_name: METRIC_GROUP_NAME)

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -71,7 +71,7 @@ class Claimant < ApplicationRecord
   end
 
   def bgs_record
-    @bgs_record ||= fetch_bgs_record
+    @bgs_record ||= try_and_retry_bgs_record
   end
 
   private

--- a/app/models/concerns/associated_bgs_record.rb
+++ b/app/models/concerns/associated_bgs_record.rb
@@ -66,7 +66,7 @@ module AssociatedBgsRecord
     if error.ignorable?
       fetch_bgs_record
     else
-      fail error # re-raise if we can't try again
+      raise error # re-raise if we can't try again
     end
   end
 

--- a/app/services/bgs_power_of_attorney.rb
+++ b/app/services/bgs_power_of_attorney.rb
@@ -40,6 +40,6 @@ class BgsPowerOfAttorney
   def load_bgs_address!
     return nil if !participant_id
 
-    BgsAddressService.new(participant_id: participant_id).fetch_bgs_record
+    BgsAddressService.new(participant_id: participant_id).address
   end
 end


### PR DESCRIPTION
When background jobs encounter ignorable BGS transient errors, re-try once rather than dying immediately.

e.g. https://dsva.slack.com/archives/CN3FQR4A1/p1581919300017200