### PR TITLE
Report a fiscal year at a time

### DIFF
--- a/app/services/metrics/date_range.rb
+++ b/app/services/metrics/date_range.rb
@@ -13,7 +13,7 @@ class Metrics::DateRange
       months = [10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       # the fiscal year is the year of the last month
       months.map do |month|
-        month_start = Date.parse(month > 9 ? "#{year.to_i - 1}-#{month}-1" : "#{year}-#{month}-1")
+        month_start = Date.parse((month > 9) ? "#{year.to_i - 1}-#{month}-1" : "#{year}-#{month}-1")
         new(month_start, month_start.end_of_month)
       end
     end

--- a/app/services/metrics/date_range.rb
+++ b/app/services/metrics/date_range.rb
@@ -33,8 +33,8 @@ class Metrics::DateRange
   end
 
   # comparison operator
-  def ==(other_range)
-    start_date == other_range.start_date && end_date == other_range.end_date
+  def ==(other)
+    start_date == other.start_date && end_date == other.end_date
   end
 
   private

--- a/app/services/metrics/date_range.rb
+++ b/app/services/metrics/date_range.rb
@@ -7,6 +7,18 @@ class Metrics::DateRange
 
   validate :valid_start_date, :valid_end_date
 
+  class << self
+    # returns array of DateRange instances for each month in a fiscal year
+    def for_fiscal_year(year)
+      months = [10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      # the fiscal year is the year of the last month
+      months.map do |month|
+        month_start = Date.parse(month > 9 ? "#{year.to_i - 1}-#{month}-1" : "#{year}-#{month}-1")
+        new(month_start, month_start.end_of_month)
+      end
+    end
+  end
+
   def initialize(start_date, end_date)
     @start_date = start_date
     @end_date = end_date

--- a/app/services/metrics/date_range.rb
+++ b/app/services/metrics/date_range.rb
@@ -32,6 +32,11 @@ class Metrics::DateRange
     @end_date.try(:to_date)
   end
 
+  # comparison operator
+  def ==(other_range)
+    start_date == other_range.start_date && end_date == other_range.end_date
+  end
+
   private
 
   def valid_start_date

--- a/app/services/metrics/hearings_show_rate.rb
+++ b/app/services/metrics/hearings_show_rate.rb
@@ -6,6 +6,9 @@
 
 class Metrics::HearingsShowRate < Metrics::Base
   def call
+    return 0 if hearings.count == 0
+    return 0 if hearings_by_disposition["held"].blank?
+
     hearings_by_disposition["held"] / (hearings.count.to_f - hearings_by_disposition["postponed"].to_f)
   end
 

--- a/spec/services/metrics/date_range_spec.rb
+++ b/spec/services/metrics/date_range_spec.rb
@@ -23,7 +23,7 @@ describe Metrics::DateRange do
   describe ".for_fiscal_year" do
     context "FY 2020" do
       it "contains range for 2019-10" do
-        ranges = described_class.for_fiscal_year('2020')
+        ranges = described_class.for_fiscal_year("2020")
         expect(ranges).to include(Metrics::DateRange.new(Date.new(2019, 10, 1), Date.new(2019, 10, 31)))
       end
     end

--- a/spec/services/metrics/date_range_spec.rb
+++ b/spec/services/metrics/date_range_spec.rb
@@ -19,4 +19,13 @@ describe Metrics::DateRange do
 
     it { expect(subject).to be_falsey }
   end
+
+  describe ".for_fiscal_year" do
+    context "FY 2020" do
+      it "contains range for 2019-10" do
+        ranges = described_class.for_fiscal_year('2020')
+        expect(ranges).to include(Metrics::DateRange.new(Date.new(2019, 10, 1), Date.new(2019, 10, 31)))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Convenience method to get a set of date ranges for an entire fiscal year.

Example usage:

```ruby
r = [
  Metrics::DateRange.for_fiscal_year(2019),
  Metrics::DateRange.for_fiscal_year(2020)
].flatten.map { |range| [range, Metrics::HearingsShowRate.new(range).call] }

r.each { |pair| puts "#{pair[0].start_date} #{pair[1]}" }
```

Also fixes some "can't find / method for nil" errors for hearings metric.