### PR TITLE
Add Datadog to the Demo env to test the traces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV LD_LIBRARY_PATH="/opt/oracle/instantclient_12_2:$LD_LIBRARY_PATH" \
     ORACLE_HOME="/opt/oracle/instantclient_12_2" \
     LANG="AMERICAN_AMERICA.US7ASCII" \
     RAILS_ENV="development" \
+    DEPLOY_ENV="demo" \
     PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
 
 # install oracle deps
@@ -39,7 +40,8 @@ RUN apt -y update && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get clean && apt-get autoclean && apt-get autoremove
 
-
+# install datadog agent
+RUN DD_INSTALL_ONLY=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=$(cat config/datadog.key) bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh)"
 
 RUN bundle install && \
     cd client && \

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,4 +1,12 @@
 Datadog.configure do |c|
-  # This will activate auto-instrumentation for Rails
-  c.use :rails
+  options = { analytics_enabled: true }
+
+  c.analytics_enabled = true
+  c.use :rails, options
+  c.use :active_record, options
+  c.use :rack, options
+  c.use :redis, options
+  c.use :shoryuken, options
+
+  c.env = ENV['DEPLOY_ENV']
 end

--- a/docker-bin/build.sh
+++ b/docker-bin/build.sh
@@ -3,35 +3,33 @@ echo "Building Caseflow Docker App.."
 
 # Create temp folders
 if [ ! -d oracle_libs ]; then
-  echo "  Creating Oracle Libs folder"
+  echo -e "\tCreating Oracle Libs folder"
   mkdir ./oracle_libs
 fi
 
 echo "  Going into the Oracle Libs folder"
 cd ./oracle_libs
 
-echo "  Checking if Oracle Instant client files exist"
+echo -e "\tChecking if Oracle Instant client files exist"
 # if file doesnt exist download it (oracle libs)
 if [ ! -f instantclient-basic-linux.x64-12.2.0.1.0.zip ]; then
 
-  echo "    Downloading Oracle Instant Client and SQLPlus"
+  echo -e "\t\tDownloading Oracle Instant Client and SQLPlus"
   aws s3 cp --region us-gov-west-1  s3://shared-s3/dsva-appeals/instantclient-basic-linux.x64-12.2.0.1.0.zip instantclient-basic-linux.x64-12.2.0.1.0.zip
-
   aws s3 cp --region us-gov-west-1 s3://shared-s3/dsva-appeals/instantclient-sqlplus-linux.x64-12.2.0.1.0.zip instantclient-sqlplus-linux.x64-12.2.0.1.0.zip
-
   aws s3 cp --region us-gov-west-1 s3://shared-s3/dsva-appeals/instantclient-sdk-linux.x64-12.2.0.1.0.zip instantclient-sdk-linux.x64-12.2.0.1.0.zip
 
 fi
 
-echo "  Checking if Instant Client has been downloaded"
+echo -e "\tChecking if Instant Client has been downloaded"
 if [ ! -f instantclient-basic-linux.x64-12.2.0.1.0.zip ] || [ ! -f instantclient-sqlplus-linux.x64-12.2.0.1.0.zip ] || [ ! -f instantclient-sdk-linux.x64-12.2.0.1.0.zip ]; then
 
-  echo "    Error: Couldn't download the files. Exiting"
+  echo -e "\t\tError: Couldn't download the files. Exiting"
   return 1
 
 fi
 
-echo "  Checking if Instant Client Folder has been unarchived"
+echo -e "\tChecking if Instant Client Folder has been unarchived"
 if [ ! -d instantclient_12_2 ]; then
   echo "    Unzipping Instant Client and SQLPlus"
   unzip instantclient-basic-linux.x64-12.2.0.1.0.zip
@@ -43,10 +41,13 @@ fi
 cd ../../
 printf "commit: `git rev-parse HEAD`\ndate: `git log -1 --format=%cd`" > config/build_version.yml
 
+credstash -t appeals-credstash get datadog.api.key > config/datadog.key
+
 # Build Docker
-echo "  Creating Caseflow App Docker Image"
+echo -e "\tCreating Caseflow App Docker Image"
 docker build -t caseflow .
 
-echo "  Cleaning Up..."
+echo -e "\tCleaning Up..."
+rm -rf config/datadog.key
 rm -rf docker-bin/oracle_libs/
-echo "  Building Caseflow Docker App: Completed"
+echo -e "\tBuilding Caseflow Docker App: Completed"

--- a/docker-bin/env.sh
+++ b/docker-bin/env.sh
@@ -6,6 +6,7 @@ export POSTGRES_HOST=appeals-db
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=postgres
 export RAILS_ENV=development
+export DEPLOY_ENV=demo
 export NLS_LANG=AMERICAN_AMERICA.US7ASCII
 export REDIS_URL_CACHE=redis://appeals-redis:6379/0/cache/
 export REDIS_URL_SIDEKIQ=redis://appeals-redis:6379

--- a/docker-bin/startup.sh
+++ b/docker-bin/startup.sh
@@ -5,6 +5,15 @@ THIS_SCRIPT_DIR=$(dirname $0)
 # Set variables for application
 source $THIS_SCRIPT_DIR/env.sh
 
+echo "Start DBus"
+dbus-daemon --system
+
+echo "Start Datadog"
+nohup /opt/datadog-agent/bin/agent/agent run -p /opt/datadog-agent/run/agent.pid > dd-agent.out &
+nohup /opt/datadog-agent/embedded/bin/trace-agent --config /etc/datadog-agent/datadog.yaml --pid /opt/datadog-agent/run/trace-agent.pid > dd-trace.out &
+nohup /opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid > dd-probe.out &
+nohup /opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml --sysprobe-config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/process-agent.pid > dd-system-probe.out &
+
 echo "Waiting for dependencies to properly start up - 90 seconds"
 sleep 90
 


### PR DESCRIPTION
### Description
On the appeals tech leads meeting we stated that it would be a good idea to have the demo environment to send traces to datadog apm.
Since this environment is being used more in some cases than UAT and Preprod this does that.

For that, I have modified the initializer of datadog in general to do all the traces accordingly and then installed and configured a few demo settings in the containers.

All of it is currently running in the demo environment at this time.

The config/initializer/datadog.rb is also needed for the uat and preprod environments accordingly 

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. Go to caseflowdemo.com and see its working as expected

### User Facing Changes
- none
 
### Code Documentation Updates
- none at this time

### Database Changes
- none