### PR TITLE
Intake | Update copy on appeal permissions alert

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -558,7 +558,7 @@
   "INTAKE_SEARCH_ERROR_NOT_ACCESSIBLE": "It looks like you do not have the necessary level of access to view this information. Please alert your manager so they can assign the form to someone else.",
   "INTAKE_SEARCH_ERROR_NOT_MODIFIABLE": "You do not appear to have permission to establish a claim for this Veteran. Often this is because they are an employee at the same station as you. Please alert your manager so they can assign the form to someone else.",
   "INTAKE_FORM_SELECTION": "Which form are you processing?",
-  "INTAKE_APPEAL_PERMISSIONS_ALERT": "You are not authorized to perform this function. Please take necessary steps to send this Notice of Disagreement form to the Board.",
+  "INTAKE_APPEAL_PERMISSIONS_ALERT": "You are not authorized to perform this function. Please take the necessary steps to have the Notice of Disagreement form uploaded to the Centralized Mail Portal application.",
   "INTAKE_VETERAN_NAME_SUFFIX_ERROR": "Please check the Veteran's suffix for any punctuations (for example use JR instead of JR.) in VBMS or Share and try again.",
   "INTAKE_VETERAN_DATE_OF_BIRTH_ERROR": "Please check that the Veteran's birthdate follows the format \"mm/dd/yyyy\" (please include zeros) in VBMS or Share and try again.",
 

--- a/client/app/intake/pages/selectForm.jsx
+++ b/client/app/intake/pages/selectForm.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import RadioField from '../../components/RadioField';
 import SearchableDropdown from '../../components/SearchableDropdown';
 import Button from '../../components/Button';
@@ -12,14 +12,6 @@ import { setFormType, clearSearchErrors } from '../actions/intake';
 import { PAGE_PATHS, FORM_TYPES } from '../constants';
 import COPY from '../../../COPY';
 import _ from 'lodash';
-
-const appealPermissionErrorMessage = <Fragment>
-  <p>{COPY.INTAKE_APPEAL_PERMISSIONS_ALERT}</p>
-  <p>
-    Mail to <strong>425 I St NW, Washington DC, 20001</strong><br />
-    Attention: <strong>Case Review and Evaluation Branch</strong>
-  </p>
-</Fragment>;
 
 class SelectForm extends React.PureComponent {
   setFormTypeFromDropdown = (formObject) => {
@@ -54,7 +46,7 @@ class SelectForm extends React.PureComponent {
         title="Not Authorized"
         type="error"
         lowerMargin>
-        {appealPermissionErrorMessage}
+        {COPY.INTAKE_APPEAL_PERMISSIONS_ALERT}
       </Alert>
       }
 

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -72,7 +72,6 @@ feature "Intake", :all_dbs do
         select_form(Constants.INTAKE_FORM_NAMES.appeal)
 
         expect(page).to have_content(COPY::INTAKE_APPEAL_PERMISSIONS_ALERT)
-        expect(page).to have_content("Mail to 425 I St NW, Washington DC, 20001")
         expect(page).to have_css(".cf-submit[disabled]")
 
         select_form(Constants.INTAKE_FORM_NAMES.higher_level_review)


### PR DESCRIPTION
connects #13948 

### Description
Small copy update to the alert that shows when a non-Mail team member tries to intake an appeal, per feedback from BVA.

Documentation updated:
[Presentation on Intake alerts](https://docs.google.com/presentation/d/1zYdLPwTJ7aXqT4oR3l3p0sYarT64t0A5VxtY3lTf4fE/edit#slide=id.g8335e642c3_1_13)
[Intake permissions wiki page](https://github.com/department-of-veterans-affairs/caseflow/wiki/Intake-Permissions)