### PR TITLE
Added Success Alert after MTV Return to Lit Support

### DIFF
--- a/app/controllers/post_decision_motions_controller.rb
+++ b/app/controllers/post_decision_motions_controller.rb
@@ -19,7 +19,6 @@ class PostDecisionMotionsController < ApplicationController
     mail_task.update_with_instructions(instructions: params[:instructions]) if params[:instructions].present?
 
     task.update!(status: Constants.TASK_STATUSES.cancelled)
-    flash[:success] = "Case returned to Litigation Support"
     appeal_tasks = mail_task.appeal.reload.tasks
     render json: { tasks: ::WorkQueue::TaskSerializer.new(appeal_tasks, is_collection: true) }
   end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -157,6 +157,8 @@
   "RETURN_TO_LIT_SUPPORT_MODAL_CONTENT": "Use this action to return the Motion to Vacate task to the previous Motions Attorney in case of a missing ruling letter draft.\n\nIf the previous attorney is inactive, this will return to the Litigation Support team queue for reassignment.",
   "RETURN_TO_LIT_SUPPORT_MODAL_INSTRUCTIONS_LABEL": "Provide context and instructions for this action",
   "RETURN_TO_LIT_SUPPORT_MODAL_DEFAULT_INSTRUCTIONS": "I am missing a link to the draft ruling letter. Please resubmit so I can review and sign.",
+  "RETURN_TO_LIT_SUPPORT_SUCCESS_TITLE": "%s's Motion to Vacate has been returned to Litigation Support",
+  "RETURN_TO_LIT_SUPPORT_SUCCESS_DETAIL": "This task will be completed by the original Motions Attorney or placed in the team's queue",
 
   "MOTIONS_ATTORNEY_ADDRESS_MTV_TITLE": "Review %s's Motion to Vacate",
   "MOTIONS_ATTORNEY_REVIEW_MTV_DESCRIPTION": "Create your review for this motion to vacate, then send it back to the Veteran's Law Judge who originally signed the case if they are available.",

--- a/client/app/queue/mtv/motionToVacateRoutes.js
+++ b/client/app/queue/mtv/motionToVacateRoutes.js
@@ -6,20 +6,33 @@ import TASK_ACTIONS from '../../../constants/TASK_ACTIONS.json';
 import ReviewMotionToVacateView from './ReviewMotionToVacateView';
 import { AddressMotionToVacateView } from './AddressMotionToVacateView';
 import { ReturnToLitSupportModal } from './ReturnToLitSupportModal';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { returnToLitSupport } from './mtvActions';
 import { MotionToVacateFlowContainer } from './MotionToVacateFlowContainer';
+import { appealWithDetailSelector } from '../selectors';
 
 const RoutedReturnToLitSupport = (props) => {
-  const { taskId } = useParams();
+  const { taskId, appealId } = useParams();
   const { goBack } = useHistory();
   const dispatch = useDispatch();
+
+  const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
 
   return (
     <ReturnToLitSupportModal
       onCancel={() => goBack()}
-      onSubmit={({ instructions }) => dispatch(returnToLitSupport({ instructions,
-        task_id: taskId }, props))}
+      onSubmit={({ instructions }) =>
+        dispatch(
+          returnToLitSupport(
+            {
+              instructions,
+              task_id: taskId
+            },
+            { ...props,
+              appeal }
+          )
+        )
+      }
     />
   );
 };

--- a/client/app/queue/mtv/mtvActions.js
+++ b/client/app/queue/mtv/mtvActions.js
@@ -2,7 +2,7 @@ import * as Constants from './actionTypes';
 import ApiUtil from '../../util/ApiUtil';
 import { onReceiveAmaTasks } from '../QueueActions';
 import { showSuccessMessage } from '../uiReducer/uiActions';
-import { addressMTVSuccessAlert } from './mtvMessages';
+import { addressMTVSuccessAlert, returnToLitSupportAlert } from './mtvMessages';
 
 export const submitMTVAttyReviewStarted = () => ({
   type: Constants.MTV_SUBMIT_ATTY_REVIEW
@@ -103,7 +103,7 @@ export const returnToLitSupport = (data, ownProps) => {
   return async (dispatch) => {
     dispatch(returnMTVToLitSupportStarted());
 
-    const { history } = ownProps;
+    const { history, appeal } = ownProps;
 
     const url = '/post_decision_motions/return';
 
@@ -114,6 +114,8 @@ export const returnToLitSupport = (data, ownProps) => {
       } = res.body;
 
       dispatch(returnMTVToLitSupportSuccess());
+
+      dispatch(showSuccessMessage(returnToLitSupportAlert({ appeal })));
 
       if (history) {
         history.push('/queue');

--- a/client/app/queue/mtv/mtvMessages.js
+++ b/client/app/queue/mtv/mtvMessages.js
@@ -2,7 +2,9 @@ import {
   JUDGE_ADDRESS_MTV_SUCCESS_TITLE_GRANTED,
   JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_GRANTED,
   JUDGE_ADDRESS_MTV_SUCCESS_TITLE_DENIED,
-  JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED
+  JUDGE_ADDRESS_MTV_SUCCESS_DETAIL_DENIED,
+  RETURN_TO_LIT_SUPPORT_SUCCESS_TITLE,
+  RETURN_TO_LIT_SUPPORT_SUCCESS_DETAIL
 } from '../../../COPY';
 import { sprintf } from 'sprintf-js';
 
@@ -29,4 +31,14 @@ export const addressMTVSuccessAlert = ({ data, appeal }) => {
       detail: ' '
     };
   }
+};
+
+export const returnToLitSupportAlert = ({ appeal }) => {
+  console.log('returnToLitSupportAlert', appeal);
+  const { veteranFullName } = appeal;
+
+  return {
+    title: sprintf(RETURN_TO_LIT_SUPPORT_SUCCESS_TITLE, veteranFullName),
+    detail: RETURN_TO_LIT_SUPPORT_SUCCESS_DETAIL
+  };
 };

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -348,6 +348,10 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")
+      expect(page).to have_content(
+        format(COPY::RETURN_TO_LIT_SUPPORT_SUCCESS_TITLE, appeal.veteran_full_name)
+      )
+      expect(page).to have_content(COPY::RETURN_TO_LIT_SUPPORT_SUCCESS_DETAIL)
 
       motion = PostDecisionMotion.find_by(task: judge_address_motion_to_vacate_task)
       expect(motion).to be_nil


### PR DESCRIPTION
Connects #13518

### Description
This properly adds a "success" alert upon completion of the "Return to Lit Support" modal (launched from `AddressMotionToVacateView`);

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Alert is shown upon successful completion of `ReturnToLitSupportModal`
