### PR TITLE
IDT only returns active Appeals

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -46,7 +46,7 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
 
   def appeals_by_file_number
     appeals = LegacyAppeal.fetch_appeals_by_file_number(file_number).select(&:activated?)
-    appeals += Appeal.where(veteran_file_number: file_number)
+    appeals += Appeal.active.where(veteran_file_number: file_number)
     appeals
   end
 

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -155,14 +155,14 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
             create(:appeal, veteran: veteran1, number_of_claimants: 1, veteran_is_not_claimant: true),
             create(:appeal, veteran: veteran2, number_of_claimants: 1),
             create(:appeal, veteran: veteran1, number_of_claimants: 1)
-          ].map { |app| app.tap { |appeal| appeal.create_tasks_on_intake_success! } }
+          ].map { |app| app.tap(&:create_tasks_on_intake_success!) }
         end
 
         let!(:parents) do
           [
             create(:ama_judge_decision_review_task, appeal: ama_appeals.first, parent: ama_appeals.first.root_task),
             create(:ama_judge_decision_review_task, appeal: ama_appeals.second, parent: ama_appeals.second.root_task),
-            create(:ama_judge_decision_review_task, appeal: ama_appeals.last, parent: ama_appeals.last.root_task),
+            create(:ama_judge_decision_review_task, appeal: ama_appeals.last, parent: ama_appeals.last.root_task)
           ]
         end
 


### PR DESCRIPTION
Resolves #13785 

### Description
Like Legacy Appeals, IDT API should list only active Appeals.

### Testing Plan
1. Confirm with Paul in #appeals-idt
