### PR TITLE
Fix undefined method appeal for nil:NilClass when creating an EoA mail task

### DIFF
--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -52,7 +52,7 @@ class MailTask < Task
         end
 
         if child_task_assignee(parent_task, params).eql? MailTeam.singleton
-          return parent_task
+          parent_task
         else
           params = modify_params_for_create(params)
           create_child_task(parent_task, user, params)

--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -51,7 +51,9 @@ class MailTask < Task
           )
         end
 
-        unless child_task_assignee(parent_task, params).eql? MailTeam.singleton
+        if child_task_assignee(parent_task, params).eql? MailTeam.singleton
+          return parent_task
+        else
           params = modify_params_for_create(params)
           create_child_task(parent_task, user, params)
         end

--- a/spec/models/tasks/mail_task_spec.rb
+++ b/spec/models/tasks/mail_task_spec.rb
@@ -24,7 +24,7 @@ describe MailTask, :postgres do
 
     context "when root_task exists for appeal" do
       it "creates AodMotionMailTask assigned to MailTeam and AodTeam" do
-        expect { task_class.create_from_params(params, user) }.to_not raise_error
+        expect(task_class.create_from_params(params, user)).to eq root_task.children[0].children[0]
         expect(root_task.children.length).to eq(1)
 
         mail_task = root_task.children[0]
@@ -56,7 +56,7 @@ describe MailTask, :postgres do
       end
 
       it "should not create any child tasks" do
-        expect { task_class.create_from_params(params, user) }.to_not raise_error
+        expect(task_class.create_from_params(params, user)).to eq root_task.children[0]
         expect(root_task.children.length).to eq(1)
 
         mail_task = root_task.children[0]


### PR DESCRIPTION
Resolves [this alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10150/?referrer=webhooks_plugin)

### Description
Previously we were returning nil when we did not need to create a child mail task assigned to another team. This makes sure we return the newly created task in this case.