### PR TITLE
Add COVID-19 timeliness exempt column

### DIFF
--- a/db/migrate/20200327174629_add_covid_exempt_column.rb
+++ b/db/migrate/20200327174629_add_covid_exempt_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCovidExemptColumn < Caseflow::Migration
+  def change
+    add_column :request_issues, :covid_timeliness_exempt, :boolean, comment: "If a veteran requests a timeliness exemption that is related to COVID-19, this is captured when adding a Request Issue and available for reporting."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_26_141733) do
+ActiveRecord::Schema.define(version: 2020_03_27_174629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1043,6 +1043,7 @@ ActiveRecord::Schema.define(version: 2020_03_26_141733) do
     t.string "contested_rating_issue_reference_id", comment: "If the contested issue is a rating issue, this is the rating issue's reference id. Will be nil if this request issue contests a decision issue."
     t.integer "corrected_by_request_issue_id", comment: "If this request issue has been corrected, the ID of the new correction request issue. This is needed for EP 930."
     t.string "correction_type", comment: "EP 930 correction type. Allowed values: control, local_quality_error, national_quality_error where 'control' is a regular correction, 'local_quality_error' was found after the fact by a local quality review team, and 'national_quality_error' was similarly found by a national quality review team. This is needed for EP 930."
+    t.boolean "covid_timeliness_exempt", comment: "If a veteran requests a timeliness exemption that is related to COVID-19, this is captured when adding a Request Issue and available for reporting."
     t.datetime "created_at", comment: "Automatic timestamp when row was created"
     t.date "decision_date", comment: "Either the rating issue's promulgation date, the decision issue's approx decision date or the decision date entered by the user (for nonrating and unidentified issues)"
     t.bigint "decision_review_id", comment: "ID of the decision review that this request issue belongs to"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -808,6 +808,7 @@ request_issues,contested_rating_issue_profile_date,string,,,,,,"If the contested
 request_issues,contested_rating_issue_reference_id,string,,,,,x,"If the contested issue is a rating issue, this is the rating issue's reference id. Will be nil if this request issue contests a decision issue."
 request_issues,corrected_by_request_issue_id,integer FK,,,x,,,"If this request issue has been corrected, the ID of the new correction request issue. This is needed for EP 930."
 request_issues,correction_type,string,,,,,,"EP 930 correction type. Allowed values: control, local_quality_error, national_quality_error where 'control' is a regular correction, 'local_quality_error' was found after the fact by a local quality review team, and 'national_quality_error' was similarly found by a national quality review team. This is needed for EP 930."
+request_issues,covid_timeliness_exempt,boolean,,,,,,"If a veteran requests a timeliness exemption that is related to COVID-19, this is captured when adding a Request Issue and available for reporting."
 request_issues,created_at,datetime,,,,,,Automatic timestamp when row was created
 request_issues,decision_date,date,,,,,,"Either the rating issue's promulgation date, the decision issue's approx decision date or the decision date entered by the user (for nonrating and unidentified issues)"
 request_issues,decision_review_id,integer (8) FK,,,x,,x,ID of the decision review that this request issue belongs to


### PR DESCRIPTION
Connects #13809 

### Description
Database migration for adding COVID-19 exempt column to request issues.

### Database Changes
*Only for Schema Changes*

* [x] Column comments updated
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
