### PR TITLE
Fix Encoding::CompatibilityError

### DIFF
--- a/app/models/concerns/asyncable.rb
+++ b/app/models/concerns/asyncable.rb
@@ -196,7 +196,7 @@ module Asyncable
 
   def sanitized_error
     # keep PII out of output
-    (self[self.class.error_column] || "none").gsub(/\s.+/s, "")
+    (self[self.class.error_column] || "none").gsub(/\s.+/m, "")
   end
 
   def expired_without_processing?


### PR DESCRIPTION
Fixes https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10035/

### Description
The //s flag means something different in Ruby than it does in Perl.

https://ruby-doc.org/core-2.2.0/Regexp.html#class-Regexp-label-Encoding