### PR TITLE
Change VACOLS user role cache time from 24hrs to 1hr

### DIFF
--- a/app/repositories/user_repository.rb
+++ b/app/repositories/user_repository.rb
@@ -66,8 +66,8 @@ class UserRepository
     private
 
     def cached_staff_record(css_id)
-      # Staff records rarely get updated so caching in Redis for 24 hours
-      Rails.cache.fetch("#{Rails.env}_staff_record_#{css_id}") do
+      # User role updates often happen in the morning, so 24 hours is probably too long.
+      Rails.cache.fetch("#{Rails.env}_staff_record_#{css_id}", expires_in: 1.hour) do
         VACOLS::Staff.find_by_sdomainid(css_id)
       end
     end

--- a/app/repositories/user_repository.rb
+++ b/app/repositories/user_repository.rb
@@ -66,7 +66,7 @@ class UserRepository
     private
 
     def cached_staff_record(css_id)
-      # User role updates often happen in the morning, so 24 hours is probably too long.
+      # Cache long enough to improve performance, but not so long that VACOLS drifts out of sync
       Rails.cache.fetch("#{Rails.env}_staff_record_#{css_id}", expires_in: 1.hour) do
         VACOLS::Staff.find_by_sdomainid(css_id)
       end


### PR DESCRIPTION
Users normally reach out to Jed in the morning to update their roles, so if they fall on the wrong side of a 24-hour cache window this could mean not being able to work for a whole day.

Via a [Slack thread](https://dsva.slack.com/archives/CHX8FMP28/p1588608843095800) where engineering agreed that 1 hour would be enough.