### PR TITLE
Fix issue where task hearing is nil

### DIFF
--- a/app/models/concerns/task_extension_for_hearings.rb
+++ b/app/models/concerns/task_extension_for_hearings.rb
@@ -18,7 +18,7 @@ module TaskExtensionForHearings
     tasks = appeal.tasks.closed.order(closed_at: :desc).where(type: HearingTask.name)
     return tasks.first&.hearing if appeal.is_a?(Appeal)
 
-    tasks.map(&:hearing).detect(&:vacols_hearing_exists?)
+    tasks.map(&:hearing).compact.detect(&:vacols_hearing_exists?)
   end
 
   def create_change_hearing_disposition_task(instructions = nil)


### PR DESCRIPTION
### Description

Resolves issue reported here: https://dsva.slack.com/archives/CHX8FMP28/p1587148588364500


Stacktrace:

```
Traceback (most recent call last):
        4: from (irb):162
        3: from app/models/concerns/task_extension_for_hearings.rb:21:in `most_recent_closed_hearing_on_appeal'
        2: from app/models/concerns/task_extension_for_hearings.rb:21:in `detect'
        1: from app/models/concerns/task_extension_for_hearings.rb:21:in `each'
NoMethodError (undefined method `vacols_hearing_exists?' for nil:NilClass)
```