### PR TITLE
AMA date tech debt bill came due

### DIFF
--- a/spec/decorators/appeal_status_api_decorator_spec.rb
+++ b/spec/decorators/appeal_status_api_decorator_spec.rb
@@ -129,7 +129,7 @@ describe AppealStatusApiDecorator, :all_dbs do
   end
 
   context "#events" do
-    let(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date + 1 }
+    let(:receipt_date) { ama_test_start_date + 1 }
     let!(:appeal) { create(:appeal, receipt_date: receipt_date) }
     let!(:decision_date) { receipt_date + 130.days }
     let!(:decision_document) { create(:decision_document, appeal: appeal, decision_date: decision_date) }

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -33,6 +33,7 @@ feature "Appeal Edit issues", :all_dbs do
   let!(:ratings_with_legacy_issues) do
     generate_rating_with_legacy_issues(veteran, receipt_date - 4.days, receipt_date - 4.days)
   end
+  let(:request_issue_decision_mdY) { rating_request_issue.decision_or_promulgation_date.mdY }
 
   let(:legacy_opt_in_approved) { false }
 
@@ -453,7 +454,7 @@ feature "Appeal Edit issues", :all_dbs do
       click_withdraw_intake_issue_dropdown("PTSD denied")
 
       expect(page).to have_content(
-        /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: 05\/10\/2019\nWithdrawal pending/i
+        /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: #{request_issue_decision_mdY}\nWithdrawal pending/i
       )
       expect(page).to have_content("Please include the date the withdrawal was requested")
 
@@ -493,7 +494,7 @@ feature "Appeal Edit issues", :all_dbs do
 
       expect(page).to_not have_content(/Requested issues\s*[0-9]+\. PTSD denied/i)
       expect(page).to have_content(
-        /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: 05\/10\/2019\nWithdrawal pending/i
+        /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: #{request_issue_decision_mdY}\nWithdrawal pending/i
       )
       expect(page).to have_content("Please include the date the withdrawal was requested")
 
@@ -512,7 +513,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit "appeals/#{appeal.uuid}/edit/"
 
       expect(page).to have_content(
-        /Withdrawn issues\s*[0-9]+\. PTSD denied\s*Decision date: 05\/10\/2019\s*Withdrawn on/i
+        /Withdrawn issues\s*[0-9]+\. PTSD denied\s*Decision date: #{request_issue_decision_mdY}\s*Withdrawn on/i
       )
     end
 
@@ -537,7 +538,7 @@ feature "Appeal Edit issues", :all_dbs do
       click_withdraw_intake_issue_dropdown("PTSD denied")
 
       expect(page).to have_content(
-        /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: 05\/10\/2019\nWithdrawal pending/i
+        /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: #{request_issue_decision_mdY}\nWithdrawal pending/i
       )
       expect(page).to have_content("Please include the date the withdrawal was requested")
 

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -1227,7 +1227,9 @@ feature "Higher Level Review Edit issues", :all_dbs do
 
         click_withdraw_intake_issue_dropdown("PTSD denied")
         expect(page).to_not have_content(/Requested issues\s*[0-9]+\. PTSD denied/i)
-        expect(page).to have_content(/[0-9]+\. PTSD denied\s*Decision date: #{request_issue_decision_mdY}\s*Withdrawal pending/i)
+        expect(page).to have_content(
+          /[0-9]+\. PTSD denied\s*Decision date: #{request_issue_decision_mdY}\s*Withdrawal pending/i
+        )
         expect(page).to have_content("Please include the date the withdrawal was requested")
 
         fill_in "withdraw-date", with: withdraw_date

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -28,6 +28,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
   let!(:ratings_with_legacy_issues) do
     generate_rating_with_legacy_issues(veteran, receipt_date - 4.days, receipt_date - 4.days)
   end
+  let(:request_issue_decision_mdY) { request_issue.decision_or_promulgation_date.mdY }
 
   let(:legacy_opt_in_approved) { false }
 
@@ -520,11 +521,13 @@ feature "Higher Level Review Edit issues", :all_dbs do
 
       click_intake_add_issue
       click_intake_no_matching_issues
+
       add_intake_nonrating_issue(
         category: "Drill Pay Adjustments",
         description: "A nonrating issue before AMA",
         date: pre_ama_start_date.to_date.mdY
       )
+      add_untimely_exemption_response("Yes")
 
       safe_click("#button-submit-update")
 
@@ -1224,7 +1227,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
 
         click_withdraw_intake_issue_dropdown("PTSD denied")
         expect(page).to_not have_content(/Requested issues\s*[0-9]+\. PTSD denied/i)
-        expect(page).to have_content(/[0-9]+\. PTSD denied\s*Decision date: 05\/09\/2019\s*Withdrawal pending/i)
+        expect(page).to have_content(/[0-9]+\. PTSD denied\s*Decision date: #{request_issue_decision_mdY}\s*Withdrawal pending/i)
         expect(page).to have_content("Please include the date the withdrawal was requested")
 
         fill_in "withdraw-date", with: withdraw_date
@@ -1272,7 +1275,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
 
         expect(page).to have_content(/Requested issues\s*[0-9]+\. Left knee granted/i)
         expect(page).to have_content(
-          /Withdrawn issues\s*[0-9]+\. PTSD denied\s*Decision date: 05\/09\/2019\s*Withdrawal pending/i
+          /Withdrawn issues\s*[0-9]+\. PTSD denied\s*Decision date: #{request_issue_decision_mdY}\s*Withdrawal pending/i
         )
         expect(page).to have_content("Please include the date the withdrawal was requested")
 
@@ -1294,7 +1297,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
         visit "higher_level_reviews/#{rating_ep_claim_id}/edit"
 
         expect(page).to have_content(
-          /Withdrawn issues\s*[0-9]+\. PTSD denied\s*Decision date: 05\/09\/2019\s*Withdrawn on/i
+          /Withdrawn issues\s*[0-9]+\. PTSD denied\s*Decision date: #{request_issue_decision_mdY}\s*Withdrawn on/i
         )
         expect(withdrawn_issue.closed_at).to eq(1.day.ago.to_date.to_datetime)
       end

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -27,6 +27,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
     generate_rating_with_legacy_issues(veteran, receipt_date - 4.days, receipt_date - 4.days)
   end
   let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran, receipt_date) }
+  let(:request_issue_decision_mdY) { request_issue.decision_or_promulgation_date.mdY }
   let(:old_rating_decision_text) { "Bone (Right arm broken) is denied." }
 
   let(:decision_review_remanded) { nil }
@@ -592,7 +593,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
         click_withdraw_intake_issue_dropdown("PTSD denied")
 
         expect(page).to_not have_content("Requested issues\n1. PTSD denied")
-        expect(page).to have_content("1. PTSD denied\nDecision date: 05/10/2019\nWithdrawal pending")
+        expect(page).to have_content("1. PTSD denied\nDecision date: #{request_issue_decision_mdY}\nWithdrawal pending")
         expect(page).to have_content("Please include the date the withdrawal was requested")
 
         fill_in "withdraw-date", with: withdraw_date
@@ -639,7 +640,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
 
         expect(page).to_not have_content("Requested issues\n1. PTSD denied")
         expect(page).to have_content(
-          /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: 05\/10\/2019\nWithdrawal pending/i
+          /Withdrawn issues\n[1-2]..PTSD denied\nDecision date: #{request_issue_decision_mdY}\nWithdrawal pending/i
         )
         expect(page).to have_content("Please include the date the withdrawal was requested")
 
@@ -662,7 +663,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
 
         expect(find("div", class: "issue-container", match: :first)).to have_content("Left knee granted")
         expect(find("div", class: "withdrawn-issue")).to have_content(
-          "PTSD denied\nDecision date: 05/10/2019\nWithdrawn on"
+          "PTSD denied\nDecision date: #{request_issue_decision_mdY}\nWithdrawn on"
         )
         expect(withdrawn_issue.closed_at).to eq(1.day.ago.to_date.to_datetime)
       end

--- a/spec/models/claim_review_spec.rb
+++ b/spec/models/claim_review_spec.rb
@@ -23,7 +23,7 @@ describe ClaimReview, :postgres do
     )
   end
 
-  let(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date + 1 }
+  let(:receipt_date) { ama_test_start_date + 1 }
   let(:informal_conference) { nil }
   let(:same_office) { nil }
   let(:benefit_type) { "compensation" }

--- a/spec/models/higher_level_review_spec.rb
+++ b/spec/models/higher_level_review_spec.rb
@@ -8,7 +8,7 @@ describe HigherLevelReview, :postgres do
   let(:veteran_file_number) { "64205555" }
   let(:ssn) { "64205555" }
   let!(:veteran) { Generators::Veteran.build(file_number: veteran_file_number, ssn: ssn) }
-  let(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date + 1 }
+  let(:receipt_date) { ama_test_start_date + 1 }
   let(:benefit_type) { "compensation" }
   let(:informal_conference) { nil }
   let(:same_office) { nil }
@@ -83,7 +83,7 @@ describe HigherLevelReview, :postgres do
         end
 
         context "when it is before AMA begin date" do
-          let(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date - 1 }
+          let(:receipt_date) { ama_test_start_date - 1 }
 
           it "adds an error to receipt_date" do
             is_expected.to be false

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -107,7 +107,7 @@ describe LegacyAppeal, :all_dbs do
 
   context "#eligible_for_opt_in? and #matchable_to_request_issue?" do
     let(:receipt_date) { Date.new(2020, 4, 10) }
-    let(:ama_date) { Constants::DATES["AMA_ACTIVATION"].to_date }
+    let(:ama_date) { ama_start_date }
     let(:ineligible_soc_date) { receipt_date - 60.days - 1.day }
     let(:ineligible_nod_date) { receipt_date - 372.days - 1.day }
     let(:eligible_soc_date) { receipt_date - 60.days + 1.day }
@@ -125,7 +125,7 @@ describe LegacyAppeal, :all_dbs do
       scenario "when the ssoc date is before AMA was launched" do
         allow(appeal).to receive(:active?).and_return(true)
         allow(appeal).to receive(:issues).and_return(issues)
-        allow(appeal).to receive(:soc_date).and_return(Constants::DATES["AMA_ACTIVATION"].to_date - 1.day)
+        allow(appeal).to receive(:soc_date).and_return(ama_start_date - 1.day)
 
         expect(appeal.eligible_for_opt_in?(receipt_date: receipt_date)).to eq(false)
         expect(appeal.eligible_for_opt_in?(receipt_date: receipt_date, covid_flag: true)).to eq(false)

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -1163,8 +1163,8 @@ describe RequestIssue, :all_dbs do
       )
       Generators::PromulgatedRating.build(
         participant_id: veteran.participant_id,
-        promulgation_date: Constants::DATES["AMA_ACTIVATION"].to_date - 5.days,
-        profile_date: Constants::DATES["AMA_ACTIVATION"].to_date - 10.days,
+        promulgation_date: ama_start_date - 5.days,
+        profile_date: ama_start_date - 10.days,
         issues: [
           { reference_id: "before_ama_ref_id", decision_text: "Non-RAMP Issue before AMA Activation" },
           { decision_text: "Issue before AMA Activation from RAMP",
@@ -1371,7 +1371,7 @@ describe RequestIssue, :all_dbs do
       end
 
       context "when legacy opt in is approved" do
-        let(:receipt_date) { Date.new(2020, 4, 10) }
+        let(:receipt_date) { Time.zone.today }
         let(:legacy_opt_in_approved) { true }
 
         context "when legacy issue is eligible" do
@@ -1433,11 +1433,11 @@ describe RequestIssue, :all_dbs do
     end
 
     context "Issues with decision dates before AMA" do
-      let(:receipt_date) { post_ama_start_date + 1.day }
-      let(:profile_date) { Constants::DATES["AMA_ACTIVATION"].to_date - 5.days }
+      let(:receipt_date) { ama_start_date + 5.days }
+      let(:profile_date) { ama_start_date - 5.days }
 
       it "flags nonrating issues before AMA" do
-        nonrating_request_issue.decision_date = Constants::DATES["AMA_ACTIVATION"].to_date - 5.days
+        nonrating_request_issue.decision_date = ama_start_date - 5.days
         nonrating_request_issue.validate_eligibility!
 
         expect(nonrating_request_issue.ineligible_reason).to eq("before_ama")
@@ -1459,7 +1459,7 @@ describe RequestIssue, :all_dbs do
         end
 
         it "does not apply before AMA checks" do
-          nonrating_request_issue.decision_date = Constants::DATES["AMA_ACTIVATION"].to_date - 5.days
+          nonrating_request_issue.decision_date = ama_start_date - 5.days
           nonrating_request_issue.validate_eligibility!
 
           expect(nonrating_request_issue.ineligible_reason).to_not eq("before_ama")

--- a/spec/models/supplemental_claim_spec.rb
+++ b/spec/models/supplemental_claim_spec.rb
@@ -99,7 +99,7 @@ describe SupplementalClaim, :postgres do
         end
 
         context "when it is before AMA begin date" do
-          let(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date - 1 }
+          let(:receipt_date) { ama_test_start_date - 1 }
 
           it "adds an error to receipt_date" do
             is_expected.to be false

--- a/spec/serializers/issue_serializer_spec.rb
+++ b/spec/serializers/issue_serializer_spec.rb
@@ -6,7 +6,7 @@ describe IssueSerializer, :all_dbs do
   end
 
   context "#appeal" do
-    let(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date + 1 }
+    let(:receipt_date) { ama_test_start_date + 1 }
 
     let(:request_issue1) do
       create(:request_issue,

--- a/spec/serializers/status_serializer_spec.rb
+++ b/spec/serializers/status_serializer_spec.rb
@@ -8,7 +8,7 @@ describe StatusSerializer, :all_dbs do
   context "#appeal" do
     let(:judge) { create(:user) }
     let!(:hearings_user) { create(:hearings_coordinator) }
-    let!(:receipt_date) { Constants::DATES["AMA_ACTIVATION_TEST"].to_date + 1 }
+    let!(:receipt_date) { ama_test_start_date + 1 }
     let(:appeal) { create(:appeal, receipt_date: receipt_date) }
     let!(:appeal_root_task) { create(:root_task, :in_progress, appeal: appeal) }
 

--- a/spec/support/date_time_helper.rb
+++ b/spec/support/date_time_helper.rb
@@ -2,7 +2,7 @@
 
 module DateTimeHelper
   def post_ama_start_date
-    ama_start_date + 100.days
+    Time.zone.today
   end
 
   def ama_start_date

--- a/spec/support/date_time_helper.rb
+++ b/spec/support/date_time_helper.rb
@@ -2,7 +2,7 @@
 
 module DateTimeHelper
   def post_ama_start_date
-    Time.zone.today
+    Time.zone.today.in_time_zone
   end
 
   def ama_start_date


### PR DESCRIPTION
Pre AMA day we used hardcoded "magic" dates to test before/after scenarios. Those magic dates are no longer magical a year+ later.

Redefine `post_ama_start_date` as `Time.zone.today` and fix test regressions.