### PR TITLE
Fix missing `end` for code block in seed data

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1133,6 +1133,7 @@ class SeedDB
         assigned_to: User.find_by(css_id: "BVAEBECKER"),
         appeal: FactoryBot.create(:appeal)
       )
+    end
 
     FactoryBot.create_list(
       :appeal,


### PR DESCRIPTION
### Description
Fix the missing `end` for the code block. See #13719.

### Acceptance Criteria
- [ ] `make reset` works
