### PR TITLE
Fix JudgeAssignTasks creation in separate appeals

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1126,13 +1126,13 @@ class SeedDB
       )
     end
 
-    FactoryBot.create_list(
-      :ama_judge_task,
-      3,
-      :in_progress,
-      assigned_to: User.find_by(css_id: "BVAEBECKER"),
-      appeal: FactoryBot.create(:appeal)
-    )
+    3.times do
+      FactoryBot.create(
+        :ama_judge_task,
+        :in_progress,
+        assigned_to: User.find_by(css_id: "BVAEBECKER"),
+        appeal: FactoryBot.create(:appeal)
+      )
 
     FactoryBot.create_list(
       :appeal,


### PR DESCRIPTION
I'm pretty sure the intent is to have one `ama_judge_task` (aka `JudgeAssignTask`) in separate appeals.

Related to #13717.

I overlooked reviewing the seeds.rb file as part of #13130.