### PR TITLE
Upgrade caseflow-commons gem to 0.4.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "36ba811e43be8b64f9bba9171779904624edf464"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f374da6041b52d73af60d79d60d4013a13d4a72e"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"
 gem "dogstatsd-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,17 +9,18 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa
-  ref: ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa
+  revision: 36ba811e43be8b64f9bba9171779904624edf464
+  ref: 36ba811e43be8b64f9bba9171779904624edf464
   specs:
-    caseflow (0.4.0)
+    caseflow (0.4.5)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails
-      jquery-rails
       momentjs-rails
       neat
       rails (>= 4.2.7.1)
+      redis-namespace
+      redis-rails
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
@@ -283,10 +284,6 @@ GEM
     ice_cube (0.16.3)
     jaro_winkler (1.5.2)
     jmespath (1.3.1)
-    jquery-rails (4.3.5)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     jshint (1.5.0)
       execjs (>= 1.4.0)
       multi_json (~> 1.0)


### PR DESCRIPTION
no functional changes just updating SHA ref to properly consume updated caseflow gem
