### PR TITLE
Add more request context to Raven errors

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -13,7 +13,7 @@ class Api::ApplicationController < ActionController::Base
                 :set_api_user
 
   rescue_from StandardError do |error|
-    Raven.capture_exception(error)
+    Raven.capture_exception(error, extra: raven_extra_context)
 
     render json: {
       "errors": [
@@ -27,6 +27,10 @@ class Api::ApplicationController < ActionController::Base
   rescue_from BGS::ShareError, VBMS::ClientError, with: :on_external_error
 
   private
+
+  def raven_extra_context
+    {}
+  end
 
   # For API calls, we use the system user to make all BGS calls
   def set_api_user

--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::V2::AppealsController < Api::ApplicationController
-  before_action :set_raven_context
-
   def index
     api_key.api_views.create(vbms_id: vbms_id, source: source)
     render json: json_appeals
@@ -16,8 +14,8 @@ class Api::V2::AppealsController < Api::ApplicationController
 
   private
 
-  def set_raven_context
-    Raven.extra_context(veteran_file_number: veteran_file_number, vbms_id: vbms_id, source: source)
+  def raven_extra_context
+    { veteran_file_number: veteran_file_number, vbms_id: vbms_id, source: source }
   end
 
   def ssn

--- a/app/controllers/api/v2/appeals_controller.rb
+++ b/app/controllers/api/v2/appeals_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::V2::AppealsController < Api::ApplicationController
+  before_action :set_raven_context
+
   def index
     api_key.api_views.create(vbms_id: vbms_id, source: source)
     render json: json_appeals
@@ -13,6 +15,10 @@ class Api::V2::AppealsController < Api::ApplicationController
   end
 
   private
+
+  def set_raven_context
+    Raven.extra_context(veteran_file_number: veteran_file_number, vbms_id: vbms_id, source: source)
+  end
 
   def ssn
     request.headers["ssn"]

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -135,8 +135,12 @@ describe "Appeals API v2", :all_dbs, type: :request do
         "Authorization": "Token token=#{api_key.key_string}"
       }
 
-      allow(ApiKey).to receive(:authorize).and_raise("Much random error")
-      expect(Raven).to receive(:capture_exception)
+      random_error = StandardError.new("Much random error")
+
+      allow(ApiKey).to receive(:authorize).and_raise(random_error)
+      expect(Raven).to receive(:capture_exception).with(
+        random_error, hash_including(extra: hash_including(vbms_id: "444444444S"))
+      )
       expect(Raven).to receive(:last_event_id).and_return("a1b2c3")
 
       get "/api/v2/appeals", headers: headers


### PR DESCRIPTION
Should enable us to debug Appeals Status API errors more easily.