### PR TITLE
Intake | When we get a DuplicateEP error for an established EP, update EPE attributes

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -536,7 +536,11 @@ class EndProductEstablishment < CaseflowRecord
     return unless source.try(:previously_attempted?)
 
     if matching_established_end_product.present?
-      update!(reference_id: matching_established_end_product.claim_id)
+      update!(
+        reference_id: matching_established_end_product.claim_id,
+        established_at: Time.zone.now,
+        modifier: matching_established_end_product.modifier
+      )
     end
   end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -312,7 +312,11 @@ describe EndProductEstablishment, :postgres do
         allow(end_product_establishment.veteran).to receive(:end_products).and_return([orphaned_end_product])
         subject
         expect(Fakes::VBMSService).not_to have_received(:establish_claim!)
-        expect(end_product_establishment.reference_id).to eq(orphaned_end_product.claim_id)
+        expect(end_product_establishment).to have_attributes(
+          reference_id: orphaned_end_product.claim_id,
+          established_at: Time.zone.now,
+          modifier: orphaned_end_product.modifier
+        )
       end
     end
 


### PR DESCRIPTION
### Description
Sometimes VBMS sends us a failed response when establishing an EP, but establishes it anyway. So we are trying to recover those established EPs on the second attempt.

The fix ([in this PR](https://github.com/department-of-veterans-affairs/caseflow/pull/13537)) did not update the attributes: established_at, and modifier on the end product establishment when using a recovered EP.  This PR sets those values.

This is from batteam:
https://dsva.slack.com/archives/CHX8FMP28/p1586875614309400