### PR TITLE
Fix appeal_in_caseflow_vacols_location for nil case_record

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -150,8 +150,11 @@ class ColocatedTask < Task
   end
 
   def appeal_in_caseflow_vacols_location?
-    appeal.is_a?(LegacyAppeal) &&
-      VACOLS::Case.find(appeal.vacols_id).bfcurloc == LegacyAppeal::LOCATION_CODES[:caseflow]
+    return false unless appeal.is_a?(LegacyAppeal)
+
+    return false unless appeal.case_record # VACOLS case must exist
+
+    appeal.case_record.bfcurloc == LegacyAppeal::LOCATION_CODES[:caseflow]
   end
 
   def vacols_location

--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -152,9 +152,9 @@ class ColocatedTask < Task
   def appeal_in_caseflow_vacols_location?
     return false unless appeal.is_a?(LegacyAppeal)
 
-    return false unless appeal.case_record # VACOLS case must exist
+    return false if appeal.case_record.nil? # VACOLS case must exist
 
-    appeal.case_record.bfcurloc == LegacyAppeal::LOCATION_CODES[:caseflow]
+    appeal.case_record.reload.bfcurloc == LegacyAppeal::LOCATION_CODES[:caseflow]
   end
 
   def vacols_location

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -460,7 +460,7 @@ describe ColocatedTask, :all_dbs do
       let(:legacy_colocated_task) { org_colocated_task.children.first }
 
       before do
-        org_colocated_task.appeal.case_record.update!(bfcurloc: location_code)
+        org_colocated_task.appeal.case_record&.update!(bfcurloc: location_code)
       end
 
       context "when the location code is CASEFLOW" do
@@ -495,6 +495,17 @@ describe ColocatedTask, :all_dbs do
         it "does not change the case's location_code" do
           legacy_colocated_task.update!(status: Constants.TASK_STATUSES.cancelled)
           expect(org_colocated_task.reload.appeal.location_code).to eq(location_code)
+        end
+      end
+
+      context "when the VACOLS case has been deleted" do
+        let!(:appeal_1) { create(:legacy_appeal) }
+        let(:task_type_trait) { ColocatedTask.actions_assigned_to_colocated.sample.to_sym }
+        let(:location_code) { "FAKELOC" }
+
+        it "does not attempt to access the location code" do
+          legacy_colocated_task.cancelled!
+          expect(org_colocated_task.reload.appeal.location_code).to be_nil
         end
       end
     end


### PR DESCRIPTION
LegacyAppeal may have nil `case_record` if VACOLS case does not exist.

This refactor allows for that possibility.

This bug is preventing our nightly sync to clean up dangling Legacy Appeals.