### PR TITLE
fall back to created_at/now if no from_date is set in EvidenceSubmissionWindowTask

### DIFF
--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -339,7 +339,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       expect(page).to have_content("There are no schedulable veterans")
     end
 
-    fscenario "Withdraw Veteran's hearing request" do
+    scenario "Withdraw Veteran's hearing request" do
       visit "hearings/schedule/assign"
       expect(page).to have_content("Regional Office")
       click_dropdown(text: "Denver")

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -227,7 +227,7 @@ describe AssignHearingDispositionTask, :all_dbs do
 
   context "disposition updates" do
     let(:disposition) { nil }
-    let(:appeal) { create(:appeal) }
+    let(:appeal) { create(:appeal, docket_type: Constants.AMA_DOCKETS.hearing) }
     let(:root_task) { create(:root_task, appeal: appeal) }
     let(:distribution_task) { create(:distribution_task, parent: root_task) }
     let(:hearing_task) { create(:hearing_task, parent: distribution_task) }

--- a/spec/models/tasks/evidence_submission_window_task_spec.rb
+++ b/spec/models/tasks/evidence_submission_window_task_spec.rb
@@ -4,13 +4,14 @@ describe EvidenceSubmissionWindowTask, :postgres do
   let(:participant_id_with_pva) { "000000" }
   let(:participant_id_with_no_vso) { "11111" }
   let!(:receipt_date) { 2.days.ago }
+  let(:docket_type) { Constants.AMA_DOCKETS.evidence_submission }
   let!(:appeal) do
-    create(:appeal, docket_type: Constants.AMA_DOCKETS.evidence_submission, receipt_date: receipt_date, claimants: [
+    create(:appeal, docket_type: docket_type, receipt_date: receipt_date, claimants: [
              create(:claimant, participant_id: participant_id_with_pva)
            ])
   end
   let!(:appeal_no_vso) do
-    create(:appeal, docket_type: Constants.AMA_DOCKETS.evidence_submission, claimants: [
+    create(:appeal, docket_type: docket_type, claimants: [
              create(:claimant, participant_id: participant_id_with_no_vso)
            ])
   end
@@ -71,58 +72,55 @@ describe EvidenceSubmissionWindowTask, :postgres do
       end
     end
 
-    context "parent is a AssignHearingDispositionTask and there is a held hearing" do
-      let(:root_task) { create(:root_task, appeal: appeal) }
-      let(:hearing_task) { create(:hearing_task, parent: root_task) }
-      let(:hearing_day) { create(:hearing_day, scheduled_for: appeal.receipt_date + 15.days) }
-      let(:hearing) do
-        create(
-          :hearing,
-          appeal: appeal,
-          disposition: Constants.HEARING_DISPOSITION_TYPES.held,
-          hearing_day: hearing_day
-        )
-      end
-      let!(:hearing_task_association) do
-        create(
-          :hearing_task_association,
-          hearing: hearing,
-          hearing_task: hearing_task
-        )
-      end
-      let!(:parent) do
-        create(
-          :assign_hearing_disposition_task,
-          :in_progress,
-          parent: hearing_task
-        )
-      end
-      let!(:task) do
-        EvidenceSubmissionWindowTask.create!(appeal: appeal, assigned_to: Bva.singleton, parent: parent)
-      end
-
-      it "sets the timer to end 90 days after the hearing day" do
-        TaskTimerJob.perform_now
-        expect(task.reload.status).to eq("assigned")
-
-        Timecop.travel(receipt_date + 90.days) do
-          TaskTimerJob.perform_now
-          expect(task.reload.status).to eq("assigned")
-        end
-
-        Timecop.travel(hearing_day.scheduled_for + 90.days) do
-          TaskTimerJob.perform_now
-          expect(task.reload.status).to eq("completed")
-        end
-      end
-    end
-
     context "appeal is in the hearing docket" do
       let(:root_task) { create(:root_task, appeal: appeal) }
       let(:hearing_task) { create(:hearing_task, parent: root_task) }
+      let(:docket_type) { Constants.AMA_DOCKETS.hearing }
 
-      before do
-        appeal.update(docket_type: Constants.AMA_DOCKETS.hearing)
+      context "parent is a AssignHearingDispositionTask and there is a held hearing" do
+        let(:root_task) { create(:root_task, appeal: appeal) }
+        let(:hearing_task) { create(:hearing_task, parent: root_task) }
+        let(:hearing_day) { create(:hearing_day, scheduled_for: appeal.receipt_date + 15.days) }
+        let(:hearing) do
+          create(
+            :hearing,
+            appeal: appeal,
+            disposition: Constants.HEARING_DISPOSITION_TYPES.held,
+            hearing_day: hearing_day
+          )
+        end
+        let!(:hearing_task_association) do
+          create(
+            :hearing_task_association,
+            hearing: hearing,
+            hearing_task: hearing_task
+          )
+        end
+        let!(:parent) do
+          create(
+            :assign_hearing_disposition_task,
+            :in_progress,
+            parent: hearing_task
+          )
+        end
+        let!(:task) do
+          EvidenceSubmissionWindowTask.create!(appeal: appeal, assigned_to: Bva.singleton, parent: parent)
+        end
+
+        it "sets the timer to end 90 days after the hearing day", :aggregate_failures do
+          TaskTimerJob.perform_now
+          expect(task.reload.status).to eq("assigned")
+
+          Timecop.travel(receipt_date + 90.days) do
+            TaskTimerJob.perform_now
+            expect(task.reload.status).to eq("assigned")
+          end
+
+          Timecop.travel(hearing_day.scheduled_for + 90.days) do
+            TaskTimerJob.perform_now
+            expect(task.reload.status).to eq("completed")
+          end
+        end
       end
 
       context "hearing is not in the evidences submission docket and the hearing request is withdrawn" do
@@ -155,13 +153,18 @@ describe EvidenceSubmissionWindowTask, :postgres do
       end
 
       context "hearing is not in the evidences submission docket" \
-              "and the hearing request is withdrawn with no scheduled hearing task" do
-        it "fails with EvidenceSubmissionWindowTask::CouldNotCalculateTimerEndsDateForEvidenceSubmissionWindowTask" do
-          expect do
-            EvidenceSubmissionWindowTask.create!(appeal: appeal, assigned_to: Bva.singleton, parent: hearing_task)
-          end.to raise_error(
-            EvidenceSubmissionWindowTask::CouldNotCalculateTimerEndsDateForEvidenceSubmissionWindowTask
+              "and the hearing request is withdrawn with no schedule hearing task" do
+        it "sends a message to Raven and sets the time to end 90 days after the task was created" do
+          expect(Raven).to receive(:capture_message).once
+
+          esw_task = EvidenceSubmissionWindowTask.create!(
+            appeal: appeal,
+            assigned_to: Bva.singleton,
+            parent: hearing_task
           )
+
+          task_timer = TaskTimer.find_by(task_id: esw_task.id)
+          expect(task_timer.submitted_at).to be_within(10.seconds).of(esw_task.created_at + 90.days)
         end
       end
     end


### PR DESCRIPTION
Connects #14077
Follows #14135

- check for evidence submission docket case first
- fall back to created_at/now so from_date is never nil
- alert sentry if from_date's nil and there's no schedule hearing task
  child of the parent task
- update the test for no schedule hearing task case
- move a test inside the 'appeal is in the hearing docket' context
  because it was failing after reordering checks in timer_ends_at
