### PR TITLE
ETL Sweeper

### DIFF
--- a/app/jobs/etl_builder_job.rb
+++ b/app/jobs/etl_builder_job.rb
@@ -7,23 +7,31 @@ class ETLBuilderJob < CaseflowJob
   application_attr :etl
 
   SLACK_CHANNEL = "#appeals-delta"
-  DATADOG_NAME = "etl_builder_job"
 
   def perform
     RequestStore.store[:current_user] = User.system_user
 
+    sweep_etl
     build_etl
+    datadog_report_runtime(metric_group_name: "etl_builder_job")
   end
 
   private
 
-  def build_etl
-    etl_build = ETL::Builder.new.incremental
+  def sweep_etl
+    start = Time.zone.now
+    ETL::Sweeper.new.call
+    datadog_report_time_segment(segment: "etl_sweeper", start_time: start)
+  end
 
-    datadog_report_runtime(metric_group_name: DATADOG_NAME)
+  def build_etl
+    start = Time.zone.now
+    etl_build = ETL::Builder.new.incremental
+    datadog_report_time_segment(segment: "etl_builder", start_time: start)
+
+    return unless etl_build.built == 0
 
     msg = "ETL failed to sync any records"
-
-    slack_service.send_notification(msg, self.class.to_s, SLACK_CHANNEL) if etl_build.built == 0
+    slack_service.send_notification(msg, self.class.to_s, SLACK_CHANNEL)
   end
 end

--- a/app/services/concerns/etl_classes.rb
+++ b/app/services/concerns/etl_classes.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# ETL:: service classes that need to know which ETL models are active.
+
+module ETLClasses
+  extend ActiveSupport::Concern
+
+  ETL_KLASSES = %w[
+    Appeal
+    AttorneyCaseReview
+    DecisionIssue
+    Hearing
+    LegacyHearing
+    Organization
+    OrganizationsUser
+    Person
+    Task
+    User
+  ].freeze
+
+  private
+
+  def syncer_klasses
+    ETL_KLASSES.map { |klass| "ETL::#{klass}Syncer".constantize }
+  end
+end

--- a/app/services/etl/builder.rb
+++ b/app/services/etl/builder.rb
@@ -4,18 +4,7 @@
 # We define a special `full` method to bypass the checkpoint marker.
 
 class ETL::Builder
-  ETL_KLASSES = %w[
-    Appeal
-    AttorneyCaseReview
-    DecisionIssue
-    Hearing
-    LegacyHearing
-    Organization
-    OrganizationsUser
-    Person
-    Task
-    User
-  ].freeze
+  include ETLClasses
 
   def initialize(since: checkpoint_time)
     @since = since
@@ -66,10 +55,6 @@ class ETL::Builder
     end
     build_record.update!(finished_at: Time.zone.now, status: status, comments: comments)
     build_record
-  end
-
-  def syncer_klasses
-    ETL_KLASSES.map { |klass| "ETL::#{klass}Syncer".constantize }
   end
 
   def checkpoint_time

--- a/app/services/etl/sweeper.rb
+++ b/app/services/etl/sweeper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Normally called via cron to clean up ETL records that refer to
+# deleted original records.
+
+class ETL::Sweeper
+  include ETLClasses
+
+  def call(etl_build)
+    syncer_klasses.each do |klass|
+      sweep_targets(klass.new(etl_build: etl_build))
+    end
+    etl_build
+  end
+
+  private
+
+  # find all the PKs in target_klass that no longer
+  # exist in origin_klass, and delete any targets that are stale.
+  def sweep_targets(syncer)
+    origin_klass = syncer.origin_class
+    target_klass = syncer.target_class
+
+    target_klass.find_in_batches.with_index do |targets, batch|
+      Rails.logger.debug("Starting #{target_klass.name} sweep batch #{batch}")
+
+      origin_pks = targets.pluck(target_klass.origin_primary_key)
+      origin_pks_count = origin_pks.count
+      Rails.logger.debug("Found #{origin_pks_count} #{target_klass.name} PKs")
+
+      origin_rows = origin_klass.unscoped.where(id: origin_pks).pluck(:id)
+      origin_rows_count = origin_rows.count 
+      Rails.logger.debug("Found #{origin_rows_count} #{origin_klass.name} rows")
+
+      next if origin_rows_count == origin_pks_count # no deletions, next batch
+
+      origin_rows_deleted = origin_pks - origin_rows
+      Rails.logger.debug("Target rows to sweep: #{origin_rows_deleted}")
+
+      target_klass.where(target_klass.origin_primary_key => origin_rows_deleted).delete_all
+    end
+  end
+end

--- a/spec/jobs/etl_builder_job_spec.rb
+++ b/spec/jobs/etl_builder_job_spec.rb
@@ -14,6 +14,18 @@ describe ETLBuilderJob, :etl, :all_dbs do
         metric_name: "runtime",
         metric_value: anything
       )
+      expect(DataDogService).to receive(:emit_gauge).with(
+        app_name: "caseflow_job_segment",
+        metric_group: "etl_builder",
+        metric_name: "runtime",
+        metric_value: anything
+      )
+      expect(DataDogService).to receive(:emit_gauge).with(
+        app_name: "caseflow_job_segment",
+        metric_group: "etl_sweeper",
+        metric_name: "runtime",
+        metric_value: anything
+      )
       ETL::Builder::ETL_KLASSES.each { |klass| expect("ETL::#{klass}".constantize.all.count).to eq(0) }
     end
 

--- a/spec/jobs/etl_builder_job_spec.rb
+++ b/spec/jobs/etl_builder_job_spec.rb
@@ -50,5 +50,19 @@ describe ETLBuilderJob, :etl, :all_dbs do
         expect(@slack_msg).to be_nil
       end
     end
+
+    context "when deleted row is swept up" do
+      before do
+        ETL::Builder.new.full
+        Appeal.last.delete
+        Appeal.last.touch
+      end
+
+      it "sends INFO message to slack" do
+        Timecop.travel(1.hour.ago) { subject }
+
+        expect(@slack_msg).to include("[INFO] ETL swept up 1 deleted records")
+      end
+    end
   end
 end

--- a/spec/jobs/etl_builder_job_spec.rb
+++ b/spec/jobs/etl_builder_job_spec.rb
@@ -39,7 +39,7 @@ describe ETLBuilderJob, :etl, :all_dbs do
       it "sends alert to Slack" do
         Timecop.travel(Time.zone.now + 1.hour) { subject }
 
-        expect(@slack_msg).to eq "ETL failed to sync any records"
+        expect(@slack_msg).to eq "[WARN] ETL failed to sync any records"
       end
     end
 

--- a/spec/services/etl/sweeper_spec.rb
+++ b/spec/services/etl/sweeper_spec.rb
@@ -1,24 +1,20 @@
 # frozen_string_literal: true
 
 describe ETL::Sweeper, :etl, :all_dbs do
-  let(:etl_build) { ETL::Build.create }
-
   describe "#call" do
-    subject { described_class.new.call(etl_build) }
+    subject { described_class.new.call }
 
     context "One Appeal is deleted" do
       before do
         appeal = create(:appeal)
-        appeal_two = create(:appeal)
+        create(:appeal)
         ETL::AppealSyncer.new(etl_build: ETL::Build.new).call
         appeal.delete
       end
 
       it "deletes the corresponding ETL::Appeal" do
         expect(ETL::Appeal.count).to eq(2)
-
-        subject
-
+        expect(subject).to eq(1)
         expect(ETL::Appeal.count).to eq(1)
       end
     end
@@ -27,7 +23,7 @@ describe ETL::Sweeper, :etl, :all_dbs do
       before do
         decision_issue = create(:decision_issue)
         decision_issue_two = create(:decision_issue)
-        decision_issue_three = create(:decision_issue)
+        create(:decision_issue)
         ETL::DecisionIssueSyncer.new(etl_build: ETL::Build.new).call
         decision_issue.delete # hard
         decision_issue_two.soft_delete # soft
@@ -35,9 +31,7 @@ describe ETL::Sweeper, :etl, :all_dbs do
 
       it "respects soft-vs-hard delete in corresponding ETL::DecisionIssue" do
         expect(ETL::DecisionIssue.count).to eq(3)
-
-        subject
-
+        expect(subject).to eq(1)
         expect(ETL::DecisionIssue.count).to eq(2)
       end
     end

--- a/spec/services/etl/sweeper_spec.rb
+++ b/spec/services/etl/sweeper_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe ETL::Sweeper, :etl, :all_dbs do
+  let(:etl_build) { ETL::Build.create }
+
+  describe "#call" do
+    subject { described_class.new.call(etl_build) }
+
+    context "One Appeal is deleted" do
+      before do
+        appeal = create(:appeal)
+        appeal_two = create(:appeal)
+        ETL::AppealSyncer.new(etl_build: ETL::Build.new).call
+        appeal.delete
+      end
+
+      it "deletes the corresponding ETL::Appeal" do
+        expect(ETL::Appeal.count).to eq(2)
+
+        subject
+
+        expect(ETL::Appeal.count).to eq(1)
+      end
+    end
+
+    context "One Decision Issue is marked deleted_at" do
+      before do
+        decision_issue = create(:decision_issue)
+        decision_issue_two = create(:decision_issue)
+        decision_issue_three = create(:decision_issue)
+        ETL::DecisionIssueSyncer.new(etl_build: ETL::Build.new).call
+        decision_issue.delete # hard
+        decision_issue_two.soft_delete # soft
+      end
+
+      it "respects soft-vs-hard delete in corresponding ETL::DecisionIssue" do
+        expect(ETL::DecisionIssue.count).to eq(3)
+
+        subject
+
+        expect(ETL::DecisionIssue.count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #12789

### Description
ETL rows can grow stale if the original records they refer to are deleted from the transactional database.

The `ETL::Sweeper` class identifies the stale rows and deletes them. It "sweeps" through all the tables looking for mismatches in the number of primary keys found.

### Testing Plan
1. Monitor #appeals-delta for `[INFO]` messages when rows are deleted. Details are written to cloudwatch logs.

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.
