### PR TITLE
Add test_link to virtual hearing email

### DIFF
--- a/app/mailers/virtual_hearing_mailer.rb
+++ b/app/mailers/virtual_hearing_mailer.rb
@@ -19,6 +19,7 @@ class VirtualHearingMailer < ActionMailer::Base
     @recipient = mail_recipient
     @virtual_hearing = virtual_hearing
     @link = link
+    @test_link = test_link
 
     attachments[calendar_invite_name] = confirmation_calendar_invite
 
@@ -29,6 +30,7 @@ class VirtualHearingMailer < ActionMailer::Base
     @recipient = mail_recipient
     @virtual_hearing = virtual_hearing
     @link = link
+    @test_link = test_link
 
     attachments[calendar_invite_name] = confirmation_calendar_invite
 
@@ -74,5 +76,9 @@ class VirtualHearingMailer < ActionMailer::Base
     return virtual_hearing.host_link if recipient.title == MailRecipient::RECIPIENT_TITLES[:judge]
 
     virtual_hearing.guest_link
+  end
+
+  def test_link
+    "https://vc.va.gov/webapp2/conference/test_call?name=Veteran&join=1"
   end
 end

--- a/app/views/virtual_hearing_mailer/sections/_test_your_connection.html.erb
+++ b/app/views/virtual_hearing_mailer/sections/_test_your_connection.html.erb
@@ -4,7 +4,7 @@
 <p>
   At least 1 week before your hearing day, test your audio and video
   connection by visiting the VA Video Connect test site <strong>with the device
-  you plan to use for your hearing</strong>: <%= external_link @link %>
+  you plan to use for your hearing</strong>: <%= external_link @test_link %>
 </p>
 <ul>
   <li>


### PR DESCRIPTION
Resolves #13383

### Description
- use the new test link in the virtual hearing emails sent to veterans and representatives
- create `test_link` method in `VirtualHearingMailer` class