### PR TITLE
Allow motions attorney to recommend partial grant

### DIFF
--- a/client/app/queue/mtv/MTVDispositionSelection.jsx
+++ b/client/app/queue/mtv/MTVDispositionSelection.jsx
@@ -8,7 +8,7 @@ import { DISPOSITION_OPTIONS, PARTIAL_GRANT_OPTION } from '../../../constants/MO
 const [grant, ...rest] = DISPOSITION_OPTIONS;
 const optsWithPartial = [grant, PARTIAL_GRANT_OPTION, ...rest];
 
-export const MTVDispositionSelection = ({ label = '', value: initialVal = null, onChange, allowPartial = false }) => {
+export const MTVDispositionSelection = ({ label = '', value: initialVal = null, onChange, allowPartial = true }) => {
   const [value, setValue] = useState(initialVal);
 
   const handleChange = (val) => {
@@ -27,7 +27,6 @@ export const MTVDispositionSelection = ({ label = '', value: initialVal = null, 
       options={options}
       onChange={handleChange}
       value={value}
-      required
       strongLabel
       className={['mtv-disposition-selection']}
     />

--- a/client/app/queue/mtv/MTVDispositionSelection.jsx
+++ b/client/app/queue/mtv/MTVDispositionSelection.jsx
@@ -2,13 +2,9 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import RadioField from '../../components/RadioField';
 
-import { DISPOSITION_OPTIONS, PARTIAL_GRANT_OPTION } from '../../../constants/MOTION_TO_VACATE';
+import { DISPOSITION_OPTIONS } from '../../../constants/MOTION_TO_VACATE';
 
-// In certain cases (judge view) we want to include a "partial grant" option
-const [grant, ...rest] = DISPOSITION_OPTIONS;
-const optsWithPartial = [grant, PARTIAL_GRANT_OPTION, ...rest];
-
-export const MTVDispositionSelection = ({ label = '', value: initialVal = null, onChange, allowPartial = true }) => {
+export const MTVDispositionSelection = ({ label = '', value: initialVal = null, onChange }) => {
   const [value, setValue] = useState(initialVal);
 
   const handleChange = (val) => {
@@ -18,13 +14,11 @@ export const MTVDispositionSelection = ({ label = '', value: initialVal = null, 
     }
   };
 
-  const options = allowPartial ? optsWithPartial : DISPOSITION_OPTIONS;
-
   return (
     <RadioField
       name="disposition"
       label={label}
-      options={options}
+      options={DISPOSITION_OPTIONS}
       onChange={handleChange}
       value={value}
       strongLabel
@@ -36,6 +30,5 @@ export const MTVDispositionSelection = ({ label = '', value: initialVal = null, 
 MTVDispositionSelection.propTypes = {
   onChange: PropTypes.func,
   value: PropTypes.string,
-  label: PropTypes.string,
-  allowPartial: PropTypes.bool
+  label: PropTypes.string
 };

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -130,7 +130,6 @@ export const MTVJudgeDisposition = ({
 
         <MTVDispositionSelection
           label={JUDGE_ADDRESS_MTV_DISPOSITION_SELECT_LABEL}
-          allowPartial
           onChange={(val) => {
             setVacateType(null);
             setDisposition(val);

--- a/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
+++ b/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
@@ -59,6 +59,8 @@ export const MotionsAttorneyDisposition = ({ judges, selectedJudge, task, appeal
     return true;
   };
 
+  const instructionsLabel = sprintf(MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL, disposition || 'granted').replace('_', ' ');
+
   return (
     <div className="address-motion-to-vacate">
       <AppSegment filledBackground>
@@ -76,7 +78,7 @@ export const MotionsAttorneyDisposition = ({ judges, selectedJudge, task, appeal
 
         <TextareaField
           name="instructions"
-          label={sprintf(MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL, disposition || 'granted').replace('_', ' ')}
+          label={instructionsLabel}
           onChange={(val) => setInstructions(val)}
           value={instructions}
           className={['mtv-review-instructions']}

--- a/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
+++ b/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
@@ -59,7 +59,10 @@ export const MotionsAttorneyDisposition = ({ judges, selectedJudge, task, appeal
     return true;
   };
 
-  const instructionsLabel = sprintf(MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL, disposition || 'granted').replace('_', ' ');
+  const instructionsLabel = sprintf(
+    MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL,
+    disposition || 'granted'
+  ).replace('_', ' ');
 
   return (
     <div className="address-motion-to-vacate">

--- a/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
+++ b/client/app/queue/mtv/MotionsAttorneyDisposition.jsx
@@ -18,12 +18,12 @@ import Button from '../../components/Button';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import { css } from 'glamor';
 import { MTVTaskHeader } from './MTVTaskHeader';
-import { DISPOSITION_TEXT } from '../../../constants/MOTION_TO_VACATE';
+import { DISPOSITION_RECOMMENDATIONS } from '../../../constants/MOTION_TO_VACATE';
 import { dispositionStrings } from './mtvConstants';
 import { sprintf } from 'sprintf-js';
 
 const formatReviewAttyInstructions = ({ disposition, hyperlink, instructions }) => {
-  const parts = [`I recommend ${DISPOSITION_TEXT[disposition]}.`, instructions];
+  const parts = [DISPOSITION_RECOMMENDATIONS[disposition], instructions];
 
   if (hyperlink) {
     parts.push(`Here is the hyperlink to the draft of the denial:\n${hyperlink}`);
@@ -76,7 +76,7 @@ export const MotionsAttorneyDisposition = ({ judges, selectedJudge, task, appeal
 
         <TextareaField
           name="instructions"
-          label={sprintf(MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL, disposition || 'granted')}
+          label={sprintf(MOTIONS_ATTORNEY_REVIEW_MTV_DISPOSITION_NOTES_LABEL, disposition || 'granted').replace('_', ' ')}
           onChange={(val) => setInstructions(val)}
           value={instructions}
           className={['mtv-review-instructions']}

--- a/client/constants/MOTION_TO_VACATE.json
+++ b/client/constants/MOTION_TO_VACATE.json
@@ -19,6 +19,11 @@
       "value": "granted"
     },
     {
+      "displayText": "Grant partial vacatur",
+      "value": "partially_granted",
+      "help": "e.g. if you do not want to vacate all the issues the veteran is requesting"
+    },
+    {
       "displayText": "Deny all issues for vacatur",
       "value": "denied"
     },
@@ -28,11 +33,6 @@
       "help": "e.g. if the veteran has passed away or has withdrawn their motion"
     }
   ],
-  "PARTIAL_GRANT_OPTION": {
-    "displayText": "Grant partial vacatur",
-    "value": "partially_granted",
-    "help": "e.g. if you do not want to vacate all the issues the veteran is requesting"
-  },
   "DISPOSITION_TEXT": {
     "granted": "grant or partial vacatur",
     "partially_granted": "partial vacatur",

--- a/client/constants/MOTION_TO_VACATE.json
+++ b/client/constants/MOTION_TO_VACATE.json
@@ -38,5 +38,11 @@
     "partially_granted": "partial vacatur",
     "denied": "denial of all issues for vacatur",
     "dismissed": "dismissal"
+  },
+  "DISPOSITION_RECOMMENDATIONS": {
+    "granted": "I recommend granting a vacatur.",
+    "partially_granted": "I recommend granting a partial vacatur.",
+    "denied": "I recommend denial of all issues for vacatur.",
+    "dismissed": "I recommend dismissal."
   }
 }

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -114,17 +114,21 @@ RSpec.feature "Motion to vacate", :all_dbs do
         # Ensure it has pre-selected judge previously assigned to case
         expect(dropdown_selected_value(find(".dropdown-judge"))).to eq judge2.display_name
 
-        click_button(text: "Submit")
+        task = submit_and_fetch_task(judge2)
+        expect(task.instructions.first).to include("I recommend granting a vacatur")
+      end
 
-        # Return back to user's queue
-        expect(page).to have_current_path("/queue")
+      it "motions attorney recommends partial grant to judge" do
+        send_to_judge(user: motions_attorney, appeal: appeal, motions_attorney_task: motions_attorney_task)
 
-        expect(page).to have_content(format(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_TITLE, judge2.display_name))
-        expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_DETAIL)
+        find("label[for=disposition_partially_granted]").click
+        fill_in("instructions", with: "Attorney context/instructions for judge")
 
-        # Verify new task was created
-        judge_task = JudgeAddressMotionToVacateTask.find_by(assigned_to: judge2)
-        expect(judge_task).to_not be_nil
+        # Ensure it has pre-selected judge previously assigned to case
+        expect(dropdown_selected_value(find(".dropdown-judge"))).to eq judge2.display_name
+
+        task = submit_and_fetch_task(judge2)
+        expect(task.instructions.first).to include("I recommend granting a partial vacatur")
       end
 
       it "motions attorney recommends denied decision to judge and fills in hyperlink" do
@@ -137,17 +141,9 @@ RSpec.feature "Motion to vacate", :all_dbs do
         fill_in("hyperlink", with: hyperlink)
         fill_in("instructions", with: "Attorney context/instructions for judge")
         click_dropdown(text: judge2.display_name)
-        click_button(text: "Submit")
 
-        # Return back to user's queue
-        expect(page).to have_current_path("/queue")
-
-        expect(page).to have_content(format(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_TITLE, judge2.display_name))
-        expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_DETAIL)
-
-        # Verify new task was created
-        judge_task = JudgeAddressMotionToVacateTask.find_by(assigned_to: judge2)
-        expect(judge_task).to_not be_nil
+        task = submit_and_fetch_task(judge2)
+        expect(task.instructions.first).to include("I recommend denial")
       end
 
       it "motions attorney triggers Pulac-Cerullo" do
@@ -162,6 +158,21 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
         expect(page).to have_content(COPY::PULAC_CERULLO_SUCCESS_TITLE)
         expect(page).to have_content(COPY::PULAC_CERULLO_SUCCESS_DETAIL.gsub("%s", appeal.veteran_full_name))
+      end
+
+      def submit_and_fetch_task(assigned_judge)
+        click_button(text: "Submit")
+
+        # Return back to user's queue
+        expect(page).to have_current_path("/queue")
+
+        expect(page).to have_content(format(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_TITLE, assigned_judge.display_name))
+        expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_DETAIL)
+
+        # Verify new task was created
+        judge_task = JudgeAddressMotionToVacateTask.find_by(assigned_to: assigned_judge)
+        expect(judge_task).to_not be_nil
+        judge_task
       end
     end
   end
@@ -324,7 +335,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
       expect(dropdown_selected_value(find(".dropdown-attorney"))).to eq atty_option_txt
 
       issues_to_select = [1, 3]
-      issues_to_select.each { |idx| select_issue_for_vacature(idx) }
+      issues_to_select.each { |idx| select_issue_for_vacatur(idx) }
 
       click_button(text: "Submit")
 
@@ -843,7 +854,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
     action_dropdown.click
   end
 
-  def select_issue_for_vacature(issue_id)
+  def select_issue_for_vacatur(issue_id)
     find(".checkbox-wrapper-issues").find("label[for=\"#{issue_id}\"]").click
   end
 

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -160,17 +160,17 @@ RSpec.feature "Motion to vacate", :all_dbs do
         expect(page).to have_content(COPY::PULAC_CERULLO_SUCCESS_DETAIL.gsub("%s", appeal.veteran_full_name))
       end
 
-      def submit_and_fetch_task(assigned_judge)
+      def submit_and_fetch_task(judge)
         click_button(text: "Submit")
 
         # Return back to user's queue
         expect(page).to have_current_path("/queue")
 
-        expect(page).to have_content(format(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_TITLE, assigned_judge.display_name))
+        expect(page).to have_content(format(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_TITLE, judge.display_name))
         expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_SUCCESS_DETAIL)
 
         # Verify new task was created
-        judge_task = JudgeAddressMotionToVacateTask.find_by(assigned_to: assigned_judge)
+        judge_task = JudgeAddressMotionToVacateTask.find_by(assigned_to: judge)
         expect(judge_task).to_not be_nil
         judge_task
       end


### PR DESCRIPTION
Connects #13864 

### Description
This PR adds an option for motions attorneys to recommend partially granting vacatur to the judge, without selecting which issues to recommend granting.

### Acceptance Criteria
- [x] Please put this work behind the feature toggle: [review_motion_to_vacate]
- [x] Motions attorneys have a radio field for "Grant partial vacatur" when selecting a recommendation to send to the judge
  - [x] Show same help text as judge address motion to vacate task
  - [x] Do not show issues for selection, just the radio button
- [x] The partial grant selection is indicated in the instructions to the judge
- [x] Remove "required" labels from fields in the Motion to Vacate flow (not related to this specific request, but a small adder from dogfooding)
- [x] Double check that code doesn't have the word "vacature" (with an e) anywhere
- [x] Include screenshot(s) in the Github issue
- [ ] Update documentation: [Motions to Vacate](https://github.com/department-of-veterans-affairs/caseflow/wiki/Motions-to-Vacate)

### Testing Plan
1. Set up a Vacate motion mail task for a motions attorney to handle
2. As the motions attorney, start the Send to Judge flow for this task
3. Select the partial grant radio button
4. New feature spec added

### User Facing Changes
<img width="668" alt="Screen Shot 2020-04-09 at 15 27 24" src="https://user-images.githubusercontent.com/282869/78933253-09a92b80-7a77-11ea-876a-fc0d847ce64c.png">
