### PR TITLE
LegacyHearing in ODS

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -156,6 +156,7 @@ detectors:
       - ClaimReviewAsyncStatsReporter#seconds_to_hms
       - ETL::Builder#last_built
       - ETL::HearingSyncer#filter?
+      - ETL::LegacyHearingSyncer#filter?
       - ETL::Syncer#filter?
       - ETL::TaskSyncer#filter?
       - Fakes::BGSService

--- a/app/models/concerns/has_virtual_hearing.rb
+++ b/app/models/concerns/has_virtual_hearing.rb
@@ -17,4 +17,10 @@ module HasVirtualHearing
   def was_virtual?
     !virtual_hearing.nil? && !virtual?
   end
+
+  def hearing_request_type
+    return "Virtual" if virtual?
+
+    readable_request_type
+  end
 end

--- a/app/models/etl/legacy_hearing.rb
+++ b/app/models/etl/legacy_hearing.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# transformed Hearing model, with associations "flattened" for reporting.
+
+class ETL::LegacyHearing < ETL::Hearing
+  class << self
+    def mirrored_hearing_attributes
+      super + [:vacols_id]
+    end
+
+    private
+
+    def merge_original_attributes_to_target(original, target)
+      super
+
+      target.judge_id = original.user_id
+      target.scheduled_time = original.scheduled_for
+
+      target
+    end
+  end
+end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -90,12 +90,6 @@ class Hearing < CaseflowRecord
     HEARING_TYPES[request_type.to_sym]
   end
 
-  def hearing_request_type
-    return "Virtual" if virtual?
-
-    readable_request_type
-  end
-
   def assigned_to_vso?(user)
     appeal.tasks.any? do |task|
       task.type == TrackVeteranTask.name &&

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -9,6 +9,7 @@ class ETL::Builder
     AttorneyCaseReview
     DecisionIssue
     Hearing
+    LegacyHearing
     Organization
     OrganizationsUser
     Person

--- a/app/services/etl/legacy_hearing_syncer.rb
+++ b/app/services/etl/legacy_hearing_syncer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ETL::LegacyHearingSyncer < ETL::Syncer
+  def origin_class
+    ::LegacyHearing
+  end
+
+  def target_class
+    ETL::LegacyHearing
+  end
+
+  def filter?(original)
+    original.appeal.blank?
+  end
+end

--- a/db/etl/migrate/20200430152234_add_hearing_type.rb
+++ b/db/etl/migrate/20200430152234_add_hearing_type.rb
@@ -1,0 +1,15 @@
+class AddHearingType < Caseflow::Migration
+  def change
+    add_column :hearings, :type, :string, comment: "Hearing (AMA) or LegacyHearing"
+    add_column :hearings, :vacols_id, :string, comment: "When type=LegacyHearing, this column points at the VACOLS case id"
+    add_column :hearings, :judge_css_id, :string, comment: "users.css_id"
+    add_column :hearings, :judge_full_name, :string, comment: "users.full_name"
+    add_column :hearings, :judge_sattyid, :string, comment: "users.sattyid"
+
+    change_column_null :hearings, :uuid, true
+
+    add_safe_index :hearings, :type
+    add_safe_index :hearings, :vacols_id
+    add_safe_index :hearings, :judge_id
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_29_164923) do
+ActiveRecord::Schema.define(version: 2020_04_30_152234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -231,7 +231,10 @@ ActiveRecord::Schema.define(version: 2020_04_29_164923) do
     t.string "hearing_location_zip_code", comment: "hearing_locations.zip_code"
     t.string "hearing_request_type", null: false, comment: "Calculated based on virtual_hearings and hearing_day.request_type"
     t.datetime "hearing_updated_at", comment: "hearings.updated_at"
+    t.string "judge_css_id", comment: "users.css_id"
+    t.string "judge_full_name", comment: "users.full_name"
     t.integer "judge_id", comment: "hearings.judge_id"
+    t.string "judge_sattyid", comment: "users.sattyid"
     t.string "military_service", comment: "hearings.military_service"
     t.string "notes", comment: "hearings.notes"
     t.boolean "prepped", comment: "hearings.prepped"
@@ -241,12 +244,14 @@ ActiveRecord::Schema.define(version: 2020_04_29_164923) do
     t.text "summary", comment: "hearings.summary"
     t.boolean "transcript_requested", comment: "hearings.transcript_requested"
     t.date "transcript_sent_date", comment: "hearings.transcript_sent_date"
+    t.string "type", comment: "Hearing (AMA) or LegacyHearing"
     t.datetime "updated_at", null: false, comment: "Default created_at/updated_at for the ETL record"
     t.bigint "updated_by_id", comment: "The ID of the user who most recently updated the Hearing"
     t.string "updated_by_user_css_id", limit: 20, comment: "users.css_id"
     t.string "updated_by_user_full_name", limit: 255, comment: "users.full_name"
     t.string "updated_by_user_sattyid", limit: 20, comment: "users.sattyid"
-    t.uuid "uuid", null: false, comment: "Unique identifier for the Hearing"
+    t.uuid "uuid", comment: "Unique identifier for the Hearing"
+    t.string "vacols_id", comment: "When type=LegacyHearing, this column points at the VACOLS case id"
     t.string "witness", comment: "hearings.witness"
     t.index ["appeal_id"], name: "index_hearings_on_appeal_id"
     t.index ["created_at"], name: "index_hearings_on_created_at"
@@ -261,8 +266,11 @@ ActiveRecord::Schema.define(version: 2020_04_29_164923) do
     t.index ["hearing_location_updated_at"], name: "index_hearings_on_hearing_location_updated_at"
     t.index ["hearing_request_type"], name: "index_hearings_on_hearing_request_type"
     t.index ["hearing_updated_at"], name: "index_hearings_on_hearing_updated_at"
+    t.index ["judge_id"], name: "index_hearings_on_judge_id"
+    t.index ["type"], name: "index_hearings_on_type"
     t.index ["updated_at"], name: "index_hearings_on_updated_at"
     t.index ["uuid"], name: "index_hearings_on_uuid"
+    t.index ["vacols_id"], name: "index_hearings_on_vacols_id"
   end
 
   create_table "organizations", comment: "Copy of Organizations table", force: :cascade do |t|

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -155,7 +155,10 @@ hearings,hearing_location_zip_code,string,,,,,,hearing_locations.zip_code
 hearings,hearing_request_type,string ∗,x,,,,x,Calculated based on virtual_hearings and hearing_day.request_type
 hearings,hearing_updated_at,datetime,,,,,x,hearings.updated_at
 hearings,id,integer (8) PK,x,x,,,,
-hearings,judge_id,integer,,,,,,hearings.judge_id
+hearings,judge_css_id,string,,,,,,users.css_id
+hearings,judge_full_name,string,,,,,,users.full_name
+hearings,judge_id,integer,,,,,x,hearings.judge_id
+hearings,judge_sattyid,string,,,,,,users.sattyid
 hearings,military_service,string,,,,,,hearings.military_service
 hearings,notes,string,,,,,,hearings.notes
 hearings,prepped,boolean,,,,,,hearings.prepped
@@ -165,12 +168,14 @@ hearings,scheduled_time,time ∗,x,,,,,hearings.scheduled_time
 hearings,summary,text,,,,,,hearings.summary
 hearings,transcript_requested,boolean,,,,,,hearings.transcript_requested
 hearings,transcript_sent_date,date,,,,,,hearings.transcript_sent_date
+hearings,type,string,,,,,x,Hearing (AMA) or LegacyHearing
 hearings,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 hearings,updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing
 hearings,updated_by_user_css_id,string (20),,,,,,users.css_id
 hearings,updated_by_user_full_name,string (255),,,,,,users.full_name
 hearings,updated_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,uuid,uuid ∗,x,,,,x,Unique identifier for the Hearing
+hearings,uuid,uuid,,,,,x,Unique identifier for the Hearing
+hearings,vacols_id,string,,,,,x,"When type=LegacyHearing, this column points at the VACOLS case id"
 hearings,witness,string,,,,,,hearings.witness
 organizations,,,,,,,,Copy of Organizations table
 organizations,created_at,datetime,,,,,x,

--- a/spec/services/etl/legacy_hearing_syncer_spec.rb
+++ b/spec/services/etl/legacy_hearing_syncer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe ETL::LegacyHearingSyncer, :etl, :all_dbs do
+  let(:etl_build) { ETL::Build.create }
+  let(:regional_office) { "RO89" }
+  let!(:virtual_hearing) { create(:virtual_hearing, hearing: video_hearing) }
+  let(:video_hearing) do
+    create(:legacy_hearing, hearing_day: hearing_day, regional_office: regional_office)
+  end
+  let(:hearing_day) do
+    create(
+      :hearing_day,
+      scheduled_for: scheduled_for,
+      regional_office: regional_office,
+      request_type: HearingDay::REQUEST_TYPES[:video]
+    )
+  end
+  let!(:regional_hearing) do
+    create(:legacy_hearing, hearing_day: hearing_day)
+  end
+  let(:scheduled_for) do
+    Time.use_zone("America/New_York") { Time.zone.local(2018, 1, 1, 0, 0, 0) }
+  end
+
+  describe "#call" do
+    subject { described_class.new(etl_build: etl_build).call }
+
+    context "virtual hearing" do
+      it "syncs" do
+        subject
+
+        expect(LegacyHearing.count).to eq(2)
+        expect(ETL::LegacyHearing.count).to eq(2)
+        etl_virtual_hearing = ETL::LegacyHearing.find_by(hearing_id: virtual_hearing.hearing_id)
+        etl_regional_hearing = ETL::LegacyHearing.find_by(hearing_id: regional_hearing.id)
+        expect(etl_virtual_hearing.hearing_request_type).to eq "Virtual"
+        expect(etl_virtual_hearing.hearing_location_zip_code).to eq "20001"
+        expect(etl_regional_hearing.hearing_request_type).to eq "Video"
+        expect(etl_regional_hearing.hearing_location_zip_code).to be_nil
+      end
+    end
+
+    context "orphaned Hearing" do
+      let!(:orphaned_hearing) { create(:legacy_hearing) }
+      let(:etl_build_table) { ETL::BuildTable.where(table_name: "hearings").last }
+
+      before do
+        orphaned_hearing.appeal.delete # not destroy, to avoid callbacks
+      end
+
+      it "skips orphans" do
+        subject
+
+        expect(LegacyHearing.count).to eq(3)
+        expect(ETL::LegacyHearing.count).to eq(2)
+        expect(etl_build_table).to be_complete
+        expect(etl_build_table.rows_rejected).to eq(1)
+        expect(etl_build_table.rows_inserted).to eq(2)
+        expect(etl_build_table.rows_updated).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description
Adds `legacy_hearings` data to the ETL/ODS `hearings` table using single-table-inheritance Active Record pattern.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [ ] #appeals-schema notified with summary and link to this PR
