### PR TITLE
Allow intake users to edit issues from the case details screen

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -102,6 +102,10 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     CaseReview.singleton.users.include?(self) || %w[NWQ VACO].exclude?(regional_office)
   end
 
+  def can_edit_issues?
+    CaseReview.singleton.users.include?(self) || can_intake_appeals?
+  end
+
   def can_intake_appeals?
     BvaIntake.singleton.users.include?(self)
   end

--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -16,11 +16,11 @@ class AppealRequestIssuesPolicy
   attr_reader :user, :appeal
 
   def editable_by_case_review_team_member?
-    current_user_is_case_review_team_member? && case_is_not_in_active_review?
+    current_user_can_edit_issues? && case_is_not_in_active_review?
   end
 
-  def current_user_is_case_review_team_member?
-    CaseReview.singleton.user_has_access?(user)
+  def current_user_can_edit_issues?
+    user.can_edit_issues?
   end
 
   def case_is_not_in_active_review?
@@ -28,7 +28,7 @@ class AppealRequestIssuesPolicy
   end
 
   def hearing_is_assigned_to_judge_user
-    FeatureToggle.enabled?(:allow_judge_edit_issues) && appeal.hearings.last&.judge == user
+    appeal.hearings.last&.judge == user
   end
 
   def case_is_in_active_review_by_current_user?

--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -20,7 +20,7 @@ class AppealRequestIssuesPolicy
   end
 
   def current_user_can_edit_issues?
-    user.can_edit_issues?
+    user&.can_edit_issues?
   end
 
   def case_is_not_in_active_review?

--- a/spec/feature/queue/case_details/edit_issues_spec.rb
+++ b/spec/feature/queue/case_details/edit_issues_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Edit Issues", :all_dbs do
     it "does not show 'Correct Issues' link" do
       visit("/queue/appeals/#{appeal.uuid}")
 
-      expect(page).not_to have_content(COPY::CORRECT_REQUEST_ISSUES_LINK)
+      expect(page).to have_no_content(COPY::CORRECT_REQUEST_ISSUES_LINK)
     end
   end
 

--- a/spec/feature/queue/case_details/edit_issues_spec.rb
+++ b/spec/feature/queue/case_details/edit_issues_spec.rb
@@ -1,48 +1,53 @@
 # frozen_string_literal: true
 
 RSpec.feature "Edit Issues", :all_dbs do
-  before do
-    FeatureToggle.enable!(:allow_judge_edit_issues)
+  shared_examples "can NOT view the 'Correct Issues' link" do
+    it "does not show 'Correct Issues' link" do
+      visit("/queue/appeals/#{appeal.uuid}")
+
+      expect(page).not_to have_content(COPY::CORRECT_REQUEST_ISSUES_LINK)
+    end
   end
 
-  after do
-    FeatureToggle.disable!(:allow_judge_edit_issues)
+  shared_examples "can view the 'Correct Issues' link" do
+    it "shows 'Correct Issues' link" do
+      visit("/queue/appeals/#{appeal.uuid}")
+
+      expect(page).to have_content(COPY::CORRECT_REQUEST_ISSUES_LINK)
+    end
+  end
+
+  let(:user) { create(:user, station_id: User::BOARD_STATION_ID) }
+  let(:appeal) { create(:appeal) }
+
+  before { User.authenticate!(user: user) }
+
+  context "for a misc user" do
+    it_behaves_like "can NOT view the 'Correct Issues' link"
+  end
+
+  context "for an intake user" do
+    before { BvaIntake.singleton.add_user(user) }
+    it_behaves_like "can view the 'Correct Issues' link"
+  end
+
+  context "for an intake user" do
+    before { CaseReview.singleton.add_user(user) }
+    it_behaves_like "can view the 'Correct Issues' link"
   end
 
   context "for a judge" do
-    let(:judge) { create(:user, station_id: User::BOARD_STATION_ID) }
-    let!(:judge_staff) { create(:staff, :judge_role, sdomainid: judge.css_id) }
-
-    before do
-      User.authenticate!(user: judge)
-    end
+    let!(:user_staff) { create(:staff, :judge_role, sdomainid: user.css_id) }
+    let!(:hearing) { create(:hearing, appeal: appeal, judge: user) }
 
     context "that is assigned to a hearing" do
-      let(:appeal) { create(:appeal) }
-      let!(:hearing) { create(:hearing, appeal: appeal, judge: judge) }
-
-      it "can view the 'Correct Issues' link" do
-        visit("/queue/appeals/#{appeal.uuid}")
-
-        expect(page).to have_content(COPY::CORRECT_REQUEST_ISSUES_LINK)
-      end
+      it_behaves_like "can view the 'Correct Issues' link"
     end
 
     context "that is not assigned to a hearing" do
-      let(:appeal) { create(:appeal) }
-      let!(:hearing) do
-        create(
-          :hearing,
-          appeal: appeal,
-          judge: create(:user, station_id: User::BOARD_STATION_ID)
-        )
-      end
+      before { hearing.update!(judge: create(:user)) }
 
-      it "can NOT view the 'Correct Issues' link" do
-        visit("/queue/appeals/#{appeal.uuid}")
-
-        expect(page).to_not have_content(COPY::CORRECT_REQUEST_ISSUES_LINK)
-      end
+      it_behaves_like "can NOT view the 'Correct Issues' link"
     end
   end
 end


### PR DESCRIPTION
Resolves board request from demo

### Description
Allows intake users to see the edit issues link on the case details page. Also removes references to feature toggle that have been enabled for all users for 9 months.

### Testing!
1. Log in as an intake user BVAISHAW and go to an ama case
2. Ensure you can see the "Correct issues" link in case details

### UI Changes
![Screen Shot 2020-05-08 at 2 23 48 PM](https://user-images.githubusercontent.com/45575454/81436519-a246d000-9137-11ea-91ed-c588124bb61c.png)
