### PR TITLE
Auto create schema documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ local/vacols/build_facols/*
 
 # makefile
 Makefile
+
+# ERD diagrams are not checked in
+*-erd.pdf

--- a/Dangerfile
+++ b/Dangerfile
@@ -24,6 +24,10 @@ if git.modified_files.grep(/db\/migrate\//).any? && git.modified_files.grep(/db\
   warn("This PR contains one or more db migrations, but the schema.rb is not modified.")
 end
 
+if git.modified_files.grep(/db\/migrate\//).any? && git.modified_files.grep(/docs\/schema/).none?
+  warn("This PR contains one or more db migrations. Did you forget to run 'make docs'?")
+end
+
 # We should not disable Rubocop rules unless there's a very good reason
 result = git.diff.flat_map do |chunk|
   chunk.patch.lines.grep(/^\+\s*\w/).select { |added_line| added_line.match?(/rubocop:disable/) }

--- a/Gemfile
+++ b/Gemfile
@@ -120,11 +120,7 @@ group :development do
   gem "fasterer", require: false
   gem "foreman"
   gem "meta_request"
-  # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  # gem 'spring', platforms: :ruby
-  # Include the IANA Time Zone Database on Windows, where Windows doesn't ship with a timezone database.
-  # POSIX systems should have this already, so we're not going to bring it in on other platforms
-  gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+  gem "rails-erd"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -121,6 +121,7 @@ group :development do
   gem "foreman"
   gem "meta_request"
   gem "rails-erd"
+  gem "skeema"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -121,7 +121,6 @@ group :development do
   gem "foreman"
   gem "meta_request"
   gem "rails-erd"
-  gem "skeema"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,6 +533,7 @@ GEM
       thor
     simplecov-html (0.10.2)
     single_cov (1.3.2)
+    skeema (0.0.2)
     socksify (1.7.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -662,6 +663,7 @@ DEPENDENCIES
   shoryuken (= 3.1.11)
   simplecov!
   single_cov
+  skeema
   sniffybara!
   stringex
   strong_migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,7 @@ GEM
       launchy
     childprocess (1.0.1)
       rake (< 13.0)
+    choice (0.2.0)
     claide (1.0.2)
     claide-plugins (0.9.2)
       cork
@@ -399,6 +400,11 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
+    rails-erd (1.6.0)
+      activerecord (>= 4.2)
+      activesupport (>= 4.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     railties (5.2.4.1)
@@ -479,6 +485,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.6)
     rubocop-performance (1.1.0)
       rubocop (>= 0.67.0)
+    ruby-graphviz (1.2.4)
     ruby-oci8 (2.2.7)
     ruby-plsql (0.7.1)
     ruby-progressbar (1.10.0)
@@ -635,6 +642,7 @@ DEPENDENCIES
   puma (~> 3.12.0)
   rack (~> 2.0.6)
   rails (= 5.2.4.1)
+  rails-erd
   rainbow
   rb-readline
   react_on_rails (= 8.0.6)
@@ -660,7 +668,6 @@ DEPENDENCIES
   therubyracer
   timecop
   tty-tree
-  tzinfo-data
   uglifier (>= 1.3.0)
   validates_email_format_of
   webdrivers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,7 +533,6 @@ GEM
       thor
     simplecov-html (0.10.2)
     single_cov (1.3.2)
-    skeema (0.0.2)
     socksify (1.7.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -663,7 +662,6 @@ DEPENDENCIES
   shoryuken (= 3.1.11)
   simplecov!
   single_cov
-  skeema
   sniffybara!
   stringex
   strong_migrations

--- a/Makefile.example
+++ b/Makefile.example
@@ -164,13 +164,13 @@ karma:  ## TODO
 	cd client && node_modules/.bin/karma start
 
 erd-etl:	## Create ERD diagram for the ETL database
-	ERD_BASE=ETL::Record bundle exec erd --filename etl-erd
+	ERD_BASE=ETL::Record bundle exec erd --filename etl-erd --title 'ODS/ETL Data Model'
 
 erd-vacols:	## Create ERD diagram for the VACOLS database
-	ERD_BASE=VACOLS::Record bundle exec erd --filename vacols-erd
+	ERD_BASE=VACOLS::Record bundle exec erd --filename vacols-erd --title 'VACOLS Data Model'
 
 erd-caseflow:	## Create ERD diagram for the Caseflow database
-	ERD_BASE=CaseflowRecord bundle exec erd --filename caseflow-erd
+	ERD_BASE=CaseflowRecord bundle exec erd --filename caseflow-erd --title 'Caseflow Data Model'
 
 erd: erd-etl erd-vacols erd-caseflow ## Create all ERD diagrams
 

--- a/Makefile.example
+++ b/Makefile.example
@@ -163,6 +163,17 @@ clear-eps:  ## TODO
 karma:  ## TODO
 	cd client && node_modules/.bin/karma start
 
+erd-etl:	## Create ERD diagram for the ETL database
+	ERD_BASE=ETL::Record bundle exec erd --filename etl-erd
+
+erd-vacols:	## Create ERD diagram for the VACOLS database
+	ERD_BASE=VACOLS::Record bundle exec erd --filename vacols-erd
+
+erd-caseflow:	## Create ERD diagram for the Caseflow database
+	ERD_BASE=CaseflowRecord bundle exec erd --filename caseflow-erd
+
+erd: erd-etl erd-vacols erd-caseflow ## Create all ERD diagrams
+
 # Self-documented makefile from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:  ## Shows help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile.example
+++ b/Makefile.example
@@ -174,6 +174,16 @@ erd-caseflow:	## Create ERD diagram for the Caseflow database
 
 erd: erd-etl erd-vacols erd-caseflow ## Create all ERD diagrams
 
+doc-schema-caseflow:	# Create docs/schema/caseflow.csv
+	ERD_BASE="CaseflowRecord" SCHEMA=caseflow bundle exec rake doc:schema
+
+doc-schema-etl:	# Create docs/schema/etl.csv
+	ERD_BASE="ETL::Record" SCHEMA=etl bundle exec rake doc:schema
+
+doc-schema:	doc-schema-caseflow doc-schema-etl	# Create all docs/schema csv files
+
+docs: erd doc-schema	# Build all documentation
+
 # Self-documented makefile from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:  ## Shows help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,5 @@ Please explain the changes you made here.
 * [ ] Column comments updated
 * [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
 * [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
+* [ ] DB schema docs updated with `make docs`
 * [ ] #appeals-schema notified with summary and link to this PR

--- a/app/models/advance_on_docket_motion.rb
+++ b/app/models/advance_on_docket_motion.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AdvanceOnDocketMotion < ApplicationRecord
+class AdvanceOnDocketMotion < CaseflowRecord
   belongs_to :person
   belongs_to :user
 

--- a/app/models/annotation.rb
+++ b/app/models/annotation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Annotation < ApplicationRecord
+class Annotation < CaseflowRecord
   belongs_to :document
   belongs_to :user
   validates :comment, presence: true

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -4,7 +4,7 @@ require "digest"
 require "securerandom"
 require "base64"
 
-class ApiKey < ApplicationRecord
+class ApiKey < CaseflowRecord
   before_create :generate_key_string
   has_many :api_views
 

--- a/app/models/api_view.rb
+++ b/app/models/api_view.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class ApiView < ApplicationRecord
+class ApiView < CaseflowRecord
   belongs_to :api_key
 end

--- a/app/models/appeal_series.rb
+++ b/app/models/appeal_series.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AppealSeries < ApplicationRecord
+class AppealSeries < CaseflowRecord
   has_many :appeals, class_name: "LegacyAppeal", dependent: :nullify
 
   # Timeliness is returned as a range of integer months from 50 to 84.1%tile.

--- a/app/models/appeal_stream_snapshot.rb
+++ b/app/models/appeal_stream_snapshot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AppealStreamSnapshot < ApplicationRecord
+class AppealStreamSnapshot < CaseflowRecord
   self.table_name = "hearing_appeal_stream_snapshots"
 
   belongs_to :hearing, class_name: "LegacyHearing"

--- a/app/models/appeal_view.rb
+++ b/app/models/appeal_view.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AppealView < ApplicationRecord
+class AppealView < CaseflowRecord
   belongs_to :appeal, polymorphic: true
   belongs_to :user
 end

--- a/app/models/attorney_case_review.rb
+++ b/app/models/attorney_case_review.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AttorneyCaseReview < ApplicationRecord
+class AttorneyCaseReview < CaseflowRecord
   include CaseReviewConcern
   include IssueUpdater
   include ::AmaAttorneyCaseReviewDocumentIdValidator

--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -3,7 +3,7 @@
 # BoardGrantEffectuation represents the work item of updating records in response to a granted issue on a Board appeal.
 # Some are represented as contentions on an EP in VBMS. Others are tracked via Caseflow tasks.
 
-class BoardGrantEffectuation < ApplicationRecord
+class BoardGrantEffectuation < CaseflowRecord
   include HasBusinessLine
   include Asyncable
   include DecisionSyncable

--- a/app/models/cached_appeal.rb
+++ b/app/models/cached_appeal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CachedAppeal < ApplicationRecord
+class CachedAppeal < CaseflowRecord
   self.table_name = "cached_appeal_attributes"
 
   def self.left_join_from_tasks_clause

--- a/app/models/cached_user.rb
+++ b/app/models/cached_user.rb
@@ -6,7 +6,7 @@
 # For future work: some methods in app/repositories/user_repository.rb might be able to
 # take advantage of this table, rather than using the Redis cache of VACOLS::Staff.
 
-class CachedUser < ApplicationRecord
+class CachedUser < CaseflowRecord
   self.table_name = "cached_user_attributes"
   self.primary_key = "sdomainid"
 

--- a/app/models/caseflow_record.rb
+++ b/app/models/caseflow_record.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class CaseflowRecord < ApplicationRecord
+  self.abstract_class = true
+
+  # all caseflow db models should inherit from this class.
+  # all vacols models inherit from VACOLS::Record
+  # all etl models inherit from ETL::Record
+end

--- a/app/models/caseflow_record.rb
+++ b/app/models/caseflow_record.rb
@@ -6,4 +6,8 @@ class CaseflowRecord < ApplicationRecord
   # all caseflow db models should inherit from this class.
   # all vacols models inherit from VACOLS::Record
   # all etl models inherit from ETL::Record
+
+  # In theory, this class should not need any additional code.
+  # It's here to make generating documentation easier, by clearly
+  # delineating db models via class inheritance.
 end

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -6,7 +6,7 @@
 # appeal. It also acts as a record of appeals that are certified
 # using Caseflow.
 #
-class Certification < ApplicationRecord
+class Certification < CaseflowRecord
   has_one :certification_cancellation, dependent: :destroy
 
   def async_start!

--- a/app/models/certification_cancellation.rb
+++ b/app/models/certification_cancellation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CertificationCancellation < ApplicationRecord
+class CertificationCancellation < CaseflowRecord
   belongs_to :certification
   validates :cancellation_reason, :email, :certification_id, presence: true
 end

--- a/app/models/claim_establishment.rb
+++ b/app/models/claim_establishment.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ClaimEstablishment < ApplicationRecord
+class ClaimEstablishment < CaseflowRecord
   belongs_to :task, class_name: "Dispatch::Task"
 
   enum decision_type: {

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Claimant < ApplicationRecord
+class Claimant < CaseflowRecord
   include AssociatedBgsRecord
 
   belongs_to :decision_review, polymorphic: true

--- a/app/models/claims_folder_search.rb
+++ b/app/models/claims_folder_search.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ClaimsFolderSearch < ApplicationRecord
+class ClaimsFolderSearch < CaseflowRecord
   belongs_to :appeal, polymorphic: true
   belongs_to :user
 end

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DecisionDocument < ApplicationRecord
+class DecisionDocument < CaseflowRecord
   include Asyncable
   include UploadableDocument
 

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DecisionIssue < ApplicationRecord
+class DecisionIssue < CaseflowRecord
   validates :benefit_type, inclusion: { in: Constants::BENEFIT_TYPES.keys.map(&:to_s) }
   validates :disposition, presence: true
   validates :end_product_last_action_date, presence: true, unless: :processed_in_caseflow?

--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DecisionReview < ApplicationRecord
+class DecisionReview < CaseflowRecord
   include CachedAttributes
   include Asyncable
 

--- a/app/models/dispatch/task.rb
+++ b/app/models/dispatch/task.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Dispatch::Task < ApplicationRecord
+class Dispatch::Task < CaseflowRecord
   self.table_name = "dispatch_tasks"
 
   include RetryHelper

--- a/app/models/distributed_case.rb
+++ b/app/models/distributed_case.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DistributedCase < ApplicationRecord
+class DistributedCase < CaseflowRecord
   belongs_to :distribution
   belongs_to :task
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Distribution < ApplicationRecord
+class Distribution < CaseflowRecord
   include ActiveModel::Serializers::JSON
   include AmaCaseDistribution
 

--- a/app/models/docket_snapshot.rb
+++ b/app/models/docket_snapshot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DocketSnapshot < ApplicationRecord
+class DocketSnapshot < CaseflowRecord
   has_many :docket_tracers
   before_validation :set_docket_count, :set_latest_docket_month, on: :create
   after_create :create_tracers

--- a/app/models/docket_tracer.rb
+++ b/app/models/docket_tracer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DocketTracer < ApplicationRecord
+class DocketTracer < CaseflowRecord
   belongs_to :docket_snapshot
 
   delegate :docket_count, :latest_docket_month, to: :docket_snapshot

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Document < ApplicationRecord
+class Document < CaseflowRecord
   has_many :annotations
   has_many :document_views
   has_many :documents_tags

--- a/app/models/document_view.rb
+++ b/app/models/document_view.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DocumentView < ApplicationRecord
+class DocumentView < CaseflowRecord
   belongs_to :document
   belongs_to :user
 end

--- a/app/models/documents_tag.rb
+++ b/app/models/documents_tag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DocumentsTag < ApplicationRecord
+class DocumentsTag < CaseflowRecord
   belongs_to :document
   belongs_to :tag
 

--- a/app/models/end_product_code_update.rb
+++ b/app/models/end_product_code_update.rb
@@ -3,6 +3,6 @@
 ##
 # Tracks when an end product established in Caseflow has its end product code manually changed outside of Caseflow.
 
-class EndProductCodeUpdate < ApplicationRecord
+class EndProductCodeUpdate < CaseflowRecord
   belongs_to :end_product_establishment
 end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -8,7 +8,7 @@
 # end product when it was created. Exceptions are `synced_status` and `last_synced_at`, used to record
 # the current status of the EP when the EndProductEstablishment is synced.
 
-class EndProductEstablishment < ApplicationRecord
+class EndProductEstablishment < CaseflowRecord
   belongs_to :source, polymorphic: true
   belongs_to :user
   has_many :end_product_code_updates

--- a/app/models/etl/appeal.rb
+++ b/app/models/etl/appeal.rb
@@ -5,6 +5,8 @@
 class ETL::Appeal < ETL::Record
   scope :active, -> { where(active_appeal: true) }
 
+  has_many :tasks, -> { where(appeal_type: "Appeal") }, class_name: "ETL::Task", primary_key: "appeal_id"
+
   class << self
     def origin_primary_key
       :appeal_id

--- a/app/models/etl/task.rb
+++ b/app/models/etl/task.rb
@@ -3,6 +3,8 @@
 # transformed Task model, with denormalized User/Org attributes
 
 class ETL::Task < ETL::Record
+  belongs_to :appeal, foreign_key: :appeal_id, foreign_type: "ETL::Appeal"
+
   class << self
     def origin_primary_key
       :task_id

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Form8 < ApplicationRecord
+class Form8 < CaseflowRecord
   include UploadableDocument
 
   FORM8_S3_SUB_BUCKET = "form_8"

--- a/app/models/global_admin_login.rb
+++ b/app/models/global_admin_login.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class GlobalAdminLogin < ApplicationRecord
+class GlobalAdminLogin < CaseflowRecord
 end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Hearing < ApplicationRecord
+class Hearing < CaseflowRecord
   include HasVirtualHearing
 
   belongs_to :hearing_day

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -4,7 +4,7 @@
 # and repository class. Eventually may persist data to
 # Caseflow DB. For now all schedule data is sent to the
 # VACOLS DB (Aug 2018 implementation).
-class HearingDay < ApplicationRecord
+class HearingDay < CaseflowRecord
   acts_as_paranoid
 
   belongs_to :judge, class_name: "User"

--- a/app/models/hearing_issue_note.rb
+++ b/app/models/hearing_issue_note.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HearingIssueNote < ApplicationRecord
+class HearingIssueNote < CaseflowRecord
   belongs_to :request_issue
   belongs_to :hearing
 

--- a/app/models/hearing_location.rb
+++ b/app/models/hearing_location.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HearingLocation < ApplicationRecord
+class HearingLocation < CaseflowRecord
   belongs_to :hearing, polymorphic: true
 
   # backwards compat data fix for "central" office.

--- a/app/models/hearing_task_association.rb
+++ b/app/models/hearing_task_association.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HearingTaskAssociation < ApplicationRecord
+class HearingTaskAssociation < CaseflowRecord
   belongs_to :hearing_task
   belongs_to :hearing, polymorphic: true
 

--- a/app/models/hearing_view.rb
+++ b/app/models/hearing_view.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class HearingView < ApplicationRecord
+class HearingView < CaseflowRecord
   belongs_to :hearing, polymorphic: true
   belongs_to :user
 end

--- a/app/models/hearings/allocation.rb
+++ b/app/models/hearings/allocation.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Allocation < ApplicationRecord
+class Allocation < CaseflowRecord
   belongs_to :schedule_period
 
   class << self

--- a/app/models/hearings/available_hearing_locations.rb
+++ b/app/models/hearings/available_hearing_locations.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AvailableHearingLocations < ApplicationRecord
+class AvailableHearingLocations < CaseflowRecord
   belongs_to :veteran, foreign_key: :file_number, primary_key: :veteran_file_number
   belongs_to :appeal, polymorphic: true
 

--- a/app/models/hearings/non_availability.rb
+++ b/app/models/hearings/non_availability.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class NonAvailability < ApplicationRecord
+class NonAvailability < CaseflowRecord
   belongs_to :schedule_period
 end

--- a/app/models/hearings/transcription.rb
+++ b/app/models/hearings/transcription.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Transcription < ApplicationRecord
+class Transcription < CaseflowRecord
   belongs_to :hearing
 end

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VirtualHearing < ApplicationRecord
+class VirtualHearing < CaseflowRecord
   alias_attribute :alias_name, :alias
 
   belongs_to :hearing, polymorphic: true

--- a/app/models/hearings/virtual_hearing_establishment.rb
+++ b/app/models/hearings/virtual_hearing_establishment.rb
@@ -3,7 +3,7 @@
 # Tracks the progress of the job responsible for creating
 # the virtual hearing conference in Pexip, and sending out
 # emails to the participants of the conference.
-class VirtualHearingEstablishment < ApplicationRecord
+class VirtualHearingEstablishment < CaseflowRecord
   include Asyncable
 
   belongs_to :virtual_hearing

--- a/app/models/intake.rb
+++ b/app/models/intake.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Intake < ApplicationRecord
+class Intake < CaseflowRecord
   class FormTypeNotSupported < StandardError; end
 
   belongs_to :user

--- a/app/models/job_note.rb
+++ b/app/models/job_note.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JobNote < ApplicationRecord
+class JobNote < CaseflowRecord
   belongs_to :user
   belongs_to :job, polymorphic: true
 

--- a/app/models/judge_case_review.rb
+++ b/app/models/judge_case_review.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JudgeCaseReview < ApplicationRecord
+class JudgeCaseReview < CaseflowRecord
   include CaseReviewConcern
   include IssueUpdater
 

--- a/app/models/judge_team_role.rb
+++ b/app/models/judge_team_role.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class JudgeTeamRole < ApplicationRecord
+class JudgeTeamRole < CaseflowRecord
   belongs_to :organizations_user, class_name: "::OrganizationsUser"
 
   has_one :user, through: :organizations_user

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -6,7 +6,7 @@
 # The source of truth for legacy appeals is VACOLS, but legacy appeals may also be worked in Caseflow.
 # Legacy appeals have VACOLS and BGS as dependencies.
 
-class LegacyAppeal < ApplicationRecord
+class LegacyAppeal < CaseflowRecord
   include AppealConcern
   include AssociatedVacolsModel
   include BgsService

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LegacyHearing < ApplicationRecord
+class LegacyHearing < CaseflowRecord
   include CachedAttributes
   include AssociatedVacolsModel
   include AppealConcern

--- a/app/models/legacy_issue.rb
+++ b/app/models/legacy_issue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LegacyIssue < ApplicationRecord
+class LegacyIssue < CaseflowRecord
   belongs_to :request_issue
   has_one :legacy_issue_optin
 

--- a/app/models/legacy_issue_optin.rb
+++ b/app/models/legacy_issue_optin.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class LegacyIssueOptin < ApplicationRecord
+class LegacyIssueOptin < CaseflowRecord
   belongs_to :request_issue
   belongs_to :legacy_issue
 

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Message < ApplicationRecord
+class Message < CaseflowRecord
   belongs_to :user
   belongs_to :detail, polymorphic: true
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Organization < ApplicationRecord
+class Organization < CaseflowRecord
   has_one :vso_config, dependent: :destroy
   has_many :tasks, as: :assigned_to
   has_many :organizations_users, dependent: :destroy

--- a/app/models/organizations_user.rb
+++ b/app/models/organizations_user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class OrganizationsUser < ApplicationRecord
+class OrganizationsUser < CaseflowRecord
   belongs_to :organization
   belongs_to :user
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Person < ApplicationRecord
+class Person < CaseflowRecord
   include BgsService
 
   has_many :advance_on_docket_motions

--- a/app/models/post_decision_motion.rb
+++ b/app/models/post_decision_motion.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PostDecisionMotion < ApplicationRecord
+class PostDecisionMotion < CaseflowRecord
   belongs_to :appeal
   belongs_to :task, optional: false
 

--- a/app/models/ramp_closed_appeal.rb
+++ b/app/models/ramp_closed_appeal.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RampClosedAppeal < ApplicationRecord
+class RampClosedAppeal < CaseflowRecord
   class NoReclosingBvaDecidedAppeals < StandardError; end
 
   belongs_to :ramp_election

--- a/app/models/ramp_election_rollback.rb
+++ b/app/models/ramp_election_rollback.rb
@@ -7,7 +7,7 @@
 # Example:
 #
 # RollbackRampElection.create!(ramp_election: ramp_election, user: user, reason: "A good reason")
-class RampElectionRollback < ApplicationRecord
+class RampElectionRollback < CaseflowRecord
   belongs_to :user
   belongs_to :ramp_election
 

--- a/app/models/ramp_issue.rb
+++ b/app/models/ramp_issue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RampIssue < ApplicationRecord
+class RampIssue < CaseflowRecord
   belongs_to :review, polymorphic: true
   belongs_to :source_issue, class_name: "RampIssue"
 

--- a/app/models/ramp_review.rb
+++ b/app/models/ramp_review.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RampReview < ApplicationRecord
+class RampReview < CaseflowRecord
   belongs_to :user
   has_one :intake, as: :detail
 

--- a/app/models/record_synced_by_job.rb
+++ b/app/models/record_synced_by_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RecordSyncedByJob < ApplicationRecord
+class RecordSyncedByJob < CaseflowRecord
   belongs_to :record, polymorphic: true
 
   def self.next_records_to_process(records, limit)

--- a/app/models/remand_reason.rb
+++ b/app/models/remand_reason.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RemandReason < ApplicationRecord
+class RemandReason < CaseflowRecord
   validates :code, inclusion: { in: Constants::AMA_REMAND_REASONS_BY_ID.values.map(&:keys).flatten }
   validates :post_aoj, inclusion: { in: [true, false] }
   belongs_to :decision_issue

--- a/app/models/request_decision_issue.rb
+++ b/app/models/request_decision_issue.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RequestDecisionIssue < ApplicationRecord
+class RequestDecisionIssue < CaseflowRecord
   belongs_to :request_issue
   belongs_to :decision_issue
 

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -6,7 +6,7 @@
 # be generated when a decision gets remanded or vacated.
 
 # rubocop:disable Metrics/ClassLength
-class RequestIssue < ApplicationRecord
+class RequestIssue < CaseflowRecord
   include Asyncable
   include HasBusinessLine
   include DecisionSyncable

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -3,7 +3,7 @@
 # Represents the action where a Caseflow user updates the request issues on
 # a review, typically to make a correction.
 
-class RequestIssuesUpdate < ApplicationRecord
+class RequestIssuesUpdate < CaseflowRecord
   include Asyncable
 
   belongs_to :user

--- a/app/models/schedule_period.rb
+++ b/app/models/schedule_period.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SchedulePeriod < ApplicationRecord
+class SchedulePeriod < CaseflowRecord
   validate :validate_schedule_period, on: :create
 
   class OverlappingSchedulePeriods < StandardError; end

--- a/app/models/special_issue_list.rb
+++ b/app/models/special_issue_list.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class SpecialIssueList < ApplicationRecord
+class SpecialIssueList < CaseflowRecord
   belongs_to :appeal, polymorphic: true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Tag < ApplicationRecord
+class Tag < CaseflowRecord
   has_many :documents_tags
   has_many :documents, through: :documents_tags
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -9,7 +9,7 @@
 #   - assigning a task to an individual
 
 # rubocop:disable Metrics/ClassLength
-class Task < ApplicationRecord
+class Task < CaseflowRecord
   has_paper_trail on: [:update, :destroy]
   acts_as_tree
 

--- a/app/models/task_timer.rb
+++ b/app/models/task_timer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TaskTimer < ApplicationRecord
+class TaskTimer < CaseflowRecord
   belongs_to :task
   include Asyncable
 

--- a/app/models/team_quota.rb
+++ b/app/models/team_quota.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TeamQuota < ApplicationRecord
+class TeamQuota < CaseflowRecord
   DEFAULT_USER_COUNT = 1
 
   class MismatchedTeamQuota < StandardError; end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class User < ApplicationRecord
+class User < CaseflowRecord
   include BgsService
 
   has_many :dispatch_tasks, class_name: "Dispatch::Task"

--- a/app/models/user_quota.rb
+++ b/app/models/user_quota.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UserQuota < ApplicationRecord
+class UserQuota < CaseflowRecord
   belongs_to :user
   belongs_to :team_quota
 

--- a/app/models/vbms_uploaded_document.rb
+++ b/app/models/vbms_uploaded_document.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class VbmsUploadedDocument < ApplicationRecord
+class VbmsUploadedDocument < CaseflowRecord
   belongs_to :appeal, optional: false
   validates :document_type, presence: true
 

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -4,7 +4,7 @@
 #
 # TODO: How do we deal with differences between the BGS vet values and the
 #       VACOLS vet values (coming from Appeal#veteran_full_name, etc)
-class Veteran < ApplicationRecord
+class Veteran < CaseflowRecord
   include AssociatedBgsRecord
 
   has_many :available_hearing_locations,

--- a/app/models/vso_config.rb
+++ b/app/models/vso_config.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class VsoConfig < ApplicationRecord
+class VsoConfig < CaseflowRecord
   belongs_to :organization
 end

--- a/app/models/worksheet_issue.rb
+++ b/app/models/worksheet_issue.rb
@@ -2,7 +2,7 @@
 
 # Worksheet Issue table represents the worksheet data entered
 # by the judge, it is not an official determination on the issue
-class WorksheetIssue < ApplicationRecord
+class WorksheetIssue < CaseflowRecord
   acts_as_paranoid
 
   belongs_to :appeal, class_name: "LegacyAppeal"

--- a/config/initializers/rails_erd.rb
+++ b/config/initializers/rails_erd.rb
@@ -1,0 +1,11 @@
+module RailsERD
+  class Domain
+    class << self
+      # since we have 3 dbs we must override to specify a specific base class (NOT ActiveRecord::Base)
+      def generate(options = {})
+        base_class = ENV.fetch("ERD_BASE", "ApplicationRecord").constantize
+        new base_class.descendants, options
+      end
+    end
+  end
+end

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1,0 +1,1068 @@
+Table,Column,Type,Required,Primary Key,Unique,Index,Description
+advance_on_docket_motions,,,,,,,
+advance_on_docket_motions,created_at,datetime ∗,true,false,false,,
+advance_on_docket_motions,granted,boolean,false,false,false,,"Whether VLJ has determined that there is sufficient cause to fast-track an appeal, i.e. grant or deny the motion to AOD."
+advance_on_docket_motions,id,integer (8) PK,true,true,false,,
+advance_on_docket_motions,person_id,integer (8) FK,false,false,false,true,Appellant ID
+advance_on_docket_motions,reason,string,false,false,false,,VLJ's rationale for their decision on motion to AOD.
+advance_on_docket_motions,updated_at,datetime ∗,true,false,false,true,
+advance_on_docket_motions,user_id,integer (8) FK,false,false,false,true,
+allocations,,,,,,,
+allocations,allocated_days,float ∗,true,false,false,,
+allocations,created_at,datetime ∗,true,false,false,,
+allocations,id,integer (8) PK,true,true,false,,
+allocations,regional_office,string ∗,true,false,false,,
+allocations,schedule_period_id,integer (8) ∗ FK,true,false,false,true,
+allocations,updated_at,datetime ∗,true,false,false,true,
+annotations,,,,,,,
+annotations,comment,string ∗,true,false,false,,
+annotations,created_at,datetime,false,false,false,,
+annotations,document_id,integer ∗ FK,true,false,false,true,
+annotations,id,integer PK,true,true,false,,
+annotations,page,integer,false,false,false,,
+annotations,relevant_date,date,false,false,false,,
+annotations,updated_at,datetime,false,false,false,,
+annotations,user_id,integer FK,false,false,false,true,
+annotations,x,integer,false,false,false,,
+annotations,y,integer,false,false,false,,
+api_keys,,,,,,,
+api_keys,consumer_name,string ∗,true,false,false,true,
+api_keys,created_at,datetime,false,false,false,,
+api_keys,id,integer PK,true,true,false,,
+api_keys,key_digest,string ∗,true,false,false,true,
+api_keys,updated_at,datetime,false,false,false,true,
+api_views,,,,,,,
+api_views,api_key_id,integer FK,false,false,false,,
+api_views,created_at,datetime,false,false,false,,
+api_views,id,integer PK,true,true,false,,
+api_views,source,string,false,false,false,,
+api_views,updated_at,datetime,false,false,false,,
+api_views,vbms_id,string,false,false,false,,
+appeals,,,,,,,Decision reviews intaken for AMA appeals to the board (also known as a notice of disagreement).
+appeals,closest_regional_office,string,false,false,false,,The code for the regional office closest to the Veteran on the appeal.
+appeals,created_at,datetime,false,false,false,,
+appeals,docket_range_date,date,false,false,false,,Date that appeal was added to hearing docket range.
+appeals,docket_type,string ∗,true,false,false,,"The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
+appeals,established_at,datetime,false,false,false,,Timestamp for when the appeal has successfully been intaken into Caseflow by the user.
+appeals,establishment_attempted_at,datetime,false,false,false,,Timestamp for when the appeal's establishment was last attempted.
+appeals,establishment_canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+appeals,establishment_error,string,false,false,false,,The error message if attempting to establish the appeal resulted in an error. This gets cleared once the establishment is successful.
+appeals,establishment_last_submitted_at,datetime,false,false,false,,Timestamp for when the the job is eligible to run (can be reset to restart the job).
+appeals,establishment_processed_at,datetime,false,false,false,,Timestamp for when the establishment has succeeded in processing.
+appeals,establishment_submitted_at,datetime,false,false,false,,Timestamp for when the the intake was submitted for asynchronous processing.
+appeals,id,integer (8) PK,true,true,false,,
+appeals,legacy_opt_in_approved,boolean,false,false,false,,Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review.
+appeals,poa_participant_id,string,false,false,false,,"Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
+appeals,receipt_date,date ∗,true,false,false,,Receipt date of the appeal form. Used to determine which issues are within the timeliness window to be appealed. Only issues decided prior to the receipt date will show up as contestable issues.
+appeals,stream_docket_number,string,false,false,false,,"Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
+appeals,stream_type,string,false,false,false,,"When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
+appeals,target_decision_date,date,false,false,false,,"If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
+appeals,updated_at,datetime,false,false,false,true,
+appeals,uuid,uuid ∗,true,false,false,true,"The universally unique identifier for the appeal, which can be used to navigate to appeals/appeal_uuid. This allows a single ID to determine an appeal whether it is a legacy appeal or an AMA appeal."
+appeals,veteran_file_number,string ∗,true,false,false,true,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+appeals,veteran_is_not_claimant,boolean,false,false,false,,"Selected by the user during intake, indicates whether the Veteran is the claimant, or if the claimant is someone else such as a dependent. Must be TRUE if Veteran is deceased."
+appeal_series,,,,,,,
+appeal_series,created_at,datetime,false,false,false,,
+appeal_series,id,integer PK,true,true,false,,
+appeal_series,incomplete,boolean,false,false,false,,
+appeal_series,merged_appeal_count,integer,false,false,false,,
+appeal_series,updated_at,datetime,false,false,false,true,
+hearing_appeal_stream_snapshots,,,,,,,
+hearing_appeal_stream_snapshots,appeal_id,integer FK,false,false,false,true,
+hearing_appeal_stream_snapshots,created_at,datetime ∗,true,false,false,,
+hearing_appeal_stream_snapshots,hearing_id,integer FK,false,false,false,true,
+hearing_appeal_stream_snapshots,updated_at,datetime,false,false,false,true,
+appeal_views,,,,,,,
+appeal_views,appeal_id,integer ∗ FK,true,false,false,true,
+appeal_views,appeal_type,string ∗,true,false,false,true,
+appeal_views,created_at,datetime ∗,true,false,false,,
+appeal_views,id,integer PK,true,true,false,,
+appeal_views,last_viewed_at,datetime,false,false,false,,
+appeal_views,updated_at,datetime ∗,true,false,false,,
+appeal_views,user_id,integer ∗ FK,true,false,false,true,
+attorney_case_reviews,,,,,,,
+attorney_case_reviews,attorney_id,integer FK,false,false,false,,
+attorney_case_reviews,created_at,datetime ∗,true,false,false,,
+attorney_case_reviews,document_id,string ∗,true,false,false,,
+attorney_case_reviews,document_type,string ∗,true,false,false,,
+attorney_case_reviews,id,integer PK,true,true,false,,
+attorney_case_reviews,note,text,false,false,false,,
+attorney_case_reviews,overtime,boolean,false,false,false,,
+attorney_case_reviews,reviewing_judge_id,integer FK,false,false,false,,
+attorney_case_reviews,task_id,string ∗ FK,true,false,false,true,
+attorney_case_reviews,untimely_evidence,boolean,false,false,false,,
+attorney_case_reviews,updated_at,datetime ∗,true,false,false,true,
+attorney_case_reviews,work_product,string ∗,true,false,false,,
+available_hearing_locations,,,,,,,
+available_hearing_locations,address,string,false,false,false,,
+available_hearing_locations,appeal_id,integer FK,false,false,false,true,
+available_hearing_locations,appeal_type,string,false,false,false,true,
+available_hearing_locations,city,string,false,false,false,,
+available_hearing_locations,classification,string,false,false,false,,
+available_hearing_locations,created_at,datetime ∗,true,false,false,,
+available_hearing_locations,distance,float,false,false,false,,
+available_hearing_locations,facility_id,string,false,false,false,,
+available_hearing_locations,facility_type,string,false,false,false,,
+available_hearing_locations,id,integer (8) PK,true,true,false,,
+available_hearing_locations,name,string,false,false,false,,
+available_hearing_locations,state,string,false,false,false,,
+available_hearing_locations,updated_at,datetime ∗,true,false,false,true,
+available_hearing_locations,veteran_file_number,string,false,false,false,true,
+available_hearing_locations,zip_code,string,false,false,false,,
+board_grant_effectuations,,,,,,,Represents the work item of updating records in response to a granted issue on a Board appeal. Some are represented as contentions on an EP in VBMS. Others are tracked via Caseflow tasks.
+board_grant_effectuations,appeal_id,integer (8) ∗ FK,true,false,false,true,The ID of the appeal containing the granted issue being effectuated.
+board_grant_effectuations,contention_reference_id,string,false,false,false,true,"The ID of the contention created in VBMS. Indicates successful creation of the contention. If the EP has been rated, this contention could have been connected to a rating issue. That connection is used to map the rating issue back to the decision issue."
+board_grant_effectuations,created_at,datetime,false,false,false,,
+board_grant_effectuations,decision_document_id,integer (8) FK,false,false,false,true,The ID of the decision document which triggered this effectuation.
+board_grant_effectuations,decision_sync_attempted_at,datetime,false,false,false,,"When the EP is cleared, an asyncronous job attempts to map the resulting rating issue back to the decision issue. Timestamp representing the time the job was last attempted."
+board_grant_effectuations,decision_sync_canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+board_grant_effectuations,decision_sync_error,string,false,false,false,,Async job processing last error message. See description for decision_sync_attempted_at for the decision sync job description.
+board_grant_effectuations,decision_sync_last_submitted_at,datetime,false,false,false,,Timestamp for when the the job is eligible to run (can be reset to restart the job).
+board_grant_effectuations,decision_sync_processed_at,datetime,false,false,false,,Async job processing completed timestamp. See description for decision_sync_attempted_at for the decision sync job description.
+board_grant_effectuations,decision_sync_submitted_at,datetime,false,false,false,,Async job processing start timestamp. See description for decision_sync_attempted_at for the decision sync job description.
+board_grant_effectuations,end_product_establishment_id,integer (8) FK,false,false,false,true,The ID of the end product establishment created for this board grant effectuation.
+board_grant_effectuations,granted_decision_issue_id,integer (8) ∗ FK,true,false,false,true,The ID of the granted decision issue.
+board_grant_effectuations,id,integer (8) PK,true,true,false,,
+board_grant_effectuations,last_submitted_at,datetime,false,false,false,,Async job processing most recent start timestamp (TODO rename)
+board_grant_effectuations,updated_at,datetime,false,false,false,true,
+cached_appeal_attributes,,,,,,,
+cached_appeal_attributes,appeal_id,integer,false,false,false,true,
+cached_appeal_attributes,appeal_type,string,false,false,false,true,
+cached_appeal_attributes,assignee_label,string,false,false,false,,Who is currently most responsible for the appeal
+cached_appeal_attributes,case_type,string,false,false,false,,"The case type, i.e. original, post remand, CAVC remand, etc"
+cached_appeal_attributes,closest_regional_office_city,string,false,false,false,,Closest regional office to the veteran
+cached_appeal_attributes,closest_regional_office_key,string,false,false,false,,Closest regional office to the veteran in 4 character key
+cached_appeal_attributes,created_at,datetime,false,false,false,,
+cached_appeal_attributes,docket_number,string,false,false,false,,
+cached_appeal_attributes,docket_type,string,false,false,false,,
+cached_appeal_attributes,is_aod,boolean,false,false,false,,Whether the case is Advanced on Docket
+cached_appeal_attributes,issue_count,integer,false,false,false,,Number of issues on the appeal.
+cached_appeal_attributes,power_of_attorney_name,string,false,false,false,,'Firstname Lastname' of power of attorney
+cached_appeal_attributes,suggested_hearing_location,string,false,false,false,,"Suggested hearing location in 'City, State (Facility Type)' format"
+cached_appeal_attributes,updated_at,datetime,false,false,false,true,
+cached_appeal_attributes,vacols_id,string,false,false,false,true,
+cached_appeal_attributes,veteran_name,string,false,false,false,,"'LastName, FirstName' of the veteran"
+cached_user_attributes,,,,,,,VACOLS cached staff table attributes
+cached_user_attributes,created_at,datetime ∗,true,false,false,,
+cached_user_attributes,sactive,string ∗,true,false,false,,
+cached_user_attributes,sattyid,string,false,false,false,,
+cached_user_attributes,sdomainid,string PK,true,true,false,true,
+cached_user_attributes,slogid,string ∗,true,false,false,,
+cached_user_attributes,smemgrp,string (8),false,false,false,,
+cached_user_attributes,stafkey,string ∗,true,false,false,,
+cached_user_attributes,stitle,string (16),false,false,false,,
+cached_user_attributes,svlj,string,false,false,false,,
+cached_user_attributes,updated_at,datetime ∗,true,false,false,true,
+certifications,,,,,,,
+certifications,already_certified,boolean,false,false,false,,
+certifications,bgs_rep_address_line_1,string,false,false,false,,
+certifications,bgs_rep_address_line_2,string,false,false,false,,
+certifications,bgs_rep_address_line_3,string,false,false,false,,
+certifications,bgs_rep_city,string,false,false,false,,
+certifications,bgs_rep_country,string,false,false,false,,
+certifications,bgs_rep_state,string,false,false,false,,
+certifications,bgs_rep_zip,string,false,false,false,,
+certifications,bgs_representative_name,string,false,false,false,,
+certifications,bgs_representative_type,string,false,false,false,,
+certifications,certification_date,string,false,false,false,,
+certifications,certifying_office,string,false,false,false,,
+certifications,certifying_official_name,string,false,false,false,,
+certifications,certifying_official_title,string,false,false,false,,
+certifications,certifying_username,string,false,false,false,,
+certifications,completed_at,datetime,false,false,false,,
+certifications,created_at,datetime ∗,true,false,false,,
+certifications,form8_started_at,datetime,false,false,false,,
+certifications,form9_matching_at,datetime,false,false,false,,
+certifications,form9_type,string,false,false,false,,
+certifications,hearing_change_doc_found_in_vbms,boolean,false,false,false,,
+certifications,hearing_preference,string,false,false,false,,
+certifications,id,integer PK,true,true,false,,
+certifications,loading_data,boolean,false,false,false,,
+certifications,loading_data_failed,boolean,false,false,false,,
+certifications,nod_matching_at,datetime,false,false,false,,
+certifications,poa_correct_in_bgs,boolean,false,false,false,,
+certifications,poa_correct_in_vacols,boolean,false,false,false,,
+certifications,poa_matches,boolean,false,false,false,,
+certifications,representative_name,string,false,false,false,,
+certifications,representative_type,string,false,false,false,,
+certifications,soc_matching_at,datetime,false,false,false,,
+certifications,ssocs_matching_at,datetime,false,false,false,,
+certifications,ssocs_required,boolean,false,false,false,,
+certifications,updated_at,datetime ∗,true,false,false,true,
+certifications,user_id,integer,false,false,false,true,
+certifications,v2,boolean,false,false,false,,
+certifications,vacols_data_missing,boolean,false,false,false,,
+certifications,vacols_hearing_preference,string,false,false,false,,
+certifications,vacols_id,string,false,false,false,,
+certifications,vacols_representative_name,string,false,false,false,,
+certifications,vacols_representative_type,string,false,false,false,,
+certification_cancellations,,,,,,,
+certification_cancellations,cancellation_reason,string ∗,true,false,false,,
+certification_cancellations,certification_id,integer ∗ FK,true,false,false,true,
+certification_cancellations,created_at,datetime,false,false,false,,
+certification_cancellations,email,string ∗,true,false,false,,
+certification_cancellations,id,integer PK,true,true,false,,
+certification_cancellations,other_reason,string,false,false,false,,
+certification_cancellations,updated_at,datetime,false,false,false,true,
+claim_establishments,,,,,,,
+claim_establishments,created_at,datetime ∗,true,false,false,,
+claim_establishments,decision_type,integer,false,false,false,,
+claim_establishments,email_recipient,string,false,false,false,,
+claim_establishments,email_ro_id,string,false,false,false,,
+claim_establishments,ep_code,string,false,false,false,,
+claim_establishments,id,integer PK,true,true,false,,
+claim_establishments,outcoding_date,datetime,false,false,false,,
+claim_establishments,task_id,integer FK,false,false,false,,
+claim_establishments,updated_at,datetime ∗,true,false,false,true,
+claimants,,,,,,,This table bridges decision reviews to participants when the participant is listed as a claimant on the decision review. A participant can be a claimant on multiple decision reviews.
+claimants,created_at,datetime,false,false,false,,
+claimants,decision_review_id,integer (8) FK,false,false,false,true,The ID of the decision review the claimant is on.
+claimants,decision_review_type,string,false,false,false,true,The type of decision review the claimant is on.
+claimants,id,integer (8) PK,true,true,false,,
+claimants,participant_id,string ∗ U,true,false,true,true,The participant ID of the claimant.
+claimants,payee_code,string,false,false,false,,"The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
+claimants,updated_at,datetime,false,false,false,true,
+claims_folder_searches,,,,,,,
+claims_folder_searches,appeal_id,integer FK,false,false,false,true,
+claims_folder_searches,appeal_type,string ∗,true,false,false,true,
+claims_folder_searches,created_at,datetime,false,false,false,,
+claims_folder_searches,id,integer PK,true,true,false,,
+claims_folder_searches,query,string,false,false,false,,
+claims_folder_searches,updated_at,datetime,false,false,false,true,
+claims_folder_searches,user_id,integer FK,false,false,false,true,
+decision_documents,,,,,,,
+decision_documents,appeal_id,integer (8) ∗ FK,true,false,false,true,
+decision_documents,appeal_type,string,false,false,false,,
+decision_documents,attempted_at,datetime,false,false,false,,
+decision_documents,canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+decision_documents,citation_number,string ∗,true,false,false,true,
+decision_documents,created_at,datetime ∗,true,false,false,,
+decision_documents,decision_date,date ∗,true,false,false,,
+decision_documents,error,string,false,false,false,,
+decision_documents,id,integer (8) PK,true,true,false,,
+decision_documents,last_submitted_at,datetime,false,false,false,,
+decision_documents,processed_at,datetime,false,false,false,,
+decision_documents,redacted_document_location,string ∗,true,false,false,,
+decision_documents,submitted_at,datetime,false,false,false,,
+decision_documents,updated_at,datetime ∗,true,false,false,true,
+decision_documents,uploaded_to_vbms_at,datetime,false,false,false,,
+decision_issues,,,,,,,Issues that represent a decision made on a decision review.
+decision_issues,benefit_type,string,false,false,false,,"Classification of the benefit being decided on. Maps 1 to 1 to VA lines of business, and typically used to know which line of business the decision correlates to."
+decision_issues,caseflow_decision_date,date,false,false,false,,"This is a decision date for decision issues where decisions are entered in Caseflow, such as for appeals or for decision reviews with a business line that is not processed in VBMS."
+decision_issues,created_at,datetime,false,false,false,,Automatic timestamp when row was created.
+decision_issues,decision_review_id,integer FK,false,false,false,,ID of the decision review the decision was made on.
+decision_issues,decision_review_type,string,false,false,false,,Type of the decision review the decision was made on.
+decision_issues,decision_text,string,false,false,false,,"If decision resulted in a change to a rating, the rating issue's decision text."
+decision_issues,deleted_at,datetime,false,false,false,,
+decision_issues,description,string,false,false,false,,Optional description that the user can input for decisions made in Caseflow.
+decision_issues,diagnostic_code,string,false,false,false,,"If a decision resulted in a rating, this is the rating issue's diagnostic code."
+decision_issues,disposition,string ∗,true,false,false,true,The disposition for a decision issue. Dispositions made in Caseflow and dispositions made in VBMS can have different values.
+decision_issues,end_product_last_action_date,date ∗,true,false,false,,"After an end product gets synced with a status of CLR (cleared), the end product's last_action_date is saved on any decision issues that are created as a result. This is used as a proxy for decision date for non-rating issues that are processed in VBMS because they don't have a rating profile date, and the exact decision date is not available."
+decision_issues,id,integer (8) PK,true,true,false,,
+decision_issues,participant_id,string ∗,true,false,false,true,The Veteran's participant id.
+decision_issues,rating_issue_reference_id,string,false,false,false,true,Identifies the specific issue on the rating that resulted from the decision issue (a rating can have multiple issues). This is unique per rating issue.
+decision_issues,rating_profile_date,datetime,false,false,false,,"The profile date of the rating that a decision issue resulted in (if applicable). The profile_date is used as an identifier for the rating, and is the date that most closely maps to what the Veteran writes down as the decision date."
+decision_issues,rating_promulgation_date,datetime,false,false,false,,The promulgation date of the rating that a decision issue resulted in (if applicable). It is used for calculating whether a decision issue is within the timeliness window to be appealed or get a higher level review.
+decision_issues,updated_at,datetime,false,false,false,true,
+dispatch_tasks,,,,,,,
+dispatch_tasks,aasm_state,string,false,false,false,,
+dispatch_tasks,appeal_id,integer ∗ FK,true,false,false,,
+dispatch_tasks,assigned_at,datetime,false,false,false,,
+dispatch_tasks,comment,string,false,false,false,,
+dispatch_tasks,completed_at,datetime,false,false,false,,
+dispatch_tasks,completion_status,integer,false,false,false,,
+dispatch_tasks,created_at,datetime ∗,true,false,false,,
+dispatch_tasks,id,integer PK,true,true,false,,
+dispatch_tasks,lock_version,integer,false,false,false,,
+dispatch_tasks,outgoing_reference_id,string,false,false,false,,
+dispatch_tasks,prepared_at,datetime,false,false,false,,
+dispatch_tasks,started_at,datetime,false,false,false,,
+dispatch_tasks,type,string ∗,true,false,false,,
+dispatch_tasks,updated_at,datetime ∗,true,false,false,true,
+dispatch_tasks,user_id,integer FK,false,false,false,true,
+distributed_cases,,,,,,,
+distributed_cases,case_id,string ∗,true,false,false,true,
+distributed_cases,created_at,datetime,false,false,false,,
+distributed_cases,distribution_id,integer FK,false,false,false,,
+distributed_cases,docket,string ∗,true,false,false,,
+distributed_cases,docket_index,integer ∗,true,false,false,,
+distributed_cases,genpop,boolean,false,false,false,,
+distributed_cases,genpop_query,string ∗,true,false,false,,
+distributed_cases,id,integer (8) PK,true,true,false,,
+distributed_cases,priority,boolean,false,false,false,,
+distributed_cases,ready_at,datetime ∗,true,false,false,,
+distributed_cases,task_id,integer ∗ FK,true,false,false,,
+distributed_cases,updated_at,datetime,false,false,false,true,
+distributions,,,,,,,
+distributions,completed_at,datetime,false,false,false,,
+distributions,created_at,datetime ∗,true,false,false,,
+distributions,errored_at,datetime,false,false,false,,when the Distribution job suffered an error
+distributions,id,integer (8) PK,true,true,false,,
+distributions,judge_id,integer FK,false,false,false,,
+distributions,started_at,datetime,false,false,false,,when the Distribution job commenced
+distributions,statistics,json,false,false,false,,
+distributions,status,string,false,false,false,,
+distributions,updated_at,datetime ∗,true,false,false,true,
+docket_snapshots,,,,,,,
+docket_snapshots,created_at,datetime,false,false,false,,
+docket_snapshots,docket_count,integer,false,false,false,,
+docket_snapshots,id,integer PK,true,true,false,,
+docket_snapshots,latest_docket_month,date,false,false,false,,
+docket_snapshots,updated_at,datetime,false,false,false,true,
+docket_tracers,,,,,,,
+docket_tracers,ahead_and_ready_count,integer,false,false,false,,
+docket_tracers,ahead_count,integer,false,false,false,,
+docket_tracers,created_at,datetime,false,false,false,,
+docket_tracers,docket_snapshot_id,integer FK,false,false,false,true,
+docket_tracers,id,integer PK,true,true,false,,
+docket_tracers,month,date,false,false,false,true,
+docket_tracers,updated_at,datetime,false,false,false,true,
+documents,,,,,,,
+documents,category_medical,boolean,false,false,false,,
+documents,category_other,boolean,false,false,false,,
+documents,category_procedural,boolean,false,false,false,,
+documents,created_at,datetime,false,false,false,,
+documents,description,string,false,false,false,,
+documents,file_number,string,false,false,false,true,
+documents,id,integer PK,true,true,false,,
+documents,previous_document_version_id,integer,false,false,false,,
+documents,received_at,date,false,false,false,,
+documents,series_id,string,false,false,false,true,
+documents,type,string,false,false,false,,
+documents,updated_at,datetime,false,false,false,,
+documents,upload_date,date,false,false,false,,
+documents,vbms_document_id,string ∗,true,false,false,true,
+document_views,,,,,,,
+document_views,created_at,datetime,false,false,false,,
+document_views,document_id,integer ∗ FK,true,false,false,true,
+document_views,first_viewed_at,datetime,false,false,false,,
+document_views,id,integer PK,true,true,false,,
+document_views,updated_at,datetime,false,false,false,,
+document_views,user_id,integer ∗ FK,true,false,false,true,
+documents_tags,,,,,,,
+documents_tags,created_at,datetime,false,false,false,,
+documents_tags,document_id,integer ∗ FK,true,false,false,true,
+documents_tags,id,integer PK,true,true,false,,
+documents_tags,tag_id,integer ∗ FK,true,false,false,true,
+documents_tags,updated_at,datetime,false,false,false,,
+end_product_code_updates,,,,,,,"Caseflow establishes end products in VBMS with specific end product codes. If that code is changed outside of Caseflow, that is tracked here."
+end_product_code_updates,code,string ∗,true,false,false,,"The new end product code, if it has changed since last checked."
+end_product_code_updates,created_at,datetime ∗,true,false,false,,
+end_product_code_updates,end_product_establishment_id,integer (8) ∗ FK,true,false,false,true,
+end_product_code_updates,id,integer (8) PK,true,true,false,,
+end_product_code_updates,updated_at,datetime ∗,true,false,false,true,
+end_product_establishments,,,,,,,"Represents end products that have been, or need to be established by Caseflow. Used to track the status of those end products as they are processed in VBMS and/or SHARE."
+end_product_establishments,benefit_type_code,string,false,false,false,,"1 if the Veteran is alive, and 2 if the Veteran is deceased. Not to be confused with benefit_type, which is unrelated."
+end_product_establishments,claim_date,date,false,false,false,,The claim_date for end product established.
+end_product_establishments,claimant_participant_id,string,false,false,false,,The participant ID of the claimant submitted on the end product.
+end_product_establishments,code,string,false,false,false,,"The end product code, which determines the type of end product that is established. For example, it can contain information about whether it is rating, nonrating, compensation, pension, created automatically due to a Duty to Assist Error, and more."
+end_product_establishments,committed_at,datetime,false,false,false,,"Timestamp indicating other actions performed as part of a larger atomic operation containing the end product establishment, such as creating contentions, are also complete."
+end_product_establishments,created_at,datetime,false,false,false,,
+end_product_establishments,development_item_reference_id,string,false,false,false,,"When a Veteran requests an informal conference with their higher level review, a tracked item is created. This stores the ID of the of the tracked item, it is also used to indicate the success of creating the tracked item."
+end_product_establishments,doc_reference_id,string,false,false,false,,"When a Veteran requests an informal conference, a claimant letter is generated. This stores the document ID of the claimant letter, and is also used to track the success of creating the claimant letter."
+end_product_establishments,established_at,datetime,false,false,false,,Timestamp for when the end product was established.
+end_product_establishments,id,integer (8) PK,true,true,false,,
+end_product_establishments,last_synced_at,datetime,false,false,false,,"The time that the status of the end product was last synced with BGS. The end product is synced until it is canceled or cleared, meaning it is no longer active."
+end_product_establishments,limited_poa_access,boolean,false,false,false,,Indicates whether the limited Power of Attorney has access to view documents
+end_product_establishments,limited_poa_code,string,false,false,false,,"The limited Power of Attorney code, which indicates whether the claim has a POA specifically for this claim, which can be different than the Veteran's POA"
+end_product_establishments,modifier,string,false,false,false,,"The end product modifier. For higher level reviews, the modifiers range from 030-039. For supplemental claims, they range from 040-049. The same modifier cannot be used twice for an active end product per Veteran. Once an end product is no longer active, the modifier can be used again."
+end_product_establishments,payee_code,string ∗,true,false,false,,The payee_code of the claimant submitted for this end product.
+end_product_establishments,reference_id,string,false,false,false,,"The claim_id of the end product, which is stored after the end product is successfully established in VBMS."
+end_product_establishments,source_id,integer (8) ∗ FK,true,false,false,true,The ID of the source that resulted in this end product establishment.
+end_product_establishments,source_type,string ∗,true,false,false,true,The type of source that resulted in this end product establishment.
+end_product_establishments,station,string,false,false,false,,The station ID of the end product's station.
+end_product_establishments,synced_status,string,false,false,false,,"The status of the end product, which is synced by a job. Once and end product is cleared (CLR) or canceled (CAN) the status is final and the end product will not continue being synced."
+end_product_establishments,updated_at,datetime,false,false,false,true,
+end_product_establishments,user_id,integer FK,false,false,false,true,The ID of the user who performed the decision review intake.
+end_product_establishments,veteran_file_number,string ∗,true,false,false,true,The file number of the Veteran submitted when establishing the end product.
+form8s,,,,,,,
+form8s,_initial_appellant_name,string,false,false,false,,
+form8s,_initial_appellant_relationship,string,false,false,false,,
+form8s,_initial_hearing_requested,string,false,false,false,,
+form8s,_initial_increased_rating_notification_date,date,false,false,false,,
+form8s,_initial_insurance_loan_number,string,false,false,false,,
+form8s,_initial_other_notification_date,date,false,false,false,,
+form8s,_initial_representative_name,string,false,false,false,,
+form8s,_initial_representative_type,string,false,false,false,,
+form8s,_initial_service_connection_notification_date,date,false,false,false,,
+form8s,_initial_soc_date,date,false,false,false,,
+form8s,_initial_ssoc_required,string,false,false,false,,
+form8s,_initial_veteran_name,string,false,false,false,,
+form8s,agent_accredited,string,false,false,false,,
+form8s,appellant_name,string,false,false,false,,
+form8s,appellant_relationship,string,false,false,false,,
+form8s,certification_date,date,false,false,false,,
+form8s,certification_id,integer,false,false,false,true,
+form8s,certifying_office,string,false,false,false,,
+form8s,certifying_official_name,string,false,false,false,,
+form8s,certifying_official_title,string,false,false,false,,
+form8s,certifying_official_title_specify_other,string,false,false,false,,
+form8s,certifying_username,string,false,false,false,,
+form8s,contested_claims_procedures_applicable,string,false,false,false,,
+form8s,contested_claims_requirements_followed,string,false,false,false,,
+form8s,created_at,datetime ∗,true,false,false,,
+form8s,file_number,string,false,false,false,,
+form8s,form9_date,date,false,false,false,,
+form8s,form_646_not_of_record_explanation,string,false,false,false,,
+form8s,form_646_of_record,string,false,false,false,,
+form8s,hearing_held,string,false,false,false,,
+form8s,hearing_preference,string,false,false,false,,
+form8s,hearing_requested,string,false,false,false,,
+form8s,hearing_requested_explanation,string,false,false,false,,
+form8s,hearing_transcript_on_file,string,false,false,false,,
+form8s,id,integer PK,true,true,false,,
+form8s,increased_rating_for,text,false,false,false,,
+form8s,increased_rating_notification_date,date,false,false,false,,
+form8s,insurance_loan_number,string,false,false,false,,
+form8s,nod_date,date,false,false,false,,
+form8s,other_for,text,false,false,false,,
+form8s,other_notification_date,date,false,false,false,,
+form8s,power_of_attorney,string,false,false,false,,
+form8s,power_of_attorney_file,string,false,false,false,,
+form8s,record_cf_or_xcf,string,false,false,false,,
+form8s,record_clinical_rec,string,false,false,false,,
+form8s,record_dental_f,string,false,false,false,,
+form8s,record_dep_ed_f,string,false,false,false,,
+form8s,record_hospital_cor,string,false,false,false,,
+form8s,record_inactive_cf,string,false,false,false,,
+form8s,record_insurance_f,string,false,false,false,,
+form8s,record_loan_guar_f,string,false,false,false,,
+form8s,record_other,string,false,false,false,,
+form8s,record_other_explanation,text,false,false,false,,
+form8s,record_outpatient_f,string,false,false,false,,
+form8s,record_r_and_e_f,string,false,false,false,,
+form8s,record_slides,string,false,false,false,,
+form8s,record_tissue_blocks,string,false,false,false,,
+form8s,record_training_sub_f,string,false,false,false,,
+form8s,record_x_rays,string,false,false,false,,
+form8s,remarks,text,false,false,false,,
+form8s,representative_name,string,false,false,false,,
+form8s,representative_type,string,false,false,false,,
+form8s,representative_type_specify_other,string,false,false,false,,
+form8s,service_connection_for,text,false,false,false,,
+form8s,service_connection_notification_date,date,false,false,false,,
+form8s,soc_date,date,false,false,false,,
+form8s,ssoc_date_1,date,false,false,false,,
+form8s,ssoc_date_2,date,false,false,false,,
+form8s,ssoc_date_3,date,false,false,false,,
+form8s,ssoc_required,string,false,false,false,,
+form8s,updated_at,datetime ∗,true,false,false,,
+form8s,vacols_id,string,false,false,false,,
+form8s,veteran_name,string,false,false,false,,
+global_admin_logins,,,,,,,
+global_admin_logins,admin_css_id,string,false,false,false,,
+global_admin_logins,created_at,datetime,false,false,false,,
+global_admin_logins,id,integer PK,true,true,false,,
+global_admin_logins,target_css_id,string,false,false,false,,
+global_admin_logins,target_station_id,string,false,false,false,,
+global_admin_logins,updated_at,datetime,false,false,false,true,
+hearings,,,,,,,
+hearings,appeal_id,integer ∗ FK,true,false,false,,
+hearings,bva_poc,string,false,false,false,,
+hearings,created_at,datetime,false,false,false,,Automatic timestamp when row was created.
+hearings,created_by_id,integer (8) FK,false,false,false,true,The ID of the user who created the Hearing
+hearings,disposition,string,false,false,false,,
+hearings,evidence_window_waived,boolean,false,false,false,,
+hearings,hearing_day_id,integer ∗ FK,true,false,false,,
+hearings,id,integer (8) PK,true,true,false,,
+hearings,judge_id,integer FK,false,false,false,,
+hearings,military_service,string,false,false,false,,
+hearings,notes,string,false,false,false,,
+hearings,prepped,boolean,false,false,false,,
+hearings,representative_name,string,false,false,false,,
+hearings,room,string,false,false,false,,
+hearings,scheduled_time,time ∗,true,false,false,,
+hearings,summary,text,false,false,false,,
+hearings,transcript_requested,boolean,false,false,false,,
+hearings,transcript_sent_date,date,false,false,false,,
+hearings,updated_at,datetime,false,false,false,true,Timestamp when record was last updated.
+hearings,updated_by_id,integer (8) FK,false,false,false,true,The ID of the user who most recently updated the Hearing
+hearings,uuid,uuid ∗,true,false,false,true,
+hearings,witness,string,false,false,false,,
+hearing_days,,,,,,,
+hearing_days,bva_poc,string,false,false,false,,
+hearing_days,created_at,datetime ∗,true,false,false,,
+hearing_days,created_by_id,integer (8) ∗ FK,true,false,false,true,The ID of the user who created the Hearing Day
+hearing_days,deleted_at,datetime,false,false,false,true,
+hearing_days,id,integer (8) PK,true,true,false,,
+hearing_days,judge_id,integer FK,false,false,false,,
+hearing_days,lock,boolean,false,false,false,,
+hearing_days,notes,text,false,false,false,,
+hearing_days,regional_office,string,false,false,false,,
+hearing_days,request_type,string ∗,true,false,false,,
+hearing_days,room,string,false,false,false,,The room at BVA where the hearing will take place
+hearing_days,scheduled_for,date ∗,true,false,false,,
+hearing_days,updated_at,datetime ∗,true,false,false,true,
+hearing_days,updated_by_id,integer (8) ∗ FK,true,false,false,true,The ID of the user who most recently updated the Hearing Day
+hearing_issue_notes,,,,,,,
+hearing_issue_notes,allow,boolean,false,false,false,,
+hearing_issue_notes,created_at,datetime,false,false,false,,
+hearing_issue_notes,deny,boolean,false,false,false,,
+hearing_issue_notes,dismiss,boolean,false,false,false,,
+hearing_issue_notes,hearing_id,integer (8) ∗ FK,true,false,false,true,
+hearing_issue_notes,id,integer (8) PK,true,true,false,,
+hearing_issue_notes,remand,boolean,false,false,false,,
+hearing_issue_notes,reopen,boolean,false,false,false,,
+hearing_issue_notes,request_issue_id,integer (8) ∗ FK,true,false,false,true,
+hearing_issue_notes,updated_at,datetime,false,false,false,true,
+hearing_issue_notes,worksheet_notes,string,false,false,false,,
+hearing_locations,,,,,,,
+hearing_locations,address,string,false,false,false,,
+hearing_locations,city,string,false,false,false,,
+hearing_locations,classification,string,false,false,false,,
+hearing_locations,created_at,datetime ∗,true,false,false,,
+hearing_locations,distance,float,false,false,false,,
+hearing_locations,facility_id,string,false,false,false,,
+hearing_locations,facility_type,string,false,false,false,,
+hearing_locations,hearing_id,integer FK,false,false,false,true,
+hearing_locations,hearing_type,string,false,false,false,true,
+hearing_locations,id,integer (8) PK,true,true,false,,
+hearing_locations,name,string,false,false,false,,
+hearing_locations,state,string,false,false,false,,
+hearing_locations,updated_at,datetime ∗,true,false,false,true,
+hearing_locations,zip_code,string,false,false,false,,
+hearing_task_associations,,,,,,,
+hearing_task_associations,created_at,datetime,false,false,false,,
+hearing_task_associations,hearing_id,integer (8) ∗ FK,true,false,false,true,
+hearing_task_associations,hearing_task_id,integer (8) ∗ FK,true,false,false,true,
+hearing_task_associations,hearing_type,string ∗,true,false,false,true,
+hearing_task_associations,id,integer (8) PK,true,true,false,,
+hearing_task_associations,updated_at,datetime,false,false,false,true,
+hearing_views,,,,,,,
+hearing_views,created_at,datetime,false,false,false,,
+hearing_views,hearing_id,integer ∗ FK,true,false,false,true,
+hearing_views,hearing_type,string,false,false,false,true,
+hearing_views,id,integer PK,true,true,false,,
+hearing_views,updated_at,datetime,false,false,false,,
+hearing_views,user_id,integer ∗ FK,true,false,false,true,
+higher_level_reviews,,,,,,,Intake data for Higher Level Reviews.
+higher_level_reviews,benefit_type,string ∗,true,false,false,,"The benefit type selected by the Veteran on their form, also known as a Line of Business."
+higher_level_reviews,created_at,datetime,false,false,false,,
+higher_level_reviews,establishment_attempted_at,datetime,false,false,false,,Timestamp for the most recent attempt at establishing a claim.
+higher_level_reviews,establishment_canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+higher_level_reviews,establishment_error,string,false,false,false,,The error captured for the most recent attempt at establishing a claim if it failed.  This is removed once establishing the claim succeeds.
+higher_level_reviews,establishment_last_submitted_at,datetime,false,false,false,,Timestamp for the latest attempt at establishing the End Products for the Decision Review.
+higher_level_reviews,establishment_processed_at,datetime,false,false,false,,Timestamp for when the End Product Establishments for the Decision Review successfully finished processing.
+higher_level_reviews,establishment_submitted_at,datetime,false,false,false,,Timestamp for when the Higher Level Review was submitted by a Claims Assistant. This adds the End Product Establishment to a job to finish processing asynchronously.
+higher_level_reviews,id,integer (8) PK,true,true,false,,
+higher_level_reviews,informal_conference,boolean,false,false,false,,Indicates whether a Veteran selected on their Higher Level Review form to have an informal conference. This creates a claimant letter and a tracked item in BGS.
+higher_level_reviews,legacy_opt_in_approved,boolean,false,false,false,,"Indicates whether a Veteran opted to withdraw their Higher Level Review request issues from the legacy system if a matching issue is found. If there is a matching legacy issue and it is not withdrawn, then that issue is ineligible to be a new request issue and a contention will not be created for it."
+higher_level_reviews,receipt_date,date ∗,true,false,false,,The date that the Higher Level Review form was received by central mail. This is used to determine which issues are eligible to be appealed based on timeliness.  Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established.
+higher_level_reviews,same_office,boolean,false,false,false,,Whether the Veteran wants their issues to be reviewed by the same office where they were previously reviewed. This creates a special issue on all of the contentions created on this Higher Level Review.
+higher_level_reviews,updated_at,datetime,false,false,false,true,
+higher_level_reviews,uuid,uuid ∗,true,false,false,true,The universally unique identifier for the Higher Level Review. Can be used to link to the claim after it is completed.
+higher_level_reviews,veteran_file_number,string ∗,true,false,false,true,The file number of the Veteran that the Higher Level Review is for.
+higher_level_reviews,veteran_is_not_claimant,boolean,false,false,false,,"Indicates whether the Veteran is the claimant on the Higher Level Review form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."
+intakes,,,,,,,Represents the intake of an form or request made by a veteran.
+intakes,cancel_other,string,false,false,false,,Notes added if a user canceled an intake for any reason other than the stock set of options.
+intakes,cancel_reason,string,false,false,false,,"The reason the intake was canceled. Could have been manually canceled by a user, or automatic."
+intakes,completed_at,datetime,false,false,false,,"Timestamp for when the intake was completed, whether it was successful or not."
+intakes,completion_started_at,datetime,false,false,false,,Timestamp for when the user submitted the intake to be completed.
+intakes,completion_status,string,false,false,false,,"Indicates whether the intake was successful, or was closed by being canceled, expired, or due to an error."
+intakes,created_at,datetime,false,false,false,,
+intakes,detail_id,integer FK,false,false,false,,The ID of the record created as a result of the intake.
+intakes,detail_type,string,false,false,false,,The type of the record created as a result of the intake.
+intakes,error_code,string,false,false,false,,"If the intake was unsuccessful due to a set of known errors, the error code is stored here. An error is also stored here for RAMP elections that are connected to an active end product, even though the intake is a success."
+intakes,id,integer PK,true,true,false,,
+intakes,started_at,datetime,false,false,false,,"Timestamp for when the intake was created, which happens when a user successfully searches for a Veteran."
+intakes,type,string,false,false,false,true,The class name of the intake.
+intakes,updated_at,datetime,false,false,false,true,
+intakes,user_id,integer ∗ FK,true,false,false,true,The ID of the user who created the intake.
+intakes,veteran_file_number,string,false,false,false,true,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+job_notes,,,,,,,
+job_notes,created_at,datetime ∗,true,false,false,,Default created_at/updated_at
+job_notes,id,integer (8) PK,true,true,false,,
+job_notes,job_id,integer (8) ∗ FK,true,false,false,true,The job to which the note applies
+job_notes,job_type,string ∗,true,false,false,true,
+job_notes,note,text ∗,true,false,false,,The note
+job_notes,send_to_intake_user,boolean,false,false,false,,Should the note trigger a message to the job intake user
+job_notes,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at
+job_notes,user_id,integer (8) ∗ FK,true,false,false,true,The user who created the note
+judge_case_reviews,,,,,,,
+judge_case_reviews,areas_for_improvement,text,false,false,false,,
+judge_case_reviews,attorney_id,integer FK,false,false,false,,
+judge_case_reviews,comment,text,false,false,false,,
+judge_case_reviews,complexity,string ∗,true,false,false,,
+judge_case_reviews,created_at,datetime ∗,true,false,false,,
+judge_case_reviews,factors_not_considered,text,false,false,false,,
+judge_case_reviews,id,integer (8) PK,true,true,false,,
+judge_case_reviews,judge_id,integer FK,false,false,false,,
+judge_case_reviews,location,string ∗,true,false,false,,
+judge_case_reviews,one_touch_initiative,boolean,false,false,false,,
+judge_case_reviews,positive_feedback,text,false,false,false,,
+judge_case_reviews,quality,string ∗,true,false,false,,
+judge_case_reviews,task_id,string ∗ FK,true,false,false,,
+judge_case_reviews,updated_at,datetime ∗,true,false,false,true,
+judge_team_roles,,,,,,,Defines roles for individual members of judge teams
+judge_team_roles,created_at,datetime ∗,true,false,false,,
+judge_team_roles,id,integer (8) PK,true,true,false,,
+judge_team_roles,organizations_user_id,integer FK,false,false,false,true,
+judge_team_roles,type,string,false,false,false,,
+judge_team_roles,updated_at,datetime ∗,true,false,false,true,
+legacy_appeals,,,,,,,
+legacy_appeals,appeal_series_id,integer (8) FK,false,false,false,true,
+legacy_appeals,closest_regional_office,string,false,false,false,,
+legacy_appeals,contaminated_water_at_camp_lejeune,boolean,false,false,false,,
+legacy_appeals,created_at,datetime,false,false,false,,
+legacy_appeals,dic_death_or_accrued_benefits_united_states,boolean,false,false,false,,
+legacy_appeals,dispatched_to_station,string,false,false,false,,
+legacy_appeals,education_gi_bill_dependents_educational_assistance_scholars,boolean,false,false,false,,
+legacy_appeals,foreign_claim_compensation_claims_dual_claims_appeals,boolean,false,false,false,,
+legacy_appeals,foreign_pension_dic_all_other_foreign_countries,boolean,false,false,false,,
+legacy_appeals,foreign_pension_dic_mexico_central_and_south_america_caribb,boolean,false,false,false,,
+legacy_appeals,hearing_including_travel_board_video_conference,boolean,false,false,false,,
+legacy_appeals,home_loan_guaranty,boolean,false,false,false,,
+legacy_appeals,id,integer (8) PK,true,true,false,,
+legacy_appeals,incarcerated_veterans,boolean,false,false,false,,
+legacy_appeals,insurance,boolean,false,false,false,,
+legacy_appeals,issues_pulled,boolean,false,false,false,,
+legacy_appeals,manlincon_compliance,boolean,false,false,false,,
+legacy_appeals,mustard_gas,boolean,false,false,false,,
+legacy_appeals,national_cemetery_administration,boolean,false,false,false,,
+legacy_appeals,nonrating_issue,boolean,false,false,false,,
+legacy_appeals,pension_united_states,boolean,false,false,false,,
+legacy_appeals,private_attorney_or_agent,boolean,false,false,false,,
+legacy_appeals,radiation,boolean,false,false,false,,
+legacy_appeals,rice_compliance,boolean,false,false,false,,
+legacy_appeals,spina_bifida,boolean,false,false,false,,
+legacy_appeals,updated_at,datetime,false,false,false,true,
+legacy_appeals,us_territory_claim_american_samoa_guam_northern_mariana_isla,boolean,false,false,false,,
+legacy_appeals,us_territory_claim_philippines,boolean,false,false,false,,
+legacy_appeals,us_territory_claim_puerto_rico_and_virgin_islands,boolean,false,false,false,,
+legacy_appeals,vacols_id,string ∗,true,false,false,true,
+legacy_appeals,vamc,boolean,false,false,false,,
+legacy_appeals,vbms_id,string,false,false,false,,
+legacy_appeals,vocational_rehab,boolean,false,false,false,,
+legacy_appeals,waiver_of_overpayment,boolean,false,false,false,,
+legacy_hearings,,,,,,,
+legacy_hearings,appeal_id,integer FK,false,false,false,,
+legacy_hearings,created_at,datetime,false,false,false,,Automatic timestamp when row was created.
+legacy_hearings,created_by_id,integer (8) FK,false,false,false,true,The ID of the user who created the Legacy Hearing
+legacy_hearings,hearing_day_id,integer (8),false,false,false,true,The hearing day the hearing will take place on
+legacy_hearings,id,integer (8) PK,true,true,false,,
+legacy_hearings,military_service,string,false,false,false,,
+legacy_hearings,prepped,boolean,false,false,false,,
+legacy_hearings,summary,text,false,false,false,,
+legacy_hearings,updated_at,datetime,false,false,false,true,Timestamp when record was last updated.
+legacy_hearings,updated_by_id,integer (8) FK,false,false,false,true,The ID of the user who most recently updated the Legacy Hearing
+legacy_hearings,user_id,integer FK,false,false,false,true,
+legacy_hearings,vacols_id,string ∗,true,false,false,true,
+legacy_hearings,witness,string,false,false,false,,
+legacy_issues,,,,,,,"On an AMA decision review, when a veteran requests to review an issue that is already being contested on a legacy appeal, the legacy issue is connected to the request issue. If the veteran also chooses to opt their legacy issues into AMA and the issue is eligible to be transferred to AMA, the issues are closed in VACOLS through a legacy issue opt-in. This table stores the legacy issues connected to each request issue, and the record for opting them into AMA (if applicable)."
+legacy_issues,created_at,datetime ∗,true,false,false,,Default created_at/updated_at
+legacy_issues,id,integer (8) PK,true,true,false,,
+legacy_issues,request_issue_id,integer (8) ∗ FK,true,false,false,true,The request issue the legacy issue is being connected to.
+legacy_issues,updated_at,datetime ∗,true,false,false,,Default created_at/updated_at
+legacy_issues,vacols_id,string ∗,true,false,false,,The VACOLS ID of the legacy appeal that the legacy issue is part of.
+legacy_issues,vacols_sequence_id,integer ∗,true,false,false,,The sequence ID of the legacy issue on the legacy appeal. The vacols_id and vacols_sequence_id form a composite key to identify a specific legacy issue.
+legacy_issue_optins,,,,,,,"When a VACOLS issue from a legacy appeal is opted-in to AMA, this table keeps track of the related request_issue, and the status of processing the opt-in, or rollback if the request issue is removed from a Decision Review."
+legacy_issue_optins,created_at,datetime ∗,true,false,false,,"When a Request Issue is connected to a VACOLS issue on a legacy appeal, and the Veteran has agreed to withdraw their legacy appeals, a legacy_issue_optin is created at the time the Decision Review is successfully intaken. This is used to indicate that the legacy issue should subsequently be opted into AMA in VACOLS. "
+legacy_issue_optins,error,string,false,false,false,,
+legacy_issue_optins,id,integer (8) PK,true,true,false,,
+legacy_issue_optins,legacy_issue_id,integer (8) FK,false,false,false,true,"The legacy issue being opted in, which connects to the request issue"
+legacy_issue_optins,optin_processed_at,datetime,false,false,false,,"The timestamp for when the opt-in was successfully processed, meaning it was updated in VACOLS as opted into AMA."
+legacy_issue_optins,original_disposition_code,string,false,false,false,,The original disposition code of the VACOLS issue being opted in. Stored in case the opt-in is rolled back.
+legacy_issue_optins,original_disposition_date,date,false,false,false,,The original disposition date of the VACOLS issue being opted in. Stored in case the opt-in is rolled back.
+legacy_issue_optins,request_issue_id,integer (8) ∗ FK,true,false,false,true,The request issue connected to the legacy VACOLS issue that has been opted in.
+legacy_issue_optins,rollback_created_at,datetime,false,false,false,,"Timestamp for when the connected request issue is removed from a Decision Review during edit, indicating that the opt-in needs to be rolled back."
+legacy_issue_optins,rollback_processed_at,datetime,false,false,false,,Timestamp for when a rolled back opt-in has successfully finished being rolled back.
+legacy_issue_optins,updated_at,datetime ∗,true,false,false,true,Automatically populated when the record is updated.
+messages,,,,,,,
+messages,created_at,datetime ∗,true,false,false,,
+messages,detail_id,integer FK,false,false,false,true,ID of the related object
+messages,detail_type,string,false,false,false,true,Model name of the related object
+messages,id,integer (8) PK,true,true,false,,
+messages,message_type,string,false,false,false,,The type of event that caused this message to be created
+messages,read_at,datetime,false,false,false,,When the message was read
+messages,text,string,false,false,false,,The message
+messages,updated_at,datetime ∗,true,false,false,true,
+messages,user_id,integer ∗ FK,true,false,false,,The user for whom the message is intended
+non_availabilities,,,,,,,
+non_availabilities,created_at,datetime ∗,true,false,false,,
+non_availabilities,date,date,false,false,false,,
+non_availabilities,id,integer (8) PK,true,true,false,,
+non_availabilities,object_identifier,string ∗,true,false,false,,
+non_availabilities,schedule_period_id,integer (8) ∗ FK,true,false,false,true,
+non_availabilities,type,string ∗,true,false,false,,
+non_availabilities,updated_at,datetime ∗,true,false,false,true,
+organizations,,,,,,,
+organizations,created_at,datetime,false,false,false,,
+organizations,id,integer (8) PK,true,true,false,,
+organizations,name,string ∗,true,false,false,,
+organizations,participant_id,string,false,false,false,,Organizations BGS partipant id
+organizations,role,string,false,false,false,,"Role users in organization must have, if present"
+organizations,status,string,false,false,false,true,"Whether organization is active, inactive, or in some other Status."
+organizations,status_updated_at,datetime,false,false,false,,Track when organization status last changed.
+organizations,type,string,false,false,false,,Single table inheritance
+organizations,updated_at,datetime,false,false,false,true,
+organizations,url,string ∗ U,true,false,true,true,Unique portion of the organization queue url
+organizations_users,,,,,,,
+organizations_users,admin,boolean,false,false,false,,
+organizations_users,created_at,datetime,false,false,false,,
+organizations_users,id,integer (8) PK,true,true,false,,
+organizations_users,organization_id,integer FK,false,false,false,true,
+organizations_users,updated_at,datetime,false,false,false,true,
+organizations_users,user_id,integer FK,false,false,false,true,
+people,,,,,,,
+people,created_at,datetime ∗,true,false,false,,
+people,date_of_birth,date,false,false,false,,
+people,email_address,string,false,false,false,,"Person email address, cached from BGS"
+people,first_name,string,false,false,false,,"Person first name, cached from BGS"
+people,id,integer (8) PK,true,true,false,,
+people,last_name,string,false,false,false,,"Person last name, cached from BGS"
+people,middle_name,string,false,false,false,,"Person middle name, cached from BGS"
+people,name_suffix,string,false,false,false,,"Person name suffix, cached from BGS"
+people,participant_id,string ∗,true,false,false,true,
+people,updated_at,datetime ∗,true,false,false,true,
+post_decision_motions,,,,,,,"Stores the disposition and associated task of post-decisional motions handled by the Litigation Support Team: Motion for Reconsideration, Motion to Vacate, and Clear and Unmistakeable Error."
+post_decision_motions,appeal_id,integer (8) FK,false,false,false,,
+post_decision_motions,created_at,datetime ∗,true,false,false,,
+post_decision_motions,disposition,string ∗,true,false,false,,"Possible options are Grant, Deny, Withdraw, and Dismiss"
+post_decision_motions,id,integer (8) PK,true,true,false,,
+post_decision_motions,task_id,integer (8) FK,false,false,false,true,
+post_decision_motions,updated_at,datetime ∗,true,false,false,true,
+post_decision_motions,vacate_type,string,false,false,false,,"Granted motion to vacate can be Straight Vacate, Vacate and Readjudication, or Vacate and De Novo."
+post_decision_motions,vacated_decision_issue_ids,integer,false,false,false,,"When a motion to vacate is partially granted, this includes an array of the appeal's decision issue IDs that were chosen for vacatur in this post-decision motion. For full grant, this includes all prior decision issue IDs."
+ramp_closed_appeals,,,,,,,Keeps track of legacy appeals that are closed or partially closed in VACOLS due to being transitioned to a RAMP election.  This data can be used to rollback the RAMP Election if needed.
+ramp_closed_appeals,closed_on,datetime,false,false,false,,The datetime that the legacy appeal was closed in VACOLS and opted into RAMP.
+ramp_closed_appeals,created_at,datetime,false,false,false,,
+ramp_closed_appeals,id,integer PK,true,true,false,,
+ramp_closed_appeals,nod_date,date,false,false,false,,The date when the Veteran filed a Notice of Disagreement for the original claims decision in the legacy system.
+ramp_closed_appeals,partial_closure_issue_sequence_ids,string,false,false,false,,"If the entire legacy appeal could not be closed and moved to the RAMP Election, the VACOLS sequence IDs of issues on the legacy appeal which were closed are stored here, indicating that it was a partial closure."
+ramp_closed_appeals,ramp_election_id,integer FK,false,false,false,,The ID of the RAMP election that closed the legacy appeal.
+ramp_closed_appeals,updated_at,datetime,false,false,false,true,
+ramp_closed_appeals,vacols_id,string ∗,true,false,false,,The VACOLS BFKEY of the legacy appeal that has been closed and opted into RAMP.
+ramp_elections,,,,,,,Intake data for RAMP elections.
+ramp_elections,created_at,datetime,false,false,false,,
+ramp_elections,established_at,datetime,false,false,false,,"Timestamp for when the review successfully established, including any related actions such as establishing a claim in VBMS if applicable."
+ramp_elections,id,integer PK,true,true,false,,
+ramp_elections,notice_date,date,false,false,false,,The date that the Veteran was notified of their option to opt their legacy appeals into RAMP.
+ramp_elections,option_selected,string ∗,true,false,false,,"Indicates whether the Veteran selected for their RAMP election to be processed as a higher level review (with or without a hearing), a supplemental claim, or a board appeal."
+ramp_elections,receipt_date,date ∗,true,false,false,,The date that the RAMP form was received by central mail.
+ramp_elections,updated_at,datetime,false,false,false,true,
+ramp_elections,veteran_file_number,string ∗,true,false,false,true,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+ramp_election_rollbacks,,,,,,,"If a RAMP election needs to get rolled back, for example if the EP is canceled, it is tracked here. Also any VACOLS issues that were closed in the legacy system and opted into RAMP are re-opened in the legacy system."
+ramp_election_rollbacks,created_at,datetime ∗,true,false,false,,Timestamp for when the rollback was created.
+ramp_election_rollbacks,id,integer (8) PK,true,true,false,,
+ramp_election_rollbacks,ramp_election_id,integer (8) FK,false,false,false,true,The ID of the RAMP Election being rolled back.
+ramp_election_rollbacks,reason,string ∗,true,false,false,,"The reason for rolling back the RAMP Election. Rollbacks happen automatically for canceled RAMP Election End Products, but can also happen for other reason such as by request."
+ramp_election_rollbacks,reopened_vacols_ids,string,false,false,false,,"The IDs of any legacy appeals which were reopened as a result of rolling back the RAMP Election, corresponding to the VACOLS BFKEY."
+ramp_election_rollbacks,updated_at,datetime ∗,true,false,false,true,Timestamp for when the rollback was last updated.
+ramp_election_rollbacks,user_id,integer (8) FK,false,false,false,true,"The user who created the RAMP Election rollback, typically a system user."
+ramp_issues,,,,,,,"Issues added to an end product as contentions for RAMP reviews. For RAMP elections, these are created in VBMS after the end product is established and updated in Caseflow when the end product is synced. For RAMP refilings, these are selected from the RAMP election's issues and added to the RAMP refiling end product that is established."
+ramp_issues,contention_reference_id,string,false,false,false,,The ID of the contention created in VBMS that corresponds to the RAMP issue.
+ramp_issues,created_at,datetime,false,false,false,,
+ramp_issues,description,string ∗,true,false,false,,The description of the contention in VBMS.
+ramp_issues,id,integer PK,true,true,false,,
+ramp_issues,review_id,integer ∗ FK,true,false,false,true,The ID of the RAMP election or RAMP refiling for this issue.
+ramp_issues,review_type,string ∗,true,false,false,true,"The type of RAMP review the issue is on, indicating whether this is a RAMP election issue or a RAMP refiling issue."
+ramp_issues,source_issue_id,integer FK,false,false,false,,"If a RAMP election issue added to a RAMP refiling, it is the source issue for the corresponding RAMP refiling issue."
+ramp_issues,updated_at,datetime,false,false,false,true,
+ramp_refilings,,,,,,,"Intake data for RAMP refilings, also known as RAMP selection."
+ramp_refilings,appeal_docket,string ∗,true,false,false,,"When the RAMP refiling option selected is appeal, they can select hearing, direct review or evidence submission as the appeal docket."
+ramp_refilings,created_at,datetime,false,false,false,,
+ramp_refilings,established_at,datetime,false,false,false,,"Timestamp for when the review successfully established, including any related actions such as establishing a claim in VBMS if applicable."
+ramp_refilings,establishment_processed_at,datetime,false,false,false,,Timestamp for when the end product establishments for the RAMP review finished processing.
+ramp_refilings,establishment_submitted_at,datetime,false,false,false,,Timestamp for when an intake for a review was submitted by the user.
+ramp_refilings,has_ineligible_issue,boolean,false,false,false,,"Selected by the user during intake, indicates whether the Veteran listed ineligible issues on their refiling."
+ramp_refilings,id,integer PK,true,true,false,,
+ramp_refilings,option_selected,string ∗,true,false,false,,"Which lane the RAMP refiling is for, between appeal, higher level review, and supplemental claim."
+ramp_refilings,receipt_date,date ∗,true,false,false,,Receipt date of the RAMP form.
+ramp_refilings,updated_at,datetime,false,false,false,true,
+ramp_refilings,veteran_file_number,string ∗,true,false,false,true,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+record_synced_by_jobs,,,,,,,
+record_synced_by_jobs,created_at,datetime,false,false,false,,
+record_synced_by_jobs,error,string,false,false,false,,
+record_synced_by_jobs,id,integer (8) PK,true,true,false,,
+record_synced_by_jobs,processed_at,datetime,false,false,false,,
+record_synced_by_jobs,record_id,integer (8) FK,false,false,false,true,
+record_synced_by_jobs,record_type,string,false,false,false,true,
+record_synced_by_jobs,sync_job_name,string,false,false,false,,
+record_synced_by_jobs,updated_at,datetime,false,false,false,true,
+remand_reasons,,,,,,,
+remand_reasons,code,string,false,false,false,,
+remand_reasons,created_at,datetime ∗,true,false,false,,
+remand_reasons,decision_issue_id,integer FK,false,false,false,true,
+remand_reasons,id,integer (8) PK,true,true,false,,
+remand_reasons,post_aoj,boolean,false,false,false,,
+remand_reasons,updated_at,datetime ∗,true,false,false,true,
+request_decision_issues,,,,,,,Join table for the has and belongs to many to many relationship between request issues and decision issues.
+request_decision_issues,created_at,datetime ∗,true,false,false,,Automatic timestamp when row was created.
+request_decision_issues,decision_issue_id,integer FK,false,false,false,true,The ID of the decision issue.
+request_decision_issues,deleted_at,datetime,false,false,false,,
+request_decision_issues,id,integer (8) PK,true,true,false,,
+request_decision_issues,request_issue_id,integer FK,false,false,false,true,The ID of the request issue.
+request_decision_issues,updated_at,datetime ∗,true,false,false,true,Automatically populated when the record is updated.
+request_issues,,,,,,,"Each Request Issue represents the Veteran's response to a Rating Issue. Request Issues come in three flavors: rating, nonrating, and unidentified. They are attached to a Decision Review and (for those that track contentions) an End Product Establishment. A Request Issue can contest a rating issue, a decision issue, or a nonrating issue without a decision issue."
+request_issues,benefit_type,string ∗,true,false,false,,The Line of Business the issue is connected with.
+request_issues,closed_at,datetime,false,false,false,,Timestamp when the request issue was closed. The reason it was closed is in closed_status.
+request_issues,closed_status,string,false,false,false,,"Indicates whether the request issue is closed, for example if it was removed from a Decision Review, the associated End Product got canceled, the Decision Review was withdrawn."
+request_issues,contention_reference_id,integer,false,false,false,true,The ID of the contention created on the End Product for this request issue. This is populated after the contention is created in VBMS.
+request_issues,contention_removed_at,datetime,false,false,false,,"When a request issue is removed from a Decision Review during an edit, if it has a contention in VBMS that is also removed. This field indicates when the contention has successfully been removed in VBMS."
+request_issues,contention_updated_at,datetime,false,false,false,,Timestamp indicating when a contention was successfully updated in VBMS.
+request_issues,contested_decision_issue_id,integer FK,false,false,false,true,The ID of the decision issue that this request issue contests. A Request issue will contest either a rating issue or a decision issue
+request_issues,contested_issue_description,string,false,false,false,,Description of the contested rating or decision issue. Will be either a rating issue's decision text or a decision issue's description.
+request_issues,contested_rating_decision_reference_id,string,false,false,false,,The BGS id for contested rating decisions. These may not have corresponding contested_rating_issue_reference_id values.
+request_issues,contested_rating_issue_diagnostic_code,string,false,false,false,,"If the contested issue is a rating issue, this is the rating issue's diagnostic code. Will be nil if this request issue contests a decision issue."
+request_issues,contested_rating_issue_profile_date,string,false,false,false,,"If the contested issue is a rating issue, this is the rating issue's profile date. Will be nil if this request issue contests a decision issue."
+request_issues,contested_rating_issue_reference_id,string,false,false,false,true,"If the contested issue is a rating issue, this is the rating issue's reference id. Will be nil if this request issue contests a decision issue."
+request_issues,corrected_by_request_issue_id,integer FK,false,false,false,,"If this request issue has been corrected, the ID of the new correction request issue. This is needed for EP 930."
+request_issues,correction_type,string,false,false,false,,"EP 930 correction type. Allowed values: control, local_quality_error, national_quality_error where 'control' is a regular correction, 'local_quality_error' was found after the fact by a local quality review team, and 'national_quality_error' was similarly found by a national quality review team. This is needed for EP 930."
+request_issues,created_at,datetime,false,false,false,,Automatic timestamp when row was created
+request_issues,decision_date,date,false,false,false,,"Either the rating issue's promulgation date, the decision issue's approx decision date or the decision date entered by the user (for nonrating and unidentified issues)"
+request_issues,decision_review_id,integer (8) FK,false,false,false,true,ID of the decision review that this request issue belongs to
+request_issues,decision_review_type,string,false,false,false,true,Class name of the decision review that this request issue belongs to
+request_issues,decision_sync_attempted_at,datetime,false,false,false,,Async job processing last attempted timestamp
+request_issues,decision_sync_canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+request_issues,decision_sync_error,string,false,false,false,,Async job processing last error message
+request_issues,decision_sync_last_submitted_at,datetime,false,false,false,,Async job processing most recent start timestamp
+request_issues,decision_sync_processed_at,datetime,false,false,false,,Async job processing completed timestamp
+request_issues,decision_sync_submitted_at,datetime,false,false,false,,Async job processing start timestamp
+request_issues,edited_description,string,false,false,false,,"The edited description for the contested issue, optionally entered by the user."
+request_issues,end_product_establishment_id,integer FK,false,false,false,true,The ID of the End Product Establishment created for this request issue.
+request_issues,id,integer (8) PK,true,true,false,,
+request_issues,ineligible_due_to_id,integer (8) FK,false,false,false,true,"If a request issue is ineligible due to another request issue, for example that issue is already being actively reviewed, then the ID of the other request issue is stored here."
+request_issues,ineligible_reason,string,false,false,false,,"The reason for a Request Issue being ineligible. If a Request Issue has an ineligible_reason, it is still captured, but it will not get a contention in VBMS or a decision."
+request_issues,is_unidentified,boolean,false,false,false,,"Indicates whether a Request Issue is unidentified, meaning it wasn't found in the list of contestable issues, and is not a new nonrating issue. Contentions for unidentified issues are created on a rating End Product if processed in VBMS but without the issue description, and someone is required to edit it in Caseflow before proceeding with the decision."
+request_issues,nonrating_issue_category,string,false,false,false,,The category selected for nonrating request issues. These vary by business line.
+request_issues,nonrating_issue_description,string,false,false,false,,The user entered description if the issue is a nonrating issue
+request_issues,notes,text,false,false,false,,"Notes added by the Claims Assistant when adding request issues. This may be used to capture handwritten notes on the form, or other comments the CA wants to capture."
+request_issues,ramp_claim_id,string,false,false,false,,"If a rating issue was created as a result of an issue intaken for a RAMP Review, it will be connected to the former RAMP issue by its End Product's claim ID."
+request_issues,rating_issue_associated_at,datetime,false,false,false,,Timestamp when a contention and its contested rating issue are associated in VBMS.
+request_issues,unidentified_issue_text,string,false,false,false,,User entered description if the request issue is neither a rating or a nonrating issue
+request_issues,untimely_exemption,boolean,false,false,false,,"If the contested issue's decision date was more than a year before the receipt date, it is considered untimely (unless it is a Supplemental Claim). However, an exemption to the timeliness can be requested. If so, it is indicated here."
+request_issues,untimely_exemption_notes,text,false,false,false,,Notes related to the untimeliness exemption requested.
+request_issues,updated_at,datetime,false,false,false,true,Automatic timestamp whenever the record changes.
+request_issues,vacols_id,string,false,false,false,,The vacols_id of the legacy appeal that had an issue found to match the request issue.
+request_issues,vacols_sequence_id,integer,false,false,false,,"The vacols_sequence_id, for the specific issue on the legacy appeal which the Claims Assistant determined to match the request issue on the Decision Review. A combination of the vacols_id (for the legacy appeal), and vacols_sequence_id (for which issue on the legacy appeal), is required to identify the issue being opted-in."
+request_issues,verified_unidentified_issue,boolean,false,false,false,,"A verified unidentified issue allows an issue whose rating data is missing to be intaken as a regular rating issue. In order to be marked as verified, a VSR needs to confirm that they were able to find the record of the decision for the issue."
+request_issues,veteran_participant_id,string,false,false,false,,The veteran participant ID. This should be unique in upstream systems and used in the future to reconcile duplicates.
+request_issues_updates,,,,,,,"Keeps track of edits to request issues on a decision review that happen after the initial intake, such as removing and adding issues.  When the decision review is processed in VBMS, this also tracks whether adding or removing contentions in VBMS for the update has succeeded."
+request_issues_updates,after_request_issue_ids,integer ∗,true,false,false,,An array of the active request issue IDs after a user has finished editing a decision review. Used with before_request_issue_ids to determine appropriate actions (such as which contentions need to be added).
+request_issues_updates,attempted_at,datetime,false,false,false,,Timestamp for when the request issue update processing was last attempted.
+request_issues_updates,before_request_issue_ids,integer ∗,true,false,false,,An array of the active request issue IDs previously on the decision review before this editing session. Used with after_request_issue_ids to determine appropriate actions (such as which contentions need to be removed).
+request_issues_updates,canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+request_issues_updates,corrected_request_issue_ids,integer,false,false,false,,An array of the request issue IDs that were corrected during this request issues update.
+request_issues_updates,created_at,datetime,false,false,false,,Timestamp when record was initially created
+request_issues_updates,edited_request_issue_ids,integer,false,false,false,,An array of the request issue IDs that were edited during this request issues update
+request_issues_updates,error,string,false,false,false,,The error message if the last attempt at processing the request issues update was not successful.
+request_issues_updates,id,integer (8) PK,true,true,false,,
+request_issues_updates,last_submitted_at,datetime,false,false,false,,Timestamp for when the processing for the request issues update was last submitted. Used to determine how long to continue retrying the processing job. Can be reset to allow for additional retries.
+request_issues_updates,processed_at,datetime,false,false,false,,Timestamp for when the request issue update successfully completed processing.
+request_issues_updates,review_id,integer (8) ∗ FK,true,false,false,true,The ID of the decision review edited.
+request_issues_updates,review_type,string ∗,true,false,false,true,The type of the decision review edited.
+request_issues_updates,submitted_at,datetime,false,false,false,,Timestamp when the request issues update was originally submitted.
+request_issues_updates,updated_at,datetime,false,false,false,true,Timestamp when record was last updated.
+request_issues_updates,user_id,integer (8) ∗ FK,true,false,false,true,The ID of the user who edited the decision review.
+request_issues_updates,withdrawn_request_issue_ids,integer,false,false,false,,An array of the request issue IDs that were withdrawn during this request issues update.
+schedule_periods,,,,,,,
+schedule_periods,created_at,datetime ∗,true,false,false,,
+schedule_periods,end_date,date ∗,true,false,false,,
+schedule_periods,file_name,string ∗,true,false,false,,
+schedule_periods,finalized,boolean,false,false,false,,
+schedule_periods,id,integer (8) PK,true,true,false,,
+schedule_periods,start_date,date ∗,true,false,false,,
+schedule_periods,type,string ∗,true,false,false,,
+schedule_periods,updated_at,datetime ∗,true,false,false,true,
+schedule_periods,user_id,integer (8) ∗ FK,true,false,false,true,
+special_issue_lists,,,,,,,
+special_issue_lists,appeal_id,integer (8) FK,false,false,false,true,
+special_issue_lists,appeal_type,string,false,false,false,true,
+special_issue_lists,contaminated_water_at_camp_lejeune,boolean,false,false,false,,
+special_issue_lists,created_at,datetime,false,false,false,,
+special_issue_lists,dic_death_or_accrued_benefits_united_states,boolean,false,false,false,,
+special_issue_lists,education_gi_bill_dependents_educational_assistance_scholars,boolean,false,false,false,,
+special_issue_lists,foreign_claim_compensation_claims_dual_claims_appeals,boolean,false,false,false,,
+special_issue_lists,foreign_pension_dic_all_other_foreign_countries,boolean,false,false,false,,
+special_issue_lists,foreign_pension_dic_mexico_central_and_south_america_caribb,boolean,false,false,false,,
+special_issue_lists,hearing_including_travel_board_video_conference,boolean,false,false,false,,
+special_issue_lists,home_loan_guaranty,boolean,false,false,false,,
+special_issue_lists,id,integer (8) PK,true,true,false,,
+special_issue_lists,incarcerated_veterans,boolean,false,false,false,,
+special_issue_lists,insurance,boolean,false,false,false,,
+special_issue_lists,manlincon_compliance,boolean,false,false,false,,
+special_issue_lists,mustard_gas,boolean,false,false,false,,
+special_issue_lists,national_cemetery_administration,boolean,false,false,false,,
+special_issue_lists,nonrating_issue,boolean,false,false,false,,
+special_issue_lists,pension_united_states,boolean,false,false,false,,
+special_issue_lists,private_attorney_or_agent,boolean,false,false,false,,
+special_issue_lists,radiation,boolean,false,false,false,,
+special_issue_lists,rice_compliance,boolean,false,false,false,,
+special_issue_lists,spina_bifida,boolean,false,false,false,,
+special_issue_lists,updated_at,datetime,false,false,false,true,
+special_issue_lists,us_territory_claim_american_samoa_guam_northern_mariana_isla,boolean,false,false,false,,
+special_issue_lists,us_territory_claim_philippines,boolean,false,false,false,,
+special_issue_lists,us_territory_claim_puerto_rico_and_virgin_islands,boolean,false,false,false,,
+special_issue_lists,vamc,boolean,false,false,false,,
+special_issue_lists,vocational_rehab,boolean,false,false,false,,
+special_issue_lists,waiver_of_overpayment,boolean,false,false,false,,
+supplemental_claims,,,,,,,Intake data for Supplemental Claims.
+supplemental_claims,benefit_type,string ∗,true,false,false,,"The benefit type selected by the Veteran on their form, also known as a Line of Business."
+supplemental_claims,created_at,datetime,false,false,false,,
+supplemental_claims,decision_review_remanded_id,integer (8) FK,false,false,false,true,"If an Appeal or Higher Level Review decision is remanded, including Duty to Assist errors, it automatically generates a new Supplemental Claim.  If this Supplemental Claim was generated, then the ID of the original Decision Review with the remanded decision is stored here."
+supplemental_claims,decision_review_remanded_type,string,false,false,false,true,"The type of the Decision Review remanded if applicable, used with decision_review_remanded_id to as a composite key to identify the remanded Decision Review."
+supplemental_claims,establishment_attempted_at,datetime,false,false,false,,Timestamp for the most recent attempt at establishing a claim.
+supplemental_claims,establishment_canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+supplemental_claims,establishment_error,string,false,false,false,,The error captured for the most recent attempt at establishing a claim if it failed.  This is removed once establishing the claim succeeds.
+supplemental_claims,establishment_last_submitted_at,datetime,false,false,false,,Timestamp for the latest attempt at establishing the End Products for the Decision Review.
+supplemental_claims,establishment_processed_at,datetime,false,false,false,,Timestamp for when the End Product Establishments for the Decision Review successfully finished processing.
+supplemental_claims,establishment_submitted_at,datetime,false,false,false,,Timestamp for when the Supplemental Claim was submitted by a Claims Assistant. This adds the End Product Establishment to a job to finish processing asynchronously.
+supplemental_claims,id,integer (8) PK,true,true,false,,
+supplemental_claims,legacy_opt_in_approved,boolean,false,false,false,,"Indicates whether a Veteran opted to withdraw their Supplemental Claim request issues from the legacy system if a matching issue is found. If there is a matching legacy issue and it is not withdrawn, then that issue is ineligible to be a new request issue and a contention will not be created for it."
+supplemental_claims,receipt_date,date ∗,true,false,false,,The date that the Supplemental Claim form was received by central mail. Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established. Supplemental Claims do not have the same timeliness restriction on contestable issues as Appeals and Higher Level Reviews.
+supplemental_claims,updated_at,datetime,false,false,false,true,
+supplemental_claims,uuid,uuid ∗,true,false,false,true,The universally unique identifier for the Supplemental Claim. Can be used to link to the claim after it is completed.
+supplemental_claims,veteran_file_number,string ∗,true,false,false,true,The file number of the Veteran that the Supplemental Claim is for.
+supplemental_claims,veteran_is_not_claimant,boolean,false,false,false,,"Indicates whether the Veteran is the claimant on the Supplemental Claim form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."
+tags,,,,,,,
+tags,created_at,datetime ∗,true,false,false,,
+tags,id,integer PK,true,true,false,,
+tags,text,string ∗,true,false,false,true,
+tags,updated_at,datetime ∗,true,false,false,true,
+tasks,,,,,,,
+tasks,appeal_id,integer ∗ FK,true,false,false,true,
+tasks,appeal_type,string ∗,true,false,false,true,
+tasks,assigned_at,datetime,false,false,false,,
+tasks,assigned_by_id,integer FK,false,false,false,,
+tasks,assigned_to_id,integer ∗ FK,true,false,false,true,
+tasks,assigned_to_type,string ∗,true,false,false,true,
+tasks,closed_at,datetime,false,false,false,,
+tasks,created_at,datetime ∗,true,false,false,,
+tasks,id,integer (8) PK,true,true,false,,
+tasks,instructions,text,false,false,false,,
+tasks,parent_id,integer FK,false,false,false,true,
+tasks,placed_on_hold_at,datetime,false,false,false,,
+tasks,started_at,datetime,false,false,false,,
+tasks,status,string ∗,true,false,false,true,
+tasks,type,string ∗,true,false,false,true,
+tasks,updated_at,datetime ∗,true,false,false,true,
+task_timers,,,,,,,"Task timers allow tasks to be run asynchronously after some future date, like EvidenceSubmissionWindowTask."
+task_timers,attempted_at,datetime,false,false,false,,Async timestamp for most recent attempt to run.
+task_timers,canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+task_timers,created_at,datetime ∗,true,false,false,,Automatic timestamp for record creation.
+task_timers,error,string,false,false,false,,Async any error message from most recent failed attempt to run.
+task_timers,id,integer (8) PK,true,true,false,,
+task_timers,last_submitted_at,datetime,false,false,false,,Async timestamp for most recent job start.
+task_timers,processed_at,datetime,false,false,false,,Async timestamp for when the job completes successfully.
+task_timers,submitted_at,datetime,false,false,false,,Async timestamp for initial job start.
+task_timers,task_id,integer (8) ∗ FK,true,false,false,true,ID of the Task to be run.
+task_timers,updated_at,datetime ∗,true,false,false,true,Automatic timestmap for record update.
+team_quotas,,,,,,,
+team_quotas,created_at,datetime ∗,true,false,false,,
+team_quotas,date,date ∗,true,false,false,true,
+team_quotas,id,integer PK,true,true,false,,
+team_quotas,task_type,string ∗,true,false,false,true,
+team_quotas,updated_at,datetime ∗,true,false,false,true,
+team_quotas,user_count,integer,false,false,false,,
+transcriptions,,,,,,,
+transcriptions,created_at,datetime,false,false,false,,
+transcriptions,expected_return_date,date,false,false,false,,
+transcriptions,hearing_id,integer (8) FK,false,false,false,true,
+transcriptions,id,integer (8) PK,true,true,false,,
+transcriptions,problem_notice_sent_date,date,false,false,false,,
+transcriptions,problem_type,string,false,false,false,,
+transcriptions,requested_remedy,string,false,false,false,,
+transcriptions,sent_to_transcriber_date,date,false,false,false,,
+transcriptions,task_number,string,false,false,false,,
+transcriptions,transcriber,string,false,false,false,,
+transcriptions,updated_at,datetime,false,false,false,true,
+transcriptions,uploaded_to_vbms_date,date,false,false,false,,
+users,,,,,,,
+users,created_at,datetime,false,false,false,,
+users,css_id,string ∗,true,false,false,,
+users,efolder_documents_fetched_at,datetime,false,false,false,,Date when efolder documents were cached in s3 for this user
+users,email,string,false,false,false,,
+users,full_name,string,false,false,false,,
+users,id,integer PK,true,true,false,,
+users,last_login_at,datetime,false,false,false,,
+users,roles,string,false,false,false,,
+users,selected_regional_office,string,false,false,false,,
+users,station_id,string ∗,true,false,false,,
+users,status,string,false,false,false,true,Whether or not the user is an active user of caseflow
+users,status_updated_at,datetime,false,false,false,,When the user's status was last updated
+users,updated_at,datetime,false,false,false,true,
+user_quotas,,,,,,,
+user_quotas,created_at,datetime ∗,true,false,false,,
+user_quotas,id,integer PK,true,true,false,,
+user_quotas,locked_task_count,integer,false,false,false,,
+user_quotas,team_quota_id,integer ∗ FK,true,false,false,true,
+user_quotas,updated_at,datetime ∗,true,false,false,true,
+user_quotas,user_id,integer ∗ FK,true,false,false,true,
+vbms_uploaded_documents,,,,,,,
+vbms_uploaded_documents,appeal_id,integer (8) ∗ FK,true,false,false,true,
+vbms_uploaded_documents,attempted_at,datetime,false,false,false,,
+vbms_uploaded_documents,canceled_at,datetime,false,false,false,,Timestamp when job was abandoned
+vbms_uploaded_documents,created_at,datetime ∗,true,false,false,,
+vbms_uploaded_documents,document_type,string ∗,true,false,false,,
+vbms_uploaded_documents,error,string,false,false,false,,
+vbms_uploaded_documents,id,integer (8) PK,true,true,false,,
+vbms_uploaded_documents,last_submitted_at,datetime,false,false,false,,
+vbms_uploaded_documents,processed_at,datetime,false,false,false,,
+vbms_uploaded_documents,submitted_at,datetime,false,false,false,,
+vbms_uploaded_documents,updated_at,datetime ∗,true,false,false,true,
+vbms_uploaded_documents,uploaded_to_vbms_at,datetime,false,false,false,,
+veterans,,,,,,,
+veterans,closest_regional_office,string,false,false,false,,
+veterans,created_at,datetime,false,false,false,,
+veterans,file_number,string ∗,true,false,false,true,
+veterans,first_name,string ∗,true,false,false,,
+veterans,id,integer (8) PK,true,true,false,,
+veterans,last_name,string ∗,true,false,false,,
+veterans,middle_name,string,false,false,false,,
+veterans,name_suffix,string,false,false,false,,
+veterans,participant_id,string,false,false,false,true,
+veterans,ssn,string,false,false,false,true,The cached Social Security Number
+veterans,updated_at,datetime,false,false,false,true,
+virtual_hearings,,,,,,,
+virtual_hearings,alias,string,false,false,false,true,Alias for conference in Pexip
+virtual_hearings,conference_deleted,boolean ∗,true,false,false,,Whether or not the conference was deleted from Pexip
+virtual_hearings,conference_id,integer,false,false,false,true,ID of conference from Pexip
+virtual_hearings,created_at,datetime ∗,true,false,false,,
+virtual_hearings,created_by_id,integer (8) ∗ FK,true,false,false,true,User who created the virtual hearing
+virtual_hearings,guest_pin,integer,false,false,false,,PIN number for guests of Pexip conference
+virtual_hearings,hearing_id,integer (8) FK,false,false,false,true,Associated hearing
+virtual_hearings,hearing_type,string,false,false,false,true,
+virtual_hearings,host_pin,integer,false,false,false,,PIN number for host of Pexip conference
+virtual_hearings,id,integer (8) PK,true,true,false,,
+virtual_hearings,judge_email,string,false,false,false,,Judge's email address
+virtual_hearings,judge_email_sent,boolean ∗,true,false,false,,Whether or not a notification email was sent to the judge
+virtual_hearings,representative_email,string,false,false,false,,Veteran's representative's email address
+virtual_hearings,representative_email_sent,boolean ∗,true,false,false,,Whether or not a notification email was sent to the veteran's representative
+virtual_hearings,status,string ∗,true,false,false,,The status of the Pexip conference
+virtual_hearings,updated_at,datetime ∗,true,false,false,true,
+virtual_hearings,veteran_email,string ∗,true,false,false,,Veteran's email address
+virtual_hearings,veteran_email_sent,boolean ∗,true,false,false,,Whether or not a notification email was sent to the veteran
+virtual_hearing_establishments,,,,,,,
+virtual_hearing_establishments,attempted_at,datetime,false,false,false,,Async timestamp for most recent attempt to run.
+virtual_hearing_establishments,canceled_at,datetime,false,false,false,,Timestamp when job was abandoned.
+virtual_hearing_establishments,created_at,datetime ∗,true,false,false,,Automatic timestamp when row was created.
+virtual_hearing_establishments,error,string,false,false,false,,Async any error message from most recent failed attempt to run.
+virtual_hearing_establishments,id,integer (8) PK,true,true,false,,
+virtual_hearing_establishments,last_submitted_at,datetime,false,false,false,,Async timestamp for most recent job start.
+virtual_hearing_establishments,processed_at,datetime,false,false,false,,Timestamp for when the virtual hearing was successfully processed.
+virtual_hearing_establishments,submitted_at,datetime,false,false,false,,Async timestamp for initial job start.
+virtual_hearing_establishments,updated_at,datetime ∗,true,false,false,,Timestamp when record was last updated.
+virtual_hearing_establishments,virtual_hearing_id,integer (8) ∗ FK,true,false,false,true,Virtual Hearing the conference is being established for.
+vso_configs,,,,,,,
+vso_configs,created_at,datetime ∗,true,false,false,,
+vso_configs,id,integer (8) PK,true,true,false,,
+vso_configs,ihp_dockets,string,false,false,false,,
+vso_configs,organization_id,integer FK,false,false,false,true,
+vso_configs,updated_at,datetime ∗,true,false,false,true,
+worksheet_issues,,,,,,,
+worksheet_issues,allow,boolean,false,false,false,,
+worksheet_issues,appeal_id,integer FK,false,false,false,true,
+worksheet_issues,created_at,datetime,false,false,false,,
+worksheet_issues,deleted_at,datetime,false,false,false,true,
+worksheet_issues,deny,boolean,false,false,false,,
+worksheet_issues,description,string,false,false,false,,
+worksheet_issues,dismiss,boolean,false,false,false,,
+worksheet_issues,disposition,string,false,false,false,,
+worksheet_issues,from_vacols,boolean,false,false,false,,
+worksheet_issues,id,integer PK,true,true,false,,
+worksheet_issues,notes,string,false,false,false,,
+worksheet_issues,omo,boolean,false,false,false,,
+worksheet_issues,remand,boolean,false,false,false,,
+worksheet_issues,reopen,boolean,false,false,false,,
+worksheet_issues,updated_at,datetime,false,false,false,true,
+worksheet_issues,vacols_sequence_id,string ∗,true,false,false,,

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -1,0 +1,188 @@
+Table,Column,Type,Required,Primary Key,Unique,Index,Description
+appeals,,,,,,,Denormalized BVA NODs
+appeals,active_appeal,boolean ∗,true,false,false,true,Calculated based on BVA status
+appeals,aod_due_to_dob,boolean,false,false,false,true,Calculated every day based on Claimant DOB
+appeals,aod_granted,boolean ∗,true,false,false,true,advance_on_docket_motions.granted
+appeals,aod_reason,string (50),false,false,false,,advance_on_docket_motions.reason
+appeals,aod_user_id,integer (8),false,false,false,true,advance_on_docket_motions.user_id
+appeals,appeal_created_at,datetime ∗,true,false,false,true,appeals.created_at
+appeals,appeal_id,integer (8) ∗ FK,true,false,false,true,ID of the Appeal
+appeals,appeal_updated_at,datetime ∗,true,false,false,true,appeals.updated_at
+appeals,claimant_dob,date,false,false,false,true,people.date_of_birth
+appeals,claimant_first_name,string,false,false,false,,people.first_name
+appeals,claimant_id,integer (8),false,false,false,true,claimants.id
+appeals,claimant_last_name,string,false,false,false,,people.last_name
+appeals,claimant_middle_name,string,false,false,false,,people.middle_name
+appeals,claimant_name_suffix,string,false,false,false,,people.name_suffix
+appeals,claimant_participant_id,string (20),false,false,false,true,claimants.participant_id
+appeals,claimant_payee_code,string (20),false,false,false,,claimants.payee_code
+appeals,claimant_person_id,integer (8),false,false,false,true,people.id
+appeals,closest_regional_office,string (20),false,false,false,,The code for the regional office closest to the Veteran on the appeal.
+appeals,created_at,datetime ∗,true,false,false,true,Creation timestamp for the ETL record
+appeals,decision_status_sort_key,integer ∗,true,false,false,true,Integer for sorting status in display order
+appeals,docket_number,string (50) ∗,true,false,false,,Docket number
+appeals,docket_range_date,date,false,false,false,,Date that appeal was added to hearing docket range.
+appeals,docket_type,string (50) ∗,true,false,false,true,Docket type
+appeals,established_at,datetime ∗,true,false,false,,Timestamp for when the appeal was intaken successfully
+appeals,id,integer (8) PK,true,true,false,,
+appeals,legacy_opt_in_approved,boolean,false,false,false,,Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review.
+appeals,poa_participant_id,string (20),false,false,false,true,Used to identify the power of attorney (POA)
+appeals,receipt_date,date ∗,true,false,false,true,Receipt date of the NOD form
+appeals,status,string (32) ∗,true,false,false,true,Calculated BVA status based on Tasks
+appeals,target_decision_date,date,false,false,false,,"If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
+appeals,updated_at,datetime ∗,true,false,false,true,Updated timestamp for the ETL record
+appeals,uuid,uuid ∗,true,false,false,true,The universally unique identifier for the appeal
+appeals,veteran_dob,date,false,false,false,,people.date_of_birth
+appeals,veteran_file_number,string (20) ∗,true,false,false,true,Veteran file number
+appeals,veteran_first_name,string,false,false,false,,veterans.first_name
+appeals,veteran_id,integer (8) ∗,true,false,false,true,veterans.id
+appeals,veteran_is_not_claimant,boolean,false,false,false,true,"Selected by the user during intake, indicates whether the Veteran is the claimant, or if the claimant is someone else such as a dependent. Must be TRUE if Veteran is deceased."
+appeals,veteran_last_name,string,false,false,false,,veterans.last_name
+appeals,veteran_middle_name,string,false,false,false,,veterans.middle_name
+appeals,veteran_name_suffix,string,false,false,false,,veterans.name_suffix
+appeals,veteran_participant_id,string (20),false,false,false,true,veterans.participant_id
+attorney_case_reviews,,,,,,,Denormalized attorney_case_reviews
+attorney_case_reviews,appeal_id,integer (8) ∗,true,false,false,true,tasks.appeal_id
+attorney_case_reviews,appeal_type,string ∗,true,false,false,true,tasks.appeal_type
+attorney_case_reviews,attorney_css_id,string (20) ∗,true,false,false,,users.css_id
+attorney_case_reviews,attorney_full_name,string (255) ∗,true,false,false,,users.full_name
+attorney_case_reviews,attorney_id,integer (8) ∗,true,false,false,true,attorney_case_reviews.attorney_id
+attorney_case_reviews,attorney_sattyid,string (20),false,false,false,,users.sattyid
+attorney_case_reviews,created_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+attorney_case_reviews,document_reference_id,string (50),false,false,false,,attorney_case_reviews.document_id
+attorney_case_reviews,document_type,string (20),false,false,false,true,attorney_case_reviews.document_type
+attorney_case_reviews,id,integer (8) PK,true,true,false,,
+attorney_case_reviews,note,text,false,false,false,,attorney_case_reviews.note
+attorney_case_reviews,overtime,boolean,false,false,false,,attorney_case_reviews.overtime
+attorney_case_reviews,review_created_at,datetime ∗,true,false,false,true,attorney_case_reviews.created_at
+attorney_case_reviews,review_id,integer (8) ∗,true,false,false,true,attorney_case_reviews.id
+attorney_case_reviews,review_updated_at,datetime ∗,true,false,false,true,attorney_case_reviews.updated_at
+attorney_case_reviews,reviewing_judge_css_id,string (20) ∗,true,false,false,,users.css_id
+attorney_case_reviews,reviewing_judge_full_name,string (255) ∗,true,false,false,,users.full_name
+attorney_case_reviews,reviewing_judge_id,integer (8) ∗,true,false,false,true,attorney_case_reviews.reviewing_judge_id
+attorney_case_reviews,reviewing_judge_sattyid,string (20),false,false,false,,users.sattyid
+attorney_case_reviews,task_id,string ∗,true,false,false,true,attorney_case_reviews.task_id
+attorney_case_reviews,untimely_evidence,boolean,false,false,false,,attorney_case_reviews.untimely_evidence
+attorney_case_reviews,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+attorney_case_reviews,vacols_id,string,false,false,false,true,Substring attorney_case_reviews.task_id for Legacy Appeals
+attorney_case_reviews,work_product,string (20),false,false,false,,attorney_case_reviews.work_product
+etl_builds,,,,,,,ETL build metadata for each job
+etl_builds,comments,string,false,false,false,,Ad hoc comments (e.g. error message)
+etl_builds,created_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+etl_builds,finished_at,datetime,false,false,false,true,Build end time
+etl_builds,id,integer (8) PK,true,true,false,,
+etl_builds,started_at,datetime,false,false,false,true,Build start time (usually identical to created_at)
+etl_builds,status,string,false,false,false,true,"Enum value: running, complete, error"
+etl_builds,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+etl_build_tables,,,,,,,"ETL table metadata, one for each table per-build"
+etl_build_tables,comments,string,false,false,false,,Ad hoc comments (e.g. error message)
+etl_build_tables,created_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+etl_build_tables,etl_build_id,integer (8) ∗ FK,true,false,false,true,PK of the etl_build
+etl_build_tables,finished_at,datetime,false,false,false,true,Build end time
+etl_build_tables,id,integer (8) PK,true,true,false,,
+etl_build_tables,rows_deleted,integer (8),false,false,false,,Number of rows deleted
+etl_build_tables,rows_inserted,integer (8),false,false,false,,Number of new rows
+etl_build_tables,rows_rejected,integer (8),false,false,false,,Number of rows skipped
+etl_build_tables,rows_updated,integer (8),false,false,false,,Number of rows changed
+etl_build_tables,started_at,datetime,false,false,false,true,Build start time (usually identical to created_at)
+etl_build_tables,status,string,false,false,false,true,"Enum value: running, complete, error"
+etl_build_tables,table_name,string,false,false,false,true,Name of the ETL table
+etl_build_tables,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+decision_issues,,,,,,,Copy of decision_issues
+decision_issues,benefit_type,string (20),false,false,false,,decision_issues.benefit_type
+decision_issues,caseflow_decision_date,date,false,false,false,,decision_issues.caseflow_decision_date
+decision_issues,created_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+decision_issues,decision_review_id,integer (8),false,false,false,true,decision_issues.decision_review_id
+decision_issues,decision_review_type,string (20),false,false,false,true,decision_issues.decision_review_type
+decision_issues,decision_text,string,false,false,false,,decision_issues.decision_text
+decision_issues,description,string,false,false,false,,decision_issues.description
+decision_issues,diagnostic_code,string (20),false,false,false,,decision_issues.diagnostic_code
+decision_issues,disposition,string (50),false,false,false,true,decision_issues.disposition
+decision_issues,end_product_last_action_date,date,false,false,false,,decision_issues.end_product_last_action_date
+decision_issues,id,integer (8) PK,true,true,false,,
+decision_issues,issue_created_at,datetime,false,false,false,true,decision_issues.created_at
+decision_issues,issue_deleted_at,datetime,false,false,false,true,decision_issues.deleted_at
+decision_issues,issue_updated_at,datetime,false,false,false,true,decision_issues.updated_at
+decision_issues,participant_id,integer (8) ∗,true,false,false,true,decision_issues.participant_id
+decision_issues,rating_issue_reference_id,integer (8),false,false,false,true,decision_issues.rating_issue_reference_id
+decision_issues,rating_profile_date,datetime,false,false,false,,decision_issues.rating_profile_date
+decision_issues,rating_promulgation_date,datetime,false,false,false,,decision_issues.rating_promulgation_date
+decision_issues,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+organizations,,,,,,,Copy of Organizations table
+organizations,created_at,datetime,false,false,false,true,
+organizations,id,integer (8) PK,true,true,false,,
+organizations,name,string,false,false,false,,
+organizations,participant_id,string,false,false,false,,Organizations BGS partipant id
+organizations,role,string,false,false,false,,"Role users in organization must have, if present"
+organizations,status,string,false,false,false,true,"Whether organization is active, inactive, or in some other Status."
+organizations,status_updated_at,datetime,false,false,false,,Track when organization status last changed.
+organizations,type,string,false,false,false,,Single table inheritance
+organizations,updated_at,datetime,false,false,false,true,
+organizations,url,string,false,false,false,true,Unique portion of the organization queue url
+organizations_users,,,,,,,Copy of OrganizationUsers table
+organizations_users,admin,boolean,false,false,false,,
+organizations_users,created_at,datetime,false,false,false,true,
+organizations_users,id,integer (8) PK,true,true,false,,
+organizations_users,organization_id,integer,false,false,false,true,
+organizations_users,updated_at,datetime,false,false,false,true,
+organizations_users,user_id,integer,false,false,false,true,
+people,,,,,,,Copy of People table
+people,created_at,datetime ∗,true,false,false,true,
+people,date_of_birth,date,false,false,false,,
+people,email_address,string,false,false,false,,"Person email address, cached from BGS"
+people,first_name,string (50),false,false,false,,"Person first name, cached from BGS"
+people,id,integer (8) PK,true,true,false,,
+people,last_name,string (50),false,false,false,,"Person last name, cached from BGS"
+people,middle_name,string (50),false,false,false,,"Person middle name, cached from BGS"
+people,name_suffix,string (20),false,false,false,,"Person name suffix, cached from BGS"
+people,participant_id,string (20) ∗,true,false,false,true,
+people,updated_at,datetime ∗,true,false,false,true,
+tasks,,,,,,,Denormalized Tasks with User/Organization
+tasks,appeal_id,integer (8) ∗ FK,true,false,false,true,tasks.appeal_id
+tasks,appeal_type,string ∗,true,false,false,true,tasks.appeal_type
+tasks,assigned_at,datetime,false,false,false,,tasks.assigned_at
+tasks,assigned_by_id,integer (8),false,false,false,,tasks.assigned_by_id
+tasks,assigned_by_user_css_id,string (20),false,false,false,,users.css_id
+tasks,assigned_by_user_full_name,string (255),false,false,false,,users.full_name
+tasks,assigned_by_user_sattyid,string (20),false,false,false,,users.sattyid
+tasks,assigned_to_id,integer (8) ∗,true,false,false,true,tasks.assigned_to_id
+tasks,assigned_to_org_name,string (255),false,false,false,,organizations.name
+tasks,assigned_to_org_type,string (50),false,false,false,,organizations.type
+tasks,assigned_to_type,string ∗,true,false,false,true,tasks.assigned_to_type
+tasks,assigned_to_user_css_id,string (20),false,false,false,,users.css_id
+tasks,assigned_to_user_full_name,string (255),false,false,false,,users.full_name
+tasks,assigned_to_user_sattyid,string (20),false,false,false,,users.sattyid
+tasks,closed_at,datetime,false,false,false,,tasks.closed_at
+tasks,created_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+tasks,id,integer (8) PK,true,true,false,,
+tasks,instructions,text,false,false,false,,tasks.instructions
+tasks,parent_id,integer (8),false,false,false,true,tasks.parent_id
+tasks,placed_on_hold_at,datetime,false,false,false,,tasks.placed_on_hold_at
+tasks,started_at,datetime,false,false,false,,tasks.started_at
+tasks,task_created_at,datetime,false,false,false,,tasks.created_at
+tasks,task_id,integer (8) ∗,true,false,false,true,tasks.id
+tasks,task_status,string (20) ∗,true,false,false,true,tasks.status
+tasks,task_type,string (50) ∗,true,false,false,true,tasks.type
+tasks,task_updated_at,datetime,false,false,false,,tasks.updated_at
+tasks,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+users,,,,,,,Combined Caseflow/VACOLS user lookups
+users,created_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+users,css_id,string (20) ∗,true,false,false,,CSEM (Active Directory) username
+users,email,string (255),false,false,false,,CSEM email
+users,full_name,string (255),false,false,false,,CSEM full name
+users,id,integer (8) PK,true,true,false,,
+users,last_login_at,datetime,false,false,false,,
+users,roles,string,false,false,false,,
+users,sactive,string (1),false,false,false,,
+users,sattyid,string (20),false,false,false,,
+users,selected_regional_office,string (255),false,false,false,,CSEM regional office
+users,slogid,string (20),false,false,false,,
+users,smemgrp,string (8),false,false,false,,VACOLS cached_user_attributes.smemgrp
+users,stafkey,string (20),false,false,false,,
+users,station_id,string (20) ∗,true,false,false,,CSEM station
+users,status,string (20),false,false,false,true,Whether or not the user is an active user of caseflow
+users,status_updated_at,datetime,false,false,false,,When the user's status was last updated
+users,stitle,string (16),false,false,false,,VACOLS cached_user_attributes.stitle
+users,svlj,string (1),false,false,false,,
+users,updated_at,datetime ∗,true,false,false,true,Default created_at/updated_at for the ETL record
+users,user_id,integer ∗,true,false,false,,ID of the User

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_erd/domain"
+require "csv"
+
+namespace :doc do
+  def table_comments
+    sql = <<-SQL
+      SELECT c.table_schema,c.table_name,c.column_name,pgd.description
+      FROM pg_catalog.pg_statio_all_tables as st
+        inner join pg_catalog.pg_description pgd on (pgd.objoid=st.relid)
+        inner join information_schema.columns c on (pgd.objsubid=c.ordinal_position
+        and c.table_schema=st.schemaname and c.table_name=st.relname)
+    SQL
+    comments = {}
+    exec_sql(sql).each do |tuple|
+      table_name = tuple["table_name"]
+      comments[table_name] ||= {}
+      comments[table_name][tuple["column_name"]] = tuple["description"]
+    end
+    comments
+  end
+
+  def comment_for_table(table_name)
+    table_comment_sql = "select obj_description(oid) from pg_class where relkind='r' and relname='?'"
+    exec_sql(table_comment_sql.sub("?", table_name)).first["obj_description"]
+  end
+
+  def exec_sql(sql)
+    db_connection.exec_query(sql).to_hash
+  end
+
+  def db_connection
+    @example_klass.connection
+  end
+
+  def indexed?(table_name, column_name)
+    @indexes ||= build_indexes
+    @indexes.dig(table_name, column_name)
+  end
+
+  def build_indexes
+    indexes = {}
+    db_connection.tables.map do |table|
+      indexes[table] = {}
+      idxs = db_connection.indexes(table)
+      idxs.each do |idx|
+        Array(idx.columns).each { |col| indexes[table][col] = true }
+      end
+    end
+    indexes
+  end
+
+  desc "Generate documentation for db schema"
+  task schema: :environment do
+    schema_name = ENV.fetch("SCHEMA") # die if not set
+
+    $VERBOSE = nil # turn off warnings about already initialized constants
+    Rails.application.eager_load!
+
+    domain = RailsERD::Domain.generate
+
+    # we do this evil instance_variable_get to make sure we are talking to the correct db.
+    @example_klass = domain.instance_variable_get(:@source_models).first
+    comments = table_comments
+
+    csv_file = Rails.root.join("docs/schema/#{schema_name}.csv")
+    CSV.open(csv_file, "wb") do |csv|
+      csv << ["Table", "Column", "Type", "Required", "Primary Key", "Unique", "Index", "Description"]
+      domain.entities.each do |entity|
+        table_name = entity.model.table_name
+        csv << [table_name, nil, nil, nil, nil, nil, nil, comment_for_table(table_name)]
+        entity.attributes.each do |attr|
+          comment = comments.dig(table_name, attr.name)
+          csv << [
+            table_name,
+            attr.name,
+            attr.type_description,
+            attr.mandatory?,
+            attr.primary_key?,
+            attr.unique?,
+            indexed?(table_name, attr.name),
+            comment
+          ]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
connects #13540 

### Description
Automatically build schema documentation.

This touches all the Caseflow models because it introduces a new subclass of `ApplicationRecord` that is specific to Caseflow (and not VACOLS or ETL).

* .csv files for each PostgreSQL db
* ERD PDF files for PostgreSQL and FACOLS
 
This is the first of a few PRs for automatically db documentation. Still TBD:

* store the .csv files in github? (my preference is yes, with a Dangerfile warning to re-create for each migration)
* store the .pdf files in github?
* is the format of the .csv appropriate?
* build a single .xlsx file from the .csv files?