### PR TITLE
set current_user on CreateConferenceJob perform

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -38,6 +38,8 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
   end
 
   def perform(hearing_id:, hearing_type:, email_type: :confirmation)
+    RequestStore.store[:current_user] = User.system_user
+
     set_virtual_hearing(hearing_id, hearing_type)
 
     virtual_hearing.establishment.attempted!

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -38,7 +38,7 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
   end
 
   def perform(hearing_id:, hearing_type:, email_type: :confirmation)
-    RequestStore.store[:current_user] ||= User.system_user
+    ensure_current_user_is_set
 
     set_virtual_hearing(hearing_id, hearing_type)
 
@@ -70,6 +70,10 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
     else
       fail ArgumentError, "Invalid hearing type supplied to job: `#{hearing_type}`"
     end
+  end
+
+  def ensure_current_user_is_set
+    RequestStore.store[:current_user] ||= User.system_user
   end
 
   def create_conference

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -38,7 +38,7 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
   end
 
   def perform(hearing_id:, hearing_type:, email_type: :confirmation)
-    RequestStore.store[:current_user] = User.system_user
+    RequestStore.store[:current_user] ||= User.system_user
 
     set_virtual_hearing(hearing_id, hearing_type)
 

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -123,11 +123,13 @@ class VirtualHearing < CaseflowRecord
   end
 
   def assign_created_by_user
-    self.created_by ||= RequestStore[:current_user]
+    self.created_by ||= RequestStore.store[:current_user]
   end
 
   def assign_updated_by_user
-    self.updated_by = RequestStore[:current_user] if RequestStore[:current_user].present?
+    return if RequestStore.store[:current_user] == User.system_user && updated_by.present?
+
+    self.updated_by = RequestStore.store[:current_user] if RequestStore.store[:current_user].present?
   end
 
   def associated_hearing_is_video


### PR DESCRIPTION
Connects #14144

### Description
Sets `RequestStore.store[:current_user]` before performing the `VirtualHearings::CreateConferenceJob` to prevent the job from failing due to a `NoMethodError (undefined method 'station_id' for nil:NilClass)`