### PR TITLE
Add yarn commands and update help in makefile

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -170,6 +170,6 @@ karma:  ## TODO
 
 # Self-documented makefile from https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
 help:  ## Shows help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[\ a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; { split($$1, C, " "); printf "\033[36m%-30s\033[0m %s\n", C[1], $$2}'
 
 .PHONY: test run clean lint check logs db update one-test client-test security build ready help

--- a/Makefile.example
+++ b/Makefile.example
@@ -145,8 +145,13 @@ install: bundle-install client-install  ## Installs all dependencies
 
 update: fresh install migrate  ## TODO
 
-client-test:  ## Runs javascript tests
+client-build-test client-test:  ## Builds webpack for tests
 	cd client && yarn run build:test
+
+client-build-demo client-demo: ## Builds webpack for local server
+	cd client && yarn run build:demo
+
+client-build-all client-all: client-test client-demo ## Builds webpack for both tests and local server
 
 one-test:  ## run the test passed in
 	bundle exec rspec $$T


### PR DESCRIPTION
### Description
Added some commands for webpack building and updated the `help` command to parse commands with multiple targets and prefer the first.

---

In a Makefile, you can have multiple targets perform the same action by listing them space-separated before the `:`, for example with this definition:

```make
status gs:
  git status
```
you could trigger the command with `make status` or `make gs`.

I updated our help script to parse entries like this and to show only the first target in its output with these changes:
1. in the grep command, added `\ ` to the initial regex to include spaces in the characters it looks for in front of the colon.
2. in the awk command, split the string matched in front of the colon by space and put the resulting list into a variable named `C`.
3. printed only the first element of that array, `C[1]`, in the output.
