### PR TITLE
ETL timeout for slow query

### DIFF
--- a/app/queries/appeals_updated_since_query.rb
+++ b/app/queries/appeals_updated_since_query.rb
@@ -9,7 +9,11 @@ class AppealsUpdatedSinceQuery
   end
 
   def call
+    # query can take up to 90 seconds
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 90000"
     build_query
+  ensure
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
   end
 
   private

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -54,7 +54,7 @@ class ETL::Syncer
       status: :error,
       finished_at: Time.zone.now
     )
-      # re-raise so sentry and parent build record know.
+    # re-raise so sentry and parent build record know.
     raise error
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -43,19 +43,19 @@ class ETL::Syncer
         rows_updated: updated,
         rows_rejected: rejected
       )
-    rescue StandardError => error
-      build_record.update!(
-        rows_inserted: inserted,
-        rows_updated: updated,
-        rows_rejected: rejected,
-        comments: error,
-        status: :error,
-        finished_at: Time.zone.now
-      )
-      # re-raise so sentry and parent build record know.
-      raise error
     end
     build_record
+  rescue StandardError => error
+    build_record(etl_build).update!(
+      rows_inserted: inserted,
+      rows_updated: updated,
+      rows_rejected: rejected,
+      comments: error,
+      status: :error,
+      finished_at: Time.zone.now
+    )
+      # re-raise so sentry and parent build record know.
+    raise error
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize


### PR DESCRIPTION
The AppealsUpdatedSinceQuery can run close to the 30 seconds currently set as the default statement timeout. That query time may grow linearly as load/rows grow.