### PR TITLE
Make disabled styling for Dropdown and text inputs consistent

### DIFF
--- a/client/app/containers/StyleGuide/StyleGuideColors.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideColors.jsx
@@ -11,6 +11,7 @@ export default class StyleGuideColors extends React.PureComponent {
     Gray: '#5b616b',
     'Gray-light': '#aeb0b5',
     'Gray-lighter': COLORS.GREY_LIGHT,
+    'Gray-lightest': '#f1f1f1',
     'Gray-warm-light': '#e4e2e0',
     Primary: '#0071bc',
     White: COLORS.WHITE,
@@ -39,6 +40,7 @@ export default class StyleGuideColors extends React.PureComponent {
     'Gray',
     'Gray-light',
     'Gray-lighter',
+    'Gray-lightest',
     'Gray-warm-light',
     'Primary',
     'White'

--- a/client/app/containers/StyleGuide/StyleGuideSearchableDropdown.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideSearchableDropdown.jsx
@@ -62,6 +62,15 @@ export default class StyleGuideSearchableDropdown extends React.PureComponent {
           onChange={this.onChange}
           required
         />
+        <h3 id="disabled-dropdown">Disabled Single Select Searchable Dropdown</h3>
+        <SearchableDropdown
+          label="Searchable dropdown"
+          name="single-select-countries"
+          options={options}
+          onChange={this.onChange}
+          required
+          readOnly
+        />
         <h3 id="multi-dropdown">Creatable Searchable Multiselect Dropdown</h3>
         <SearchableDropdown
           creatable

--- a/client/app/containers/StyleGuide/StyleGuideTextInput.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideTextInput.jsx
@@ -44,7 +44,7 @@ export default class StyleGuideTextInput extends React.PureComponent {
       <h3 id="disabled">Disabled Text Input</h3>
       <TextField
         name="Disabled Text Input Label"
-        value={""}
+        value=""
         readOnly
         required={false} />
     </div>;

--- a/client/app/containers/StyleGuide/StyleGuideTextInput.jsx
+++ b/client/app/containers/StyleGuide/StyleGuideTextInput.jsx
@@ -41,6 +41,12 @@ export default class StyleGuideTextInput extends React.PureComponent {
         onChange={(value) => {
           this.setState({ value });
         }} />
+      <h3 id="disabled">Disabled Text Input</h3>
+      <TextField
+        name="Disabled Text Input Label"
+        value={""}
+        readOnly
+        required={false} />
     </div>;
   }
 }

--- a/client/app/styles/react/_select-dropdown.scss
+++ b/client/app/styles/react/_select-dropdown.scss
@@ -23,7 +23,7 @@
 }
 
 .Select.is-disabled > .Select-control {
-  background-color: $color-gray-lighter;
+  background-color: $color-gray-lightest;
 }
 
 .Select.is-disabled > .Select-control:hover {


### PR DESCRIPTION
### Description

Use same color for disabled dropdown and text inputs

- [ ] Check if this affects accessibility

### User Facing Changes

---

## Daily Docket

### BEFORE

<img width="773" alt="Screen Shot 2020-05-07 at 5 36 33 PM" src="https://user-images.githubusercontent.com/1298274/81346992-4de51700-9089-11ea-932f-960913e5369e.png">

---

### AFTER

<img width="773" alt="Screen Shot 2020-05-07 at 5 35 26 PM" src="https://user-images.githubusercontent.com/1298274/81346917-2b52fe00-9089-11ea-815d-3315313b4f54.png">


---
## Hearing Details

### BEFORE

<img width="1178" alt="Screen Shot 2020-05-07 at 5 37 10 PM" src="https://user-images.githubusercontent.com/1298274/81347045-62c1aa80-9089-11ea-887a-f991ca0dc3ed.png">


---

### AFTER

<img width="1222" alt="Screen Shot 2020-05-07 at 5 33 35 PM" src="https://user-images.githubusercontent.com/1298274/81346784-e3cc7200-9088-11ea-9c07-5e4402800d6a.png">