### PR TITLE
Motion to Vacate | Hide option to create VacateMotionMailTask until an appeal is outcoded

### DIFF
--- a/app/controllers/post_decision_motions_controller.rb
+++ b/app/controllers/post_decision_motions_controller.rb
@@ -38,8 +38,4 @@ class PostDecisionMotionsController < ApplicationController
   def motion_params
     params.permit(:disposition, :task_id, :vacate_type, :instructions, :assigned_to_id, vacated_decision_issue_ids: [])
   end
-
-  def post_decision_motion
-    PostDecisionMotion.find(motion_id)
-  end
 end

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -19,7 +19,7 @@ class TaskActionRepository
 
     def mail_assign_to_organization_data(task, _user = nil)
       options = MailTask.subclass_routing_options
-      valid_options = options.reject { |option| option[:value] == "VacateMotionMailTask" unless task.appeal.outcoded? }
+      valid_options = task.appeal.outcoded? ? options : options.reject { |opt| opt[:value] == "VacateMotionMailTask" }
       { options: valid_options }
     end
 

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -17,8 +17,10 @@ class TaskActionRepository
       }
     end
 
-    def mail_assign_to_organization_data(_task, _user = nil)
-      { options: MailTask.subclass_routing_options }
+    def mail_assign_to_organization_data(task, _user = nil)
+      options = MailTask.subclass_routing_options
+      valid_options = options.reject{ |option| option[:value] == "VacateMotionMailTask" unless task.appeal.outcoded? }
+      { options: valid_options }
     end
 
     def cancel_task_data(task, _user = nil)

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -19,7 +19,7 @@ class TaskActionRepository
 
     def mail_assign_to_organization_data(task, _user = nil)
       options = MailTask.subclass_routing_options
-      valid_options = options.reject{ |option| option[:value] == "VacateMotionMailTask" unless task.appeal.outcoded? }
+      valid_options = options.reject { |option| option[:value] == "VacateMotionMailTask" unless task.appeal.outcoded? }
       { options: valid_options }
     end
 

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
   let!(:lit_support_team) { LitigationSupport.singleton }
   let(:receipt_date) { Time.zone.today - 20 }
   let!(:appeal) do
-    create(:appeal, :outcoded, receipt_date: receipt_date)
+    create(:appeal, receipt_date: receipt_date)
   end
   let!(:decision_issues) do
     3.times do |idx|
@@ -20,7 +20,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
       )
     end
   end
-  let!(:root_task) { create(:root_task, appeal: appeal) }
+  let!(:root_task) { create(:root_task, :completed, appeal: appeal) }
   let!(:motions_attorney) { create(:user, full_name: "Motions attorney") }
   let!(:judge) { create(:user, full_name: "Judge the First", css_id: "JUDGE_1") }
   let!(:hyperlink) { "https://va.gov/fake-link-to-file" }
@@ -56,9 +56,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
     after { FeatureToggle.disable!(:review_motion_to_vacate) }
 
     context "When the appeal is not outcoded" do
-      let!(:appeal) do
-        create(:appeal, receipt_date: receipt_date)
-      end
+      let!(:root_task) { create(:root_task, appeal: appeal) }
 
       it "does not show option to create a VacateMotionMailTask" do
         User.authenticate!(user: mail_user)

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -390,7 +390,7 @@ feature "Task queue", :all_dbs do
     end
 
     context "when a VacateMotionMailTask task is routed to Pulac Cerullo" do
-      let!(:root_task) { create(:root_task) }
+      let!(:root_task) { create(:root_task, :completed) }
 
       it "creates two child tasks: one Pulac Cerullo Task, and a child of that task " \
         "assigned to the first user in the Pulac Cerullo org" do


### PR DESCRIPTION
Connects #13614

### Description
This hides the option for a mail user or litigation support user to create a new "VacateMotionMailTask", unless the appeal being acted on is outcoded. Motions to vacate happen post-decision, and the code relies on the appeal having decision issues.

### Testing Plan
1. Check that the option doesn't exist for an appeal that is not outcoded

### User Facing Changes

 - [x] Screenshots of UI changes added to PR & Original Issue
