### PR TITLE
Fixed Routing for Organizations Views

### DIFF
--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -263,11 +263,17 @@ class QueueApp extends React.PureComponent {
 
   routedBulkAssignTaskModal = (props) => <BulkAssignModal {...props} />;
 
-  routedOrganization = (props) => (
-    <OrganizationQueueLoadingScreen urlToLoad={`${props.location.pathname}/tasks`}>
-      <OrganizationQueue {...this.props} paginationOptions={querystring.parse(window.location.search.slice(1))} />
-    </OrganizationQueueLoadingScreen>
-  );
+  routedOrganization = (props) => {
+    const {
+      match: { url }
+    } = props;
+
+    return (
+      <OrganizationQueueLoadingScreen urlToLoad={`${url}/tasks`}>
+        <OrganizationQueue {...this.props} paginationOptions={querystring.parse(window.location.search.slice(1))} />
+      </OrganizationQueueLoadingScreen>
+    );
+  };
 
   routedOrganizationUsers = (props) => <OrganizationUsers {...props.match.params} />;
 

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -121,8 +121,12 @@ class QueueApp extends React.PureComponent {
   );
 
   routedJudgeQueueList = (label) => ({ match }) => (
-    <QueueLoadingScreen {...this.propsForQueueLoadingScreen()} match={match} userRole={USER_ROLE_TYPES.judge}
-      loadAttorneys={label === 'assign'} >
+    <QueueLoadingScreen
+      {...this.propsForQueueLoadingScreen()}
+      match={match}
+      userRole={USER_ROLE_TYPES.judge}
+      loadAttorneys={label === 'assign'}
+    >
       {label === 'assign' ? (
         <JudgeAssignTaskListView {...this.props} match={match} />
       ) : (
@@ -429,6 +433,12 @@ class QueueApp extends React.PureComponent {
               />
 
               <PageRoute
+                path="/organizations/:organization"
+                title="Organization Queue | Caseflow"
+                render={this.routedOrganization}
+              />
+
+              <PageRoute
                 path="/team_management"
                 title="Team Management | Caseflow"
                 render={this.routedTeamManagement}
@@ -602,16 +612,12 @@ class QueueApp extends React.PureComponent {
                 title="Change Task Type | Caseflow"
                 render={this.routedChangeTaskTypeModal}
               />
+
               <Route
                 path="/organizations/:organization/modal/bulk_assign_tasks"
                 render={this.routedBulkAssignTaskModal}
               />
-              <PageRoute
-                exact
-                path={['/organizations/:organization', '/organizations/:organization/modal/:modalType']}
-                title="Organization Queue | Caseflow"
-                render={this.routedOrganization}
-              />
+
               <PageRoute
                 exact
                 path="/organizations/:organization/users"

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -433,6 +433,12 @@ class QueueApp extends React.PureComponent {
               />
 
               <PageRoute
+                exact
+                path="/organizations/:organization/users"
+                title="Organization Users | Caseflow"
+                render={this.routedOrganizationUsers}
+              />
+              <PageRoute
                 path="/organizations/:organization"
                 title="Organization Queue | Caseflow"
                 render={this.routedOrganization}
@@ -618,12 +624,6 @@ class QueueApp extends React.PureComponent {
                 render={this.routedBulkAssignTaskModal}
               />
 
-              <PageRoute
-                exact
-                path="/organizations/:organization/users"
-                title="Organization Users | Caseflow"
-                render={this.routedOrganizationUsers}
-              />
               <Route path="/team_management/add_judge_team" render={this.routedAddJudgeTeam} />
               <Route path="/team_management/add_vso" render={this.routedAddVsoModal} />
               <Route path="/team_management/add_private_bar" render={this.routedAddPrivateBarModal} />

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -261,7 +261,12 @@ class QueueApp extends React.PureComponent {
     return <CompleteTaskModal modalType="send_colocated_task" {...props.match.params} />;
   };
 
-  routedBulkAssignTaskModal = (props) => <BulkAssignModal {...props} />;
+  routedBulkAssignTaskModal = (props) => {
+    const { match } = props;
+    const pageRoute = match.path.replace('modal/bulk_assign_tasks', '');
+
+    return <BulkAssignModal {...props} onCancel={() => props.history.push(pageRoute)} />;
+  };
 
   routedOrganization = (props) => {
     const {

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -208,6 +208,7 @@ class BulkAssignModal extends React.PureComponent {
     return <QueueFlowModal
       pathAfterSubmit={`/organizations/${this.organizationUrl()}`}
       button={COPY.BULK_ASSIGN_BUTTON_TEXT}
+      onCancel={this.props.onCancel}
       submit={this.bulkAssignTasks}
       validateForm={this.validateForm}
       title={COPY.BULK_ASSIGN_MODAL_TITLE}>
@@ -225,7 +226,8 @@ BulkAssignModal.propTypes = {
   bulkAssignTasks: PropTypes.func,
   highlightFormItems: PropTypes.bool,
   history: PropTypes.object,
-  location: PropTypes.object
+  location: PropTypes.object,
+  onCancel: PropTypes.func
 };
 
 const mapStateToProps = (state) => {

--- a/client/app/queue/components/QueueFlowModal.jsx
+++ b/client/app/queue/components/QueueFlowModal.jsx
@@ -16,7 +16,7 @@ class QueueFlowModal extends React.PureComponent {
     };
   }
 
-  cancelHandler = () => this.props.history.goBack();
+  cancelHandler = () => this.props.onCancel ? this.props.onCancel() : this.props.history.goBack();
 
   closeHandler = () => this.props.history.replace(this.props.pathAfterSubmit);
 
@@ -77,6 +77,7 @@ QueueFlowModal.propTypes = {
   history: PropTypes.object,
   title: PropTypes.string,
   button: PropTypes.string,
+  onCancel: PropTypes.func,
   pathAfterSubmit: PropTypes.string,
   // submit should return a promise on which .then() can be called
   submit: PropTypes.func,


### PR DESCRIPTION
### Description
This fixes the placement of the `/organizations/:organization` route so it's in the "page" route `Switch` instead of the `Switch` for modal routes in `QueueApp`.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `BulkAssignModal` properly shows *over* the main org route