### PR TITLE
Fix ArgumentError in LegacyAppeal#address

### DIFF
--- a/app/mappers/address_mapper.rb
+++ b/app/mappers/address_mapper.rb
@@ -11,7 +11,8 @@ module AddressMapper
       city: bgs_address[:city_nm],
       country: bgs_address[:cntry_nm],
       state: bgs_address[:postal_cd],
-      zip: bgs_address[:zip_prefix_nbr]
+      zip: bgs_address[:zip_prefix_nbr],
+      type: bgs_address[:ptcpnt_addrs_type_nm]
     }
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -763,8 +763,13 @@ class LegacyAppeal < ApplicationRecord
     location_code
   end
 
+  # Appellant's addressed wrapped as an instance of `Address`.
   def address
-    @address ||= Address.new(appellant[:address]) if appellant[:address].present?
+    if appellant[:address].present?
+      @address ||= Address.new(
+        appellant[:address].slice(:address_line_1, :address_line_2, :address_line_3, :city, :zip, :country, :state)
+      )
+    end
   end
 
   def paper_case?

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -765,11 +765,7 @@ class LegacyAppeal < ApplicationRecord
 
   # Appellant's addressed wrapped as an instance of `Address`.
   def address
-    if appellant[:address].present?
-      @address ||= Address.new(
-        appellant[:address].slice(:address_line_1, :address_line_2, :address_line_3, :city, :zip, :country, :state)
-      )
-    end
+    @address ||= Address.new(appellant[:address]) if appellant[:address].present?
   end
 
   def paper_case?

--- a/app/services/bgs_address_service.rb
+++ b/app/services/bgs_address_service.rb
@@ -11,7 +11,17 @@ class BgsAddressService
   def address
     return nil unless found?
 
-    bgs_record
+    # The address from BGS includes a type field. Filter the hash keys to only include
+    # address components (for Address#new).
+    bgs_record.slice(
+      :address_line_1,
+      :address_line_2,
+      :address_line_3,
+      :city,
+      :zip,
+      :country,
+      :state
+    )
   end
 
   def fetch_bgs_record

--- a/app/services/external_api/bgs_address_finder.rb
+++ b/app/services/external_api/bgs_address_finder.rb
@@ -37,7 +37,7 @@ class ExternalApi::BgsAddressFinder
     bgs_addresses = Array.wrap(response).select { |addr| addr.key?(:addrs_one_txt) }
     bgs_addresses
       .sort_by { |addr| addr[:efctv_dt] }
-      .map { |addr| get_address_from_bgs_address(addr).merge(type: addr[:ptcpnt_addrs_type_nm]) }
+      .map { |addr| get_address_from_bgs_address(addr) }
   end
 
   def client

--- a/spec/factories/legacy_appeal.rb
+++ b/spec/factories/legacy_appeal.rb
@@ -74,7 +74,8 @@ FactoryBot.define do
           city_nm: FakeConstants.BGS_SERVICE.DEFAULT_CITY,
           cntry_nm: FakeConstants.BGS_SERVICE.DEFAULT_COUNTRY,
           postal_cd: FakeConstants.BGS_SERVICE.DEFAULT_STATE,
-          zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP
+          zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP,
+          ptcpnt_addrs_type_nm: "Mailing"
         }
       end
     end

--- a/spec/mappers/address_mapper_spec.rb
+++ b/spec/mappers/address_mapper_spec.rb
@@ -22,7 +22,8 @@ describe AddressMapper do
         city_nm: city,
         postal_cd: state,
         zip_prefix_nbr: zip_code,
-        cntry_nm: country
+        cntry_nm: country,
+        ptcpnt_addrs_type_nm: "Mailing"
       }
     end
     let(:bgs_address) { bgs_address_template }
@@ -35,7 +36,8 @@ describe AddressMapper do
         city: city,
         country: country,
         state: state,
-        zip: zip_code
+        zip: zip_code,
+        type: "Mailing"
       }
     end
     let(:result) { result_template }

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2658,6 +2658,45 @@ describe LegacyAppeal, :all_dbs do
     end
   end
 
+  context "#address" do
+    let(:appeal) do
+      create(
+        :legacy_appeal,
+        :with_veteran,
+        vacols_case: create(:case),
+        veteran_address: veteran_address
+      )
+    end
+
+    subject { appeal.address }
+
+    context "when veteran is the appellant" do
+      let(:veteran_address) do
+        {
+          addrs_one_txt: "123 K St. NW",
+          addrs_two_txt: "Suite 456",
+          addrs_three_txt: nil,
+          city_nm: "Washington",
+          postal_cd: "DC",
+          cntry_nm: nil,
+          zip_prefix_nbr: "20001",
+          ptcpnt_addrs_type_nm: "Mailing"
+        }
+      end
+
+      it "returns the veterans's address from BGS" do
+        expect(subject).not_to eq(nil)
+        expect(subject.address_line_1).to eq(veteran_address[:addrs_one_txt])
+        expect(subject.address_line_2).to eq(veteran_address[:addrs_two_txt])
+        expect(subject.address_line_3).to eq(veteran_address[:addrs_three_txt])
+        expect(subject.city).to eq(veteran_address[:city_nm])
+        expect(subject.state).to eq(veteran_address[:postal_cd])
+        expect(subject.country).to eq(veteran_address[:country])
+        expect(subject.zip).to eq(veteran_address[:zip_prefix_nbr])
+      end
+    end
+  end
+
   context "#representatives" do
     context "when there is no VSO" do
       before do


### PR DESCRIPTION
Resolves #13545 

### Description

  * Move mapping of `ptcpnt_addrs_type_nm => type` to `AddressMapper`
  * Update `address` so `Address` constructor is only called with expected args
  * Add test to ensure changes to `address` method work 

### Acceptance Criteria
- [ ] Reproduce and fix underlying issue


