### PR TITLE
RAMP | Allow new refiling intake if previous refiling EP was cancelled

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -205,7 +205,7 @@ class EndProductEstablishment < CaseflowRecord
         synced_status: result.status_type_code,
         last_synced_at: Time.zone.now
       )
-      status_canceled? ? handle_canceled_ep! : sync_source!
+      status_cancelled? ? handle_cancelled_ep! : sync_source!
       close_request_issues_with_no_decision!
     end
 
@@ -230,7 +230,7 @@ class EndProductEstablishment < CaseflowRecord
     }
   end
 
-  def status_canceled?
+  def status_cancelled?
     synced_status == CANCELED_STATUS
   end
 
@@ -389,12 +389,12 @@ class EndProductEstablishment < CaseflowRecord
       # delete end product in bgs & set sync status to canceled
       BGSService.new.cancel_end_product(veteran_file_number, code, modifier)
       update!(synced_status: CANCELED_STATUS)
-      handle_canceled_ep!
+      handle_cancelled_ep!
     end
   end
 
-  def handle_canceled_ep!
-    return unless status_canceled?
+  def handle_cancelled_ep!
+    return unless status_cancelled?
 
     source.try(:canceled!)
     request_issues.all.find_each(&:close_after_end_product_canceled!)

--- a/app/models/ramp_closed_appeal.rb
+++ b/app/models/ramp_closed_appeal.rb
@@ -40,7 +40,7 @@ class RampClosedAppeal < CaseflowRecord
 
     # If the end product was canceled, don't re-close the VACOLS appeal.
     # Instead rollback the RAMP election data from Caseflow
-    return ramp_election.rollback! if ramp_election.end_product_establishment.status_canceled?
+    return ramp_election.rollback! if ramp_election.end_product_establishment.status_cancelled?
 
     fail NoReclosingBvaDecidedAppeals if appeal.decided_by_bva?
 

--- a/app/models/ramp_election.rb
+++ b/app/models/ramp_election.rb
@@ -62,7 +62,7 @@ class RampElection < RampReview
   def on_sync(end_product_establishment)
     recreate_issues_from_contentions!(end_product_establishment)
 
-    if FeatureToggle.enabled?(:automatic_ramp_rollback) && end_product_establishment.status_canceled?
+    if FeatureToggle.enabled?(:automatic_ramp_rollback) && end_product_establishment.status_cancelled?
       rollback_ramp_review
     end
   end

--- a/app/models/ramp_election_rollback.rb
+++ b/app/models/ramp_election_rollback.rb
@@ -46,7 +46,7 @@ class RampElectionRollback < CaseflowRecord
   # require that it was canceled manually beforehand
   def validate_canceled_end_product
     establishment = EndProductEstablishment.find_by(source: ramp_election)
-    unless establishment&.status_canceled?
+    unless establishment&.status_cancelled?
       errors.add(:ramp_election, "end_product_not_canceled")
     end
   end

--- a/app/models/ramp_refiling_intake.rb
+++ b/app/models/ramp_refiling_intake.rb
@@ -85,13 +85,15 @@ class RampRefilingIntake < Intake
       self.error_code = :ramp_election_no_issues
     elsif ramp_refiling_already_processed?
       # For now caseflow does not support processing the multiple ramp refilings
-      # for the same veteran
+      # for the same veteran, unless previous ones have been cancelled
       self.error_code = :ramp_refiling_already_processed
     end
   end
 
   def ramp_refiling_already_processed?
-    !RampRefiling.where(veteran_file_number: veteran_file_number).empty?
+    duplicate_refilings = RampRefiling.where(veteran_file_number: veteran_file_number)
+    end_product_establishments = duplicate_refilings.map(&:end_product_establishment)
+    end_product_establishments.present? && !end_product_establishments.all?(&:status_cancelled?)
   end
 
   def find_or_build_initial_detail

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -440,7 +440,7 @@ class RequestIssue < CaseflowRecord
   end
 
   def close_after_end_product_canceled!
-    return unless end_product_establishment&.reload&.status_canceled?
+    return unless end_product_establishment&.reload&.status_cancelled?
 
     close!(status: :end_product_canceled) do
       legacy_issue_optin&.flag_for_rollback!

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -972,8 +972,8 @@ describe EndProductEstablishment, :postgres do
     end
   end
 
-  context "#status_canceled?" do
-    subject { end_product_establishment.status_canceled? }
+  context "#status_cancelled?" do
+    subject { end_product_establishment.status_cancelled? }
 
     context "returns true if canceled" do
       let(:synced_status) { "CAN" }

--- a/spec/models/ramp_refiling_intake_spec.rb
+++ b/spec/models/ramp_refiling_intake_spec.rb
@@ -311,7 +311,7 @@ describe RampRefilingIntake, :postgres do
             end
 
             context "the preexisting RAMP refilings only have cancelled EPs" do
-              let!(:other_refiling_epe) { create(:end_product_establishment, :canceled, source: preexisting_ramp_refiling) }
+              let!(:previous_epe) { create(:end_product_establishment, :canceled, source: preexisting_ramp_refiling) }
 
               it { is_expected.to eq(true) }
             end

--- a/spec/models/ramp_refiling_intake_spec.rb
+++ b/spec/models/ramp_refiling_intake_spec.rb
@@ -309,6 +309,12 @@ describe RampRefilingIntake, :postgres do
               expect(subject).to eq(false)
               expect(intake.error_code).to eq("ramp_refiling_already_processed")
             end
+
+            context "the preexisting RAMP refilings only have cancelled EPs" do
+              let!(:other_refiling_epe) { create(:end_product_establishment, :canceled, source: preexisting_ramp_refiling) }
+
+              it { is_expected.to eq(true) }
+            end
           end
         end
       end


### PR DESCRIPTION
### Description
Currently we do not allow multiple RAMP Refilings for a veteran.  However, if the only RAMP Refiling's end product was cancelled, we should allow it to be re-intaken.

This also does a tiny bit of renaming of canceled -> cancelled.