### PR TITLE
add conditional to migration

### DIFF
--- a/db/migrate/20200318204112_add_judge_email_and_judge_email_sent_to_virtual_hearings.rb
+++ b/db/migrate/20200318204112_add_judge_email_and_judge_email_sent_to_virtual_hearings.rb
@@ -1,14 +1,27 @@
 class AddJudgeEmailAndJudgeEmailSentToVirtualHearings < ActiveRecord::Migration[5.2]
-  def change
-    safety_assured do
-      unless column_exists? :virtual_hearings, :judge_email, :string
-        add_column :virtual_hearings, :judge_email, :string,
-                   comment: "Judge's email address"
-      end
-      unless column_exists? :virtual_hearings, :judge_email_sent, :boolean
-        add_column :virtual_hearings, :judge_email_sent, :boolean, default: false, null: false,
-                   comment: "Whether or not a notification email was sent to the judge"
-      end
+  def maybe_add_judge_email
+    unless column_exists? :virtual_hearings, :judge_email, :string
+      add_column :virtual_hearings, :judge_email, :string,
+                 comment: "Judge's email address"
     end
+  end
+
+  def maybe_add_judge_email_sent
+    unless column_exists? :virtual_hearings, :judge_email_sent, :boolean
+      add_column :virtual_hearings, :judge_email_sent, :boolean, default: false, null: false,
+                 comment: "Whether or not a notification email was sent to the judge"
+    end
+  end
+
+  def up
+    safety_assured do
+      maybe_add_judge_email
+      maybe_add_judge_email_sent
+    end
+  end
+
+  def down
+    remove_column :virtual_hearings, :judge_email, :string
+    remove_column :virtual_hearings, :judge_email_sent, :boolean
   end
 end

--- a/db/migrate/20200318204112_add_judge_email_and_judge_email_sent_to_virtual_hearings.rb
+++ b/db/migrate/20200318204112_add_judge_email_and_judge_email_sent_to_virtual_hearings.rb
@@ -1,10 +1,14 @@
 class AddJudgeEmailAndJudgeEmailSentToVirtualHearings < ActiveRecord::Migration[5.2]
   def change
     safety_assured do
-      add_column :virtual_hearings, :judge_email, :string,
-                 comment: "Judge's email address"
-      add_column :virtual_hearings, :judge_email_sent, :boolean, default: false, null: false,
-                 comment: "Whether or not a notification email was sent to the judge"
+      unless column_exists? :virtual_hearings, :judge_email, :string
+        add_column :virtual_hearings, :judge_email, :string,
+                   comment: "Judge's email address"
+      end
+      unless column_exists? :virtual_hearings, :judge_email_sent, :boolean
+        add_column :virtual_hearings, :judge_email_sent, :boolean, default: false, null: false,
+                   comment: "Whether or not a notification email was sent to the judge"
+      end
     end
   end
 end


### PR DESCRIPTION
We reverted a PR that had a migration in it that was merged accidentally. We had to add back the columns since the reverted code expected those columns to exist. This caused `PG::DuplicateColumn` errors. This PR puts conditionals around the column adds.

[Related Slack thread](https://dsva.slack.com/archives/C2ZAMLK88/p1584653077210100)
