### PR TITLE
Only check attorney task assigner and assignee roles upon update

### DIFF
--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -10,8 +10,8 @@ class AttorneyTask < Task
   validates :assigned_by, presence: true
   validates :parent, presence: true, if: :ama?
 
-  validate :assigned_by_role_is_valid
-  validate :assigned_to_role_is_valid
+  validate :assigned_by_role_is_valid, on: :create
+  validate :assigned_to_role_is_valid, on: :create
   validate :child_attorney_tasks_are_completed, on: :create
 
   after_update :send_back_to_judge_assign, if: :attorney_task_just_cancelled?

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -72,7 +72,7 @@ class AttorneyTask < Task
   end
 
   def assigned_by_role_is_valid
-    if assigned_by && (!assigned_by.judge_in_vacols? && !assigned_by.can_act_on_behalf_of_judges?)
+    if assigned_by && (!assigned_by.judge? && !assigned_by.can_act_on_behalf_of_judges?)
       errors.add(:assigned_by, "has to be a judge or special case movement team member")
     end
   end

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -10,8 +10,8 @@ class AttorneyTask < Task
   validates :assigned_by, presence: true
   validates :parent, presence: true, if: :ama?
 
-  validate :assigned_by_role_is_valid, on: :create
-  validate :assigned_to_role_is_valid, on: :create
+  validate :assigned_by_role_is_valid, if: :will_save_change_to_assigned_by_id?
+  validate :assigned_to_role_is_valid, if: :will_save_change_to_assigned_to_id?
   validate :child_attorney_tasks_are_completed, on: :create
 
   after_update :send_back_to_judge_assign, if: :attorney_task_just_cancelled?

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -100,9 +100,7 @@ describe AttorneyTask, :all_dbs do
     end
     let(:update_params) { { status: Task.statuses[:on_hold] } }
 
-    subject do
-      attorney_task.update(update_params)
-    end
+    subject { attorney_task.update(update_params) }
 
     context "when not updating the assigner or assignee" do
       it "does not check the assignee or the assigner roles and the task is valid" do

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -69,6 +69,66 @@ describe AttorneyTask, :all_dbs do
         expect(subject.errors.messages[:parent].first).to eq "has open child tasks"
       end
     end
+
+    context "when the assigner is invalid" do
+      let!(:assigning_judge_staff) { create(:staff, sdomainid: assigning_judge.css_id, sattyid: nil) }
+      it "fails" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors.messages[:assigned_by].first).to eq(
+          "has to be a judge or special case movement team member"
+        )
+      end
+    end
+
+    context "when the assignee is invalid" do
+      let!(:attorney_staff) { create(:staff, sdomainid: attorney.css_id, sattyid: nil) }
+      it "fails" do
+        expect(subject.valid?).to eq false
+        expect(subject.errors.messages[:assigned_to].first).to eq "has to be an attorney"
+      end
+    end
+  end
+
+  context ".update" do
+    let!(:attorney_task) do
+      AttorneyTask.create(
+        assigned_to: attorney,
+        assigned_by: assigning_judge,
+        appeal: appeal,
+        parent: parent
+      )
+    end
+    let(:update_params) { { status: Task.statuses[:on_hold] } }
+
+    subject do
+      attorney_task.update(update_params)
+    end
+
+    context "when not updating the assigner or assignee" do
+      it "does not check the assignee or the assigner roles and the task is valid" do
+        expect(attorney_task).not_to receive(:assigned_to_role_is_valid)
+        expect(attorney_task).not_to receive(:assigned_by_role_is_valid)
+        expect(subject).to be true
+      end
+    end
+
+    context "when updating the assigner" do
+      let(:update_params) { { assigned_by_id: create(:user).id } }
+
+      it "does not check the assignee role and is not valid" do
+        expect(attorney_task).not_to receive(:assigned_to_role_is_valid)
+        expect(subject).to be false
+      end
+    end
+
+    context "when updating the assignee" do
+      let(:update_params) { { assigned_to_id: create(:user).id } }
+
+      it "does not check the assigner role and is not valid" do
+        expect(attorney_task).not_to receive(:assigned_by_role_is_valid)
+        expect(subject).to be false
+      end
+    end
   end
 
   context ".available_actions" do


### PR DESCRIPTION
Resolves [this user](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10180/?referrer=webhooks_plugin)'s inability to close their task.

### Description
A colocated user is trying to close an IHP colocated task. This would update the parent attorney task to assigned. Updates to a record run all validations unless specified. One of the validations is to make sure only [judges and scm team members](https://github.com/department-of-veterans-affairs/caseflow/blob/a98638c5050bb14332876fbe1cba0d4b48f0f4cb/app/models/tasks/attorney_task.rb#L74-L78) can create attorney tasks. The assigned_by judge is no longer active at the board so this validation returns false. Instead we should check this validation on create and if we have changed the assignee or assigner.