### PR TITLE
Intake | Bug | Return true for blank city in claimant validator

### DIFF
--- a/app/models/validators/claimant_validator.rb
+++ b/app/models/validators/claimant_validator.rb
@@ -74,7 +74,7 @@ class ClaimantValidator
 
   # Validates claimant city using this regex that VBMS uses.
   def claimant_city_valid?
-    return true if city.blank?
+    return true if claimant.city.blank?
 
     claimant.city =~ /\A[ a-zA-Z0-9`\\'~=+\[\]{}#?\^*<>!@$%&()\-_|;:",.\/]*\Z/ && claimant.city.length <= 30
   end

--- a/app/models/validators/claimant_validator.rb
+++ b/app/models/validators/claimant_validator.rb
@@ -74,6 +74,8 @@ class ClaimantValidator
 
   # Validates claimant city using this regex that VBMS uses.
   def claimant_city_valid?
+    return true if city.blank?
+
     claimant.city =~ /\A[ a-zA-Z0-9`\\'~=+\[\]{}#?\^*<>!@$%&()\-_|;:",.\/]*\Z/ && claimant.city.length <= 30
   end
 

--- a/spec/models/validators/claimant_validator_spec.rb
+++ b/spec/models/validators/claimant_validator_spec.rb
@@ -35,6 +35,14 @@ describe ClaimantValidator, :postgres do
       it "sets no errors" do
         expect(subject[:claimant]).to be_empty
       end
+
+      context "claimant has a nil city" do
+        let(:city) { nil }
+
+        it "sets no errors" do
+          expect(subject[:claimant]).to be_empty
+        end
+      end
     end
 
     context "claimant has no participant id" do


### PR DESCRIPTION
### Description
This is to fix a bug introduced by [this PR](https://github.com/department-of-veterans-affairs/caseflow/pull/13746), and [reported in batteam here](https://dsva.slack.com/archives/CHX8FMP28/p1585861542154400).

The PR added validation to a claimant's city, and if was nil failed validation but did not return an error message.  This impacts veterans with military addresses, because they are not required to have a city.

Related: #13880

Note - I don't think  the above PR fixed the issue, but I think this PR will do it.