### PR TITLE
Add judge_email and judge_email_sent columns to virtual hearings

### DIFF
--- a/db/migrate/20200318204112_add_judge_email_and_judge_email_sent_to_virtual_hearings.rb
+++ b/db/migrate/20200318204112_add_judge_email_and_judge_email_sent_to_virtual_hearings.rb
@@ -1,0 +1,10 @@
+class AddJudgeEmailAndJudgeEmailSentToVirtualHearings < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      add_column :virtual_hearings, :judge_email, :string,
+                 comment: "Judge's email address"
+      add_column :virtual_hearings, :judge_email_sent, :boolean, default: false, null: false,
+                 comment: "Whether or not a notification email was sent to the judge"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_03_223649) do
+ActiveRecord::Schema.define(version: 2020_03_18_204112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### Description

Adds back the `judge_email` and `judge_email_sent` columns removed in #13632. The PR was reverted in #13659, but the fields were not added back

*Note: schema files didn't change because the revert of #13632 did not re-run migrate or `make docs`*

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
