### PR TITLE
Fix Cannot read property 'value' of null

### DIFF
--- a/client/app/queue/colocatedTasks/AddColocatedTaskForm.jsx
+++ b/client/app/queue/colocatedTasks/AddColocatedTaskForm.jsx
@@ -32,7 +32,7 @@ export const AddColocatedTaskForm = ({
           label={COPY.ADD_COLOCATED_TASK_ACTION_TYPE_LABEL}
           placeholder="Select an action type"
           options={actionTypes}
-          onChange={(opt) => setType(opt.value)}
+          onChange={(opt) => setType(opt?.value)}
           value={selectedType}
         />
       </div>


### PR DESCRIPTION
Resolves [this alert ](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10148/?referrer=webhooks_plugin)

To reproduce
1. on master, sign in as an atty or a judge
2. go to a case assigned to you and add an admin action
3. select any action type
4. open dev console
5. click back into dropdown and hit backspace
6. notice error
7. pull branch
8. repeat steps and notice no error
9. ensure validation works when no type is selected
