### PR TITLE
Remove optional from Special Issues page.

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -371,7 +371,7 @@
   "MODAL_CANCEL_ATTORNEY_CHECKOUT": "All changes made to this page will be lost, except for the adding, editing, and deleting of issues.",
 
   "SPECIAL_ISSUES_PAGE_TITLE": "Select special issues",
-  "SPECIAL_ISSUES_PAGE_NOTE": "Select the special issues that pertain to this case. If none, please select \"No Special Issues.\" Cases with special issues are routed to specific groups who are in charge of adjusting the case.",
+  "SPECIAL_ISSUES_PAGE_NOTE": "Select the special issues that pertain to this case. Cases with special issues are routed to specific groups who are in charge of adjusting the case.",
   "SPECIAL_ISSUES_ABOUT_SECTION": "About the appellant: ",
   "SPECIAL_ISSUES_RESIDENCE_SECTION": "Appellant resides in: ",
   "SPECIAL_ISSUES_BENEFIT_TYPE_SECTION": "Benefit Types: ",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -370,8 +370,8 @@
   "MODAL_CANCEL_ATTORNEY_CHECKOUT_PROMPT": "Are you sure you want to cancel?",
   "MODAL_CANCEL_ATTORNEY_CHECKOUT": "All changes made to this page will be lost, except for the adding, editing, and deleting of issues.",
 
-  "SPECIAL_ISSUES_PAGE_TITLE": "Select special issues (optional)",
-  "SPECIAL_ISSUES_PAGE_NOTE": "Select the special issues that pertain to this case. Cases with special issues are routed to specific groups who are in charge of adjusting the case.",
+  "SPECIAL_ISSUES_PAGE_TITLE": "Select special issues",
+  "SPECIAL_ISSUES_PAGE_NOTE": "Select the special issues that pertain to this case. If none, please select \"No Special Issues.\" Cases with special issues are routed to specific groups who are in charge of adjusting the case.",
   "SPECIAL_ISSUES_ABOUT_SECTION": "About the appellant: ",
   "SPECIAL_ISSUES_RESIDENCE_SECTION": "Appellant resides in: ",
   "SPECIAL_ISSUES_BENEFIT_TYPE_SECTION": "Benefit Types: ",

--- a/spec/feature/queue/ama_queue_spec.rb
+++ b/spec/feature/queue/ama_queue_spec.rb
@@ -483,7 +483,7 @@ feature "AmaQueue", :all_dbs do
 
         click_dropdown(prompt: "Select an action", text: "Decision ready for review")
 
-        expect(page).not_to have_content("Select special issues (optional)")
+        expect(page).not_to have_content("Select special issues")
 
         expect(page).to have_content("Add decisions")
 
@@ -555,7 +555,7 @@ feature "AmaQueue", :all_dbs do
 
         click_dropdown(prompt: "Select an action", text: "Decision ready for review")
 
-        expect(page).not_to have_content("Select special issues (optional)")
+        expect(page).not_to have_content("Select special issues")
 
         expect(page).to have_content("Add decisions")
         expect(page).to have_content("Allowed")
@@ -602,7 +602,7 @@ feature "AmaQueue", :all_dbs do
 
         click_dropdown(prompt: "Select an action", text: "Decision ready for review")
 
-        expect(page).not_to have_content("Select special issues (optional)")
+        expect(page).not_to have_content("Select special issues")
 
         expect(page).to have_content("Add decisions")
 
@@ -673,7 +673,7 @@ feature "AmaQueue", :all_dbs do
 
         click_dropdown(prompt: "Select an action", text: "Decision ready for review")
 
-        expect(page).not_to have_content("Select special issues (optional)")
+        expect(page).not_to have_content("Select special issues")
 
         expect(page).to have_content("Add decisions")
         click_on "Continue"
@@ -776,7 +776,7 @@ feature "AmaQueue", :all_dbs do
 
           click_dropdown(prompt: "Select an action", text: "Decision ready for review")
 
-          expect(page).not_to have_content("Select special issues (optional)")
+          expect(page).not_to have_content("Select special issues")
 
           expect(page).to have_content("Add decisions")
 

--- a/spec/feature/queue/quality_review_flow_spec.rb
+++ b/spec/feature/queue/quality_review_flow_spec.rb
@@ -137,7 +137,7 @@ RSpec.feature "Quality Review workflow", :all_dbs do
         find(".Select-control", text: "Select an action").click
         find("div", class: "Select-option", text: Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h[:label]).click
 
-        expect(page).not_to have_content("Select special issues (optional)")
+        expect(page).not_to have_content("Select special issues")
 
         expect(page).to have_content("Add decisions")
         all("button", text: "+ Add decision", count: 1)[0].click


### PR DESCRIPTION
Resolves #9638 

### Description
Updates the title to reflect that special issues selection is not optional.

### Acceptance Criteria
- [x] Tests pass
- [x] Optional gone

### Testing Plan
1. Become Attorney Casper
1. Naviate to the user's queue and select a Legacy Case (`L`)
1. Begin checkout on the task by selection "Decision ready for review"
1. Confirm the title is updated on the Special Issues page.

### User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue

| Before | After |
| --------- | -------|
| ![image](https://user-images.githubusercontent.com/6129479/77352749-0d6a4d80-6d16-11ea-93ab-1cc33d4283fa.png) | ![image](https://user-images.githubusercontent.com/6129479/77352696-f6c3f680-6d15-11ea-8a81-4d11a1c7b61e.png) | 
