### PR TITLE
Reader JS exceptions should be quieter

### DIFF
--- a/client/app/reader/DocumentListHeader.jsx
+++ b/client/app/reader/DocumentListHeader.jsx
@@ -19,8 +19,13 @@ class DocumentListHeader extends React.Component {
       { data: { query } },
       ENDPOINT_NAMES.CLAIMS_FOLDER_SEARCHES
     ).
-      then(_.noop).
-      catch(_.noop);
+      then(() => {
+        // no op
+      }).
+      catch((error) => {
+        // we don't care reporting via Raven.
+        console.error(error);
+      });
   }
 
   render() {


### PR DESCRIPTION
`lodash.noop` may not be what we want