### PR TITLE
Fix Appeal API ArgumentError

### DIFF
--- a/app/models/decision_review.rb
+++ b/app/models/decision_review.rb
@@ -255,7 +255,7 @@ class DecisionReview < CaseflowRecord
     return unless remand_supplemental_claims.any?
     return if active_remanded_claims?
 
-    remand_supplemental_claims.map(&:decision_event_date).max.try(&:to_date)
+    remand_supplemental_claims.map(&:decision_event_date).compact.max.try(&:to_date)
   end
 
   def fetch_all_decision_issues


### PR DESCRIPTION
See https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/8794/events/cfa04b82c7d24246b19ee2e9882e5e6e/

### Description

If a Remand SC has zero decision issues, it will have a nil `decision_event_date`. This causes the date comparison to fail in the Appeals Status API.