### PR TITLE
efolder document_count as background job

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -48,7 +48,9 @@ class AppealsController < ApplicationController
   end
 
   def document_count
-    render json: { document_count: EFolderService.document_count(appeal.veteran_file_number, current_user) }
+    doc_count = EFolderService.document_count(appeal.veteran_file_number, current_user)
+    status = doc_count == -1 ? 202 : 200
+    render json: { document_count: doc_count }, status: status
   rescue Caseflow::Error::EfolderAccessForbidden => error
     render(error.serialize_response)
   rescue StandardError => error

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -49,7 +49,7 @@ class AppealsController < ApplicationController
 
   def document_count
     doc_count = EFolderService.document_count(appeal.veteran_file_number, current_user)
-    status = (doc_count == -1) ? 202 : 200
+    status = (doc_count == EfolderService::DOCUMENT_COUNT_DEFERRED) ? 202 : 200
     render json: { document_count: doc_count }, status: status
   rescue Caseflow::Error::EfolderAccessForbidden => error
     render(error.serialize_response)

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -49,7 +49,7 @@ class AppealsController < ApplicationController
 
   def document_count
     doc_count = EFolderService.document_count(appeal.veteran_file_number, current_user)
-    status = doc_count == -1 ? 202 : 200
+    status = (doc_count == -1) ? 202 : 200
     render json: { document_count: doc_count }, status: status
   rescue Caseflow::Error::EfolderAccessForbidden => error
     render(error.serialize_response)

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -49,7 +49,7 @@ class AppealsController < ApplicationController
 
   def document_count
     doc_count = EFolderService.document_count(appeal.veteran_file_number, current_user)
-    status = (doc_count == EfolderService::DOCUMENT_COUNT_DEFERRED) ? 202 : 200
+    status = (doc_count == ::ExternalApi::EfolderService::DOCUMENT_COUNT_DEFERRED) ? 202 : 200
     render json: { document_count: doc_count }, status: status
   rescue Caseflow::Error::EfolderAccessForbidden => error
     render(error.serialize_response)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,6 +60,8 @@ class ApplicationController < ApplicationBaseController
   end
 
   def handle_non_critical_error(endpoint, err)
+    Rails.logger.error "#{err.message}\n#{err.backtrace.join("\n")}"
+
     error_type = err.class.name
     if !err.class.method_defined? :serialize_response
       code = (err.class == ActiveRecord::RecordNotFound) ? 404 : 500

--- a/app/jobs/fetch_efolder_document_count_job.rb
+++ b/app/jobs/fetch_efolder_document_count_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class FetchEfolderDocumentCountJob < CaseflowJob
+  queue_with_priority :high_priority
+  application_attr :queue
+
+  def perform(file_number:, user:)
+    RequestStore.store[:current_user] = user
+
+    doc_count = ExternalApi::EfolderService.fetch_document_count(file_number, user)
+
+    datadog_report_runtime(metric_group_name: "efolder_fetch_document_count")
+
+    doc_count
+  end
+end

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -3,6 +3,8 @@
 require "json"
 
 class ExternalApi::EfolderService
+  DOCUMENT_COUNT_DEFERRED = -1
+
   def self.document_count_cache_key(file_number)
     "Efolder-document-count-#{file_number}"
   end
@@ -23,7 +25,7 @@ class ExternalApi::EfolderService
     end
 
     # indicate to caller to check back later
-    -1
+    DOCUMENT_COUNT_DEFERRED
   end
 
   # synchronous API call

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -21,6 +21,9 @@ class ExternalApi::EfolderService
     Rails.cache.fetch(efolder_doc_count_bgjob_key, expires_in: 15.minutes) do
       FetchEfolderDocumentCountJob.perform_later(file_number: file_number, user: user)
     end
+
+    # indicate to caller to check back later
+    -1
   end
 
   # synchronous API call

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -12,7 +12,7 @@ class ExternalApi::EfolderService
     efolder_doc_count_bgjob_key = "Efolder-document-count-bgjob-#{file_number}"
 
     # if it's in the cache return it.
-    doc_count = Rails.cache.fetch(self.document_count_cache_key(file_number))
+    doc_count = Rails.cache.fetch(document_count_cache_key(file_number))
     return doc_count if doc_count
 
     # if not in the cache, start a bg job to cache it.
@@ -28,7 +28,7 @@ class ExternalApi::EfolderService
 
   # synchronous API call
   def self.fetch_document_count(file_number, user)
-    Rails.cache.fetch(self.document_count_cache_key(file_number), expires_in: 4.hours) do
+    Rails.cache.fetch(document_count_cache_key(file_number), expires_in: 4.hours) do
       headers = { "FILE-NUMBER" => file_number }
       response = send_efolder_request("/api/v2/document_counts", user, headers)
       response_body = JSON.parse(response.body)

--- a/client/app/queue/AppealDocumentCount.jsx
+++ b/client/app/queue/AppealDocumentCount.jsx
@@ -36,11 +36,24 @@ class AppealDocumentCount extends React.PureComponent {
 
     this.props.loadAppealDocCount(this.props.externalId);
 
-    ApiUtil.get(`/appeals/${this.props.externalId}/document_count`, requestOptions).then((response) => {
-      this.props.setAppealDocCount(this.props.externalId, response.body.document_count);
-    }, () => {
-      this.props.errorFetchingDocumentCount(this.props.externalId);
-    });
+    const tryFetchingDocumentCount = () => {
+      ApiUtil.get(`/appeals/${this.props.externalId}/document_count`, requestOptions).then((response) => {
+        const docCount = response.body.document_count;
+
+        // if we were told "try again later" then do do.
+        if (response.status === 202 && parseInt(docCount) === -1) {
+          setTimeout(tryFetchingDocumentCount, 30000); // try every 30 seconds
+
+          return;
+        }
+
+        this.props.setAppealDocCount(this.props.externalId, docCount);
+      }, () => {
+        this.props.errorFetchingDocumentCount(this.props.externalId);
+      });
+    }
+
+    tryFetchingDocumentCount();
   }
 
   render = () => {

--- a/client/app/queue/AppealDocumentCount.jsx
+++ b/client/app/queue/AppealDocumentCount.jsx
@@ -41,8 +41,9 @@ class AppealDocumentCount extends React.PureComponent {
         const docCount = response.body.document_count;
 
         // if we were told "try again later" then do do.
-        if (response.status === 202 && parseInt(docCount) === -1) {
-          setTimeout(tryFetchingDocumentCount, 30000); // try every 30 seconds
+        if (response.status === 202 && parseInt(docCount, 10) === -1) {
+          // try again in 30 seconds
+          setTimeout(tryFetchingDocumentCount, 30000);
 
           return;
         }
@@ -51,7 +52,7 @@ class AppealDocumentCount extends React.PureComponent {
       }, () => {
         this.props.errorFetchingDocumentCount(this.props.externalId);
       });
-    }
+    };
 
     tryFetchingDocumentCount();
   }

--- a/spec/jobs/fetch_efolder_document_count_job_spec.rb
+++ b/spec/jobs/fetch_efolder_document_count_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+describe FetchEfolderDocumentCountJob do
+  describe ".perform" do
+    before do
+      allow(ExternalApi::EfolderService).to receive(:fetch_document_count) { 10 }
+
+      @emitted_gauges = []
+      allow(DataDogService).to receive(:emit_gauge) do |args|
+        @emitted_gauges.push(args)
+      end
+    end
+
+    let(:file_number) { "1234" }
+    let(:user) { double(:user) }
+
+    it "calls Efolder API service" do
+      doc_count = FetchEfolderDocumentCountJob.perform_now(file_number: file_number, user: user)
+
+      expect(doc_count).to eq(10)
+      expect(@emitted_gauges.first).to include(
+        app_name: "caseflow_job",
+        metric_group: "efolder_fetch_document_count",
+        metric_name: "runtime",
+        metric_value: anything
+      )
+    end
+  end
+end

--- a/spec/services/external_api/efolder_service_spec.rb
+++ b/spec/services/external_api/efolder_service_spec.rb
@@ -81,13 +81,14 @@ describe ExternalApi::EfolderService, :postgres do
     end
 
     context "doc count is not yet cached" do
-      it "creates background job" do
+      it "creates background job, once" do
         expect(Rails.cache.exist?(cache_key)).to eq(false)
         expect(Rails.cache.exist?(job_cache_key)).to eq(false)
         subject
         expect(Rails.cache.exist?(cache_key)).to eq(false)
         expect(Rails.cache.exist?(job_cache_key)).to eq(true)
-        expect(FetchEfolderDocumentCountJob).to have_received(:perform_later)
+        subject # call again to test sentinel cache key
+        expect(FetchEfolderDocumentCountJob).to have_received(:perform_later).once
       end
     end
   end


### PR DESCRIPTION
Resolves #13851 

### Description
Refactor to call the efolder document count endpoint via a background job, async.

This should reduce wait times on the caseflow server for synchronous HTTP requests.