### PR TITLE
Allow judges to see the queues of their attorneys

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -149,7 +149,7 @@ class TasksController < ApplicationController
   def verify_view_access
     return true unless FeatureToggle.enabled?(:scm_view_judge_assign_queue)
 
-    return true if user == current_user
+    return true if user == current_user || Judge.new(current_user).attorneys.include?(user)
 
     if !SpecialCaseMovementTeam.singleton.user_has_access?(current_user)
       fail Caseflow::Error::ActionForbiddenError, message: "Only accessible by members of the Case Movement Team."


### PR DESCRIPTION
Fixes error returned when a judge tries to see at the queue of an attorney

BEFORE|AFTER
---|---
![Screen Shot 2020-04-28 at 2 39 25 PM](https://user-images.githubusercontent.com/45575454/80525203-da435b80-895e-11ea-9ab8-dcd928b8d55d.png)|![Screen Shot 2020-04-28 at 2 41 30 PM](https://user-images.githubusercontent.com/45575454/80525214-de6f7900-895e-11ea-9af0-c0ea9d95bfab.png)

To replicate, ensure :scm_view_judge_assign_queue feature is on. As a judge, go to your assign queue and click into an attorney's queue.
