### PR TITLE
Refresh link data on Details

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -64,8 +64,7 @@ class HearingsController < HearingsApplicationController
     render json: {
       job_completed: hearing.virtual_hearing&.job_completed?,
       alias: hearing.virtual_hearing&.alias,
-      host_pin: hearing.virtual_hearing&.host_pin,
-      guest_pin: hearing.virtual_hearing&.guest_pin
+      host_pin: hearing.virtual_hearing&.host_pin
     }
   end
 

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -61,7 +61,12 @@ class HearingsController < HearingsApplicationController
   end
 
   def virtual_hearing_job_status
-    render json: { job_completed: hearing.virtual_hearing&.job_completed? }
+    render json: {
+      job_completed: hearing.virtual_hearing&.job_completed?,
+      alias: hearing.virtual_hearing&.alias,
+      host_pin: hearing.virtual_hearing&.host_pin,
+      guest_pin: hearing.virtual_hearing&.guest_pin
+    }
   end
 
   private

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -235,7 +235,7 @@ class HearingDetails extends React.Component {
 
   startPolling = () => {
     return pollVirtualHearingData(this.props.hearing.externalId, (response) => {
-      // response includes jobCompleted, alias, hostPin, and guestPin
+      // response includes jobCompleted, alias, and hostPin
       const resp = ApiUtil.convertToCamelCase(response);
 
       if (resp.jobCompleted) {

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -235,8 +235,11 @@ class HearingDetails extends React.Component {
 
   startPolling = () => {
     return pollVirtualHearingData(this.props.hearing.externalId, (response) => {
-      if (response.job_completed) {
-        this.props.onChangeFormData(VIRTUAL_HEARING_FORM_NAME, { jobCompleted: response.job_completed });
+      // response includes jobCompleted, alias, hostPin, and guestPin
+      const resp = ApiUtil.convertToCamelCase(response);
+
+      if (resp.jobCompleted) {
+        this.props.onChangeFormData(VIRTUAL_HEARING_FORM_NAME, resp);
         this.props.transitionAlert('virtualHearing');
         this.setState({ startPolling: false });
       }

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -281,7 +281,7 @@ class DailyDocketRow extends React.Component {
 
   startPolling = () => {
     return pollVirtualHearingData(this.props.hearing.externalId, (response) => {
-      //response includes jobCompleted, alias, hostPin, guestPin
+      //response includes jobCompleted, alias, and hostPin
       const resp = ApiUtil.convertToCamelCase(response);
 
       if (resp.jobCompleted) {

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -9,6 +9,8 @@ import { docketRowStyle } from './style';
 
 import Button from '../../../components/Button';
 
+import ApiUtil from '../../../util/ApiUtil';
+
 import { onUpdateDocketHearing } from '../../actions/dailyDocketActions';
 import { AodModal } from './DailyDocketModals';
 import HearingText from './DailyDocketRowDisplayText';
@@ -279,8 +281,11 @@ class DailyDocketRow extends React.Component {
 
   startPolling = () => {
     return pollVirtualHearingData(this.props.hearing.externalId, (response) => {
-      if (response.job_completed) {
-        this.updateVirtualHearing({ jobCompleted: response.job_completed });
+      //response includes jobCompleted, alias, hostPin, guestPin
+      const resp = ApiUtil.convertToCamelCase(response);
+
+      if (resp.jobCompleted) {
+        this.updateVirtualHearing(resp);
         this.props.transitionAlert('virtualHearing');
         this.setState({ startPolling: false });
       }

--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -281,7 +281,7 @@ class DailyDocketRow extends React.Component {
 
   startPolling = () => {
     return pollVirtualHearingData(this.props.hearing.externalId, (response) => {
-      //response includes jobCompleted, alias, and hostPin
+      // response includes jobCompleted, alias, and hostPin
       const resp = ApiUtil.convertToCamelCase(response);
 
       if (resp.jobCompleted) {


### PR DESCRIPTION
Relates to #13702 

This PR Fix issue where if the hearing is initially switched to virtual hearing, the alias and pins also need to be refreshed for the link to generate correctly. Right now, this is how the link appears on Details Page. 

<img width="842" alt="Screen Shot 2020-04-08 at 11 26 57 AM" src="https://user-images.githubusercontent.com/20735998/78802485-e190ce00-798b-11ea-8368-2fc71341bfd9.png">

### Description
- return 2 new data fields from `/virtual_hearing_job_status`: `alias` and `host_pin`
- update the form with the new fields when polling stops


