### PR TITLE
Add veteran state of residence to assign hearings table - Part 1

### DIFF
--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -76,7 +76,7 @@ class AssignHearingTab
   # in-use by the frontend.
   def self.serialize_columns
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
       Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME,

--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -72,6 +72,18 @@ class AssignHearingTab
     ]
   end
 
+  # Used with the `TaskColumnSerializer` to serialize only the columns that are
+  # in-use by the frontend.
+  def self.serialize_columns
+    [
+      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME,
+      Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME
+    ]
+  end
+
   def power_of_attorney_name_options
     tasks.joins(CachedAppeal.left_join_from_tasks_clause)
       .group(:power_of_attorney_name).count.each_pair.map do |option, count|
@@ -91,11 +103,7 @@ class AssignHearingTab
   def task_includes
     [
       { appeal: [:available_hearing_locations, :claimants] },
-      { attorney_case_reviews: [:attorney] },
-      :assigned_by,
-      :assigned_to,
-      :children,
-      :parent
+      :assigned_by
     ]
   end
 end

--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -165,6 +165,27 @@ class WorkQueue::TaskColumnSerializer
     }
   end
 
+  # Used by /hearings/schedule/assign. Not present in the full `task_serializer`.
+  attribute :power_of_attorney_name do |object, params|
+    columns = [Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME]
+
+    if serialize_attribute?(params, columns)
+      # The `power_of_attorney_name` field doesn't exist on the actual model. This
+      # field needs to be added in a select statement and represents the field from
+      # the `cached_appeal_attributes` table.
+      object&.[](:power_of_attorney_name)
+    end
+  end
+
+  # Used by /hearings/schedule/assign. Not present in the full `task_serializer`.
+  attribute :suggested_hearing_location do |object, params|
+    columns = [Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME]
+
+    if serialize_attribute?(params, columns)
+      object.appeal.suggested_hearing_location&.to_hash
+    end
+  end
+
   # UNUSED
 
   attribute :assignee_name do

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -103,10 +103,6 @@ class WorkQueue::TaskSerializer
     object.appeal.available_hearing_locations
   end
 
-  attribute :suggested_hearing_location do |object|
-    object.appeal.suggested_hearing_location&.to_hash
-  end
-
   attribute :previous_task do |object|
     {
       assigned_at: object.previous_task.try(:assigned_at)

--- a/client/app/components/DocketTypeBadge.jsx
+++ b/client/app/components/DocketTypeBadge.jsx
@@ -31,10 +31,10 @@ const DocketTypeBadge = ({ name, number }) => {
 
 DocketTypeBadge.propTypes = {
   name: PropTypes.string,
-  number: PropTypes.oneOfType(
+  number: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string
-  )
+  ])
 };
 
 export default DocketTypeBadge;

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -135,8 +135,8 @@ Pagination.propTypes = {
   pageSize: PropTypes.number.isRequired,
   currentPage: PropTypes.number.isRequired,
   currentCases: PropTypes.number.isRequired,
-  totalPages: PropTypes.number.isRequired,
-  totalCases: PropTypes.number.isRequired,
+  totalPages: PropTypes.number,
+  totalCases: PropTypes.number,
   updatePage: PropTypes.func.isRequired
 };
 

--- a/client/app/components/Pagination.jsx
+++ b/client/app/components/Pagination.jsx
@@ -52,7 +52,7 @@ class Pagination extends React.PureComponent {
     // Otherwise, the beginning of the range is the previous amount of cases + 1
     const beginningCaseNumber = totalCases === 0 ? 0 : ((currentPage * pageSize) - pageSize + 1);
     // If there are no pages, there is no data, so the range should be 0-0.
-    // Otherwise, the end of the range is the previous amount of cases + 
+    // Otherwise, the end of the range is the previous amount of cases +
     // the amount of data in the current page.
     const endingCaseNumber = totalCases === 0 ? 0 : (beginningCaseNumber + currentCases - 1);
     // Create the range

--- a/client/app/hearings/components/assignHearings/AssignHearingsFields.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsFields.jsx
@@ -64,7 +64,10 @@ export const HearingDocketTag = ({ hearing }) => {
 HearingDocketTag.propTypes = {
   hearing: PropTypes.shape({
     docketName: PropTypes.string,
-    docketNumber: PropTypes.number
+    docketNumber: PropTypes.oneOfType([
+      PropTypes.number,
+      PropTypes.string
+    ])
   })
 };
 

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -19,7 +19,6 @@ import { renderAppealType } from '../../../queue/utils';
 import { tableNumberStyling } from './styles';
 import ApiUtil from '../../../util/ApiUtil';
 import LinkToAppeal from './LinkToAppeal';
-import PowerOfAttorneyDetail from '../../../queue/PowerOfAttorneyDetail';
 import QUEUE_CONFIG from '../../../../constants/QUEUE_CONFIG';
 import QueueTable from '../../../queue/QueueTable';
 
@@ -86,7 +85,7 @@ export default class AssignHearingsTable extends React.PureComponent {
 
     const { colsFromApi } = this.state;
 
-    if (_.isNil(selectedHearingDay)) {
+    if (_.isNil(selectedHearingDay) || _.isNil(colsFromApi)) {
       return [];
     }
 
@@ -159,22 +158,12 @@ export default class AssignHearingsTable extends React.PureComponent {
       {
         name: 'powerOfAttorneyName',
         header: 'Power of Attorney (POA)',
+        valueName: 'powerOfAttorneyName',
         columnName: 'Power of Attorney',
         align: 'left',
-        valueFunction: (row) => (
-          <PowerOfAttorneyDetail
-            appealId={row.externalAppealId}
-            displayNameOnly
-          />
-        ),
         label: 'Filter by Power of Attorney',
         enableFilter: true,
         anyFiltersAreSet: true,
-        filterValueTransform: (_value, row) => {
-          const { powerOfAttorneyNamesForAppeals } = this.props;
-
-          return powerOfAttorneyNamesForAppeals[row.externalAppealId];
-        },
         filterOptions: colsFromApi && colsFromApi.find((col) => col.name === 'powerOfAttorneyName').filter_options
       }
     ];
@@ -260,8 +249,6 @@ export default class AssignHearingsTable extends React.PureComponent {
 AssignHearingsTable.propTypes = {
   columns: PropTypes.array,
   clicked: PropTypes.bool,
-  // Appeal ID => Attorney Name Array
-  powerOfAttorneyNamesForAppeals: PropTypes.objectOf(PropTypes.string),
   selectedHearingDay: PropTypes.shape({
     scheduledFor: PropTypes.string
   }),

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -9,11 +9,12 @@ import {
   SuggestedHearingLocation
 } from './AssignHearingsFields';
 import { NoVeteransToAssignMessage } from './Messages';
+import { VeteranStateDetail } from '../../../queue/VeteranDetail';
+import { docketCutoffLineStyle } from './AssignHearingsDocketLine';
 import {
   encodeQueryParams,
   getQueryParams
 } from '../../../util/QueryParamsUtil';
-import { docketCutoffLineStyle } from './AssignHearingsDocketLine';
 import { renderAppealType } from '../../../queue/utils';
 import { tableNumberStyling } from './styles';
 import ApiUtil from '../../../util/ApiUtil';
@@ -146,13 +147,22 @@ export default class AssignHearingsTable extends React.PureComponent {
         filterOptions: colsFromApi && colsFromApi.find((col) => col.name === 'suggestedLocation').filter_options
       },
       {
+        name: 'veteranState',
+        header: 'Veteran State of Residence',
+        align: 'left',
+        valueFunction: (row) => (
+          <VeteranStateDetail
+            appealId={row.externalAppealId}
+          />
+        )
+      },
+      {
         name: 'powerOfAttorneyName',
         header: 'Power of Attorney (POA)',
         columnName: 'Power of Attorney',
         align: 'left',
         valueFunction: (row) => (
           <PowerOfAttorneyDetail
-            key={`poa-${row.externalAppealId}-detail`}
             appealId={row.externalAppealId}
             displayNameOnly
           />

--- a/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
@@ -1,4 +1,3 @@
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
@@ -25,7 +24,7 @@ const getCurrentTabIndex = () => {
   return 0;
 };
 
-export class AssignHearingsTabs extends React.PureComponent {
+export default class AssignHearingsTabs extends React.PureComponent {
   onTabChange = (tabNumber) => {
     this.setState({ clickedTab: tabNumber });
   }
@@ -102,23 +101,9 @@ AssignHearingsTabs.propTypes = {
     totalSlots: PropTypes.number
   }),
   selectedRegionalOffice: PropTypes.string,
-  room: PropTypes.string,
-  // Appeal ID => Attorney Name Array
-  powerOfAttorneyNamesForAppeals: PropTypes.objectOf(PropTypes.string)
+  room: PropTypes.string
 };
 
 AssignHearingsTabs.defaultProps = {
-  defaultTabIndex: getCurrentTabIndex(),
-  powerOfAttorneyNamesForAppeals: {}
+  defaultTabIndex: getCurrentTabIndex()
 };
-
-const mapStateToProps = (state) => {
-  const powerOfAttorneyNamesForAppeals = _.mapValues(
-    _.get(state, 'queue.appealDetails', {}),
-    (val) => _.get(val, 'powerOfAttorney.representative_name')
-  );
-
-  return { powerOfAttorneyNamesForAppeals };
-};
-
-export default connect(mapStateToProps)(AssignHearingsTabs);

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -119,7 +119,7 @@ export const CaseDetailsView = (props) => {
           {(appeal.hearings.length || appeal.completedHearingOnPreviousAppeal) && (
             <CaseHearingsDetail title="Hearings" appeal={appeal} />
           )}
-          <VeteranDetail title="About the Veteran" appeal={appeal} />
+          <VeteranDetail title="About the Veteran" appealId={appealId} />
           {!_.isNull(appeal.appellantFullName) && appeal.appellantIsNotVeteran && (
             <AppellantDetail title="About the Appellant" appeal={appeal} />
           )}

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -33,7 +33,6 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
     }
 
     return <span>{COPY.CASE_DETAILS_NO_POA}</span>;
-
   }
 
   renderLoadingOrError() {
@@ -104,20 +103,16 @@ PowerOfAttorneyDetail.defaultProps = {
 const mapStateToProps = (state, ownProps) => {
   const loadingPowerOfAttorney = _.get(state.queue.loadingAppealDetail[ownProps.appealId], 'powerOfAttorney');
 
-  if (_.isUndefined(loadingPowerOfAttorney) || loadingPowerOfAttorney.loading) {
+  if (loadingPowerOfAttorney?.loading) {
     return { loading: true };
   }
 
   const appeal = appealWithDetailSelector(state, { appealId: ownProps.appealId });
 
-  if (!appeal) {
-    return { loading: true };
-  }
-
   return {
-    powerOfAttorney: appeal.powerOfAttorney,
-    loading: null,
-    error: loadingPowerOfAttorney.error
+    powerOfAttorney: appeal?.powerOfAttorney,
+    loading: !appeal,
+    error: loadingPowerOfAttorney?.error
   };
 };
 

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -25,16 +25,6 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
     return powerOfAttorney.representative_type && powerOfAttorney.representative_name;
   }
 
-  renderNameOnly() {
-    if (this.hasPowerOfAttorneyDetails) {
-      const { powerOfAttorney } = this.props;
-
-      return <span>{powerOfAttorney.representative_name}</span>;
-    }
-
-    return <span>{COPY.CASE_DETAILS_NO_POA}</span>;
-  }
-
   renderLoadingOrError() {
     const { loading, error } = this.props;
 
@@ -50,14 +40,10 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
   }
 
   render = () => {
-    const { displayNameOnly, powerOfAttorney } = this.props;
+    const { powerOfAttorney } = this.props;
 
     if (!powerOfAttorney) {
       return this.renderLoadingOrError();
-    }
-
-    if (displayNameOnly) {
-      return this.renderNameOnly();
     }
 
     if (!this.hasPowerOfAttorneyDetails()) {
@@ -87,17 +73,12 @@ PowerOfAttorneyDetail.propTypes = {
   error: PropTypes.object,
   getAppealValue: PropTypes.func,
   loading: PropTypes.bool,
-  displayNameOnly: PropTypes.bool,
   powerOfAttorney: PropTypes.shape({
     representative_type: PropTypes.string,
     representative_name: PropTypes.string,
     representative_address: PropTypes.object,
     representative_email_address: PropTypes.string
   })
-};
-
-PowerOfAttorneyDetail.defaultProps = {
-  displayNameOnly: false
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -1,6 +1,7 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { css } from 'glamor';
+import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
@@ -10,7 +11,7 @@ import { boldText } from './constants';
 import { getAppealValue } from './QueueActions';
 import Address from './components/Address';
 import BareList from '../components/BareList';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const detailListStyling = css({
   paddingLeft: 0,
@@ -18,16 +19,16 @@ const detailListStyling = css({
   marginBottom: '3rem'
 });
 
-const VeteranState = ({ veteran: { address: { state }}}) => {
+const VeteranState = ({ veteran: { address: { state } } }) => {
   return <>{state}</>;
-}
+};
 
 class VeteranDetail extends React.PureComponent {
   getDetails = () => {
     const {
       veteran: {
         address,
-        full_name,
+        full_name: fullName,
         gender,
         date_of_birth: dob,
         date_of_death: dod,
@@ -37,7 +38,7 @@ class VeteranDetail extends React.PureComponent {
 
     const details = [{
       label: 'Name',
-      value: full_name
+      value: fullName
     }];
 
     const genderValue = gender === 'F' ? COPY.CASE_DETAILS_GENDER_FIELD_VALUE_FEMALE :
@@ -79,7 +80,7 @@ class VeteranDetail extends React.PureComponent {
     }
 
     const getDetailField = ({ label, value }) => () => (
-      <><span {...boldText}>{label}:</span> {value}</>
+      <><span {...boldText}>{label}:</span>''{value}</>
     );
 
     return <BareList ListElementComponent="ul" items={details.map(getDetailField)} />;
@@ -95,9 +96,22 @@ class VeteranDetail extends React.PureComponent {
   };
 }
 
+VeteranState.propTypes = VeteranDetail.propTypes = {
+  veteran: PropTypes.shape({
+    address: PropTypes.shape({
+      state: PropTypes.string
+    }),
+    date_of_birth: PropTypes.string,
+    date_of_death: PropTypes.string,
+    email_address: PropTypes.string,
+    full_name: PropTypes.string,
+    gender: PropTypes.string
+  })
+};
+
 const mapStateToProps = (state, ownProps) => {
   const loadingVeteranInfo = _.get(state.queue.loadingAppealDetail[ownProps.appealId], 'veteranInfo');
-  
+
   if (loadingVeteranInfo?.loading) {
     return { loading: true };
   }
@@ -125,6 +139,14 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 const wrapVeteranDetailComponent = _.flow(
   (WrappedComponent) => (
     class extends React.PureComponent {
+      static propTypes = {
+        appealId: PropTypes.string,
+        error: PropTypes.object,
+        getAppealValue: PropTypes.func,
+        loading: PropTypes.bool,
+        veteranInfo: PropTypes.object
+      }
+
       componentDidMount = () => {
         if (!this.props.veteranInfo) {
           this.props.getAppealValue(this.props.appealId, 'veteran', 'veteranInfo');

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -80,7 +80,7 @@ class VeteranDetail extends React.PureComponent {
     }
 
     const getDetailField = ({ label, value }) => () => (
-      <><span {...boldText}>{label}:</span>''{value}</>
+      <><span {...boldText}>{label}:</span> {value}</>
     );
 
     return <BareList ListElementComponent="ul" items={details.map(getDetailField)} />;

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -80,7 +80,7 @@ class VeteranDetail extends React.PureComponent {
     }
 
     const getDetailField = ({ label, value }) => () => (
-      <><span {...boldText}>{label}:</span> {value}</>
+      <><span {...boldText}>{label}:</span>{' '}{value}</>
     );
 
     return <BareList ListElementComponent="ul" items={details.map(getDetailField)} />;

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -113,6 +113,10 @@ const taskAttributesFromRawTask = (task) => {
     hideFromTaskSnapshot: task.attributes.hide_from_task_snapshot,
     hideFromCaseTimeline: task.attributes.hide_from_case_timeline,
     availableHearingLocations: task.attributes.available_hearing_locations,
+    // `powerOfAttorneyName` and `suggestedHearingLocation` are only present for
+    // /hearings/scheduled/assign page, and are not returned from the API when
+    // requesting the full task.
+    powerOfAttorneyName: task.attributes.power_of_attorney_name,
     suggestedHearingLocation: task.attributes.suggested_hearing_location
   };
 };


### PR DESCRIPTION
Resolves #12648

Part 2 (#13737) contains an optimization to remove the usage of `PowerOfAttorneyDetail`. This will make it so the number of requests made from the table remains constant.

### Description

  - Add separate component to display only veteran state
  - Add veteran state column to assign hearings table
  - Refactor: `VeteranDetail` to use `appealId` instead of `appeal`
  - Refactor: `PowerOfAttorneyDetail` to use safe navigation
  - Refactor: Adding prop types

### Acceptance Criteria

- [x] The name of the US state or territory in which the Veteran currently lives is displayed in the Schedule Veterans table under the column heading 'Veteran State of Residence'

### Screenshots

<img width="1345" alt="Screen Shot 2020-03-18 at 2 16 03 PM" src="https://user-images.githubusercontent.com/1298274/76993300-0234ad80-6923-11ea-9850-2a17e1170a19.png">
