### PR TITLE
Change max length for some ETL models, fix association definitions

### DIFF
--- a/app/models/etl/hearing.rb
+++ b/app/models/etl/hearing.rb
@@ -3,7 +3,7 @@
 # transformed Hearing model, with associations "flattened" for reporting.
 
 class ETL::Hearing < ETL::Record
-  belongs_to :appeal, foreign_key: :appeal_id, foreign_type: "ETL::Appeal"
+  belongs_to :appeal, primary_key: :appeal_id, foreign_key: :appeal_id, class_name: "ETL::Appeal"
 
   class << self
     def origin_primary_key

--- a/app/models/etl/task.rb
+++ b/app/models/etl/task.rb
@@ -3,7 +3,7 @@
 # transformed Task model, with denormalized User/Org attributes
 
 class ETL::Task < ETL::Record
-  belongs_to :appeal, foreign_key: :appeal_id, foreign_type: "ETL::Appeal"
+  belongs_to :appeal, primary_key: :appeal_id, foreign_key: :appeal_id, class_name: "ETL::Appeal"
 
   class << self
     def origin_primary_key

--- a/db/etl/migrate/20200504133723_change_css_limit.rb
+++ b/db/etl/migrate/20200504133723_change_css_limit.rb
@@ -1,0 +1,33 @@
+class ChangeCssLimit < ActiveRecord::Migration[5.2]
+  def up
+    safety_assured do
+      change_column :appeals, :claimant_participant_id, :string, limit: 50
+      change_column :attorney_case_reviews, :attorney_css_id, :string, limit: 50
+      change_column :attorney_case_reviews, :reviewing_judge_css_id, :string, limit: 50
+      change_column :hearings, :created_by_user_css_id, :string, limit: 50
+      change_column :hearings, :hearing_day_created_by_user_css_id, :string, limit: 50
+      change_column :hearings, :hearing_day_updated_by_user_css_id, :string, limit: 50
+      change_column :hearings, :updated_by_user_css_id, :string, limit: 50
+      change_column :people, :participant_id, :string, limit: 50
+      change_column :tasks, :assigned_by_user_css_id, :string, limit: 50
+      change_column :tasks, :assigned_to_user_css_id, :string, limit: 50
+      change_column :users, :css_id, :string, limit: 50
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column :appeals, :claimant_participant_id, :string, limit: 20
+      change_column :attorney_case_reviews, :attorney_css_id, :string, limit: 20
+      change_column :attorney_case_reviews, :reviewing_judge_css_id, :string, limit: 20
+      change_column :hearings, :created_by_user_css_id, :string, limit: 20
+      change_column :hearings, :hearing_day_created_by_user_css_id, :string, limit: 20
+      change_column :hearings, :hearing_day_updated_by_user_css_id, :string, limit: 20
+      change_column :hearings, :updated_by_user_css_id, :string, limit: 20
+      change_column :people, :participant_id, :string, limit: 20
+      change_column :tasks, :assigned_by_user_css_id, :string, limit: 20
+      change_column :tasks, :assigned_to_user_css_id, :string, limit: 20
+      change_column :users, :css_id, :string, limit: 20
+    end
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_211351) do
+ActiveRecord::Schema.define(version: 2020_05_04_133723) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,7 +30,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.string "claimant_last_name", comment: "people.last_name"
     t.string "claimant_middle_name", comment: "people.middle_name"
     t.string "claimant_name_suffix", comment: "people.name_suffix"
-    t.string "claimant_participant_id", limit: 20, comment: "claimants.participant_id"
+    t.string "claimant_participant_id", limit: 50, comment: "claimants.participant_id"
     t.string "claimant_payee_code", limit: 20, comment: "claimants.payee_code"
     t.bigint "claimant_person_id", comment: "people.id"
     t.string "closest_regional_office", limit: 20, comment: "The code for the regional office closest to the Veteran on the appeal."
@@ -84,7 +84,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
   create_table "attorney_case_reviews", comment: "Denormalized attorney_case_reviews", force: :cascade do |t|
     t.bigint "appeal_id", null: false, comment: "tasks.appeal_id"
     t.string "appeal_type", null: false, comment: "tasks.appeal_type"
-    t.string "attorney_css_id", limit: 20, null: false, comment: "users.css_id"
+    t.string "attorney_css_id", limit: 50, null: false, comment: "users.css_id"
     t.string "attorney_full_name", limit: 255, null: false, comment: "users.full_name"
     t.bigint "attorney_id", null: false, comment: "attorney_case_reviews.attorney_id"
     t.string "attorney_sattyid", limit: 20, comment: "users.sattyid"
@@ -96,7 +96,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.datetime "review_created_at", null: false, comment: "attorney_case_reviews.created_at"
     t.bigint "review_id", null: false, comment: "attorney_case_reviews.id"
     t.datetime "review_updated_at", null: false, comment: "attorney_case_reviews.updated_at"
-    t.string "reviewing_judge_css_id", limit: 20, null: false, comment: "users.css_id"
+    t.string "reviewing_judge_css_id", limit: 50, null: false, comment: "users.css_id"
     t.string "reviewing_judge_full_name", limit: 255, null: false, comment: "users.full_name"
     t.bigint "reviewing_judge_id", null: false, comment: "attorney_case_reviews.reviewing_judge_id"
     t.string "reviewing_judge_sattyid", limit: 20, comment: "users.sattyid"
@@ -190,7 +190,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.string "bva_poc", comment: "hearings.bva_poc"
     t.datetime "created_at", null: false, comment: "Default created_at/updated_at for the ETL record"
     t.bigint "created_by_id", comment: "The ID of the user who created the Hearing"
-    t.string "created_by_user_css_id", limit: 20, comment: "users.css_id"
+    t.string "created_by_user_css_id", limit: 50, comment: "users.css_id"
     t.string "created_by_user_full_name", limit: 255, comment: "users.full_name"
     t.string "created_by_user_sattyid", limit: 20, comment: "users.sattyid"
     t.string "disposition", comment: "hearings.disposition"
@@ -199,7 +199,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.string "hearing_day_bva_poc", comment: "hearing_days.bva_poc"
     t.datetime "hearing_day_created_at", null: false, comment: "hearing_days.created_at"
     t.bigint "hearing_day_created_by_id", null: false, comment: "The ID of the user who created the Hearing Day"
-    t.string "hearing_day_created_by_user_css_id", limit: 20, comment: "users.css_id"
+    t.string "hearing_day_created_by_user_css_id", limit: 50, comment: "users.css_id"
     t.string "hearing_day_created_by_user_full_name", limit: 255, comment: "users.full_name"
     t.string "hearing_day_created_by_user_sattyid", limit: 20, comment: "users.sattyid"
     t.datetime "hearing_day_deleted_at", comment: "hearing_days.deleted_at"
@@ -213,7 +213,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.date "hearing_day_scheduled_for", null: false, comment: "hearing_days.scheduled_for"
     t.datetime "hearing_day_updated_at", null: false, comment: "hearing_days.updated_at"
     t.bigint "hearing_day_updated_by_id", null: false, comment: "The ID of the user who most recently updated the Hearing Day"
-    t.string "hearing_day_updated_by_user_css_id", limit: 20, comment: "users.css_id"
+    t.string "hearing_day_updated_by_user_css_id", limit: 50, comment: "users.css_id"
     t.string "hearing_day_updated_by_user_full_name", limit: 255, comment: "users.full_name"
     t.string "hearing_day_updated_by_user_sattyid", limit: 20, comment: "users.sattyid"
     t.bigint "hearing_id", null: false, comment: "ID of the Hearing"
@@ -247,7 +247,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.string "type", comment: "Hearing (AMA) or LegacyHearing"
     t.datetime "updated_at", null: false, comment: "Default created_at/updated_at for the ETL record"
     t.bigint "updated_by_id", comment: "The ID of the user who most recently updated the Hearing"
-    t.string "updated_by_user_css_id", limit: 20, comment: "users.css_id"
+    t.string "updated_by_user_css_id", limit: 50, comment: "users.css_id"
     t.string "updated_by_user_full_name", limit: 255, comment: "users.full_name"
     t.string "updated_by_user_sattyid", limit: 20, comment: "users.sattyid"
     t.uuid "uuid", comment: "Unique identifier for the Hearing"
@@ -309,7 +309,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.string "last_name", limit: 50, comment: "Person last name, cached from BGS"
     t.string "middle_name", limit: 50, comment: "Person middle name, cached from BGS"
     t.string "name_suffix", limit: 20, comment: "Person name suffix, cached from BGS"
-    t.string "participant_id", limit: 20, null: false
+    t.string "participant_id", limit: 50, null: false
     t.datetime "updated_at", null: false
     t.index ["created_at"], name: "index_people_on_created_at"
     t.index ["participant_id"], name: "index_people_on_participant_id"
@@ -321,14 +321,14 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
     t.string "appeal_type", null: false, comment: "tasks.appeal_type"
     t.datetime "assigned_at", comment: "tasks.assigned_at"
     t.bigint "assigned_by_id", comment: "tasks.assigned_by_id"
-    t.string "assigned_by_user_css_id", limit: 20, comment: "users.css_id"
+    t.string "assigned_by_user_css_id", limit: 50, comment: "users.css_id"
     t.string "assigned_by_user_full_name", limit: 255, comment: "users.full_name"
     t.string "assigned_by_user_sattyid", limit: 20, comment: "users.sattyid"
     t.bigint "assigned_to_id", null: false, comment: "tasks.assigned_to_id"
     t.string "assigned_to_org_name", limit: 255, comment: "organizations.name"
     t.string "assigned_to_org_type", limit: 50, comment: "organizations.type"
     t.string "assigned_to_type", null: false, comment: "tasks.assigned_to_type"
-    t.string "assigned_to_user_css_id", limit: 20, comment: "users.css_id"
+    t.string "assigned_to_user_css_id", limit: 50, comment: "users.css_id"
     t.string "assigned_to_user_full_name", limit: 255, comment: "users.full_name"
     t.string "assigned_to_user_sattyid", limit: 20, comment: "users.sattyid"
     t.datetime "closed_at", comment: "tasks.closed_at"
@@ -355,7 +355,7 @@ ActiveRecord::Schema.define(version: 2020_05_01_211351) do
 
   create_table "users", comment: "Combined Caseflow/VACOLS user lookups", force: :cascade do |t|
     t.datetime "created_at", null: false, comment: "Default created_at/updated_at for the ETL record"
-    t.string "css_id", limit: 20, null: false, comment: "CSEM (Active Directory) username"
+    t.string "css_id", limit: 50, null: false, comment: "CSEM (Active Directory) username"
     t.string "email", limit: 255, comment: "CSEM email"
     t.string "full_name", limit: 255, comment: "CSEM full name"
     t.datetime "last_login_at"

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -14,7 +14,7 @@ appeals,claimant_id,integer (8),,,,,x,claimants.id
 appeals,claimant_last_name,string,,,,,,people.last_name
 appeals,claimant_middle_name,string,,,,,,people.middle_name
 appeals,claimant_name_suffix,string,,,,,,people.name_suffix
-appeals,claimant_participant_id,string (20),,,,,x,claimants.participant_id
+appeals,claimant_participant_id,string (50),,,,,x,claimants.participant_id
 appeals,claimant_payee_code,string (20),,,,,,claimants.payee_code
 appeals,claimant_person_id,integer (8),,,,,x,people.id
 appeals,closest_regional_office,string (20),,,,,,The code for the regional office closest to the Veteran on the appeal.
@@ -44,7 +44,7 @@ appeals,veteran_participant_id,string (20),,,,,x,veterans.participant_id
 attorney_case_reviews,,,,,,,,Denormalized attorney_case_reviews
 attorney_case_reviews,appeal_id,integer (8) ∗,x,,,,x,tasks.appeal_id
 attorney_case_reviews,appeal_type,string ∗,x,,,,x,tasks.appeal_type
-attorney_case_reviews,attorney_css_id,string (20) ∗,x,,,,,users.css_id
+attorney_case_reviews,attorney_css_id,string (50) ∗,x,,,,,users.css_id
 attorney_case_reviews,attorney_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,attorney_id,integer (8) ∗,x,,,,x,attorney_case_reviews.attorney_id
 attorney_case_reviews,attorney_sattyid,string (20),,,,,,users.sattyid
@@ -57,7 +57,7 @@ attorney_case_reviews,overtime,boolean,,,,,,attorney_case_reviews.overtime
 attorney_case_reviews,review_created_at,datetime ∗,x,,,,x,attorney_case_reviews.created_at
 attorney_case_reviews,review_id,integer (8) ∗,x,,,,x,attorney_case_reviews.id
 attorney_case_reviews,review_updated_at,datetime ∗,x,,,,x,attorney_case_reviews.updated_at
-attorney_case_reviews,reviewing_judge_css_id,string (20) ∗,x,,,,,users.css_id
+attorney_case_reviews,reviewing_judge_css_id,string (50) ∗,x,,,,,users.css_id
 attorney_case_reviews,reviewing_judge_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,reviewing_judge_id,integer (8) ∗,x,,,,x,attorney_case_reviews.reviewing_judge_id
 attorney_case_reviews,reviewing_judge_sattyid,string (20),,,,,,users.sattyid
@@ -113,7 +113,7 @@ hearings,appeal_id,integer ∗,x,,,,x,ID of the associated Appeal
 hearings,bva_poc,string,,,,,,hearings.bva_poc
 hearings,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 hearings,created_by_id,integer (8),,,,,,The ID of the user who created the Hearing
-hearings,created_by_user_css_id,string (20),,,,,,users.css_id
+hearings,created_by_user_css_id,string (50),,,,,,users.css_id
 hearings,created_by_user_full_name,string (255),,,,,,users.full_name
 hearings,created_by_user_sattyid,string (20),,,,,,users.sattyid
 hearings,disposition,string,,,,,,hearings.disposition
@@ -122,7 +122,7 @@ hearings,hearing_created_at,datetime,,,,,x,hearings.created_at
 hearings,hearing_day_bva_poc,string,,,,,,hearing_days.bva_poc
 hearings,hearing_day_created_at,datetime ∗,x,,,,x,hearing_days.created_at
 hearings,hearing_day_created_by_id,integer (8) ∗,x,,,,,The ID of the user who created the Hearing Day
-hearings,hearing_day_created_by_user_css_id,string (20),,,,,,users.css_id
+hearings,hearing_day_created_by_user_css_id,string (50),,,,,,users.css_id
 hearings,hearing_day_created_by_user_full_name,string (255),,,,,,users.full_name
 hearings,hearing_day_created_by_user_sattyid,string (20),,,,,,users.sattyid
 hearings,hearing_day_deleted_at,datetime,,,,,x,hearing_days.deleted_at
@@ -136,7 +136,7 @@ hearings,hearing_day_room,string,,,,,,The room at BVA where the hearing will tak
 hearings,hearing_day_scheduled_for,date ∗,x,,,,,hearing_days.scheduled_for
 hearings,hearing_day_updated_at,datetime ∗,x,,,,x,hearing_days.updated_at
 hearings,hearing_day_updated_by_id,integer (8) ∗,x,,,,,The ID of the user who most recently updated the Hearing Day
-hearings,hearing_day_updated_by_user_css_id,string (20),,,,,,users.css_id
+hearings,hearing_day_updated_by_user_css_id,string (50),,,,,,users.css_id
 hearings,hearing_day_updated_by_user_full_name,string (255),,,,,,users.full_name
 hearings,hearing_day_updated_by_user_sattyid,string (20),,,,,,users.sattyid
 hearings,hearing_id,integer (8) ∗,x,,,,x,ID of the Hearing
@@ -171,7 +171,7 @@ hearings,transcript_sent_date,date,,,,,,hearings.transcript_sent_date
 hearings,type,string,,,,,x,Hearing (AMA) or LegacyHearing
 hearings,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 hearings,updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing
-hearings,updated_by_user_css_id,string (20),,,,,,users.css_id
+hearings,updated_by_user_css_id,string (50),,,,,,users.css_id
 hearings,updated_by_user_full_name,string (255),,,,,,users.full_name
 hearings,updated_by_user_sattyid,string (20),,,,,,users.sattyid
 hearings,uuid,uuid,,,,,x,Unique identifier for the Hearing
@@ -204,21 +204,21 @@ people,id,integer (8) PK,x,x,,,,
 people,last_name,string (50),,,,,,"Person last name, cached from BGS"
 people,middle_name,string (50),,,,,,"Person middle name, cached from BGS"
 people,name_suffix,string (20),,,,,,"Person name suffix, cached from BGS"
-people,participant_id,string (20) ∗,x,,,,x,
+people,participant_id,string (50) ∗,x,,,,x,
 people,updated_at,datetime ∗,x,,,,x,
 tasks,,,,,,,,Denormalized Tasks with User/Organization
 tasks,appeal_id,integer (8) ∗ FK,x,,x,,x,tasks.appeal_id
 tasks,appeal_type,string ∗,x,,,,x,tasks.appeal_type
 tasks,assigned_at,datetime,,,,,,tasks.assigned_at
 tasks,assigned_by_id,integer (8),,,,,,tasks.assigned_by_id
-tasks,assigned_by_user_css_id,string (20),,,,,,users.css_id
+tasks,assigned_by_user_css_id,string (50),,,,,,users.css_id
 tasks,assigned_by_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_by_user_sattyid,string (20),,,,,,users.sattyid
 tasks,assigned_to_id,integer (8) ∗,x,,,,x,tasks.assigned_to_id
 tasks,assigned_to_org_name,string (255),,,,,,organizations.name
 tasks,assigned_to_org_type,string (50),,,,,,organizations.type
 tasks,assigned_to_type,string ∗,x,,,,x,tasks.assigned_to_type
-tasks,assigned_to_user_css_id,string (20),,,,,,users.css_id
+tasks,assigned_to_user_css_id,string (50),,,,,,users.css_id
 tasks,assigned_to_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_to_user_sattyid,string (20),,,,,,users.sattyid
 tasks,closed_at,datetime,,,,,,tasks.closed_at
@@ -236,7 +236,7 @@ tasks,task_updated_at,datetime,,,,,,tasks.updated_at
 tasks,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,,,,,,,,Combined Caseflow/VACOLS user lookups
 users,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-users,css_id,string (20) ∗,x,,,,,CSEM (Active Directory) username
+users,css_id,string (50) ∗,x,,,,,CSEM (Active Directory) username
 users,email,string (255),,,,,,CSEM email
 users,full_name,string (255),,,,,,CSEM full name
 users,id,integer (8) PK,x,x,,,,


### PR DESCRIPTION
### Description
Some local development strings are longer than 20 characters. Since postgresql does not actually optimize anything for varchar length, make these field limits longer to allow.

Also fixes a couple relationship definitions per #14139 

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [ ] #appeals-schema notified with summary and link to this PR
