### PR TITLE
Set closed_at inside update_all when we close tasks

### DIFF
--- a/app/models/tasks/assign_hearing_disposition_task.rb
+++ b/app/models/tasks/assign_hearing_disposition_task.rb
@@ -110,7 +110,9 @@ class AssignHearingDispositionTask < Task
   private
 
   def update_children_status_after_closed
-    children.open.update_all(status: status)
+    update_args = { status: status }
+    update_args[:closed_at] = Time.zone.now if self.class.closed_statuses.include?(status)
+    children.open.update_all(update_args)
   end
 
   def cascade_closure_from_child_task?(_child_task)

--- a/app/models/tasks/assign_hearing_disposition_task.rb
+++ b/app/models/tasks/assign_hearing_disposition_task.rb
@@ -76,7 +76,7 @@ class AssignHearingDispositionTask < Task
       )
     end
 
-    update!(status: Constants.TASK_STATUSES.cancelled)
+    update!(status: Constants.TASK_STATUSES.cancelled, closed_at: Time.zone.now)
   end
 
   def postpone!

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -54,9 +54,9 @@ class ScheduleHearingTask < Task
     end
 
     # cancel my children, myself, and my hearing task ancestor
-    children.open.update_all(status: Constants.TASK_STATUSES.cancelled)
-    update!(status: Constants.TASK_STATUSES.cancelled)
-    ancestor_task_of_type(HearingTask)&.update!(status: Constants.TASK_STATUSES.cancelled)
+    children.open.update_all(status: Constants.TASK_STATUSES.cancelled, closed_at: Time.zone.now)
+    update!(status: Constants.TASK_STATUSES.cancelled, closed_at: Time.zone.now)
+    ancestor_task_of_type(HearingTask)&.update!(status: Constants.TASK_STATUSES.cancelled, closed_at: Time.zone.now)
 
     # cancel the old HearingTask and create a new one associated with the same hearing
     new_hearing_task = hearing_task.cancel_and_recreate

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -32,12 +32,13 @@ describe AssignHearingDispositionTask, :all_dbs do
       end
 
       it "sets the hearing disposition and calls cancel!" do
-        expect(disposition_task).to receive(:cancel!).exactly(1).times
+        expect(disposition_task).to receive(:cancel!).exactly(1).times.and_call_original
 
         subject
 
         expect(Hearing.count).to eq 1
         expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.cancelled
+        expect(disposition_task.reload.closed_at).to_not be_nil
       end
     end
 
@@ -281,6 +282,8 @@ describe AssignHearingDispositionTask, :all_dbs do
 
             expect(disposition_task.reload.cancelled?).to be_truthy
             expect(hearing_task.reload.cancelled?).to be_truthy
+            expect(disposition_task.closed_at).to_not be_nil
+            expect(hearing_task.closed_at).to_not be_nil
             expect(InformalHearingPresentationTask.where(appeal: appeal).length).to eq 0
             expect(EvidenceSubmissionWindowTask.first.appeal).to eq disposition_task.appeal
             expect(EvidenceSubmissionWindowTask.first.parent).to eq disposition_task.hearing_task.parent

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -133,6 +133,7 @@ describe ScheduleHearingTask, :all_dbs do
             schedule_hearing_task.update_from_params(update_params, hearings_management_user)
 
             expect(schedule_hearing_task.status).to eq(Constants.TASK_STATUSES.cancelled)
+            expect(schedule_hearing_task.closed_at).to_not be_nil
             expect(vacols_case.reload.bfcurloc).to eq(LegacyAppeal::LOCATION_CODES[:case_storage])
             expect(vacols_case.bfha).to eq("5")
             expect(vacols_case.bfhr).to eq("5")
@@ -209,9 +210,13 @@ describe ScheduleHearingTask, :all_dbs do
       subject
 
       expect(hearing_task.reload.open?).to be_falsey
+      expect(hearing_task.closed_at).to_not be_nil
       expect(disposition_task.reload.open?).to be_falsey
+      expect(disposition_task.closed_at).to_not be_nil
       expect(hearing_task_2.reload.status).to eq Constants.TASK_STATUSES.cancelled
+      expect(hearing_task_2.closed_at).to_not be_nil
       expect(task.reload.status).to eq Constants.TASK_STATUSES.cancelled
+      expect(task.closed_at).to_not be_nil
       new_hearing_tasks = appeal.tasks.open.where(type: HearingTask.name)
       expect(new_hearing_tasks.count).to eq 1
       expect(new_hearing_tasks.first.hearing).to eq hearing


### PR DESCRIPTION
In https://github.com/department-of-veterans-affairs/dsva-vacols/issues/107 we learned that some cancelled tasks do not have a `closed_at` value set.

This PR is a start of remedying that.

See also #13058 
