### PR TITLE
[PART 1] Break mostRecentHeldHearingForAppeal out into utils to reuse

### DIFF
--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -54,7 +54,7 @@ class QueueTab
   # rubocop:disable Metrics/AbcSize
   def self.attorney_column_names
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -24,7 +24,7 @@ class AssignedTasksTab < QueueTab
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
 
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -24,7 +24,7 @@ class CompletedTasksTab < QueueTab
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
 
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -24,7 +24,7 @@ class OnHoldTasksTab < QueueTab
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
 
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/queue_tabs/organization_assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/organization_assigned_tasks_tab.rb
@@ -22,7 +22,7 @@ class OrganizationAssignedTasksTab < QueueTab
   # rubocop:disable Metrics/AbcSize
   def column_names
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/queue_tabs/organization_completed_tasks_tab.rb
+++ b/app/models/queue_tabs/organization_completed_tasks_tab.rb
@@ -22,7 +22,7 @@ class OrganizationCompletedTasksTab < QueueTab
   # rubocop:disable Metrics/AbcSize
   def column_names
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/queue_tabs/organization_on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/organization_on_hold_tasks_tab.rb
@@ -22,7 +22,7 @@ class OrganizationOnHoldTasksTab < QueueTab
   # rubocop:disable Metrics/AbcSize
   def column_names
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/queue_tabs/organization_unassigned_tasks_tab.rb
+++ b/app/models/queue_tabs/organization_unassigned_tasks_tab.rb
@@ -24,7 +24,7 @@ class OrganizationUnassignedTasksTab < QueueTab
   # rubocop:disable Metrics/AbcSize
   def column_names
     [
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
       Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
       show_regional_office_column ? Constants.QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name : nil,

--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -26,7 +26,7 @@ class WorkQueue::TaskColumnSerializer
   attribute :external_appeal_id do |object, params|
     columns = [
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
-      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name
     ]
 

--- a/client/app/queue/AssignedCasesPage.jsx
+++ b/client/app/queue/AssignedCasesPage.jsx
@@ -76,7 +76,7 @@ class AssignedCasesPage extends React.Component {
         onTaskAssignment={(params) => props.reassignTasksToUser(params)}
         selectedTasks={selectedTasks} />
       <TaskTable
-        includeHearingBadge
+        includeBadges
         includeSelect
         includeDetailsLink
         includeType

--- a/client/app/queue/CaseListTable.jsx
+++ b/client/app/queue/CaseListTable.jsx
@@ -13,9 +13,8 @@ import { COLORS } from '../constants/AppConstants';
 import { clearCaseListSearch } from './CaseList/CaseListActions';
 
 import { DateString } from '../util/DateUtil';
-import { renderAppealType } from './utils';
-import COPY from '../../COPY.json';
-import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES.json';
+import { renderAppealType, mostRecentHeldHearingForAppeal } from './utils';
+import COPY from '../../COPY';
 
 const currentAssigneeStyling = css({
   color: COLORS.GREEN
@@ -79,20 +78,13 @@ class CaseListTable extends React.PureComponent {
     ];
 
     const doAnyAppealsHaveHeldHearings = Boolean(
-      _.find(this.props.appeals, (appeal) => {
-        return appeal.hearings.
-          filter((hearing) => hearing.disposition === HEARING_DISPOSITION_TYPES.held).
-          length;
-      }));
+      _.find(this.props.appeals, (appeal) => mostRecentHeldHearingForAppeal(appeal))
+    );
 
     if (doAnyAppealsHaveHeldHearings) {
       const hearingColumn = {
         valueFunction: (appeal) => {
-          const hearings = appeal.hearings.
-            filter((hearing) => hearing.disposition === HEARING_DISPOSITION_TYPES.held).
-            sort((h1, h2) => h1.date < h2.date ? 1 : -1);
-
-          const mostRecentHearing = hearings[0];
+          const mostRecentHearing = mostRecentHeldHearingForAppeal(appeal);
 
           return mostRecentHearing ? <HearingBadge hearing={mostRecentHearing} /> : null;
         }
@@ -121,7 +113,10 @@ class CaseListTable extends React.PureComponent {
 
 CaseListTable.propTypes = {
   appeals: PropTypes.arrayOf(PropTypes.object).isRequired,
-  styling: PropTypes.object
+  styling: PropTypes.object,
+  clearCaseListSearch: PropTypes.func,
+  userRole: PropTypes.string,
+  userCssId: PropTypes.string
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -8,6 +8,7 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 
 import { COLORS } from '../constants/AppConstants';
 import CopyTextButton from '../components/CopyTextButton';
+import BadgeArea from './components/BadgeArea';
 import { toggleVeteranCaseList } from './uiReducer/uiActions';
 
 const containingDivStyling = css({
@@ -62,6 +63,7 @@ class CaseTitle extends React.PureComponent {
           { veteranCaseListIsVisible ? 'Hide' : 'View' } all cases
         </Link>
       </span>
+      <BadgeArea appeal={appeal} />
     </CaseTitleScaffolding>;
   }
 }

--- a/client/app/queue/JudgeDecisionReviewTaskListView.jsx
+++ b/client/app/queue/JudgeDecisionReviewTaskListView.jsx
@@ -20,7 +20,7 @@ import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
 import { judgeDecisionReviewTasksSelector } from './selectors';
 
 import { fullWidth } from './constants';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 
 const containerStyles = css({
   position: 'relative'
@@ -54,7 +54,7 @@ class JudgeDecisionReviewTaskListView extends React.PureComponent {
       </p>;
     } else {
       tableContent = <TaskTable
-        includeHearingBadge
+        includeBadges
         includeTask
         includeDetailsLink
         includeDocumentId
@@ -81,7 +81,22 @@ class JudgeDecisionReviewTaskListView extends React.PureComponent {
 }
 
 JudgeDecisionReviewTaskListView.propTypes = {
-  tasks: PropTypes.array.isRequired
+  tasks: PropTypes.array.isRequired,
+  resetSaveState: PropTypes.func,
+  resetSuccessMessages: PropTypes.func,
+  resetErrorMessages: PropTypes.func,
+  clearCaseSelectSearch: PropTypes.func,
+  organizations: PropTypes.array,
+  messages: PropTypes.shape({
+    error: PropTypes.shape({
+      title: PropTypes.string,
+      detail: PropTypes.string
+    }),
+    success: PropTypes.shape({
+      title: PropTypes.string,
+      detail: PropTypes.string
+    })
+  })
 };
 
 const mapStateToProps = (state) => {

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 
 import BulkAssignButton from './components/BulkAssignButton';
 import TabWindow from '../components/TabWindow';
-import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, issueCountColumn,
+import { docketNumberColumn, badgesColumn, detailsColumn, taskColumn, regionalOfficeColumn, issueCountColumn,
   typeColumn, assignedToColumn, daysWaitingColumn, daysOnHoldColumn, readerLinkColumn, completedToNameColumn } from
   './components/TaskTableColumns';
 
@@ -64,7 +64,7 @@ class OrganizationQueue extends React.PureComponent {
 
   createColumnObject = (column, config, tasks) => {
     const functionForColumn = {
-      hearingBadgeColumn: hearingBadgeColumn(tasks),
+      badgesColumn: badgesColumn(tasks),
       detailsColumn: detailsColumn(tasks, false, config.userRole),
       taskColumn: taskColumn(tasks, this.filterValuesForColumn(column, config)),
       regionalOfficeColumn: regionalOfficeColumn(tasks, this.filterValuesForColumn(column, config)),

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -7,7 +7,7 @@ import QueueTable from './QueueTable';
 import TabWindow from '../components/TabWindow';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
 import { completedToNameColumn, daysOnHoldColumn, daysWaitingColumn, detailsColumn, docketNumberColumn,
-  hearingBadgeColumn, issueCountColumn, readerLinkColumn, readerLinkColumnWithNewDocsIcon, regionalOfficeColumn,
+  badgesColumn, issueCountColumn, readerLinkColumn, readerLinkColumnWithNewDocsIcon, regionalOfficeColumn,
   taskColumn, taskCompletedDateColumn, typeColumn } from './components/TaskTableColumns';
 
 import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
@@ -43,7 +43,7 @@ class QueueTableBuilder extends React.PureComponent {
       [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(requireDasRecord, true),
-      [QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name]: hearingBadgeColumn(tasks),
+      [QUEUE_CONFIG.COLUMNS.BADGES.name]: badgesColumn(tasks),
       [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, false),

--- a/client/app/queue/UnassignedCasesPage.jsx
+++ b/client/app/queue/UnassignedCasesPage.jsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import PropTypes from 'prop-types';
+
 import TaskTable from './components/TaskTable';
 import {
   initialAssignTasksToUser
 } from './QueueActions';
 import AssignWidget from './components/AssignWidget';
-import { JUDGE_QUEUE_UNASSIGNED_CASES_PAGE_TITLE } from '../../COPY.json';
+import { JUDGE_QUEUE_UNASSIGNED_CASES_PAGE_TITLE } from '../../COPY';
 import {
   resetErrorMessages,
   resetSuccessMessages
@@ -51,7 +53,7 @@ class UnassignedCasesPage extends React.PureComponent {
           }
           {!this.props.distributionCompleteCasesLoading &&
             <TaskTable
-              includeHearingBadge
+              includeBadges
               includeSelect
               includeDetailsLink
               includeType
@@ -93,6 +95,24 @@ const mapStateToProps = (state, ownProps) => {
     success,
     error
   };
+};
+
+UnassignedCasesPage.propTypes = {
+  tasks: PropTypes.array,
+  userId: PropTypes.number,
+  selectedTasks: PropTypes.array,
+  distributionCompleteCasesLoading: PropTypes.bool,
+  initialAssignTasksToUser: PropTypes.func,
+  resetSuccessMessages: PropTypes.func,
+  resetErrorMessages: PropTypes.func,
+  error: PropTypes.shape({
+    title: PropTypes.string,
+    detail: PropTypes.string
+  }),
+  success: PropTypes.shape({
+    title: PropTypes.string,
+    detail: PropTypes.string
+  })
 };
 
 const mapDispatchToProps = (dispatch) =>

--- a/client/app/queue/components/BadgeArea.jsx
+++ b/client/app/queue/components/BadgeArea.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import { css } from 'glamor';
+import * as React from 'react';
+
+import HearingBadge from './HearingBadge';
+import { mostRecentHeldHearingForAppeal } from '../utils';
+
+const badgesStyling = css({
+  display: 'inline-block'
+});
+
+class BadgeArea extends React.PureComponent {
+  render = () => {
+    return <div {...badgesStyling}>
+      {this.props.appeal ?
+        <HearingBadge hearing={mostRecentHeldHearingForAppeal(this.props.appeal)} /> :
+        <HearingBadge task={this.props.task} />}
+    </div>;
+  }
+}
+
+BadgeArea.propTypes = {
+  appeal: PropTypes.object,
+  task: PropTypes.object
+};
+
+export default BadgeArea;

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 
 import QueueTable from '../QueueTable';
 import Checkbox from '../../components/Checkbox';
-import { docketNumberColumn, hearingBadgeColumn, detailsColumn, taskColumn, regionalOfficeColumn, daysWaitingColumn,
+import { docketNumberColumn, badgesColumn, detailsColumn, taskColumn, regionalOfficeColumn, daysWaitingColumn,
   issueCountColumn, typeColumn, assignedToColumn, readerLinkColumn, daysOnHoldColumn, completedToNameColumn,
   taskCompletedDateColumn } from
   './TaskTableColumns';
@@ -44,8 +44,8 @@ export class TaskTableUnconnected extends React.PureComponent {
 
   collapseColumnIfNoDASRecord = (task) => this.taskHasDASRecord(task) ? 1 : 0
 
-  caseHearingColumn = () => {
-    return this.props.includeHearingBadge ? hearingBadgeColumn() : null;
+  caseBadgesColumn = () => {
+    return this.props.includeBadges ? badgesColumn() : null;
   }
 
   caseSelectColumn = () => {
@@ -163,7 +163,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   getQueueColumns = () =>
     _.orderBy((this.props.customColumns || []).concat(
       _.compact([
-        this.caseHearingColumn(),
+        this.caseBadgesColumn(),
         this.caseSelectColumn(),
         this.caseDetailsColumn(),
         this.caseTaskColumn(),
@@ -210,7 +210,7 @@ TaskTableUnconnected.propTypes = {
   isTaskAssignedToUserSelected: PropTypes.object,
   userId: PropTypes.number,
   requireDasRecord: PropTypes.bool,
-  includeHearingBadge: PropTypes.bool,
+  includeBadges: PropTypes.bool,
   includeSelect: PropTypes.bool,
   setSelectionOfTaskOfUser: PropTypes.func,
   includeDetailsLink: PropTypes.bool,

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -4,7 +4,7 @@ import pluralize from 'pluralize';
 import _ from 'lodash';
 
 import DocketTypeBadge from '../../components/DocketTypeBadge';
-import HearingBadge from './HearingBadge';
+import BadgeArea from './BadgeArea';
 import CaseDetailsLink from '../CaseDetailsLink';
 import ReaderLink from '../ReaderLink';
 import ContinuousProgressBar from '../../components/ContinuousProgressBar';
@@ -57,11 +57,11 @@ export const docketNumberColumn = (tasks, filterOptions, requireDasRecord) => {
   };
 };
 
-export const hearingBadgeColumn = () => {
+export const badgesColumn = () => {
   return {
     header: '',
-    name: QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
-    valueFunction: (task) => <HearingBadge task={task} />
+    name: QUEUE_CONFIG.COLUMNS.BADGES.name,
+    valueFunction: (task) => <BadgeArea task={task} />
   };
 };
 

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -16,6 +16,7 @@ import UNDECIDED_VACOLS_DISPOSITIONS_BY_ID from '../../constants/UNDECIDED_VACOL
 import DECISION_TYPES from '../../constants/APPEAL_DECISION_TYPES';
 import TASK_STATUSES from '../../constants/TASK_STATUSES';
 import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMATION';
+import HEARING_DISPOSITION_TYPES from '../../constants/HEARING_DISPOSITION_TYPES';
 import COPY from '../../COPY';
 import { formatDateStrUtc } from '../util/DateUtil';
 
@@ -37,6 +38,14 @@ export const getUndecidedIssues = (issues) => _.filter(issues, (issue) => {
     return true;
   }
 });
+
+export const mostRecentHeldHearingForAppeal = (appeal) => {
+  const hearings = appeal.hearings.
+    filter((hearing) => hearing.disposition === HEARING_DISPOSITION_TYPES.held).
+    sort((h1, h2) => h1.date < h2.date ? 1 : -1);
+
+  return hearings.length ? hearings[0] : null;
+};
 
 export const prepareMostRecentlyHeldHearingForStore = (appealId, hearing) => {
   return {

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -41,8 +41,8 @@
     "DOCUMENT_COUNT_READER_LINK": {
       "name": "readerLinkColumn"
     },
-    "HEARING_BADGE": {
-      "name": "hearingBadgeColumn"
+    "BADGES": {
+      "name": "badgesColumn"
     },
     "ISSUE_COUNT": {
       "name": "issueCountColumn",

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -128,7 +128,7 @@ describe('ColocatedTaskListView', () => {
                 {
                     "filter_options": [],
                     "filterable": false,
-                    "name": "hearingBadgeColumn"
+                    "name": "badgesColumn"
                 },
                 {
                     "filter_options": [],
@@ -222,7 +222,7 @@ describe('ColocatedTaskListView', () => {
                 {
                     "filter_options": [],
                     "filterable": false,
-                    "name": "hearingBadgeColumn"
+                    "name": "badgesColumn"
                 },
                 {
                     "filter_options": [],
@@ -269,7 +269,7 @@ describe('ColocatedTaskListView', () => {
                 {
                     "filter_options": [],
                     "filterable": false,
-                    "name": "hearingBadgeColumn"
+                    "name": "badgesColumn"
                 },
                 {
                     "filter_options": [],

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -134,6 +134,9 @@ RSpec.feature "Case details", :all_dbs do
           .click_link
 
         expect(page).to have_current_path("/queue/appeals/#{appeal.vacols_id}")
+
+        expect(page).to have_selector(".cf-hearing-badge")
+
         scroll_to("#hearings-section")
         worksheet_link = page.find(
           "a[href='/hearings/worksheet/print?keep_open=true&hearing_ids=#{hearing.external_id}']"


### PR DESCRIPTION
## This change

Stacked PR as it relates to #8213 

[PART 1](https://github.com/department-of-veterans-affairs/caseflow/pull/13720)
[PART 2](https://github.com/department-of-veterans-affairs/caseflow/pull/13721)
[PART 3](https://github.com/department-of-veterans-affairs/caseflow/pull/13722)

[_What is this stacked pr nonsense?_](https://unhashable.com/stacked-pull-requests-keeping-github-diffs-small/)

### Description

Breaks out `mostRecentHeldHearingForAppeal` into utils to be reused down the stack

### Acceptance Criteria
- [ ] Tests pass


## OVERALL CHANGE

Resolves #8213

### Description
Add all badges (currently only a hearing badge) to the case details screen. Also uses this badge area in the task list in prep for showing overtime cases (#13417). Also did some refactoring of finding the most recently held hearing for an appeal. Also proptypes.

Renaming all hearing badge related stuff to generic "badges"
```diff
- Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name
+ Constants.QUEUE_CONFIG.COLUMNS.BADGES.name
```

```diff
- includeHearingBadge
+ includeBadges
```

```diff
- hearingBadgeColumn
+ badgesColumn
```

```diff
- this.caseHearingColumn()
+ this.caseBadgesColumn()
```

### Acceptance Criteria
- [ ] Hearing badge is show in case details

### Testing Plan
1. Log in a BVAAABSHIRE
2. Go to the user's queue
3. Ensure hearing badges still show
4. Click into a case with a hearing badge
5. Ensure the hearing badge is show in the case details title as well

### User Facing Changes

#### Task list (no visible change)
![Screen Shot 2020-03-16 at 3 26 33 PM](https://user-images.githubusercontent.com/45575454/76793171-f3bb8a00-679a-11ea-82aa-992174ccb134.png)

#### Case details no hearing (no visible change)
![Screen Shot 2020-03-16 at 3 26 53 PM](https://user-images.githubusercontent.com/45575454/76793195-ff0eb580-679a-11ea-8676-145acff337a6.png)

#### Case details hearing (CHANGE!)
![Screen Shot 2020-03-16 at 3 24 59 PM](https://user-images.githubusercontent.com/45575454/76793220-1057c200-679b-11ea-9a4a-55dbae906c6d.png)