### PR TITLE
Capture DataIntegrityChecksJob errors to slack/sentry

### DIFF
--- a/app/jobs/caseflow_job.rb
+++ b/app/jobs/caseflow_job.rb
@@ -33,4 +33,10 @@ class CaseflowJob < ApplicationJob
   def slack_service
     @slack_service ||= SlackService.new(url: slack_url)
   end
+
+  def log_error(error, extra: {})
+    Rails.logger.error(error)
+    Rails.logger.error(error.backtrace.join("\n"))
+    capture_exception(error, extra)
+  end
 end

--- a/app/jobs/caseflow_job.rb
+++ b/app/jobs/caseflow_job.rb
@@ -37,6 +37,6 @@ class CaseflowJob < ApplicationJob
   def log_error(error, extra: {})
     Rails.logger.error(error)
     Rails.logger.error(error.backtrace.join("\n"))
-    capture_exception(error, extra)
+    capture_exception(error: error, extra: extra)
   end
 end

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -31,7 +31,11 @@ class DataIntegrityChecksJob < CaseflowJob
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")
-    slack_service.send_notification("All checks complete", "DataIntegrityChecksJob", DataIntegrityChecker.new.slack_channel)
+    slack_service.send_notification(
+      "All checks complete",
+      "DataIntegrityChecksJob",
+      DataIntegrityChecker.new.slack_channel
+    )
   end
 
   private

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -31,12 +31,12 @@ class DataIntegrityChecksJob < CaseflowJob
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")
+    slack_service.send_notification("All checks complete", "DataIntegrityChecksJob", DataIntegrityChecker.new.slack_channel)
   end
 
   private
 
   def send_to_slack(checker)
-    slack = SlackService.new(url: ENV["SLACK_DISPATCH_ALERT_URL"])
-    slack.send_notification(checker.report, checker.class.name, checker.slack_channel)
+    slack_service.send_notification(checker.report, checker.class.name, checker.slack_channel)
   end
 end

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -30,7 +30,7 @@ class DataIntegrityChecksJob < CaseflowJob
       end
     # don't retry via normal shoryuken, just log and move to next checker.
     rescue StandardError => error
-      log_error(error, { class: klass })
+      log_error(error, class: klass)
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -30,7 +30,7 @@ class DataIntegrityChecksJob < CaseflowJob
       end
     # don't retry via normal shoryuken, just log and move to next checker.
     rescue StandardError => error
-      log_error(error)
+      log_error(error, { class: klass })
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -30,15 +30,11 @@ class DataIntegrityChecksJob < CaseflowJob
       end
     # don't retry via normal shoryuken, just log and move to next checker.
     rescue StandardError => error
-      log_error(error, class: klass)
+      log_error(error, extra: { checker: klass })
+      slack_service.send_notification("Error running #{klass}", klass, checker.slack_channel)
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")
-    slack_service.send_notification(
-      "All checks complete",
-      "DataIntegrityChecksJob",
-      DataIntegrityChecker.new.slack_channel
-    )
   end
 
   private

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -28,6 +28,9 @@ class DataIntegrityChecksJob < CaseflowJob
       if checker.report?
         send_to_slack(checker)
       end
+    # don't retry via normal shoryuken, just log and move to next checker.
+    rescue StandardError => error
+      log_error(error)
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -94,7 +94,7 @@ describe DataIntegrityChecksJob do
 
     context "one report throws an error" do
       before do
-        allow(expired_async_jobs_checker).to receive(:call) { fail StandardError.new("oops!") }
+        allow(expired_async_jobs_checker).to receive(:call) { fail StandardError, "oops!" }
       end
 
       it "rescues error and logs to sentry and slack" do


### PR DESCRIPTION
Do not retry failed data integrity checks, because they should always succeed or fail since they are readonly reporting.