### PR TITLE
Add request_issues indices for slow query

### DIFF
--- a/db/migrate/20200325200232_add_missing_request_issue_indices.rb
+++ b/db/migrate/20200325200232_add_missing_request_issue_indices.rb
@@ -1,0 +1,7 @@
+class AddMissingRequestIssueIndices < Caseflow::Migration
+  def change
+    add_safe_index :request_issues, [:contested_rating_decision_reference_id]
+    add_safe_index :request_issues, [:closed_at]
+    add_safe_index :request_issues, [:ineligible_reason]
+  end
+end

--- a/db/migrate/20200325211113_add_distribution_indices.rb
+++ b/db/migrate/20200325211113_add_distribution_indices.rb
@@ -1,0 +1,7 @@
+class AddDistributionIndices < Caseflow::Migration
+  def change
+    add_safe_index :appeals, :docket_type
+    add_safe_index :appeals, :established_at
+    add_safe_index :advance_on_docket_motions, :granted
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_18_204112) do
+ActiveRecord::Schema.define(version: 2020_03_25_200232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1066,12 +1066,15 @@ ActiveRecord::Schema.define(version: 2020_03_18_204112) do
     t.integer "vacols_sequence_id", comment: "The vacols_sequence_id, for the specific issue on the legacy appeal which the Claims Assistant determined to match the request issue on the Decision Review. A combination of the vacols_id (for the legacy appeal), and vacols_sequence_id (for which issue on the legacy appeal), is required to identify the issue being opted-in."
     t.boolean "verified_unidentified_issue", comment: "A verified unidentified issue allows an issue whose rating data is missing to be intaken as a regular rating issue. In order to be marked as verified, a VSR needs to confirm that they were able to find the record of the decision for the issue."
     t.string "veteran_participant_id", comment: "The veteran participant ID. This should be unique in upstream systems and used in the future to reconcile duplicates."
+    t.index ["closed_at"], name: "index_request_issues_on_closed_at"
     t.index ["contention_reference_id"], name: "index_request_issues_on_contention_reference_id", unique: true
     t.index ["contested_decision_issue_id"], name: "index_request_issues_on_contested_decision_issue_id"
+    t.index ["contested_rating_decision_reference_id"], name: "index_request_issues_on_contested_rating_decision_reference_id"
     t.index ["contested_rating_issue_reference_id"], name: "index_request_issues_on_contested_rating_issue_reference_id"
     t.index ["decision_review_type", "decision_review_id"], name: "index_request_issues_on_decision_review_columns"
     t.index ["end_product_establishment_id"], name: "index_request_issues_on_end_product_establishment_id"
     t.index ["ineligible_due_to_id"], name: "index_request_issues_on_ineligible_due_to_id"
+    t.index ["ineligible_reason"], name: "index_request_issues_on_ineligible_reason"
     t.index ["updated_at"], name: "index_request_issues_on_updated_at"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_200232) do
+ActiveRecord::Schema.define(version: 2020_03_25_211113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 2020_03_25_200232) do
     t.string "reason", comment: "VLJ's rationale for their decision on motion to AOD."
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["granted"], name: "index_advance_on_docket_motions_on_granted"
     t.index ["person_id"], name: "index_advance_on_docket_motions_on_person_id"
     t.index ["updated_at"], name: "index_advance_on_docket_motions_on_updated_at"
     t.index ["user_id"], name: "index_advance_on_docket_motions_on_user_id"
@@ -110,6 +111,8 @@ ActiveRecord::Schema.define(version: 2020_03_25_200232) do
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false, comment: "The universally unique identifier for the appeal, which can be used to navigate to appeals/appeal_uuid. This allows a single ID to determine an appeal whether it is a legacy appeal or an AMA appeal."
     t.string "veteran_file_number", null: false, comment: "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
     t.boolean "veteran_is_not_claimant", comment: "Selected by the user during intake, indicates whether the Veteran is the claimant, or if the claimant is someone else such as a dependent. Must be TRUE if Veteran is deceased."
+    t.index ["docket_type"], name: "index_appeals_on_docket_type"
+    t.index ["established_at"], name: "index_appeals_on_established_at"
     t.index ["updated_at"], name: "index_appeals_on_updated_at"
     t.index ["uuid"], name: "index_appeals_on_uuid"
     t.index ["veteran_file_number"], name: "index_appeals_on_veteran_file_number"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -198,7 +198,7 @@ class SeedDB
         if schedule_hearing_task_status == :completed
           disposition_task = FactoryBot.create(
             :assign_hearing_disposition_task,
-            parent: parent_hearing_task, 
+            parent: parent_hearing_task,
             appeal: appeal
           )
           FactoryBot.create(
@@ -893,7 +893,7 @@ class SeedDB
       docket_type: Constants.AMA_DOCKETS.direct_review,
       closest_regional_office: "RO17",
       request_issues: FactoryBot.create_list(
-        :request_issue, 2, contested_issue_description: description, notes: notes
+        :request_issue, 2, :rating, contested_issue_description: description, notes: notes
       )
     )
   end
@@ -1281,7 +1281,7 @@ class SeedDB
       docket_type: Constants.AMA_DOCKETS.hearing,
       closest_regional_office: "RO17",
       request_issues: FactoryBot.create_list(
-        :request_issue, 1, contested_issue_description: description, notes: notes
+        :request_issue, 1, :rating, contested_issue_description: description, notes: notes
       )
     )
     @ama_appeals << FactoryBot.create(
@@ -1292,7 +1292,7 @@ class SeedDB
       docket_type: Constants.AMA_DOCKETS.hearing,
       closest_regional_office: "RO17",
       request_issues: FactoryBot.create_list(
-        :request_issue, 8, contested_issue_description: description, notes: notes
+        :request_issue, 8, :rating, contested_issue_description: description, notes: notes
       )
     )
 

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -795,14 +795,14 @@ request_decision_issues,request_issue_id,integer FK,,,x,,x,The ID of the request
 request_decision_issues,updated_at,datetime ∗,x,,,,x,Automatically populated when the record is updated.
 request_issues,,,,,,,,"Each Request Issue represents the Veteran's response to a Rating Issue. Request Issues come in three flavors: rating, nonrating, and unidentified. They are attached to a Decision Review and (for those that track contentions) an End Product Establishment. A Request Issue can contest a rating issue, a decision issue, or a nonrating issue without a decision issue."
 request_issues,benefit_type,string ∗,x,,,,,The Line of Business the issue is connected with.
-request_issues,closed_at,datetime,,,,,,Timestamp when the request issue was closed. The reason it was closed is in closed_status.
+request_issues,closed_at,datetime,,,,,x,Timestamp when the request issue was closed. The reason it was closed is in closed_status.
 request_issues,closed_status,string,,,,,,"Indicates whether the request issue is closed, for example if it was removed from a Decision Review, the associated End Product got canceled, the Decision Review was withdrawn."
 request_issues,contention_reference_id,integer,,,,,x,The ID of the contention created on the End Product for this request issue. This is populated after the contention is created in VBMS.
 request_issues,contention_removed_at,datetime,,,,,,"When a request issue is removed from a Decision Review during an edit, if it has a contention in VBMS that is also removed. This field indicates when the contention has successfully been removed in VBMS."
 request_issues,contention_updated_at,datetime,,,,,,Timestamp indicating when a contention was successfully updated in VBMS.
 request_issues,contested_decision_issue_id,integer FK,,,x,,x,The ID of the decision issue that this request issue contests. A Request issue will contest either a rating issue or a decision issue
 request_issues,contested_issue_description,string,,,,,,Description of the contested rating or decision issue. Will be either a rating issue's decision text or a decision issue's description.
-request_issues,contested_rating_decision_reference_id,string,,,,,,The BGS id for contested rating decisions. These may not have corresponding contested_rating_issue_reference_id values.
+request_issues,contested_rating_decision_reference_id,string,,,,,x,The BGS id for contested rating decisions. These may not have corresponding contested_rating_issue_reference_id values.
 request_issues,contested_rating_issue_diagnostic_code,string,,,,,,"If the contested issue is a rating issue, this is the rating issue's diagnostic code. Will be nil if this request issue contests a decision issue."
 request_issues,contested_rating_issue_profile_date,string,,,,,,"If the contested issue is a rating issue, this is the rating issue's profile date. Will be nil if this request issue contests a decision issue."
 request_issues,contested_rating_issue_reference_id,string,,,,,x,"If the contested issue is a rating issue, this is the rating issue's reference id. Will be nil if this request issue contests a decision issue."
@@ -822,7 +822,7 @@ request_issues,edited_description,string,,,,,,"The edited description for the co
 request_issues,end_product_establishment_id,integer FK,,,x,,x,The ID of the End Product Establishment created for this request issue.
 request_issues,id,integer (8) PK,x,x,,,,
 request_issues,ineligible_due_to_id,integer (8) FK,,,x,,x,"If a request issue is ineligible due to another request issue, for example that issue is already being actively reviewed, then the ID of the other request issue is stored here."
-request_issues,ineligible_reason,string,,,,,,"The reason for a Request Issue being ineligible. If a Request Issue has an ineligible_reason, it is still captured, but it will not get a contention in VBMS or a decision."
+request_issues,ineligible_reason,string,,,,,x,"The reason for a Request Issue being ineligible. If a Request Issue has an ineligible_reason, it is still captured, but it will not get a contention in VBMS or a decision."
 request_issues,is_unidentified,boolean,,,,,,"Indicates whether a Request Issue is unidentified, meaning it wasn't found in the list of contestable issues, and is not a new nonrating issue. Contentions for unidentified issues are created on a rating End Product if processed in VBMS but without the issue description, and someone is required to edit it in Caseflow before proceeding with the decision."
 request_issues,nonrating_issue_category,string,,,,,,The category selected for nonrating request issues. These vary by business line.
 request_issues,nonrating_issue_description,string,,,,,,The user entered description if the issue is a nonrating issue

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1,7 +1,7 @@
 Table,Column,Type,Required,Primary Key,Foreign Key,Unique,Index,Description
 advance_on_docket_motions,,,,,,,,
 advance_on_docket_motions,created_at,datetime ∗,x,,,,,
-advance_on_docket_motions,granted,boolean,,,,,,"Whether VLJ has determined that there is sufficient cause to fast-track an appeal, i.e. grant or deny the motion to AOD."
+advance_on_docket_motions,granted,boolean,,,,,x,"Whether VLJ has determined that there is sufficient cause to fast-track an appeal, i.e. grant or deny the motion to AOD."
 advance_on_docket_motions,id,integer (8) PK,x,x,,,,
 advance_on_docket_motions,person_id,integer (8) FK,,,x,,x,Appellant ID
 advance_on_docket_motions,reason,string,,,,,,VLJ's rationale for their decision on motion to AOD.
@@ -42,8 +42,8 @@ appeals,,,,,,,,Decision reviews intaken for AMA appeals to the board (also known
 appeals,closest_regional_office,string,,,,,,The code for the regional office closest to the Veteran on the appeal.
 appeals,created_at,datetime,,,,,,
 appeals,docket_range_date,date,,,,,,Date that appeal was added to hearing docket range.
-appeals,docket_type,string ∗,x,,,,,"The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
-appeals,established_at,datetime,,,,,,Timestamp for when the appeal has successfully been intaken into Caseflow by the user.
+appeals,docket_type,string ∗,x,,,,x,"The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
+appeals,established_at,datetime,,,,,x,Timestamp for when the appeal has successfully been intaken into Caseflow by the user.
 appeals,establishment_attempted_at,datetime,,,,,,Timestamp for when the appeal's establishment was last attempted.
 appeals,establishment_canceled_at,datetime,,,,,,Timestamp when job was abandoned
 appeals,establishment_error,string,,,,,,The error message if attempting to establish the appeal resulted in an error. This gets cleared once the establishment is successful.

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -659,7 +659,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
         # reload to verify that the new issues populate the form
         visit "supplemental_claims/#{rating_ep_claim_id}/edit/"
 
-        expect(find("div", class:"issue-container", match: :first)).to have_content("Left knee granted")
+        expect(find("div", class: "issue-container", match: :first)).to have_content("Left knee granted")
         expect(find("div", class: "withdrawn-issue")).to have_content(
           "PTSD denied\nDecision date: 05/10/2019\nWithdrawn on"
         )

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -659,8 +659,10 @@ feature "Supplemental Claim Edit issues", :all_dbs do
         # reload to verify that the new issues populate the form
         visit "supplemental_claims/#{rating_ep_claim_id}/edit/"
 
-        expect(page).to have_content("Requested issues\n1. Left knee granted")
-        expect(page).to have_content("Withdrawn issues\n2. PTSD denied\nDecision date: 05/10/2019\nWithdrawn on")
+        expect(find("div", class:"issue-container", match: :first)).to have_content("Left knee granted")
+        expect(find("div", class: "withdrawn-issue")).to have_content(
+          "PTSD denied\nDecision date: 05/10/2019\nWithdrawn on"
+        )
         expect(withdrawn_issue.closed_at).to eq(1.day.ago.to_date.to_datetime)
       end
     end


### PR DESCRIPTION
We saw this slow query while debugging db CPU usage. 

Adds 3 new indices for common query.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
