### PR TITLE
Success Alert upon Completion of JudgeAddressMotionToVacate

### DIFF
--- a/app/controllers/post_decision_motions_controller.rb
+++ b/app/controllers/post_decision_motions_controller.rb
@@ -11,7 +11,6 @@ class PostDecisionMotionsController < ApplicationController
       render json: { errors: [detail: motion_updater.errors.full_messages.join(", ")] }, status: :bad_request
       return
     end
-    flash[:success] = "Disposition saved!"
     render json: {}
   end
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -148,6 +148,10 @@
   "JUDGE_ADDRESS_MTV_DISPOSITION_NOTES_LABEL": "Provide context and instructions on which issues you will be granting",
   "JUDGE_ADDRESS_MTV_ASSIGN_ATTORNEY_LABEL": "Assign to decisions attorney",
   "JUDGE_ADDRESS_MTV_ISSUE_SELECTION_LABEL": "Which issues would you like to vacate?",
+  "JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED": "%s's Motion to Vacate has been marked for vacatur",
+  "JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED": "This task will be sent to the assigned attorney on your team",
+  "JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED": "%s's Motion to Vacate has been %s",
+  "JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED": "This task will be completed by the original motions attorney or placed in the team's queue",
 
   "RETURN_TO_LIT_SUPPORT_MODAL_TITLE": "Return to Litigation Support",
   "RETURN_TO_LIT_SUPPORT_MODAL_CONTENT": "Use this action to return the Motion to Vacate task to the previous Motions Attorney in case of a missing ruling letter draft.\n\nIf the previous attorney is inactive, this will return to the Litigation Support team queue for reassignment.",

--- a/client/app/queue/mtv/AddressMotionToVacateView.jsx
+++ b/client/app/queue/mtv/AddressMotionToVacateView.jsx
@@ -27,7 +27,12 @@ export const AddressMotionToVacateView = () => {
   }));
 
   const handleSubmit = (result) => {
-    dispatch(submitMTVJudgeDecision(result, { history, appeal }));
+    dispatch(
+      submitMTVJudgeDecision(result, {
+        history,
+        appeal
+      })
+    );
   };
 
   return (

--- a/client/app/queue/mtv/AddressMotionToVacateView.jsx
+++ b/client/app/queue/mtv/AddressMotionToVacateView.jsx
@@ -27,7 +27,7 @@ export const AddressMotionToVacateView = () => {
   }));
 
   const handleSubmit = (result) => {
-    dispatch(submitMTVJudgeDecision(result, { history }));
+    dispatch(submitMTVJudgeDecision(result, { history, appeal }));
   };
 
   return (

--- a/client/app/queue/mtv/mtvActions.js
+++ b/client/app/queue/mtv/mtvActions.js
@@ -1,6 +1,8 @@
 import * as Constants from './actionTypes';
 import ApiUtil from '../../util/ApiUtil';
 import { onReceiveAmaTasks } from '../QueueActions';
+import { showSuccessMessage } from '../uiReducer/uiActions';
+import { addressMTVSuccessAlert } from './mtvMessages';
 
 export const submitMTVAttyReviewStarted = () => ({
   type: Constants.MTV_SUBMIT_ATTY_REVIEW
@@ -59,11 +61,11 @@ export const submitMTVJudgeDecisionError = () => ({
   type: Constants.MTV_SUBMIT_JUDGE_DECISION_ERROR
 });
 
-export const submitMTVJudgeDecision = (data, ownProps) => {
+export const submitMTVJudgeDecision = (data, otherParams) => {
   return async (dispatch) => {
     dispatch(submitMTVJudgeDecisionStarted());
 
-    const { history } = ownProps;
+    const { history, appeal } = otherParams;
 
     const url = '/post_decision_motions';
 
@@ -71,6 +73,9 @@ export const submitMTVJudgeDecision = (data, ownProps) => {
       const res = await ApiUtil.post(url, { data });
 
       dispatch(submitMTVJudgeDecisionSuccess(res));
+
+      dispatch(showSuccessMessage(addressMTVSuccessAlert({ data,
+        appeal })));
 
       if (history) {
         history.push('/queue');

--- a/client/app/queue/mtv/mtvMessages.js
+++ b/client/app/queue/mtv/mtvMessages.js
@@ -1,0 +1,32 @@
+import {
+  JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED,
+  JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED,
+  JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED,
+  JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED
+} from '../../../COPY';
+import { sprintf } from 'sprintf-js';
+
+export const addressMTVSuccessAlert = ({ data, appeal }) => {
+  const { disposition } = data;
+  const { veteranFullName } = appeal;
+
+  switch (disposition) {
+  case 'granted':
+  case 'partial':
+    return {
+      title: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED, veteranFullName),
+      detail: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED)
+    };
+  case 'denied':
+  case 'dismissed':
+    return {
+      title: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, veteranFullName),
+      detail: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED, disposition)
+    };
+  default:
+    return {
+      title: 'Task Complete',
+      detail: ' '
+    };
+  }
+};

--- a/client/app/queue/mtv/mtvMessages.js
+++ b/client/app/queue/mtv/mtvMessages.js
@@ -20,8 +20,8 @@ export const addressMTVSuccessAlert = ({ data, appeal }) => {
   case 'denied':
   case 'dismissed':
     return {
-      title: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, veteranFullName),
-      detail: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED, disposition)
+      title: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, veteranFullName, disposition),
+      detail: JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED
     };
   default:
     return {

--- a/client/app/queue/mtv/mtvMessages.js
+++ b/client/app/queue/mtv/mtvMessages.js
@@ -12,7 +12,7 @@ export const addressMTVSuccessAlert = ({ data, appeal }) => {
 
   switch (disposition) {
   case 'granted':
-  case 'partial':
+  case 'partially_granted':
     return {
       title: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED, veteranFullName),
       detail: sprintf(JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED)

--- a/spec/controllers/post_decision_motions_controller_spec.rb
+++ b/spec/controllers/post_decision_motions_controller_spec.rb
@@ -81,7 +81,6 @@ describe PostDecisionMotionsController do
         post :create, params: params
 
         expect(response).to be_success
-        expect(flash[:success]).to be_present
       end
     end
   end

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -307,7 +307,9 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
-      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name, "denied"))
+      expect(page).to have_content(
+        format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name, "denied")
+      )
       expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED)
 
       # Verify PostDecisionMotion is created; should ultimately also check new tasks
@@ -373,7 +375,9 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
-      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name, "dismissed"))
+      expect(page).to have_content(
+        format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name, "dismissed")
+      )
       expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED)
 
       # Verify PostDecisionMotion is created; should ultimately also check new tasks

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -307,8 +307,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
-      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name))
-      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED, "denied"))
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name, "denied"))
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED)
 
       # Verify PostDecisionMotion is created; should ultimately also check new tasks
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
@@ -373,8 +373,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
-      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name))
-      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED, "dismissed"))
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name, "dismissed"))
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED)
 
       # Verify PostDecisionMotion is created; should ultimately also check new tasks
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -205,6 +205,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED, appeal.veteran_full_name))
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED)
 
       # Verify PostDecisionMotion is created
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
@@ -227,6 +229,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED, appeal.veteran_full_name))
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED)
 
       # Verify PostDecisionMotion is created
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
@@ -249,6 +253,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED, appeal.veteran_full_name))
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED)
 
       # Verify PostDecisionMotion is created
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
@@ -276,6 +282,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED, appeal.veteran_full_name))
+      expect(page).to have_content(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED)
 
       # Verify PostDecisionMotion is created
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
@@ -299,6 +307,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name))
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED, "denied"))
 
       # Verify PostDecisionMotion is created; should ultimately also check new tasks
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
@@ -363,6 +373,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED, appeal.veteran_full_name))
+      expect(page).to have_content(format(COPY::JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED, "dismissed"))
 
       # Verify PostDecisionMotion is created; should ultimately also check new tasks
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)


### PR DESCRIPTION
Connects #13073

### Description
We now display success alerts at the top of judge's queue upon completion of `AddressMotionToVacate` task. This also removes the flash message that was being displayed when going back to the appeal detail page, as that should not have been happening.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Success alert shows upon successful completion of `AddressMotionToVacate`
