### PR TITLE
Fixed Cancel Behavior on `AddHyperlinkModal` 

### DIFF
--- a/client/app/queue/mtv/forms/AddHyperlinkModal.jsx
+++ b/client/app/queue/mtv/forms/AddHyperlinkModal.jsx
@@ -28,7 +28,12 @@ export const AddHyperlinkModal = ({ onSubmit, onCancel }) => {
   ];
 
   return (
-    <Modal buttons={buttons} title={MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE} closeHandler={onCancel} className="add-hyperlinks-modal">
+    <Modal
+      buttons={buttons}
+      title={MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE}
+      closeHandler={onCancel}
+      className="add-hyperlinks-modal"
+    >
       <div className="cf-margin-bottom-2rem">{MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS}</div>
 
       <TextField

--- a/client/app/queue/mtv/forms/AddHyperlinkModal.jsx
+++ b/client/app/queue/mtv/forms/AddHyperlinkModal.jsx
@@ -28,7 +28,7 @@ export const AddHyperlinkModal = ({ onSubmit, onCancel }) => {
   ];
 
   return (
-    <Modal buttons={buttons} title={MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE} closeHandler={onCancel}>
+    <Modal buttons={buttons} title={MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE} closeHandler={onCancel} className="add-hyperlinks-modal">
       <div className="cf-margin-bottom-2rem">{MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS}</div>
 
       <TextField

--- a/client/app/queue/mtv/forms/AddHyperlinkModal.jsx
+++ b/client/app/queue/mtv/forms/AddHyperlinkModal.jsx
@@ -28,7 +28,7 @@ export const AddHyperlinkModal = ({ onSubmit, onCancel }) => {
   ];
 
   return (
-    <Modal buttons={buttons} title={MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE}>
+    <Modal buttons={buttons} title={MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE} closeHandler={onCancel}>
       <div className="cf-margin-bottom-2rem">{MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS}</div>
 
       <TextField

--- a/client/app/queue/mtv/forms/DecisionHyperlinks.jsx
+++ b/client/app/queue/mtv/forms/DecisionHyperlinks.jsx
@@ -100,7 +100,7 @@ export const DecisionHyperlinks = ({ onChange, disposition }) => {
 
       <Button onClick={() => setShowModal(true)}>+ Add hyperlink</Button>
 
-      {showModal && <AddHyperlinkModal onSubmit={(value) => addHyperlink(value)} />}
+      {showModal && <AddHyperlinkModal onSubmit={(value) => addHyperlink(value)} onCancel={() => setShowModal(false)} />}
     </>
   );
 };

--- a/client/app/queue/mtv/forms/DecisionHyperlinks.jsx
+++ b/client/app/queue/mtv/forms/DecisionHyperlinks.jsx
@@ -100,7 +100,9 @@ export const DecisionHyperlinks = ({ onChange, disposition }) => {
 
       <Button onClick={() => setShowModal(true)}>+ Add hyperlink</Button>
 
-      {showModal && <AddHyperlinkModal onSubmit={(value) => addHyperlink(value)} onCancel={() => setShowModal(false)} />}
+      {showModal && (
+        <AddHyperlinkModal onSubmit={(value) => addHyperlink(value)} onCancel={() => setShowModal(false)} />
+      )}
     </>
   );
 };

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -128,6 +128,9 @@ RSpec.feature "Motion to vacate", :all_dbs do
 
           fill_in("motionFile", with: atty_hyperlinks[0][:link])
 
+          # verify hyperlink modal works
+          check_hyperlink_modal
+
           fill_and_check_other_hyperlinks(atty_hyperlinks)
 
           # Ensure it has pre-selected judge previously assigned to case
@@ -1071,6 +1074,14 @@ RSpec.feature "Motion to vacate", :all_dbs do
         link: "https://example.com/file2.pdf"
       }
     ]
+  end
+
+  def check_hyperlink_modal
+    click_button(text: "+ Add hyperlink")
+    expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE)
+    expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS)
+    click_button(text: "Cancel")
+    expect(page).to_not have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS)
   end
 
   def fill_and_check_other_hyperlinks(atty_hyperlinks)

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -1080,7 +1080,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
     click_button(text: "+ Add hyperlink")
     expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_TITLE)
     expect(page).to have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS)
-    click_button(text: "Cancel")
+    find("#Add-hyperlink-button-id-0").click
     expect(page).to_not have_content(COPY::MOTIONS_ATTORNEY_REVIEW_MTV_HYPERLINK_MODAL_INSTRUCTIONS)
   end
 


### PR DESCRIPTION
### Description
Fixes issue where `AddHyperlinkModal` would not properly close when cancel buttons are pushed when in context of `DecisionHyperlinks` component and adds a test to verify this functionality

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Modal can be cancelled
