### PR TITLE
Fix make reset

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -138,14 +138,15 @@ fresh:  ## https://github.com/imsky/git-fresh - updates local master to match or
 
 reset: reset-dbs seed-dbs enable-feature-flags ## Resets databases and enable feature flags
 
-reset-dbs: ## Resets database schemas
+reset-dbs: ## Resets Caseflow and ETL database schemas
 	DB=etl bundle exec rake db:drop db:create db:schema:load
 	bundle exec rake db:drop db:create db:schema:load
 
-seed-dbs:	## Seed databases
+seed-dbs:	## Seed all databases
 	bundle exec rake local:vacols:seed
 	bundle exec rake spec:setup_vacols
 	bundle exec rake db:seed
+	DB=etl bundle exec rake db:seed
 
 enable-feature-flags: ## enable all feature flags
 	bundle exec rails runner scripts/enable_features_dev.rb

--- a/Makefile.example
+++ b/Makefile.example
@@ -138,11 +138,11 @@ fresh:  ## https://github.com/imsky/git-fresh - updates local master to match or
 
 reset: reset-dbs seed-dbs enable-feature-flags ## Resets databases and enable feature flags
 
-reset-dbs: ## Resets databases
+reset-dbs: ## Resets database schemas
 	DB=etl bundle exec rake db:drop db:create db:schema:load
 	bundle exec rake db:drop db:create db:schema:load
 
-seed-dbs:
+seed-dbs:	## Seed databases
 	bundle exec rake local:vacols:seed
 	bundle exec rake spec:setup_vacols
 	bundle exec rake db:seed

--- a/Makefile.example
+++ b/Makefile.example
@@ -136,11 +136,16 @@ rollback: etl-rollback db-rollback	## Rollback all Rails databases
 fresh:  ## https://github.com/imsky/git-fresh - updates local master to match origin, stashes changes, prunes remote branches
 	git fresh
 
-reset: reset-dbs enable-feature-flags ## Resets databases and enable feature flags
+reset: reset-dbs seed-dbs enable-feature-flags ## Resets databases and enable feature flags
 
 reset-dbs: ## Resets databases
 	DB=etl bundle exec rake db:drop db:create db:schema:load
-	bundle exec rake db:drop db:create db:schema:load local:vacols:seed spec:setup_vacols db:seed
+	bundle exec rake db:drop db:create db:schema:load
+
+seed-dbs:
+	bundle exec rake local:vacols:seed
+	bundle exec rake spec:setup_vacols
+	bundle exec rake db:seed
 
 enable-feature-flags: ## enable all feature flags
 	bundle exec rails runner scripts/enable_features_dev.rb


### PR DESCRIPTION
In theory we should be able to run multiple rake tasks in a single shell invocation but in practice that does not always seem to work.

This refactor creates a new `make seed-dbs` target and splits the rake tasks into separate shell invocations.