### PR TITLE
Fix tiny Datadog bug in send_email

### DIFF
--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -82,7 +82,7 @@ class VirtualHearings::SendEmail
       response_external_url = response.body.dig("_links", "self")
 
       DataDogService.increment_counter(
-        app_name: DATADOG_METRICS.HEARINGS.APP_NAME,
+        app_name: Constants.DATADOG_METRICS.HEARINGS.APP_NAME,
         metric_group: Constants.DATADOG_METRICS.HEARINGS.VIRTUAL_HEARINGS_GROUP_NAME,
         metric_name: "emails.submitted"
       )


### PR DESCRIPTION
This PR fixes a namespace bug when incrementing a Datadog counter in `send_email`

Via this unrouted Sentry alert: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/9759/