### PR TITLE
Fix ETL timing bug

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -136,6 +136,7 @@ detectors:
     public_methods_only: true
     exclude:
       - ClaimReviewAsyncStatsReporter#seconds_to_hms
+      - ETL::Builder#last_built
       - ETL::Syncer#filter?
       - ETL::TaskSyncer#filter?
       - HearingAdminActionVerifyAddressTask#available_hearing_admin_actions

--- a/app/queries/appeals_updated_since_query.rb
+++ b/app/queries/appeals_updated_since_query.rb
@@ -9,11 +9,7 @@ class AppealsUpdatedSinceQuery
   end
 
   def call
-    # query can take up to 90 seconds
-    ActiveRecord::Base.connection.execute "SET statement_timeout = 90000"
     build_query
-  ensure
-    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # 30 seconds
   end
 
   private

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -23,11 +23,11 @@ class ETL::Syncer
     # query can take up to 90 seconds
     ETL::Record.connection.execute "SET statement_timeout = 90000"
 
+    # create build record only if we intend to use it.
+    build_record if instances_needing_update.count > 0
+
     instances_needing_update.find_in_batches.with_index do |originals, batch|
       Rails.logger.debug("Starting batch #{batch} for #{target_class}")
-
-      # create within loop so we ignore when instances is empty
-      build_record
 
       target_class.transaction do
         possible = originals.length

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -18,6 +18,10 @@ class ETL::Syncer
     inserted = 0
     updated = 0
     rejected = 0
+
+    # query can take up to 90 seconds
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 90000"
+
     instances_needing_update.find_in_batches.with_index do |originals, batch|
       Rails.logger.debug("Starting batch #{batch} for #{target_class}")
       build_record(etl_build) # create inside the loop so we reflect what we actually update
@@ -56,6 +60,8 @@ class ETL::Syncer
     )
     # re-raise so sentry and parent build record know.
     raise error
+  ensure
+    ActiveRecord::Base.connection.execute "SET statement_timeout = 30000" # restore to 30 seconds
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize

--- a/spec/jobs/etl_builder_job_spec.rb
+++ b/spec/jobs/etl_builder_job_spec.rb
@@ -20,6 +20,10 @@ describe ETLBuilderJob, :etl, :all_dbs do
     subject { described_class.perform_now }
 
     context "when nothing has changed" do
+      before do
+        ETL::Builder.new.full
+      end
+
       it "sends alert to Slack" do
         Timecop.travel(Time.zone.now + 1.hour) { subject }
 

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -55,9 +55,10 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
 
     context "Appeal is not yet established" do
       let!(:appeal) { create(:appeal, established_at: nil) }
+      let(:etl_build_table) { ETL::BuildTable.where(table_name: "appeals").last }
 
       it "skips non-established Appeals" do
-        etl_build_table = subject
+        subject
 
         expect(ETL::Appeal.count).to eq(13)
         expect(etl_build_table.rows_rejected).to eq(0) # not part of .filter so we can't know about it.

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -8,19 +8,19 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
   let(:etl_build) { ETL::Build.create }
 
   describe "#origin_class" do
-    subject { described_class.new.origin_class }
+    subject { described_class.new(etl_build: etl_build).origin_class }
 
     it { is_expected.to eq Appeal }
   end
 
   describe "#target_class" do
-    subject { described_class.new.target_class }
+    subject { described_class.new(etl_build: etl_build).target_class }
 
     it { is_expected.to eq ETL::Appeal }
   end
 
   describe "#call" do
-    subject { described_class.new.call(etl_build) }
+    subject { described_class.new(etl_build: etl_build).call }
 
     before do
       expect(ETL::Appeal.count).to eq(0)
@@ -44,7 +44,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
     end
 
     context "sync tomorrow" do
-      subject { described_class.new(since: Time.zone.now + 1.day).call(etl_build) }
+      subject { described_class.new(since: Time.zone.now + 1.day, etl_build: etl_build).call }
 
       it "does not sync" do
         subject

--- a/spec/services/etl/attorney_case_review_syncer_spec.rb
+++ b/spec/services/etl/attorney_case_review_syncer_spec.rb
@@ -29,7 +29,7 @@ describe ETL::AttorneyCaseReviewSyncer, :etl, :all_dbs do
       CachedUser.sync_from_vacols
     end
 
-    subject { described_class.new.call(etl_build) }
+    subject { described_class.new(etl_build: etl_build).call }
 
     context "LegacyAppeal" do
       let(:task_id) { "#{appeal.vacols_id}-2019-12-17" }

--- a/spec/services/etl/decision_issue_syncer_spec.rb
+++ b/spec/services/etl/decision_issue_syncer_spec.rb
@@ -5,7 +5,7 @@ describe ETL::DecisionIssueSyncer, :etl, :all_dbs do
   let(:etl_build) { ETL::Build.create }
 
   describe "#call" do
-    subject { described_class.new.call(etl_build) }
+    subject { described_class.new(etl_build: etl_build).call }
 
     context "one decision issue" do
       it "syncs attributes" do

--- a/spec/services/etl/organization_syncer_spec.rb
+++ b/spec/services/etl/organization_syncer_spec.rb
@@ -7,7 +7,7 @@ describe ETL::OrganizationSyncer, :etl do
     let(:etl_build) { ETL::Build.create }
 
     context "2 org records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       it "syncs 1 record" do
         expect(ETL::Organization.all.count).to eq(0)
@@ -20,7 +20,7 @@ describe ETL::OrganizationSyncer, :etl do
     end
 
     context "2 org records, full sync" do
-      subject { described_class.new.call(etl_build) }
+      subject { described_class.new(etl_build: etl_build).call }
 
       it "syncs all records" do
         expect(ETL::Organization.all.count).to eq(0)
@@ -32,10 +32,10 @@ describe ETL::OrganizationSyncer, :etl do
     end
 
     context "origin Org record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       before do
-        described_class.new.call(etl_build)
+        described_class.new(etl_build: etl_build).call
       end
 
       let(:new_name) { "foobar" }

--- a/spec/services/etl/organizations_user_syncer_spec.rb
+++ b/spec/services/etl/organizations_user_syncer_spec.rb
@@ -10,7 +10,7 @@ describe ETL::OrganizationsUserSyncer, :etl do
     let(:etl_build) { ETL::Build.create }
 
     context "2 org_user records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       it "syncs 1 record" do
         expect(ETL::OrganizationsUser.all.count).to eq(0)
@@ -23,7 +23,7 @@ describe ETL::OrganizationsUserSyncer, :etl do
     end
 
     context "2 org records, full sync" do
-      subject { described_class.new.call(etl_build) }
+      subject { described_class.new(etl_build: etl_build).call }
 
       it "syncs all records" do
         expect(ETL::OrganizationsUser.all.count).to eq(0)
@@ -35,10 +35,10 @@ describe ETL::OrganizationsUserSyncer, :etl do
     end
 
     context "origin record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       before do
-        described_class.new.call(etl_build)
+        described_class.new(etl_build: etl_build).call
       end
 
       let(:new_admin) { true }

--- a/spec/services/etl/person_syncer_spec.rb
+++ b/spec/services/etl/person_syncer_spec.rb
@@ -7,7 +7,7 @@ describe ETL::PersonSyncer, :etl do
     let(:etl_build) { ETL::Build.create }
 
     context "2 person records, one needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       it "syncs 1 record" do
         expect(ETL::Person.all.count).to eq(0)
@@ -20,7 +20,7 @@ describe ETL::PersonSyncer, :etl do
     end
 
     context "2 person records, full sync" do
-      subject { described_class.new.call(etl_build) }
+      subject { described_class.new(etl_build: etl_build).call }
 
       it "syncs all records" do
         expect(ETL::Person.all.count).to eq(0)
@@ -32,10 +32,10 @@ describe ETL::PersonSyncer, :etl do
     end
 
     context "origin Person record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       before do
-        described_class.new.call(etl_build)
+        described_class.new(etl_build: etl_build).call
       end
 
       let(:new_last_name) { "foobar" }

--- a/spec/services/etl/syncer_spec.rb
+++ b/spec/services/etl/syncer_spec.rb
@@ -14,6 +14,9 @@ describe ETL::Syncer, :etl do
     end
   end
 
+  let(:etl_build) { ETL::Build.create }
+  subject { described_class.new(etl_build: etl_build) }
+
   describe "#origin_class" do
     it "raises error when called on abstract class" do
       expect { subject.origin_class }.to raise_error(RuntimeError)
@@ -34,12 +37,10 @@ describe ETL::Syncer, :etl do
       allow(DummyEtlClass).to receive(:sync_with_original) { dummy_target }
     end
 
-    let(:etl_build) { ETL::Build.create }
-
     context "one stale origin class instance needing sync" do
       let!(:user) { create(:user) }
 
-      subject { MySyncer.new.call(etl_build) }
+      subject { MySyncer.new(etl_build: etl_build).call }
 
       it "saves a new target class instance" do
         subject

--- a/spec/services/etl/task_syncer_spec.rb
+++ b/spec/services/etl/task_syncer_spec.rb
@@ -21,12 +21,14 @@ describe ETL::TaskSyncer, :etl, :all_dbs do
 
     context "orphaned Task" do
       let!(:orphaned_task) { create(:task) }
+      let(:etl_build_table) { ETL::BuildTable.where(table_name: "tasks").last }
+
       before do
         orphaned_task.appeal.delete # not destroy, to avoid callbacks
       end
 
       it "skips orphans" do
-        etl_build_table = subject
+        subject
 
         expect(Task.count).to eq(32)
         expect(ETL::Task.count).to eq(31)

--- a/spec/services/etl/task_syncer_spec.rb
+++ b/spec/services/etl/task_syncer_spec.rb
@@ -8,7 +8,7 @@ describe ETL::TaskSyncer, :etl, :all_dbs do
   let(:etl_build) { ETL::Build.create }
 
   describe "#call" do
-    subject { described_class.new.call(etl_build) }
+    subject { described_class.new(etl_build: etl_build).call }
 
     context "BVA status distribution" do
       it "has expected distribution" do

--- a/spec/services/etl/user_syncer_spec.rb
+++ b/spec/services/etl/user_syncer_spec.rb
@@ -16,7 +16,7 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "3 User records, 2 needing sync" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       it "syncs 2 records" do
         expect(ETL::User.all.count).to eq(0)
@@ -31,10 +31,10 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "VACOLS attribute changes" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       before do
-        described_class.new.call(etl_build)
+        described_class.new(etl_build: etl_build).call
         user2.vacols_user.svlj = "J"
         user2.vacols_user.save!
       end
@@ -50,7 +50,7 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "3 User records, full sync" do
-      subject { described_class.new.call(etl_build) }
+      subject { described_class.new(etl_build: etl_build).call }
 
       it "syncs all records" do
         expect(ETL::User.all.count).to eq(0)
@@ -62,10 +62,10 @@ describe ETL::UserSyncer, :etl do
     end
 
     context "origin User record changes" do
-      subject { described_class.new(since: 2.days.ago.round).call(etl_build) }
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
 
       before do
-        described_class.new.call(etl_build)
+        described_class.new(etl_build: etl_build).call
       end
 
       let(:new_name) { "foobar" }


### PR DESCRIPTION
We periodically see statement time outs from the ETL bg job, like:

https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/8562/events/11f9989849624d8fadf4226bd3d2db99/

We thought we had fixed those in #13487 but we were wrong.

This PR does 3 things:

* fixes the set timeout bug (where we set the connection timeout)
* fixes a timing bug with regard to how we track the checkpoint for incremental builds
* changes the instantiation of `ETL::Syncer` to move the `etl_build` param to `new` instead of `call`.

Now, we track per-table checkpoints so that we start our incremental builds based on the start time of the last successful incremental build.