### PR TITLE
[Part 3] Allow SCM members to request cases for another judge

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -14,10 +14,7 @@ class DistributionsController < ApplicationController
     enqueue_distribution_job(distribution)
     render_single(distribution)
   rescue ActiveRecord::RecordInvalid => error
-    errors = error.record.errors.details.values.flatten.map { |e| e[:error] }
-    return render_single(pending_distribution) if errors.include? :pending_distribution
-
-    render_403_error(errors)
+    render_errors(error)
   end
 
   def show
@@ -37,6 +34,13 @@ class DistributionsController < ApplicationController
     else
       StartDistributionJob.perform_now(distribution)
     end
+  end
+
+  def render_errors(error)
+    errors = error.record.errors.details.values.flatten.map { |e| e[:error] }
+    return render_single(pending_distribution) if errors.include? :pending_distribution
+
+    render_403_error(errors)
   end
 
   def render_single(distribution)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -344,6 +344,10 @@ class User < CaseflowRecord
     false
   end
 
+  def can_act_on_behalf_of_judges?
+    member_of_organization?(SpecialCaseMovementTeam.singleton) && FeatureToggle.enabled?(:scm_view_judge_assign_queue)
+  end
+
   def show_regional_office_in_queue?
     HearingsManagement.singleton.user_has_access?(self)
   end

--- a/client/app/queue/JudgeAssignTaskListView.jsx
+++ b/client/app/queue/JudgeAssignTaskListView.jsx
@@ -71,9 +71,7 @@ class JudgeAssignTaskListView extends React.PureComponent {
             exact
             path={match.url}
             title="Cases to Assign | Caseflow"
-            render={
-              () => <UnassignedCasesPage
-                userId={userId.toString()} />}
+            render={() => <UnassignedCasesPage userId={userId.toString()} />}
           />
           <PageRoute
             path={`${match.url}/:attorneyId`}

--- a/client/app/queue/JudgeAssignTaskListView.jsx
+++ b/client/app/queue/JudgeAssignTaskListView.jsx
@@ -73,7 +73,7 @@ class JudgeAssignTaskListView extends React.PureComponent {
             title="Cases to Assign | Caseflow"
             render={
               () => <UnassignedCasesPage
-                userId={userId.toString()} />}
+                userId={(match?.params.userId || userId).toString()} />}
           />
           <PageRoute
             path={`${match.url}/:attorneyId`}

--- a/client/app/queue/JudgeAssignTaskListView.jsx
+++ b/client/app/queue/JudgeAssignTaskListView.jsx
@@ -73,7 +73,7 @@ class JudgeAssignTaskListView extends React.PureComponent {
             title="Cases to Assign | Caseflow"
             render={
               () => <UnassignedCasesPage
-                userId={(match?.params.userId || userId).toString()} />}
+                userId={userId.toString()} />}
           />
           <PageRoute
             path={`${match.url}/:attorneyId`}
@@ -100,7 +100,7 @@ JudgeAssignTaskListView.propTypes = {
   organizations: PropTypes.array
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   const {
     queue: {
       attorneysOfJudge
@@ -112,7 +112,8 @@ const mapStateToProps = (state) => {
     userCssId: state.ui.userCssId,
     targetUserCssId: state.ui.targetUserCssId,
     tasksByUserId: getTasksByUserId(state),
-    attorneysOfJudge
+    attorneysOfJudge,
+    userId: ownProps.match.params.userId
   };
 };
 

--- a/spec/feature/queue/scm_judge_assignment_spec.rb
+++ b/spec/feature/queue/scm_judge_assignment_spec.rb
@@ -106,14 +106,8 @@ RSpec.feature "SCM Team access to judge assignment features", :all_dbs do
       let!(:appeal) { create(:appeal, :ready_for_distribution) }
 
       before do
-        allow_any_instance_of(DirectReviewDocket)
-          .to receive(:nonpriority_receipts_per_year)
-          .and_return(100)
-
-        allow(Docket)
-          .to receive(:nonpriority_decisions_per_year)
-          .and_return(1000)
-
+        allow_any_instance_of(DirectReviewDocket).to receive(:nonpriority_receipts_per_year).and_return(100)
+        allow(Docket).to receive(:nonpriority_decisions_per_year).and_return(1000)
         allow_any_instance_of(LegacyDocket).to receive(:weight).and_return(101.4)
         allow_any_instance_of(DirectReviewDocket).to receive(:weight).and_return(10)
       end
@@ -121,8 +115,17 @@ RSpec.feature "SCM Team access to judge assignment features", :all_dbs do
       scenario "viewing the assign task queue" do
         visit "/queue/#{judge_one.user.id}/assign"
 
+        expect(page).to have_content("Assign 1 Cases for #{judge_one.user.css_id}")
+        expect(page).to_not have_content("#{appeal.veteran.first_name} #{appeal.veteran.last_name}")
+
         click_on("Request more cases")
         expect(page).to have_content("Distribution complete")
+
+        expect(page).to have_content("Assign 2 Cases for #{judge_one.user.css_id}")
+
+        expect(page).to have_content(appeal.veteran_file_number)
+        expect(page).to have_content("Original")
+        expect(page).to have_content(appeal.docket_number)
       end
     end
   end

--- a/spec/feature/queue/scm_judge_assignment_spec.rb
+++ b/spec/feature/queue/scm_judge_assignment_spec.rb
@@ -65,42 +65,64 @@ RSpec.feature "SCM Team access to judge assignment features", :all_dbs do
     let!(:appeal) { create(:appeal, :assigned_to_judge, associated_judge: judge_one.user) }
     let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case, staff: vacols_user_one)) }
 
-    context "with both legacy and ama tasks" do
+    scenario "with both ama and legacy case" do
+      visit "/queue/#{judge_one.user.id}/assign"
+
+      expect(page).to have_content("Assign 2 Cases for #{judge_one.user.css_id}")
+
+      expect(page).to have_content("#{appeal.veteran.first_name} #{appeal.veteran.last_name}")
+      expect(page).to have_content(appeal.veteran_file_number)
+      expect(page).to have_content("Original")
+      expect(page).to have_content(appeal.docket_number)
+
+      expect(page).to have_content("#{legacy_appeal.veteran_first_name} #{legacy_appeal.veteran_last_name}")
+      expect(page).to have_content(legacy_appeal.veteran_file_number)
+      expect(page).to have_content(legacy_appeal.docket_number)
+
+      expect(page).to have_content("Cases to Assign")
+      expect(page).to have_content("Moe Syzlak")
+      expect(page).to have_content("Alice Macgyvertwo")
+
+      expect(page.find(".usa-sidenav-list")).to have_content attorney_one.full_name
+      expect(page.find(".usa-sidenav-list")).to have_content attorney_two.full_name
+
+      safe_click ".Select"
+      expect(page.find(".dropdown-Assignee")).to have_content attorney_one.full_name
+      expect(page.find(".dropdown-Assignee")).to have_content attorney_two.full_name
+
+      click_dropdown(text: "Other")
+      safe_click ".dropdown-Other"
+      # expect attorneys and acting judges but not judges
+      expect(page.find(".dropdown-Other")).to have_content acting_judge.user.full_name
+      expect(page.find(".dropdown-Other")).to have_no_content judge_one.user.full_name
+      expect(page.find(".dropdown-Other")).to have_no_content judge_two.user.full_name
+      expect(page.find(".dropdown-Other")).to have_content attorney_one.full_name
+      expect(page.find(".dropdown-Other")).to have_content attorney_two.full_name
+
+      expect(page).to have_content "Request more cases"
+    end
+
+    context "and can request cases for a judge" do
+      let!(:appeal) { create(:appeal, :ready_for_distribution) }
+
+      before do
+        allow_any_instance_of(DirectReviewDocket)
+          .to receive(:nonpriority_receipts_per_year)
+          .and_return(100)
+
+        allow(Docket)
+          .to receive(:nonpriority_decisions_per_year)
+          .and_return(1000)
+
+        allow_any_instance_of(LegacyDocket).to receive(:weight).and_return(101.4)
+        allow_any_instance_of(DirectReviewDocket).to receive(:weight).and_return(10)
+      end
+
       scenario "viewing the assign task queue" do
         visit "/queue/#{judge_one.user.id}/assign"
 
-        expect(page).to have_content("Assign 2 Cases for #{judge_one.user.css_id}")
-
-        expect(page).to have_content("#{appeal.veteran.first_name} #{appeal.veteran.last_name}")
-        expect(page).to have_content(appeal.veteran_file_number)
-        expect(page).to have_content("Original")
-        expect(page).to have_content(appeal.docket_number)
-
-        expect(page).to have_content("#{legacy_appeal.veteran_first_name} #{legacy_appeal.veteran_last_name}")
-        expect(page).to have_content(legacy_appeal.veteran_file_number)
-        expect(page).to have_content(legacy_appeal.docket_number)
-
-        expect(page).to have_content("Cases to Assign")
-        expect(page).to have_content("Moe Syzlak")
-        expect(page).to have_content("Alice Macgyvertwo")
-
-        expect(page.find(".usa-sidenav-list")).to have_content attorney_one.full_name
-        expect(page.find(".usa-sidenav-list")).to have_content attorney_two.full_name
-
-        safe_click ".Select"
-        expect(page.find(".dropdown-Assignee")).to have_content attorney_one.full_name
-        expect(page.find(".dropdown-Assignee")).to have_content attorney_two.full_name
-
-        click_dropdown(text: "Other")
-        safe_click ".dropdown-Other"
-        # expect attorneys and acting judges but not judges
-        expect(page.find(".dropdown-Other")).to have_content acting_judge.user.full_name
-        expect(page.find(".dropdown-Other")).to have_no_content judge_one.user.full_name
-        expect(page.find(".dropdown-Other")).to have_no_content judge_two.user.full_name
-        expect(page.find(".dropdown-Other")).to have_content attorney_one.full_name
-        expect(page.find(".dropdown-Other")).to have_content attorney_two.full_name
-
-        expect(page).to have_content "Request more cases"
+        click_on("Request more cases")
+        expect(page).to have_content("Distribution complete")
       end
     end
   end


### PR DESCRIPTION
Part 3 of stacked PR

Part 1: #13727
Part 2: #13729
Part 3: #13731

![ezgif-5-e08c41975fcd](https://user-images.githubusercontent.com/45575454/76900501-da384200-686f-11ea-906f-be346ee5270b.gif)

### Description
Allows SCM members to request cases for judges

### Acceptance Criteria
- [ ] SCM team member can request cases for a judge

### Testing plan
1. Log in as an SCM team member
2. Navigate to BVAAABSHIRE's assign queue at /queue/3/assign
3. Select "Request more cases"
4. Ensure no errors
5. Ensure cases are distributed

### UI Changes

- [ ] SCM distributions don't throw errors

Before|After
---|---
![Screen Shot 2020-03-17 at 3 48 27 PM](https://user-images.githubusercontent.com/45575454/76895689-dbb13c80-6866-11ea-80d5-3c4512251b09.png)|![Screen Shot 2020-03-17 at 4 52 54 PM](https://user-images.githubusercontent.com/45575454/76900475-ce4c8000-686f-11ea-905b-62c063b9da1b.png)
