### PR TITLE
Correct Case Review Rails Model

### DIFF
--- a/app/models/organizations/bva_intake.rb
+++ b/app/models/organizations/bva_intake.rb
@@ -1,23 +1,26 @@
+# frozen_string_literal: true
 
 class BvaIntake < Organization
-  def self.singleton
-    # after the production database is correct, replace the tmp function with BvaIntake.first
-    find_and_update_incorrect_bva_intake || BvaIntake.create(name: "Bva Intake", url: "bva-intake")
-  end
+  class << self
+    def singleton
+      # after the production database is correct, replace the tmp function with BvaIntake.first
+      find_and_update_incorrect_bva_intake || BvaIntake.create(name: "Bva Intake", url: "bva-intake")
+    end
 
-  private
+    private
 
-  # temporary function to split the original mistake where the org Case Review was
-  # referred to as BvaIntake. Can be removed after the production database is up to date.
-  def self.find_and_update_incorrect_bva_intake
-    # check if the mismatch exists; if not default back to BvaIntake.first
-    case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")
-    return BvaIntake.first unless case_review_misnamed
+    # temporary function to split the original mistake where the org Case Review was
+    # referred to as BvaIntake. Can be removed after the production database is up to date.
+    def find_and_update_incorrect_bva_intake
+      # check if the mismatch exists; if not default back to BvaIntake.first
+      case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")
+      return BvaIntake.first unless case_review_misnamed
 
-    # we're the first invocation - fix the mismatch
-    case_review_misnamed.update(type: "CaseReview")
+      # we're the first invocation - fix the mismatch
+      case_review_misnamed.update(type: "CaseReview")
 
-    # return BvaIntake.first; if it doesn't exist it will fall through up in singleton to the create
-    BvaIntake.first
+      # return BvaIntake.first; if it doesn't exist it will fall through up in singleton to the create
+      BvaIntake.first
+    end
   end
 end

--- a/app/models/organizations/bva_intake.rb
+++ b/app/models/organizations/bva_intake.rb
@@ -11,6 +11,7 @@ class BvaIntake < Organization
 
     # temporary function to split the original mistake where the org Case Review was
     # referred to as BvaIntake. Can be removed after the production database is up to date.
+    # :nocov:
     def find_and_update_incorrect_bva_intake
       # check if the mismatch exists; if not default back to BvaIntake.first
       case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")

--- a/app/models/organizations/bva_intake.rb
+++ b/app/models/organizations/bva_intake.rb
@@ -4,7 +4,7 @@ class BvaIntake < Organization
   class << self
     def singleton
       # after the production database is correct, replace the tmp function with BvaIntake.first
-      find_and_update_incorrect_bva_intake || BvaIntake.create(name: "Bva Intake", url: "bva-intake")
+      find_and_update_incorrect_bva_intake || BvaIntake.create(name: "BVA Intake", url: "bva-intake")
     end
 
     private

--- a/app/models/organizations/case_review.rb
+++ b/app/models/organizations/case_review.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
 class CaseReview < Organization
-  def self.singleton
-    # after the production database is correct, replace the tmp function with CaseReview.first
-    find_and_update_incorrect_bva_intake || CaseReview.create(name: "Case Review", url: "case-review")
-  end
+  class << self
+    def singleton
+      # after the production database is correct, replace the tmp function with CaseReview.first
+      find_and_update_incorrect_bva_intake || CaseReview.create(name: "Case Review", url: "case-review")
+    end
 
-  private
+    private
 
-  # temporary function to split the original mistake where the org Case Review was
-  # referred to as BvaIntake. Can be removed after the production database is up to date.
-  def self.find_and_update_incorrect_bva_intake
-    # check if the mismatch exists; if not default back to BvaIntake.first
-    case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")
-    return CaseReview.first unless case_review_misnamed
+    # temporary function to split the original mistake where the org Case Review was
+    # referred to as BvaIntake. Can be removed after the production database is up to date.
+    def find_and_update_incorrect_bva_intake
+      # check if the mismatch exists; if not default back to BvaIntake.first
+      case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")
+      return CaseReview.first unless case_review_misnamed
 
-    # we're the first invocation - fix the mismatch
-    case_review_misnamed.update(type: "CaseReview")
+      # we're the first invocation - fix the mismatch
+      case_review_misnamed.update(type: "CaseReview")
 
-    # return CaseReview.first; if it doesn't exist it will fall through up in singleton to the create - though it _should_ since we just created it via that update!
-    CaseReview.first
+      # return CaseReview.first; if it doesn't exist it will fall through up
+      # in singleton to the create - though it _should_ since we just
+      # created it via that update!
+      CaseReview.first
+    end
   end
 end

--- a/app/models/organizations/case_review.rb
+++ b/app/models/organizations/case_review.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
 
-class BvaIntake < Organization
+class CaseReview < Organization
   def self.singleton
-    # after the production database is correct, replace the tmp function with BvaIntake.first
-    find_and_update_incorrect_bva_intake || BvaIntake.create(name: "Bva Intake", url: "bva-intake")
+    # after the production database is correct, replace the tmp function with CaseReview.first
+    find_and_update_incorrect_bva_intake || CaseReview.create(name: "Case Review", url: "case-review")
   end
 
   private
@@ -12,12 +13,12 @@ class BvaIntake < Organization
   def self.find_and_update_incorrect_bva_intake
     # check if the mismatch exists; if not default back to BvaIntake.first
     case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")
-    return BvaIntake.first unless case_review_misnamed
+    return CaseReview.first unless case_review_misnamed
 
     # we're the first invocation - fix the mismatch
     case_review_misnamed.update(type: "CaseReview")
 
-    # return BvaIntake.first; if it doesn't exist it will fall through up in singleton to the create
-    BvaIntake.first
+    # return CaseReview.first; if it doesn't exist it will fall through up in singleton to the create - though it _should_ since we just created it via that update!
+    CaseReview.first
   end
 end

--- a/app/models/organizations/case_review.rb
+++ b/app/models/organizations/case_review.rb
@@ -11,6 +11,7 @@ class CaseReview < Organization
 
     # temporary function to split the original mistake where the org Case Review was
     # referred to as BvaIntake. Can be removed after the production database is up to date.
+    # :nocov:
     def find_and_update_incorrect_bva_intake
       # check if the mismatch exists; if not default back to BvaIntake.first
       case_review_misnamed = Organization.find_by(name: "Case Review", type: "BvaIntake")

--- a/app/models/tasks/appeal_withdrawal_mail_task.rb
+++ b/app/models/tasks/appeal_withdrawal_mail_task.rb
@@ -6,6 +6,6 @@ class AppealWithdrawalMailTask < MailTask
   end
 
   def self.default_assignee(_parent)
-    BvaIntake.singleton
+    CaseReview.singleton
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,7 @@ class User < CaseflowRecord
   end
 
   def can_withdraw_issues?
-    BvaIntake.singleton.users.include?(self) || %w[NWQ VACO].exclude?(regional_office)
+    CaseReview.singleton.users.include?(self) || %w[NWQ VACO].exclude?(regional_office)
   end
 
   def can_intake_appeals?

--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -20,7 +20,7 @@ class AppealRequestIssuesPolicy
   end
 
   def current_user_is_case_review_team_member?
-    BvaIntake.singleton.user_has_access?(user)
+    CaseReview.singleton.user_has_access?(user)
   end
 
   def case_is_not_in_active_review?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -56,8 +56,8 @@ class SeedDB
     User.create(css_id: "BVAGGREY", station_id: 101, full_name: "Gina BVADispatchUser_NoCases Grey")
     dispatch_admin = User.create(css_id: "BVAGBLACK", station_id: 101, full_name: "Geoffrey BVADispatchAdmin_NoCases Black")
     OrganizationsUser.make_user_admin(dispatch_admin, BvaDispatch.singleton)
-    bva_intake_admin = User.create(css_id: "BVAKBLUE", station_id: 101, full_name: "Kim BVAIntakeAdmin Blue")
-    OrganizationsUser.make_user_admin(bva_intake_admin, BvaIntake.singleton)
+    case_review_admin = User.create(css_id: "BVAKBLUE", station_id: 101, full_name: "Kim CaseReviewAdmin Blue")
+    OrganizationsUser.make_user_admin(case_review_admin, CaseReview.singleton)
     special_case_movement_user = User.create(css_id: "BVARDUNKLE",
                                              station_id: 101,
                                              full_name: "Rosalie SpecialCaseMovement Dunkle")

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -358,7 +358,7 @@ FactoryBot.define do
       end
 
       factory :appeal_withdrawal_bva_task, class: AppealWithdrawalMailTask do
-        assigned_to { BvaIntake.singleton }
+        assigned_to { CaseReview.singleton }
         parent { create(:appeal_withdrawal_mail_task, appeal: appeal) }
       end
 

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -569,7 +569,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
 
     context "when a user can withdraw issues" do
       before do
-        BvaIntake.singleton.add_user(current_user)
+        CaseReview.singleton.add_user(current_user)
         allow(Fakes::VBMSService).to receive(:remove_contention!).and_call_original
       end
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1196,7 +1196,7 @@ RSpec.feature "Case details", :all_dbs do
       let(:user) { create(:user) }
 
       before do
-        BvaIntake.singleton.add_user(user)
+        CaseReview.singleton.add_user(user)
         User.authenticate!(user: user)
       end
 
@@ -1221,7 +1221,7 @@ RSpec.feature "Case details", :all_dbs do
 
         new_task = new_tasks.first
         expect(new_task.status).to eq Constants.TASK_STATUSES.cancelled
-        expect(appeal_withdrawal_bva_task.assigned_to).to eq(BvaIntake.singleton)
+        expect(appeal_withdrawal_bva_task.assigned_to).to eq(CaseReview.singleton)
         expect(appeal_withdrawal_bva_task.parent.assigned_to).to eq(MailTeam.singleton)
       end
     end

--- a/spec/models/tasks/mail_task_spec.rb
+++ b/spec/models/tasks/mail_task_spec.rb
@@ -238,7 +238,7 @@ describe MailTask, :postgres do
     context "for an AppealWithdrawalMailTask" do
       let(:task_class) { AppealWithdrawalMailTask }
 
-      it "should always route to BVA Intake" do
+      it "should always route to Case Review" do
         expect(subject).to eq(CaseReview.singleton)
       end
     end

--- a/spec/models/tasks/mail_task_spec.rb
+++ b/spec/models/tasks/mail_task_spec.rb
@@ -239,7 +239,7 @@ describe MailTask, :postgres do
       let(:task_class) { AppealWithdrawalMailTask }
 
       it "should always route to BVA Intake" do
-        expect(subject).to eq(BvaIntake.singleton)
+        expect(subject).to eq(CaseReview.singleton)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -710,7 +710,7 @@ describe User, :all_dbs do
     end
 
     context "when the user is a member of Case review Organization" do
-      before { BvaIntake.singleton.add_user(user) }
+      before { CaseReview.singleton.add_user(user) }
       it "returns true" do
         expect(subject).to eq(true)
       end

--- a/spec/policies/appeal_request_issues_policy_spec.rb
+++ b/spec/policies/appeal_request_issues_policy_spec.rb
@@ -69,7 +69,7 @@ describe AppealRequestIssuesPolicy, :postgres do
       let(:user) { create(:user) }
 
       it "returns true" do
-        BvaIntake.singleton.add_user(user)
+        CaseReview.singleton.add_user(user)
         create(:task,
                type: "ColocatedTask",
                appeal: appeal,
@@ -84,7 +84,7 @@ describe AppealRequestIssuesPolicy, :postgres do
       let(:user) { create(:user) }
 
       it "returns false" do
-        BvaIntake.singleton.add_user(user)
+        CaseReview.singleton.add_user(user)
         create(:task,
                type: "AttorneyTask",
                appeal: appeal,


### PR DESCRIPTION
Connects #13865 

### Description
Fully converts the existing Case Review team to be properly named in the Rails application.

Includes some placeholder code to handle converting the Singleton object once live in production. To be removed directly after this PR releases.

### Acceptance Criteria
- [ ] Case Review Team continues to function normally.

### Testing Plan
#### Confirm renaming in code
grep around, like a lot, looking if I missed any permutation of BVAIntake, BvaIntake, bva_intake, etc.
The only place it should be left are the two Organization models.

#### Confirm CaseReview Org model works
1. Checkout `master` and fully reseed your database `make reset`
2. Confirm in the Rails Console the Case Review team entry:
```ruby
>  pp Organization.where(name: "Case Review").pluck(:id, :name, :type)
 [2, "Case Review", "BvaIntake"]
```
3. Checkout this PR
4. Open a rails console & load the CaseReview singleton
```ruby
> CaseReview.singleton
```
5. Confirm the object that loads has the _same id_ as before, but now has the type `CaseReview`
6. Confirm the BvaIntake org does not exist, only CaseReview, and with the correct ID
```ruby
> pp Organization.where('name in (?, ?)', "Case Review", "BVA Intake").pluck(:id, :name, :type)
=> [[2, "Case Review", "CaseReview"]] 
> pp Organization.where('type in (?, ?)', "CaseReview", "BvaIntake").pluck(:id, :name, :type)
=> [[2, "Case Review", "CaseReview"]]
```
7. Load the BvaIntake Org object
```ruby
> BvaIntake.singleton
```
8. Confirm there are no errors, that the BVAIntake org has the new ID, and that both Orgs exist.
```ruby
> pp Organization.where('name in (?, ?)', "Case Review", "BVA Intake").pluck(:id, :name, :type)
=> [[2, "Case Review", "CaseReview"], [29, "BVA Intake", "BvaIntake"]]
```
9. Confirm reinvoking `BvaIntake.singleton` and `CaseReview.singleton` causes no issue.
 
#### Confirm BvaIntake Org model works
1. Checkout `master` and fully reseed your database `make reset`
2. Confirm in the Rails Console the Case Review team entry:
```ruby
>  pp Organization.where(name: "Case Review").pluck(:id, :name, :type)
 [2, "Case Review", "BvaIntake"]
```
3. Checkout this PR
4. Open a rails console & load the BvaIntake singleton
```
> BvaIntake.singleton
```
5. Confirm the object that loads a new id, and the name "BVA Intake"
6. Confirm both the new BvaIntake org and the updated CaseReview org exist, and the CaseReview org has the same ID as before
```
> pp Organization.where('name in (?, ?)', "Case Review", "BVA Intake").pluck(:id, :name, :type)
=> [[2, "Case Review", "CaseReview"], [29, "BVA Intake", "BvaIntake"]]
```
7. Confirm reinvoking `BvaIntake.singleton` and `CaseReview.singleton` causes no issue.

### User Facing Changes

None
 
### Documentation Updates
- [ ] Topline File Descriptions Added or Updated as Needed

### Database Changes
[Conferring with Delta team](https://dsva.slack.com/archives/CPEMQPVKR/p1586274891014000) (@pkarman) to confirm whether anyone was looking for `type: BvaIntake`