### PR TITLE
Wait 4 min for FACOLS to start

### DIFF
--- a/docker-bin/startup.sh
+++ b/docker-bin/startup.sh
@@ -14,9 +14,9 @@ nohup /opt/datadog-agent/embedded/bin/trace-agent --config /etc/datadog-agent/da
 nohup /opt/datadog-agent/embedded/bin/system-probe --config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/system-probe.pid > dd-probe.out &
 nohup /opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml --sysprobe-config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/process-agent.pid > dd-system-probe.out &
 
-echo "Waiting for dependencies to properly start up - 120 seconds"
+echo "Waiting for dependencies to properly start up - 240 seconds"
 date
-sleep 120
+sleep 240
 
 echo "Starting Appeals App"
 date


### PR DESCRIPTION
On average Facols takes 3.5 min to properly startup.

![image](https://user-images.githubusercontent.com/3811786/80804284-b1031500-8b82-11ea-9b44-8e60808e0476.png)

Previously `rake local:vacols:wait_for_connection` would ping Facols until it is ready and Facols would keep responding with `ORACLE initialization or shutdown in progress`. Example,
![image](https://user-images.githubusercontent.com/3811786/80804374-eb6cb200-8b82-11ea-98fb-dc474d527791.png)

Now after the first ping, our Ruby library throws an error message:
```
OCIError: ORA-01033: ORACLE initialization or shutdown in progress
oci8.c:603:in oci8lib_250.so
/usr/local/bundle/gems/ruby-oci8-2.2.7/lib/oci8/oci8.rb:147:in `initialize'
/usr/local/bundle/gems/activerecord-oracle_enhanced-adapter-5.2.8/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb:326:in `new'
```

Let's wait 4 min before calling `rake local:vacols:wait_for_connection` 
 
 
