### PR TITLE
Move nil check in CreateConferenceJob

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -101,8 +101,8 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
       fail ArgumentError, "Invalid hearing type supplied to job: `#{hearing_type}`"
     end
 
-    fail VirtualHearingRequestCancelled if virtual_hearing.cancelled?
     fail VirtualHearingNotCreatedError if virtual_hearing.nil?
+    fail VirtualHearingRequestCancelled if virtual_hearing.cancelled?
   end
 
   def log_virtual_hearing_state


### PR DESCRIPTION
Resolves Sentry Alert: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10131/?referrer=webhooks_plugin

### Description

Move `nil?` check before `cancelled?` check