### PR TITLE
Keep completed AttorneyTasks with reassigned JudgeDecisionReviewTasks

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -500,7 +500,7 @@ class Task < ApplicationRecord
     end
 
     # Preserve the open children and status of the old task
-    children.open.update_all(parent_id: sibling.id)
+    children.select(&:stays_with_reassigned_parent?).each { |child| child.update!(parent_id: sibling.id) }
     sibling.update!(status: status)
 
     update_with_instructions(status: Constants.TASK_STATUSES.cancelled, instructions: reassign_params[:instructions])
@@ -563,6 +563,10 @@ class Task < ApplicationRecord
 
   def child_must_have_active_assignee?
     true
+  end
+
+  def stays_with_reassigned_parent?
+    open?
   end
 
   private

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -47,6 +47,10 @@ class AttorneyTask < Task
     COPY::ATTORNEY_TASK_LABEL
   end
 
+  def stays_with_reassigned_parent?
+    super || completed?
+  end
+
   private
 
   def child_attorney_tasks_are_completed

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -833,17 +833,12 @@ describe Task, :all_dbs do
     end
 
     context "When old assignee reassigns task with several child tasks to a new user" do
-      let(:completed_children_cnt) { 4 }
-      let!(:completed_children) do
-        create_list(
-          :ama_task,
-          completed_children_cnt,
-          :completed,
-          parent_id: task.id
-        )
-      end
-      let(:incomplete_children_cnt) { 5 }
-      let!(:incomplete_children) { create_list(:ama_task, incomplete_children_cnt, parent_id: task.id) }
+      let(:task_type) { :ama_task }
+      let(:closed_children_cnt) { 2 }
+      let!(:completed_children) { create_list(task_type, closed_children_cnt / 2, :completed, parent_id: task.id) }
+      let!(:cancelled_children) { create_list(task_type, closed_children_cnt / 2, :cancelled, parent_id: task.id) }
+      let(:incomplete_children_cnt) { 2 }
+      let!(:incomplete_children) { create_list(task_type, incomplete_children_cnt, parent_id: task.id) }
 
       before { task.on_hold! }
 
@@ -860,12 +855,12 @@ describe Task, :all_dbs do
         expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
         task.reload
-        expect(task.children.length).to eq(completed_children_cnt)
+        expect(task.children.length).to eq(closed_children_cnt)
       end
 
       context "when the children are task timers" do
         let(:incomplete_children_cnt) { 1 }
-        let!(:incomplete_children) { create_list(:timed_hold_task, incomplete_children_cnt, parent_id: task.id) }
+        let(:task_type) { :timed_hold_task }
 
         it "children timer tasks are adopted by new task and not cancelled" do
           expect { subject }.to_not raise_error
@@ -877,7 +872,28 @@ describe Task, :all_dbs do
           expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
           task.reload
-          expect(task.children.length).to eq(completed_children_cnt)
+          expect(task.children.length).to eq(closed_children_cnt)
+        end
+      end
+
+      context "when the children are attorney tasks" do
+        let(:incomplete_children_cnt) { 1 }
+        let(:task_type) { :ama_attorney_task }
+
+        it "assigned AND completed child tasks are adopted by new task" do
+          expect { subject }.to_not raise_error
+          expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
+
+          new_task = task.parent.children.open.first
+          expect(new_task.children.length).to eq(incomplete_children_cnt + closed_children_cnt / 2)
+          expect(new_task.children.map(&:status)).to match_array(
+            [Constants.TASK_STATUSES.assigned, Constants.TASK_STATUSES.completed]
+          )
+          expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
+
+          task.reload
+          expect(task.children.length).to eq(closed_children_cnt / 2)
+          expect(task.children.map(&:status)).to match_array([Constants.TASK_STATUSES.cancelled])
         end
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -834,16 +834,16 @@ describe Task, :all_dbs do
 
     context "When old assignee reassigns task with several child tasks to a new user" do
       let(:task_type) { :ama_task }
-      let(:closed_children_cnt) { 2 }
-      let!(:completed_children) { create_list(task_type, closed_children_cnt / 2, :completed, parent_id: task.id) }
-      let!(:cancelled_children) { create_list(task_type, closed_children_cnt / 2, :cancelled, parent_id: task.id) }
-      let(:incomplete_children_cnt) { 2 }
-      let!(:incomplete_children) { create_list(task_type, incomplete_children_cnt, parent_id: task.id) }
+      let(:closed_children_count) { 2 }
+      let!(:completed_children) { create_list(task_type, closed_children_count / 2, :completed, parent_id: task.id) }
+      let!(:cancelled_children) { create_list(task_type, closed_children_count / 2, :cancelled, parent_id: task.id) }
+      let(:incomplete_children_count) { 2 }
+      let!(:incomplete_children) { create_list(task_type, incomplete_children_count, parent_id: task.id) }
 
       before { task.on_hold! }
 
       it "reassign method should return list with old and new tasks and incomplete child tasks" do
-        expect(subject.length).to eq(2 + incomplete_children_cnt)
+        expect(subject.length).to eq(2 + incomplete_children_count)
       end
 
       it "incomplete children tasks are adopted by new task and completed tasks are not" do
@@ -851,15 +851,15 @@ describe Task, :all_dbs do
         expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
 
         new_task = task.parent.children.open.first
-        expect(new_task.children.length).to eq(incomplete_children_cnt)
+        expect(new_task.children.length).to eq(incomplete_children_count)
         expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
         task.reload
-        expect(task.children.length).to eq(closed_children_cnt)
+        expect(task.children.length).to eq(closed_children_count)
       end
 
       context "when the children are task timers" do
-        let(:incomplete_children_cnt) { 1 }
+        let(:incomplete_children_count) { 1 }
         let(:task_type) { :timed_hold_task }
 
         it "children timer tasks are adopted by new task and not cancelled" do
@@ -867,17 +867,17 @@ describe Task, :all_dbs do
           expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
 
           new_task = task.parent.children.open.first
-          expect(new_task.children.length).to eq(incomplete_children_cnt)
+          expect(new_task.children.length).to eq(incomplete_children_count)
           expect(new_task.children.all?(&:assigned?)).to eq(true)
           expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
           task.reload
-          expect(task.children.length).to eq(closed_children_cnt)
+          expect(task.children.length).to eq(closed_children_count)
         end
       end
 
       context "when the children are attorney tasks" do
-        let(:incomplete_children_cnt) { 1 }
+        let(:incomplete_children_count) { 1 }
         let(:task_type) { :ama_attorney_task }
 
         it "assigned AND completed child tasks are adopted by new task" do
@@ -885,14 +885,14 @@ describe Task, :all_dbs do
           expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
 
           new_task = task.parent.children.open.first
-          expect(new_task.children.length).to eq(incomplete_children_cnt + closed_children_cnt / 2)
+          expect(new_task.children.length).to eq(incomplete_children_count + closed_children_count / 2)
           expect(new_task.children.map(&:status)).to match_array(
             [Constants.TASK_STATUSES.assigned, Constants.TASK_STATUSES.completed]
           )
           expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
           task.reload
-          expect(task.children.length).to eq(closed_children_cnt / 2)
+          expect(task.children.length).to eq(closed_children_count / 2)
           expect(task.children.map(&:status)).to match_array([Constants.TASK_STATUSES.cancelled])
         end
       end


### PR DESCRIPTION
References #13279

### Description
We always expect an open or complete `JudgeDecisionReviewTask` to have a child `AttorneyTask`. This ensures that the child `AttorneyTask` is reassigned with the `JudgeDecisionReviewTask`, even if it is complete

### Acceptance Criteria
- [ ] completed `AttorneyTask`s are adopted by new parent on reassign

### Testing Plan
1. Sign is as BVAAABSHIRE
2. Go to an AMA appeal that has an open `JudgeDecisionReviewTask` assigned to AAAAABSHIRE
3. Peep the task tree
```ruby
Appeal.find_by(uuid: "398eac67-c102-4865-94c1-4b5889efd4b1").treee
                                ┌───────────────────────────────────────────────────────────────────────┐
Appeal 50 (direct_review) ───── │ ID  │ STATUS    │ ASGN_BY     │ ASGN_TO     │ UPDATED_AT              │
└── RootTask                    │ 585 │ on_hold   │             │ Bva         │ 2020-02-03 16:48:34 UTC │
    └── JudgeDecisionReviewTask │ 586 │ assigned  │ CSS_ID103   │ BVAAABSHIRE │ 2020-02-03 16:48:34 UTC │
        └── AttorneyTask        │ 587 │ completed │ BVAAABSHIRE │ BVASCASPER1 │ 2020-02-03 16:48:34 UTC │
                                └───────────────────────────────────────────────────────────────────────┘
```
4. Reassign this task to another judge
5. Ensure the completed `AttorneyTask` is moved under the new `JudgeDecisionReviewTask`
```ruby
Appeal.find_by(uuid: "398eac67-c102-4865-94c1-4b5889efd4b1").treee
                                ┌────────────────────────────────────────────────────────────────────────┐
Appeal 50 (direct_review) ───── │ ID   │ STATUS    │ ASGN_BY     │ ASGN_TO     │ UPDATED_AT              │
└── RootTask                    │ 585  │ on_hold   │             │ Bva         │ 2020-02-03 16:48:34 UTC │
    ├── JudgeDecisionReviewTask │ 586  │ cancelled │ CSS_ID103   │ BVAAABSHIRE │ 2020-02-18 20:01:13 UTC │
    └── JudgeDecisionReviewTask │ 1213 │ assigned  │ BVAAABSHIRE │ BVAEBECKER  │ 2020-02-18 20:01:13 UTC │
        └── AttorneyTask        │ 587  │ completed │ BVAAABSHIRE │ BVASCASPER1 │ 2020-02-18 20:01:13 UTC │
                                └────────────────────────────────────────────────────────────────────────┘
```