### PR TITLE
Check for existing claim before re-attempting establishment

### DIFF
--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -216,6 +216,10 @@ module Asyncable
     submitted? && !processed?
   end
 
+  def previously_attempted?
+    self[self.class.last_submitted_at_column] != self[self.class.submitted_at_column]
+  end
+
   def sort_by_last_submitted_at
     self[self.class.last_submitted_at_column] || Time.zone.now
   end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -51,6 +51,9 @@ class EndProductEstablishment < ApplicationRecord
   def perform!(commit: false)
     return if reference_id
 
+    save_recovered_end_product!
+    return if reference_id
+
     fail InvalidEndProductError unless end_product_to_establish.valid?
 
     establish_claim_in_vbms(end_product_to_establish).tap do |result|
@@ -455,6 +458,16 @@ class EndProductEstablishment < ApplicationRecord
     @cached_result ||= end_product_with_modifier
   end
 
+  # Fetch and cache an EP whose attributes match this EPE (or nil if none found)
+  # The complicated version of ||= is used because nil is a common value for this method.
+  def matching_established_end_product
+    return @matching_established_end_product if defined?(@matching_established_end_product)
+
+    @matching_established_end_product = veteran.end_products.find do |end_product|
+      matches_end_product?(end_product)
+    end
+  end
+
   def end_product_with_modifier(the_modifier = nil)
     the_modifier ||= modifier
     EndProduct.new(
@@ -486,6 +499,17 @@ class EndProductEstablishment < ApplicationRecord
     result
   end
 
+  def matches_end_product?(end_product)
+    return true if ep_created? && reference_id == end_product.claim_id
+    return false unless end_product.active? &&
+                        end_product.claim_type_code == code &&
+                        end_product.claim_date == claim_date &&
+                        end_product.payee_code == payee_code
+
+    # Call it a match once we confirm that other EPE has the same claim ID
+    EndProductEstablishment.find_by(reference_id: end_product.claim_id).nil?
+  end
+
   def sync_source!
     return unless source&.respond_to?(:on_sync)
 
@@ -497,6 +521,14 @@ class EndProductEstablishment < ApplicationRecord
       return if result.claim_type_code == end_product_code_updates.last&.code
 
       end_product_code_updates.create(code: result.claim_type_code)
+    end
+  end
+
+  def save_recovered_end_product!
+    return unless source.try(:previously_attempted?)
+
+    if matching_established_end_product.present?
+      update!(reference_id: matching_established_end_product.claim_id)
     end
   end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -57,6 +57,15 @@ describe EndProductEstablishment, :postgres do
       limited_poa_access: limited_poa_access
     )
   end
+  let(:orphaned_end_product) do
+    EndProduct.new(
+      claim_id: "1234",
+      claim_date: end_product_establishment.claim_date,
+      claim_type_code: end_product_establishment.code,
+      payee_code: end_product_establishment.payee_code,
+      status_type_code: "PEND"
+    )
+  end
 
   let(:vbms_error) do
     VBMS::HTTPError.new("500", "More EPs more problems")
@@ -266,6 +275,16 @@ describe EndProductEstablishment, :postgres do
 
       it "returns NoAvailableModifiers error" do
         expect { subject }.to raise_error(EndProductModifierFinder::NoAvailableModifiers)
+      end
+    end
+
+    context "when a previous establishment attempt actually succeeded" do
+      it "recovers and saves the previous EP" do
+        allow(source).to receive(:previously_attempted?).and_return(true)
+        allow(end_product_establishment.veteran).to receive(:end_products).and_return([orphaned_end_product])
+        subject
+        expect(Fakes::VBMSService).not_to have_received(:establish_claim!)
+        expect(end_product_establishment.reference_id).to eq(orphaned_end_product.claim_id)
       end
     end
 


### PR DESCRIPTION
Connects #13312 

### Description
When re-attempting EP establishment, check if the previous attempt actually created an orphaned EP that should be recovered instead of creating a brand new one.

### Acceptance Criteria
- [x] Include this check if a claim_establishment is being re-attempted (the submitted_at date is at least 3 hours earlier)
- [x] Before establishing the claim, look for a matching end product in the veteran's end products.
  - "claim_type_code" is equivalent to "code" in EndProductEstablishment
  - "claim_date" is equivalent to "receipt_date" in EndProductEstablishment
  - The claim should still be active
  - The claim should have no contentions
- [x] If found, update the EndProductEstablishment reference_id to the "claim_id"
- [x] Proceed with the rest of the code in "establish!" as usual. This would create contentions.

### Testing Plan
1. Added new test for `EndProductEstablishment#perform!`