### PR TITLE
More accurate hearings seed data; add VSO user that can access hearings

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -330,7 +330,7 @@ class SeedDB
       participant_id: "2452415"
     )
 
-    %w[BILLIE MICHAEL WINNIE].each do |name|
+    %w[BILLIE MICHAEL].each do |name|
       u = User.create(
         css_id: "#{name}_VSO",
         station_id: 101,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -165,7 +165,9 @@ class SeedDB
         appeal = FactoryBot.create(
           :appeal,
           :hearing_docket,
-          claimants: [FactoryBot.create(:claimant, participant_id: "CLAIMANT_WITH_PVA_AS_VSO")],
+          claimants: [
+            FactoryBot.create(:claimant, participant_id: "CLAIMANT_WITH_PVA_AS_VSO_#{rand(10 ** 10)}")
+          ],
           closest_regional_office: regional_office
         )
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -417,9 +417,9 @@ class SeedDB
 
     %w[WINNIE].each do |name|
       u = User.create(
-        css_id: "#{name}_VSO",
+        css_id: "#{name}_PVA_VSO",
         station_id: 101,
-        full_name: "#{name} VSOUser James",
+        full_name: "#{name} PVA_VSOUser James",
         roles: %w[VSO]
       )
       vso.add_user(u)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -250,7 +250,6 @@ class SeedDB
 
     TrackVeteranTask.sync_tracking_tasks(appeal)
 
-    # Legacy Hearings can be created here due to hearing_day_full? check
     hearing = FactoryBot.create(
       :hearing,
       hearing_day: day,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -173,8 +173,118 @@ class SeedDB
         [:no_show_hearing_task, :evidence_submission_window_task].sample,
         parent: disposition_task,
         appeal: appeal
+
+  def create_ama_hearing(day)
+    veteran = FactoryBot.create(
+      :veteran,
+      first_name: Faker::Name.first_name,
+      last_name: Faker::Name.last_name
+    )
+
+    appeal = FactoryBot.create(
+      :appeal,
+      veteran_file_number: veteran.file_number,
+      claimants: [FactoryBot.create(:claimant, participant_id: "CLAIMANT_WITH_PVA_AS_VSO")],
+      docket_type: Constants.AMA_DOCKETS.hearing
+    )
+
+    root_task = FactoryBot.create(:root_task, appeal: appeal)
+    distribution_task = FactoryBot.create(
+      :distribution_task,
+      appeal: appeal,
+      parent: root_task
+    )
+    parent_hearing_task = FactoryBot.create(
+      :hearing_task,
+      parent: distribution_task,
+      appeal: appeal
+    )
+
+    FactoryBot.create(
+      :schedule_hearing_task,
+      :completed,
+      parent: parent_hearing_task,
+      appeal: appeal
+    )
+    FactoryBot.create(
+      :assign_hearing_disposition_task,
+      :in_progress,
+      parent: parent_hearing_task,
+      appeal: appeal
+    )
+
+    TrackVeteranTask.sync_tracking_tasks(appeal)
+
+    # Legacy Hearings can be created here due to hearing_day_full? check
+    hearing = FactoryBot.create(
+      :hearing,
+      hearing_day: day,
+      appeal: appeal,
+      bva_poc: User.find_by_css_id("BVAAABSHIRE").full_name,
+      scheduled_time: Time.utc(
+        Time.zone.today.year, Time.zone.today.month, Time.zone.today.day, 9, 0, 0
       )
+    )
+
+    FactoryBot.create(
+      :hearing_task_association,
+      hearing: hearing,
+      hearing_task: parent_hearing_task
+    )
+  end
+
+  def create_legacy_hearing(day, ro_key)
+    case ro_key
+    when "RO17"
+      folder_nr = "3620725"
+    when "RO45"
+      folder_nr = "3411278"
+    when "C"
+      folder_nr = "3542942"
     end
+
+    FactoryBot.create(
+      :case_hearing,
+      folder_nr: folder_nr,
+      vdkey: day.id,
+      board_member: User.find_by_css_id("BVAAABSHIRE").vacols_attorney_id.to_i
+    )
+  end
+
+  def create_hearing_days
+    user = User.find_by(css_id: "BVATWARNER")
+
+    # Set the current user var here, which is used to populate the
+    # created by field.
+    RequestStore[:current_user] = user
+
+    %w[C RO17 RO19 RO31 RO43 RO45].each do |ro_key|
+      (1..5).each do |index|
+        day = HearingDay.create!(
+          regional_office: (ro_key == "C") ? nil : ro_key,
+          room: "1",
+          judge: User.find_by_css_id("BVAAABSHIRE"),
+          request_type: (ro_key == "C") ? "C" : "V",
+          scheduled_for: Time.zone.today + (index * 11).days,
+          created_by: user,
+          updated_by: user
+        )
+
+        case index
+        when 1
+          create_ama_hearing(day)
+        when 2
+          create_legacy_hearing(day, ro_key)
+        when 3
+          create_legacy_hearing(day, ro_key)
+          create_ama_hearing(day)
+        end
+      end
+    end
+
+    # The current user var should be set to nil at the start of this
+    # function. Restore it before executing the next seed function.
+    RequestStore[:current_user] = nil
   end
 
   def create_change_hearing_disposition_task
@@ -466,85 +576,6 @@ class SeedDB
       tag_id: Generators::Tag.create(text: "Right Knee").id,
       document_id: 2
     )
-  end
-
-  def create_ama_hearing(day)
-    vet = Generators::Veteran.build(
-      file_number: Faker::Number.number(digits: 9).to_s,
-      first_name: Faker::Name.first_name,
-      last_name: Faker::Name.last_name
-    )
-    vet.save
-
-    app = FactoryBot.create(
-      :appeal,
-      veteran_file_number: vet.file_number,
-      docket_type: Constants.AMA_DOCKETS.hearing
-    )
-
-    # Legacy Hearings can be created here due to hearing_day_full? check
-    Hearing.create(
-      hearing_day: day,
-      appeal: app,
-      bva_poc: User.find_by_css_id("BVAAABSHIRE").full_name,
-      scheduled_time: Time.utc(
-        Time.zone.today.year, Time.zone.today.month, Time.zone.today.day, 9, 0, 0
-      )
-    )
-  end
-
-  def create_legacy_hearing(day, ro_key)
-    case ro_key
-    when "RO17"
-      folder_nr = "3620725"
-    when "RO45"
-      folder_nr = "3411278"
-    when "C"
-      folder_nr = "3542942"
-    end
-
-    FactoryBot.create(
-      :case_hearing,
-      folder_nr: folder_nr,
-      vdkey: day.id,
-      board_member: User.find_by_css_id("BVAAABSHIRE").vacols_attorney_id.to_i
-    )
-  end
-
-  def create_hearing_days
-    user = User.find_by(css_id: "BVATWARNER")
-
-    # Set the current user var here, which is used to populate the
-    # created by field.
-    RequestStore[:current_user] = user
-
-    %w[C RO17 RO45].each do |ro_key|
-      (1..5).each do |index|
-        day = HearingDay.create!(
-          regional_office: (ro_key == "C") ? nil : ro_key,
-          room: "1",
-          judge: User.find_by_css_id("BVAAABSHIRE"),
-          request_type: (ro_key == "C") ? "C" : "V",
-          scheduled_for: Time.zone.today + (index * 11).days,
-          created_by: user,
-          updated_by: user
-        )
-
-        case index
-        when 1
-          create_ama_hearing(day)
-        when 2
-          create_legacy_hearing(day, ro_key)
-        when 3
-          create_legacy_hearing(day, ro_key)
-          create_ama_hearing(day)
-        end
-      end
-    end
-
-    # The current user var should be set to nil at the start of this
-    # function. Restore it before executing the next seed function.
-    RequestStore[:current_user] = nil
   end
 
   def create_api_key

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -268,7 +268,7 @@ class SeedDB
     )
   end
 
-  def create_legacy_hearing(day, ro_key)
+  def create_case_hearing(day, ro_key)
     case ro_key
     when "RO17"
       folder_nr = "3620725"
@@ -411,7 +411,7 @@ class SeedDB
   #
   # Use the participant ID `CLAIMANT_WITH_PVA_AS_VSO` to tie this org to a
   # claimant.
-  def create_pva_vso_users
+  def create_pva_vso_and_users
     vso = Vso.create(
       name: "PARALYZED VETERANS OF AMERICA, INC.",
       url: "paralyzed-veteran-of-america",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -255,9 +255,7 @@ class SeedDB
       hearing_day: day,
       appeal: appeal,
       bva_poc: User.find_by_css_id("BVAAABSHIRE").full_name,
-      scheduled_time: Time.utc(
-        Time.zone.today.year, Time.zone.today.month, Time.zone.today.day, 9, 0, 0
-      )
+      scheduled_time: "9:00AM"
     )
 
     FactoryBot.create(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -170,6 +170,9 @@ class SeedDB
           claimants: [FactoryBot.create(:claimant, participant_id: "CLAIMANT_WITH_PVA_AS_VSO")],
           closest_regional_office: regional_office
         )
+
+        FactoryBot.create(:available_hearing_locations, regional_office, appeal: appeal)
+
         root_task = FactoryBot.create(:root_task, appeal: appeal)
         distribution_task = FactoryBot.create(
           :distribution_task,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -547,45 +547,6 @@ class SeedDB
     RequestStore[:current_user] = nil
   end
 
-  def create_legacy_case_with_open_schedule_hearing_task(ro_key)
-    case ro_key
-    when "RO17"
-      vacols_id = "2668454"
-    when "RO45"
-      vacols_id = "3261587"
-    when "C"
-      vacols_id = "3019752"
-    end
-
-    LegacyAppeal.find_or_create_by_vacols_id(vacols_id)
-  end
-
-  def create_ama_case_with_open_schedule_hearing_task(ro_key)
-    vet = Generators::Veteran.build(
-      file_number: Faker::Number.number(digits: 9).to_s,
-      first_name: Faker::Name.first_name,
-      last_name: Faker::Name.last_name
-    )
-
-    vet.save
-
-    FactoryBot.create(
-      :appeal,
-      :with_post_intake_tasks,
-      number_of_claimants: 1,
-      closest_regional_office: ro_key,
-      veteran_file_number: vet.file_number,
-      docket_type: Constants.AMA_DOCKETS.hearing
-    )
-  end
-
-  def create_veterans_ready_for_hearing
-    %w[C RO45 RO17].each do |ro_key|
-      create_legacy_case_with_open_schedule_hearing_task(ro_key)
-      create_ama_case_with_open_schedule_hearing_task(ro_key)
-    end
-  end
-
   def create_api_key
     ApiKey.new(consumer_name: "PUBLIC", key_string: "PUBLICDEMO123").save!
   end
@@ -1483,7 +1444,6 @@ class SeedDB
     call_and_log_seed_step :create_users
     call_and_log_seed_step :create_ama_appeals
     call_and_log_seed_step :create_hearing_days
-    call_and_log_seed_step :create_veterans_ready_for_hearing
     call_and_log_seed_step :create_tasks
     call_and_log_seed_step :create_higher_level_review_tasks
     call_and_log_seed_step :setup_dispatch

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1422,7 +1422,6 @@ class SeedDB
 
   def perform_seeding_jobs
     # Active Jobs which populate tables based on seed data
-    FetchHearingLocationsForVeteransJob.perform_now
     UpdateCachedAppealsAttributesJob.perform_now
     NightlySyncsJob.perform_now
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -74,7 +74,7 @@ class SeedDB
     create_transcription_team
     create_vso_users_and_tasks
     create_field_vso_and_users
-    create_pva_vso_users
+    create_pva_vso_and_users
     create_org_queue_users
     create_qr_user
     create_aod_user_and_tasks
@@ -308,9 +308,9 @@ class SeedDB
         when 1
           create_ama_hearing(day)
         when 2
-          create_legacy_hearing(day, ro_key)
+          create_case_hearing(day, ro_key)
         when 3
-          create_legacy_hearing(day, ro_key)
+          create_case_hearing(day, ro_key)
           create_ama_hearing(day)
         end
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -129,6 +129,7 @@ class SeedDB
     TranscriptionTeam.singleton.add_user(transcription_member)
   end
 
+  ### Hearings Setup ###
   def create_hearings_user_and_tasks
     hearings_member = User.find_or_create_by(css_id: "BVATWARNER", station_id: 101)
     HearingsManagement.singleton.add_user(hearings_member)
@@ -340,6 +341,7 @@ class SeedDB
     FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: parent_hearing_task)
     FactoryBot.create(:change_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal)
   end
+  ### End Hearings Setup ###
 
   def create_colocated_users
     secondary_user = FactoryBot.create(:user, full_name: "Harper SecondaryVLJSupportStaff Tash", roles: %w[Reader])

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -159,8 +159,6 @@ class SeedDB
 
   def create_different_hearings_tasks
     (%w[RO17 RO19 RO31 RO43 RO45] + [nil]).each do |regional_office|
-      puts "Regional Office #{regional_office}"
-
       create_legacy_case_with_open_schedule_hearing_task(regional_office)
 
       rand(10..30).times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -74,6 +74,7 @@ class SeedDB
     create_transcription_team
     create_vso_users_and_tasks
     create_field_vso_and_users
+    create_pva_vso_users
     create_org_queue_users
     create_qr_user
     create_aod_user_and_tasks
@@ -367,6 +368,29 @@ class SeedDB
                                                                   assigned_to_type: User.name
                                                                 }], u)
       end
+    end
+  end
+
+  # Creates a VSO org for the PARALYZED VETERANS OF AMERICA VSO that the fake BGS
+  # service returns.
+  #
+  # Use the participant ID `CLAIMANT_WITH_PVA_AS_VSO` to tie this org to a
+  # claimant.
+  def create_pva_vso_users
+    vso = Vso.create(
+      name: "PARALYZED VETERANS OF AMERICA, INC.",
+      url: "paralyzed-veteran-of-america",
+      participant_id: "2452383"
+    )
+
+    %w[WINNIE].each do |name|
+      u = User.create(
+        css_id: "#{name}_VSO",
+        station_id: 101,
+        full_name: "#{name} VSOUser James",
+        roles: %w[VSO]
+      )
+      vso.add_user(u)
     end
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -233,7 +233,7 @@ class Fakes::BGSService
   def fetch_poas_by_participant_ids(participant_ids)
     get_hash_of_poa_from_bgs_poas(
       participant_ids.map do |participant_id|
-        vso = if participant_id == "CLAIMANT_WITH_PVA_AS_VSO"
+        vso = if participant_id.starts_with?("CLAIMANT_WITH_PVA_AS_VSO")
                 {
                   legacy_poa_cd: "071",
                   nm: "PARALYZED VETERANS OF AMERICA, INC.",

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -18,12 +18,6 @@ FactoryBot.define do
     end
 
     after(:create) do |appeal, _evaluator|
-      if appeal.closest_regional_office.present?
-        create(:available_hearing_locations, appeal.closest_regional_office, appeal: appeal)
-      end
-    end
-
-    after(:create) do |appeal, _evaluator|
       appeal.request_issues.each do |issue|
         issue.decision_review = appeal
         issue.save

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -18,6 +18,12 @@ FactoryBot.define do
     end
 
     after(:create) do |appeal, _evaluator|
+      if appeal.closest_regional_office.present?
+        create(:available_hearing_locations, appeal.closest_regional_office, appeal: appeal)
+      end
+    end
+
+    after(:create) do |appeal, _evaluator|
       appeal.request_issues.each do |issue|
         issue.decision_review = appeal
         issue.save

--- a/spec/factories/available_hearing_locations.rb
+++ b/spec/factories/available_hearing_locations.rb
@@ -2,5 +2,64 @@
 
 FactoryBot.define do
   factory :available_hearing_locations do
+    association :appeal
+    distance { 0.0 }
+    updated_at { Time.now.utc }
+    veteran_file_number { appeal&.veteran_file_number || "" }
+
+    trait "RO17" do
+      address { "9500 Bay Pines Blvd." }
+      city { "St. Petersburg" }
+      classification { "Regional Benefit Office"}
+      facility_id { "vba_317" }
+      facility_type { "va_benefits_facility" }
+      name { "St. Petersburg Regional Benefit Office" }
+      state { "FL" }
+      zip_code { "33744" }
+    end
+
+    trait "RO19" do
+      address { "6437 Garners Ferry Rd" }
+      city { "Columbia" }
+      classification { "Regional Benefit Office"}
+      facility_id { "vba_319" }
+      facility_type { "va_benefits_facility" }
+      name { "Columbia Regional Benefit Office" }
+      state { "SC" }
+      zip_code { "29209" }
+    end
+
+    trait "RO31" do
+      address { "9700 Page Ave." }
+      city { "ST. Louis" }
+      classification { "Regional Benefit Office"}
+      facility_id { "vba_331" }
+      facility_type { "va_benefits_facility" }
+      name { "St. Louis Regional Benefit Office" }
+      state { "MO" }
+      zip_code { "63132" }
+    end
+
+    trait "RO43" do
+      address { "1301 Clay Street North Tower, Rm. 1400" }
+      city { "Oakland" }
+      classification { "Regional Benefit Office"}
+      facility_id { "vba_343" }
+      facility_type { "va_benefits_facility" }
+      name { "Oakland Regional Benefit Office" }
+      state { "CA" }
+      zip_code { "94612" }
+    end
+
+    trait "RO45" do
+      address { "3333 North Central Avenue" }
+      city { "Phoenix" }
+      classification { "Regional Benefit Office"}
+      facility_id { "vba_345" }
+      facility_type { "va_benefits_facility" }
+      name { "Phoenix Regional Benefit Office" }
+      state { "AZ" }
+      zip_code { "85012" }
+    end
   end
 end

--- a/spec/factories/available_hearing_locations.rb
+++ b/spec/factories/available_hearing_locations.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     trait "RO17" do
       address { "9500 Bay Pines Blvd." }
       city { "St. Petersburg" }
-      classification { "Regional Benefit Office"}
+      classification { "Regional Benefit Office" }
       facility_id { "vba_317" }
       facility_type { "va_benefits_facility" }
       name { "St. Petersburg Regional Benefit Office" }
@@ -21,7 +21,7 @@ FactoryBot.define do
     trait "RO19" do
       address { "6437 Garners Ferry Rd" }
       city { "Columbia" }
-      classification { "Regional Benefit Office"}
+      classification { "Regional Benefit Office" }
       facility_id { "vba_319" }
       facility_type { "va_benefits_facility" }
       name { "Columbia Regional Benefit Office" }
@@ -32,7 +32,7 @@ FactoryBot.define do
     trait "RO31" do
       address { "9700 Page Ave." }
       city { "ST. Louis" }
-      classification { "Regional Benefit Office"}
+      classification { "Regional Benefit Office" }
       facility_id { "vba_331" }
       facility_type { "va_benefits_facility" }
       name { "St. Louis Regional Benefit Office" }
@@ -43,7 +43,7 @@ FactoryBot.define do
     trait "RO43" do
       address { "1301 Clay Street North Tower, Rm. 1400" }
       city { "Oakland" }
-      classification { "Regional Benefit Office"}
+      classification { "Regional Benefit Office" }
       facility_id { "vba_343" }
       facility_type { "va_benefits_facility" }
       name { "Oakland Regional Benefit Office" }
@@ -54,7 +54,7 @@ FactoryBot.define do
     trait "RO45" do
       address { "3333 North Central Avenue" }
       city { "Phoenix" }
-      classification { "Regional Benefit Office"}
+      classification { "Regional Benefit Office" }
       facility_id { "vba_345" }
       facility_type { "va_benefits_facility" }
       name { "Phoenix Regional Benefit Office" }


### PR DESCRIPTION
Resolves #13581 

### Description

  * Create new VSO for PARALYZED VETERANS OF AMERICA, INC (PVA)
    * Move `WINNIE` to new PVA VSO
  * Consolidate code to create hearings tasks to `create_different_hearings_tasks`
    * Create more hearings tasks, and different kinds of hearings tasks
    * Create more realistic task trees for appeals with hearings
  * Change POA for hearings appeals to PVA
  * Add traits to setup AHLs for specific ROs used in seed script
  * Create AHLs for appeals with hearing tasks manually (not via. the job)
  * Remove `FetchHearingLocationsForVeteransJob.perform_now` call to seed file (this can overwrite the `closest_regional_office` for data that the seed script sets up)

### Screenshots

VSO view for Virtual Hearings:

<img width="1270" alt="Screen Shot 2020-03-05 at 5 02 17 PM" src="https://user-images.githubusercontent.com/1298274/76029801-2ba51080-5f03-11ea-85c2-cc5226e4e60f.png">

