### PR TITLE
Delete dangling Legacy Appeal records nightly

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -68,6 +68,7 @@ detectors:
       - RedistributedCase#legacy_appeal_relevant_tasks
       - LegacyAppeal#cancel_open_caseflow_tasks!
       - MonthlyMetricsReportJob#build_report
+      - NightlySyncsJob#sync_vacols_cases
       - RequestIssue#find_or_create_decision_issue_from_rating_issue
       - RequestIssue#special_issues
       - RequestIssueReporter#as_csv

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -31,12 +31,11 @@ class NightlySyncsJob < CaseflowJob
       # delete pure danglers
       if legacy_appeal.tasks.none?
         legacy_appeal.destroy!
-        next
+      else
+        # if we have tasks and no case_record, then we need to cancel all the tasks,
+        # but we do not delete the dangling LegacyAppeal record.
+        legacy_appeal.tasks.open.each(&:cancelled!)
       end
-
-      # if we have tasks and no case_record, then we need to cancel all the tasks,
-      # but we do not delete the dangling LegacyAppeal record.
-      legacy_appeal.tasks.open.each(&:cancelled!)
     end
     datadog_report_time_segment(segment: "sync_cases_from_vacols", start_time: start_time)
   end

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -10,6 +10,7 @@ class NightlySyncsJob < CaseflowJob
     RequestStore.store[:current_user] = User.system_user
 
     sync_vacols_users
+    sync_vacols_cases
 
     datadog_report_runtime(metric_group_name: "nightly_syncs_job")
   end
@@ -20,5 +21,24 @@ class NightlySyncsJob < CaseflowJob
     user_cache_start = Time.zone.now
     CachedUser.sync_from_vacols
     datadog_report_time_segment(segment: "sync_users_from_vacols", start_time: user_cache_start)
+  end
+
+  def sync_vacols_cases
+    start_time = Time.zone.now
+    reporter = LegacyAppealsWithNoVacolsCase.new
+    reporter.call
+    reporter.buffer.each do |vacols_id|
+      legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_id)
+
+      next if legacy_appeal.case_record.present?
+
+      # delete pure danglers
+      legacy_appeal.destroy! if legacy_appeal.tasks.none?
+
+      # if we have tasks and no case_record, then we need to cancel all the tasks,
+      # but we do not delete the dangling LegacyAppeal record.
+      legacy_appeal.tasks.open(&:cancelled!)
+    end
+    datadog_report_time_segment(segment: "sync_cases_from_vacols", start_time: start_time)
   end
 end

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -33,11 +33,14 @@ class NightlySyncsJob < CaseflowJob
       next if legacy_appeal.case_record.present?
 
       # delete pure danglers
-      legacy_appeal.destroy! if legacy_appeal.tasks.none?
+      if legacy_appeal.tasks.none?
+        legacy_appeal.destroy!
+        next
+      end
 
       # if we have tasks and no case_record, then we need to cancel all the tasks,
       # but we do not delete the dangling LegacyAppeal record.
-      legacy_appeal.tasks.open(&:cancelled!)
+      legacy_appeal.tasks.open.each(&:cancelled!)
     end
     datadog_report_time_segment(segment: "sync_cases_from_vacols", start_time: start_time)
   end

--- a/app/services/data_integrity_checker.rb
+++ b/app/services/data_integrity_checker.rb
@@ -4,8 +4,11 @@
 # subclasses will be called by the job.
 
 class DataIntegrityChecker
+  attr_reader :buffer
+
   def initialize
     @report = []
+    @buffer = []
   end
 
   def call
@@ -22,6 +25,10 @@ class DataIntegrityChecker
 
   def add_to_report(msg)
     @report << msg
+  end
+
+  def add_to_buffer(thing)
+    @buffer << thing
   end
 
   def slack_channel

--- a/app/services/legacy_appeals_with_no_vacols_case.rb
+++ b/app/services/legacy_appeals_with_no_vacols_case.rb
@@ -42,6 +42,7 @@ class LegacyAppealsWithNoVacolsCase < DataIntegrityChecker
     missing_from_vacols = vacols_ids - vacols_ids_found
     missing_from_vacols.each do |vacols_id|
       add_to_report "LegacyAppeal.find_by(vacols_id: '#{vacols_id}')"
+      add_to_buffer vacols_id
     end
   end
 

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -4,6 +4,11 @@ describe NightlySyncsJob, :all_dbs do
   context "when the job runs successfully" do
     before do
       5.times { create(:staff) }
+
+      @emitted_gauges = []
+      allow(DataDogService).to receive(:emit_gauge) do |args|
+        @emitted_gauges.push(args)
+      end
     end
 
     subject { described_class.perform_now }
@@ -15,19 +20,37 @@ describe NightlySyncsJob, :all_dbs do
     end
 
     it "updates DataDog" do
-      emitted_gauges = []
-      allow(DataDogService).to receive(:emit_gauge) do |args|
-        emitted_gauges.push(args)
-      end
-
       subject
 
-      expect(emitted_gauges).to include(
+      expect(@emitted_gauges).to include(
         app_name: "caseflow_job",
         metric_group: "nightly_syncs_job",
         metric_name: "runtime",
         metric_value: anything
       )
+    end
+
+    context "dangling LegacyAppeal" do
+      context "with zero tasks" do
+        let!(:legacy_appeal) { create(:legacy_appeal) }
+
+        it "deletes the legacy appeal" do
+          subject
+
+          expect { legacy_appeal.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context "with open tasks" do
+        let!(:legacy_appeal) { create(:legacy_appeal, :with_judge_assign_task) }
+
+        it "cancels all open tasks and leaves the legacy appeal intact" do
+          subject
+
+          expect(legacy_appeal.reload).to_not be_nil
+          expect(legacy_appeal.reload.tasks.open).to be_empty
+        end
+      end
     end
   end
 end

--- a/spec/services/legacy_appeals_with_no_vacols_case_spec.rb
+++ b/spec/services/legacy_appeals_with_no_vacols_case_spec.rb
@@ -18,6 +18,7 @@ describe LegacyAppealsWithNoVacolsCase do
         subject.call
         expect(subject.report?).to be_truthy
         expect(subject.report).to eq("LegacyAppeal.find_by(vacols_id: '#{legacy_appeal.vacols_id}')")
+        expect(subject.buffer).to eq([legacy_appeal.vacols_id])
       end
 
       context "when Legacy Appeal has only cancelled tasks" do
@@ -28,6 +29,7 @@ describe LegacyAppealsWithNoVacolsCase do
         it "reports zero missing cases" do
           subject.call
           expect(subject.report?).to be_falsey
+          expect(subject.buffer).to eq []
         end
       end
     end


### PR DESCRIPTION
connects #12791 

### Description
BVA continues to delete records in VACOLS, leaving dangling records in the `legacy_appeals` table.

This PR leverages the existing query to locate these dangling records, and adds a nightly sync step to handle them.

Legacy Appeals with zero tasks are deleted.

Legacy Appeals with open tasks are all cancelled but retained.