### PR TITLE
Handle undefined alerts from server

### DIFF
--- a/client/app/components/common/actions.js
+++ b/client/app/components/common/actions.js
@@ -65,7 +65,7 @@ export const onReceiveAlerts = (alerts) => {
   return {
     type: ACTIONS.RECEIVE_ALERTS,
     payload: {
-      alerts: alerts.map((alert) => ({
+      alerts: (alerts || []).map((alert) => ({
         ...alert,
         timestamp
       }))

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -189,9 +189,8 @@ class HearingDetails extends React.Component {
     return ApiUtil.patch(`/hearings/${externalId}`, {
       data: ApiUtil.convertToSnakeCase(data)
     }).then((response) => {
-
       const hearing = ApiUtil.convertToCamelCase(response.body.data);
-      const alerts = response.body.alerts;
+      const alerts = response.body?.alerts;
 
       this.setState({
         updated: false,
@@ -203,18 +202,24 @@ class HearingDetails extends React.Component {
       this.props.setHearing(hearing, () => {
         const initialFormData = this.getInitialFormData();
 
-        this.setState({
-          initialFormData
-        });
+        this.setState({ initialFormData });
 
         this.updateAllFormData(initialFormData);
-        if (alerts.hearing) {
-          this.props.onReceiveAlerts(alerts.hearing);
-        }
-        if (!_.isEmpty(alerts.virtual_hearing)) {
-          this.setState({ startPolling: true });
-          this.props.onReceiveTransitioningAlert(alerts.virtual_hearing, 'virtualHearing');
 
+        if (alerts) {
+          const {
+            hearing,
+            virtual_hearing: virtualHearing
+          } = alerts;
+
+          if (hearing) {
+            this.props.onReceiveAlerts(hearing);
+          }
+
+          if (!_.isEmpty(virtualHearing)) {
+            this.props.onReceiveTransitioningAlert(virtualHearing, 'virtualHearing');
+            this.setState({ startPolling: true });
+          }
         }
       });
     }).

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -208,16 +208,16 @@ class HearingDetails extends React.Component {
 
         if (alerts) {
           const {
-            hearing,
-            virtual_hearing: virtualHearing
+            hearing: hearingAlerts,
+            virtual_hearing: virtualHearingAlerts
           } = alerts;
 
-          if (hearing) {
-            this.props.onReceiveAlerts(hearing);
+          if (hearingAlerts) {
+            this.props.onReceiveAlerts(hearingAlerts);
           }
 
-          if (!_.isEmpty(virtualHearing)) {
-            this.props.onReceiveTransitioningAlert(virtualHearing, 'virtualHearing');
+          if (!_.isEmpty(virtualHearingAlerts)) {
+            this.props.onReceiveTransitioningAlert(virtualHearingAlerts, 'virtualHearing');
             this.setState({ startPolling: true });
           }
         }

--- a/client/app/hearings/components/VirtualHearingModal.jsx
+++ b/client/app/hearings/components/VirtualHearingModal.jsx
@@ -33,8 +33,8 @@ const formatTimeString = (hearing, timeWasEdited) => {
 
 const DateTime = ({ hearing, timeWasEdited }) => (
   <div>
-    <strong>{'Date:'}&nbsp;</strong>{moment(hearing.scheduledFor).format('MM/DD/YYYY')}<br />
-    <strong>{'Time:'}&nbsp;</strong>{formatTimeString(hearing, timeWasEdited)}
+    <strong>Date:&nbsp;</strong>{moment(hearing.scheduledFor).format('MM/DD/YYYY')}<br />
+    <strong>Time:&nbsp;</strong>{formatTimeString(hearing, timeWasEdited)}
   </div>
 );
 
@@ -115,7 +115,7 @@ const ChangeEmail = (props) => (
 const ChangeFromVirtual = ({ hearing, ...props }) => (
   <React.Fragment>
     <DateTime {...props} hearing={hearing} />
-    {hearing.location && <div><strong>{'Location:'}&nbsp;</strong>{hearing.location.name}</div>}
+    {hearing.location && <div><strong>Location:&nbsp;</strong>{hearing.location.name}</div>}
     <ReadOnlyEmails {...props} showAllEmails />
   </React.Fragment>
 );

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -172,16 +172,16 @@ class DailyDocketRow extends React.Component {
 
         if (alerts) {
           const {
-            hearing,
-            virtual_hearing: virtualHearing
+            hearing: hearingAlerts,
+            virtual_hearing: virtualHearingAlerts
           } = alerts;
 
-          if (hearing) {
-            this.props.onReceiveAlerts(hearing);
+          if (hearingAlerts) {
+            this.props.onReceiveAlerts(hearingAlerts);
           }
 
-          if (!_.isEmpty(virtualHearing)) {
-            this.props.onReceiveTransitioningAlert(virtualHearing, 'virtualHearing');
+          if (!_.isEmpty(virtualHearingAlerts)) {
+            this.props.onReceiveTransitioningAlert(virtualHearingAlerts, 'virtualHearing');
             this.setState({ startPolling: true });
           }
         }

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -168,14 +168,22 @@ class DailyDocketRow extends React.Component {
 
     return this.props.saveHearing(this.props.hearing.externalId, hearing).
       then((response) => {
-        const alerts = response.body.alerts;
+        const alerts = response.body?.alerts;
 
-        if (alerts.hearing) {
-          this.props.onReceiveAlerts(alerts.hearing);
-        }
-        if (!_.isEmpty(alerts.virtual_hearing)) {
-          this.props.onReceiveTransitioningAlert(alerts.virtual_hearing, 'virtualHearing');
-          this.setState({ startPolling: true });
+        if (alerts) {
+          const {
+            hearing,
+            virtual_hearing: virtualHearing
+          } = alerts;
+
+          if (hearing) {
+            this.props.onReceiveAlerts(hearing);
+          }
+
+          if (!_.isEmpty(virtualHearing)) {
+            this.props.onReceiveTransitioningAlert(virtualHearing, 'virtualHearing');
+            this.setState({ startPolling: true });
+          }
         }
 
         this.setState({


### PR DESCRIPTION
In the event of a 422, it looks like the server returns an empty body, and causes the front-end to throw an error. This basically just leaves the VirtualHearingModal displaying when it should automatically close (I thought it might cause a white screen, but it doesn't). With this change, the modal closes on receiving an error.

I *think* the 422 is caused by an expired CSRF error.

https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/9827/?referrer=webhooks_plugin

---

**Before:**

![Screen Recording 2020-04-07 at 3 35 50 PM](https://user-images.githubusercontent.com/1298274/78712312-70e3a600-78e6-11ea-92f5-daa0d1cb2171.gif)

---

**After:**

![Screen Recording 2020-04-07 at 3 36 20 PM](https://user-images.githubusercontent.com/1298274/78712240-4db8f680-78e6-11ea-8ad4-e26b007b2b67.gif)


### Description

- Added some handling around undefined alerts/body
- Lint changes
