### PR TITLE
Add indices to decision_issues

### DIFF
--- a/db/migrate/20200326141733_add_decision_issue_indexes.rb
+++ b/db/migrate/20200326141733_add_decision_issue_indexes.rb
@@ -1,0 +1,6 @@
+class AddDecisionIssueIndexes < Caseflow::Migration
+  def change
+    add_safe_index :decision_issues, :deleted_at
+    add_safe_index :decision_issues, [:decision_review_id, :decision_review_type], name: :index_decision_issues_decision_review
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_211113) do
+ActiveRecord::Schema.define(version: 2020_03_26_141733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -344,6 +344,8 @@ ActiveRecord::Schema.define(version: 2020_03_25_211113) do
     t.datetime "rating_profile_date", comment: "The profile date of the rating that a decision issue resulted in (if applicable). The profile_date is used as an identifier for the rating, and is the date that most closely maps to what the Veteran writes down as the decision date."
     t.datetime "rating_promulgation_date", comment: "The promulgation date of the rating that a decision issue resulted in (if applicable). It is used for calculating whether a decision issue is within the timeliness window to be appealed or get a higher level review."
     t.datetime "updated_at"
+    t.index ["decision_review_id", "decision_review_type"], name: "index_decision_issues_decision_review"
+    t.index ["deleted_at"], name: "index_decision_issues_on_deleted_at"
     t.index ["disposition"], name: "index_decision_issues_on_disposition"
     t.index ["rating_issue_reference_id", "disposition", "participant_id"], name: "decision_issues_uniq_by_disposition_and_ref_id", unique: true
     t.index ["updated_at"], name: "index_decision_issues_on_updated_at"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -250,10 +250,10 @@ decision_issues,,,,,,,,Issues that represent a decision made on a decision revie
 decision_issues,benefit_type,string,,,,,,"Classification of the benefit being decided on. Maps 1 to 1 to VA lines of business, and typically used to know which line of business the decision correlates to."
 decision_issues,caseflow_decision_date,date,,,,,,"This is a decision date for decision issues where decisions are entered in Caseflow, such as for appeals or for decision reviews with a business line that is not processed in VBMS."
 decision_issues,created_at,datetime,,,,,,Automatic timestamp when row was created.
-decision_issues,decision_review_id,integer FK,,,x,,,ID of the decision review the decision was made on.
-decision_issues,decision_review_type,string,,,,,,Type of the decision review the decision was made on.
+decision_issues,decision_review_id,integer FK,,,x,,x,ID of the decision review the decision was made on.
+decision_issues,decision_review_type,string,,,,,x,Type of the decision review the decision was made on.
 decision_issues,decision_text,string,,,,,,"If decision resulted in a change to a rating, the rating issue's decision text."
-decision_issues,deleted_at,datetime,,,,,,
+decision_issues,deleted_at,datetime,,,,,x,
 decision_issues,description,string,,,,,,Optional description that the user can input for decisions made in Caseflow.
 decision_issues,diagnostic_code,string,,,,,,"If a decision resulted in a rating, this is the rating issue's diagnostic code."
 decision_issues,disposition,string ∗,x,,,,x,The disposition for a decision issue. Dispositions made in Caseflow and dispositions made in VBMS can have different values.

--- a/spec/models/attorney_case_review_spec.rb
+++ b/spec/models/attorney_case_review_spec.rb
@@ -99,9 +99,15 @@ describe AttorneyCaseReview, :all_dbs do
         expect(something2_decision.disposition).to eq "remanded"
 
         expect(something2_decision.remand_reasons.size).to eq 3
-        expect(something2_decision.remand_reasons.find { |rr| rr.code == "va_records" }.post_aoj).to eq false
-        expect(something2_decision.remand_reasons.find { |rr| rr.code == "incorrect_notice_sent" }.post_aoj).to eq true
-        expect(something2_decision.remand_reasons.find { |rr| rr.code == "due_process_deficiency" }.post_aoj).to eq false
+        expect(something2_decision.remand_reasons.find do |rr|
+          rr.code == "va_records"
+        end.post_aoj).to eq false
+        expect(something2_decision.remand_reasons.find do |rr|
+          rr.code == "incorrect_notice_sent"
+        end.post_aoj).to eq true
+        expect(something2_decision.remand_reasons.find do |rr|
+          rr.code == "due_process_deficiency"
+        end.post_aoj).to eq false
 
         expect(request_issue3.reload.decision_issues.size).to eq 1
         expect(request_issue4.reload.decision_issues.size).to eq 1

--- a/spec/models/attorney_case_review_spec.rb
+++ b/spec/models/attorney_case_review_spec.rb
@@ -91,27 +91,27 @@ describe AttorneyCaseReview, :all_dbs do
         expect(request_issue1.reload.decision_issues.size).to eq 2
         expect(request_issue2.reload.decision_issues.size).to eq 2
         expect(request_issue1.decision_issues).to eq request_issue2.decision_issues
-        expect(request_issue1.decision_issues[0].disposition).to eq "allowed"
-        expect(request_issue1.decision_issues[0].description).to eq "something1"
 
-        expect(request_issue1.decision_issues[1].disposition).to eq "remanded"
-        expect(request_issue1.decision_issues[1].description).to eq "something2"
+        something1_decision = request_issue1.decision_issues.find { |di| di.description == "something1" }
+        something2_decision = request_issue1.decision_issues.find { |di| di.description == "something2" }
 
-        expect(request_issue1.decision_issues[1].remand_reasons.size).to eq 3
-        expect(request_issue1.decision_issues[1].remand_reasons[0].code).to eq "va_records"
-        expect(request_issue1.decision_issues[1].remand_reasons[0].post_aoj).to eq false
+        expect(something1_decision.disposition).to eq "allowed"
+        expect(something2_decision.disposition).to eq "remanded"
 
-        expect(request_issue1.decision_issues[1].remand_reasons[1].code).to eq "incorrect_notice_sent"
-        expect(request_issue1.decision_issues[1].remand_reasons[1].post_aoj).to eq true
-
-        expect(request_issue1.decision_issues[1].remand_reasons[2].code).to eq "due_process_deficiency"
-        expect(request_issue1.decision_issues[1].remand_reasons[2].post_aoj).to eq false
+        expect(something2_decision.remand_reasons.size).to eq 3
+        expect(something2_decision.remand_reasons.find { |rr| rr.code == "va_records" }.post_aoj).to eq false
+        expect(something2_decision.remand_reasons.find { |rr| rr.code == "incorrect_notice_sent" }.post_aoj).to eq true
+        expect(something2_decision.remand_reasons.find { |rr| rr.code == "due_process_deficiency" }.post_aoj).to eq false
 
         expect(request_issue3.reload.decision_issues.size).to eq 1
         expect(request_issue4.reload.decision_issues.size).to eq 1
         expect(request_issue3.reload.decision_issues.first).to eq request_issue4.decision_issues.first
         expect(request_issue5.reload.decision_issues.size).to eq 2
-        expect(request_issue5.decision_issues[1].remand_reasons.size).to eq 2
+
+        something5_decision = request_issue5.decision_issues.find { |di| di.description == "something5" }
+
+        expect(something5_decision.remand_reasons.size).to eq 2
+
         expect(request_issue6.decision_issues.size).to eq 1
         expect(withdrawn_request_issue.decision_issues.size).to eq 1
         expect(withdrawn_request_issue.decision_issues[0].disposition).to eq "withdrawn"


### PR DESCRIPTION
follow on to #13792 

### Description

Adds indices to columns in slow query.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
