### PR TITLE
Use the presence of a decision doc id to determine if a case has already gone to an attorney

### DIFF
--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -31,7 +31,7 @@ class LegacyWorkQueue
         # If the user is a judge they are only assigned JudgeLegacyTasks
         # If the user is an acting judge, assume any case that already has a decision doc is assigned to them as a judge
         if user&.vacols_roles&.first&.downcase == "judge" ||
-          (user&.acting_judge_in_vacols? && appeal.vacols_case_review.document_id)
+           (user&.acting_judge_in_vacols? && appeal.vacols_case_review.document_id)
           task_class = JudgeLegacyTask
         end
 

--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -28,7 +28,10 @@ class LegacyWorkQueue
         user = validate_or_create_user(user, task.assigned_to_css_id)
 
         task_class = AttorneyLegacyTask
-        if user&.vacols_roles&.first&.downcase == "judge" || (user&.judge_in_vacols? && appeal.attorney_case_review)
+        # If the user is a judge they are only assigned JudgeLegacyTasks
+        # If the user is an acting judge, assume any case that already has a decision doc is assigned to them as a judge
+        if user&.vacols_roles&.first&.downcase == "judge" ||
+          (user&.acting_judge_in_vacols? && appeal.vacols_case_review.document_id)
           task_class = JudgeLegacyTask
         end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,10 @@ class User < ApplicationRecord
     selected_regional_office || regional_office
   end
 
+  def acting_judge_in_vacols?
+    attorney_in_vacols? && judge_in_vacols?
+  end
+
   def attorney_in_vacols?
     vacols_roles.include?("attorney")
   end

--- a/spec/models/queues/legacy_work_queue_spec.rb
+++ b/spec/models/queues/legacy_work_queue_spec.rb
@@ -7,7 +7,7 @@ describe LegacyWorkQueue, :all_dbs do
     let!(:appeals) do
       [
         create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user)),
-        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user))
+        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user, document_id: "02255-00000002"))
       ]
     end
 
@@ -28,6 +28,16 @@ describe LegacyWorkQueue, :all_dbs do
       it "returns tasks" do
         expect(subject.length).to eq(2)
         expect(subject[0].class).to eq(JudgeLegacyDecisionReviewTask)
+      end
+    end
+
+    context "when it is an acting judge" do
+      let(:role) { :attorney_judge_role }
+
+      it "returns attorney tasks for the case without a document id, but judge task for the case with a document id" do
+        expect(subject.length).to eq(2)
+        expect(subject[0].class).to eq(AttorneyLegacyTask)
+        expect(subject[1].class).to eq(JudgeLegacyDecisionReviewTask)
       end
     end
   end


### PR DESCRIPTION
Resolves [these](https://dsva.slack.com/archives/CHX8FMP28/p1581619301317600) batteam [issues](https://dsva.slack.com/archives/CHX8FMP28/p1577821139163100) 

### Description
It looks like looking for an associated attorney case review is not enough to determine if a legacy case decision has already been drafted. Instead, we'll look at the decass record for the case to see if there is a decision document. 

### Notes
In testing I saw no ill effects when dispatching a case as an AVLJ when there was a missing attorney case review

### Testing plan
1. Sign in as BVASCASPER1 and draft a decision for a legacy appeal
2. At the end, send this case to an acting judge AVLJ - Acting judge
3. Sign in as said judge
4. Delete the associated case review
   ```ruby
   vacols_id = <vacols_id>
   LegacyAppeal.find_by(vacols_id: vacols_id).attorney_case_review.destroy!
   ```
5. Ensure the case shows up in the user's queue as a Judge review task
6. Ensure the user has the option to send this case to dispatch
7. Ensure completing judge checkout completes successfully 
