### PR TITLE
Fix null object error in Establish claim

### DIFF
--- a/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaim.jsx
@@ -219,11 +219,11 @@ export class EstablishClaim extends React.Component {
       },
       (error) => {
         this.props.performEstablishClaimFailure();
-        const errorMessage = CREATE_EP_ERRORS[error.response.body.error_code] || CREATE_EP_ERRORS.default;
+        const errorMessage = CREATE_EP_ERRORS[error.response.body?.error_code] || CREATE_EP_ERRORS.default;
 
         const nextModifier = this.validModifiers()[1];
 
-        if (error.response.body.error_code === 'duplicate_ep' && nextModifier) {
+        if (error.response.body?.error_code === 'duplicate_ep' && nextModifier) {
           this.props.onDuplicateEP(nextModifier);
         }
 


### PR DESCRIPTION
Connects #13405
I am currently doing VBMS UAT dispatch testing and keep getting error_code of null on the submitDecisionPageSuccess part. This error was handled in https://github.com/department-of-veterans-affairs/caseflow/pull/13407 but not in every part of the code


<img width="980" alt="Screen Shot 2020-02-21 at 4 51 51 PM" src="https://user-images.githubusercontent.com/23080951/75077222-22ae4b00-54d0-11ea-935f-2c8d6a0796b4.png">
