### PR TITLE
upgrade caseflow-commons gem to 0.4.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fb6fa9658825c143eb8d202b87128f34ca7e210b"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f374da6041b52d73af60d79d60d4013a13d4a72e"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"
 gem "dogstatsd-ruby"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa
-  ref: ffb77dd0395cbd5b7c1a5729f7f8275b5ec681fa
+  revision: fb6fa9658825c143eb8d202b87128f34ca7e210b
+  ref: fb6fa9658825c143eb8d202b87128f34ca7e210b
   specs:
-    caseflow (0.4.0)
+    caseflow (0.4.6)
       aws-sdk (~> 2.10)
       bourbon (= 4.2.7)
       d3-rails
@@ -20,6 +20,8 @@ GIT
       momentjs-rails
       neat
       rails (>= 4.2.7.1)
+      redis-namespace
+      redis-rails
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git


### PR DESCRIPTION
### Description

It was determined that a CircleCI [failure](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/29631/workflows/e7ebb229-35a5-4822-9811-943c6007d21f/jobs/108805) on the upgrade to 0.4.5 related to the removal of the `jquery-rails` dependency removed in [this](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/168/commits/24bb42a9ff5e1bb69f675c31938c089bb848b33e) pr necessitated that the gem be re-added to solve the failure.

No other functional changes aside from updating SHA ref to properly consume updated caseflow gem
