### PR TITLE
Handle LegacyHearings ETL sync where no VACOLS record found

### DIFF
--- a/app/models/etl/hearing.rb
+++ b/app/models/etl/hearing.rb
@@ -77,7 +77,6 @@ class ETL::Hearing < ETL::Record
       target.appeal_id = original.appeal_id
       target.hearing_created_at = original.created_at
       target.hearing_updated_at = original.updated_at
-      target.bva_poc = original.bva_poc
       target.created_by_id = original.created_by_id
       target.created_by_user_css_id = created_by&.css_id
       target.created_by_user_full_name = created_by&.full_name
@@ -93,8 +92,6 @@ class ETL::Hearing < ETL::Record
       mirrored_hearing_attributes.each do |attr|
         target[attr] = original[attr]
       end
-
-      target.hearing_request_type = original.hearing_request_type
 
       # hearing day
       if hearing_day.present?
@@ -124,6 +121,10 @@ class ETL::Hearing < ETL::Record
 
       # STI does not work on the base class so we set explicitly
       target.type = name
+
+      # do these last as they may raise exceptions in legacy hearings
+      target.bva_poc = original.bva_poc
+      target.hearing_request_type = original.hearing_request_type
 
       target
     end

--- a/app/models/etl/legacy_hearing.rb
+++ b/app/models/etl/legacy_hearing.rb
@@ -4,18 +4,19 @@
 
 class ETL::LegacyHearing < ETL::Hearing
   class << self
-    def mirrored_hearing_attributes
-      super + [:vacols_id]
-    end
-
     private
 
     def merge_original_attributes_to_target(original, target)
       super
-
-      target.judge_id = original.user_id
+    rescue Caseflow::Error::VacolsRecordNotFound => err
+      Rails.logger.error(err)
+      target
+    ensure
+      # whether we catch an error or not, make sure these are populated
+      target.hearing_request_type ||= "unknown"
+      target.vacols_id = original.vacols_id
       target.scheduled_time = original.scheduled_for
-
+      target.judge_id = original.user_id
       target
     end
   end

--- a/app/models/etl/legacy_hearing.rb
+++ b/app/models/etl/legacy_hearing.rb
@@ -8,8 +8,8 @@ class ETL::LegacyHearing < ETL::Hearing
 
     def merge_original_attributes_to_target(original, target)
       super
-    rescue Caseflow::Error::VacolsRecordNotFound => err
-      Rails.logger.error(err)
+    rescue Caseflow::Error::VacolsRecordNotFound => error
+      Rails.logger.error(error)
       target
     ensure
       # whether we catch an error or not, make sure these are populated

--- a/db/etl/migrate/20200508141923_drop_legacy_hearing_scheduled_for.rb
+++ b/db/etl/migrate/20200508141923_drop_legacy_hearing_scheduled_for.rb
@@ -1,0 +1,5 @@
+class DropLegacyHearingScheduledFor < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :hearings, :scheduled_time, true
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_04_204154) do
+ActiveRecord::Schema.define(version: 2020_05_08_141923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -240,7 +240,7 @@ ActiveRecord::Schema.define(version: 2020_05_04_204154) do
     t.boolean "prepped", comment: "hearings.prepped"
     t.string "representative_name", comment: "hearings.representative_name"
     t.string "room", comment: "hearings.room"
-    t.time "scheduled_time", null: false, comment: "hearings.scheduled_time"
+    t.time "scheduled_time", comment: "hearings.scheduled_time"
     t.text "summary", comment: "hearings.summary"
     t.boolean "transcript_requested", comment: "hearings.transcript_requested"
     t.date "transcript_sent_date", comment: "hearings.transcript_sent_date"
@@ -379,5 +379,4 @@ ActiveRecord::Schema.define(version: 2020_05_04_204154) do
     t.index ["updated_at"], name: "index_users_on_updated_at"
     t.index ["user_id"], name: "index_users_on_user_id"
   end
-
 end

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -164,7 +164,7 @@ hearings,notes,string,,,,,,hearings.notes
 hearings,prepped,boolean,,,,,,hearings.prepped
 hearings,representative_name,string,,,,,,hearings.representative_name
 hearings,room,string,,,,,,hearings.room
-hearings,scheduled_time,time ∗,x,,,,,hearings.scheduled_time
+hearings,scheduled_time,time ∗,,,,,,hearings.scheduled_time
 hearings,summary,text,,,,,,hearings.summary
 hearings,transcript_requested,boolean,,,,,,hearings.transcript_requested
 hearings,transcript_sent_date,date,,,,,,hearings.transcript_sent_date

--- a/spec/services/etl/legacy_hearing_syncer_spec.rb
+++ b/spec/services/etl/legacy_hearing_syncer_spec.rb
@@ -40,6 +40,21 @@ describe ETL::LegacyHearingSyncer, :etl, :all_dbs do
       end
     end
 
+    context "VACOLS hearing not found" do
+      before do
+        create(:legacy_hearing, vacols_id: "no-such-vacols-record")
+        allow(Rails.logger).to receive(:error).and_call_original
+      end
+
+      it "rescues Caseflow::Error::VacolsRecordNotFound and continues" do
+        subject
+
+        expect(LegacyHearing.count).to eq(3)
+        expect(ETL::LegacyHearing.count).to eq(3)
+        expect(Rails.logger).to have_received(:error).once
+      end
+    end
+
     context "orphaned Hearing" do
       let!(:orphaned_hearing) { create(:legacy_hearing) }
       let(:etl_build_table) { ETL::BuildTable.where(table_name: "hearings").last }


### PR DESCRIPTION
### Description

Sometimes records disappear from VACOLS and cause Caseflow records to "dangle" pointing at non-existent ID values.

Context https://dsva.slack.com/archives/C3EAF3Q15/p1588882209135600

Handle that situation by rescuing the specific exception and logging it to determine the scope of the problem.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [ ] #appeals-schema notified with summary and link to this PR
