### PR TITLE
Add TimezoneService for address to timezone lookups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "business_time", "~> 0.9.3"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fb6fa9658825c143eb8d202b87128f34ca7e210b"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "f374da6041b52d73af60d79d60d4013a13d4a72e"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"
+gem "countries"
 gem "ddtrace"
 gem "dogstatsd-ruby"
 gem "dry-schema", "~> 1.4"
@@ -66,6 +67,7 @@ gem "shoryuken", "3.1.11"
 gem "stringex", require: false
 # catch problematic migrations at development/test time
 gem "strong_migrations"
+gem "tzinfo"
 # execjs runtime
 gem "therubyracer", platforms: :ruby
 # print trees
@@ -73,6 +75,7 @@ gem "tty-tree"
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", ">= 1.3.0"
 gem "validates_email_format_of"
+gem "ziptz"
 
 group :production, :staging, :ssh_forwarding, :development, :test do
   # Oracle DB

--- a/Gemfile
+++ b/Gemfile
@@ -67,11 +67,11 @@ gem "shoryuken", "3.1.11"
 gem "stringex", require: false
 # catch problematic migrations at development/test time
 gem "strong_migrations"
-gem "tzinfo"
 # execjs runtime
 gem "therubyracer", platforms: :ruby
 # print trees
 gem "tty-tree"
+gem "tzinfo"
 # Use Uglifier as compressor for JavaScript assets
 gem "uglifier", ">= 1.3.0"
 gem "validates_email_format_of"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,10 @@ GEM
     connection_pool (2.2.1)
     cork (0.3.0)
       colored2 (~> 3.1)
+    countries (3.0.1)
+      i18n_data (~> 0.10.0)
+      sixarm_ruby_unaccent (~> 1.1)
+      unicode_utils (~> 1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -314,6 +318,7 @@ GEM
       socksify
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    i18n_data (0.10.0)
     icalendar (2.6.1)
       ice_cube (~> 0.16)
     ice_cube (0.16.3)
@@ -573,6 +578,7 @@ GEM
       thor
     simplecov-html (0.10.2)
     single_cov (1.3.2)
+    sixarm_ruby_unaccent (1.2.0)
     socksify (1.7.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -600,6 +606,7 @@ GEM
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.6.1)
+    unicode_utils (1.4.0)
     uniform_notifier (1.12.1)
     validates_email_format_of (1.6.3)
       i18n
@@ -628,6 +635,7 @@ GEM
       nokogiri (~> 1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    ziptz (2.1.6)
 
 PLATFORMS
   ruby
@@ -651,6 +659,7 @@ DEPENDENCIES
   caseflow!
   connect_vbms!
   console_tree_renderer!
+  countries
   danger (~> 5.10)
   database_cleaner
   ddtrace
@@ -715,10 +724,12 @@ DEPENDENCIES
   therubyracer
   timecop
   tty-tree
+  tzinfo
   uglifier (>= 1.3.0)
   validates_email_format_of
   webdrivers
   webmock
+  ziptz
 
 BUNDLED WITH
    1.17.3

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,9 +1,17 @@
 # frozen_string_literal: true
 
 class Address
+  ZIP5_REGEX = /[0-9]{5}/.freeze
   ZIP_CODE_REGEX = /(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/.freeze
 
   attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state
+
+  class << self
+    # Validates a 5-digit US zip code.
+    def validate_zip5_code(zip)
+      fail ArgumentError, "invalid zip code" unless zip.match?(ZIP5_REGEX)
+    end
+  end
 
   # rubocop:disable Metrics/ParameterLists
   def initialize(

--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -9,7 +9,7 @@ class TimezoneService
 
   # Could not find a timezone by zip code.
   class InvalidZip5Error < StandardError; end
- 
+
   # There were multiple timezones for an address.
   class AmbiguousTimezoneError < StandardError; end
 
@@ -32,13 +32,16 @@ class TimezoneService
 
     # Maps a US 5-digit zip code to a timezone.
     def zip5_to_timezone(zip)
-      fail InvalidZip5Error, "invalid zip code \"#{zip}\"" unless zip.size == 5
+      Address.validate_zip5_code(zip)
 
       timezone_name = Ziptz.new.time_zone_name(zip)
 
       fail InvalidZip5Error, "could not find timezone for zip code \"#{zip}\"" if timezone_name.blank?
 
       TZInfo::Timezone.get(timezone_name)
+    rescue ArgumentError
+      # Zip code is in an invalid format
+      raise InvalidZip5Error, "invalid zip code \"#{zip}\""
     rescue TZInfo::InvalidTimezoneIdentifier
       # For military zip codes, `ziptz` returns "APO/FPO", which causes an invalid timezone error.
       raise InvalidZip5Error, "could not find timezone for zip code \"#{zip}\""

--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -31,12 +31,12 @@ class TimezoneService
     end
 
     # Maps a US 5-digit zip code to a timezone.
-    def zip5_to_timezone(zip5)
-      fail InvalidZip5Error, "invalid zip code \"#{zip5}\"" unless zip5.size == 5
+    def zip5_to_timezone(zip)
+      fail InvalidZip5Error, "invalid zip code \"#{zip}\"" unless zip.size == 5
 
-      timezone_name = Ziptz.new.time_zone_name(zip5)
+      timezone_name = Ziptz.new.time_zone_name(zip)
 
-      fail InvalidZip5Error, "could not find timezone for zip code \"#{zip5}\"" unless timezone_name.present?
+      fail InvalidZip5Error, "could not find timezone for zip code \"#{zip}\"" if timezone_name.blank?
 
       TZInfo::Timezone.get(timezone_name)
     end
@@ -59,16 +59,16 @@ class TimezoneService
       fail AmbiguousTimezoneError, "ambiguous timezone for #{iso3166_code}"
     rescue TZInfo::InvalidCountryCode
       # Re-raise custom error for more info.
-      fail InvalidCountryCodeError, "invalid country code \"#{iso3166_code}\""
+      raise InvalidCountryCodeError, "invalid country code \"#{iso3166_code}\""
     end
 
     # Finds the ISO 3166 country code corresponding to the given country name, or fails
     # with an error if not found.
     def iso3166_alpha2_code_from_name(country_name)
       iso3166_code = ISO3166::Country.find_country_by_name(country_name)
-      iso3166_code = ISO3166::Country.find_country_by_alpha3(country_name) unless iso3166_code.present?
+      iso3166_code = ISO3166::Country.find_country_by_alpha3(country_name) if iso3166_code.blank?
 
-      unless iso3166_code.present?
+      if iso3166_code.blank?
         fail InvalidCountryNameError, "no ISO 3166 country code found for \"#{country_name}\""
       end
 

--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -9,13 +9,13 @@ class TimezoneService
 
   # Could not find a timezone by zip code.
   class InvalidZip5Error < StandardError; end
-  
+ 
   # There were multiple timezones for an address.
   class AmbiguousTimezoneError < StandardError; end
 
   class << self
     # Attempts to find a timezone based on an address. For addresses within the United States,
-    # this does a lookup of timezone based on zipcode. For addresses outisde of the US,
+    # this does a lookup of timezone based on zip code. For addresses outisde of the US,
     # this does a lookup based on country code.
     #
     # Fails if there are multiple timezones for a country outside of the US.

--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -39,6 +39,9 @@ class TimezoneService
       fail InvalidZip5Error, "could not find timezone for zip code \"#{zip}\"" if timezone_name.blank?
 
       TZInfo::Timezone.get(timezone_name)
+    rescue TZInfo::InvalidTimezoneIdentifier
+      # For military zip codes, `ziptz` returns "APO/FPO", which causes an invalid timezone error.
+      raise InvalidZip5Error, "could not find timezone for zip code \"#{zip}\""
     end
 
     # Maps an ISO 3166 country code to a timezone.

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -105,7 +105,6 @@ describe TimezoneService do
             expected_timezone = TZInfo::Timezone.get(expected_timezone_name)
             resolved_timezone = subject
 
-            expect(resolved_timezone.identifier).not_to eq(expected_timezone_name)
             expect(resolved_timezone.current_period.offset).to eq(expected_timezone.current_period.offset)
           end
 
@@ -199,16 +198,16 @@ describe TimezoneService do
   end
 
   describe "#iso3166_alpha2_code_to_timezone" do
-    shared_examples "country code resolves to timezone" do |country_code, expected_timezone_id|
-      it "#{country_code.inspect} resolves to TZ (#{expected_timezone_id})" do
+    shared_examples "country code resolves to timezone" do |country_code, *expected_timezone_ids|
+      it "#{country_code.inspect} resolves to one of TZ (#{expected_timezone_ids})" do
         timezone = described_class.iso3166_alpha2_code_to_timezone(country_code)
-        expect(timezone.identifier).to eq(expected_timezone_id)
+        expect(timezone.identifier).to be_in(expected_timezone_ids)
       end
     end
 
     include_examples "country code resolves to timezone", "CI", "Africa/Abidjan"
     include_examples "country code resolves to timezone", "CH", "Europe/Zurich"
-    include_examples "country code resolves to timezone", "DM", "America/Port_of_Spain"
+    include_examples "country code resolves to timezone", "DM", "America/Port_of_Spain", "America/Dominica"
     include_examples "country code resolves to timezone", "JP", "Asia/Tokyo"
 
     shared_examples "it throws error if country code resolves to ambiguous timezone" do |country_code|

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -3,7 +3,7 @@
 describe TimezoneService, focus: true do
   describe "#iso3166_alpha2_code_from_name" do
     shared_examples "it resolves to a valid ISO 3166 country code" do |country_name, expected_code|
-      it "\"#{country_name}\" resolves to \"#{expected_code}\"" do
+      it "#{country_name.inspect} resolves to #{expected_code.inspect}" do
         country_code = described_class.iso3166_alpha2_code_from_name(country_name)
         expect(country_code).to eq(expected_code)
       end
@@ -26,11 +26,26 @@ describe TimezoneService, focus: true do
     include_examples "it resolves to a valid ISO 3166 country code", "Switzerland", "CH"
     include_examples "it resolves to a valid ISO 3166 country code", "Taiwan", "TW"
     include_examples "it resolves to a valid ISO 3166 country code", "United Kingdom", "GB"
+
+    shared_examples "it throws an error if not a valid country name" do |country_name|
+      it "#{country_name.inspect} raises InvalidCountryNameError" do
+        expect do
+          described_class.iso3166_alpha2_code_from_name(country_name)
+        end.to raise_error(TimezoneService::InvalidCountryNameError)
+      end
+    end
+
+    include_examples "it throws an error if not a valid country name", nil
+    include_examples "it throws an error if not a valid country name", ""
+    include_examples "it throws an error if not a valid country name", "Africa"
+    include_examples "it throws an error if not a valid country name", "F R A N C E"
+    include_examples "it throws an error if not a valid country name", "New York"
+    include_examples "it throws an error if not a valid country name", "United St."
   end
 
   describe "#iso3166_alpha2_code_to_timezone" do
     shared_examples "country code resolves to timezone" do |country_code, expected_timezone_id|
-      it "\"#{country_code}\" resolves to TZ (#{expected_timezone_id})" do
+      it "#{country_code.inspect} resolves to TZ (#{expected_timezone_id})" do
         timezone = described_class.iso3166_alpha2_code_to_timezone(country_code)
         expect(timezone.identifier).to eq(expected_timezone_id)
       end
@@ -41,19 +56,19 @@ describe TimezoneService, focus: true do
     include_examples "country code resolves to timezone", "DM", "America/Port_of_Spain"
     include_examples "country code resolves to timezone", "JP", "Asia/Tokyo"
 
-    shared_examples "country code resolves to ambiguous timezone" do |country_code|
-      it "\"#{country_code}\" resolves to ambiguous TZ" do
+    shared_examples "it throws error if country code resolves to ambiguous timezone" do |country_code|
+      it "#{country_code.inspect} raises AmbiguousTimezoneError" do
         expect do
           described_class.iso3166_alpha2_code_to_timezone(country_code)
         end.to raise_error(TimezoneService::AmbiguousTimezoneError)
       end
     end
 
-    include_examples "country code resolves to ambiguous timezone", "AU"
-    include_examples "country code resolves to ambiguous timezone", "BR"
-    include_examples "country code resolves to ambiguous timezone", "CA"
-    include_examples "country code resolves to ambiguous timezone", "CN"
-    include_examples "country code resolves to ambiguous timezone", "GL"
-    include_examples "country code resolves to ambiguous timezone", "US"
+    include_examples "it throws error if country code resolves to ambiguous timezone", "AU"
+    include_examples "it throws error if country code resolves to ambiguous timezone", "BR"
+    include_examples "it throws error if country code resolves to ambiguous timezone", "CA"
+    include_examples "it throws error if country code resolves to ambiguous timezone", "CN"
+    include_examples "it throws error if country code resolves to ambiguous timezone", "GL"
+    include_examples "it throws error if country code resolves to ambiguous timezone", "US"
   end
 end

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe TimezoneService, focus: true do
+  describe "#iso3166_alpha2_code_from_name" do
+    shared_examples "it resolves to a valid ISO 3166 country code" do |country_name, expected_code|
+      it "\"#{country_name}\" resolves to \"#{expected_code}\"" do
+        country_code = described_class.iso3166_alpha2_code_from_name(country_name)
+        expect(country_code).to eq(expected_code)
+      end
+    end
+
+    include_examples "it resolves to a valid ISO 3166 country code", "USA", "US"
+    include_examples "it resolves to a valid ISO 3166 country code", "united states", "US"
+    include_examples "it resolves to a valid ISO 3166 country code", "Australia", "AU"
+    include_examples "it resolves to a valid ISO 3166 country code", "Canada", "CA"
+    include_examples "it resolves to a valid ISO 3166 country code", "Colombia", "CO"
+    include_examples "it resolves to a valid ISO 3166 country code", "Côte d'Ivoire", "CI"
+    include_examples "it resolves to a valid ISO 3166 country code", "Cote d'Ivoire", "CI"
+    include_examples "it resolves to a valid ISO 3166 country code", "Dominica", "DM"
+    include_examples "it resolves to a valid ISO 3166 country code", "Dominican Republic", "DO"
+    include_examples "it resolves to a valid ISO 3166 country code", "Germany", "DE"
+    include_examples "it resolves to a valid ISO 3166 country code", "Greenland", "GL"
+    include_examples "it resolves to a valid ISO 3166 country code", "Italy", "IT"
+    include_examples "it resolves to a valid ISO 3166 country code", "JAPAN", "JP"
+    include_examples "it resolves to a valid ISO 3166 country code", "Philippines", "PH"
+    include_examples "it resolves to a valid ISO 3166 country code", "Switzerland", "CH"
+    include_examples "it resolves to a valid ISO 3166 country code", "Taiwan", "TW"
+    include_examples "it resolves to a valid ISO 3166 country code", "United Kingdom", "GB"
+  end
+
+  describe "#iso3166_alpha2_code_to_timezone" do
+    shared_examples "country code resolves to timezone" do |country_code, expected_timezone_id|
+      it "\"#{country_code}\" resolves to TZ (#{expected_timezone_id})" do
+        timezone = described_class.iso3166_alpha2_code_to_timezone(country_code)
+        expect(timezone.identifier).to eq(expected_timezone_id)
+      end
+    end
+
+    include_examples "country code resolves to timezone", "CI", "Africa/Abidjan"
+    include_examples "country code resolves to timezone", "CH", "Europe/Zurich"
+    include_examples "country code resolves to timezone", "DM", "America/Port_of_Spain"
+    include_examples "country code resolves to timezone", "JP", "Asia/Tokyo"
+
+    shared_examples "country code resolves to ambiguous timezone" do |country_code|
+      it "\"#{country_code}\" resolves to ambiguous TZ" do
+        expect do
+          described_class.iso3166_alpha2_code_to_timezone(country_code)
+        end.to raise_error(TimezoneService::AmbiguousTimezoneError)
+      end
+    end
+
+    include_examples "country code resolves to ambiguous timezone", "AU"
+    include_examples "country code resolves to ambiguous timezone", "BR"
+    include_examples "country code resolves to ambiguous timezone", "CA"
+    include_examples "country code resolves to ambiguous timezone", "CN"
+    include_examples "country code resolves to ambiguous timezone", "GL"
+    include_examples "country code resolves to ambiguous timezone", "US"
+  end
+end

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -97,11 +97,11 @@ describe TimezoneService do
       # See: https://github.com/tzinfo/tzinfo-data/issues/17#issuecomment-421379950
       # See: https://github.com/hexorx/countries/pull/397
       # See: https://tz.iana.narkive.com/DTtwvfsT/tz-proposal-to-use-asia-tel-aviv-for-israel-jerusalem-is-not-internationally-recognized-as-part-of
-      shared_examples "address in non-US country resolves to equivalent timezone" do |country_name, expected_timezone_name|
-        context "address is in #{country_name}" do
-          let(:country) { country_name }
+      shared_examples "address in non-US country resolves to equivalent timezone" do |country, expected_timezone_name|
+        context "address is in #{country}" do
+          let(:country) { country }
 
-          it "#{country_name} resolves to timezone with same attributes as #{expected_timezone_name}" do
+          it "#{country} resolves to timezone with same attributes as #{expected_timezone_name}" do
             expected_timezone = TZInfo::Timezone.get(expected_timezone_name)
             resolved_timezone = subject
 
@@ -109,7 +109,7 @@ describe TimezoneService do
             expect(resolved_timezone.current_period.offset).to eq(expected_timezone.current_period.offset)
           end
 
-          it "time for #{country_name} timezone displays the same as #{expected_timezone_name}" do
+          it "time for #{country} timezone displays the same as #{expected_timezone_name}" do
             expected_timezone = TZInfo::Timezone.get(expected_timezone_name)
             resolved_timezone = subject
 
@@ -141,7 +141,7 @@ describe TimezoneService do
       include_examples "address in non-US country resolves to single timezone", "South Korea", "Asia/Seoul"
       include_examples "address in non-US country resolves to single timezone", "Syria", "Asia/Damascus"
 
-      shared_examples 'address in non-US country has ambiguous timezone' do |country_name|
+      shared_examples "address in non-US country has ambiguous timezone" do |country_name|
         context "address is in #{country_name}" do
           let(:country) { country_name }
 


### PR DESCRIPTION
Resolves #13889

### Description

  * Added new dependencies
    * [`countries`](https://github.com/hexorx/countries) - added to convert a country name into the [ISO 3166 2-letter code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) (which `tzinfo` can find a timezone for)
    * [`ziptz`](https://github.com/infused/ziptz) - maps US zip codes to timezones
    * `tzinfo` - explicitly declared this (it was being pulled in by another dependency before)
  * Added `TimezoneService` class, which can find the timezone for an `Address` instance
  * Added a _bunch_ of tests

Note: `tzinfo` and `ziptz` aren't 100% accurate. For example, a zip code in the U.S. Virgin Islands returns the timezone `"America/Puerto_Rico"`, but the [IANA timezone database](https://www.iana.org/time-zones) has one timezone for the U.S. Virgin Islands, [`"America/St_Thomas"`](https://time.is/U.S._Virgin_Islands).

I did some research into whether or not this would ultimately be an issue when displaying the hearing time, but it _seems_ like it should be fine because both timezones fall under the same geographic zone (which gets abbreviated as `AST` in the example below). There are other issues with the IANA timezone database, but since it appears to be the standard for classifying timezones, it's probably best to use.

```
[18] pry(main)> TZInfo::Timezone.get("America/Puerto_Rico").strftime("%A, %-d %B %Y at %-l:%M%P %Z", Time.now.utc)
=> "Monday, 13 April 2020 at 1:57pm AST"
[19] pry(main)> TZInfo::Timezone.get("America/St_Thomas").strftime("%A, %-d %B %Y at %-l:%M%P %Z", Time.now.utc)
=> "Monday, 13 April 2020 at 1:58pm AST"
```
