### PR TITLE
Intake | Bug | Do not require veteran city for intake

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -188,6 +188,8 @@ class Veteran < CaseflowRecord
         errors.add(address.to_sym, "invalid_characters")
       end
     end
+
+    true
   end
 
   def validate_date_of_birth
@@ -199,7 +201,7 @@ class Veteran < CaseflowRecord
   end
 
   def validate_city
-    return if city.blank?
+    return true city.blank?
 
     # This regex validation is used in VBMS to validate address of veteran
     errors.add(:city, "invalid_characters") unless city.match?(/^[ a-zA-Z0-9`\\'~=+\[\]{}#?\^*<>!@$%&()\-_|;:",.\/]*$/)

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -186,7 +186,6 @@ class Veteran < CaseflowRecord
       # This regex validation is used in VBMS to validate address of veteran
       unless address_line.match?(/^(?!.*\s\s)[a-zA-Z0-9+#@%&()_:',.\-\/\s]*$/)
         errors.add(address.to_sym, "invalid_characters")
-        return
       end
     end
   end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -186,10 +186,9 @@ class Veteran < CaseflowRecord
       # This regex validation is used in VBMS to validate address of veteran
       unless address_line.match?(/^(?!.*\s\s)[a-zA-Z0-9+#@%&()_:',.\-\/\s]*$/)
         errors.add(address.to_sym, "invalid_characters")
+        return
       end
     end
-
-    true
   end
 
   def validate_date_of_birth
@@ -201,7 +200,7 @@ class Veteran < CaseflowRecord
   end
 
   def validate_city
-    return true city.blank?
+    return true if city.blank?
 
     # This regex validation is used in VBMS to validate address of veteran
     errors.add(:city, "invalid_characters") unless city.match?(/^[ a-zA-Z0-9`\\'~=+\[\]{}#?\^*<>!@$%&()\-_|;:",.\/]*$/)


### PR DESCRIPTION
### Description
This is to fix a bug introduced by [this PR](https://github.com/department-of-veterans-affairs/caseflow/pull/13746), and [reported in batteam here](https://dsva.slack.com/archives/CHX8FMP28/p1585861542154400).

The PR added validation to a veteran's city, and if was nil failed validation but did not return an error message.  This impacts veterans with military addresses, because they are not required to have a city.

It looks like there's a test for this in the veteran spec, but still have to investigate why that didn't catch this.  Not 100% if this is the problem but hoping this fixes it.