### PR TITLE
[11699 PART 4] Use queue builder to build attorney queues from config

### DIFF
--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -12,7 +12,7 @@ class AssignedTasksTab < QueueTab
   end
 
   def description
-    COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION
+    COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -109,8 +109,6 @@
   "ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL": "If you made a mistake, please email your judge to resolve the issue.",
   "ATTORNEY_QUEUE_TABLE_TASK_NEEDS_ASSIGNMENT_ERROR_MESSAGE": "Please ask your judge to assign this case to you in DAS",
   "ATTORNEY_QUEUE_TABLE_TASK_NO_DOCUMENTS_READER_LINK": "View in Reader",
-  "ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to you.",
-  "ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "When a hold is complete, cases here will automatically return to the Assigned tab.",
   "ORGANIZATION_QUEUE_TABLE_TITLE": "%s cases",
   "TASKS_NEED_ASSIGNMENT_ERROR_TITLE": "Some cases need preliminary DAS assignments",
   "TASKS_NEED_ASSIGNMENT_ERROR_MESSAGE": "Cases marked with exclamation points need to be assigned to you through DAS. Please contact your judge or senior counsel to create preliminary DAS assignments.",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -119,7 +119,7 @@
   "QUEUE_PAGE_ON_HOLD_TAB_TITLE": "On hold (%d)",
 
   "USER_QUEUE_PAGE_TABLE_TITLE": "Your cases",
-  "USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION": "Cases assigned to you:",
+  "USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to you:",
   "USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
   "QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases completed (last two weeks):",
 

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import moment from 'moment';
+import pluralize from 'pluralize';
 import _ from 'lodash';
 
 import DocketTypeBadge from '../../components/DocketTypeBadge';
@@ -203,11 +204,17 @@ export const daysWaitingColumn = (requireDasRecord) => {
     tooltip: <React.Fragment>Calendar days since <br /> this case was assigned</React.Fragment>,
     align: 'center',
     valueFunction: (task) => {
+      const daysSinceAssigned = moment().startOf('day').
+          diff(moment(task.assignedOn), 'days'),
+        daysSincePlacedOnHold = moment().startOf('day').
+          diff(task.placedOnHoldAt, 'days');
+
       return <React.Fragment>
-        <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>{moment().startOf('day').
-          diff(moment(task.assignedOn), 'days')} days</span>
-        { taskHasCompletedHold(task) ? <ContinuousProgressBar level={moment().startOf('day').
-          diff(task.placedOnHoldAt, 'days')} limit={task.onHoldDuration} warning /> : null }
+        <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>
+          {daysSinceAssigned} {pluralize('day', daysSinceAssigned)}
+        </span>
+        { taskHasCompletedHold(task) &&
+          <ContinuousProgressBar level={daysSincePlacedOnHold} limit={task.onHoldDuration} warning /> }
       </React.Fragment>;
     },
     backendCanSort: true,

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -205,7 +205,7 @@ export const daysWaitingColumn = (requireDasRecord) => {
     valueFunction: (task) => {
       return <React.Fragment>
         <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>{moment().startOf('day').
-          diff(moment(task.assignedOn), 'days')}</span>
+          diff(moment(task.assignedOn), 'days')} days</span>
         { taskHasCompletedHold(task) ? <ContinuousProgressBar level={moment().startOf('day').
           diff(task.placedOnHoldAt, 'days')} limit={task.onHoldDuration} warning /> : null }
       </React.Fragment>;

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -373,7 +373,7 @@ describe('ColocatedTaskListView', () => {
       expect(columnTasks.text()).to.include(task.label);
       expect(types.text()).to.include(appeal.caseType);
       expect(docketNumber.text()).to.include(appeal.docketNumber);
-      expect(daysWaiting.text()).to.equal('1 days');
+      expect(daysWaiting.text()).to.equal('1 day');
       expect(documents.html()).to.include(`/reader/appeal/${task.externalAppealId}/documents`);
       expect(documents.text()).to.include('Loading number of docs...');
 

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -373,7 +373,7 @@ describe('ColocatedTaskListView', () => {
       expect(columnTasks.text()).to.include(task.label);
       expect(types.text()).to.include(appeal.caseType);
       expect(docketNumber.text()).to.include(appeal.docketNumber);
-      expect(daysWaiting.text()).to.equal('1');
+      expect(daysWaiting.text()).to.equal('1 days');
       expect(documents.html()).to.include(`/reader/appeal/${task.externalAppealId}/documents`);
       expect(documents.text()).to.include('Loading number of docs...');
 
@@ -387,7 +387,7 @@ describe('ColocatedTaskListView', () => {
 
       const onHoldDaysWaiting = cells.at(12);
 
-      expect(onHoldDaysWaiting.text()).to.equal(daysOnHold.toString());
+      expect(onHoldDaysWaiting.text()).to.equal(`${daysOnHold.toString()} days`);
       expect(onHoldDaysWaiting.find('.cf-red-text').length).to.eq(1);
       expect(onHoldDaysWaiting.find('.cf-continuous-progress-bar-warning').length).to.eq(1);
     });

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -708,7 +708,7 @@ RSpec.feature "Case details", :all_dbs do
         click_on vet_name
         expect(page).to have_content(COPY::TASK_SNAPSHOT_ACTIVE_TASKS_LABEL, wait: 30)
         click_on "Caseflow"
-        expect(page).to have_content(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION, wait: 30)
+        expect(page).to have_content(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, wait: 30)
         fontweight_visited = get_computed_styles("#veteran-name-for-task-#{assigned_task.id}", "font-weight")
         expect(fontweight_visited).to be < fontweight_new
       end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -151,7 +151,7 @@ feature "Task queue", :all_dbs do
 
     it "shows the right number of cases in each tab" do
       # Assigned tab
-      expect(page).to have_content(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(vacols_tasks.length)
 
       # On Hold tab

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -143,7 +143,7 @@ feature "Task queue", :all_dbs do
     end
 
     it "shows tabs on the queue page" do
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_TABLE_TITLE)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       expect(page).to have_content(format(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, vacols_tasks.length))
       expect(page).to have_content(format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, attorney_on_hold_task_count))
       expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
@@ -151,12 +151,12 @@ feature "Task queue", :all_dbs do
 
     it "shows the right number of cases in each tab" do
       # Assigned tab
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(vacols_tasks.length)
 
       # On Hold tab
       find("button", text: format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, attorney_on_hold_task_count)).click
-      expect(page).to have_content(COPY::ATTORNEY_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
+      expect(page).to have_content(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
       expect(find("tbody").find_all("tr").length).to eq(attorney_on_hold_task_count)
       appeal = attorney_task.appeal
       expect(page).to have_content("#{appeal.veteran_full_name} (#{appeal.veteran_file_number})")

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -256,7 +256,7 @@ describe QueueConfig, :postgres do
           it "displays the correct descriptions for the tabs" do
             tabs = subject
 
-            expect(tabs[0][:description]).to eq(COPY::USER_QUEUE_PAGE_NEW_TASKS_DESCRIPTION)
+            expect(tabs[0][:description]).to eq(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
             expect(tabs[1][:description]).to eq(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
             expect(tabs[2][:description]).to eq(COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION)
           end


### PR DESCRIPTION
Final PR of #11699

### Description
Use queue builder introduced in #13578 to build attorney queues from config. As a followup to #11698 and a precursor to the Grand Unified Queue #10032, offload the specific queue configuration for attorneys to the back end

## Acceptance Criteria
- [ ] The queue for attorneys is built from queue config rather than front end logic

## Testing Plan
### Attorney Queue
1. Go to BVASCASPER1's queue
2. Everything still works
3. UI matches master
### Colocated Queue
1. Go to CSS_ID1's queue
2. Everything still works
3. UI matches master

## User Facing Changes

### Attorney queues
 - [ ] None, other than
   - [ ] Note that the only "change" in the UI is the days waiting column. These red bars won't actually show up in the user's queue unless they have put their attorney task on hold and the hold has expired. There are currently no attorney tasks on a timed hold in production, let alone any with expired holds. This is not a change that users will see.
   - [ ] Copy on the on hold tab description is updated


Master|Changes
---|---
![Screen Shot 2020-03-02 at 2 56 57 PM](https://user-images.githubusercontent.com/45575454/75713014-feecc100-5c96-11ea-823c-6686db1e6624.png)|![Screen Shot 2020-03-02 at 4 51 20 PM](https://user-images.githubusercontent.com/45575454/75721433-5fcfc580-5ca6-11ea-80fd-61586571193d.png)
![Screen Shot 2020-03-02 at 2 57 04 PM](https://user-images.githubusercontent.com/45575454/75713021-014f1b00-5c97-11ea-9333-845ad3a39c91.png)|![Screen Shot 2020-03-02 at 4 51 26 PM](https://user-images.githubusercontent.com/45575454/75721447-64947980-5ca6-11ea-95af-a8203d2d24f5.png)
![Screen Shot 2020-03-02 at 2 57 16 PM](https://user-images.githubusercontent.com/45575454/75713030-03b17500-5c97-11ea-95f4-910772b169fb.png)|![Screen Shot 2020-03-02 at 4 51 41 PM](https://user-images.githubusercontent.com/45575454/75721467-69592d80-5ca6-11ea-8358-17a83ab612b6.png)

### Colocated Queues
- [ ] "Days" in the days waiting tab

Master|Changes
---|---
![Screen Shot 2020-03-02 at 4 47 04 PM](https://user-images.githubusercontent.com/45575454/75721090-bb4d8380-5ca5-11ea-9a4d-484028243940.png)|![Screen Shot 2020-03-02 at 4 47 04 PM](https://user-images.githubusercontent.com/45575454/75721384-49296e80-5ca6-11ea-81db-868fb139188e.png)
![Screen Shot 2020-03-02 at 4 46 31 PM](https://user-images.githubusercontent.com/45575454/75721105-c2749180-5ca5-11ea-8a2c-4b9a1b89c17b.png)|![Screen Shot 2020-03-02 at 4 47 11 PM](https://user-images.githubusercontent.com/45575454/75721410-50e91300-5ca6-11ea-97cd-3a13c08f6396.png)
![Screen Shot 2020-03-02 at 4 46 37 PM](https://user-images.githubusercontent.com/45575454/75721124-cbfdf980-5ca5-11ea-88a6-49aaa707b411.png)|![Screen Shot 2020-03-02 at 4 47 17 PM](https://user-images.githubusercontent.com/45575454/75721130-cef8ea00-5ca5-11ea-9bbd-5c6405c3e221.png)

[_What is this stacked pr nonsense?_](https://unhashable.com/stacked-pull-requests-keeping-github-diffs-small/)