### PR TITLE
Fix few virtual hearing related issues

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -56,8 +56,7 @@ detectors:
       - ClaimReviewAsyncStatsReporter#as_csv
       - DataIntegrityChecksJob
       - DecisionIssueSyncJob
-      - VirtualHearings::DeleteConferencesJob#delete_conference
-      - VirtualHearings::DeleteConferencesJob#process_virtual_hearing
+      - VirtualHearings::DeleteConferencesJob
       - Fakes::EndProductStore
       - Fakes::BGSService#get_participant_id_for_user
       - Fakes::BGSServiceRecordMaker

--- a/.reek.yml
+++ b/.reek.yml
@@ -56,7 +56,9 @@ detectors:
       - ClaimReviewAsyncStatsReporter#as_csv
       - DataIntegrityChecksJob
       - DecisionIssueSyncJob
-      - VirtualHearings::DeleteConferencesJob
+      - VirtualHearings::DeleteConferencesJob#delete_conference
+      - VirtualHearings::DeleteConferencesJob#perform
+      - VirtualHearings::DeleteConferencesJob#process_virtual_hearing
       - Fakes::EndProductStore
       - Fakes::BGSService#get_participant_id_for_user
       - Fakes::BGSServiceRecordMaker

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -64,11 +64,7 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
     end
   end
 
-  def log_error
-    Rails.logger.info("Pexip response: #{resp}")
-    Rails.logger.error "CreateConferenceJob failed: (#{resp.error.code}) #{resp.error.message}"
-  end
-
+  # rubocop:disable Metrics/AbcSize
   def create_conference
     assign_virtual_hearing_alias_and_pins if should_initialize_alias_and_pins?
 
@@ -79,7 +75,9 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
     )
 
     if resp.error
-      log_error
+      Rails.logger.info("Pexip response: #{resp}")
+      Rails.logger.error "CreateConferenceJob failed: (#{resp.error.code}) #{resp.error.message}"
+
       virtual_hearing.establishment.update_error!("(#{resp.error.code}) #{resp.error.message}")
 
       fail resp.error
@@ -87,6 +85,7 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
 
     virtual_hearing.update(conference_id: resp.data[:conference_id], status: :active)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def should_initialize_alias_and_pins?
     virtual_hearing.alias.nil? || virtual_hearing.host_pin.nil? || virtual_hearing.guest_pin.nil?

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -72,9 +72,10 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
     )
 
     if resp.error
-      Rails.logger.warn "CreateConferenceJob failed: #{resp.error.message}"
+      Rails.logger.info("Pexip response: #{resp}")
+      Rails.logger.error "CreateConferenceJob failed: (#{resp.error.code}) #{resp.error.message}"
 
-      virtual_hearing.establishment.update_error!(resp.error.message)
+      virtual_hearing.establishment.update_error!("(#{resp.error.code}) #{resp.error.message}")
 
       fail resp.error
     end

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -34,12 +34,12 @@ class VirtualHearings::CreateConferenceJob < ApplicationJob
 
     virtual_hearing.establishment.attempted!
 
-    create_conference if !virtual_hearing.conference_id && !virtual_hearing.alias
+    create_conference if !virtual_hearing.conference_id || !virtual_hearing.alias
 
     VirtualHearings::SendEmail.new(
       virtual_hearing: virtual_hearing,
       type: email_type
-    ).call
+    ).call if virtual_hearing.conference_id
 
     if virtual_hearing.active? && virtual_hearing.all_emails_sent?
       virtual_hearing.establishment.clear_error!

--- a/app/jobs/virtual_hearings/delete_conferences_job.rb
+++ b/app/jobs/virtual_hearings/delete_conferences_job.rb
@@ -43,7 +43,7 @@ class VirtualHearings::DeleteConferencesJob < ApplicationJob
     true
   rescue Caseflow::Error::PexipNotFoundError
     Rails.logger.info("Pexip response: #{response}")
-    Rails.logger.info("Conference for hearing (#{virtual_hearing.hearing_id}) was already deleted" )
+    Rails.logger.info("Conference for hearing (#{virtual_hearing.hearing_id}) was already deleted")
 
     # Assume the conference was already deleted if it's no longer in Pexip.
     true

--- a/app/jobs/virtual_hearings/delete_conferences_job.rb
+++ b/app/jobs/virtual_hearings/delete_conferences_job.rb
@@ -8,10 +8,14 @@ class VirtualHearings::DeleteConferencesJob < ApplicationJob
 
   def perform
     VirtualHearingRepository.ready_for_deletion.each do |virtual_hearing|
+      Rails.logger.info("Deleting Pexip conference for hearing (#{virtual_hearing.hearing_id})")
+
       process_virtual_hearing(virtual_hearing)
     end
 
     VirtualHearingRepository.cancelled_hearings_with_pending_emails.each do |virtual_hearing|
+      Rails.logger.info("Sending cancellation emails to recipients for hearing (#{virtual_hearing.hearing_id})")
+
       VirtualHearings::SendEmail.new(virtual_hearing: virtual_hearing, type: :cancellation).call
     end
   end
@@ -24,6 +28,8 @@ class VirtualHearings::DeleteConferencesJob < ApplicationJob
     virtual_hearing.update(conference_deleted: true)
 
     if virtual_hearing.cancelled?
+      Rails.logger.info("Sending cancellation emails to recipients for hearing (#{virtual_hearing.hearing_id})")
+
       VirtualHearings::SendEmail.new(virtual_hearing: virtual_hearing, type: :cancellation).call
     end
   end
@@ -36,12 +42,14 @@ class VirtualHearings::DeleteConferencesJob < ApplicationJob
 
     true
   rescue Caseflow::Error::PexipNotFoundError
+    Rails.logger.info("Pexip response: #{response}")
+    Rails.logger.info("Conference for hearing (#{virtual_hearing.hearing_id}) was already deleted" )
+
     # Assume the conference was already deleted if it's no longer in Pexip.
     true
   rescue Caseflow::Error::PexipApiError => error
-    Rails.logger.error(
-      "Failed to delete conference from Pexip with error: (#{error.code}) #{error.message}"
-    )
+    Rails.logger.info("Pexip response: #{response}")
+    Rails.logger.error("Failed to delete conference from Pexip with error: (#{error.code}) #{error.message}")
 
     capture_exception(
       error: error,

--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -14,7 +14,8 @@ class VirtualHearings::SendEmail
       virtual_hearing.veteran_email_sent = true
     end
 
-    if !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent
+    # Judge should not receive cancellation email
+    if !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent && type != :cancellation
       send_email(:judge)
       virtual_hearing.judge_email_sent = true
     end

--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -14,7 +14,7 @@ class VirtualHearings::SendEmail
       virtual_hearing.veteran_email_sent = true
     end
 
-    if !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent
+    if should_judge_receive_email?
       send_email(:judge)
       virtual_hearing.judge_email_sent = true
     end
@@ -71,5 +71,9 @@ class VirtualHearings::SendEmail
         title: MailRecipient::RECIPIENT_TITLES[:representative]
       )
     }
+  end
+
+  def should_judge_receive_email?
+    !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent && type != :cancellation
   end
 end

--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -14,7 +14,6 @@ class VirtualHearings::SendEmail
       virtual_hearing.veteran_email_sent = true
     end
 
-    # Judge should not receive cancellation email
     if !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent
       send_email(:judge)
       virtual_hearing.judge_email_sent = true

--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -15,7 +15,7 @@ class VirtualHearings::SendEmail
     end
 
     # Judge should not receive cancellation email
-    if !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent && type != :cancellation
+    if !virtual_hearing.judge_email.nil? && !virtual_hearing.judge_email_sent
       send_email(:judge)
       virtual_hearing.judge_email_sent = true
     end

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -104,9 +104,10 @@ class BaseHearingUpdateForm
 
   def virtual_hearing_updates
     # The email sent flag should always be set to false if any changes are made.
+    # The judge_email_sent flag should not be set to false if virtual hearing is cancelled.
     emails_sent_updates = {
       veteran_email_sent: email_sent_flag(:veteran_email),
-      judge_email_sent: email_sent_flag(:judge_email),
+      judge_email_sent: email_sent_flag(:judge_email) || (virtual_hearing_attributes[:status] == :cancelled),
       representative_email_sent: email_sent_flag(:representative_email)
     }.reject { |_k, email_sent| email_sent == true }
 

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -107,7 +107,8 @@ class BaseHearingUpdateForm
     # The judge_email_sent flag should not be set to false if virtual hearing is cancelled.
     emails_sent_updates = {
       veteran_email_sent: email_sent_flag(:veteran_email),
-      judge_email_sent: email_sent_flag(:judge_email) || (virtual_hearing_attributes[:status] == :cancelled),
+      judge_email_sent: email_sent_flag(:judge_email) ||
+                        (!virtual_hearing_attributes.blank? && virtual_hearing_attributes[:status] == :cancelled),
       representative_email_sent: email_sent_flag(:representative_email)
     }.reject { |_k, email_sent| email_sent == true }
 

--- a/app/services/external_api/pexip_service.rb
+++ b/app/services/external_api/pexip_service.rb
@@ -54,8 +54,8 @@ class ExternalApi::PexipService
     url = "https://#{host}:#{port}/#{endpoint}"
     request = HTTPI::Request.new(url)
     request.auth.basic(user_name, password)
-    request.open_timeout = 30
-    request.read_timeout = 30
+    request.open_timeout = 300
+    request.read_timeout = 300
     request.auth.ssl.ca_cert_file = ENV["SSL_CERT_FILE"]
     request.body = body.to_json unless body.nil?
 

--- a/app/services/external_api/pexip_service/response.rb
+++ b/app/services/external_api/pexip_service/response.rb
@@ -24,8 +24,7 @@ class ExternalApi::PexipService::Response
   def check_for_error
     return if success?
 
-    msg = error_message(resp)
-
+    msg = error_message
     case code
     when 400
       Caseflow::Error::PexipBadRequestError.new(code: code, message: msg)
@@ -40,13 +39,13 @@ class ExternalApi::PexipService::Response
     end
   end
 
-  def error_message(resp)
-    return "No error message" if resp.raw_body.empty?
+  def error_message
+    return "No error message from Pexip" if resp.raw_body.empty?
 
     begin
       JSON.parse(resp.raw_body)["conference"]["name"].first
     rescue JSON::ParserError
-      "No error message"
+      "No error message from Pexip"
     end
   end
   # :nocov:

--- a/spec/jobs/virtual_hearings/create_conference_job_spec.rb
+++ b/spec/jobs/virtual_hearings/create_conference_job_spec.rb
@@ -34,7 +34,7 @@ describe VirtualHearings::CreateConferenceJob, :all_dbs do
     end
 
     it "job goes back on queue and logs if error", :aggregate_failures do
-      expect(Rails.logger).to receive(:warn)
+      expect(Rails.logger).to receive(:error)
       expect(create_job).to receive(:client).and_return(fake_pexip)
       expect { subject }.to have_enqueued_job(VirtualHearings::CreateConferenceJob)
       virtual_hearing.establishment.reload

--- a/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
+++ b/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
@@ -48,7 +48,7 @@ describe VirtualHearings::DeleteConferencesJob, :postgres do
         expect(virtual_hearing.conference_deleted).to eq(true)
         expect(virtual_hearing.veteran_email_sent).to eq(true)
         expect(virtual_hearing.representative_email_sent).to eq(true)
-        expect(virtual_hearing.judge_email_sent).to eq(true)
+        expect(virtual_hearing.judge_email_sent).to eq(false) # judge should not receive cancellation email
       end
     end
 
@@ -63,7 +63,7 @@ describe VirtualHearings::DeleteConferencesJob, :postgres do
         expect(job).to_not receive(:delete_conference)
         expect(virtual_hearing.veteran_email_sent).to eq(true)
         expect(virtual_hearing.representative_email_sent).to eq(true)
-        expect(virtual_hearing.judge_email_sent).to eq(true)
+        expect(virtual_hearing.judge_email_sent).to eq(false) # judge should not receive cancellation email
       end
     end
 


### PR DESCRIPTION
Resolves #13763 
- add more logging in CreateConferenceJob and DeleteConferenceJob
- ensure judge does not receive cancellation emails
- increase timeout for pexip request
-  few logic changes in CreateConferenceJob
- few small nit changes to Response.rb

Acceptance Criteria
- [x] Log full response from Pexip API
- [x] Only send email if conference ID is set
- [x] Change (in job) to `or` instead of `and` - currently we create the conference if the ID and alias are both nil
- [x] Increase timeout for Pexip request
- [x] Output status code
- [x] Delete conferences job does not to send email to judge
- [x] Add logging to delete conferences job