### PR TITLE
Demo - Startup.sh needs a bit of love

### DIFF
--- a/docker-bin/startup.sh
+++ b/docker-bin/startup.sh
@@ -5,6 +5,9 @@ THIS_SCRIPT_DIR=$(dirname $0)
 # Set variables for application
 source $THIS_SCRIPT_DIR/env.sh
 
+echo "Waiting for dependencies to properly start up - 90 seconds"
+sleep 90
+
 echo "Starting Appeals App"
 date
 


### PR DESCRIPTION
Wait for dependencies to start.
This was override here https://github.com/department-of-veterans-affairs/caseflow/pull/13298 but I have noted that sometimes FACOLS or Localstack SQS takes a bit longer to start (around 15-45 seconds), so this adds a buffer before we start everything since the `rake local:vacols:wait_for_connection` also uses sqs and not only FACOLS


Error:
```
VACOLS_DB-development     | DATABASE IS READY TO USE!
VACOLS_DB-development     | #########################
VACOLS_DB-development     | The following output is now a tail of the alert.log:
VACOLS_DB-development     | ORCLPDB1(3):[100] Successfully onlined Undo Tablespace 2.
VACOLS_DB-development     | ORCLPDB1(3):Undo initialization finished serial:0 start:4164399921 end:4164399972 diff:51 ms (0.1 seconds)
VACOLS_DB-development     | ORCLPDB1(3):Database Characterset for ORCLPDB1 is AL32UTF8
VACOLS_DB-development     | ORCLPDB1(3):Opatch validation is skipped for PDB ORCLPDB1 (con_id=0)
VACOLS_DB-development     | ORCLPDB1(3):Opening pdb with Resource Manager plan: DEFAULT_PLAN
VACOLS_DB-development     | Pluggable database ORCLPDB1 opened read write
VACOLS_DB-development     | Starting background process CJQ0
VACOLS_DB-development     | Completed: ALTER DATABASE OPEN
VACOLS_DB-development     | 2020-02-19T19:42:37.229555+00:00
VACOLS_DB-development     | CJQ0 started with pid=38, OS id=244
appeals-app               | rake aborted!
appeals-app               | Seahorse::Client::NetworkingError: Failed to open TCP connection to localstack:4576 (getaddrinfo: Name or service not known)
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/connection_pool.rb:285:in `start_session'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/connection_pool.rb:92:in `session_for'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/handler.rb:119:in `session'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/handler.rb:71:in `transmit'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/handler.rb:45:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/content_length.rb:12:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/xml/error_handler.rb:8:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/request_signer.rb:88:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/helpful_socket_errors.rb:10:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:89:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:120:in `retry_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:103:in `retry_if_possible'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:91:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:120:in `retry_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:103:in `retry_if_possible'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:91:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:120:in `retry_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:103:in `retry_if_possible'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:91:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/sqs_queue_urls.rb:13:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/query/handler.rb:27:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/user_agent.rb:12:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/endpoint.rb:41:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/param_validator.rb:21:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/idempotency_token.rb:18:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/response_target.rb:21:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/request.rb:70:in `send_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
appeals-app               | /caseflow/config/initializers/shoryuken.rb:15:in `<top (required)>'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:54:in `load'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/dependencies.rb:285:in `block in load'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/dependencies.rb:257:in `load_dependency'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/dependencies.rb:285:in `load'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/engine.rb:663:in `block in load_config_initializer'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/notifications.rb:170:in `instrument'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/engine.rb:662:in `load_config_initializer'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/engine.rb:620:in `block (2 levels) in <class:Engine>'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/engine.rb:619:in `each'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/engine.rb:619:in `block in <class:Engine>'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/initializable.rb:32:in `instance_exec'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/initializable.rb:32:in `run'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/initializable.rb:61:in `block in run_initializers'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/initializable.rb:50:in `each'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/initializable.rb:50:in `tsort_each_child'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/initializable.rb:60:in `run_initializers'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/application.rb:361:in `initialize!'
appeals-app               | /caseflow/config/environment.rb:5:in `<top (required)>'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `block in require_with_bootsnap_lfi'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require_with_bootsnap_lfi'
appeals-app               | /usr/local/bundle/gems/bootsnap-1.4.4/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/dependencies.rb:291:in `block in require'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/dependencies.rb:257:in `load_dependency'
appeals-app               | /usr/local/bundle/gems/activesupport-5.2.4.1/lib/active_support/dependencies.rb:291:in `require'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/application.rb:337:in `require_environment!'
appeals-app               | /usr/local/bundle/gems/railties-5.2.4.1/lib/rails/application.rb:520:in `block in run_tasks_blocks'
appeals-app               | /usr/local/bundle/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
appeals-app               | Tasks: TOP => local:vacols:wait_for_connection => environment
appeals-app               | (See full trace by running task with --trace)
appeals-app               | Creating DB in PG
VACOLS_DB-development     | 2020-02-19T19:42:38.111116+00:00
VACOLS_DB-development     | ===========================================================
VACOLS_DB-development     | Dumping current patch information
VACOLS_DB-development     | ===========================================================
VACOLS_DB-development     | No patches have been applied
VACOLS_DB-development     | ===========================================================
appeals-app               | rake aborted!
appeals-app               | Seahorse::Client::NetworkingError: Failed to open TCP connection to localstack:4576 (getaddrinfo: Name or service not known)
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/connection_pool.rb:285:in `start_session'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/connection_pool.rb:92:in `session_for'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/handler.rb:119:in `session'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/handler.rb:71:in `transmit'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/net_http/handler.rb:45:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/content_length.rb:12:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/xml/error_handler.rb:8:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/request_signer.rb:88:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/helpful_socket_errors.rb:10:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:89:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:120:in `retry_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:103:in `retry_if_possible'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:91:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:120:in `retry_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:103:in `retry_if_possible'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:91:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:120:in `retry_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:103:in `retry_if_possible'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/retry_errors.rb:91:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/sqs_queue_urls.rb:13:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/query/handler.rb:27:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/user_agent.rb:12:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/endpoint.rb:41:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/param_validator.rb:21:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/raise_response_errors.rb:14:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/idempotency_token.rb:18:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/aws-sdk-core/plugins/param_converter.rb:20:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/plugins/response_target.rb:21:in `call'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/request.rb:70:in `send_request'
appeals-app               | /usr/local/bundle/gems/aws-sdk-core-2.10.112/lib/seahorse/client/base.rb:207:in `block (2 levels) in define_operation_methods'
appeals-app               | /caseflow/config/initializers/shoryuken.rb:15:in `<top (required)>'
```