### PR TITLE
Rescue from StandardError to catch problems beyond VBMS

### DIFF
--- a/app/models/establish_claim.rb
+++ b/app/models/establish_claim.rb
@@ -166,7 +166,7 @@ class EstablishClaim < Dispatch::Task
       return :missing_decision if appeal.decisions.empty?
 
       appeal.decisions.each(&:fetch_and_cache_document_from_vbms)
-    rescue VBMS::ClientError => error
+    rescue StandardError => error
       Rails.logger.info "Failed EstablishClaim (id = #{id}), Error: #{error}"
       Raven.capture_exception(error, extra: { establish_claim: id })
       return :failed


### PR DESCRIPTION
Expand the range of what we rescue from during background job so that we capture Ruby native errors too.