### PR TITLE
Prevent multiple vacaturs from multiple submit clicks

### DIFF
--- a/client/app/queue/mtv/AddressMotionToVacateView.jsx
+++ b/client/app/queue/mtv/AddressMotionToVacateView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useSelector, useDispatch } from 'react-redux';
 import { useRouteMatch, useParams, useHistory } from 'react-router-dom';
@@ -14,6 +14,7 @@ export const AddressMotionToVacateView = () => {
   const match = useRouteMatch();
   const history = useHistory();
   const dispatch = useDispatch();
+  const [submitting, setSubmitting] = useState(false);
 
   const task = useSelector((state) => taskById(state, { taskId }));
   const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
@@ -27,6 +28,7 @@ export const AddressMotionToVacateView = () => {
   }));
 
   const handleSubmit = (result) => {
+    setSubmitting(true);
     dispatch(
       submitMTVJudgeDecision(result, {
         history,
@@ -43,6 +45,7 @@ export const AddressMotionToVacateView = () => {
       appeal={appeal}
       onSubmit={handleSubmit}
       returnToLitSupportLink={`${match.url}/${JUDGE_RETURN_TO_LIT_SUPPORT.value}`}
+      submitting={submitting}
     />
   );
 };


### PR DESCRIPTION
Connects #13617 

### Description
This PR fixes the bug where quickly clicking Submit multiple times on the MTV grant flow would create multiple vacaturs.

### Testing Plan
I couldn't get Capybara to rapidly click Submit -- neither `double_click` nor consecutive calls to `click` seemed to work. My original repro was manually clicking during a `binding.pry` (I was able to squeeze in 3-4 submissions) and therefore my testing plan was to confirm that this no longer works.

### User Facing Changes

Here is a screenshot of the new frontend code disabling the button right after a click, before the flow proceeds.
<img width="527" alt="Screen Shot 2020-03-13 at 16 27 18" src="https://user-images.githubusercontent.com/282869/76657362-0b4f0480-6548-11ea-8538-e2a759d33d6e.png">