### PR TITLE
Add prefix to facilities request cache key

### DIFF
--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -33,7 +33,7 @@ class ExternalApi::VADotGovService
     private
 
     def send_facilities_request(query:)
-      cache_key = Digest::SHA1.hexdigest query.to_json
+      cache_key = "send_facilities_request_#{Digest::SHA1.hexdigest(query.to_json)}"
       response = Rails.cache.fetch(cache_key, expires_in: 2.hours) do
         send_va_dot_gov_request(
           query: query,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10223,7 +10223,7 @@ killable@^1.0.1:
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
   integrity sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==
 
-kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
+kind-of@>=6.0.3, kind-of@^2.0.1, kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0, kind-of@^4.0.0, kind-of@^5.0.0, kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==


### PR DESCRIPTION
### Description
Adds a prefix to the key for cached `send_facilities_request` data in the VADotGovService. This will make it possible to clear the cache if needed.

Also updates yarn.lock to be current [at JC's request](https://dsva.slack.com/archives/CQNPUG8EQ/p1586898678000600?thread_ts=1586898501.000300&cid=CQNPUG8EQ).
