### PR TITLE
Make hearing times in virtual hearings emails consistent

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -163,7 +163,6 @@ detectors:
       - Reporter#median
       - Reporter#seconds_to_hms
       - Reporter#percent
-      - VirtualHearings::CalendarTemplateHelper#formatted_date_time_for_zone
       - VirtualHearings::ExternalLinkHelper#external_link
       - VirtualHearings::ExternalLinkHelper#phone_link
       - VirtualHearings::VeteranNameHelper#formatted_veteran_name

--- a/app/helpers/virtual_hearings/calendar_template_helper.rb
+++ b/app/helpers/virtual_hearings/calendar_template_helper.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
 ##
-# Helpers for use inside a template for a calendar invite related to
-# virtual hearings.
+# Helpers for use inside a template for a calendar invite or
+# email related to virtual hearings.
 
 module VirtualHearings::CalendarTemplateHelper
-  # "Monday, 9 March 2020 at 5:10pm UTC"
-  HEARING_TIME_DISPLAY_FORMAT = "%A, %-d %B %Y at %-l:%M%P %Z"
+  class << self
+    # "Monday, 9 March 2020 at 5:10pm UTC"
+    HEARING_TIME_DISPLAY_FORMAT = "%A, %-d %B %Y at %-l:%M%P %Z"
 
-  def central_office_display_time_for_virtual_hearing(virtual_hearing)
-    virtual_hearing.hearing.time.central_office_time.strftime(HEARING_TIME_DISPLAY_FORMAT)
-  end
+    def central_office_display_time_for_virtual_hearing(virtual_hearing)
+      virtual_hearing.hearing.time.central_office_time.strftime(HEARING_TIME_DISPLAY_FORMAT)
+    end
 
-  def local_display_time_for_virtual_hearing(virtual_hearing)
-    virtual_hearing.hearing.time.local_time.strftime(HEARING_TIME_DISPLAY_FORMAT)
-  end
+    def local_display_time_for_virtual_hearing(virtual_hearing)
+      virtual_hearing.hearing.time.local_time.strftime(HEARING_TIME_DISPLAY_FORMAT)
+    end
 
-  # time_zone is a TZInfo::DataTimezone object; date_time_utc is a Time object
-  def formatted_date_time_for_zone(time_zone, date_time_utc)
-    time_zone.strftime(HEARING_TIME_DISPLAY_FORMAT, date_time_utc)
+    # time_zone is a TZInfo::DataTimezone object; date_time_utc is a Time object
+    def formatted_date_time_for_zone(time_zone, date_time_utc)
+      time_zone.strftime(HEARING_TIME_DISPLAY_FORMAT, date_time_utc)
+    end
   end
 end

--- a/app/helpers/virtual_hearings/calendar_template_helper.rb
+++ b/app/helpers/virtual_hearings/calendar_template_helper.rb
@@ -5,7 +5,19 @@
 # virtual hearings.
 
 module VirtualHearings::CalendarTemplateHelper
+  # "Monday, 9 March 2020 at 5:10pm UTC"
+  HEARING_TIME_DISPLAY_FORMAT = "%A, %-d %B %Y at %-l:%M%P %Z"
+
+  def central_office_display_time_for_virtual_hearing(virtual_hearing)
+    virtual_hearing.hearing.time.central_office_time.strftime(HEARING_TIME_DISPLAY_FORMAT)
+  end
+
+  def local_display_time_for_virtual_hearing(virtual_hearing)
+    virtual_hearing.hearing.time.local_time.strftime(HEARING_TIME_DISPLAY_FORMAT)
+  end
+
+  # time_zone is a TZInfo::DataTimezone object; date_time_utc is a Time object
   def formatted_date_time_for_zone(time_zone, date_time_utc)
-    time_zone.strftime("%A, %-d %B %Y at %-l:%M %p %Z", date_time_utc)
+    time_zone.strftime(HEARING_TIME_DISPLAY_FORMAT, date_time_utc)
   end
 end

--- a/app/mailers/virtual_hearing_mailer.rb
+++ b/app/mailers/virtual_hearing_mailer.rb
@@ -8,6 +8,8 @@ class VirtualHearingMailer < ActionMailer::Base
   helper VirtualHearings::CalendarTemplateHelper
 
   def cancellation(mail_recipient:, virtual_hearing: nil)
+    return if mail_recipient.title == MailRecipient::RECIPIENT_TITLES[:judge]
+
     @recipient = mail_recipient
     @virtual_hearing = virtual_hearing
 

--- a/app/mailers/virtual_hearing_mailer.rb
+++ b/app/mailers/virtual_hearing_mailer.rb
@@ -5,6 +5,7 @@ class VirtualHearingMailer < ActionMailer::Base
   layout "virtual_hearing_mailer"
   helper VirtualHearings::ExternalLinkHelper
   helper VirtualHearings::VeteranNameHelper
+  helper VirtualHearings::CalendarTemplateHelper
 
   def cancellation(mail_recipient:, virtual_hearing: nil)
     @recipient = mail_recipient

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -93,27 +93,22 @@ class BaseHearingUpdateForm
     end
   end
 
-  # returns false if the virtual hearing status, email address associated
-  # with the passed key, or scheduled time is being updated
-  def email_sent_flag(email_key)
-    attr_changed = virtual_hearing_attributes&.key?(:status) ||
-                   virtual_hearing_attributes&.key?(email_key) ||
-                   scheduled_time_string.present?
-
-    !attr_changed
+  def updates_requiring_email?
+    virtual_hearing_attributes&.key?(:status) || scheduled_time_string.present?
   end
 
   def veteran_email_sent_flag
-    email_sent_flag(:veteran_email)
+    !(updates_requiring_email? || virtual_hearing_attributes&.key?(:veteran_email))
   end
 
   def representative_email_sent_flag
-    email_sent_flag(:representative_email)
+    !(updates_requiring_email? || virtual_hearing_attributes&.key?(:representative_email))
   end
 
-  # also returns false if no judge id is present or if the virtual hearing is being cancelled
+  # also returns false if the judge id is present or if the virtual hearing is being cancelled
   def judge_email_sent_flag
-    email_sent_flag(:judge_email) || judge_id.blank? || virtual_hearing_attributes&.dig(:status) == :cancelled
+    flag = !(updates_requiring_email? || virtual_hearing_attributes&.key?(:judge_email) || judge_id.present?)
+    flag || virtual_hearing_attributes&.dig(:status) == :cancelled
   end
 
   def virtual_hearing_updates

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -105,7 +105,7 @@ class BaseHearingUpdateForm
     !(updates_requiring_email? || virtual_hearing_attributes&.key?(:representative_email))
   end
 
-  # also returns false if the judge id is present or if the virtual hearing is being cancelled
+  # also returns false if the judge id is present or true if the virtual hearing is being cancelled
   def judge_email_sent_flag
     flag = !(updates_requiring_email? || virtual_hearing_attributes&.key?(:judge_email) || judge_id.present?)
     flag || virtual_hearing_attributes&.dig(:status) == :cancelled

--- a/app/services/virtual_hearings/calendar_service.rb
+++ b/app/services/virtual_hearings/calendar_service.rb
@@ -100,8 +100,15 @@ class VirtualHearings::CalendarService
         include VirtualHearings::VeteranNameHelper
       end
 
-      # Some *~ magic ~* here. The recipient title is used to determine
-      # which template to load.
+      # Some *~ magic ~* here. The recipient title is used to determine which template to load:
+      #
+      #              judge_confirmation_event_description
+      #     representative_confirmation_event_description
+      #            veteran_confirmation_event_description
+      #
+      # representative_changed_to_video_event_description
+      #        veteran_changed_to_video_event_description
+
       template_name = "#{recipient.title.downcase}_#{event_type}_event_description"
 
       template.render(

--- a/app/views/virtual_hearing_mailer/_representative_location_changed.html.erb
+++ b/app/views/virtual_hearing_mailer/_representative_location_changed.html.erb
@@ -1,38 +1,39 @@
-<p>
-  Dear <%= @recipient.name %>,
-</p>
+<%= content_for :intro do %>
+  <p>
+    Dear <%= @recipient.name %>,
+  </p>
 
-<p>
-  The location has changed for your Veteran's hearing with the Board of Veterans' Appeals. You will
-  arrive at <%= @virtual_hearing.hearing.hearing_location.name %> and the Veterans Law Judge will meet
-  with you via video conference.
-</p>
+  <p>
+    The location has changed for your Veteran's hearing with the Board of Veterans' Appeals. You will
+    arrive at <%= @virtual_hearing.hearing.hearing_location.name %> and the Veterans Law Judge will meet
+    with you via video conference.
+  </p>
 
-<h3>
-  <%= formatted_veteran_name(@virtual_hearing.hearing.appeal.veteran) %>
-</h3>
-<p>
-  <a href="https://appeals.cf.ds.va.gov/queue/appeals/<%= @virtual_hearing.hearing.appeal.external_id %>">
-    View the case details
-  </a> (Note: You must be logged in to the VA network to access case details.)
-</p>
+  <h3>
+    <%= formatted_veteran_name(@virtual_hearing.hearing.appeal.veteran) %>
+  </h3>
+  <p>
+    <a href="https://appeals.cf.ds.va.gov/queue/appeals/<%= @virtual_hearing.hearing.appeal.external_id %>">
+      View the case details
+    </a> (Note: You must be logged in to the VA network to access case details.)
+  </p>
+<% end %>
 
-<h3>
-  Date and Time
-</h3>
-<p>
-  <%= @virtual_hearing.hearing.scheduled_for.strftime("%A, %d %B %Y at %I:%M%P %Z") %>
-</p>
+<%= content_for :date_time do %>
+  <%= render "virtual_hearing_mailer/sections/date_time" %>
 
-<h3>
-  Location
-</h3>
-<p>
-  <%= @virtual_hearing.hearing.hearing_location.name %><br/>
-  <%= @virtual_hearing.hearing.hearing_location.address %><br/>
-</p>
+  <h3>
+    Location
+  </h3>
+  <p>
+    <%= @virtual_hearing.hearing.hearing_location.name %><br/>
+    <%= @virtual_hearing.hearing.hearing_location.address %><br/>
+  </p>
+<% end %>
 
-<p>
-  Sincerely,<br />
-  The Board of Veterans' Appeals
-</p>
+<%= content_for :signature do %>
+  <p>
+    Sincerely,<br/>
+    The Board of Veterans' Appeals
+  </p>
+<% end %>

--- a/app/views/virtual_hearing_mailer/_veteran_location_changed.html.erb
+++ b/app/views/virtual_hearing_mailer/_veteran_location_changed.html.erb
@@ -1,28 +1,29 @@
-<p>
-  Dear <%= @recipient.name %>,
-</p>
+<%= content_for :intro do %>
+  <p>
+    Dear <%= @recipient.name %>,
+  </p>
 
-<p>
-  The location has changed for your hearing with a Veterans Law Judge of the Board of Veterans' Appeals.
-  You will arrive at <%= @virtual_hearing.hearing.hearing_location.name %> and the Judge will meet with you via video conference.
-</p>
+  <p>
+    The location has changed for your hearing with a Veterans Law Judge of the Board of Veterans' Appeals.
+    You will arrive at <%= @virtual_hearing.hearing.hearing_location.name %> and the Judge will meet with you via video conference.
+  </p>
+<% end %>
 
-<h3>
-  Date and Time
-</h3>
-<p>
-  <%= @virtual_hearing.hearing.scheduled_for.strftime("%A, %d %B %Y at %I:%M%P %Z") %>
-</p>
+<%= content_for :date_time do %>
+  <%= render "virtual_hearing_mailer/sections/date_time" %>
 
-<h3>
-  Location
-</h3>
-<p>
-  <%= @virtual_hearing.hearing.hearing_location.name %><br/>
-  <%= @virtual_hearing.hearing.hearing_location.address %><br/>
-</p>
+  <h3>
+    Location
+  </h3>
+  <p>
+    <%= @virtual_hearing.hearing.hearing_location.name %><br/>
+    <%= @virtual_hearing.hearing.hearing_location.address %><br/>
+  </p>
+<% end %>
 
-<p>
-  Sincerely,<br />
-  The Board of Veterans' Appeals
-</p>
+<%= content_for :signature do %>
+  <p>
+    Sincerely,<br/>
+    The Board of Veterans' Appeals
+  </p>
+<% end %>

--- a/app/views/virtual_hearing_mailer/calendar_events/judge_confirmation_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/judge_confirmation_event_description.text.erb
@@ -1,6 +1,6 @@
 You're scheduled for a virtual hearing with <%= formatted_veteran_name(virtual_hearing.hearing.appeal.veteran) %>:
 View the Hearing Worksheet: https://appeals.cf.ds.va.gov/hearings/<%= virtual_hearing.hearing.external_id %>/worksheet
- 
+
 Date and Time
 <%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
 

--- a/app/views/virtual_hearing_mailer/calendar_events/judge_confirmation_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/judge_confirmation_event_description.text.erb
@@ -2,7 +2,7 @@ You're scheduled for a virtual hearing with <%= formatted_veteran_name(virtual_h
 View the Hearing Worksheet: https://appeals.cf.ds.va.gov/hearings/<%= virtual_hearing.hearing.external_id %>/worksheet
 
 Date and Time
-<%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
+<%= VirtualHearings::CalendarTemplateHelper.formatted_date_time_for_zone(time_zone, start_time_utc) %>
 
 How to Join
 Click on the link below, or copy and paste the link into the address field of your web browser:

--- a/app/views/virtual_hearing_mailer/calendar_events/representative_changed_to_video_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/representative_changed_to_video_event_description.text.erb
@@ -4,7 +4,7 @@ Your Veteran is scheduled for a hearing with a Veterans Law Judge of the Board o
 View the case details: https://appeals.cf.ds.va.gov/queue/appeals/<%= hearing.appeal.external_id %>
 
 Date and Time
-<%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
+<%= VirtualHearings::CalendarTemplateHelper.formatted_date_time_for_zone(time_zone, start_time_utc) %>
 
 Location
 <%= hearing.hearing_location.name %>

--- a/app/views/virtual_hearing_mailer/calendar_events/representative_confirmation_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/representative_confirmation_event_description.text.erb
@@ -2,7 +2,7 @@ You have a Veteran scheduled for a virtual hearing with a Veterans Law Judge of 
 
 <%= formatted_veteran_name(virtual_hearing.hearing.appeal.veteran) %>
 View the case details: https://appeals.cf.ds.va.gov/queue/appeals/<%= virtual_hearing.hearing.appeal.external_id %> (Note: You must be logged in to the VA network to access case details.)
- 
+
 Date and Time
 <%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
 

--- a/app/views/virtual_hearing_mailer/calendar_events/representative_confirmation_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/representative_confirmation_event_description.text.erb
@@ -4,7 +4,7 @@ You have a Veteran scheduled for a virtual hearing with a Veterans Law Judge of 
 View the case details: https://appeals.cf.ds.va.gov/queue/appeals/<%= virtual_hearing.hearing.appeal.external_id %> (Note: You must be logged in to the VA network to access case details.)
 
 Date and Time
-<%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
+<%= VirtualHearings::CalendarTemplateHelper.formatted_date_time_for_zone(time_zone, start_time_utc) %>
 
 How to Join
 We recommend joining 15 minutes before your hearing start time. Click on the link below, or copy and paste the link into the address field of your web browser:

--- a/app/views/virtual_hearing_mailer/calendar_events/veteran_changed_to_video_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/veteran_changed_to_video_event_description.text.erb
@@ -1,7 +1,7 @@
 You're scheduled for a hearing with a Veterans Law Judge of the Board of Veterans' Appeals. You will arrive at <%= hearing.hearing_location.name %> and the Judge will meet with you via video conference.
 
 Date and Time
-<%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
+<%= VirtualHearings::CalendarTemplateHelper.formatted_date_time_for_zone(time_zone, start_time_utc) %>
 
 Location
 <%= hearing.hearing_location.name %>

--- a/app/views/virtual_hearing_mailer/calendar_events/veteran_confirmation_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/veteran_confirmation_event_description.text.erb
@@ -1,7 +1,7 @@
 You're scheduled for a virtual hearing with a Veterans Law Judge of the Board of Veterans' Appeals.
 
 Date and Time
-<%= formatted_date_time_for_zone(time_zone, start_time_utc) %>
+<%= VirtualHearings::CalendarTemplateHelper.formatted_date_time_for_zone(time_zone, start_time_utc) %>
 
 How to Join
 We recommend joining 15 minutes before your hearing start time. Click on the link below, or copy and paste the link into the address field of your web browser:

--- a/app/views/virtual_hearing_mailer/calendar_events/veteran_confirmation_event_description.text.erb
+++ b/app/views/virtual_hearing_mailer/calendar_events/veteran_confirmation_event_description.text.erb
@@ -1,4 +1,4 @@
-You're scheduled for a virtual hearing with a Veterans Law Judge of the Board of Veterans' Appeals. 
+You're scheduled for a virtual hearing with a Veterans Law Judge of the Board of Veterans' Appeals.
 
 Date and Time
 <%= formatted_date_time_for_zone(time_zone, start_time_utc) %>

--- a/app/views/virtual_hearing_mailer/sections/_date_time.html.erb
+++ b/app/views/virtual_hearing_mailer/sections/_date_time.html.erb
@@ -3,8 +3,8 @@
 </h3>
 <p>
 <% if @recipient.title == MailRecipient::RECIPIENT_TITLES[:judge] %>
-  <%= @virtual_hearing.hearing.time.central_office_time.strftime("%A, %d %B %Y at %I:%M%P %Z") %>
+  <%= central_office_display_time_for_virtual_hearing(@virtual_hearing) %>
 <% else %>
-  <%= @virtual_hearing.hearing.time.local_time.strftime("%A, %d %B %Y at %I:%M%P %Z") %>
+  <%= local_display_time_for_virtual_hearing(@virtual_hearing) %>
 <% end %>
 </p>

--- a/app/views/virtual_hearing_mailer/sections/_date_time.html.erb
+++ b/app/views/virtual_hearing_mailer/sections/_date_time.html.erb
@@ -3,8 +3,8 @@
 </h3>
 <p>
 <% if @recipient.title == MailRecipient::RECIPIENT_TITLES[:judge] %>
-  <%= central_office_display_time_for_virtual_hearing(@virtual_hearing) %>
+  <%= VirtualHearings::CalendarTemplateHelper.central_office_display_time_for_virtual_hearing(@virtual_hearing) %>
 <% else %>
-  <%= local_display_time_for_virtual_hearing(@virtual_hearing) %>
+  <%= VirtualHearings::CalendarTemplateHelper.local_display_time_for_virtual_hearing(@virtual_hearing) %>
 <% end %>
 </p>

--- a/spec/jobs/virtual_hearings/send_email_spec.rb
+++ b/spec/jobs/virtual_hearings/send_email_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe VirtualHearings::SendEmail, :all_dbs do
+  let(:nyc_ro_eastern) { "RO06" }
+  let(:judge_email_sent) { false }
+  let(:representative_email_sent) { false }
+  let(:veteran_email_sent) { false }
+  let(:hearing) { create(:hearing, regional_office: nyc_ro_eastern) }
+  let!(:virtual_hearing) do
+    create(
+      :virtual_hearing,
+      hearing: hearing,
+      judge_email_sent: judge_email_sent,
+      representative_email_sent: representative_email_sent,
+      veteran_email_sent: veteran_email_sent
+    )
+  end
+  let(:email_type) { nil }
+  let(:mail_recipients) do
+    {
+      veteran: instance_double(MailRecipient),
+      judge: instance_double(MailRecipient),
+      representative: instance_double(MailRecipient)
+    }
+  end
+  let(:send_email_job) { VirtualHearings::SendEmail.new(virtual_hearing: virtual_hearing, type: email_type) }
+  let(:virtual_hearing_mailer) { double(VirtualHearingMailer) }
+
+  describe ".call" do
+    before do
+      allow(VirtualHearings::SendEmail).to receive(:new).and_return(send_email_job)
+      allow(send_email_job).to receive(:mail_recipients).and_return(mail_recipients)
+      allow(virtual_hearing_mailer).to receive(:deliver_now)
+    end
+
+    subject do
+      send_email_job.call
+    end
+
+    context "a cancellation email" do
+      let(:email_type) { :cancellation }
+
+      it "calls VirtualHearingMailer.cancellation for everyone but the judge", :aggregate_failures do
+        # YES for veteran and representative
+        expect(VirtualHearingMailer)
+          .to receive(:cancellation)
+          .once
+          .with(mail_recipient: mail_recipients[:veteran], virtual_hearing: virtual_hearing)
+          .and_return(virtual_hearing_mailer)
+
+        expect(VirtualHearingMailer)
+          .to receive(:cancellation)
+          .once
+          .with(mail_recipient: mail_recipients[:representative], virtual_hearing: virtual_hearing)
+          .and_return(virtual_hearing_mailer)
+
+        # NO for judge
+        expect(VirtualHearingMailer)
+          .to_not receive(:cancellation)
+          .with(mail_recipient: mail_recipients[:judge], virtual_hearing: virtual_hearing)
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -3,7 +3,7 @@
 describe VirtualHearingMailer do
   let(:nyc_ro_eastern) { "RO06" }
   let(:oakland_ro_pacific) { "RO43" }
-  let(:regional_office) { nil }
+  let(:regional_office) { nyc_ro_eastern }
   let(:hearing_day) do
     create(
       :hearing_day,
@@ -34,13 +34,28 @@ describe VirtualHearingMailer do
         hearing_type: hearing_day.request_type,
         hearing_date: VacolsHelper.format_datetime_with_utc_timezone(hearing_date) # VACOLS always has EST time
       )
+      hearing_location = create(:hearing_location, regional_office: regional_office)
 
       create(
         :legacy_hearing,
         case_hearing: case_hearing,
-        hearing_day: hearing_day,
-        hearing_day_id: hearing_day.id
+        hearing_day_id: hearing_day.id,
+        hearing_location: hearing_location
       )
+    end
+  end
+
+  shared_context "cancellation email" do
+    subject { VirtualHearingMailer.cancellation(mail_recipient: recipient, virtual_hearing: virtual_hearing) }
+  end
+
+  shared_context "confirmation email" do
+    subject { VirtualHearingMailer.confirmation(mail_recipient: recipient, virtual_hearing: virtual_hearing) }
+  end
+
+  shared_context "updated time confirmation email" do
+    subject do
+      VirtualHearingMailer.updated_time_confirmation(mail_recipient: recipient, virtual_hearing: virtual_hearing)
     end
   end
 
@@ -49,53 +64,61 @@ describe VirtualHearingMailer do
     Timecop.freeze(Time.utc(2020, 1, 20, 16, 50, 0))
   end
 
-  shared_examples_for "sends all email types" do
-    let(:regional_office) { nyc_ro_eastern }
-
-    describe "#cancellation" do
-      it "sends a cancellation email" do
-        expect do
-          VirtualHearingMailer.cancellation(
-            mail_recipient: recipient,
-            virtual_hearing: virtual_hearing
-          ).deliver_now
-        end
-          .to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-    end
-
-    describe "#confirmation" do
-      it "sends a confirmation email" do
-        expect do
-          VirtualHearingMailer.confirmation(
-            mail_recipient: recipient,
-            virtual_hearing: virtual_hearing
-          ).deliver_now
-        end
-          .to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-    end
-
-    describe "#updated_time_confirmation" do
-      it "sends a confirmation email" do
-        expect do
-          VirtualHearingMailer.updated_time_confirmation(
-            mail_recipient: recipient,
-            virtual_hearing: virtual_hearing
-          ).deliver_now
-        end
-          .to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
+  shared_examples_for "sends an email" do
+    it "sends an email" do
+      expect { subject.deliver_now }.to change { ActionMailer::Base.deliveries.count }.by 1
     end
   end
 
-  shared_examples_for "email body has the right times" do |expected_eastern, expected_pacific|
-    subject { VirtualHearingMailer.confirmation(mail_recipient: recipient, virtual_hearing: virtual_hearing) }
+  shared_examples_for "doesn't send an email" do
+    it "doesn't send an email" do
+      expect { subject.deliver_now }.to_not(change { ActionMailer::Base.deliveries.count })
+    end
+  end
 
+  shared_examples_for "doesn't send a cancellation email" do
+    describe "#cancellation" do
+      include_context "cancellation email"
+
+      it_behaves_like "doesn't send an email"
+    end
+  end
+
+  shared_examples_for "sends a cancellation email" do
+    describe "#cancellation" do
+      include_context "cancellation email"
+
+      it_behaves_like "sends an email"
+    end
+  end
+
+  shared_examples_for "sends a confirmation email" do
+    describe "#confirmation" do
+      include_context "confirmation email"
+
+      it_behaves_like "sends an email"
+    end
+  end
+
+  shared_examples_for "sends an updated time confirmation email" do
+    describe "#updated_time_confirmation" do
+      include_context "updated time confirmation email"
+
+      it_behaves_like "sends an email"
+    end
+  end
+
+  shared_examples_for "sends all email types" do
+    it_behaves_like "sends a cancellation email"
+    it_behaves_like "sends a confirmation email"
+    it_behaves_like "sends an updated time confirmation email"
+  end
+
+  shared_examples_for "email body has the right times" do |expected_eastern, expected_pacific|
     context "regional office is in eastern timezone" do
       let(:regional_office) { nyc_ro_eastern }
 
-      it "has the correct time in the confirmation email" do
+      it "has the correct time in the email" do
         expect(subject.html_part.body).to include(expected_eastern)
       end
     end
@@ -103,8 +126,34 @@ describe VirtualHearingMailer do
     context "regional office is in pacific timezone" do
       let(:regional_office) { oakland_ro_pacific }
 
-      it "has the correct time in the confirmation email" do
+      it "has the correct time in the email" do
         expect(subject.html_part.body).to include(expected_pacific)
+      end
+    end
+  end
+
+  shared_examples_for "email body has the right times for types" do |expected_eastern, expected_pacific, types|
+    if types.include? :cancellation
+      describe "#cancellation" do
+        include_context "cancellation email"
+
+        it_behaves_like "email body has the right times", expected_eastern, expected_pacific
+      end
+    end
+
+    if types.include? :confirmation
+      describe "#confirmation" do
+        include_context "confirmation email"
+
+        it_behaves_like "email body has the right times", expected_eastern, expected_pacific
+      end
+    end
+
+    if types.include? :updated_time_confirmation
+      describe "#updated_time_confirmation" do
+        include_context "updated time confirmation email"
+
+        it_behaves_like "email body has the right times", expected_eastern, expected_pacific
       end
     end
   end
@@ -112,12 +161,17 @@ describe VirtualHearingMailer do
   # ama_times & legacy_times are in the format { expected_eastern: "10:30 EST", expected_pacific: "7:30 PST" }
   # expected_eastern is the time displayed in the email body when the regional office is in the eastern time zone
   # expected_pacific is the time displayed in the email body when the regional office is in the pacific time zone
-  shared_examples_for "email body has the right times with ama and legacy hearings" do |ama_times, legacy_times|
+  shared_examples_for "email body has the right times with ama and legacy hearings" do |ama_times, legacy_times, types|
+    types = [:cancellation, :confirmation, :updated_time_confirmation] if types.nil?
+
     context "with ama hearing" do
       include_context "ama hearing"
 
       it_behaves_like(
-        "email body has the right times", ama_times[:expected_eastern], ama_times[:expected_pacific]
+        "email body has the right times for types",
+        ama_times[:expected_eastern],
+        ama_times[:expected_pacific],
+        types
       )
     end
 
@@ -125,7 +179,10 @@ describe VirtualHearingMailer do
       include_context "legacy hearing"
 
       it_behaves_like(
-        "email body has the right times", legacy_times[:expected_eastern], legacy_times[:expected_pacific]
+        "email body has the right times for types",
+        legacy_times[:expected_eastern],
+        legacy_times[:expected_pacific],
+        types
       )
     end
   end
@@ -135,7 +192,9 @@ describe VirtualHearingMailer do
 
     let(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:judge] }
 
-    it_behaves_like "sends all email types"
+    it_behaves_like "doesn't send a cancellation email"
+    it_behaves_like "sends a confirmation email"
+    it_behaves_like "sends an updated time confirmation email"
 
     # we expect the judge to always see the hearing time in central office (eastern) time zone
 
@@ -144,7 +203,10 @@ describe VirtualHearingMailer do
     # legacy hearing is scheduled at 11:30am in the central office's time zone (eastern)
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am EST" }
     it_behaves_like(
-      "email body has the right times with ama and legacy hearings", expected_ama_times, expected_legacy_times
+      "email body has the right times with ama and legacy hearings",
+      expected_ama_times,
+      expected_legacy_times,
+      [:confirmation, :updated_time_confirmation]
     )
   end
 
@@ -172,5 +234,15 @@ describe VirtualHearingMailer do
     let(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:representative] }
 
     it_behaves_like "sends all email types"
+
+    # we expect the representative to always see the hearing time in the regional office time zone
+
+    # ama hearing is scheduled at 8:30am in the regional office's time zone
+    expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "8:30am PST" }
+    # legacy hearing is scheduled at 11:30am in the central office's time zone (eastern)
+    expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "8:30am PST" }
+    it_behaves_like(
+      "email body has the right times with ama and legacy hearings", expected_ama_times, expected_legacy_times
+    )
   end
 end


### PR DESCRIPTION
Resolves #13749

### Description
Makes the way hearing times that appear in virtual hearing emails are rendered consistent. Comprehensive VirtualHearingMailer tests were added to exercise every combination of email type, user type, and hearing type; and other errors surfaced by these tests were fixed.
