### PR TITLE
Change GovDelivery from email address

### DIFF
--- a/app/mailers/virtual_hearing_mailer.rb
+++ b/app/mailers/virtual_hearing_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class VirtualHearingMailer < ActionMailer::Base
-  default from: "solutions@public.govdelivery.com"
+  default from: "BoardofVeteransAppealsHearings@public.govdelivery.com"
   layout "virtual_hearing_mailer"
   helper VirtualHearings::ExternalLinkHelper
   helper VirtualHearings::VeteranNameHelper


### PR DESCRIPTION
Resolves #13093

### Description

New GovDelivery token only allows using it with the corresponding email address. See: https://github.com/department-of-veterans-affairs/caseflow/pull/13638 for a similar change for sending test emails
