### PR TITLE
Add updating documentation to GH templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/engineering-task.md
+++ b/.github/ISSUE_TEMPLATE/engineering-task.md
@@ -11,7 +11,7 @@ assignees: ''
 
 
 ## Acceptance criteria
-- [ ] Update documentation:
+- [ ] Update documentation: [link]
 
 ## Background/context/resources
 

--- a/.github/ISSUE_TEMPLATE/engineering-task.md
+++ b/.github/ISSUE_TEMPLATE/engineering-task.md
@@ -7,14 +7,13 @@ assignees: ''
 
 ---
 
-<!-- This is a simplified template for engineers creating tickets for bugs, tech improvement, etc. Please adapt and add/remove sections as needed. -->
 ## Description
-<!-- The description should summarize enough information that someone can know what this ticket is about without having to look at information in background/context -->
 
+
+## Acceptance criteria
+- [ ] Update documentation:
 
 ## Background/context/resources
-<!-- A place for additional information such as links to Slack chats, Sentry alerts, data IDs, research links -->
 
 
 ## Technical notes
-<!-- Include notes that might help an engineer get started on this more quickly, or potential pitfalls to watch out for. -->

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -16,7 +16,7 @@ Job story: When a [user] does [x], they need [y], so that [z]
 - [ ] Please put this work behind the feature toggle: [toggle name]
 - [ ] This feature should be accessible to the following user groups:
 - [ ] Include screenshot(s) in the Github issue if there are front-end changes
-- [ ] Update documentation:
+- [ ] Update documentation: [link]
 
 ## Release notes
 <!-- Write what should be included in release notes (Caseflow uses Headway), updated when the story is built, before it's deployed. -->

--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -16,6 +16,7 @@ Job story: When a [user] does [x], they need [y], so that [z]
 - [ ] Please put this work behind the feature toggle: [toggle name]
 - [ ] This feature should be accessible to the following user groups:
 - [ ] Include screenshot(s) in the Github issue if there are front-end changes
+- [ ] Update documentation:
 
 ## Release notes
 <!-- Write what should be included in release notes (Caseflow uses Headway), updated when the story is built, before it's deployed. -->


### PR DESCRIPTION
### Description
Small update to add "Update documentation" to GitHub issue templates.

Also remove the comments from the "Engineering task" template because we don't really need them.
