### PR TITLE
Update schema doc for new users.user_id index

### DIFF
--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -185,4 +185,4 @@ users,status_updated_at,datetime,,,,,,When the user's status was last updated
 users,stitle,string (16),,,,,,VACOLS cached_user_attributes.stitle
 users,svlj,string (1),,,,,,
 users,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-users,user_id,integer ∗,x,,,,,ID of the User
+users,user_id,integer ∗,x,,,,x,ID of the User


### PR DESCRIPTION
We changed our doc generator, and then added the index before either PR was merged. This gets us back in sync.