### PR TITLE
Reduce default hearing day range size for index_with_hearings

### DIFF
--- a/app/controllers/hearings/hearing_day_controller.rb
+++ b/app/controllers/hearings/hearing_day_controller.rb
@@ -104,7 +104,8 @@ class Hearings::HearingDayController < HearingsApplicationController
 
   def default_range_end_date
     default = Time.zone.today.beginning_of_day
-    default += ((params[:action] == "index") ? 365.days : 182.days)
+    # 2 month range for index_with_hearings, since fetching hearings is *slow*.
+    default += ((params[:action] == "index") ? 365.days : 62.days)
     default
   end
 

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       create(
         :hearing_day,
         request_type: HearingDay::REQUEST_TYPES[:video],
-        scheduled_for: Time.zone.today + 160,
+        scheduled_for: Time.zone.today + 30.days,
         regional_office: "RO39"
       )
     end

--- a/spec/requests/hearing_day_spec.rb
+++ b/spec/requests/hearing_day_spec.rb
@@ -205,9 +205,9 @@ RSpec.describe "Hearing Day", :all_dbs, type: :request do
       RequestStore[:current_user] = user
       Generators::Vacols::Staff.create(sattyid: "111")
       HearingDay.create(
-        [{ request_type: HearingDay::REQUEST_TYPES[:video], scheduled_for: "7-Mar-2019 09:00:00.000-4:00",
+        [{ request_type: HearingDay::REQUEST_TYPES[:video], scheduled_for: "7-Feb-2019 09:00:00.000-4:00",
            room: "1", regional_office: "RO04" },
-         { request_type: HearingDay::REQUEST_TYPES[:video], scheduled_for: "9-Mar-2019 09:00:00.000-4:00",
+         { request_type: HearingDay::REQUEST_TYPES[:video], scheduled_for: "9-Feb-2019 09:00:00.000-4:00",
            room: "3", regional_office: "RO04" }]
       )
     end


### PR DESCRIPTION
Related to https://github.com/department-of-veterans-affairs/caseflow/pull/12608

### Description

The range of hearing days returned by `index_with_hearings` was reduced by half in #12608. I think it's basically an arbitrary number of days, so I'm setting it to roughly 2 months.