### PR TITLE
Skip non actionable RedistributedCase::CannotRedistribute errors

### DIFF
--- a/app/services/redistributed_case.rb
+++ b/app/services/redistributed_case.rb
@@ -13,7 +13,7 @@ class RedistributedCase
     if ok_to_redistribute?
       rename_existing_distributed_case!
     else
-      alert_existing_distributed_case_not_unique
+      alert_existing_distributed_case_not_unique if throw_error?
       false
     end
   end
@@ -30,6 +30,10 @@ class RedistributedCase
 
     # be conservative; return false so that appeal is manually addressed
     false
+  end
+
+  def throw_error?
+    !legacy_appeal.location_code.eql? new_distribution.judge.vacols_user.slogid
   end
 
   private


### PR DESCRIPTION
Resolves [these alerts](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7524/?referrer=webhooks_plugin) that are not actionable according to the [batteam wiki](https://github.com/department-of-veterans-affairs/caseflow/wiki/Bat-Team#redistributedcasecannotredistribute-sentry-alert)

### Description
Skips alert if the case is already with the intended judge