### PR TITLE
Handling of PDF Files via Webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ storybook-static/
 /public/assets/*
 /public/fonts/*
 /public/images/*
+/public/documents/*
 
 # Oracle instant client
 ci-bin/circle_docker_container/instant*

--- a/client/app/queue/pulacCerullo/PulacCerulloReminderAlert.jsx
+++ b/client/app/queue/pulacCerullo/PulacCerulloReminderAlert.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Alert from '../../components/Alert';
-import { chairmanMemoUrl } from '.';
 import { CavcLinkInfo } from './CavcLinkInfo';
+import chairmanMemo from '../../../../app/assets/documents/chairman_memorandum_01-10-18.pdf';
 
 export const PulacCerulloReminderAlert = () => {
   return (
@@ -18,7 +18,7 @@ export const PulacCerulloReminderAlert = () => {
       </p>
       <p>
         See{' '}
-        <a href={chairmanMemoUrl} target="_blank" rel="noopener noreferrer">
+        <a href={chairmanMemo} target="_blank" rel="noopener noreferrer">
           Chairman's Memorandum No. 01-10-18
         </a>{' '}
         for more information about how to conduct NOA checks.

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -12,9 +12,7 @@ const config = {
     sourceMapFilename: 'sourcemap-[file].map',
     path: path.join(__dirname, '../app/assets/javascripts')
   },
-  plugins: _.compact([
-    new webpack.EnvironmentPlugin({ NODE_ENV: 'development' })
-  ]),
+  plugins: _.compact([new webpack.EnvironmentPlugin({ NODE_ENV: 'development' })]),
   resolve: {
     extensions: ['.js', '.jsx', '.json'],
     alias: {
@@ -27,9 +25,7 @@ const config = {
     rules: [
       {
         test: /\.jsx?$/,
-        exclude: new RegExp(
-          'node_modules/(?!@department-of-veterans-affairs/caseflow-frontend-toolkit)'
-        ),
+        exclude: new RegExp('node_modules/(?!@department-of-veterans-affairs/caseflow-frontend-toolkit)'),
         use: [
           {
             loader: 'babel-loader'
@@ -39,8 +35,7 @@ const config = {
       {
         test: /\.(ttf|eot|woff|woff2)$/,
         use: {
-          loader:
-            'url-loader?limit=1024&name=fonts/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/'
+          loader: 'url-loader?limit=1024&name=fonts/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/'
         }
       },
       {
@@ -102,8 +97,20 @@ const config = {
       },
       {
         test: /\.(png|svg|jpg|gif)$/,
+        use: ['url-loader?limit=1024&name=images/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/']
+      },
+      {
+        test: /\.(pdf)$/,
         use: [
-          'url-loader?limit=1024&name=images/[name]-[hash].[ext]&outputPath=../../../public/&publicPath=/'
+          {
+            loader: 'url-loader',
+            options: {
+              limit: 1024,
+              name: 'documents/[name]-[hash].[ext]',
+              outputPath: '../../../public/',
+              publicPath: '/'
+            }
+          }
         ]
       }
     ]


### PR DESCRIPTION
Connects #13611

### Description
Adds ability to import PDF files via webpack, which in turn will be placed in `/public/documents` folder. This should allow for the correct handling of these files in uat & prod environments in addition to local & demo.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Links to PDF files (such as the chairman's memo linked from `PulacCerulloReminderAlert`) correctly open in all environments
### Testing Plan
1. Test locally
2. Work with devops to take over uat for testing in those environments
