### PR TITLE
Workaround for `Cannot read property 'range' of null` ESLint Bug

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -20,7 +20,14 @@ module.exports = {
         ignore: [],
         customValidators: []
       }
-    ]
+    ],
+    // Adding next two rules to avoid bug in babel-eslint:
+    // https://github.com/babel/babel-eslint/issues/799
+    indent: [
+      'warn', 2,
+      { ignoredNodes: ['TemplateLiteral'] }
+    ],
+    'template-curly-spacing': 'off'
   },
   settings: {
     react: {


### PR DESCRIPTION
### Description
This is a temporary workaround to avoid a bug occurring with newer versions of `babel-eslint`. This adds a couple of items to ESLint rules to avoid it attempting to parse template literals.

The error:
```
TypeError: Cannot read property 'range' of null
Occurred while linting 
```

### Background
- [Slack thread 1](https://dsva.slack.com/archives/CQNPUG8EQ/p1585841970006500)
- [Slack thread 2](https://dsva.slack.com/archives/C2ZAMLK88/p1585844930076800)
- [GH Issue](https://github.com/babel/babel-eslint/issues/799)

### Acceptance Criteria
- [ ] Code compiles correctly