### PR TITLE
Accessibility | Show "Claim details" as button instead of tab

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -81,7 +81,7 @@
     "pdfjs-dist": "1.10.97",
     "pluralize": "^7.0.0",
     "prop-types": "^15.7.2",
-    "rc-collapse": "^1.7.6",
+    "rc-collapse": "^1.11.8",
     "react": "^16.12.0",
     "react-copy-to-clipboard": "^5.0.1",
     "react-csv": "^1.1.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -12270,14 +12270,18 @@ rc-animate@2.x:
     css-animation "^1.3.2"
     prop-types "15.x"
 
-rc-collapse@^1.7.6:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-1.7.6.tgz#64433512d921f750df61433e675bb9547ba5ef6b"
+rc-collapse@^1.11.8:
+  version "1.11.8"
+  resolved "https://registry.yarnpkg.com/rc-collapse/-/rc-collapse-1.11.8.tgz#66a40089d469519e9424009ab1c927e214041d80"
+  integrity sha512-8EhfPyScTYljkbRuIoHniSwZagD5UPpZ3CToYgoNYWC85L2qCbPYF7+OaC713FOrIkp6NbfNqXsITNxmDAmxog==
   dependencies:
     classnames "2.x"
     css-animation "1.x"
     prop-types "^15.5.6"
     rc-animate "2.x"
+    react-is "^16.7.0"
+    react-lifecycles-compat "^3.0.4"
+    shallowequal "^1.1.0"
 
 rc@^1.2.7:
   version "1.2.8"


### PR DESCRIPTION
connects #12143

### Description
A button was given the "tab" role. This was happening in a dependency called rc-collapse.  When checking out their module, the latest version has fixed this, so this PR just upgrades to the latest version.

In the latest version, if there can be multiple panels active at the same time, then it becomes a tab.

This component is also used in HearingWorksheetDocs.  Looking at the code, I can't see a problem with it being coded as a button instead of a tab there, but wanted to mention it as a side effect.