### PR TITLE
Add Sign In menu option on /help page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -141,11 +141,15 @@ class ApplicationController < ApplicationBaseController
     urls.concat(manage_teams_menu_items) if current_user&.administered_teams&.any?
     urls.concat(admin_menu_items) if Bva.singleton.user_has_access?(current_user)
 
-    if ApplicationController.dependencies_faked?
+    if ApplicationController.dependencies_faked? && current_user.present?
       urls.append(title: "Switch User", link: url_for(controller: "/test/users", action: "index"))
     end
 
-    urls.append(title: "Sign Out", link: url_for(controller: "/sessions", action: "destroy"), border: true)
+    if current_user.present?
+      urls.append(title: "Sign Out", link: url_for(controller: "/sessions", action: "destroy"), border: true)
+    else
+      urls.append(title: "Sign In", link: url_for("/login"), border: true)
+    end
 
     urls
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
     end
     # :nocov:
 
-    return redirect_to(ENV["SSO_URL"]) unless current_user
+    return redirect_to(sso_url) unless current_user
 
     # In order to use Caseflow, we need to know what regional office (RO) the user is from.
     # CSS will give us the station office ID. Some station office IDs correspond to multiple
@@ -72,5 +72,9 @@ class SessionsController < ApplicationController
   def remove_user_from_session
     session.delete(:regional_office)
     session.delete("user")
+  end
+
+  def sso_url
+    ENV.fetch("SSO_URL", "/help")
   end
 end

--- a/spec/feature/certification/start_certification_spec.rb
+++ b/spec/feature/certification/start_certification_spec.rb
@@ -46,9 +46,9 @@ RSpec.feature "Start Certification", :all_dbs do
   end
 
   context "As a user who's not logged in" do
-    scenario "Starting a certification redirects to login page" do
+    scenario "Starting a certification redirects to help page" do
       visit "certifications/new/#{appeal_ready.vacols_id}"
-      expect(page).to have_current_path("/login")
+      expect(page).to have_current_path("/help")
     end
   end
 

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -129,6 +129,27 @@ RSpec.feature "Login", :all_dbs do
   end
   # :nocov:
 
+  context "user is logged out" do
+    before do
+      Fakes::AuthenticationService.user_session = nil
+      @cached_sso_url = ENV["SSO_URL"]
+      ENV["SSO_URL"] = "/fake-login-page"
+    end
+
+    after do
+      ENV["SSO_URL"] = @cached_sso_url
+    end
+
+    scenario "Sign In menu option on /help page" do
+      visit "/help"
+
+      click_on "Menu"
+      click_on "Sign In"
+
+      expect(current_path).to eq("/fake-login-page")
+    end
+  end
+
   scenario "email and selected regional office should be set on login" do
     visit "certifications/new/#{appeal.vacols_id}"
     select_ro_from_dropdown

--- a/spec/models/hearings/schedule_hearing_task_pager_spec.rb
+++ b/spec/models/hearings/schedule_hearing_task_pager_spec.rb
@@ -35,7 +35,7 @@ describe Hearings::ScheduleHearingTaskPager, :all_dbs do
           :type_cavc_remand,
           bfcorlid: "123454787S",
           bfcurloc: "CASEFLOW",
-          folder: create(
+          folder: build(
             :folder,
             ticknum: "91",
             tinum: "1545678",
@@ -54,7 +54,7 @@ describe Hearings::ScheduleHearingTaskPager, :all_dbs do
           :type_original,
           bfcorlid: "123454788S",
           bfcurloc: "CASEFLOW",
-          folder: create(
+          folder: build(
             :folder,
             ticknum: "92",
             tinum: "1645678",
@@ -73,7 +73,7 @@ describe Hearings::ScheduleHearingTaskPager, :all_dbs do
           :type_original,
           bfcorlid: "323454787S",
           bfcurloc: "CASEFLOW",
-          folder: create(
+          folder: build(
             :folder,
             ticknum: "93",
             tinum: "1645001",


### PR DESCRIPTION
### Description

The /help (default) page in AWS does not provide an easy way to login. This PR adds a Sign In link and offers it instead of "Sign Out" when the user is not yet signed in.

### User Facing Changes

 - [x] Screenshots of UI changes added to PR & Original Issue
 
<img width="989" alt="Screen Shot 2020-03-20 at 7 45 41 AM" src="https://user-images.githubusercontent.com/1205061/77164857-1f7e8e80-6a7f-11ea-91d4-70363cf608b2.png">
