### PR TITLE
Explicitly prefer BGS POA on cached appeals attributes

### DIFF
--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -10,9 +10,7 @@
 # and lets the user modify VACOLS with BGS information
 # (but not the other way around).
 #
-# TODO: we query VACOLS when the vacols methods are
-# called, even if we've also queried VACOLS outside of this
-# model but in the same request. is this something we should optimize?
+
 class PowerOfAttorney
   include ActiveModel::Model
   include AssociatedVacolsModel


### PR DESCRIPTION
connects #13384 

### Description
We prefer displaying BGS POA name, so explicitly cache that. Otherwise, the `PowerOfAttorney` model will trigger loads of VACOLS `case_record` and `representative` that we will not use.

If BGS POA is not found, fall back to VACOLS.

In my manual tests in production, this greatly reduces calls to VACOLS, and instead shifts POA info to the BGS service (which is now cached for 30 days in Redis).