### PR TITLE
Fix dislocated parent tasks in FactoryBot - Part 5

### DIFF
--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -634,16 +634,14 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
     it "updates status to completed" do
       expect(admin_action.versions.length).to be 0
-      expect(admin_action.parent.versions.length).to be 1
       patch :update, params: { task: { status: Constants.TASK_STATUSES.completed }, id: admin_action.id }
       expect(response.status).to eq 200
       response_body = JSON.parse(response.body)["tasks"]["data"]
       expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.completed
       expect(response_body.first["attributes"]["closed_at"]).to_not be nil
       expect(admin_action.reload.versions.length).to eq 1
-      expect(admin_action.parent.versions.length).to eq 2
       versions = PaperTrail::Version.where(request_id: admin_action.versions.first.request_id)
-      expect(versions.length).to eq 3
+      expect(versions.length).to eq 1
     end
 
     context "when some other user updates another user's task" do

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -799,7 +799,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
         assert_response :success
         response_body = JSON.parse(response.body)
-        expect(response_body["tasks"].length).to eq 2
+        expect(response_body["tasks"].length).to eq 3
 
         colocated_task = response_body["tasks"].find { |task| task["attributes"]["type"] == "IhpColocatedTask" }
         expect(colocated_task).to_not be_nil
@@ -826,7 +826,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["assigned_to"]["css_id"]).to eq vso_user.css_id
         expect(task["attributes"]["appeal_id"]).to eq appeal.id
 
-        expect(appeal.tasks.size).to eq 3
+        expect(appeal.tasks.size).to eq 5
       end
     end
   end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -72,7 +72,8 @@ FactoryBot.define do
     end
 
     factory :colocated_task, traits: [ColocatedTask.actions_assigned_to_colocated.sample.to_sym] do
-      parent { create(:ama_task) }
+      appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:appeal) }
+      parent { create(:ama_task, appeal) }
       assigned_to { Colocated.singleton }
 
       trait :ihp do

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -5,8 +5,10 @@ FactoryBot.define do
     assigned_at { rand(30..35).days.ago }
     association :assigned_by, factory: :user
     association :assigned_to, factory: :user
-    appeal { create(:legacy_appeal, vacols_case: create(:case)) }
     type { Task.name }
+
+    # if a parent is specified, make sure to use that parent's appeal
+    appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:legacy_appeal, vacols_case: create(:case)) }
 
     after(:create) do |task, _evaluator|
       if task.parent
@@ -75,8 +77,6 @@ FactoryBot.define do
     factory :colocated_task, traits: [ColocatedTask.actions_assigned_to_colocated.sample.to_sym] do
       # don't expect to have a parent for LegacyAppeals
       parent { nil }
-      # if a parent is specified, make sure to use that parent's appeal
-      appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:legacy_appeal, vacols_case: create(:case)) }
       assigned_to { Colocated.singleton }
 
       trait :ihp do
@@ -469,21 +469,21 @@ FactoryBot.define do
       end
 
       factory :judge_address_motion_to_vacate_task, class: JudgeAddressMotionToVacateTask do
-        association :parent, factory: :vacate_motion_mail_task
+        parent { create(:vacate_motion_mail_task, appeal: appeal) }
       end
 
       factory :abstract_motion_to_vacate_task, class: AbstractMotionToVacateTask do
-        association :parent, factory: :vacate_motion_mail_task
+        parent { create(:vacate_motion_mail_task, appeal: appeal) }
       end
 
       factory :denied_motion_to_vacate_task, class: DeniedMotionToVacateTask do
-        association :parent, factory: :abstract_motion_to_vacate_task
+        parent { create(:abstract_motion_to_vacate_task, appeal: appeal) }
         assigned_by { create(:user, full_name: "Judge User", css_id: "JUDGE_1") }
         assigned_to { create(:user, full_name: "Motions Attorney", css_id: "LIT_SUPPORT_ATTY_1") }
       end
 
       factory :dismissed_motion_to_vacate_task, class: DismissedMotionToVacateTask do
-        association :parent, factory: :abstract_motion_to_vacate_task
+        parent { create(:abstract_motion_to_vacate_task, appeal: appeal) }
         assigned_by { create(:user, full_name: "Judge User", css_id: "JUDGE_1") }
         assigned_to { create(:user, full_name: "Motions Attorney", css_id: "LIT_SUPPORT_ATTY_1") }
       end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -261,6 +261,7 @@ FactoryBot.define do
 
       factory :ama_colocated_task, traits: [ColocatedTask.actions_assigned_to_colocated.sample.to_sym],
                                    parent: :colocated_task do
+        parent { create(:ama_task) }
       end
 
       factory :root_task, class: RootTask do

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  # By default, this task is created in a new Legacy appeal
   factory :task do
     assigned_at { rand(30..35).days.ago }
     association :assigned_by, factory: :user
@@ -13,12 +14,12 @@ FactoryBot.define do
     after(:create) do |task, _evaluator|
       if task.parent
         if task.parent&.appeal_id != task.appeal_id
-          fail "Warning: Parent task #{task.parent&.id} is in a different appeal than child task #{task.id}"
+          fail "Parent task #{task.parent&.id} is in a different appeal than child task #{task.id}"
         end
 
         # appeal_id may happen to be the same in the test env, so check the appeal_type as well
         if task.parent&.appeal_type != task.appeal_type
-          fail "Warning: Parent task #{task.parent&.id} has different appeal_type #{task.parent&.appeal_type} " \
+          fail "Parent task #{task.parent&.id} has different appeal_type #{task.parent&.appeal_type} " \
                "than child task's appeal_type #{task.id} #{task.appeal_type}"
         end
       end
@@ -74,6 +75,7 @@ FactoryBot.define do
       end
     end
 
+    # Colocated tasks for Legacy appeals
     factory :colocated_task, traits: [ColocatedTask.actions_assigned_to_colocated.sample.to_sym] do
       # don't expect to have a parent for LegacyAppeals
       parent { nil }
@@ -253,6 +255,7 @@ FactoryBot.define do
       end
     end
 
+    # Tasks for AMA appeals
     factory :ama_task, class: Task do
       appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:appeal) }
 

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -260,9 +260,10 @@ FactoryBot.define do
         task.update(type: task.class.name)
       end
 
+      # Uses parent factory `:colocated_task`
       factory :ama_colocated_task, traits: [ColocatedTask.actions_assigned_to_colocated.sample.to_sym],
                                    parent: :colocated_task do
-        parent { create(:ama_task) }
+        parent { create(:ama_task, appeal: appeal) }
       end
 
       factory :root_task, class: RootTask do

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -249,18 +249,6 @@ FactoryBot.define do
       end
     end
 
-    factory :appeal_task, class: DecisionReviewTask do
-      type { DecisionReviewTask.name }
-      appeal { create(:appeal, benefit_type: "education") }
-      assigned_by { nil }
-    end
-
-    factory :higher_level_review_task, class: DecisionReviewTask do
-      type { DecisionReviewTask.name }
-      appeal { create(:higher_level_review, benefit_type: "education") }
-      assigned_by { nil }
-    end
-
     factory :ama_task, class: Task do
       appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:appeal) }
 
@@ -275,6 +263,16 @@ FactoryBot.define do
       factory :root_task, class: RootTask do
         assigned_by { nil }
         assigned_to { Bva.singleton }
+      end
+
+      factory :appeal_task, class: DecisionReviewTask do
+        appeal { create(:appeal, benefit_type: "education") }
+        assigned_by { nil }
+      end
+
+      factory :higher_level_review_task, class: DecisionReviewTask do
+        appeal { create(:higher_level_review, benefit_type: "education") }
+        assigned_by { nil }
       end
 
       factory :distribution_task, class: DistributionTask do

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -72,8 +72,10 @@ FactoryBot.define do
     end
 
     factory :colocated_task, traits: [ColocatedTask.actions_assigned_to_colocated.sample.to_sym] do
-      appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:appeal) }
-      parent { create(:ama_task, appeal) }
+      # don't expect to have a parent for LegacyAppeals
+      parent { nil }
+      # if a parent is specified, make sure to use that parent's appeal
+      appeal { @overrides[:parent] ? @overrides[:parent].appeal : create(:legacy_appeal, vacols_case: create(:case)) }
       assigned_to { Colocated.singleton }
 
       trait :ihp do

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -8,6 +8,20 @@ FactoryBot.define do
     appeal { create(:legacy_appeal, vacols_case: create(:case)) }
     type { Task.name }
 
+    after(:create) do |task, _evaluator|
+      if task.parent
+        if task.parent&.appeal_id != task.appeal_id
+          fail "Warning: Parent task #{task.parent&.id} is in a different appeal than child task #{task.id}"
+        end
+
+        # appeal_id may happen to be the same in the test env, so check the appeal_type as well
+        if task.parent&.appeal_type != task.appeal_type
+          fail "Warning: Parent task #{task.parent&.id} has different appeal_type #{task.parent&.appeal_type} " \
+               "than child task's appeal_type #{task.id} #{task.appeal_type}"
+        end
+      end
+    end
+
     trait :assigned do
       status { Constants.TASK_STATUSES.assigned }
     end

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -72,9 +72,9 @@ feature "AmaQueue", :all_dbs do
 
     let(:poa_address) { "123 Poplar St." }
     let(:participant_id) { "600153863" }
-    let!(:root_task) { create(:root_task) }
+    let!(:root_task) { create(:root_task, appeal: appeals.first) }
     let!(:parent_task) do
-      create(:ama_judge_task, assigned_to: judge_user, appeal: appeals.first, parent: root_task)
+      create(:ama_judge_task, assigned_to: judge_user, parent: root_task)
     end
 
     let(:poa_name) { "Test POA" }
@@ -120,7 +120,6 @@ feature "AmaQueue", :all_dbs do
             assigned_to: attorney_user,
             assigned_by: judge_user,
             parent: parent_task,
-            appeal: appeals.first
           ),
           create(
             :ama_attorney_task,

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -12,11 +12,10 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
 
   context "given a valid ama appeal" do
     before do
-      root_task = create(:root_task)
+      root_task = create(:root_task, appeal: appeal)
       parent_task = create(
         :ama_judge_decision_review_task,
         assigned_to: judge_user,
-        appeal: appeal,
         parent: root_task
       )
 
@@ -25,8 +24,7 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
         :in_progress,
         assigned_to: attorney_user,
         assigned_by: judge_user,
-        parent: parent_task,
-        appeal: appeal
+        parent: parent_task
       )
 
       User.authenticate!(user: attorney_user)

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1047,14 +1047,13 @@ RSpec.feature "Case details", :all_dbs do
 
   describe "case timeline" do
     context "when the only completed task is a TrackVeteranTask" do
-      let(:root_task) { create(:root_task) }
-      let(:appeal) { root_task.appeal }
+      let(:appeal) { create(:appeal) }
       let!(:tracking_task) do
         create(
           :track_veteran_task,
           :completed,
           appeal: appeal,
-          parent: root_task
+          parent: appeal.root_task
         )
       end
 

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -27,13 +27,12 @@ RSpec.feature "Judge checkout flow", :all_dbs do
     end
     let!(:decision_issue) { create(:decision_issue, decision_review: appeal, request_issues: appeal.request_issues) }
 
-    let(:root_task) { create(:root_task) }
+    let(:root_task) { create(:root_task, appeal: appeal) }
     let(:parent_task) do
       create(
         :ama_judge_decision_review_task,
         :in_progress,
         assigned_to: judge_user,
-        appeal: appeal,
         parent: root_task
       )
     end
@@ -44,8 +43,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
         :in_progress,
         assigned_to: attorney_user,
         assigned_by: judge_user,
-        parent: parent_task,
-        appeal: appeal
+        parent: parent_task
       )
     end
 

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -557,7 +557,7 @@ feature "Task queue", :all_dbs do
         allow_any_instance_of(Organization).to receive(:use_task_pages_api?).and_return(true)
         Task.on_hold.where(assigned_to_type: Organization.name, assigned_to_id: organization.id)
           .each_with_index do |task, idx|
-            child_task = create(:ama_task, parent_id: task.id)
+            child_task = create(:ama_task, parent: task)
             child_task.update!(status: Constants.TASK_STATUSES.on_hold) if idx < on_hold_count
           end
         Task.active.where(assigned_to_type: Organization.name, assigned_to_id: organization.id)

--- a/spec/feature/withdrawn_request_issues_spec.rb
+++ b/spec/feature/withdrawn_request_issues_spec.rb
@@ -80,7 +80,6 @@ feature "attorney checkout flow when appeal has withdrawn request issues", :all_
       assigned_to: attorney,
       assigned_by: judge,
       parent: parent_task,
-      appeal: appeal
     )
   end
 
@@ -96,7 +95,6 @@ feature "attorney checkout flow when appeal has withdrawn request issues", :all_
     create(
       :ama_judge_decision_review_task,
       assigned_to: judge,
-      appeal: appeal,
       parent: create(:root_task)
     )
   end

--- a/spec/feature/withdrawn_request_issues_spec.rb
+++ b/spec/feature/withdrawn_request_issues_spec.rb
@@ -95,7 +95,7 @@ feature "attorney checkout flow when appeal has withdrawn request issues", :all_
     create(
       :ama_judge_decision_review_task,
       assigned_to: judge,
-      parent: create(:root_task)
+      parent: create(:root_task, appeal: appeal)
     )
   end
 

--- a/spec/jobs/fetch_documents_for_reader_user_spec.rb
+++ b/spec/jobs/fetch_documents_for_reader_user_spec.rb
@@ -70,7 +70,7 @@ describe FetchDocumentsForReaderUserJob, :all_dbs do
       end
       let!(:task) do
         create(
-          :colocated_task,
+          :ama_colocated_task,
           assigned_to: create(:user),
           assigned_by: user,
           appeal: ama_appeal

--- a/spec/models/queue_tabs/organization_assigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/organization_assigned_tasks_tab_spec.rb
@@ -44,8 +44,8 @@ describe OrganizationAssignedTasksTab, :postgres do
       let!(:assignee_on_hold_tasks) { create_list(:ama_task, 3, :assigned, assigned_to: assignee) }
       let!(:on_hold_tasks_children) do
         assignee_on_hold_tasks.map do |task|
-          create(:ama_task, :in_progress, parent_id: task.id)
-          create(:timed_hold_task, :assigned, parent_id: task.id)
+          create(:ama_task, :in_progress, parent: task)
+          create(:timed_hold_task, :assigned, parent: task)
           task.update!(status: Constants.TASK_STATUSES.on_hold)
           task.children
         end.flatten

--- a/spec/models/queue_tabs/organization_on_hold_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/organization_on_hold_tasks_tab_spec.rb
@@ -44,8 +44,8 @@ describe OrganizationOnHoldTasksTab, :postgres do
       let!(:assignee_on_hold_tasks) { create_list(:ama_task, 3, :assigned, assigned_to: assignee) }
       let!(:on_hold_tasks_children) do
         assignee_on_hold_tasks.map do |task|
-          create(:ama_task, parent_id: task.id)
-          create(:timed_hold_task, parent_id: task.id)
+          create(:ama_task, parent: task)
+          create(:timed_hold_task, parent: task)
           task.descendants.each(&:on_hold!)
           task.children
         end.flatten

--- a/spec/models/queues/attorney_queue_spec.rb
+++ b/spec/models/queues/attorney_queue_spec.rb
@@ -17,7 +17,7 @@ describe AttorneyQueue, :all_dbs do
       let(:org1) { Colocated.singleton }
       let!(:action1) { create(:colocated_task, assigned_by: user, assigned_to: org1) }
       let(:org2) { Colocated.singleton }
-      let!(:action2) { create(:colocated_task, appeal: appeal, assigned_by: user, assigned_to: org2) }
+      let!(:action2) { create(:colocated_task, :ihp, appeal: appeal, assigned_by: user, assigned_to: org2) }
       let!(:action3) do
         create(
           :colocated_task,

--- a/spec/models/queues/attorney_queue_spec.rb
+++ b/spec/models/queues/attorney_queue_spec.rb
@@ -21,6 +21,7 @@ describe AttorneyQueue, :all_dbs do
       let!(:action3) do
         create(
           :colocated_task,
+          :poa_clarification,
           appeal: appeal,
           assigned_by: user
         ).tap do |task|

--- a/spec/models/task_pager_spec.rb
+++ b/spec/models/task_pager_spec.rb
@@ -377,7 +377,7 @@ describe TaskPager, :all_dbs do
         end
         appeals = [appeal_1, appeal_2]
         appeals.map do |appeal|
-          create(:colocated_task, assigned_to: assignee, appeal: appeal)
+          create(:ama_colocated_task, assigned_to: assignee, appeal: appeal)
           create(:cached_appeal,
                  appeal_id: appeal.id,
                  appeal_type: Appeal.name,

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -300,7 +300,7 @@ describe TaskSorter, :all_dbs do
 
           appeals = [create(:appeal, :advanced_on_docket_due_to_motion), create(:appeal)]
           appeals.each do |appeal|
-            create(:colocated_task, appeal: appeal, assigned_to: org)
+            create(:ama_colocated_task, appeal: appeal, assigned_to: org)
             create(:cached_appeal,
                    appeal_id: appeal.id,
                    appeal_type: Appeal.name,

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -43,23 +43,23 @@ describe Task, :all_dbs do
     subject { ama_task.post_dispatch_task? }
 
     context "dispatch task is not complete" do
-      let!(:bva_task) { create(:bva_dispatch_task, :in_progress, parent: root_task, appeal: appeal) }
-      let(:ama_task) { create(:ama_task, parent: root_task, appeal: appeal) }
+      let!(:bva_task) { create(:bva_dispatch_task, :in_progress, parent: root_task) }
+      let(:ama_task) { create(:ama_task, parent: root_task) }
 
       it { is_expected.to be_falsey }
     end
 
     context "dispatch task is complete" do
-      let!(:bva_task) { create(:bva_dispatch_task, :completed, parent: root_task, appeal: appeal) }
+      let!(:bva_task) { create(:bva_dispatch_task, :completed, parent: root_task) }
 
       context "sibling task created before dispatch task completed" do
-        let(:ama_task) { create(:ama_task, created_at: bva_task.closed_at - 1, parent: root_task, appeal: appeal) }
+        let(:ama_task) { create(:ama_task, created_at: bva_task.closed_at - 1, parent: root_task) }
 
         it { is_expected.to be_falsey }
       end
 
       context "sibling task created after dispatch task completed" do
-        let(:ama_task) { create(:ama_task, created_at: bva_task.closed_at + 1, parent: root_task, appeal: appeal) }
+        let(:ama_task) { create(:ama_task, created_at: bva_task.closed_at + 1, parent: root_task) }
 
         it { is_expected.to be_truthy }
       end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -117,7 +117,7 @@ describe Task, :all_dbs do
       end
 
       context "when task has some complete and some incomplete child tasks" do
-        let!(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let!(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent: task) }
 
         it "should not change the task's status" do
           status_before = task.status
@@ -127,7 +127,7 @@ describe Task, :all_dbs do
       end
 
       context "when task has only complete child tasks" do
-        let(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent: task) }
         let!(:child) { completed_children.last }
 
         it "should change task's status to assigned" do
@@ -184,7 +184,7 @@ describe Task, :all_dbs do
       end
 
       context "when task has some complete and some incomplete child tasks" do
-        let!(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let!(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent: task) }
 
         it "should not update any attribute of the task" do
           task_status = task.status
@@ -194,7 +194,7 @@ describe Task, :all_dbs do
       end
 
       context "when task has only complete child tasks" do
-        let(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent_id: task.id) }
+        let(:completed_children) { create_list(:task, 3, :completed, type: Task.name, parent: task) }
         let!(:child) { completed_children.last }
 
         it "should update the task" do
@@ -204,7 +204,7 @@ describe Task, :all_dbs do
       end
 
       context "when child task has a different type than parent" do
-        let!(:child) { create(:quality_review_task, :completed, parent_id: task.id) }
+        let!(:child) { create(:quality_review_task, :completed, parent: task) }
 
         it "sets the status of the parent to assigned" do
           subject
@@ -242,7 +242,7 @@ describe Task, :all_dbs do
     end
 
     context "when there is an attorney_case_review" do
-      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent_id: task.id) }
+      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent: task) }
       let!(:attorney_case_reviews) do
         create(:attorney_case_review, task_id: child.id, attorney: create(:user, full_name: "Bob Smith"))
       end
@@ -284,7 +284,7 @@ describe Task, :all_dbs do
     end
 
     context "when there is a sub task" do
-      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent_id: task.id) }
+      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent: task) }
       let!(:attorney_case_reviews) do
         [
           create(:attorney_case_review, task_id: child.id, created_at: 1.day.ago),
@@ -322,8 +322,8 @@ describe Task, :all_dbs do
     context "when sub-sub-sub...task has a root task" do
       let(:root_task) { create(:root_task) }
       let(:task) do
-        t = create(:ama_task, parent_id: root_task.id)
-        5.times { t = create(:ama_task, parent_id: t.id) }
+        t = create(:ama_task, parent: root_task)
+        5.times { t = create(:ama_task, parent: t) }
         Task.last
       end
 
@@ -335,7 +335,7 @@ describe Task, :all_dbs do
     context "when sub-sub-sub...task does not have a root task" do
       let(:task) do
         t = create(:ama_task)
-        5.times { t = create(:ama_task, parent_id: t.id) }
+        5.times { t = create(:ama_task, parent: t) }
         Task.last
       end
 
@@ -803,8 +803,8 @@ describe Task, :all_dbs do
   describe ".reassign" do
     let(:org) { Organization.find(create(:organization).id) }
     let(:root_task) { RootTask.find(create(:root_task).id) }
-    let(:org_task) { create(:ama_task, parent_id: root_task.id, assigned_to: org) }
-    let(:task) { create(:ama_task, parent_id: org_task.id) }
+    let(:org_task) { create(:ama_task, parent: root_task, assigned_to: org) }
+    let(:task) { create(:ama_task, parent: org_task) }
     let(:old_assignee) { task.assigned_to }
     let(:new_assignee) { create(:user) }
     let(:params) do
@@ -835,10 +835,10 @@ describe Task, :all_dbs do
     context "When old assignee reassigns task with several child tasks to a new user" do
       let(:task_type) { :ama_task }
       let(:closed_children_count) { 2 }
-      let!(:completed_children) { create_list(task_type, closed_children_count / 2, :completed, parent_id: task.id) }
-      let!(:cancelled_children) { create_list(task_type, closed_children_count / 2, :cancelled, parent_id: task.id) }
+      let!(:completed_children) { create_list(task_type, closed_children_count / 2, :completed, parent: task) }
+      let!(:cancelled_children) { create_list(task_type, closed_children_count / 2, :cancelled, parent: task) }
       let(:incomplete_children_count) { 2 }
-      let!(:incomplete_children) { create_list(task_type, incomplete_children_count, parent_id: task.id) }
+      let!(:incomplete_children) { create_list(task_type, incomplete_children_count, parent: task) }
 
       before { task.on_hold! }
 
@@ -867,12 +867,12 @@ describe Task, :all_dbs do
           expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
 
           new_task = task.parent.children.open.first
-          expect(new_task.children.length).to eq(incomplete_children_count)
+          # Hunter?: 0 != 1 expect(new_task.children.length).to eq(incomplete_children_count)
           expect(new_task.children.all?(&:assigned?)).to eq(true)
           expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
           task.reload
-          expect(task.children.length).to eq(closed_children_count)
+          # Hunter?: 3 != 2 expect(task.children.length).to eq(closed_children_count)
         end
       end
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -863,16 +863,17 @@ describe Task, :all_dbs do
         let(:task_type) { :timed_hold_task }
 
         it "children timer tasks are adopted by new task and not cancelled" do
+          task.reload
           expect { subject }.to_not raise_error
           expect(task.status).to eq(Constants.TASK_STATUSES.cancelled)
 
           new_task = task.parent.children.open.first
-          # Hunter?: 0 != 1 expect(new_task.children.length).to eq(incomplete_children_count)
+          expect(new_task.children.length).to eq(incomplete_children_count)
           expect(new_task.children.all?(&:assigned?)).to eq(true)
           expect(new_task.status).to eq(Constants.TASK_STATUSES.on_hold)
 
           task.reload
-          # Hunter?: 3 != 2 expect(task.children.length).to eq(closed_children_count)
+          expect(task.children.length).to eq(closed_children_count)
         end
       end
 

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -374,12 +374,11 @@ describe ColocatedTask, :all_dbs do
     let(:colocated_user) { create(:user) }
     let(:colocated_task) do
       # We expect all ColocatedTasks that are assigned to individuals to have parent tasks assigned to the organization.
-      org_task = create(:colocated_task, assigned_by: attorney)
+      org_task = create(:colocated_task, appeal: appeal_1, assigned_by: attorney)
       create(
         :colocated_task,
         assigned_by: attorney,
         assigned_to: colocated_user,
-        appeal: appeal_1,
         parent: org_task
       )
     end

--- a/spec/workflows/bulk_task_reassignment_spec.rb
+++ b/spec/workflows/bulk_task_reassignment_spec.rb
@@ -85,7 +85,7 @@ describe BulkTaskReassignment, :all_dbs do
         let(:task_type) { :ama_judge_task }
 
         context "with open children" do
-          let(:child_tasks) { tasks.map { |task| create(:task, parent_id: task.id) } }
+          let(:child_tasks) { tasks.map { |task| create(:task, parent: task) } }
 
           it "fails and warns the caller of open children of JudgeAssignTasks" do
             bad_parent_output = child_tasks.map(&:id).sort.join(", ")
@@ -116,8 +116,8 @@ describe BulkTaskReassignment, :all_dbs do
         let(:task_type) { :ama_judge_decision_review_task }
 
         context "with no open children" do
-          let(:child_tasks) { tasks.first(2).map { |task| create(:task, parent_id: task.id) } }
-          let!(:child_atty_tasks) { tasks.last(2).map { |task| create(:ama_attorney_task, parent_id: task.id) } }
+          let(:child_tasks) { tasks.first(2).map { |task| create(:task, parent: task) } }
+          let!(:child_atty_tasks) { tasks.last(2).map { |task| create(:ama_attorney_task, parent: task) } }
 
           it "fails and warns the caller of open children of JudgeAssignTasks" do
             bad_parent_output = child_tasks.map(&:parent_id).sort.join(", ")
@@ -129,7 +129,7 @@ describe BulkTaskReassignment, :all_dbs do
         context "with children attorney tasks (and assignee attorney is being made inactive)" do
           let(:attorney) { create(:user) }
           let!(:child_tasks) do
-            tasks.map { |task| create(:ama_attorney_task, :completed, parent_id: task.id, assigned_to: attorney) }
+            tasks.map { |task| create(:ama_attorney_task, :completed, parent: task, assigned_to: attorney) }
           end
 
           context "but no judge team for the attorney" do
@@ -342,7 +342,7 @@ describe BulkTaskReassignment, :all_dbs do
       context "with children attorney tasks" do
         let(:attorney) { create(:user) }
         let!(:child_tasks) do
-          tasks.map { |task| create(:ama_attorney_task, :completed, parent_id: task.id, assigned_to: attorney) }
+          tasks.map { |task| create(:ama_attorney_task, :completed, parent: task, assigned_to: attorney) }
         end
         let!(:judge_team) { JudgeTeam.create_for_judge(create(:user)) }
 

--- a/spec/workflows/fetch_documents_for_reader_spec.rb
+++ b/spec/workflows/fetch_documents_for_reader_spec.rb
@@ -69,7 +69,7 @@ describe FetchDocumentsForReaderJob, :all_dbs do
       end
       let!(:task) do
         create(
-          :colocated_task,
+          :ama_colocated_task,
           assigned_to: create(:user),
           assigned_by: user,
           appeal: appeal


### PR DESCRIPTION
Connects #13130
Part 4 #13607

### Description
Fixes FactoryBot's `colocated_task` and associated tests.
Adds parent-child validation after FactoryBot creates a task.

### Acceptance Criteria
- [ ] All tests pass
