### PR TITLE
Handle blank diagnostic codes for request issues from the front end

### DIFF
--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -44,7 +44,7 @@ module IssueUpdater
         disposition: issue_attrs[:disposition],
         description: issue_attrs[:description],
         benefit_type: issue_attrs[:benefit_type],
-        diagnostic_code: issue_attrs[:diagnostic_code],
+        diagnostic_code: issue_attrs[:diagnostic_code].presence,
         participant_id: appeal.veteran.participant_id,
         decision_review: appeal,
         caseflow_decision_date: appeal.decision_document&.decision_date

--- a/spec/controllers/case_reviews_controller_spec.rb
+++ b/spec/controllers/case_reviews_controller_spec.rb
@@ -19,6 +19,44 @@ RSpec.describe CaseReviewsController, :all_dbs, type: :controller do
       let(:request_issue3) { create(:request_issue, decision_review: task.appeal) }
 
       context "Attorney Case Review" do
+        shared_examples "valid params" do
+          let!(:bva_dispatch_task_count_before) { BvaDispatchTask.count }
+
+          it "should be successful" do
+            post :complete, params: { task_id: task.id, tasks: params }
+            expect(response.status).to eq 200
+            response_body = JSON.parse(response.body)
+            expect(response_body["task"]["document_id"]).to eq "12345678.1234"
+            expect(response_body["task"]["overtime"]).to eq true
+            expect(response_body["task"]["note"]).to eq "something"
+            expect(response_body.keys).to include "issues"
+
+            expect(DecisionIssue.count).to eq 2
+            expect(request_issue1.decision_issues.first.disposition).to eq "allowed"
+            expect(request_issue1.decision_issues.first.description).to eq "wonderful life"
+            expect(request_issue1.decision_issues.first.benefit_type).to eq "pension"
+            expect(request_issue3.decision_issues.first.disposition).to eq "allowed"
+            expect(request_issue3.decision_issues.first.description).to eq "wonderful life"
+            expect(request_issue3.decision_issues.first.benefit_type).to eq "pension"
+            expect(request_issue3.decision_issues.first.diagnostic_code).to eq diagnostic_code
+
+            expect(request_issue2.decision_issues.first.disposition).to eq "remanded"
+            expect(request_issue2.decision_issues.first.description).to eq "great moments"
+            expect(request_issue2.decision_issues.first.benefit_type).to eq "vha"
+            expect(request_issue2.decision_issues.first.diagnostic_code).to eq "5002"
+            expect(request_issue2.decision_issues.first.remand_reasons.size).to eq 1
+            expect(request_issue2.decision_issues.first.remand_reasons.first.code).to eq "va_records"
+            expect(request_issue2.decision_issues.first.remand_reasons.first.post_aoj).to eq true
+
+            expect(task.reload.status).to eq "completed"
+            expect(task.closed_at).to_not eq nil
+            expect(task.parent.reload.status).to eq "assigned"
+            expect(task.parent.type).to eq JudgeDecisionReviewTask.name
+
+            expect(bva_dispatch_task_count_before).to eq(BvaDispatchTask.count)
+          end
+        end
+
         before do
           User.stub = attorney
         end
@@ -27,38 +65,40 @@ RSpec.describe CaseReviewsController, :all_dbs, type: :controller do
         let(:judge_task) { create(:ama_judge_decision_review_task, assigned_to: judge, parent: root_task) }
         let(:task) { create(:ama_attorney_task, assigned_to: attorney, assigned_by: judge, parent: judge_task) }
 
+        let(:disposition) { "allowed" }
+        let(:request_issue_ids) { [request_issue1.id, request_issue3.id] }
+        let(:diagnostic_code) { "5001" }
+        let(:params) do
+          {
+            "type": "AttorneyCaseReview",
+            "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
+            "reviewing_judge_id": judge.id,
+            "work_product": "Decision",
+            "document_id": "12345678.1234",
+            "overtime": true,
+            "note": "something",
+            "issues": [{ "disposition": disposition,
+                         "description": "wonderful life",
+                         "benefit_type": "pension",
+                         "diagnostic_code": diagnostic_code,
+                         "request_issue_ids": request_issue_ids },
+                       { "disposition": "remanded",
+                         "description": "great moments",
+                         "benefit_type": "vha",
+                         "diagnostic_code": "5002",
+                         "request_issue_ids": [request_issue2.id],
+                         "remand_reasons": [{ "code": "va_records", "post_aoj": true }] }]
+          }
+        end
+
+        subject { post :complete, params: { task_id: task.id, tasks: params }, as: :json }
+
         context "when creating a draft decision" do
           context "when missing dispositions" do
-            let(:params) do
-              {
-                "type": "AttorneyCaseReview",
-                "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
-                "reviewing_judge_id": judge.id,
-                "work_product": "Decision",
-                "document_id": "12345678.1234",
-                "overtime": true,
-                "note": "something",
-                "issues": [
-                  {
-                    "description": "wonderful life",
-                    "benefit_type": "pension",
-                    "diagnostic_code": "5001",
-                    "request_issue_ids": [request_issue1.id, request_issue3.id]
-                  },
-                  {
-                    "disposition": "remanded",
-                    "description": "great moments",
-                    "benefit_type": "vha",
-                    "diagnostic_code": "5001",
-                    "request_issue_ids": [request_issue2.id],
-                    "remand_reasons": [{ "code": "va_records", "post_aoj": true }]
-                  }
-                ]
-              }
-            end
+            let(:disposition) { nil }
 
             it "should not be successful" do
-              post :complete, params: { task_id: task.id, tasks: params }, as: :json
+              subject
               expect(response.status).to eq 400
               response_body = JSON.parse(response.body)
               msg = "Validation failed: Disposition can't be blank, Disposition is not included in the list"
@@ -67,91 +107,23 @@ RSpec.describe CaseReviewsController, :all_dbs, type: :controller do
           end
 
           context "when not all request issues are sent" do
-            let(:params) do
-              {
-                "type": "AttorneyCaseReview",
-                "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
-                "reviewing_judge_id": judge.id,
-                "work_product": "Decision",
-                "document_id": "12345678.1234",
-                "overtime": true,
-                "note": "something",
-                "issues": [{ "disposition": "allowed", "description": "wonderful life",
-                             "benefit_type": "pension",
-                             "diagnostic_code": "5001",
-                             "request_issue_ids": [request_issue3.id] },
-                           { "disposition": "remanded", "description": "great moments",
-                             "benefit_type": "vha",
-                             "diagnostic_code": "5001",
-                             "request_issue_ids": [request_issue2.id],
-                             "remand_reasons": [{ "code": "va_records", "post_aoj": true }] }]
-              }
-            end
+            let(:request_issue_ids) { [request_issue3.id] }
 
             it "should not be successful" do
-              post :complete, params: { task_id: task.id, tasks: params }
+              subject
               expect(response.status).to eq 400
               response_body = JSON.parse(response.body)
               expect(response_body["errors"].first["detail"]).to eq "Not every request issue has a decision issue"
             end
           end
 
+          context "when missing diagnostic code" do
+            let(:diagnostic_code) { nil }
+            it_behaves_like "valid params"
+          end
+
           context "when all parameters are present" do
-            let(:params) do
-              {
-                "type": "AttorneyCaseReview",
-                "document_type": Constants::APPEAL_DECISION_TYPES["DRAFT_DECISION"],
-                "reviewing_judge_id": judge.id,
-                "work_product": "Decision",
-                "document_id": "12345678.1234",
-                "overtime": true,
-                "note": "something",
-                "issues": [{ "disposition": "allowed", "description": "wonderful life",
-                             "benefit_type": "pension",
-                             "diagnostic_code": "5001",
-                             "request_issue_ids": [request_issue1.id, request_issue3.id] },
-                           { "disposition": "remanded", "description": "great moments",
-                             "benefit_type": "vha",
-                             "diagnostic_code": "5002",
-                             "request_issue_ids": [request_issue2.id],
-                             "remand_reasons": [{ "code": "va_records", "post_aoj": true }] }]
-              }
-            end
-            let!(:bva_dispatch_task_count_before) { BvaDispatchTask.count }
-
-            it "should be successful" do
-              post :complete, params: { task_id: task.id, tasks: params }
-              expect(response.status).to eq 200
-              response_body = JSON.parse(response.body)
-              expect(response_body["task"]["document_id"]).to eq "12345678.1234"
-              expect(response_body["task"]["overtime"]).to eq true
-              expect(response_body["task"]["note"]).to eq "something"
-              expect(response_body.keys).to include "issues"
-
-              expect(DecisionIssue.count).to eq 2
-              expect(request_issue1.decision_issues.first.disposition).to eq "allowed"
-              expect(request_issue1.decision_issues.first.description).to eq "wonderful life"
-              expect(request_issue1.decision_issues.first.benefit_type).to eq "pension"
-              expect(request_issue3.decision_issues.first.disposition).to eq "allowed"
-              expect(request_issue3.decision_issues.first.description).to eq "wonderful life"
-              expect(request_issue3.decision_issues.first.benefit_type).to eq "pension"
-              expect(request_issue3.decision_issues.first.diagnostic_code).to eq "5001"
-
-              expect(request_issue2.decision_issues.first.disposition).to eq "remanded"
-              expect(request_issue2.decision_issues.first.description).to eq "great moments"
-              expect(request_issue2.decision_issues.first.benefit_type).to eq "vha"
-              expect(request_issue2.decision_issues.first.diagnostic_code).to eq "5002"
-              expect(request_issue2.decision_issues.first.remand_reasons.size).to eq 1
-              expect(request_issue2.decision_issues.first.remand_reasons.first.code).to eq "va_records"
-              expect(request_issue2.decision_issues.first.remand_reasons.first.post_aoj).to eq true
-
-              expect(task.reload.status).to eq "completed"
-              expect(task.closed_at).to_not eq nil
-              expect(task.parent.reload.status).to eq "assigned"
-              expect(task.parent.type).to eq JudgeDecisionReviewTask.name
-
-              expect(bva_dispatch_task_count_before).to eq(BvaDispatchTask.count)
-            end
+            it_behaves_like "valid params"
           end
         end
       end


### PR DESCRIPTION
Resolves #10948

### Description
Diagnostic code is not required on the [front end](https://github.com/department-of-veterans-affairs/caseflow/pull/9825) or on the [back end](https://github.com/department-of-veterans-affairs/caseflow/blob/43562ed9e75b14c6f949802521da9df6a4214c2b/app/models/decision_issue.rb#L10-L11) for decision issues. However, when diagnostic code is not included, the back end receives an empty string, not a nil, causing us to throw a `Caseflow::Error::AttorneyJudgeCheckoutError: Validation failed: Diagnostic code is not included in the list` to [sentry](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/9479/events/2bcdd75a2f7648cab9998ada98a0002d/). This PR fixes that error but returning nil for blank diagnostic codes.

### Acceptance Criteria
- [ ] Empty diagnostic codes passed to case review controller are correctly handled by making them nil

### Testing Plan
1. Was unable to replicate this is testing as my dev environment always passes nil when completing an attorney case review with a blank diagnostic code 🤷 