### PR TITLE
Remove redundant `appeal` parameter from FactoryBot.create call - Part 2

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -339,7 +339,7 @@ class SeedDB
       updated_by: hearings_member
     )
     FactoryBot.create(:hearing_task_association, hearing: hearing, hearing_task: parent_hearing_task)
-    FactoryBot.create(:change_hearing_disposition_task, parent: parent_hearing_task, appeal: appeal)
+    FactoryBot.create(:change_hearing_disposition_task, parent: parent_hearing_task)
   end
   ### End Hearings Setup ###
 

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -166,8 +166,8 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
         let!(:tasks) do
           [
-            create(:ama_attorney_task, assigned_to: user, appeal: ama_appeals.first, parent: parents.first),
-            create(:ama_attorney_task, assigned_to: user, appeal: ama_appeals.second, parent: parents.second)
+            create(:ama_attorney_task, assigned_to: user, parent: parents.first),
+            create(:ama_attorney_task, assigned_to: user, parent: parents.second)
           ]
         end
 

--- a/spec/controllers/tasks/end_hold_controller_spec.rb
+++ b/spec/controllers/tasks/end_hold_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Tasks::EndHoldController, :postgres, type: :controller do
     let!(:parent) { create(:ama_task) }
     let(:parent_id) { parent.id }
     let!(:timed_hold_task) do
-      create(:timed_hold_task, appeal: parent.appeal, assigned_to: user, days_on_hold: 18, parent: parent)
+      create(:timed_hold_task, assigned_to: user, days_on_hold: 18, parent: parent)
     end
 
     subject { post(:create, params: { task_id: parent_id }) }

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -435,7 +435,7 @@ feature "AmaQueue", :all_dbs do
     end
     let!(:root_task) { create(:root_task, appeal: appeal) }
     let!(:judge_task) do
-      create(:ama_judge_task, appeal: appeal, parent: root_task, assigned_to: judge_user, status: :assigned)
+      create(:ama_judge_task, parent: root_task, assigned_to: judge_user, status: :assigned)
     end
 
     before do

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1113,7 +1113,7 @@ RSpec.feature "Case details", :all_dbs do
       before do
         judge = create(:user, station_id: 101)
         create(:staff, :judge_role, user: judge)
-        judge_task = JudgeAssignTask.create!(parent: root_task, assigned_to: judge)
+        judge_task = JudgeAssignTask.create!(appeal: appeal, parent: root_task, assigned_to: judge)
 
         atty = create(:user, station_id: 101)
         create(:staff, :attorney_role, user: atty)

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -840,17 +840,16 @@ RSpec.feature "Case details", :all_dbs do
       let!(:appeal) { create(:appeal) }
       let!(:appeal2) { create(:appeal) }
       let!(:root_task) { create(:root_task, appeal: appeal, assigned_to: user) }
-      let!(:assign_task) { create(:ama_judge_task, appeal: appeal, assigned_to: user, parent: root_task) }
+      let!(:assign_task) { create(:ama_judge_task, assigned_to: user, parent: root_task) }
       let!(:judge_task) do
         create(
           :ama_judge_decision_review_task,
-          appeal: appeal,
           parent: root_task,
           assigned_to: user
         )
       end
-      let!(:attorney_task) { create(:ama_attorney_task, appeal: appeal, parent: judge_task, assigned_to: user) }
-      let!(:attorney_task2) { create(:ama_attorney_task, appeal: appeal, parent: root_task, assigned_to: user) }
+      let!(:attorney_task) { create(:ama_attorney_task, parent: judge_task, assigned_to: user) }
+      let!(:attorney_task2) { create(:ama_attorney_task, parent: root_task, assigned_to: user) }
 
       before do
         # The status attribute needs to be set here due to update_parent_status hook in the task model
@@ -1114,7 +1113,7 @@ RSpec.feature "Case details", :all_dbs do
       before do
         judge = create(:user, station_id: 101)
         create(:staff, :judge_role, user: judge)
-        judge_task = JudgeAssignTask.create!(appeal: appeal, parent: root_task, assigned_to: judge)
+        judge_task = JudgeAssignTask.create!(parent: root_task, assigned_to: judge)
 
         atty = create(:user, station_id: 101)
         create(:staff, :attorney_role, user: atty)
@@ -1154,7 +1153,7 @@ RSpec.feature "Case details", :all_dbs do
     context "when the only task is a TrackVeteranTask" do
       let(:root_task) { create(:root_task) }
       let(:appeal) { root_task.appeal }
-      let(:tracking_task) { create(:track_veteran_task, appeal: appeal, parent: root_task) }
+      let(:tracking_task) { create(:track_veteran_task, parent: root_task) }
 
       it "should not show the tracking task in task snapshot" do
         visit("/queue/appeals/#{tracking_task.appeal.uuid}")

--- a/spec/feature/queue/hearings_tasks_spec.rb
+++ b/spec/feature/queue/hearings_tasks_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Hearings tasks workflows", :all_dbs do
     let(:appeal) { create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number) }
     let(:veteran_link_text) { "#{appeal.veteran_full_name} (#{appeal.veteran_file_number})" }
     let(:root_task) { create(:root_task, appeal: appeal) }
-    let(:distribution_task) { create(:distribution_task, appeal: appeal, parent: root_task) }
+    let(:distribution_task) { create(:distribution_task, parent: root_task) }
     let(:parent_hearing_task) { create(:hearing_task, parent: distribution_task) }
     let(:disposition_task) do
       create(:assign_hearing_disposition_task, parent: parent_hearing_task)

--- a/spec/feature/queue/judge_assignment_spec.rb
+++ b/spec/feature/queue/judge_assignment_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
 
     context "there's another in-progress JudgeAssignTask" do
       let!(:judge_task) do
-        create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, appeal: appeal, parent: root_task)
+        create(:ama_judge_task, :in_progress, assigned_to: judge_one.user, parent: root_task)
       end
 
       scenario "viewing the assign task queue" do
@@ -138,14 +138,12 @@ RSpec.feature "Judge assignment to attorney and judge", :all_dbs do
 
     context "there's an in-progress JudgeDecisionReviewTask" do
       let!(:judge_review_task) do
-        create(
-          :ama_judge_decision_review_task, :in_progress, assigned_to: judge_one.user, appeal: appeal, parent: root_task
-        )
+        create(:ama_judge_decision_review_task, :in_progress, assigned_to: judge_one.user, parent: root_task)
       end
 
       scenario "viewing the review task queue" do
         expect(judge_review_task.status).to eq("in_progress")
-        attorney_completed_task = create(:ama_attorney_task, appeal: appeal, parent: judge_review_task)
+        attorney_completed_task = create(:ama_attorney_task, parent: judge_review_task)
         attorney_completed_task.update!(status: Constants.TASK_STATUSES.completed)
         case_review = create(:attorney_case_review, task_id: attorney_completed_task.id)
 

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
     context "motions attorney reviews case" do
       let!(:motions_attorney_task) do
-        create(:vacate_motion_mail_task, appeal: appeal, assigned_to: motions_attorney, parent: root_task)
+        create(:vacate_motion_mail_task, assigned_to: motions_attorney, parent: root_task)
       end
 
       it "motions attorney recommends grant decision to judge" do
@@ -481,7 +481,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
              assigned_to: judge, appeal: appeal, created_at: receipt_date + 3.days, parent: root_task)
     end
     let(:vacate_motion_mail_task) do
-      create(:vacate_motion_mail_task, appeal: appeal, assigned_to: motions_attorney, parent: root_task)
+      create(:vacate_motion_mail_task, assigned_to: motions_attorney, parent: root_task)
     end
     let(:judge_address_motion_to_vacate_task) do
       create(:judge_address_motion_to_vacate_task,
@@ -490,7 +490,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
              parent: vacate_motion_mail_task)
     end
     let(:abstract_motion_to_vacate_task) do
-      create(:abstract_motion_to_vacate_task, appeal: appeal, parent: vacate_motion_mail_task)
+      create(:abstract_motion_to_vacate_task, parent: vacate_motion_mail_task)
     end
 
     let(:vacate_type) { "straight_vacate" }
@@ -719,13 +719,13 @@ RSpec.feature "Motion to vacate", :all_dbs do
              assigned_to: judge, appeal: appeal, created_at: receipt_date + 3.days, parent: root_task)
     end
     let(:vacate_motion_mail_task) do
-      create(:vacate_motion_mail_task, appeal: appeal, assigned_to: motions_attorney, parent: root_task)
+      create(:vacate_motion_mail_task, assigned_to: motions_attorney, parent: root_task)
     end
     let(:judge_address_motion_to_vacate_task) do
-      create(:judge_address_motion_to_vacate_task, appeal: appeal, assigned_to: judge, parent: vacate_motion_mail_task)
+      create(:judge_address_motion_to_vacate_task, assigned_to: judge, parent: vacate_motion_mail_task)
     end
     let(:abstract_motion_to_vacate_task) do
-      create(:abstract_motion_to_vacate_task, appeal: appeal, parent: vacate_motion_mail_task)
+      create(:abstract_motion_to_vacate_task, parent: vacate_motion_mail_task)
     end
     let(:denied_motion_to_vacate_task) do
       create(

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -219,7 +219,7 @@ RSpec.feature "Quality Review workflow", :all_dbs do
     let(:hold_length) { 30 }
 
     let!(:judge_task) do
-      create(:ama_judge_task, :completed, appeal: appeal, parent: root_task, assigned_to: judge_user)
+      create(:ama_judge_task, :completed, parent: root_task, assigned_to: judge_user)
     end
     let!(:qr_org_task) { QualityReviewTask.create_from_root_task(root_task) }
 

--- a/spec/jobs/hearing_disposition_change_job_spec.rb
+++ b/spec/jobs/hearing_disposition_change_job_spec.rb
@@ -4,8 +4,8 @@ describe HearingDispositionChangeJob, :all_dbs do
   def create_disposition_task_ancestry(disposition: nil, scheduled_for: nil, associated_hearing: true)
     appeal = create(:appeal)
     root_task = create(:root_task, appeal: appeal)
-    distribution_task = create(:distribution_task, appeal: appeal, parent: root_task)
-    parent_hearing_task = create(:hearing_task, appeal: appeal, parent: distribution_task)
+    distribution_task = create(:distribution_task, parent: root_task)
+    parent_hearing_task = create(:hearing_task, parent: distribution_task)
 
     hearing = create(:hearing, appeal: appeal, disposition: disposition)
     if scheduled_for
@@ -23,21 +23,21 @@ describe HearingDispositionChangeJob, :all_dbs do
       create(:hearing_task_association, hearing: hearing, hearing_task: parent_hearing_task)
     end
 
-    create(:assign_hearing_disposition_task, appeal: appeal, parent: parent_hearing_task)
+    create(:assign_hearing_disposition_task, parent: parent_hearing_task)
   end
 
   def create_disposition_task_for_legacy_hearings_ancestry(associated_hearing: nil)
     appeal = create(:legacy_appeal, vacols_case: create(:case))
     root_task = create(:root_task, appeal: appeal)
-    distribution_task = create(:distribution_task, appeal: appeal, parent: root_task)
-    parent_hearing_task = create(:hearing_task, appeal: appeal, parent: distribution_task)
+    distribution_task = create(:distribution_task, parent: root_task)
+    parent_hearing_task = create(:hearing_task, parent: distribution_task)
 
     hearing_args = { appeal: appeal }
     hearing_args[:case_hearing] = associated_hearing if associated_hearing
     hearing = create(:legacy_hearing, hearing_args)
 
     create(:hearing_task_association, hearing: hearing, hearing_task: parent_hearing_task)
-    create(:assign_hearing_disposition_task, appeal: appeal, parent: parent_hearing_task)
+    create(:assign_hearing_disposition_task, parent: parent_hearing_task)
   end
 
   describe ".lock_hearing_days" do

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -13,20 +13,20 @@ describe "fixes", :all_dbs do
       # a legacy appeal
       let(:appeal1) { create(:legacy_appeal, vacols_case: create(:case)) }
       let(:root_task1) { create(:root_task, appeal: appeal1) }
-      let(:hearing_task1) { create(:hearing_task, appeal: appeal1, parent: root_task1) }
-      let!(:schedule_hearing_task1) { create(:schedule_hearing_task, appeal: appeal1, parent: hearing_task1) }
+      let(:hearing_task1) { create(:hearing_task, parent: root_task1) }
+      let!(:schedule_hearing_task1) { create(:schedule_hearing_task, parent: hearing_task1) }
       # a second legacy appeal
       let(:appeal2) { create(:legacy_appeal, vacols_case: create(:case)) }
       let(:root_task2) { create(:root_task, appeal: appeal2) }
-      let(:hearing_task2) { create(:hearing_task, appeal: appeal2, parent: root_task2) }
-      let!(:schedule_hearing_task2) { create(:schedule_hearing_task, appeal: appeal2, parent: hearing_task2) }
+      let(:hearing_task2) { create(:hearing_task, parent: root_task2) }
+      let!(:schedule_hearing_task2) { create(:schedule_hearing_task, parent: hearing_task2) }
       # an ama appeal
       let(:appeal3) { create(:appeal) }
       let(:root_task3) { create(:root_task, appeal: appeal3) }
-      let(:distribution_task3) { create(:distribution_task, appeal: appeal3, parent: root_task3) }
-      let(:hearing_task3) { create(:hearing_task, appeal: appeal3, parent: distribution_task3) }
-      let!(:schedule_hearing_task3) { create(:schedule_hearing_task, appeal: appeal3, parent: hearing_task3) }
-      let!(:track_veteran_task3) { create(:track_veteran_task, appeal: appeal3, parent: root_task3) }
+      let(:distribution_task3) { create(:distribution_task, parent: root_task3) }
+      let(:hearing_task3) { create(:hearing_task, parent: distribution_task3) }
+      let!(:schedule_hearing_task3) { create(:schedule_hearing_task, parent: hearing_task3) }
+      let!(:track_veteran_task3) { create(:track_veteran_task, parent: root_task3) }
 
       let(:schedule_hearing_tasks) { [schedule_hearing_task1, schedule_hearing_task2, schedule_hearing_task3] }
 
@@ -155,8 +155,8 @@ describe "fixes", :all_dbs do
           end
 
           context "there's another HearingTask on the same appeal as one of the stalled HearingTasks" do
-            let(:hearing_task2b) { create(:hearing_task, appeal: appeal2, parent: root_task2) }
-            let!(:schedule_hearing_task2b) { create(:schedule_hearing_task, appeal: appeal2, parent: hearing_task2b) }
+            let(:hearing_task2b) { create(:hearing_task, parent: root_task2) }
+            let!(:schedule_hearing_task2b) { create(:schedule_hearing_task, parent: hearing_task2b) }
 
             it "doesn't try to change the open HearingTask on the same appeal" do
               ids = [hearing_task1.id, hearing_task3.id]
@@ -195,7 +195,7 @@ describe "fixes", :all_dbs do
 
           context "a HearingTask has more than one child" do
             let!(:disposition_task1) do
-              create(:assign_hearing_disposition_task, appeal: appeal1, parent: hearing_task1)
+              create(:assign_hearing_disposition_task, parent: hearing_task1)
             end
 
             before do
@@ -219,7 +219,7 @@ describe "fixes", :all_dbs do
 
           context "a HearingTask's on_hold ScheduleHearingTask child has an open descendant" do
             let!(:verify_address_task2) do
-              create(:hearing_admin_action_verify_address_task, appeal: appeal2, parent: schedule_hearing_task2)
+              create(:hearing_admin_action_verify_address_task, parent: schedule_hearing_task2)
             end
 
             before do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -785,8 +785,8 @@ describe Appeal, :all_dbs do
 
       let(:root_task) { create(:root_task, :in_progress, appeal: appeal) }
       before do
-        create(:track_veteran_task, :in_progress, appeal: appeal, parent: root_task, updated_at: today + 21)
-        create(:timed_hold_task, :in_progress, appeal: appeal, parent: root_task, updated_at: today + 21)
+        create(:track_veteran_task, :in_progress, parent: root_task, updated_at: today + 21)
+        create(:timed_hold_task, :in_progress, parent: root_task, updated_at: today + 21)
       end
 
       describe "when there are no other tasks" do
@@ -798,7 +798,7 @@ describe Appeal, :all_dbs do
       describe "when there is an actionable task with an assignee", skip: "flake" do
         let(:assignee) { create(:user) }
         let!(:task) do
-          create(:ama_attorney_task, :in_progress, assigned_to: assignee, appeal: appeal, parent: root_task)
+          create(:ama_attorney_task, :in_progress, assigned_to: assignee, parent: root_task)
         end
 
         it "returns the actionable task's label and does not include nonactionable tasks in its determinations" do
@@ -819,13 +819,13 @@ describe Appeal, :all_dbs do
 
       before do
         organization_root_task = create(:root_task, appeal: appeal_organization)
-        create(:ama_task, assigned_to: organization, appeal: appeal_organization, parent: organization_root_task)
+        create(:ama_task, assigned_to: organization, parent: organization_root_task)
 
         user_root_task = create(:root_task, appeal: appeal_user)
-        create(:ama_task, assigned_to: user, appeal: appeal_user, parent: user_root_task)
+        create(:ama_task, assigned_to: user, parent: user_root_task)
 
         on_hold_root = create(:root_task, appeal: appeal_on_hold, updated_at: today - 1)
-        create(:ama_task, :on_hold, appeal: appeal_on_hold, parent: on_hold_root, updated_at: today + 1)
+        create(:ama_task, :on_hold, parent: on_hold_root, updated_at: today + 1)
 
         # These tasks are the most recently updated but should be ignored in the determination
         create(:track_veteran_task, :in_progress, appeal: appeal, updated_at: today + 20)

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2586,8 +2586,8 @@ describe LegacyAppeal, :all_dbs do
         let(:today) { Time.zone.today }
         let!(:root_task) { create(:root_task, :in_progress, appeal: appeal) }
         before do
-          create(:track_veteran_task, :in_progress, appeal: appeal, parent: root_task, updated_at: today + 11)
-          create(:timed_hold_task, :in_progress, appeal: appeal, parent: root_task, updated_at: today + 11)
+          create(:track_veteran_task, :in_progress, parent: root_task, updated_at: today + 11)
+          create(:timed_hold_task, :in_progress, parent: root_task, updated_at: today + 11)
         end
 
         describe "when there are no other tasks" do
@@ -2599,7 +2599,7 @@ describe LegacyAppeal, :all_dbs do
         describe "when there is an assigned actionable task" do
           let(:task_assignee) { create(:user) }
           let!(:task) do
-            create(:colocated_task, :in_progress, assigned_to: task_assignee, appeal: appeal, parent: root_task)
+            create(:colocated_task, :in_progress, assigned_to: task_assignee, parent: root_task)
           end
 
           it "returns the actionable task's label and does not include nonactionable tasks in its determinations" do
@@ -2617,7 +2617,7 @@ describe LegacyAppeal, :all_dbs do
 
           before do
             organization_root_task = create(:root_task, appeal: appeal)
-            create(:ama_task, assigned_to: organization, appeal: appeal, parent: organization_root_task)
+            create(:ama_task, assigned_to: organization, parent: organization_root_task)
 
             # These tasks are the most recently updated but should be ignored in the determination
             create(:track_veteran_task, :in_progress, appeal: appeal, updated_at: today + 10)
@@ -2634,7 +2634,7 @@ describe LegacyAppeal, :all_dbs do
 
           before do
             user_root_task = create(:root_task, appeal: appeal)
-            create(:ama_task, assigned_to: user, appeal: appeal, parent: user_root_task)
+            create(:ama_task, assigned_to: user, parent: user_root_task)
           end
 
           it "it returns the id" do
@@ -2647,7 +2647,7 @@ describe LegacyAppeal, :all_dbs do
 
           before do
             on_hold_root = create(:root_task, appeal: appeal, updated_at: pre_ama - 1)
-            create(:ama_task, :on_hold, appeal: appeal, parent: on_hold_root, updated_at: pre_ama + 1)
+            create(:ama_task, :on_hold, parent: on_hold_root, updated_at: pre_ama + 1)
           end
 
           it "it returns something" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -242,7 +242,7 @@ describe Task, :all_dbs do
     end
 
     context "when there is an attorney_case_review" do
-      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent: task) }
+      let!(:child) { create(:task, type: Task.name, parent: task) }
       let!(:attorney_case_reviews) do
         create(:attorney_case_review, task_id: child.id, attorney: create(:user, full_name: "Bob Smith"))
       end
@@ -284,7 +284,7 @@ describe Task, :all_dbs do
     end
 
     context "when there is a sub task" do
-      let!(:child) { create(:task, type: Task.name, appeal: task.appeal, parent: task) }
+      let!(:child) { create(:task, type: Task.name, parent: task) }
       let!(:attorney_case_reviews) do
         [
           create(:attorney_case_review, task_id: child.id, created_at: 1.day.ago),
@@ -301,8 +301,8 @@ describe Task, :all_dbs do
   describe "#cancel_task_and_child_subtasks" do
     let(:appeal) { create(:appeal) }
     let!(:top_level_task) { create(:task, appeal: appeal) }
-    let!(:second_level_tasks) { create_list(:task, 2, appeal: appeal, parent: top_level_task) }
-    let!(:third_level_task) { create_list(:task, 2, appeal: appeal, parent: second_level_tasks.first) }
+    let!(:second_level_tasks) { create_list(:task, 2, parent: top_level_task) }
+    let!(:third_level_task) { create_list(:task, 2, parent: second_level_tasks.first) }
 
     it "cancels all tasks and child subtasks" do
       initial_versions = second_level_tasks[0].versions.count
@@ -472,7 +472,7 @@ describe Task, :all_dbs do
 
     context "with a timed hold task" do
       let!(:timed_hold_task) do
-        create(:timed_hold_task, appeal: task.appeal, assigned_to: user, days_on_hold: 18, parent: task)
+        create(:timed_hold_task, assigned_to: user, days_on_hold: 18, parent: task)
       end
 
       it "includes end timed hold in the returned actions" do
@@ -950,7 +950,7 @@ describe Task, :all_dbs do
 
     context "there is an active timed hold task child" do
       let!(:timed_hold_task) do
-        create(:timed_hold_task, appeal: task.appeal, assigned_to: user, days_on_hold: 18, parent: task)
+        create(:timed_hold_task, assigned_to: user, days_on_hold: 18, parent: task)
       end
 
       context "status is updated" do

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -229,8 +229,8 @@ describe AssignHearingDispositionTask, :all_dbs do
     let(:disposition) { nil }
     let(:appeal) { create(:appeal) }
     let(:root_task) { create(:root_task, appeal: appeal) }
-    let(:distribution_task) { create(:distribution_task, appeal: appeal, parent: root_task) }
-    let(:hearing_task) { create(:hearing_task, appeal: appeal, parent: distribution_task) }
+    let(:distribution_task) { create(:distribution_task, parent: root_task) }
+    let(:hearing_task) { create(:hearing_task, parent: distribution_task) }
     let(:evidence_window_waived) { nil }
     let(:hearing_scheduled_for) { appeal.receipt_date + 15.days }
     let(:hearing_day) { create(:hearing_day, scheduled_for: hearing_scheduled_for) }
@@ -254,16 +254,14 @@ describe AssignHearingDispositionTask, :all_dbs do
       create(
         :assign_hearing_disposition_task,
         :in_progress,
-        parent: hearing_task,
-        appeal: appeal
+        parent: hearing_task
       )
     end
     let!(:schedule_hearing_task) do
       create(
         :schedule_hearing_task,
         :completed,
-        parent: hearing_task,
-        appeal: appeal
+        parent: hearing_task
       )
     end
 
@@ -291,7 +289,7 @@ describe AssignHearingDispositionTask, :all_dbs do
 
           context "the appeal has an existing EvidenceSubmissionWindowTask" do
             let!(:evidence_submission_window_task) do
-              create(:evidence_submission_window_task, appeal: appeal, parent: distribution_task)
+              create(:evidence_submission_window_task, parent: distribution_task)
             end
 
             it "does not raise an error" do

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -76,6 +76,7 @@ describe AttorneyTask, :all_dbs do
       AttorneyTask.create(
         assigned_to: attorney,
         assigned_by: assigning_judge,
+        appeal: appeal,
         parent: parent,
         status: Constants.TASK_STATUSES.assigned
       )

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -13,7 +13,6 @@ describe AttorneyTask, :all_dbs do
       :ama_judge_decision_review_task,
       assigned_by: assigning_judge,
       assigned_to: reviewing_judge,
-      appeal: appeal,
       parent: appeal.root_task
     )
   end
@@ -46,7 +45,6 @@ describe AttorneyTask, :all_dbs do
                :completed,
                assigned_to: attorney,
                assigned_by: assigning_judge,
-               appeal: appeal,
                parent: parent)
       end
 
@@ -61,7 +59,6 @@ describe AttorneyTask, :all_dbs do
           :ama_attorney_task,
           assigned_to: attorney,
           assigned_by: assigning_judge,
-          appeal: appeal,
           parent: parent
         )
       end
@@ -78,7 +75,6 @@ describe AttorneyTask, :all_dbs do
       AttorneyTask.create(
         assigned_to: attorney,
         assigned_by: assigning_judge,
-        appeal: appeal,
         parent: parent,
         status: Constants.TASK_STATUSES.assigned
       )
@@ -129,7 +125,7 @@ describe AttorneyTask, :all_dbs do
   end
 
   context "when cancelling the task" do
-    let!(:attorney_task) { create(:ama_attorney_task, assigned_by: assigning_judge, appeal: appeal, parent: parent) }
+    let!(:attorney_task) { create(:ama_attorney_task, assigned_by: assigning_judge, parent: parent) }
 
     subject { attorney_task.update!(status: Constants.TASK_STATUSES.cancelled) }
 

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -8,12 +8,13 @@ describe AttorneyTask, :all_dbs do
   let!(:assigning_judge_staff) { create(:staff, :judge_role, sdomainid: assigning_judge.css_id) }
   let!(:reviewing_judge_staff) { create(:staff, :judge_role, sdomainid: reviewing_judge.css_id) }
   let(:appeal) { create(:appeal) }
+  let(:root_task) { create(:root_task, appeal: appeal) }
   let!(:parent) do
     create(
       :ama_judge_decision_review_task,
       assigned_by: assigning_judge,
       assigned_to: reviewing_judge,
-      parent: appeal.root_task
+      parent: root_task
     )
   end
 

--- a/spec/models/tasks/quality_review_task_spec.rb
+++ b/spec/models/tasks/quality_review_task_spec.rb
@@ -24,7 +24,7 @@ describe QualityReviewTask, :all_dbs do
 
       let!(:judge) { create(:user) }
       let!(:vacols_judge) { create(:staff, :judge_role, user: judge) }
-      let!(:judge_task) { JudgeAssignTask.create!(appeal: appeal, parent: root_task, assigned_to: judge) }
+      let!(:judge_task) { JudgeAssignTask.create!(parent: root_task, assigned_to: judge) }
 
       let!(:atty) { create(:user) }
       let!(:vacols_atty) { create(:staff, :attorney_role, user: atty) }

--- a/spec/models/tasks/quality_review_task_spec.rb
+++ b/spec/models/tasks/quality_review_task_spec.rb
@@ -24,7 +24,7 @@ describe QualityReviewTask, :all_dbs do
 
       let!(:judge) { create(:user) }
       let!(:vacols_judge) { create(:staff, :judge_role, user: judge) }
-      let!(:judge_task) { JudgeAssignTask.create!(parent: root_task, assigned_to: judge) }
+      let!(:judge_task) { JudgeAssignTask.create!(appeal: appeal, parent: root_task, assigned_to: judge) }
 
       let!(:atty) { create(:user) }
       let!(:vacols_atty) { create(:staff, :attorney_role, user: atty) }

--- a/spec/models/tasks/root_task_spec.rb
+++ b/spec/models/tasks/root_task_spec.rb
@@ -37,8 +37,8 @@ describe RootTask, :postgres do
     subject { root_task.update_children_status_after_closed }
 
     context "when there are multiple children tasks" do
-      let!(:task) { create(:ama_task, appeal: appeal, parent: root_task) }
-      let!(:tracking_task) { create(:track_veteran_task, appeal: appeal, parent: root_task) }
+      let!(:task) { create(:ama_task, parent: root_task) }
+      let!(:tracking_task) { create(:track_veteran_task, parent: root_task) }
 
       it "should only close the tracking task" do
         expect { subject }.to_not raise_error
@@ -53,14 +53,14 @@ describe RootTask, :postgres do
     let!(:appeal) { root_task.appeal }
 
     context "when the Appeal has already been dispatched" do
-      let!(:tracking_task) { create(:track_veteran_task, appeal: appeal, parent: root_task) }
+      let!(:tracking_task) { create(:track_veteran_task, parent: root_task) }
       let!(:dispatch_task) do
-        create(:bva_dispatch_task, :completed, closed_at: Time.zone.now - 1, appeal: appeal, parent: root_task)
+        create(:bva_dispatch_task, :completed, closed_at: Time.zone.now - 1, parent: root_task)
       end
-      let!(:mail_task) { create(:reconsideration_motion_mail_task, appeal: appeal, parent: root_task) }
+      let!(:mail_task) { create(:reconsideration_motion_mail_task, parent: root_task) }
 
       context "when there are non-closeable child tasks present" do
-        let!(:task) { create(:ama_task, appeal: appeal, parent: root_task) }
+        let!(:task) { create(:ama_task, parent: root_task) }
 
         it "the RootTask does not close itself" do
           expect(root_task).to be_on_hold

--- a/spec/models/tasks/track_veteran_task_spec.rb
+++ b/spec/models/tasks/track_veteran_task_spec.rb
@@ -7,7 +7,6 @@ describe TrackVeteranTask, :postgres do
     create(
       :track_veteran_task,
       parent: root_task,
-      appeal: root_task.appeal,
       assigned_to: vso
     )
   end
@@ -147,7 +146,7 @@ describe TrackVeteranTask, :postgres do
       let(:vso) { create(:vso) }
       let(:vso_staff) { create(:user) }
       let(:org_ihp_task) do
-        create(:informal_hearing_presentation_task, appeal: appeal, parent: root_task, assigned_to: vso)
+        create(:informal_hearing_presentation_task, parent: root_task, assigned_to: vso)
       end
       let!(:individual_ihp_task) do
         create(

--- a/spec/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query_spec.rb
+++ b/spec/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query_spec.rb
@@ -5,8 +5,8 @@ describe AppealsWithNoTasksOrAllTasksOnHoldQuery, :postgres do
   let!(:appeal_with_tasks) { create(:appeal, :with_post_intake_tasks) }
   let!(:appeal_with_all_tasks_on_hold) do
     appeal = create(:appeal, :with_post_intake_tasks)
-    hearing_task = create(:hearing_task, appeal: appeal, parent: appeal.root_task)
-    schedule_hearing_task = create(:schedule_hearing_task, appeal: appeal, parent: hearing_task)
+    hearing_task = create(:hearing_task, parent: appeal.root_task)
+    schedule_hearing_task = create(:schedule_hearing_task, parent: hearing_task)
     appeal.root_task.descendants.each(&:on_hold!)
     appeal
   end

--- a/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
+++ b/spec/services/open_hearing_tasks_without_active_descendants_checker_spec.rb
@@ -37,13 +37,13 @@ describe OpenHearingTasksWithoutActiveDescendantsChecker, :all_dbs do
 
   let(:appeal) { create(:appeal) }
   let(:root_task_2) { create(:root_task, appeal: appeal) }
-  let(:hearing_task_2) { create(:hearing_task, appeal: appeal, parent: root_task_2) }
-  let(:schedule_hearing_task_2) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task_2) }
+  let(:hearing_task_2) { create(:hearing_task, parent: root_task_2) }
+  let(:schedule_hearing_task_2) { create(:schedule_hearing_task, parent: hearing_task_2) }
 
   context "there are open hearing tasks without active descendants and without any descendants" do
     let(:appeal_2) { create(:appeal) }
     let(:root_task_3) { create(:root_task, appeal: appeal_2) }
-    let!(:hearing_task_3) { create(:hearing_task, appeal: appeal_2, parent: root_task_3) }
+    let!(:hearing_task_3) { create(:hearing_task, parent: root_task_3) }
 
     before do
       user_verify_task.update_columns(status: Constants.TASK_STATUSES.completed)

--- a/spec/services/open_tasks_with_closed_at_checker_spec.rb
+++ b/spec/services/open_tasks_with_closed_at_checker_spec.rb
@@ -15,7 +15,7 @@ describe OpenTasksWithClosedAtChecker, :postgres do
   let!(:open_task_with_closed_parent) do
     appeal = create(:appeal)
     parent = create(:task, appeal: appeal)
-    task = create(:task, :assigned, appeal: appeal, parent: parent)
+    task = create(:task, :assigned, parent: parent)
     parent.update!(closed_at: Time.zone.now, status: :completed)
     task
   end

--- a/spec/services/stuck_appeals_checker_spec.rb
+++ b/spec/services/stuck_appeals_checker_spec.rb
@@ -5,8 +5,8 @@ describe StuckAppealsChecker, :postgres do
   let!(:appeal_with_tasks) { create(:appeal, :with_post_intake_tasks) }
   let!(:appeal_with_all_tasks_on_hold) do
     appeal = create(:appeal, :with_post_intake_tasks)
-    hearing_task = create(:hearing_task, appeal: appeal, parent: appeal.root_task)
-    create(:schedule_hearing_task, appeal: appeal, parent: hearing_task)
+    hearing_task = create(:hearing_task, parent: appeal.root_task)
+    create(:schedule_hearing_task, parent: hearing_task)
     appeal.root_task.descendants.each(&:on_hold!)
     appeal
   end

--- a/spec/support/shared_examples/ama_sql.rb
+++ b/spec/support/shared_examples/ama_sql.rb
@@ -26,71 +26,32 @@ shared_context "AMA Tableau SQL", shared_context: :metadata do
   end
   let!(:not_distributed_with_timed_hold) do
     create(:appeal, :ready_for_distribution, veteran_file_number: aod_veteran.file_number).tap do |appeal|
-      create(:timed_hold_task, appeal: appeal, parent: appeal.root_task)
+      create(:timed_hold_task, parent: appeal.root_task)
     end
   end
   let!(:distributed_to_judge) { create(:appeal, :assigned_to_judge) }
-  let!(:assigned_to_attorney) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:ama_attorney_task, appeal: appeal, parent: root_task)
-    end
-  end
-  let!(:assigned_to_colocated) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:ama_colocated_task, appeal: appeal, assigned_to: attorney, parent: root_task)
-    end
-  end
+  let!(:assigned_to_attorney) { create(:ama_attorney_task, parent: create(:root_task)) }
+  let!(:assigned_to_colocated) { create(:ama_colocated_task, assigned_to: attorney, parent: create(:root_task)) }
   let!(:decision_in_progress) do
-    create(:appeal).tap do |appeal|
-      create(:root_task, appeal: appeal)
-      create(:ama_attorney_task, :in_progress, appeal: appeal, assigned_by: judge, parent: appeal.root_task)
-    end
+    create(:ama_attorney_task, :in_progress, assigned_by: judge, parent: create(:root_task))
   end
   let!(:decision_ready_for_signature) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:ama_judge_decision_review_task, :in_progress, appeal: appeal, parent: root_task)
-    end
+    create(:ama_judge_decision_review_task, :in_progress, parent: create(:root_task))
   end
-  let!(:decision_signed) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:bva_dispatch_task, :in_progress, appeal: appeal, parent: root_task)
-    end
-  end
+  let!(:decision_signed) { create(:bva_dispatch_task, :in_progress, parent: create(:root_task)) }
   let!(:decision_dispatched) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:bva_dispatch_task, :completed, appeal: appeal, parent: root_task)
-      root_task.completed!
-    end
+    root_task = create(:root_task)
+    create(:bva_dispatch_task, :completed, parent: root_task)
+    root_task.completed!
   end
   let!(:dispatched_with_subsequent_assigned_task) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:bva_dispatch_task, :completed, appeal: appeal, parent: root_task)
-      create(:ama_attorney_task, assigned_to: attorney, appeal: appeal, parent: root_task)
-    end
+    root_task = create(:root_task)
+    create(:bva_dispatch_task, :completed, parent: root_task)
+    create(:ama_attorney_task, assigned_to: attorney, parent: root_task)
   end
-  let!(:cancelled) do
-    create(:appeal).tap do |appeal|
-      create(:root_task, :cancelled, appeal: appeal)
-    end
-  end
-  let!(:on_hold) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:timed_hold_task, appeal: appeal, parent: root_task)
-    end
-  end
-  let!(:misc) do
-    create(:appeal).tap do |appeal|
-      root_task = create(:root_task, appeal: appeal)
-      create(:ama_judge_dispatch_return_task, appeal: appeal, parent: root_task)
-    end
-  end
+  let!(:cancelled) { create(:root_task, :cancelled) }
+  let!(:on_hold) { create(:timed_hold_task, parent: create(:root_task)) }
+  let!(:misc) { create(:ama_judge_dispatch_return_task, parent: create(:root_task)) }
 
   let(:expected_report) do
     {

--- a/spec/support/shared_examples/ama_sql.rb
+++ b/spec/support/shared_examples/ama_sql.rb
@@ -30,28 +30,60 @@ shared_context "AMA Tableau SQL", shared_context: :metadata do
     end
   end
   let!(:distributed_to_judge) { create(:appeal, :assigned_to_judge) }
-  let!(:assigned_to_attorney) { create(:ama_attorney_task, parent: create(:root_task)) }
-  let!(:assigned_to_colocated) { create(:ama_colocated_task, assigned_to: attorney, parent: create(:root_task)) }
+  let!(:assigned_to_attorney) do
+    create(:appeal).tap do |appeal|
+      create(:ama_attorney_task, parent: create(:root_task, appeal: appeal))
+    end
+  end
+  let!(:assigned_to_colocated) do
+    create(:appeal).tap do |appeal|
+      create(:ama_colocated_task, assigned_to: attorney, parent: create(:root_task, appeal: appeal))
+    end
+  end
   let!(:decision_in_progress) do
-    create(:ama_attorney_task, :in_progress, assigned_by: judge, parent: create(:root_task))
+    create(:appeal).tap do |appeal|
+      create(:ama_attorney_task, :in_progress, assigned_by: judge, parent: create(:root_task, appeal: appeal))
+    end
   end
   let!(:decision_ready_for_signature) do
-    create(:ama_judge_decision_review_task, :in_progress, parent: create(:root_task))
+    create(:appeal).tap do |appeal|
+      create(:ama_judge_decision_review_task, :in_progress, parent: create(:root_task, appeal: appeal))
+    end
   end
-  let!(:decision_signed) { create(:bva_dispatch_task, :in_progress, parent: create(:root_task)) }
+  let!(:decision_signed) do
+    create(:appeal).tap do |appeal|
+      create(:bva_dispatch_task, :in_progress, parent: create(:root_task, appeal: appeal))
+    end
+  end
   let!(:decision_dispatched) do
-    root_task = create(:root_task)
-    create(:bva_dispatch_task, :completed, parent: root_task)
-    root_task.completed!
+    create(:appeal).tap do |appeal|
+      root_task = create(:root_task, appeal: appeal)
+      create(:bva_dispatch_task, :completed, parent: root_task)
+      root_task.completed!
+    end
   end
   let!(:dispatched_with_subsequent_assigned_task) do
-    root_task = create(:root_task)
-    create(:bva_dispatch_task, :completed, parent: root_task)
-    create(:ama_attorney_task, assigned_to: attorney, parent: root_task)
+    create(:appeal).tap do |appeal|
+      root_task = create(:root_task, appeal: appeal)
+      create(:bva_dispatch_task, :completed, parent: root_task)
+      create(:ama_attorney_task, assigned_to: attorney, parent: root_task)
+    end
   end
-  let!(:cancelled) { create(:root_task, :cancelled) }
-  let!(:on_hold) { create(:timed_hold_task, parent: create(:root_task)) }
-  let!(:misc) { create(:ama_judge_dispatch_return_task, parent: create(:root_task)) }
+  let!(:cancelled) do
+    create(:appeal).tap do |appeal|
+      create(:root_task, :cancelled, appeal: appeal)
+    end
+  end
+  let!(:on_hold) do
+    create(:appeal).tap do |appeal|
+      create(:timed_hold_task, parent: create(:root_task, appeal: appeal))
+    end
+  end
+  let!(:misc) do
+    create(:appeal).tap do |appeal|
+      create(:ama_judge_dispatch_return_task, parent: create(:root_task, appeal: appeal))
+    end
+  end
 
   let(:expected_report) do
     {


### PR DESCRIPTION
Following up #13130
Part 1 - #13773
This is part 2 of 2.
Split to make the review load more reasonable

### Description
When specifying a `parent` task as a parameter, the task FactoryBot correctly uses the parent's appeal (#13604) for the created task, thus making the `appeal` parameter redundant. This PR removes this extraneous `appeal` parameter so that the obsolete pattern is not copied in future tests.

Changes should only be for `FactoryBot.create` calls that create tasks, not `*Task.create`.
Changes should only be for spec files and `seeds.rb`.

### Acceptance Criteria
- [ ] All tests pass