### PR TITLE
Upgrade puma to 3.12.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "pg", platforms: :ruby
 # Application server: Puma
 # Puma was chosen because it handles load of 40+ concurrent users better than Unicorn and Passenger
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
-gem "puma", "~> 3.12.3"
+gem "puma", "~> 3.12.4"
 # rack versions before 2.0.6 are affected by CVE-2018-16470 and CVE-2018-16471.
 # Explicitly define rack version here to avoid that.
 gem "rack", "~> 2.0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -378,7 +378,7 @@ GEM
       pry (~> 0.10)
     psych (3.1.0)
     public_suffix (3.1.1)
-    puma (3.12.3)
+    puma (3.12.4)
     rack (2.0.8)
     rack-contrib (2.1.0)
       rack (~> 2.0)
@@ -641,7 +641,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
-  puma (~> 3.12.3)
+  puma (~> 3.12.4)
   rack (~> 2.0.6)
   rails (= 5.2.4.1)
   rails-erd


### PR DESCRIPTION
### Description

Upgrading `puma` per this advisory:

```
Name: puma
Version: 3.12.3
Advisory: CVE-2020-5247
Criticality: Unknown
URL: https://github.com/puma/puma/security/advisories/GHSA-84j7-475p-hp8v
Title: HTTP Response Splitting vulnerability in puma
Solution: upgrade to ~> 3.12.4, >= 4.3.3
```