### PR TITLE
Add veteran state of residence to assign hearings table - Part 2

### DIFF
--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -72,6 +72,18 @@ class AssignHearingTab
     ]
   end
 
+  # Used with the `TaskColumnSerializer` to serialize only the columns that are
+  # in-use by the frontend.
+  def self.serialize_columns
+    [
+      Constants.QUEUE_CONFIG.COLUMNS.HEARING_BADGE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME,
+      Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME
+    ]
+  end
+
   def power_of_attorney_name_options
     tasks.joins(CachedAppeal.left_join_from_tasks_clause)
       .group(:power_of_attorney_name).count.each_pair.map do |option, count|

--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -103,11 +103,7 @@ class AssignHearingTab
   def task_includes
     [
       { appeal: [:available_hearing_locations, :claimants] },
-      { attorney_case_reviews: [:attorney] },
-      :assigned_by,
-      :assigned_to,
-      :children,
-      :parent
+      :assigned_by
     ]
   end
 end

--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -165,6 +165,27 @@ class WorkQueue::TaskColumnSerializer
     }
   end
 
+  # Used by /hearings/schedule/assign. Not present in the full `task_serializer`.
+  attribute :power_of_attorney_name do |object, params|
+    columns = [Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME]
+
+    if serialize_attribute?(params, columns)
+      # The `power_of_attorney_name` field doesn't exist on the actual model. This
+      # field needs to be added in a select statement and represents the field from
+      # the `cached_appeal_attributes` table.
+      object&.[](:power_of_attorney_name)
+    end
+  end
+
+  # Used by /hearings/schedule/assign. Not present in the full `task_serializer`.
+  attribute :suggested_hearing_location do |object, params|
+    columns = [Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME]
+
+    if serialize_attribute?(params, columns)
+      object.appeal.suggested_hearing_location&.to_hash
+    end
+  end
+
   # UNUSED
 
   attribute :assignee_name do

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -101,10 +101,6 @@ class WorkQueue::TaskSerializer
     object.appeal.available_hearing_locations
   end
 
-  attribute :suggested_hearing_location do |object|
-    object.appeal.suggested_hearing_location&.to_hash
-  end
-
   attribute :previous_task do |object|
     {
       assigned_at: object.previous_task.try(:assigned_at)

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -19,7 +19,6 @@ import { renderAppealType } from '../../../queue/utils';
 import { tableNumberStyling } from './styles';
 import ApiUtil from '../../../util/ApiUtil';
 import LinkToAppeal from './LinkToAppeal';
-import PowerOfAttorneyDetail from '../../../queue/PowerOfAttorneyDetail';
 import QUEUE_CONFIG from '../../../../constants/QUEUE_CONFIG';
 import QueueTable from '../../../queue/QueueTable';
 
@@ -159,22 +158,12 @@ export default class AssignHearingsTable extends React.PureComponent {
       {
         name: 'powerOfAttorneyName',
         header: 'Power of Attorney (POA)',
+        valueName: 'powerOfAttorneyName',
         columnName: 'Power of Attorney',
         align: 'left',
-        valueFunction: (row) => (
-          <PowerOfAttorneyDetail
-            appealId={row.externalAppealId}
-            displayNameOnly
-          />
-        ),
         label: 'Filter by Power of Attorney',
         enableFilter: true,
         anyFiltersAreSet: true,
-        filterValueTransform: (_value, row) => {
-          const { powerOfAttorneyNamesForAppeals } = this.props;
-
-          return powerOfAttorneyNamesForAppeals[row.externalAppealId];
-        },
         filterOptions: colsFromApi && colsFromApi.find((col) => col.name === 'powerOfAttorneyName').filter_options
       }
     ];
@@ -260,8 +249,6 @@ export default class AssignHearingsTable extends React.PureComponent {
 AssignHearingsTable.propTypes = {
   columns: PropTypes.array,
   clicked: PropTypes.bool,
-  // Appeal ID => Attorney Name Array
-  powerOfAttorneyNamesForAppeals: PropTypes.objectOf(PropTypes.string),
   selectedHearingDay: PropTypes.shape({
     scheduledFor: PropTypes.string
   }),

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -85,7 +85,7 @@ export default class AssignHearingsTable extends React.PureComponent {
 
     const { colsFromApi } = this.state;
 
-    if (_.isNil(selectedHearingDay)) {
+    if (_.isNil(selectedHearingDay) || _.isNil(colsFromApi)) {
       return [];
     }
 

--- a/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTabs.jsx
@@ -1,4 +1,3 @@
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
@@ -25,7 +24,7 @@ const getCurrentTabIndex = () => {
   return 0;
 };
 
-export class AssignHearingsTabs extends React.PureComponent {
+export default class AssignHearingsTabs extends React.PureComponent {
   onTabChange = (tabNumber) => {
     this.setState({ clickedTab: tabNumber });
   }
@@ -102,23 +101,9 @@ AssignHearingsTabs.propTypes = {
     totalSlots: PropTypes.number
   }),
   selectedRegionalOffice: PropTypes.string,
-  room: PropTypes.string,
-  // Appeal ID => Attorney Name Array
-  powerOfAttorneyNamesForAppeals: PropTypes.objectOf(PropTypes.string)
+  room: PropTypes.string
 };
 
 AssignHearingsTabs.defaultProps = {
-  defaultTabIndex: getCurrentTabIndex(),
-  powerOfAttorneyNamesForAppeals: {}
+  defaultTabIndex: getCurrentTabIndex()
 };
-
-const mapStateToProps = (state) => {
-  const powerOfAttorneyNamesForAppeals = _.mapValues(
-    _.get(state, 'queue.appealDetails', {}),
-    (val) => _.get(val, 'powerOfAttorney.representative_name')
-  );
-
-  return { powerOfAttorneyNamesForAppeals };
-};
-
-export default connect(mapStateToProps)(AssignHearingsTabs);

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -25,16 +25,6 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
     return powerOfAttorney.representative_type && powerOfAttorney.representative_name;
   }
 
-  renderNameOnly() {
-    if (this.hasPowerOfAttorneyDetails) {
-      const { powerOfAttorney } = this.props;
-
-      return <span>{powerOfAttorney.representative_name}</span>;
-    }
-
-    return <span>{COPY.CASE_DETAILS_NO_POA}</span>;
-  }
-
   renderLoadingOrError() {
     const { loading, error } = this.props;
 
@@ -50,14 +40,10 @@ export class PowerOfAttorneyDetail extends React.PureComponent {
   }
 
   render = () => {
-    const { displayNameOnly, powerOfAttorney } = this.props;
+    const { powerOfAttorney } = this.props;
 
     if (!powerOfAttorney) {
       return this.renderLoadingOrError();
-    }
-
-    if (displayNameOnly) {
-      return this.renderNameOnly();
     }
 
     if (!this.hasPowerOfAttorneyDetails()) {
@@ -87,17 +73,12 @@ PowerOfAttorneyDetail.propTypes = {
   error: PropTypes.object,
   getAppealValue: PropTypes.func,
   loading: PropTypes.bool,
-  displayNameOnly: PropTypes.bool,
   powerOfAttorney: PropTypes.shape({
     representative_type: PropTypes.string,
     representative_name: PropTypes.string,
     representative_address: PropTypes.object,
     representative_email_address: PropTypes.string
   })
-};
-
-PowerOfAttorneyDetail.defaultProps = {
-  displayNameOnly: false
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -104,6 +104,10 @@ const taskAttributesFromRawTask = (task) => {
     hideFromTaskSnapshot: task.attributes.hide_from_task_snapshot,
     hideFromCaseTimeline: task.attributes.hide_from_case_timeline,
     availableHearingLocations: task.attributes.available_hearing_locations,
+    // `powerOfAttorneyName` and `suggestedHearingLocation` are only present for
+    // /hearings/scheduled/assign page, and are not returned from the API when
+    // requesting the full task.
+    powerOfAttorneyName: task.attributes.power_of_attorney_name,
     suggestedHearingLocation: task.attributes.suggested_hearing_location
   };
 };


### PR DESCRIPTION
Part 2 of #13705 

### Description

Updates the API to return the POA name from the `CachedAppeal` table instead of having the frontend fetch the POA through the `PowerOfAttorneyDetail` component. This is an optimization to avoid performing too many requests against the API on the assign hearings table, since adding the veteran state of residence column will effectively double the number of requests made.

*Changes*:

  * Use `TaskColumnSerializer` instead of `TaskSerializer`, which limits the columns serialized to exactly what is needed by the frontend.
    * Move `suggested_hearing_location` from `TaskSerializer` to `TaskColumnSerializer` since it's only being used by the assign hearings table
    * Serialize `power_of_attorney_name`, using the value stored from the `CachedAppeal` table. Since the pager is already doing a join with the `CachedAppeal` table, selecting an additional field  makes it so no additional querying is needed
  * Use `powerOfAttorneyName` directly from API instead of fetching it through the `PowerOfAttorneyDetail`
  * Refactor: Remove unnecessary task includes
  * Refactor: Remove `powerOfAttorneyNamesForAppeals` prop