### PR TITLE
Update Schedule Hearing Task Pagination Permissions

### DIFF
--- a/app/controllers/hearings/schedule_hearing_tasks_columns_controller.rb
+++ b/app/controllers/hearings/schedule_hearing_tasks_columns_controller.rb
@@ -6,7 +6,7 @@
 class Hearings::ScheduleHearingTasksColumnsController < ApplicationController
   include HearingsConcerns::VerifyAccess
 
-  before_action :verify_build_hearing_schedule_access
+  before_action :verify_edit_hearing_schedule_access
 
   def index
     tab = AssignHearingTab.new(

--- a/app/controllers/hearings/schedule_hearing_tasks_controller.rb
+++ b/app/controllers/hearings/schedule_hearing_tasks_controller.rb
@@ -6,7 +6,7 @@
 class Hearings::ScheduleHearingTasksController < ApplicationController
   include HearingsConcerns::VerifyAccess
 
-  before_action :verify_build_hearing_schedule_access
+  before_action :verify_edit_hearing_schedule_access
 
   def index
     task_pager = Hearings::ScheduleHearingTaskPager.new(


### PR DESCRIPTION
Resolves this sentry alert: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/8176/?referrer=webhooks_plugin

```
Error

Forbidden
```

On an XHR request to `/hearings/schedule/assign?tab=legacyAssignHearingsTab&regional_office_key=C&page=1`

### Description

Updates permissions on the controller route
