### PR TITLE
Add validation to claimant address

### DIFF
--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -73,9 +73,9 @@ class DecisionReviewIntake < Intake
 
   def claimant_address_error
     @claimant_address_error ||= [
-      ClaimantValidator::CLAIMANT_ADDRESS_REQUIRED,
-      ClaimantValidator::CLAIMANT_ADDRESS_INVALID,
-      ClaimantValidator::CLAIMANT_ADDRESS_CITY_INVALID
+      ClaimantValidator::ERRORS[:claimant_address_required],
+      ClaimantValidator::ERRORS[:claimant_address_invalid],
+      ClaimantValidator::ERRORS[:claimant_address_city_invalid]
     ].find do |error|
       detail.errors.messages[:claimant].include?(error)
     end
@@ -84,15 +84,15 @@ class DecisionReviewIntake < Intake
   def claimant_required_error
     @claimant_required_error ||=
       detail.errors.messages[:veteran_is_not_claimant].include?(
-        ClaimantValidator::CLAIMANT_REQUIRED
-      ) && ClaimantValidator::BLANK
+        ClaimantValidator::ERRORS[:claimant_required]
+      ) && ClaimantValidator::ERRORS[:blank]
   end
 
   def payee_code_error
     @payee_code_error ||=
       detail.errors.messages[:benefit_type].include?(
-        ClaimantValidator::PAYEE_CODE_REQUIRED
-      ) && ClaimantValidator::BLANK
+        ClaimantValidator::ERRORS[:payee_code_required]
+      ) && ClaimantValidator::ERRORS[:blank]
   end
 
   # run during start!

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -72,10 +72,13 @@ class DecisionReviewIntake < Intake
   end
 
   def claimant_address_error
-    @claimant_address_error ||=
-      detail.errors.messages[:claimant].include?(
-        ClaimantValidator::CLAIMANT_ADDRESS_REQUIRED
-      ) && ClaimantValidator::CLAIMANT_ADDRESS_REQUIRED
+    @claimant_address_error ||= [
+      ClaimantValidator::CLAIMANT_ADDRESS_REQUIRED,
+      ClaimantValidator::CLAIMANT_ADDRESS_INVALID,
+      ClaimantValidator::CLAIMANT_ADDRESS_CITY_INVALID
+    ].find do |error|
+      detail.errors.messages[:claimant].include?(error)
+    end
   end
 
   def claimant_required_error

--- a/app/models/validators/claimant_validator.rb
+++ b/app/models/validators/claimant_validator.rb
@@ -1,13 +1,16 @@
 # frozen_string_literal: true
 
 class ClaimantValidator
-  PAYEE_CODE_REQUIRED = "payee_code may not be blank"
-  CLAIMANT_REQUIRED = "participant_id may not be blank"
-  CLAIMANT_ADDRESS_REQUIRED = "claimant_address_required"
-  CLAIMANT_ADDRESS_INVALID = "claimant_address_invalid"
-  CLAIMANT_CITY_INVALID = "claimant_city_invalid"
-  BLANK = "blank"
-  INVALID = "invalid"
+  ERRORS = {
+    payee_code_required: "payee_code may not be blank",
+    claimant_required: "participant_id may not be blank",
+    claimant_address_required: "claimant_address_required",
+    claimant_address_invalid: "claimant_address_invalid",
+    claimant_city_invalid: "claimant_city_invalid",
+    blank: "blank",
+    invalid: "invalid"
+  }.freeze
+
   BENEFIT_TYPE_REQUIRES_PAYEE_CODE = %w[compensation pension].freeze
 
   def initialize(claimant)
@@ -22,6 +25,7 @@ class ClaimantValidator
     if claimant_details_required?
       validate_payee_code
       validate_claimant_address
+      validate_claimant_city
     end
   end
 
@@ -33,27 +37,31 @@ class ClaimantValidator
     return if payee_code
     return if veteran_is_claimant?
 
-    errors[:payee_code] << BLANK
-    decision_review.errors[:benefit_type] << PAYEE_CODE_REQUIRED
+    errors[:payee_code] << ERRORS[:blank]
+    decision_review.errors[:benefit_type] << ERRORS[:payee_code_required]
   end
 
   def validate_participant_id
     return if participant_id
 
-    errors[:participant_id] << BLANK
-    decision_review.errors[:veteran_is_not_claimant] << CLAIMANT_REQUIRED
+    errors[:participant_id] << ERRORS[:blank]
+    decision_review.errors[:veteran_is_not_claimant] << ERRORS[:claimant_required]
   end
 
   def validate_claimant_address
     if claimant.address_line_1.nil?
-      errors[:address] << BLANK
-      decision_review.errors[:claimant] << CLAIMANT_ADDRESS_REQUIRED
+      errors[:address] << ERRORS[:blank]
+      decision_review.errors[:claimant] << ERRORS[:claimant_address_required]
     elsif !claimant_address_lines_valid?
-      errors[:address] << INVALID
-      decision_review.errors[:claimant] << CLAIMANT_ADDRESS_INVALID
-    elsif !claimant_city_valid?
-      errors[:address] << INVALID
-      decision_review.errors[:claimant] << CLAIMANT_ADDRESS_CITY_INVALID
+      errors[:address] << ERRORS[:invalid]
+      decision_review.errors[:claimant] << ERRORS[:claimant_address_invalid]
+    end
+  end
+
+  def validate_claimant_city
+    if !claimant_city_valid?
+      errors[:address] << ERRORS[:invalid]
+      decision_review.errors[:claimant] << ERRORS[:claimant_city_invalid]
     end
   end
 

--- a/app/models/validators/claimant_validator.rb
+++ b/app/models/validators/claimant_validator.rb
@@ -5,7 +5,7 @@ class ClaimantValidator
   CLAIMANT_REQUIRED = "participant_id may not be blank"
   CLAIMANT_ADDRESS_REQUIRED = "claimant_address_required"
   CLAIMANT_ADDRESS_INVALID = "claimant_address_invalid"
-  CLAIMANT_ADDRESS_CITY_INVALID = "claimant_address_city_invalid"
+  CLAIMANT_CITY_INVALID = "claimant_city_invalid"
   BLANK = "blank"
   INVALID = "invalid"
   BENEFIT_TYPE_REQUIRES_PAYEE_CODE = %w[compensation pension].freeze
@@ -57,12 +57,14 @@ class ClaimantValidator
     end
   end
 
+  # Validates address lines using this regex that VBMS uses.
   def claimant_address_lines_valid?
     [claimant.address_line_1, claimant.address_line_2, claimant.address_line_3].all? do |value|
       value.nil? || (value =~ /\A(?!.*\s\s)[a-zA-Z0-9+#@%&()_:',.\-\/\s]*\Z/ && value.length <= 20)
     end
   end
 
+  # Validates claimant city using this regex that VBMS uses.
   def claimant_city_valid?
     claimant.city =~ /\A[ a-zA-Z0-9`\\'~=+\[\]{}#?\^*<>!@$%&()\-_|;:",.\/]*\Z/ && claimant.city.length <= 30
   end

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -170,6 +170,13 @@ export const REVIEW_OPTIONS = {
   }
 };
 
+export const CLAIMANT_ERRORS = {
+  blank: 'Please select an option.',
+  claimant_address_required: "Please supply the claimant's address in VBMS.",
+  claimant_address_invalid: "Please update the claimant's address in VBMS to be valid.",
+  claimant_city_invalid: "Please update the claimant's city in VBMS to be valid."
+};
+
 export const ENDPOINT_NAMES = {
   START_INTAKE: 'start-intake',
   REVIEW_INTAKE: 'review-intake',

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -10,7 +10,7 @@ export const getBlankOptionError = (responseErrorCodes, field) => (
 export const getClaimantError = (responseErrorCodes) => {
   const errorCode = _.get(responseErrorCodes.claimant, 0);
 
-  return CLAIMANT_ERRORS[errorCodes];
+  return CLAIMANT_ERRORS[errorCode];
 };
 
 export const getPageError = (responseErrorCodes) => (

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { REVIEW_OPTIONS } from '../constants';
+import { REVIEW_OPTIONS, CLAIMANT_ERRORS } from '../constants';
 import DATES from '../../../constants/DATES';
 import { formatDateStr } from '../../util/DateUtil';
 
@@ -10,15 +10,7 @@ export const getBlankOptionError = (responseErrorCodes, field) => (
 export const getClaimantError = (responseErrorCodes) => {
   const errorCode = _.get(responseErrorCodes.claimant, 0);
 
-  if (errorCode === 'blank') {
-    return 'Please select an option.';
-  } else if (errorCode === 'claimant_address_required') {
-    return "Please supply the claimant's address in VBMS.";
-  } else if (errorCode === 'claimant_address_invalid') {
-    return "Please update the claimant's address in VBMS to be valid.";
-  } else if (errorCode === 'claimant_address_city_invalid') {
-    return "Please update the claimant's address city in VBMS to be valid.";
-  }
+  return CLAIMANT_ERRORS[errorCodes];
 };
 
 export const getPageError = (responseErrorCodes) => (

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -13,7 +13,11 @@ export const getClaimantError = (responseErrorCodes) => {
   if (errorCode === 'blank') {
     return 'Please select an option.';
   } else if (errorCode === 'claimant_address_required') {
-    return "Please update the claimant's address.";
+    return "Please supply the claimant's address in VBMS.";
+  } else if (errorCode === 'claimant_address_invalid') {
+    return "Please update the claimant's address in VBMS to be valid.";
+  } else if (errorCode === 'claimant_address_city_invalid') {
+    return "Please update the claimant's address city in VBMS to be valid.";
   }
 };
 

--- a/spec/models/validators/claimant_validator_spec.rb
+++ b/spec/models/validators/claimant_validator_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+describe ClaimantValidator, :postgres do
+  let(:veteran) { create(:veteran) }
+  let(:claimant) do
+    Claimant.new(
+      decision_review: decision_review,
+      participant_id: participant_id,
+      payee_code: payee_code
+    )
+  end
+  let(:address_line_1) { "123 Some Road" }
+  let(:address_line_2) { "Suite A" }
+  let(:address_line_3) { nil }
+  let(:city) { "Springfield" }
+  let(:decision_review) { HigherLevelReview.new(benefit_type: "compensation") }
+  let(:participant_id) { "different from the veteran's" }
+  let(:payee_code) { "10" }
+
+  before do
+    allow(claimant).to receive(:address_line_1).and_return(address_line_1)
+    allow(claimant).to receive(:address_line_2).and_return(address_line_2)
+    allow(claimant).to receive(:address_line_3).and_return(address_line_3)
+    allow(claimant).to receive(:city).and_return(city)
+    allow(decision_review).to receive(:veteran).and_return(veteran)
+  end
+
+  subject do
+    ClaimantValidator.new(claimant).validate
+    decision_review.errors
+  end
+
+  describe "#validate" do
+    context "claimant is valid" do
+      it "sets no errors" do
+        expect(subject[:claimant]).to be_empty
+      end
+    end
+
+    context "claimant has no participant id" do
+      let(:participant_id) { nil }
+      it "sets a claimant required error" do
+        expect(subject[:veteran_is_not_claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_REQUIRED)
+      end
+    end
+
+    context "claimant is missing a payee code" do
+      let(:payee_code) { nil }
+      it "sets a missing payee code error" do
+        expect(subject[:benefit_type]).to contain_exactly(ClaimantValidator::PAYEE_CODE_REQUIRED)
+      end
+    end
+
+    context "claimant is missing address" do
+      let(:address_line_1) { nil }
+      it "sets an address required error" do
+        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_ADDRESS_REQUIRED)
+      end
+    end
+
+    context "claimant has an invalid address line" do
+      let(:address_line_2) { "Apt  3" }
+      it "sets an invalid address line error" do
+        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_ADDRESS_INVALID)
+      end
+    end
+
+    context "claimant has an invalid city" do
+      let(:city) { "An improbably lengthy city name that exceeds 30 characters" }
+      it "sets an invalid address city error" do
+        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_ADDRESS_CITY_INVALID)
+      end
+    end
+  end
+end

--- a/spec/models/validators/claimant_validator_spec.rb
+++ b/spec/models/validators/claimant_validator_spec.rb
@@ -40,35 +40,35 @@ describe ClaimantValidator, :postgres do
     context "claimant has no participant id" do
       let(:participant_id) { nil }
       it "sets a claimant required error" do
-        expect(subject[:veteran_is_not_claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_REQUIRED)
+        expect(subject[:veteran_is_not_claimant]).to contain_exactly(ClaimantValidator::ERRORS[:claimant_required])
       end
     end
 
     context "claimant is missing a payee code" do
       let(:payee_code) { nil }
       it "sets a missing payee code error" do
-        expect(subject[:benefit_type]).to contain_exactly(ClaimantValidator::PAYEE_CODE_REQUIRED)
+        expect(subject[:benefit_type]).to contain_exactly(ClaimantValidator::ERRORS[:payee_code_required])
       end
     end
 
     context "claimant is missing address" do
       let(:address_line_1) { nil }
       it "sets an address required error" do
-        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_ADDRESS_REQUIRED)
+        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::ERRORS[:claimant_address_required])
       end
     end
 
     context "claimant has an invalid address line" do
       let(:address_line_2) { "Apt  3" }
       it "sets an invalid address line error" do
-        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_ADDRESS_INVALID)
+        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::ERRORS[:claimant_address_invalid])
       end
     end
 
     context "claimant has an invalid city" do
       let(:city) { "An improbably lengthy city name that exceeds 30 characters" }
       it "sets an invalid address city error" do
-        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::CLAIMANT_ADDRESS_CITY_INVALID)
+        expect(subject[:claimant]).to contain_exactly(ClaimantValidator::ERRORS[:claimant_city_invalid])
       end
     end
   end


### PR DESCRIPTION
Connects #13394 

### Description
This PR adds more validation for claimant addresses whenever they are required, and prevents claim reviews from being established when invalid addresses are detected.

### Acceptance Criteria
- [x] If the claimant's address is invalid, return an error asking them to update the claimant's address in VBMS, and prevent them from continuing the intake

### Testing Plan
1. Added a whole new spec for ClaimantValidator, set up so that it's easy/efficient to test a bunch of input combinations.
2. Updated intake review page feature test to check for new error text.

### User Facing Changes
The user-facing copy hasn't been finalized yet, but support for the new validation errors is shown here (note also the reference to VBMS, which should help with support requests)
<img width="588" alt="Screen Shot 2020-03-23 at 16 23 25" src="https://user-images.githubusercontent.com/282869/77365405-73fa6600-6d2c-11ea-9810-4e884768f5f7.png">
<img width="657" alt="Screen Shot 2020-03-23 at 16 24 56" src="https://user-images.githubusercontent.com/282869/77365413-778ded00-6d2c-11ea-931d-c6b7a490791a.png">
 