### PR TITLE
Added proper escaping to search string in CommentsTable regex

### DIFF
--- a/client/app/reader/CommentsTable.jsx
+++ b/client/app/reader/CommentsTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _, {escapeRegExp} from 'lodash';
+import _, { escapeRegExp } from 'lodash';
 import { connect } from 'react-redux';
 
 import { getAnnotationsPerDocument } from './selectors';
@@ -11,13 +11,15 @@ export const getRowObjects = (documents, annotationsPerDocument, searchQuery = '
   const groupedAnnotations = _(annotationsPerDocument).
     map((notes) =>
       notes.map((note) => {
+        // eslint-disable-next-line camelcase
         const { type, serialized_receipt_date } = documents.filter((doc) => doc.id === note.documentId)[0];
 
         return _.extend({}, note, {
           docType: type,
           serialized_receipt_date
         });
-      })).
+      })
+    ).
     flatten().
     filter((note) => {
       if (!searchQuery) {
@@ -28,56 +30,62 @@ export const getRowObjects = (documents, annotationsPerDocument, searchQuery = '
 
       return note.comment.match(query) || note.docType.match(query);
     }).
-    groupBy((note) => note.relevant_date ? 'relevant_date' : 'serialized_receipt_date').
+    groupBy((note) => (note.relevant_date ? 'relevant_date' : 'serialized_receipt_date')).
     value();
 
   // groupBy returns { relevant_date: [notes w/relevant_date], serialized_receipt_date: [notes w/out] }
-  return _.sortBy(groupedAnnotations.relevant_date, 'relevant_date').
-    concat(_.sortBy(groupedAnnotations.serialized_receipt_date, 'serialized_receipt_date'));
+  return _.sortBy(groupedAnnotations.relevant_date, 'relevant_date').concat(
+    _.sortBy(groupedAnnotations.serialized_receipt_date, 'serialized_receipt_date')
+  );
 };
 
 class CommentsTable extends React.PureComponent {
-  getCommentColumn = () => [{
-    header: 'Sorted by relevant date',
-    valueFunction: (comment, idx) => <Comment
-      key={comment.uuid}
-      id={`comment-${idx}`}
-      page={comment.page}
-      onJumpToComment={this.props.onJumpToComment(comment)}
-      uuid={comment.uuid}
-      date={comment.relevant_date}
-      docType={comment.docType}
-      horizontalLayout>
-      {comment.comment}
-    </Comment>
-  }];
+  getCommentColumn = () => [
+    {
+      header: 'Sorted by relevant date',
+      valueFunction: (comment, idx) => (
+        <Comment
+          key={comment.uuid}
+          id={`comment-${idx}`}
+          page={comment.page}
+          onJumpToComment={this.props.onJumpToComment(comment)}
+          uuid={comment.uuid}
+          date={comment.relevant_date}
+          docType={comment.docType}
+          horizontalLayout
+        >
+          {comment.comment}
+        </Comment>
+      )
+    }
+  ];
 
   getKeyForRow = (rowNumber, object) => object.uuid;
 
   render() {
-    const {
-      documents,
-      annotationsPerDocument,
-      searchQuery
-    } = this.props;
+    const { documents, annotationsPerDocument, searchQuery } = this.props;
 
-    return <div>
-      <Table
-        columns={this.getCommentColumn}
-        rowObjects={getRowObjects(documents, annotationsPerDocument, searchQuery)}
-        className="documents-table full-width"
-        bodyClassName="cf-document-list-body"
-        getKeyForRow={this.getKeyForRow}
-        headerClassName="comments-table-header"
-        rowClassNames={_.constant('borderless')}
-      />
-    </div>;
+    return (
+      <div>
+        <Table
+          columns={this.getCommentColumn}
+          rowObjects={getRowObjects(documents, annotationsPerDocument, searchQuery)}
+          className="documents-table full-width"
+          bodyClassName="cf-document-list-body"
+          getKeyForRow={this.getKeyForRow}
+          headerClassName="comments-table-header"
+          rowClassNames={_.constant('borderless')}
+        />
+      </div>
+    );
   }
 }
 
 CommentsTable.propTypes = {
   documents: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onJumpToComment: PropTypes.func.isRequired
+  onJumpToComment: PropTypes.func.isRequired,
+  annotationsPerDocument: PropTypes.array,
+  searchQuery: PropTypes.string
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/reader/CommentsTable.jsx
+++ b/client/app/reader/CommentsTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import _, {escapeRegExp} from 'lodash';
 import { connect } from 'react-redux';
 
 import { getAnnotationsPerDocument } from './selectors';
@@ -24,7 +24,7 @@ export const getRowObjects = (documents, annotationsPerDocument, searchQuery = '
         return true;
       }
 
-      const query = new RegExp(searchQuery, 'i');
+      const query = new RegExp(escapeRegExp(searchQuery), 'i');
 
       return note.comment.match(query) || note.docType.match(query);
     }).

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -577,7 +577,12 @@ RSpec.feature "Reader", :all_dbs do
             document_id: documents[1].id,
             y: 300,
             page: 3
-          )
+          ),
+          Generators::Annotation.create(
+            comment: "comment with a * char in it",
+            document_id: documents[0].id,
+            y: 250
+          ),
         ]
       end
 
@@ -590,6 +595,10 @@ RSpec.feature "Reader", :all_dbs do
 
         # A doc without a comment should not show up
         expect(page.has_no_content?(documents[2].type)).to eq(true)
+
+        # Filter properly escapes characters
+        fill_in "searchBar", with: "*"
+        expect(page).to have_content(annotations[6].comment)
 
         # Filtering the document list should work in "Comments" mode.
         fill_in "searchBar", with: "form"

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -581,7 +581,7 @@ RSpec.feature "Reader", :all_dbs do
           Generators::Annotation.create(
             comment: "comment with a * char in it",
             document_id: documents[0].id,
-            y: 250
+            y: 350
           )
         ]
       end
@@ -625,10 +625,10 @@ RSpec.feature "Reader", :all_dbs do
       # :nocov:
       scenario "Leave annotation with keyboard" do
         visit "/reader/appeal/#{appeal.vacols_id}/documents/#{documents[0].id}"
-        assert_selector(".commentIcon-container", count: 5)
+        assert_selector(".commentIcon-container", count: 6)
         find("body").send_keys [:alt, "c"]
         expect(page).to have_css(".cf-pdf-placing-comment")
-        assert_selector(".commentIcon-container", count: 6)
+        assert_selector(".commentIcon-container", count: 7)
 
         def placing_annotation_icon_position
           element_position "[data-placing-annotation-icon]"
@@ -692,12 +692,12 @@ RSpec.feature "Reader", :all_dbs do
         expect(page).to have_css(".page")
 
         # Click on the second to last comment icon (last comment icon is off screen)
-        all(".commentIcon-container", wait: 3, count: documents[0].annotations.size)[annotations.size - 3].click
+        all(".commentIcon-container", wait: 3, count: documents[0].annotations.size)[annotations.size - 4].click
 
         # Make sure the comment icon and comment are shown as selected
         expect(find(".comment-container-selected").text).to eq "baby metal 4 lyfe"
 
-        id = "#{annotations[annotations.size - 3].id}-filter-1"
+        id = "#{annotations[annotations.size - 4].id}-filter-1"
 
         # This filter is the blue highlight around the comment icon
         find("g[filter=\"url(##{id})\"]")
@@ -718,8 +718,8 @@ RSpec.feature "Reader", :all_dbs do
         element_class = "ReactVirtualized__Grid__innerScrollContainer"
         original_scroll = scrolled_amount(element_class)
 
-        # Click on the off screen comment (0 through 3 are on screen)
-        find("#comment4").click
+        # Click on the off screen comment (0 through 4 are on screen)
+        find("#comment5").click
         after_click_scroll = scrolled_amount(element_class)
 
         expect(after_click_scroll - original_scroll).to be > 0

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -582,7 +582,7 @@ RSpec.feature "Reader", :all_dbs do
             comment: "comment with a * char in it",
             document_id: documents[0].id,
             y: 250
-          ),
+          )
         ]
       end
 


### PR DESCRIPTION
### Description
This fixes an error when a user enters certain characters when filtering in `CommentsTable`

### Resources
- [Sentry alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/9983/)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Entering special characters such as '*' doesn't break the page with JS error
