### PR TITLE
Response timeout is not individually actionable

### DIFF
--- a/client/app/queue/components/HearingBadge.jsx
+++ b/client/app/queue/components/HearingBadge.jsx
@@ -50,7 +50,7 @@ class HearingBadge extends React.PureComponent {
       }).
         catch((err) => {
           // we don't care if the browser gave up for some reason.
-          if (err.message.match(/Request has been terminated/)) {
+          if (err.message.match(/Request has been terminated|Response timeout/)) {
             return;
           }
 


### PR DESCRIPTION
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/8559/events/2fe392886e1c4193adefb78d49bf91ac/

We get these Sentry alerts that cannot be acted on. Individual testing shows that the URLs are, in fact, responsive, and whatever is causing the request to occasionally time out is outside our control.