### PR TITLE
Fix exception name scope for BgsPOANotFound

### DIFF
--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -70,7 +70,7 @@ class PowerOfAttorney
 
   def fetch_bgs_power_of_attorney
     fetch_bgs_power_of_attorney_by_file_number || fetch_bgs_power_of_attorney_by_claimant_participant_id
-  rescue BgsPOANotFound
+  rescue BgsPowerOfAttorney::BgsPOANotFound
     nil
   end
 


### PR DESCRIPTION
Surfaced by this [Sentry alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10174/)