### PR TITLE
More aggressive caching of BGS POA

### DIFF
--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -8,10 +8,11 @@ class WarmBgsCachesJob < CaseflowJob
     RequestStore.store[:current_user] = User.system_user
     RequestStore.store[:application] = "hearings"
 
+    warm_poa_caches # run first since other warmers benefit from it being updated.
     warm_participant_caches
     warm_veteran_attribute_caches
     warm_people_caches
-    warm_poa_caches
+
     datadog_report_runtime(metric_group_name: "warm_bgs_caches_job")
   end
 

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -41,7 +41,7 @@ class WarmBgsCachesJob < CaseflowJob
   def warm_poa_for_oldest_cached_records
     start_time = Time.zone.now
     oldest_bgs_poa_records.limit(1000).each do |bgs_poa|
-      bgs_poa.update_cached_attributes! if bgs_poa.stale_attributes?
+      bgs_poa.save_with_updated_bgs_record! if bgs_poa.stale_attributes?
     end
     datadog_report_time_segment(segment: "warm_poa_bgs", start_time: start_time)
   end

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -20,7 +20,7 @@ class BgsPowerOfAttorney < CaseflowRecord
   delegate :email_address,
            to: :person, prefix: :representative
 
-  validates :claimant_participant_id, :poa_participant_id, :representative_name, :representative_type, presence: true
+  validates :claimant_participant_id, :poa_participant_id, :file_number, :representative_name, :representative_type, presence: true
 
   before_save :update_cached_attributes!
 

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -20,7 +20,11 @@ class BgsPowerOfAttorney < CaseflowRecord
   delegate :email_address,
            to: :person, prefix: :representative
 
-  validates :claimant_participant_id, :poa_participant_id, :file_number, :representative_name, :representative_type, presence: true
+  validates :claimant_participant_id,
+            :poa_participant_id,
+            :file_number,
+            :representative_name,
+            :representative_type, presence: true
 
   before_save :update_cached_attributes!
 

--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -58,7 +58,7 @@ class PowerOfAttorney
   private
 
   def bgs_power_of_attorney
-    @bgs_power_of_attorney ||= BgsPowerOfAttorney.find_or_load_by_file_number(file_number)
+    @bgs_power_of_attorney ||= BgsPowerOfAttorney.find_or_create_by_file_number(file_number)
   end
 
   class << self

--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -32,6 +32,12 @@ class PowerOfAttorney
            :participant_id,
            to: :bgs_power_of_attorney, prefix: :bgs
 
+  class << self
+    def repository
+      PowerOfAttorneyRepository
+    end
+  end
+
   def update_vacols_rep_info!(appeal:, representative_type:, representative_name:, address:)
     repo = self.class.repository
     vacols_code = repo.get_vacols_rep_code_from_poa(representative_type, representative_name)
@@ -58,14 +64,12 @@ class PowerOfAttorney
   private
 
   def bgs_power_of_attorney
-    @bgs_power_of_attorney ||= BgsPowerOfAttorney.find_or_create_by_file_number(file_number)
-  rescue ActiveRecord::RecordInvalid # not found at BGS
-    BgsPowerOfAttorney.new(file_number: file_number) # empty object to satisfy caller.
+    @bgs_power_of_attorney ||= fetch_bgs_power_of_attorney || BgsPowerOfAttorney.new(file_number: file_number)
   end
 
-  class << self
-    def repository
-      PowerOfAttorneyRepository
-    end
+  def fetch_bgs_power_of_attorney
+    BgsPowerOfAttorney.find_or_create_by_file_number(file_number)
+  rescue ActiveRecord::RecordInvalid # not found at BGS
+    nil
   end
 end

--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -59,6 +59,8 @@ class PowerOfAttorney
 
   def bgs_power_of_attorney
     @bgs_power_of_attorney ||= BgsPowerOfAttorney.find_or_create_by_file_number(file_number)
+  rescue ActiveRecord::RecordInvalid # not found at BGS
+    BgsPowerOfAttorney.new(file_number: file_number) # empty object to satisfy caller.
   end
 
   class << self


### PR DESCRIPTION
connects #13883 

### Description
Some BGS POA records were not being persisted correctly.

Fixes bug in `file_number` validation (some BGS responses do not include file_number).