### PR TITLE
Change session length to 12 hours

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,7 +2,7 @@
 options = {
   key: '_caseflow_session',
   secure: Rails.env.production?,
-  expire_after: 24.hours
+  expire_after: 12.hours
 }
 
 if ENV["DEPLOY_ENV"]


### PR DESCRIPTION
connects https://github.com/department-of-veterans-affairs/appeals-deployment/issues/2542

### Description
Config change to cookie expiration. Was 24 hours now 12 hours.

### Testing Plan
1. Verify cookie expiration is 12 hours from initial login.
