### PR TITLE
Add Pulac Cerullo reminder for "vacate" streams

### DIFF
--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -28,6 +28,7 @@ class AttorneyTask < Task
     return [] if assigned_to != user
 
     [
+      (Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h if appeal.vacate?),
       Constants.TASK_ACTIONS.REVIEW_DECISION_DRAFT.to_h,
       Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
       Constants.TASK_ACTIONS.CANCEL_TASK.to_h

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -32,7 +32,7 @@ class AttorneyTask < Task
       Constants.TASK_ACTIONS.REVIEW_DECISION_DRAFT.to_h,
       Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
       Constants.TASK_ACTIONS.CANCEL_TASK.to_h
-    ]
+    ].compact
   end
 
   def timeline_title

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -28,7 +28,7 @@ class AttorneyTask < Task
     return [] if assigned_to != user
 
     [
-      (Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h if appeal.vacate?),
+      (Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h if ama? && appeal.vacate?),
       Constants.TASK_ACTIONS.REVIEW_DECISION_DRAFT.to_h,
       Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
       Constants.TASK_ACTIONS.CANCEL_TASK.to_h

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -71,7 +71,7 @@ export const CaseDetailsView = (props) => {
     }
   }, []);
 
-  const doPulacCerulloReminder = useMemo(() => needsPulacCerulloAlert(tasks), [tasks]);
+  const doPulacCerulloReminder = useMemo(() => needsPulacCerulloAlert(appeal, tasks), [appeal, tasks]);
 
   return (
     <React.Fragment>

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -24,7 +24,7 @@ import { getQueryParams } from '../util/QueryParamsUtil';
 
 import { CATEGORIES, TASK_ACTIONS } from './constants';
 import { COLORS } from '../constants/AppConstants';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 
 import { appealWithDetailSelector, getAllTasksForAppeal } from './selectors';

--- a/client/app/queue/pulacCerullo/index.js
+++ b/client/app/queue/pulacCerullo/index.js
@@ -1,7 +1,11 @@
 export const cavcUrl = 'https://www.uscourts.cavc.gov/';
 export const chairmanMemoUrl = '/assets/chairman_memorandum_01-10-18.pdf';
 
-export const needsPulacCerulloAlert = (tasks) => {
+export const needsPulacCerulloAlert = (appeal, tasks) => {
+  if (appeal?.caseType?.toLowerCase() === 'vacate') {
+    return true;
+  }
+
   const taskTypes = tasks.map((task) => task.type);
 
   return taskTypes.includes('VacateMotionMailTask');

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -466,6 +466,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
         visit "/queue/appeals/#{vacate_stream.uuid}"
 
+        check_cavc_alert
         verify_cavc_conflict_action
 
         find(".Select-placeholder", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
@@ -513,6 +514,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
         visit "/queue/appeals/#{vacate_stream.uuid}"
 
+        check_cavc_alert
         verify_cavc_conflict_action
 
         find(".Select-placeholder", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -465,6 +465,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
         User.authenticate!(user: drafting_attorney)
 
         visit "/queue/appeals/#{vacate_stream.uuid}"
+        
+        verify_cavc_conflict_action
 
         find(".Select-placeholder", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
         find("div", class: "Select-option", text: Constants.TASK_ACTIONS.REVIEW_VACATE_DECISION.label).click
@@ -510,6 +512,8 @@ RSpec.feature "Motion to vacate", :all_dbs do
         User.authenticate!(user: drafting_attorney)
 
         visit "/queue/appeals/#{vacate_stream.uuid}"
+
+        verify_cavc_conflict_action
 
         find(".Select-placeholder", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
         find("div", class: "Select-option", text: Constants.TASK_ACTIONS.REVIEW_VACATE_DECISION.label).click

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -465,7 +465,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
         User.authenticate!(user: drafting_attorney)
 
         visit "/queue/appeals/#{vacate_stream.uuid}"
-        
+
         verify_cavc_conflict_action
 
         find(".Select-placeholder", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click


### PR DESCRIPTION
Connects #13313

### Description
Adds the Pulac Cerullo reminder for all vacate streams in addition to where it already was.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Pulac Cerullo reminder shows up during the attorney checkout process
- [ ] "Notify Litigation Support..." task action is available for `AttorneyTask` on vacate stream