### PR TITLE
Optimize UpdateCachedAppealsAttributesJob

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -82,7 +82,8 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
   def cache_legacy_appeals
     # Avoid lazy evaluation bugs by immediately plucking all VACOLS IDs. Lazy evaluation of the LegacyAppeal.find(...)
     # was previously causing this code to insert legacy appeal attributes that corresponded to NULL ID fields.
-    legacy_appeals = LegacyAppeal.includes(:available_hearing_locations).where(id: open_appeals_from_tasks(LegacyAppeal.name))
+    legacy_appeals = LegacyAppeal.includes(:available_hearing_locations)
+      .where(id: open_appeals_from_tasks(LegacyAppeal.name))
     all_vacols_ids = legacy_appeals.pluck(:vacols_id).flatten
 
     cache_postgres_data_start = Time.zone.now

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -34,7 +34,7 @@ class WarmBgsCachesJob < CaseflowJob
       claimant.representative_name # updates_cache
       claimant.update!(updated_at: Time.zone.now)
     end
-    datadog_report_time_segment(segment: "warn_poa_caches", start_time: start_time)
+    datadog_report_time_segment(segment: "warm_poa_caches", start_time: start_time)
   end
 
   def claimants_for_open_appeals

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -11,6 +11,7 @@ class WarmBgsCachesJob < CaseflowJob
     warm_participant_caches
     warm_veteran_attribute_caches
     warm_people_caches
+    warm_poa_caches
     datadog_report_runtime(metric_group_name: "warm_bgs_caches_job")
   end
 
@@ -28,10 +29,12 @@ class WarmBgsCachesJob < CaseflowJob
     # UpdateCachedAppealsAttributesJob cares about.
     # assuming we have 40k open appeals/claimants at any given time,
     # and we cache each one for 30 days, we want to cache about 1400 a day.
+    start_time = Time.zone.now
     oldest_claimants_for_open_appeals.limit(1400).each do |claimant|
       claimant.representative_name # updates_cache
       claimant.update!(updated_at: Time.zone.now)
     end
+    datadog_report_time_segment(segment: "warn_poa_caches", start_time: start_time)
   end
 
   def claimants_for_open_appeals

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -46,13 +46,15 @@ class AppealRepository
     if id.is_a?(Array)
       id.in_groups_of(1000, false).map do |group|
         if ignore_misses
-          VACOLS::Case.includes(:correspondent, :case_issues, folder: [:outcoder]).where(bfkey: group)
+          VACOLS::Case.eager_load(:correspondent, :case_issues, folder: [:outcoder]).where(bfkey: group)
         else
-          VACOLS::Case.includes(:correspondent, :case_issues, folder: [:outcoder]).find(group)
+          VACOLS::Case.eager_load(:correspondent, :case_issues, folder: [:outcoder]).find(group)
         end
       end.flatten
     else
-      VACOLS::Case.includes(:correspondent, :case_issues, folder: [:outcoder]).find(id)
+      # using .includes() creates 4 SQL queries at ~ 90ms each (measured in production).
+      # using .eager_load() creates 2 SQL queries at ~ 90ms each
+      VACOLS::Case.eager_load(:correspondent, :case_issues, folder: [:outcoder]).find(id)
     end
   end
 

--- a/app/services/bgs_power_of_attorney.rb
+++ b/app/services/bgs_power_of_attorney.rb
@@ -17,6 +17,8 @@ class BgsPowerOfAttorney
   delegate :email_address,
            to: :person, prefix: :representative
 
+  CACHE_TTL = 30.days
+
   private
 
   def person
@@ -26,12 +28,12 @@ class BgsPowerOfAttorney
   def fetch_bgs_record
     if claimant_participant_id
       cache_key = "bgs-participant-poa-#{claimant_participant_id}"
-      Rails.cache.fetch(cache_key, expires_in: 30.days) do
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
         bgs.fetch_poas_by_participant_ids([claimant_participant_id])[claimant_participant_id]
       end
     else
       cache_key = "bgs-participant-poa-#{file_number}"
-      Rails.cache.fetch(cache_key, expires_in: 30.days) do
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
         bgs.fetch_poa_by_file_number(file_number)
       end
     end

--- a/app/services/bgs_power_of_attorney.rb
+++ b/app/services/bgs_power_of_attorney.rb
@@ -26,12 +26,12 @@ class BgsPowerOfAttorney
   def fetch_bgs_record
     if claimant_participant_id
       cache_key = "bgs-participant-poa-#{claimant_participant_id}"
-      Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      Rails.cache.fetch(cache_key, expires_in: 30.days) do
         bgs.fetch_poas_by_participant_ids([claimant_participant_id])[claimant_participant_id]
       end
     else
       cache_key = "bgs-participant-poa-#{file_number}"
-      Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      Rails.cache.fetch(cache_key, expires_in: 30.days) do
         bgs.fetch_poa_by_file_number(file_number)
       end
     end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -725,7 +725,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
         expect(task["attributes"]["available_actions"].size).to eq 2
 
-        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(18)
+        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(13)
       end
 
       context "when appeal is not assigned to current user" do


### PR DESCRIPTION
connects #13384 

### Description
Our BGS POA caches were previously set to live for 24 hours. We were only warming those caches based on scheduled hearings.

Now we will cache for 30 days, and apply the pre-warming logic to all claimants on open appeals, regardless of whether they have a hearing scheduled.

In addition, the UpdatedCachedAppealsAttributesJob is slightly optimized to:

* build a lookup table of appeal_id => representative name, similar to the pattern elsewhere in the job.
* preload available_hearing_locations

The biggest performance impact however is switching from `includes()` to `eager_load` in VACOLS::Case.