### PR TITLE
Handle VBMS requirement for newline-free contention text

### DIFF
--- a/app/models/contention.rb
+++ b/app/models/contention.rb
@@ -7,16 +7,22 @@ class Contention
     self.description = description
   end
 
-  # BGS limits contention text to 255 bytes
+  # BGS limits contention text to 255 bytes long, and free of newlines
   def text
     return unless description
 
-    (description.bytesize > 255) ? truncated_description : description
+    truncate(remove_newlines(description))
   end
 
   private
 
-  def truncated_description
+  def remove_newlines(description)
+    description.gsub(/\s*[\r\n]+\s*/, " ")
+  end
+
+  def truncate(description)
+    return description if description.bytesize <= 255
+
     trimmed = []
     description.split("").each do |char|
       break if trimmed.join("").bytesize >= 252

--- a/spec/models/contention_spec.rb
+++ b/spec/models/contention_spec.rb
@@ -2,7 +2,7 @@
 
 describe Contention do
   let(:utf8_text) do
-    "The claim of entitlement to compensation under 38 U.S.C. § 1151 for " \
+    "The claim of entitlement\nto compensation under\r\n38 U.S.C. § 1151\rfor " \
     "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ is remanded."
   end
 
@@ -10,9 +10,15 @@ describe Contention do
 
   describe "#text" do
     it "truncates description to 255 bytes" do
-      expect(utf8_text.length).to eq(176)
-      expect(utf8_text.bytesize).to eq(272)
+      expect(utf8_text.length).to eq(177)
+      expect(utf8_text.bytesize).to eq(273)
       expect(subject.text.bytesize).to eq(254) # 255 would break a multi-byte codepoint
+    end
+
+    it "removes newlines" do
+      expect(subject.text).to include("entitlement to compensation under 38 U.S.C. § 1151 for")
+      expect(subject.text).not_to include("\n")
+      expect(subject.text).not_to include("\r")
     end
   end
 end


### PR DESCRIPTION
Connects #13311 

### Description
This PR removes newlines from contention text before it is submitted to VBMS, which will otherwise save the text as blank.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Added a new test to check that newlines are removed
2. Existing test updated