### PR TITLE
Bat Team | Allow nil for delegation to veteran in Legacy Appeal

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -78,7 +78,8 @@ class LegacyAppeal < ApplicationRecord
 
   # NOTE: we cannot currently match end products to a specific appeal.
   delegate :end_products,
-           to: :veteran
+           to: :veteran,
+           allow_nil: true
 
   delegate :address, :address_line_1, :address_line_2, :city, :country, :state, :zip,
            to: :bgs_address_service,


### PR DESCRIPTION
### Description
In LegacyAppeal, a matching veteran is not always found, as seen by the `veteran_if_exists` method, and that where address is delegated to the veteran, allow_nil is set to true.

This is to prevent this Sentry alert:
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/8316
https://dsva.slack.com/archives/CAP9C43E2/p1582559340000700

Which is complaining to delegating to veteran when veteran is nil.