### PR TITLE
Fix constraint on non-duplicate org assignments in db seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1117,13 +1117,14 @@ class SeedDB
 
     create_colocated_legacy_tasks(attorney)
 
-    FactoryBot.create_list(
-      :ama_task,
-      5,
-      assigned_by: judge,
-      assigned_to: Translation.singleton,
-      parent: FactoryBot.create(:root_task)
-    )
+    5.times do
+      FactoryBot.create(
+        :ama_task,
+        assigned_by: judge,
+        assigned_to: Translation.singleton,
+        parent: FactoryBot.create(:root_task)
+      )
+    end
 
     FactoryBot.create_list(
       :ama_judge_task,


### PR DESCRIPTION
The `rake db:seeds` task was failing because we were not creating a unique root task + appeal for each task assigned to the same organization.