### PR TITLE
Upgrade connect_vbms: pagination fixes, small security warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa"
-gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "6cc4243fac69e0aa6bc6a55293c165d848d5c06f"
+gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f374da6041b52d73af60d79d60d4013a13d4a72e"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"
 gem "dogstatsd-ruby"
 gem "fast_jsonapi"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 6cc4243fac69e0aa6bc6a55293c165d848d5c06f
-  ref: 6cc4243fac69e0aa6bc6a55293c165d848d5c06f
+  revision: f374da6041b52d73af60d79d60d4013a13d4a72e
+  ref: f374da6041b52d73af60d79d60d4013a13d4a72e
   specs:
     connect_vbms (1.2.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
### Description
Upgrade to latest `connect_vbms` git hash to get these goodies:

https://github.com/department-of-veterans-affairs/connect_vbms/pull/250 - fix pagination bug when VBMS returns fewer documents than reported

https://github.com/department-of-veterans-affairs/connect_vbms/pull/252 - handle VBMS returning no pages at all

https://github.com/department-of-veterans-affairs/connect_vbms/pull/253 - fix small security warning in Rake