### PR TITLE
[11699 PART 2] Return attorney queue columns to the front end

### DIFF
--- a/app/models/queue_config.rb
+++ b/app/models/queue_config.rb
@@ -17,7 +17,7 @@ class QueueConfig
   end
 
   def to_hash
-    table_title = COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE
+    table_title = COPY::USER_QUEUE_PAGE_TABLE_TITLE
     {
       table_title: assignee_is_org? ? format(COPY::ORGANIZATION_QUEUE_TABLE_TITLE, assignee.name) : table_title,
       active_tab: assignee.class.default_active_tab,

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -51,6 +51,21 @@ class QueueTab
     false
   end
 
+  # rubocop:disable Metrics/AbcSize
+  def self.attorney_column_names
+    [
+      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+      Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
+    ]
+  end
+  # rubocop:enable Metrics/AbcSize
+
   private
 
   def assignee_is_org?

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -21,6 +21,8 @@ class AssignedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
+
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -12,7 +12,7 @@ class AssignedTasksTab < QueueTab
   end
 
   def description
-    COPY::COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION
+    COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -21,6 +21,8 @@ class CompletedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
+
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -12,7 +12,7 @@ class OnHoldTasksTab < QueueTab
   end
 
   def description
-    COPY::COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION
+    COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -21,6 +21,8 @@ class OnHoldTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
+
     [
       Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -109,8 +109,6 @@
   "ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL": "If you made a mistake, please email your judge to resolve the issue.",
   "ATTORNEY_QUEUE_TABLE_TASK_NEEDS_ASSIGNMENT_ERROR_MESSAGE": "Please ask your judge to assign this case to you in DAS",
   "ATTORNEY_QUEUE_TABLE_TASK_NO_DOCUMENTS_READER_LINK": "View in Reader",
-  "ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to you.",
-  "ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, cases here will automatically return to the Assigned tab.",
   "ORGANIZATION_QUEUE_TABLE_TITLE": "%s cases",
   "TASKS_NEED_ASSIGNMENT_ERROR_TITLE": "Some cases need preliminary DAS assignments",
   "TASKS_NEED_ASSIGNMENT_ERROR_MESSAGE": "Cases marked with exclamation points need to be assigned to you through DAS. Please contact your judge or senior counsel to create preliminary DAS assignments.",
@@ -120,11 +118,9 @@
   "QUEUE_PAGE_ASSIGNED_TAB_TITLE": "Assigned (%d)",
   "QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold (%d)",
 
-  "COLOCATED_QUEUE_PAGE_TABLE_TITLE": "Your cases",
-  "COLOCATED_QUEUE_PAGE_NEW_TAB_TITLE": "Assigned (%d)",
-  "COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "Cases assigned to you:",
-  "COLOCATED_QUEUE_PAGE_PENDING_TASKS_DESCRIPTION": "Cases no longer on hold:",
-  "COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
+  "USER_QUEUE_PAGE_TABLE_TITLE": "Your cases",
+  "USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to you:",
+  "USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
   "QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases completed (last two weeks):",
 
   "ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TAB_TITLE": "Unassigned (%d)",

--- a/client/app/queue/QueueLoadingScreen.jsx
+++ b/client/app/queue/QueueLoadingScreen.jsx
@@ -46,7 +46,7 @@ class QueueLoadingScreen extends React.PureComponent {
     const config = this.props.queueConfig;
 
     // If no queue config is in state (may be using attorney or judge queue) then it is not stale.
-    if (config && config.table_title && config.table_title !== COPY.COLOCATED_QUEUE_PAGE_TABLE_TITLE) {
+    if (config && config.table_title && config.table_title !== COPY.USER_QUEUE_PAGE_TABLE_TITLE) {
       return true;
     }
 

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import moment from 'moment';
+import pluralize from 'pluralize';
 import _ from 'lodash';
 
 import DocketTypeBadge from '../../components/DocketTypeBadge';
@@ -203,11 +204,17 @@ export const daysWaitingColumn = (requireDasRecord) => {
     tooltip: <React.Fragment>Calendar days since <br /> this case was assigned</React.Fragment>,
     align: 'center',
     valueFunction: (task) => {
+      const daysSinceAssigned = moment().startOf('day').
+          diff(moment(task.assignedOn), 'days'),
+        daysSincePlacedOnHold = moment().startOf('day').
+          diff(task.placedOnHoldAt, 'days');
+
       return <React.Fragment>
-        <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>{moment().startOf('day').
-          diff(moment(task.assignedOn), 'days')}</span>
-        { taskHasCompletedHold(task) ? <ContinuousProgressBar level={moment().startOf('day').
-          diff(task.placedOnHoldAt, 'days')} limit={task.onHoldDuration} warning /> : null }
+        <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>
+          {daysSinceAssigned} {pluralize('day', daysSinceAssigned)}
+        </span>
+        { taskHasCompletedHold(task) &&
+          <ContinuousProgressBar level={daysSincePlacedOnHold} limit={task.onHoldDuration} warning /> }
       </React.Fragment>;
     },
     backendCanSort: true,

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -373,7 +373,7 @@ describe('ColocatedTaskListView', () => {
       expect(columnTasks.text()).to.include(task.label);
       expect(types.text()).to.include(appeal.caseType);
       expect(docketNumber.text()).to.include(appeal.docketNumber);
-      expect(daysWaiting.text()).to.equal('1');
+      expect(daysWaiting.text()).to.equal('1 day');
       expect(documents.html()).to.include(`/reader/appeal/${task.externalAppealId}/documents`);
       expect(documents.text()).to.include('Loading number of docs...');
 
@@ -387,7 +387,7 @@ describe('ColocatedTaskListView', () => {
 
       const onHoldDaysWaiting = cells.at(12);
 
-      expect(onHoldDaysWaiting.text()).to.equal(daysOnHold.toString());
+      expect(onHoldDaysWaiting.text()).to.equal(`${daysOnHold.toString()} days`);
       expect(onHoldDaysWaiting.find('.cf-red-text').length).to.eq(1);
       expect(onHoldDaysWaiting.find('.cf-continuous-progress-bar-warning').length).to.eq(1);
     });

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -878,7 +878,7 @@ RSpec.feature "AmaQueue", :all_dbs do
         )
         fill_in("taskInstructions", with: "instructions here")
         click_on(COPY::MODAL_SUBMIT_BUTTON)
-        expect(page).to have_content(COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       end
 
       step "Use the back button to return to the team queue to retain data stored in front-end state" do
@@ -896,7 +896,7 @@ RSpec.feature "AmaQueue", :all_dbs do
         )
         fill_in("taskInstructions", with: "instructions here")
         click_on(COPY::MODAL_SUBMIT_BUTTON)
-        expect(page).to have_content(COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       end
     end
   end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -708,7 +708,7 @@ RSpec.feature "Case details", :all_dbs do
         click_on vet_name
         expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL, wait: 30)
         click_on "Caseflow"
-        expect(page).to have_content(COPY::COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION, wait: 30)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, wait: 30)
         fontweight_visited = get_computed_styles("#veteran-name-for-task-#{assigned_task.id}", "font-weight")
         expect(fontweight_visited).to be < fontweight_new
       end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -143,7 +143,7 @@ feature "Task queue", :all_dbs do
     end
 
     it "shows tabs on the queue page" do
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_TABLE_TITLE)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       expect(page).to have_content(format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, vacols_tasks.length))
       expect(page).to have_content(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, attorney_on_hold_task_count))
       expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
@@ -151,12 +151,12 @@ feature "Task queue", :all_dbs do
 
     it "shows the right number of cases in each tab" do
       # Assigned tab
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(vacols_tasks.length)
 
       # On Hold tab
       find("button", text: format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, attorney_on_hold_task_count)).click
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(attorney_on_hold_task_count)
       appeal = attorney_task.appeal
       expect(page).to have_content("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -62,7 +62,7 @@ describe QueueConfig, :postgres do
         let(:assignee) { user }
 
         it "is formatted as expected" do
-          expect(subject[:table_title]).to eq(COPY::COLOCATED_QUEUE_PAGE_TABLE_TITLE)
+          expect(subject[:table_title]).to eq(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
         end
       end
     end
@@ -256,8 +256,8 @@ describe QueueConfig, :postgres do
           it "displays the correct descriptions for the tabs" do
             tabs = subject
 
-            expect(tabs[0][:description]).to eq(COPY::COLOCATED_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
-            expect(tabs[1][:description]).to eq(COPY::COLOCATED_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
+            expect(tabs[0][:description]).to eq(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
+            expect(tabs[1][:description]).to eq(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
             expect(tabs[2][:description]).to eq(COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION)
           end
         end


### PR DESCRIPTION
Part of #11699

### Description
Return a different set of queue columns to the front end for attorney users (not yet used on the front end)

### Acceptance Criteria
- [ ] Test pass (no real changes here)

[_What is this stacked pr nonsense?_](https://unhashable.com/stacked-pull-requests-keeping-github-diffs-small/)