### PR TITLE
[PART 3] Add badge area in case details to hold all badges

### DIFF
--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -8,6 +8,7 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 
 import { COLORS } from '../constants/AppConstants';
 import CopyTextButton from '../components/CopyTextButton';
+import BadgeArea from './components/BadgeArea';
 import { toggleVeteranCaseList } from './uiReducer/uiActions';
 
 const containingDivStyling = css({
@@ -62,6 +63,7 @@ class CaseTitle extends React.PureComponent {
           { veteranCaseListIsVisible ? 'Hide' : 'View' } all cases
         </Link>
       </span>
+      <BadgeArea appeal={appeal} />
     </CaseTitleScaffolding>;
   }
 }

--- a/client/app/queue/components/BadgeArea.jsx
+++ b/client/app/queue/components/BadgeArea.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import { css } from 'glamor';
+import * as React from 'react';
+
+import HearingBadge from './HearingBadge';
+import { mostRecentHeldHearingForAppeal } from '../utils';
+
+const badgesStyling = css({
+  display: 'inline-block'
+});
+
+class BadgeArea extends React.PureComponent {
+  render = () => {
+    return <div {...badgesStyling}>
+      {this.props.appeal ?
+        <HearingBadge hearing={mostRecentHeldHearingForAppeal(this.props.appeal)} /> :
+        <HearingBadge task={this.props.task} />}
+    </div>;
+  }
+}
+
+BadgeArea.propTypes = {
+  appeal: PropTypes.object,
+  task: PropTypes.object
+};
+
+export default BadgeArea;

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -4,7 +4,7 @@ import pluralize from 'pluralize';
 import _ from 'lodash';
 
 import DocketTypeBadge from '../../components/DocketTypeBadge';
-import HearingBadge from './HearingBadge';
+import BadgeArea from './BadgeArea';
 import CaseDetailsLink from '../CaseDetailsLink';
 import ReaderLink from '../ReaderLink';
 import ContinuousProgressBar from '../../components/ContinuousProgressBar';
@@ -61,7 +61,7 @@ export const badgesColumn = () => {
   return {
     header: '',
     name: QUEUE_CONFIG.COLUMNS.BADGES.name,
-    valueFunction: (task) => <HearingBadge task={task} />
+    valueFunction: (task) => <BadgeArea task={task} />
   };
 };
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -134,6 +134,9 @@ RSpec.feature "Case details", :all_dbs do
           .click_link
 
         expect(page).to have_current_path("/queue/appeals/#{appeal.vacols_id}")
+
+        expect(page).to have_selector(".cf-hearing-badge")
+
         scroll_to("#hearings-section")
         worksheet_link = page.find(
           "a[href='/hearings/worksheet/print?keep_open=true&hearing_ids=#{hearing.external_id}']"


### PR DESCRIPTION
Stacked PR as it relates to #8213 

[PART 1](https://github.com/department-of-veterans-affairs/caseflow/pull/13720)
[PART 2](https://github.com/department-of-veterans-affairs/caseflow/pull/13721)
[PART 3](https://github.com/department-of-veterans-affairs/caseflow/pull/13722)

[_What is this stacked pr nonsense?_](https://unhashable.com/stacked-pull-requests-keeping-github-diffs-small/)

### Description
Adds a hearing badge to the case details title. Also sets up the badge area in task lists for future additions of badges.

![Screen Shot 2020-03-16 at 3 24 59 PM](https://user-images.githubusercontent.com/45575454/76802493-2458ef00-67ae-11ea-9351-78ebba624c56.png)

### Testing Plan
1. Log in a BVAAABSHIRE
2. Go to the user's queue
3. Ensure hearing badges still show
4. Click into a case with a hearing badge
5. Ensure the hearing badge is show in the case details title as well
