### PR TITLE
Fallback to appellant address in VACOLS for LegacyAppeal

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -28,6 +28,8 @@ detectors:
     exclude:
       - Address
       - Fakes::PersistentStore#convert_dates_from
+  UncommunicativeMethodName:
+    exclude:
       - LegacyAppeal#appellant_address_line_1
       - LegacyAppeal#appellant_address_line_2
   UncommunicativeParameterName:

--- a/.reek.yml
+++ b/.reek.yml
@@ -28,6 +28,8 @@ detectors:
     exclude:
       - Address
       - Fakes::PersistentStore#convert_dates_from
+      - LegacyAppeal#appellant_address_line_1
+      - LegacyAppeal#appellant_address_line_2
   UncommunicativeParameterName:
     exclude:
       - Address
@@ -113,6 +115,7 @@ detectors:
     exclude:
       - HearingLocation
       - JudgeTeam
+      - LegacyAppeal
       - QueueConfig
       - RequestIssue
       - BulkTaskReassignment

--- a/.reek.yml
+++ b/.reek.yml
@@ -140,6 +140,7 @@ detectors:
   UtilityFunction:
     public_methods_only: true
     exclude:
+      - AddressMapper#get_address_from_veteran_record
       - ClaimReviewAsyncStatsReporter#seconds_to_hms
       - ETL::Syncer#filter?
       - ETL::TaskSyncer#filter?

--- a/app/mappers/address_mapper.rb
+++ b/app/mappers/address_mapper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 module AddressMapper
-  private
-
   def get_address_from_bgs_address(bgs_address)
     return {} unless bgs_address
 

--- a/app/mappers/address_mapper.rb
+++ b/app/mappers/address_mapper.rb
@@ -28,6 +28,20 @@ module AddressMapper
     }
   end
 
+  def get_address_from_veteran_record(veteran)    
+    return nil unless veteran    
+
+    {   
+      address_line_1: veteran.address_line1,   
+      address_line_2: veteran.address_line2,   
+      address_line_3: veteran.address_line3,   
+      city: veteran.city,    
+      state: veteran.state,    
+      country: veteran.country,    
+      zip: veteran.zip_code    
+    }    
+  end
+
   def get_address_from_rep_entry(rep_entry)
     return {} unless rep_entry
 

--- a/app/mappers/address_mapper.rb
+++ b/app/mappers/address_mapper.rb
@@ -28,18 +28,18 @@ module AddressMapper
     }
   end
 
-  def get_address_from_veteran_record(veteran)    
-    return nil unless veteran    
+  def get_address_from_veteran_record(veteran)
+    return nil unless veteran
 
-    {   
-      address_line_1: veteran.address_line1,   
-      address_line_2: veteran.address_line2,   
-      address_line_3: veteran.address_line3,   
-      city: veteran.city,    
-      state: veteran.state,    
-      country: veteran.country,    
-      zip: veteran.zip_code    
-    }    
+    {
+      address_line_1: veteran.address_line1,
+      address_line_2: veteran.address_line2,
+      address_line_3: veteran.address_line3,
+      city: veteran.city,
+      state: veteran.state,
+      country: veteran.country,
+      zip: veteran.zip_code
+    }
   end
 
   def get_address_from_rep_entry(rep_entry)

--- a/app/mappers/address_mapper.rb
+++ b/app/mappers/address_mapper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module AddressMapper
+  private
+
   def get_address_from_bgs_address(bgs_address)
     return {} unless bgs_address
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -248,7 +248,7 @@ class LegacyAppeal < ApplicationRecord
     appellant_address&.[](:state)
   end
 
-  def appellant_state
+  def appellant_zip
     appellant_address&.[](:zip)
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -11,6 +11,7 @@ class LegacyAppeal < ApplicationRecord
   include AssociatedVacolsModel
   include BgsService
   include CachedAttributes
+  include AddressMapper
   include Taskable
   include PrintsTaskTree
   include HasTaskHistory

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -80,11 +80,6 @@ class LegacyAppeal < ApplicationRecord
            to: :veteran,
            allow_nil: true
 
-  delegate :address, :address_line_1, :address_line_2, :city, :country, :state, :zip,
-           to: :bgs_address_service,
-           prefix: :appellant,
-           allow_nil: true
-
   cache_attribute :aod do
     self.class.repository.aod(vacols_id)
   end
@@ -219,8 +214,42 @@ class LegacyAppeal < ApplicationRecord
     (decision_date + 120.days).to_date
   end
 
-  def appellant
-    claimant
+  def appellant_address
+    appellant_address_from_bgs = bgs_address_service.address
+
+    # Attempt to get the address from BGS, or fall back to VACOLS. These are expected
+    # to have the same hash keys.
+    if appellant_is_not_veteran
+      appellant_address_from_bgs || get_address_from_corres_entry(case_record.correspondent)
+    else
+      appellant_address_from_bgs ||
+        get_address_from_veteran_record(veteran) ||
+        get_address_from_corres_entry(case_record.correspondent)
+    end
+  end
+
+  def appellant_address_line_1
+    appellant_address&.[](:address_line_1)
+  end
+
+  def appellant_address_line_2
+    appellant_address&.[](:address_line_2)
+  end
+
+  def appellant_city
+    appellant_address&.[](:city)
+  end
+
+  def appellant_country
+    appellant_address&.[](:country)
+  end
+
+  def appellant_state
+    appellant_address&.[](:state)
+  end
+
+  def appellant_state
+    appellant_address&.[](:zip)
   end
 
   def appellant_is_not_veteran

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -215,7 +215,7 @@ class LegacyAppeal < ApplicationRecord
   end
 
   def appellant_address
-    appellant_address_from_bgs = bgs_address_service.address
+    appellant_address_from_bgs = bgs_address_service&.address
 
     # Attempt to get the address from BGS, or fall back to VACOLS. These are expected
     # to have the same hash keys.

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -366,6 +366,8 @@ class LegacyAppeal < ApplicationRecord
     end
   end
 
+  alias appellant claimant
+
   # reptype C is a contested claimant
   def contested_claimants
     vacols_representatives.where(reptype: "C").map(&:as_claimant)


### PR DESCRIPTION
https://dsva.slack.com/archives/CD5DAQNCU/p1582834251001700

### Description

Add fallback to VACOLS for appellant address since BGS doesn't always have data. This tries to preserve populating the address from a consistent source (e.g. calling `claimant[:address]` and `appellant_address` should give you the same thing)

Fixes a regression from: https://github.com/department-of-veterans-affairs/caseflow/pull/13411

