### PR TITLE
Add test to ensure newly added Reader labels return correctly

### DIFF
--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -228,7 +228,7 @@ describe Document, :postgres do
           alt_doc_types: nil
         )
       end
-      it "returns the documents" do
+      it "assigns the correct label type" do
         expect(subject.type).to eq("VA Form 20-0995 Supplemental Claim Application")
       end
     end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -220,7 +220,7 @@ describe Document, :postgres do
       it { is_expected.to have_attributes(type: "Form 9") }
     end
 
-    context "when the doc type is a newly recognized label" do 
+    context "when the doc type is a newly recognized label" do
       let(:vbms_document) do
         OpenStruct.new(
           document_id: "1",

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -219,6 +219,19 @@ describe Document, :postgres do
 
       it { is_expected.to have_attributes(type: "Form 9") }
     end
+
+    context "when the doc type is a newly recognized label" do 
+      let(:vbms_document) do
+        OpenStruct.new(
+          document_id: "1",
+          doc_type: "1249",
+          alt_doc_types: nil
+        )
+      end
+      it "returns the documents" do
+        expect(subject.type).to eq("VA Form 20-0995 Supplemental Claim Application")
+      end
+    end
   end
 
   context "content tests" do


### PR DESCRIPTION
Resolves #12979 

### Description
Add test to ensure the labels added in [this](https://github.com/department-of-veterans-affairs/caseflow-commons/pull/170) PR are returning correctly 

### Acceptance Criteria
- [ ] Correct Reader label is pulled in from list stored in [caseflow-commons](https://github.com/department-of-veterans-affairs/caseflow-commons/blob/fb6fa9658825c143eb8d202b87128f34ca7e210b/app/models/caseflow/document_types.rb#L3)

### Testing Plan
1. Run rspec test to check for correct result