### PR TITLE
Use test mailer in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,11 +83,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.delivery_method = :govdelivery_tms
-  config.action_mailer.govdelivery_tms_settings = {
-    auth_token: ENV["GOVDELIVERY_TOKEN"],
-    api_root: "https://#{ENV["GOVDELIVERY_SERVER"]}"
-  }
+  config.action_mailer.delivery_method = :test
 
   # eFolder API URL to retrieve appeal documents
   config.efolder_url = "http://localhost:4000"


### PR DESCRIPTION
Related to #13789

### Description

#13789 changed it to use `deliver_now!`, which will always error and actually try to send an email through GovDelivery TMS. 

This leads to an error in the dev environment now, where an error from GovDelivery actually surfaces, and makes it impossible to schedule a virtual hearing (also because in dev., the create conference job is run synchronously).

This changes the development environment to use the test mailer, instead of GovDelivery, to avoid any errors when sending emails.
