### PR TITLE
TypeError Culprit action(app/queue/uiReducer/uiActions) fix

### DIFF
--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -72,7 +72,7 @@ const saveFailure = (err) => (dispatch) => {
   let uiErrorMessage;
 
   try {
-    uiErrorMessage = response.body;
+    uiErrorMessage = response.body.errors[0];
   } catch (ex) {
     // the default case if there is no `text` node in the response (ie the backend did not return sufficient info)
     uiErrorMessage = {
@@ -84,7 +84,7 @@ const saveFailure = (err) => (dispatch) => {
     };
   }
 
-  dispatch(showErrorMessage(uiErrorMessage.errors[0]));
+  dispatch(showErrorMessage(uiErrorMessage));
   dispatch({ type: ACTIONS.SAVE_FAILURE });
   // the promise rejection below is also uncaught
   // but this seems to be by design since that's the same as the frontend handling and throwing an error


### PR DESCRIPTION
Resolves [this sentry alert](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/7344/?referrer=webhooks_plugin)

### Description
We are encountering errors outside of the try block. Toss everything that would throw an exception into said try block.

### Testing
1. Open your dev console here and run 
```javascript
> uiErrorMessage = response.body.errors[0];
⛔ Uncaught ReferenceError: response is not defined
    at <anonymous>:1:1
```
2. Try the block (😄 )
```javascript
try {
  uiErrorMessage = response.body.errors[0];
} catch (ex) {
  uiErrorMessage = "Tada"
}
<- "Tada"
```
