### PR TITLE
[PART 2] Require a user id for a new distribution rather than assuming the current user

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -8,7 +8,7 @@ class DistributionsController < ApplicationController
   end
 
   def new
-    distribution = Distribution.create!(judge: current_user)
+    distribution = Distribution.create!(judge: judge)
     enqueue_distribution_job(distribution)
     render_single(distribution)
   rescue ActiveRecord::RecordInvalid => error
@@ -27,11 +27,15 @@ class DistributionsController < ApplicationController
     render_single(distribution)
   end
 
+  def judge
+    @judge ||= User.find(params[:user_id])
+  end
+
   private
 
   def enqueue_distribution_job(distribution)
     if run_async?
-      StartDistributionJob.perform_later(distribution, current_user)
+      StartDistributionJob.perform_later(distribution, judge)
     else
       StartDistributionJob.perform_now(distribution)
     end
@@ -96,6 +100,6 @@ class DistributionsController < ApplicationController
   end
 
   def pending_distribution
-    Distribution.pending_for_judge(current_user)
+    Distribution.pending_for_judge(judge)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -344,6 +344,10 @@ class User < CaseflowRecord
     false
   end
 
+  def can_act_on_behalf_of_judges?
+    member_of_organization?(SpecialCaseMovementTeam.singleton) && FeatureToggle.enabled?(:scm_view_judge_assign_queue)
+  end
+
   def show_regional_office_in_queue?
     HearingsManagement.singleton.user_has_access?(self)
   end

--- a/client/app/queue/JudgeAssignTaskListView.jsx
+++ b/client/app/queue/JudgeAssignTaskListView.jsx
@@ -71,9 +71,7 @@ class JudgeAssignTaskListView extends React.PureComponent {
             exact
             path={match.url}
             title="Cases to Assign | Caseflow"
-            render={
-              () => <UnassignedCasesPage
-                userId={userId.toString()} />}
+            render={() => <UnassignedCasesPage userId={userId.toString()} />}
           />
           <PageRoute
             path={`${match.url}/:attorneyId`}
@@ -100,7 +98,7 @@ JudgeAssignTaskListView.propTypes = {
   organizations: PropTypes.array
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   const {
     queue: {
       attorneysOfJudge
@@ -112,7 +110,8 @@ const mapStateToProps = (state) => {
     userCssId: state.ui.userCssId,
     targetUserCssId: state.ui.targetUserCssId,
     tasksByUserId: getTasksByUserId(state),
-    attorneysOfJudge
+    attorneysOfJudge,
+    userId: ownProps.match.params.userId
   };
 };
 

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -607,7 +607,7 @@ const receiveDistribution = (dispatch, userId, response) => {
 export const requestDistribution = (userId) => (dispatch) => {
   dispatch(setPendingDistribution({ status: 'pending' }));
 
-  ApiUtil.get('/distributions/new').
+  ApiUtil.get(`/distributions/new?user_id=${userId}`).
     then((response) => receiveDistribution(dispatch, userId, response)).
     catch((error) => distributionError(dispatch, userId, error));
 };

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -33,13 +33,43 @@ describe DistributionsController, :all_dbs do
     end
 
     context "provided user is a judge" do
+      before { create(:staff, :judge_role, sdomainid: user.css_id) }
+
       it "renders the created distribution as json" do
-        create(:staff, :judge_role, sdomainid: user.css_id)
         subject
 
         expect(response.status).to eq 200
         body = JSON.parse(response.body)
         expect(body["distribution"].keys).to match_array(%w[id created_at updated_at status distributed_cases_count])
+      end
+
+      context "but is not the logged in user" do
+        let(:authed_user) { create(:user) }
+
+        before { User.authenticate!(user: authed_user) }
+
+        it "returns an error" do
+          subject
+
+          body = JSON.parse(response.body)
+          expect(body["errors"].first["title"]).to eq "Cannot request cases for another judge"
+        end
+
+        context "but scm is enabled" do
+          before do
+            FeatureToggle.enable!(:scm_view_judge_assign_queue)
+            SpecialCaseMovementTeam.singleton.add_user(authed_user)
+          end
+          after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
+
+          it "renders the created distribution as json" do
+            subject
+
+            expect(response.status).to eq 200
+            body = JSON.parse(response.body)
+            expect(body["distribution"].keys).to match_array(%w[id created_at updated_at status distributed_cases_count])
+          end
+        end
       end
     end
   end

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -2,10 +2,15 @@
 
 describe DistributionsController, :all_dbs do
   describe "#new" do
-    context "current user is not a judge" do
+    let(:user) { create(:user) }
+
+    subject { get :new, params: { user_id: user.id } }
+
+    before { User.authenticate!(user: user) }
+
+    context "provided user is not a judge" do
       it "renders an error" do
-        User.authenticate!(user: create(:user))
-        get :new
+        subject
 
         body = JSON.parse(response.body)
         expect(body["errors"].first["error"]).to eq "not_judge"
@@ -14,14 +19,11 @@ describe DistributionsController, :all_dbs do
 
     context "there is a pending distribution" do
       it "returns the pending distribution and no more were created" do
-        judge = create(:user)
-        create(:staff, :judge_role, sdomainid: judge.css_id)
-        User.authenticate!(user: judge)
+        create(:staff, :judge_role, sdomainid: user.css_id)
 
-        distribution = Distribution.create!(judge: judge, status: "pending")
+        distribution = Distribution.create!(judge: user, status: "pending")
         number_of_distributions = Distribution.count
-
-        get :new
+        subject
 
         body = JSON.parse(response.body)
         expect(body["distribution"]["id"]).to eq distribution.id
@@ -30,12 +32,10 @@ describe DistributionsController, :all_dbs do
       end
     end
 
-    context "current user is a judge" do
+    context "provided user is a judge" do
       it "renders the created distribution as json" do
-        judge = create(:user)
-        create(:staff, :judge_role, sdomainid: judge.css_id)
-        User.authenticate!(user: judge)
-        get :new
+        create(:staff, :judge_role, sdomainid: user.css_id)
+        subject
 
         expect(response.status).to eq 200
         body = JSON.parse(response.body)

--- a/spec/feature/queue/scm_judge_assignment_spec.rb
+++ b/spec/feature/queue/scm_judge_assignment_spec.rb
@@ -65,42 +65,67 @@ RSpec.feature "SCM Team access to judge assignment features", :all_dbs do
     let!(:appeal) { create(:appeal, :assigned_to_judge, associated_judge: judge_one.user) }
     let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case, staff: vacols_user_one)) }
 
-    context "with both legacy and ama tasks" do
+    scenario "with both ama and legacy case" do
+      visit "/queue/#{judge_one.user.id}/assign"
+
+      expect(page).to have_content("Assign 2 Cases for #{judge_one.user.css_id}")
+
+      expect(page).to have_content("#{appeal.veteran.first_name} #{appeal.veteran.last_name}")
+      expect(page).to have_content(appeal.veteran_file_number)
+      expect(page).to have_content("Original")
+      expect(page).to have_content(appeal.docket_number)
+
+      expect(page).to have_content("#{legacy_appeal.veteran_first_name} #{legacy_appeal.veteran_last_name}")
+      expect(page).to have_content(legacy_appeal.veteran_file_number)
+      expect(page).to have_content(legacy_appeal.docket_number)
+
+      expect(page).to have_content("Cases to Assign")
+      expect(page).to have_content("Moe Syzlak")
+      expect(page).to have_content("Alice Macgyvertwo")
+
+      expect(page.find(".usa-sidenav-list")).to have_content attorney_one.full_name
+      expect(page.find(".usa-sidenav-list")).to have_content attorney_two.full_name
+
+      safe_click ".Select"
+      expect(page.find(".dropdown-Assignee")).to have_content attorney_one.full_name
+      expect(page.find(".dropdown-Assignee")).to have_content attorney_two.full_name
+
+      click_dropdown(text: "Other")
+      safe_click ".dropdown-Other"
+      # expect attorneys and acting judges but not judges
+      expect(page.find(".dropdown-Other")).to have_content acting_judge.user.full_name
+      expect(page.find(".dropdown-Other")).to have_no_content judge_one.user.full_name
+      expect(page.find(".dropdown-Other")).to have_no_content judge_two.user.full_name
+      expect(page.find(".dropdown-Other")).to have_content attorney_one.full_name
+      expect(page.find(".dropdown-Other")).to have_content attorney_two.full_name
+
+      expect(page).to have_content "Request more cases"
+    end
+
+    context "and can request cases for a judge" do
+      let!(:appeal) { create(:appeal, :ready_for_distribution) }
+
+      before do
+        allow_any_instance_of(DirectReviewDocket).to receive(:nonpriority_receipts_per_year).and_return(100)
+        allow(Docket).to receive(:nonpriority_decisions_per_year).and_return(1000)
+        allow_any_instance_of(LegacyDocket).to receive(:weight).and_return(101.4)
+        allow_any_instance_of(DirectReviewDocket).to receive(:weight).and_return(10)
+      end
+
       scenario "viewing the assign task queue" do
         visit "/queue/#{judge_one.user.id}/assign"
 
+        expect(page).to have_content("Assign 1 Cases for #{judge_one.user.css_id}")
+        expect(page).to_not have_content("#{appeal.veteran.first_name} #{appeal.veteran.last_name}")
+
+        click_on("Request more cases")
+        expect(page).to have_content("Distribution complete")
+
         expect(page).to have_content("Assign 2 Cases for #{judge_one.user.css_id}")
 
-        expect(page).to have_content("#{appeal.veteran.first_name} #{appeal.veteran.last_name}")
         expect(page).to have_content(appeal.veteran_file_number)
         expect(page).to have_content("Original")
         expect(page).to have_content(appeal.docket_number)
-
-        expect(page).to have_content("#{legacy_appeal.veteran_first_name} #{legacy_appeal.veteran_last_name}")
-        expect(page).to have_content(legacy_appeal.veteran_file_number)
-        expect(page).to have_content(legacy_appeal.docket_number)
-
-        expect(page).to have_content("Cases to Assign")
-        expect(page).to have_content("Moe Syzlak")
-        expect(page).to have_content("Alice Macgyvertwo")
-
-        expect(page.find(".usa-sidenav-list")).to have_content attorney_one.full_name
-        expect(page.find(".usa-sidenav-list")).to have_content attorney_two.full_name
-
-        safe_click ".Select"
-        expect(page.find(".dropdown-Assignee")).to have_content attorney_one.full_name
-        expect(page.find(".dropdown-Assignee")).to have_content attorney_two.full_name
-
-        click_dropdown(text: "Other")
-        safe_click ".dropdown-Other"
-        # expect attorneys and acting judges but not judges
-        expect(page.find(".dropdown-Other")).to have_content acting_judge.user.full_name
-        expect(page.find(".dropdown-Other")).to have_no_content judge_one.user.full_name
-        expect(page.find(".dropdown-Other")).to have_no_content judge_two.user.full_name
-        expect(page.find(".dropdown-Other")).to have_content attorney_one.full_name
-        expect(page.find(".dropdown-Other")).to have_content attorney_two.full_name
-
-        expect(page).to have_content "Request more cases"
       end
     end
   end


### PR DESCRIPTION
Part 2 of stacked PR

Part 1: #13727
Part 2: #13729
Part 3: #13731

### Description
Rather than creating a distribution for the signed in user, provide the user id for who we want to distribute cases for.

### Acceptance Criteria
- [ ] Use provided user id to determine user for distribution