### PR TITLE
Uncaught js XHR error

### DIFF
--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -604,7 +604,7 @@ export default class QueueTable extends React.PureComponent {
           rowClassNames={rowClassNames}
           bodyStyling={bodyStyling}
           {...this.state} />
-        <FooterRow columns={columns} />
+        <FooterRow rowObjects={[]} columns={columns} />
       </table>;
 
     return <div className="cf-table-wrapper" ref={(div) => {

--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -47,6 +47,8 @@ class HearingBadge extends React.PureComponent {
     if (!this.props.mostRecentlyHeldHearingForAppeal && !this.props.hearing && this.props.externalId) {
       ApiUtil.get(`/appeals/${this.props.externalId}/hearings`).then((response) => {
         this.props.setMostRecentlyHeldHearingForAppeal(this.props.externalId, response.body);
+      }, () => {
+        console.error(`There was an error getting hearings for ${this.props.externalId}`);
       });
     }
   }

--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -49,6 +49,7 @@ class HearingBadge extends React.PureComponent {
         this.props.setMostRecentlyHeldHearingForAppeal(this.props.externalId, response.body);
       }, () => {
         const error = new Error(`There was an error getting hearings for appeal ${this.props.externalId}`);
+
         if (window.Raven) {
           window.Raven.captureException(error);
         }

--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -47,14 +47,15 @@ class HearingBadge extends React.PureComponent {
     if (!this.props.mostRecentlyHeldHearingForAppeal && !this.props.hearing && this.props.externalId) {
       ApiUtil.get(`/appeals/${this.props.externalId}/hearings`).then((response) => {
         this.props.setMostRecentlyHeldHearingForAppeal(this.props.externalId, response.body);
-      }).catch((err) => {
-        const error = new Error(`There was an error getting hearings for appeal ${this.props.externalId} ${err}`);
+      }).
+        catch((err) => {
+          const error = new Error(`There was an error getting hearings for appeal ${this.props.externalId} ${err}`);
 
-        if (window.Raven) {
-          window.Raven.captureException(error);
-        }
-        console.error(error);
-      });
+          if (window.Raven) {
+            window.Raven.captureException(error);
+          }
+          console.error(error);
+        });
     }
   }
 

--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -52,7 +52,7 @@ class HearingBadge extends React.PureComponent {
         if (window.Raven) {
           window.Raven.captureException(error);
         }
-        console.log(error);
+        console.error(error);
       });
     }
   }

--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -47,8 +47,8 @@ class HearingBadge extends React.PureComponent {
     if (!this.props.mostRecentlyHeldHearingForAppeal && !this.props.hearing && this.props.externalId) {
       ApiUtil.get(`/appeals/${this.props.externalId}/hearings`).then((response) => {
         this.props.setMostRecentlyHeldHearingForAppeal(this.props.externalId, response.body);
-      }, () => {
-        const error = new Error(`There was an error getting hearings for appeal ${this.props.externalId}`);
+      }).catch((err) => {
+        const error = new Error(`There was an error getting hearings for appeal ${this.props.externalId} ${err}`);
 
         if (window.Raven) {
           window.Raven.captureException(error);

--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -48,7 +48,11 @@ class HearingBadge extends React.PureComponent {
       ApiUtil.get(`/appeals/${this.props.externalId}/hearings`).then((response) => {
         this.props.setMostRecentlyHeldHearingForAppeal(this.props.externalId, response.body);
       }, () => {
-        console.error(`There was an error getting hearings for ${this.props.externalId}`);
+        const error = new Error(`There was an error getting hearings for appeal ${this.props.externalId}`);
+        if (window.Raven) {
+          window.Raven.captureException(error);
+        }
+        console.log(error);
       });
     }
   }

--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -25,7 +25,7 @@ export class ReaderLoadingScreen extends React.Component {
         this.props.onReceiveDocs(documents, this.props.vacolsId);
         this.props.onReceiveManifests(manifestVbmsFetchedAt, manifestVvaFetchedAt);
         this.props.onReceiveAnnotations(annotations);
-      }).catch(err) => {
+      }).catch((err) => {
         // allow HTTP errors to fall on the floor via the console.
         console.error(new Error(`Problem with GET /reader/appeal/${this.props.vacolsId}/documents?json ${err}`));
       });

--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -25,7 +25,8 @@ export class ReaderLoadingScreen extends React.Component {
         this.props.onReceiveDocs(documents, this.props.vacolsId);
         this.props.onReceiveManifests(manifestVbmsFetchedAt, manifestVvaFetchedAt);
         this.props.onReceiveAnnotations(annotations);
-      }).catch((err) => {
+      }).
+      catch((err) => {
         // allow HTTP errors to fall on the floor via the console.
         console.error(new Error(`Problem with GET /reader/appeal/${this.props.vacolsId}/documents?json ${err}`));
       });

--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -25,9 +25,9 @@ export class ReaderLoadingScreen extends React.Component {
         this.props.onReceiveDocs(documents, this.props.vacolsId);
         this.props.onReceiveManifests(manifestVbmsFetchedAt, manifestVvaFetchedAt);
         this.props.onReceiveAnnotations(annotations);
-      }, () => {
+      }).catch(err) => {
         // allow HTTP errors to fall on the floor via the console.
-        console.error(new Error(`Problem with GET /reader/appeal/${this.props.vacolsId}/documents?json`));
+        console.error(new Error(`Problem with GET /reader/appeal/${this.props.vacolsId}/documents?json ${err}`));
       });
   }
 

--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -25,6 +25,9 @@ export class ReaderLoadingScreen extends React.Component {
         this.props.onReceiveDocs(documents, this.props.vacolsId);
         this.props.onReceiveManifests(manifestVbmsFetchedAt, manifestVvaFetchedAt);
         this.props.onReceiveAnnotations(annotations);
+      }, () => {
+        // allow HTTP errors to fall on the floor via the console.
+        console.error(new Error(`Problem with GET /reader/appeal/${this.props.vacolsId}/documents?json`));
       });
   }
 


### PR DESCRIPTION
connects #13077 

sentry error https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7774

is an uncaught non-200 XHR response. Instead of letting it get to Raven as a generic exception, log it to the console (at least) with a more helpful error.

This happens when a hearing has been deleted in VACOLS and Caseflow is out of sync. That should be caught by an actionable data integrity checker.

Example console output:

<img width="466" alt="Screen Shot 2020-02-19 at 3 29 15 PM" src="https://user-images.githubusercontent.com/1205061/74878288-a2031980-532c-11ea-891f-1a779736ae84.png">
