### PR TITLE
Claims folder search 422 error

### DIFF
--- a/app/controllers/reader/claims_folder_searches_controller.rb
+++ b/app/controllers/reader/claims_folder_searches_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Reader::ClaimsFolderSearchesController < Reader::ApplicationController
+  protect_from_forgery with: :null_session
+  
   def create
     ClaimsFolderSearch.create(
       user: current_user,

--- a/app/controllers/reader/claims_folder_searches_controller.rb
+++ b/app/controllers/reader/claims_folder_searches_controller.rb
@@ -2,7 +2,7 @@
 
 class Reader::ClaimsFolderSearchesController < Reader::ApplicationController
   protect_from_forgery with: :null_session
-  
+
   def create
     ClaimsFolderSearch.create(
       user: current_user,

--- a/app/workflows/ama_appeal_dispatch.rb
+++ b/app/workflows/ama_appeal_dispatch.rb
@@ -19,7 +19,7 @@ class AmaAppealDispatch
 
     @success = valid?
 
-    outcode_appeal if success
+    outcode_appeal if successf
 
     FormResponse.new(success: success, errors: [errors.full_messages.join(", ")])
   end

--- a/app/workflows/ama_appeal_dispatch.rb
+++ b/app/workflows/ama_appeal_dispatch.rb
@@ -19,7 +19,7 @@ class AmaAppealDispatch
 
     @success = valid?
 
-    outcode_appeal if successf
+    outcode_appeal if success
 
     FormResponse.new(success: success, errors: [errors.full_messages.join(", ")])
   end


### PR DESCRIPTION
### Description
Adding `protect_from_forgery with: :null_session` to the ClaimsFolderSearches controller because it's getting an error related to not being able to verify CSRF token authenticity.

Another suggestion (from [this StackOverflow article](https://stackoverflow.com/questions/35181340/rails-cant-verify-csrf-token-authenticity-when-making-a-post-request)) is to add this, but I think the above is better because a lot of the POST requests are successful.
`skip_before_action :verify_authenticity_token, only: [:create]`

Successful post requests show the user in the logs, but this one did not have the user. The query is the same as a query the user was entering though (on a later successful post).

I'm not sure if this is the right fix, and it would also benefit from someone else's guidance on best practices here with respect to security.

[Sentry error](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/8731/)
[Slack thread](https://dsva.slack.com/archives/CANGG9BMK/p1582648486009600)
[Relevant logs](https://console.amazonaws-us-gov.com/cloudwatch/home?region=us-gov-west-1#logEventViewer:group=dsva-appeals-certification-prod/opt/caseflow-certification/src/log/caseflow-certification.out;stream=ip-172-30-86-170.us-gov-west-1.compute.internal;filter=4161bec19573;start=2020-02-25T14:00:00Z;end=2020-02-25T14:59:59Z)