### PR TITLE
Build attorney queues from config

### DIFF
--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -17,7 +17,7 @@ class QueueConfig
   end
 
   def to_hash
-    table_title = COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE
+    table_title = COPY::USER_QUEUE_PAGE_TABLE_TITLE
     {
       table_title: assignee_is_org? ? format(COPY::ORGANIZATION_QUEUE_TABLE_TITLE, assignee.name) : table_title,
       active_tab: assignee.class.default_active_tab,

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -108,7 +108,8 @@ class QueueTab
   end
 end
 
-def attorney_column_names
+# rubocop:disable Metrics/AbcSize
+def self.attorney_column_names
   [
     Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
     Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
@@ -120,7 +121,7 @@ def attorney_column_names
     Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
   ]
 end
-
+# rubocop:enable Metrics/AbcSize
 
 require_dependency "assigned_tasks_tab"
 require_dependency "completed_tasks_tab"

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -108,6 +108,20 @@ class QueueTab
   end
 end
 
+def attorney_column_names
+  [
+    Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+    Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+    Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+    Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
+  ]
+end
+
+
 require_dependency "assigned_tasks_tab"
 require_dependency "completed_tasks_tab"
 require_dependency "on_hold_tasks_tab"

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -51,6 +51,21 @@ class QueueTab
     false
   end
 
+  # rubocop:disable Metrics/AbcSize
+def self.attorney_column_names
+  [
+    Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+    Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+    Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+    Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
+  ]
+end
+# rubocop:enable Metrics/AbcSize
+
   private
 
   def assignee_is_org?
@@ -107,21 +122,6 @@ class QueueTab
     errors.add(:assignee, COPY::QUEUE_TAB_NON_ORGANIZATION_ASSIGNEE_MESSAGE) unless assignee.is_a?(Organization)
   end
 end
-
-# rubocop:disable Metrics/AbcSize
-def self.attorney_column_names
-  [
-    Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
-    Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
-    Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
-    Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
-    Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
-    Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
-    Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
-    Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
-  ]
-end
-# rubocop:enable Metrics/AbcSize
 
 require_dependency "assigned_tasks_tab"
 require_dependency "completed_tasks_tab"

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -52,19 +52,19 @@ class QueueTab
   end
 
   # rubocop:disable Metrics/AbcSize
-def self.attorney_column_names
-  [
-    Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
-    Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
-    Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
-    Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
-    Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
-    Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
-    Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
-    Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
-  ]
-end
-# rubocop:enable Metrics/AbcSize
+  def self.attorney_column_names
+    [
+      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+      Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
+    ]
+  end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -12,7 +12,7 @@ class AssignedTasksTab < QueueTab
   end
 
   def description
-    COPY::COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION
+    COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -21,6 +21,8 @@ class AssignedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    return attorney_column_names if assignee.attorney_in_vacols?
+
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -21,7 +21,7 @@ class AssignedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
-    return attorney_column_names if assignee.attorney_in_vacols?
+    return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -21,7 +21,7 @@ class CompletedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
-    return attorney_column_names if assignee.attorney_in_vacols?
+    return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -21,6 +21,8 @@ class CompletedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    return attorney_column_names if assignee.attorney_in_vacols?
+
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -12,7 +12,7 @@ class OnHoldTasksTab < QueueTab
   end
 
   def description
-    COPY::COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION
+    COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -21,6 +21,8 @@ class OnHoldTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    return attorney_column_names if assignee.attorney_in_vacols?
+
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -21,7 +21,7 @@ class OnHoldTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
-    return attorney_column_names if assignee.attorney_in_vacols?
+    return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -109,8 +109,6 @@
   "ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL": "If you made a mistake, please email your judge to resolve the issue.",
   "ATTORNEY_QUEUE_TABLE_TASK_NEEDS_ASSIGNMENT_ERROR_MESSAGE": "Please ask your judge to assign this case to you in DAS",
   "ATTORNEY_QUEUE_TABLE_TASK_NO_DOCUMENTS_READER_LINK": "View in Reader",
-  "ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to you.",
-  "ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, cases here will automatically return to the Assigned tab.",
   "ORGANIZATION_QUEUE_TABLE_TITLE": "%s cases",
   "TASKS_NEED_ASSIGNMENT_ERROR_TITLE": "Some cases need preliminary DAS assignments",
   "TASKS_NEED_ASSIGNMENT_ERROR_MESSAGE": "Cases marked with exclamation points need to be assigned to you through DAS. Please contact your judge or senior counsel to create preliminary DAS assignments.",
@@ -120,11 +118,9 @@
   "QUEUE_PAGE_ASSIGNED_TAB_TITLE": "Assigned (%d)",
   "QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold (%d)",
 
-  "COLOCATED_QUEUE_PAGE_TABLE_TITLE": "Your cases",
-  "COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE": "Assigned (%d)",
-  "COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "Cases assigned to you:",
-  "COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION": "Cases no longer on hold:",
-  "COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
+  "USER_QUEUE_PAGE_TABLE_TITLE": "Your cases",
+  "USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "Cases assigned to you:",
+  "USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
   "QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases completed (last two weeks):",
 
   "ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE": "Unassigned (%d)",

--- a/client/app/components/DocketTypeBadge.jsx
+++ b/client/app/components/DocketTypeBadge.jsx
@@ -31,7 +31,7 @@ const DocketTypeBadge = ({ name, number }) => {
 
 DocketTypeBadge.propTypes = {
   name: PropTypes.string,
-  number: PropTypes.number
+  number: PropTypes.string
 };
 
 export default DocketTypeBadge;

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -73,7 +73,6 @@ class AttorneyTaskListView extends React.PureComponent {
         assignedTasks={this.props.assignedTasks}
         onHoldTasks={this.props.onHoldTasks}
         completedTasks={this.props.completedTasks}
-        attorneyQueue
       />
     </AppSegment>;
   }

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -4,10 +4,13 @@ import { bindActionCreators } from 'redux';
 import _ from 'lodash';
 import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
 
 import TabWindow from '../components/TabWindow';
-import TaskTable from './components/TaskTable';
+import QueueTable from './QueueTable';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
+import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, typeColumn, daysWaitingColumn,
+  readerLinkColumnWithNewDocsIcon, issueCountColumn } from './components/TaskTableColumns';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import Alert from '../components/Alert';
@@ -27,7 +30,8 @@ import {
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
 
 import { fullWidth } from './constants';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
+import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 
 const containerStyles = css({
   position: 'relative'
@@ -45,7 +49,7 @@ class AttorneyTaskListView extends React.PureComponent {
     this.props.resetErrorMessages();
 
     if (_.some(
-      [...this.props.workableTasks, ...this.props.onHoldTasks, ...this.props.completedTasks],
+      [...this.props.assignedTasks, ...this.props.onHoldTasks, ...this.props.completedTasks],
       (task) => !task.taskId)) {
       this.props.showErrorMessage({
         title: COPY.TASKS_NEED_ASSIGNMENT_ERROR_TITLE,
@@ -54,60 +58,78 @@ class AttorneyTaskListView extends React.PureComponent {
     }
   };
 
+  tasksForTab = (tabName) => {
+    const mapper = {
+      [QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME]: this.props.assignedTasks,
+      [QUEUE_CONFIG.INDIVIDUALLY_ON_HOLD_TASKS_TAB_NAME]: this.props.onHoldTasks,
+      [QUEUE_CONFIG.INDIVIDUALLY_COMPLETED_TASKS_TAB_NAME]: this.props.completedTasks
+    };
+
+    return mapper[tabName];
+  }
+
+  createColumnObject = (column, config, tasks) => {
+    const functionForColumn = {
+      [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
+      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, false, config.userRole),
+      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false),
+      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, false),
+      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, false),
+      [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(true),
+      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(false),
+      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(true)
+    };
+
+    return functionForColumn[column.name];
+  }
+
+  columnsFromConfig = (config, tabConfig, tasks) =>
+    (tabConfig.columns || []).map((column) => this.createColumnObject(column, config, tasks));
+
+  taskTableTabFactory = (tabConfig, config) => {
+    const tasks = this.tasksForTab(tabConfig.name);
+
+    return {
+      label: sprintf(tabConfig.label, tasks.length),
+      page: <React.Fragment>
+        <p className="cf-margin-top-0">{tabConfig.description}</p>
+        <QueueTable
+          key={tabConfig.name}
+          columns={this.columnsFromConfig(config, tabConfig, tasks)}
+          rowObjects={tasks}
+          getKeyForRow={(_rowNumber, task) => task.uniqueId}
+          enablePagination
+        />
+      </React.Fragment>
+    };
+  }
+
+  tabsFromConfig = (config) => (config.tabs || []).map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
+
+  makeQueueComponents = (config) => <React.Fragment>
+    <h1 {...fullWidth}>{config.table_title}</h1>
+    <QueueOrganizationDropdown organizations={this.props.organizations} />
+    <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} />
+  </React.Fragment>;
+
   render = () => {
-    const { messages, organizations } = this.props;
-    const noOpenTasks = !_.size([...this.props.workableTasks, ...this.props.onHoldTasks]);
+    const { error, success } = this.props;
+    const noOpenTasks = !_.size([...this.props.assignedTasks, ...this.props.onHoldTasks]);
     const noCasesMessage = noOpenTasks ?
       <p>
         {COPY.NO_CASES_IN_QUEUE_MESSAGE}
         <b><Link to="/search">{COPY.NO_CASES_IN_QUEUE_LINK_TEXT}</Link></b>.
       </p> : '';
 
-    const tabs = [
-      {
-        label: sprintf(
-          COPY.QUEUE_PAGE_ASSIGNED_TAB_TITLE,
-          this.props.workableTasks.length),
-        page: <TaskTableTab
-          description={COPY.ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION}
-          tasks={this.props.workableTasks}
-          includeNewDocsIcon={false}
-          useOnHoldDate={false}
-        />
-      },
-      {
-        label: sprintf(
-          COPY.QUEUE_PAGE_ON_HOLD_TAB_TITLE,
-          this.props.onHoldTasks.length),
-        page: <TaskTableTab
-          description={COPY.ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION}
-          tasks={this.props.onHoldTasks}
-          includeNewDocsIcon
-          useOnHoldDate
-        />
-      },
-      {
-        label: COPY.QUEUE_PAGE_COMPLETE_TAB_TITLE,
-        page: <TaskTableTab
-          description={COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}
-          tasks={this.props.completedTasks}
-          includeNewDocsIcon={false}
-          useOnHoldDate={false}
-        />
-      }
-    ];
-
     return <AppSegment filledBackground styling={containerStyles}>
-      <h1 {...fullWidth}>{COPY.ATTORNEY_QUEUE_TABLE_TITLE}</h1>
-      <QueueOrganizationDropdown organizations={organizations} />
-      {messages.error && <Alert type="error" title={messages.error.title}>
-        {messages.error.detail}
+      {error && <Alert type="error" title={error.title}>
+        {error.detail}
       </Alert>}
-      {messages.success && <Alert type="success" title={messages.success.title}>
-        {messages.success.detail || COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
+      {success && <Alert type="success" title={success.title}>
+        {success.detail || COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
       </Alert>}
       {noCasesMessage}
-      <TabWindow name="tasks-attorney-list" tabs={tabs} />
+      {this.makeQueueComponents(this.props.queueConfig)}
     </AppSegment>;
   }
 }
@@ -126,10 +148,12 @@ const mapStateToProps = (state) => {
   } = state;
 
   return ({
-    workableTasks: workableTasksByAssigneeCssIdSelector(state),
+    assignedTasks: workableTasksByAssigneeCssIdSelector(state),
     onHoldTasks: onHoldTasksForAttorney(state),
     completedTasks: completeTasksByAssigneeCssIdSelector(state),
-    messages,
+    queueConfig: state.queue.queueConfig,
+    success: messages.success,
+    error: messages.error,
     organizations,
     taskDecision
   });
@@ -147,20 +171,24 @@ const mapDispatchToProps = (dispatch) => ({
 
 export default (connect(mapStateToProps, mapDispatchToProps)(AttorneyTaskListView));
 
-const TaskTableTab = ({ description, tasks, includeNewDocsIcon, useOnHoldDate }) => <React.Fragment>
-  <p className="cf-margin-top-0" >{description}</p>
-  <TaskTable
-    includeHearingBadge
-    includeDetailsLink
-    includeTask
-    includeType
-    includeDocketNumber
-    includeIssueCount
-    includeDueDate
-    includeReaderLink
-    requireDasRecord
-    tasks={tasks}
-    includeNewDocsIcon={includeNewDocsIcon}
-    useOnHoldDate={useOnHoldDate}
-  />
-</React.Fragment>;
+AttorneyTaskListView.propTypes = {
+  assignedTasks: PropTypes.array,
+  clearCaseSelectSearch: PropTypes.func,
+  completedTasks: PropTypes.array,
+  hideSuccessMessage: PropTypes.func,
+  resetSaveState: PropTypes.func,
+  resetSuccessMessages: PropTypes.func,
+  resetErrorMessages: PropTypes.func,
+  showErrorMessage: PropTypes.func,
+  onHoldTasks: PropTypes.array,
+  organizations: PropTypes.array,
+  queueConfig: PropTypes.object,
+  success: PropTypes.shape({
+    title: PropTypes.string,
+    detail: PropTypes.string
+  }),
+  error: PropTypes.shape({
+    title: PropTypes.string,
+    detail: PropTypes.string
+  })
+};

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -95,7 +95,6 @@ const mapStateToProps = (state) => {
     workableTasks: workableTasksByAssigneeCssIdSelector(state),
     onHoldTasks: onHoldTasksForAttorney(state),
     completedTasks: completeTasksByAssigneeCssIdSelector(state),
-    queueConfig: state.queue.queueConfig,
     success: messages.success,
     error: messages.error,
     organizations,
@@ -126,7 +125,6 @@ AttorneyTaskListView.propTypes = {
   showErrorMessage: PropTypes.func,
   onHoldTasks: PropTypes.array,
   organizations: PropTypes.array,
-  queueConfig: PropTypes.object,
   success: PropTypes.shape({
     title: PropTypes.string,
     detail: PropTypes.string

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -43,7 +43,7 @@ class AttorneyTaskListView extends React.PureComponent {
     this.props.resetErrorMessages();
 
     if (_.some(
-      [...this.props.assignedTasks, ...this.props.onHoldTasks, ...this.props.completedTasks],
+      [...this.props.workableTasks, ...this.props.onHoldTasks, ...this.props.completedTasks],
       (task) => !task.taskId)) {
       this.props.showErrorMessage({
         title: COPY.TASKS_NEED_ASSIGNMENT_ERROR_TITLE,
@@ -54,7 +54,7 @@ class AttorneyTaskListView extends React.PureComponent {
 
   render = () => {
     const { error, success } = this.props;
-    const noOpenTasks = !_.size([...this.props.assignedTasks, ...this.props.onHoldTasks]);
+    const noOpenTasks = !_.size([...this.props.workableTasks, ...this.props.onHoldTasks]);
     const noCasesMessage = noOpenTasks ?
       <p>
         {COPY.NO_CASES_IN_QUEUE_MESSAGE}
@@ -70,7 +70,7 @@ class AttorneyTaskListView extends React.PureComponent {
       </Alert>}
       {noCasesMessage}
       <QueueTableBuilder
-        assignedTasks={this.props.assignedTasks}
+        assignedTasks={this.props.workableTasks}
         onHoldTasks={this.props.onHoldTasks}
         completedTasks={this.props.completedTasks}
       />
@@ -92,7 +92,7 @@ const mapStateToProps = (state) => {
   } = state;
 
   return ({
-    assignedTasks: workableTasksByAssigneeCssIdSelector(state),
+    workableTasks: workableTasksByAssigneeCssIdSelector(state),
     onHoldTasks: onHoldTasksForAttorney(state),
     completedTasks: completeTasksByAssigneeCssIdSelector(state),
     queueConfig: state.queue.queueConfig,
@@ -116,7 +116,7 @@ const mapDispatchToProps = (dispatch) => ({
 export default (connect(mapStateToProps, mapDispatchToProps)(AttorneyTaskListView));
 
 AttorneyTaskListView.propTypes = {
-  assignedTasks: PropTypes.array,
+  workableTasks: PropTypes.array,
   clearCaseSelectSearch: PropTypes.func,
   completedTasks: PropTypes.array,
   hideSuccessMessage: PropTypes.func,

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -2,15 +2,11 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import _ from 'lodash';
-import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 
-import TabWindow from '../components/TabWindow';
-import QueueTable from './QueueTable';
-import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
-import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, typeColumn, daysWaitingColumn,
-  readerLinkColumnWithNewDocsIcon, issueCountColumn } from './components/TaskTableColumns';
+import QueueTableBuilder from './QueueTableBuilder';
+
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import Alert from '../components/Alert';
@@ -29,9 +25,7 @@ import {
 } from './uiReducer/uiActions';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
 
-import { fullWidth } from './constants';
 import COPY from '../../COPY';
-import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 
 const containerStyles = css({
   position: 'relative'
@@ -58,60 +52,6 @@ class AttorneyTaskListView extends React.PureComponent {
     }
   };
 
-  tasksForTab = (tabName) => {
-    const mapper = {
-      [QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME]: this.props.assignedTasks,
-      [QUEUE_CONFIG.INDIVIDUALLY_ON_HOLD_TASKS_TAB_NAME]: this.props.onHoldTasks,
-      [QUEUE_CONFIG.INDIVIDUALLY_COMPLETED_TASKS_TAB_NAME]: this.props.completedTasks
-    };
-
-    return mapper[tabName];
-  }
-
-  createColumnObject = (column, config, tasks) => {
-    const functionForColumn = {
-      [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
-      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, false, config.userRole),
-      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false),
-      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, false),
-      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, false),
-      [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(true),
-      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(false),
-      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(true)
-    };
-
-    return functionForColumn[column.name];
-  }
-
-  columnsFromConfig = (config, tabConfig, tasks) =>
-    (tabConfig.columns || []).map((column) => this.createColumnObject(column, config, tasks));
-
-  taskTableTabFactory = (tabConfig, config) => {
-    const tasks = this.tasksForTab(tabConfig.name);
-
-    return {
-      label: sprintf(tabConfig.label, tasks.length),
-      page: <React.Fragment>
-        <p className="cf-margin-top-0">{tabConfig.description}</p>
-        <QueueTable
-          key={tabConfig.name}
-          columns={this.columnsFromConfig(config, tabConfig, tasks)}
-          rowObjects={tasks}
-          getKeyForRow={(_rowNumber, task) => task.uniqueId}
-          enablePagination
-        />
-      </React.Fragment>
-    };
-  }
-
-  tabsFromConfig = (config) => (config.tabs || []).map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
-
-  makeQueueComponents = (config) => <React.Fragment>
-    <h1 {...fullWidth}>{config.table_title}</h1>
-    <QueueOrganizationDropdown organizations={this.props.organizations} />
-    <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} />
-  </React.Fragment>;
-
   render = () => {
     const { error, success } = this.props;
     const noOpenTasks = !_.size([...this.props.assignedTasks, ...this.props.onHoldTasks]);
@@ -129,7 +69,12 @@ class AttorneyTaskListView extends React.PureComponent {
         {success.detail || COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
       </Alert>}
       {noCasesMessage}
-      {this.makeQueueComponents(this.props.queueConfig)}
+      <QueueTableBuilder
+        assignedTasks={this.props.assignedTasks}
+        onHoldTasks={this.props.onHoldTasks}
+        completedTasks={this.props.completedTasks}
+        attorneyQueue
+      />
     </AppSegment>;
   }
 }

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -1,16 +1,10 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
 
-import QueueTable from './QueueTable';
-import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
-import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, typeColumn,
-  daysWaitingColumn, daysOnHoldColumn, readerLinkColumn, completedToNameColumn, taskCompletedDateColumn,
-  readerLinkColumnWithNewDocsIcon } from
-  './components/TaskTableColumns';
+import QueueTableBuilder from './QueueTableBuilder';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
 import {
@@ -21,13 +15,10 @@ import {
 import { hideSuccessMessage } from './uiReducer/uiActions';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
 import {
-  fullWidth,
   marginBottom
 } from './constants';
-import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 
 import Alert from '../components/Alert';
-import TabWindow from '../components/TabWindow';
 
 const containerStyles = css({
   position: 'relative'
@@ -40,70 +31,16 @@ class ColocatedTaskListView extends React.PureComponent {
 
   componentWillUnmount = () => this.props.hideSuccessMessage();
 
-  tasksForTab = (tabName) => {
-    const mapper = {
-      [QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME]: this.props.assignedTasks,
-      [QUEUE_CONFIG.INDIVIDUALLY_ON_HOLD_TASKS_TAB_NAME]: this.props.onHoldTasks,
-      [QUEUE_CONFIG.INDIVIDUALLY_COMPLETED_TASKS_TAB_NAME]: this.props.completedTasks
-    };
-
-    return mapper[tabName];
-  }
-
-  createColumnObject = (column, config, tasks) => {
-    const functionForColumn = {
-      [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
-      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, false, config.userRole),
-      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false),
-      [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, false),
-      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, false),
-      [QUEUE_CONFIG.COLUMNS.TASK_ASSIGNER.name]: completedToNameColumn(),
-      [QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name]: taskCompletedDateColumn(),
-      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, false),
-      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(false),
-      [QUEUE_CONFIG.COLUMNS.DAYS_ON_HOLD.name]: daysOnHoldColumn(false),
-      [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(false, true),
-      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(false)
-    };
-
-    return functionForColumn[column.name];
-  }
-
-  columnsFromConfig = (config, tabConfig, tasks) =>
-    (tabConfig.columns || []).map((column) => this.createColumnObject(column, config, tasks));
-
-  taskTableTabFactory = (tabConfig, config) => {
-    const tasks = this.tasksForTab(tabConfig.name);
-
-    return {
-      label: sprintf(tabConfig.label, tasks.length),
-      page: <React.Fragment>
-        <p className="cf-margin-top-0">{tabConfig.description}</p>
-        <QueueTable
-          key={tabConfig.name}
-          columns={this.columnsFromConfig(config, tabConfig, tasks)}
-          rowObjects={tasks}
-          getKeyForRow={(_rowNumber, task) => task.uniqueId}
-          enablePagination
-        />
-      </React.Fragment>
-    };
-  }
-
-  tabsFromConfig = (config) => (config.tabs || []).map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
-
-  makeQueueComponents = (config) => <React.Fragment>
-    <h1 {...fullWidth}>{config.table_title}</h1>
-    <QueueOrganizationDropdown organizations={this.props.organizations} />
-    <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} />
-  </React.Fragment>;
-
   render = () => {
     const { success } = this.props;
 
     return <AppSegment filledBackground styling={containerStyles}>
       {success && <Alert type="success" title={success.title} message={success.detail} styling={marginBottom(1)} />}
-      {this.makeQueueComponents(this.props.queueConfig)}
+      <QueueTableBuilder
+        assignedTasks={this.props.assignedTasks}
+        onHoldTasks={this.props.onHoldTasks}
+        completedTasks={this.props.completedTasks}
+      />
     </AppSegment>;
   };
 }

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -46,7 +46,7 @@ class QueueLoadingScreen extends React.PureComponent {
     const config = this.props.queueConfig;
 
     // If no queue config is in state (may be using attorney or judge queue) then it is not stale.
-    if (config && config.table_title && config.table_title !== COPY.COLOCATED_QUEUE_PAGE_TABLE_TITLE) {
+    if (config && config.table_title && config.table_title !== COPY.USER_QUEUE_PAGE_TABLE_TITLE) {
       return true;
     }
 

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -35,20 +35,21 @@ class QueueTableBuilder extends React.PureComponent {
   }
 
   createColumnObject = (column, config, tasks) => {
+    const { attorneyQueue } = this.props;
     const functionForColumn = {
       [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
-      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, false, config.userRole),
+      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, attorneyQueue, config.userRole),
       [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false),
-      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, false),
-      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, false),
-      [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(true),
-      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(false),
-      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(this.props.attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(attorneyQueue),
       [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, false),
       [QUEUE_CONFIG.COLUMNS.TASK_ASSIGNER.name]: completedToNameColumn(),
       [QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name]: taskCompletedDateColumn(),
-      [QUEUE_CONFIG.COLUMNS.DAYS_ON_HOLD.name]: daysOnHoldColumn(false),
-      [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(false, true)
+      [QUEUE_CONFIG.COLUMNS.DAYS_ON_HOLD.name]: daysOnHoldColumn(attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(attorneyQueue, true)
     };
 
     return functionForColumn[column.name];

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -15,7 +15,7 @@ import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import { fullWidth } from './constants';
 
 /**
- * This component can be used to easily build tables.
+ * This is used to create a queue table from a queue config
  * The required props are:
  * - @assignedTasks {array[object]} array of task objects to appear in the assigned tab
  * - @onHoldTasks {array[object]} array of task objects to appear in the on hold tab

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { sprintf } from 'sprintf-js';
+import { connect } from 'react-redux';
+
+import QueueTable from './QueueTable';
+import TabWindow from '../components/TabWindow';
+import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
+import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, typeColumn, daysWaitingColumn,
+  readerLinkColumnWithNewDocsIcon, issueCountColumn, regionalOfficeColumn, completedToNameColumn,
+  taskCompletedDateColumn, daysOnHoldColumn, readerLinkColumn } from './components/TaskTableColumns';
+
+import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
+import { fullWidth } from './constants';
+
+/**
+ * This component can be used to easily build tables.
+ * The required props are:
+ * - @assignedTasks {array[object]} array of task objects to appear in the assigned tab
+ * - @onHoldTasks {array[object]} array of task objects to appear in the on hold tab
+ * - @completedTasks {array[object]} array of task objects to appear in the completed tab
+ * - @attorneyQueue {boolean} (might be able to use role) Whether or not this queue is for an attorney
+ **/
+
+class QueueTableBuilder extends React.PureComponent {
+
+  tasksForTab = (tabName) => {
+    const mapper = {
+      [QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME]: this.props.assignedTasks,
+      [QUEUE_CONFIG.INDIVIDUALLY_ON_HOLD_TASKS_TAB_NAME]: this.props.onHoldTasks,
+      [QUEUE_CONFIG.INDIVIDUALLY_COMPLETED_TASKS_TAB_NAME]: this.props.completedTasks
+    };
+
+    return mapper[tabName];
+  }
+
+  createColumnObject = (column, config, tasks) => {
+    const functionForColumn = {
+      [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
+      [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, false, config.userRole),
+      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false),
+      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, false),
+      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, false),
+      [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(true),
+      [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(false),
+      [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(this.props.attorneyQueue),
+      [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, false),
+      [QUEUE_CONFIG.COLUMNS.TASK_ASSIGNER.name]: completedToNameColumn(),
+      [QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name]: taskCompletedDateColumn(),
+      [QUEUE_CONFIG.COLUMNS.DAYS_ON_HOLD.name]: daysOnHoldColumn(false),
+      [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(false, true)
+    };
+
+    return functionForColumn[column.name];
+  }
+
+  columnsFromConfig = (config, tabConfig, tasks) =>
+    (tabConfig.columns || []).map((column) => this.createColumnObject(column, config, tasks));
+
+  taskTableTabFactory = (tabConfig, config) => {
+    const tasks = this.tasksForTab(tabConfig.name);
+
+    return {
+      label: sprintf(tabConfig.label, tasks.length),
+      page: <React.Fragment>
+        <p className="cf-margin-top-0">{tabConfig.description}</p>
+        <QueueTable
+          key={tabConfig.name}
+          columns={this.columnsFromConfig(config, tabConfig, tasks)}
+          rowObjects={tasks}
+          getKeyForRow={(_rowNumber, task) => task.uniqueId}
+          enablePagination
+        />
+      </React.Fragment>
+    };
+  }
+
+  tabsFromConfig = (config) => (config.tabs || []).map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
+
+  render = () => {
+    const { config } = this.props;
+
+    return <React.Fragment>
+      <h1 {...fullWidth}>{config.table_title}</h1>
+      <QueueOrganizationDropdown organizations={this.props.organizations} />
+      <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} />
+    </React.Fragment>;
+  };
+}
+
+const mapStateToProps = (state) => {
+  return ({
+    config: state.queue.queueConfig,
+    organizations: state.ui.organizations
+  });
+};
+
+QueueTableBuilder.propTypes = {
+  organizations: PropTypes.array,
+  assignedTasks: PropTypes.array,
+  onHoldTasks: PropTypes.array,
+  completedTasks: PropTypes.array,
+  attorneyQueue: PropTypes.bool,
+  config: PropTypes.shape({
+    table_title: PropTypes.string
+  })
+};
+
+export default (connect(mapStateToProps)(QueueTableBuilder));

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -11,6 +11,7 @@ import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, type
   taskCompletedDateColumn, daysOnHoldColumn, readerLinkColumn } from './components/TaskTableColumns';
 
 import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
+import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import { fullWidth } from './constants';
 
 /**
@@ -19,7 +20,6 @@ import { fullWidth } from './constants';
  * - @assignedTasks {array[object]} array of task objects to appear in the assigned tab
  * - @onHoldTasks {array[object]} array of task objects to appear in the on hold tab
  * - @completedTasks {array[object]} array of task objects to appear in the completed tab
- * - @attorneyQueue {boolean} (might be able to use role) Whether or not this queue is for an attorney
  **/
 
 class QueueTableBuilder extends React.PureComponent {
@@ -35,7 +35,7 @@ class QueueTableBuilder extends React.PureComponent {
   }
 
   createColumnObject = (column, config, tasks) => {
-    const { attorneyQueue } = this.props;
+    const attorneyQueue = config.userRole === USER_ROLE_TYPES.attorney;
     const functionForColumn = {
       [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
       [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, attorneyQueue, config.userRole),
@@ -101,7 +101,6 @@ QueueTableBuilder.propTypes = {
   assignedTasks: PropTypes.array,
   onHoldTasks: PropTypes.array,
   completedTasks: PropTypes.array,
-  attorneyQueue: PropTypes.bool,
   config: PropTypes.shape({
     table_title: PropTypes.string
   })

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -205,7 +205,7 @@ export const daysWaitingColumn = (requireDasRecord) => {
     valueFunction: (task) => {
       return <React.Fragment>
         <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>{moment().startOf('day').
-          diff(moment(task.assignedOn), 'days')}</span>
+          diff(moment(task.assignedOn), 'days')} days</span>
         { taskHasCompletedHold(task) ? <ContinuousProgressBar level={moment().startOf('day').
           diff(task.placedOnHoldAt, 'days')} limit={task.onHoldDuration} warning /> : null }
       </React.Fragment>;

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -387,7 +387,7 @@ describe('ColocatedTaskListView', () => {
 
       const onHoldDaysWaiting = cells.at(12);
 
-      expect(onHoldDaysWaiting.text()).to.equal(daysOnHold.toString());
+      expect(onHoldDaysWaiting.text()).to.equal(`${daysOnHold.toString()} days`);
       expect(onHoldDaysWaiting.find('.cf-red-text').length).to.eq(1);
       expect(onHoldDaysWaiting.find('.cf-continuous-progress-bar-warning').length).to.eq(1);
     });

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -373,7 +373,7 @@ describe('ColocatedTaskListView', () => {
       expect(columnTasks.text()).to.include(task.label);
       expect(types.text()).to.include(appeal.caseType);
       expect(docketNumber.text()).to.include(appeal.docketNumber);
-      expect(daysWaiting.text()).to.equal('1');
+      expect(daysWaiting.text()).to.equal('1 days');
       expect(documents.html()).to.include(`/reader/appeal/${task.externalAppealId}/documents`);
       expect(documents.text()).to.include('Loading number of docs...');
 

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -878,7 +878,7 @@ RSpec.feature "AmaQueue", :all_dbs do
         )
         fill_in("taskInstructions", with: "instructions here")
         click_on(COPY::MODAL_SUBMIT_BUTTON)
-        expect(page).to have_content(COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       end
 
       step "Use the back button to return to the team queue to retain data stored in front-end state" do
@@ -896,7 +896,7 @@ RSpec.feature "AmaQueue", :all_dbs do
         )
         fill_in("taskInstructions", with: "instructions here")
         click_on(COPY::MODAL_SUBMIT_BUTTON)
-        expect(page).to have_content(COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       end
     end
   end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -708,7 +708,7 @@ RSpec.feature "Case details", :all_dbs do
         click_on vet_name
         expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL, wait: 30)
         click_on "Caseflow"
-        expect(page).to have_content(COPY::COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION, wait: 30)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION, wait: 30)
         fontweight_visited = get_computed_styles("#veteran-name-for-task-#{assigned_task.id}", "font-weight")
         expect(fontweight_visited).to be < fontweight_new
       end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -143,7 +143,7 @@ feature "Task queue", :all_dbs do
     end
 
     it "shows tabs on the queue page" do
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_TABLE_TITLE)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       expect(page).to have_content(format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, vacols_tasks.length))
       expect(page).to have_content(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, attorney_on_hold_task_count))
       expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
@@ -151,12 +151,12 @@ feature "Task queue", :all_dbs do
 
     it "shows the right number of cases in each tab" do
       # Assigned tab
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(vacols_tasks.length)
 
       # On Hold tab
       find("button", text: format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, attorney_on_hold_task_count)).click
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(attorney_on_hold_task_count)
       appeal = attorney_task.appeal
       expect(page).to have_content("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -62,7 +62,7 @@ describe QueueConfig, :postgres do
         let(:assignee) { user }
 
         it "is formatted as expected" do
-          expect(subject[:table_title]).to eq(COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE)
+          expect(subject[:table_title]).to eq(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
         end
       end
     end
@@ -256,8 +256,8 @@ describe QueueConfig, :postgres do
           it "displays the correct descriptions for the tabs" do
             tabs = subject
 
-            expect(tabs[0][:description]).to eq(COPY::COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
-            expect(tabs[1][:description]).to eq(COPY::COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
+            expect(tabs[0][:description]).to eq(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
+            expect(tabs[1][:description]).to eq(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
             expect(tabs[2][:description]).to eq(COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION)
           end
         end


### PR DESCRIPTION
Resolves #11699

## Description
As a followup to #11698 and a precursor to the Grand Unified Queue #10032, offload the specific queue configuration for attorneys to the back end

## Acceptance Criteria
- [ ] The queue for attorneys is built from queue config rather than front end logic

## Testing Plan
### Attorney Queue
1. Go to BVASCASPER1's queue
2. Everything still works
3. UI matches master
### Colocated Queue
1. Go to CSS_ID1's queue
2. Everything still works
3. UI matches master

## User Facing Changes

### Attorney queues
 - [ ] None, other than
   - [ ] Note that the only "change" in the UI is the days waiting column. These red bars won't actually show up in the user's queue unless they have put their attorney task on hold and the hold has expired. There are currently no attorney tasks on a timed hold in production, let alone any with expired holds. This is not a change that users will see.
   - [ ] Copy on the on hold tab description is updated


Master|Changes
---|---
![Screen Shot 2020-03-02 at 2 56 57 PM](https://user-images.githubusercontent.com/45575454/75713014-feecc100-5c96-11ea-823c-6686db1e6624.png)|![Screen Shot 2020-03-02 at 4 51 20 PM](https://user-images.githubusercontent.com/45575454/75721433-5fcfc580-5ca6-11ea-80fd-61586571193d.png)
![Screen Shot 2020-03-02 at 2 57 04 PM](https://user-images.githubusercontent.com/45575454/75713021-014f1b00-5c97-11ea-9333-845ad3a39c91.png)|![Screen Shot 2020-03-02 at 4 51 26 PM](https://user-images.githubusercontent.com/45575454/75721447-64947980-5ca6-11ea-95af-a8203d2d24f5.png)
![Screen Shot 2020-03-02 at 2 57 16 PM](https://user-images.githubusercontent.com/45575454/75713030-03b17500-5c97-11ea-95f4-910772b169fb.png)|![Screen Shot 2020-03-02 at 4 51 41 PM](https://user-images.githubusercontent.com/45575454/75721467-69592d80-5ca6-11ea-8358-17a83ab612b6.png)

### Colocated Queues
- [ ] "Days" in the days waiting tab

Master|Changes
---|---
![Screen Shot 2020-03-02 at 4 47 04 PM](https://user-images.githubusercontent.com/45575454/75721090-bb4d8380-5ca5-11ea-9a4d-484028243940.png)|![Screen Shot 2020-03-02 at 4 47 04 PM](https://user-images.githubusercontent.com/45575454/75721384-49296e80-5ca6-11ea-81db-868fb139188e.png)
![Screen Shot 2020-03-02 at 4 46 31 PM](https://user-images.githubusercontent.com/45575454/75721105-c2749180-5ca5-11ea-8a2c-4b9a1b89c17b.png)|![Screen Shot 2020-03-02 at 4 47 11 PM](https://user-images.githubusercontent.com/45575454/75721410-50e91300-5ca6-11ea-97cd-3a13c08f6396.png)
![Screen Shot 2020-03-02 at 4 46 37 PM](https://user-images.githubusercontent.com/45575454/75721124-cbfdf980-5ca5-11ea-88a6-49aaa707b411.png)|![Screen Shot 2020-03-02 at 4 47 17 PM](https://user-images.githubusercontent.com/45575454/75721130-cef8ea00-5ca5-11ea-9bbd-5c6405c3e221.png)
