### PR TITLE
Data integrity job slack message prefix

### DIFF
--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -41,13 +41,12 @@ class DataIntegrityChecksJob < CaseflowJob
   private
 
   def report_msg(msg)
-    unless msg =~ /\[(INFO|WARN|ERROR)\]/
-      return "[WARN] #{msg}"
-    end
+    return "[WARN] #{msg}" unless msg.match?(/\[(INFO|WARN|ERROR)\]/)
+
     msg
   end
 
   def send_to_slack(checker)
-    slack_service.send_notification("#{report_msg(checker.report)}", checker.class.name, checker.slack_channel)
+    slack_service.send_notification(report_msg(checker.report), checker.class.name, checker.slack_channel)
   end
 end

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -40,7 +40,14 @@ class DataIntegrityChecksJob < CaseflowJob
 
   private
 
+  def report_msg(msg)
+    unless msg =~ /\[INFO|WARN|ERROR\]/
+      return "[WARN] #{msg}"
+    end
+    msg
+  end
+
   def send_to_slack(checker)
-    slack_service.send_notification("[WARN] #{checker.report}", checker.class.name, checker.slack_channel)
+    slack_service.send_notification("#{report_msg(checker.report)}", checker.class.name, checker.slack_channel)
   end
 end

--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -41,7 +41,7 @@ class DataIntegrityChecksJob < CaseflowJob
   private
 
   def report_msg(msg)
-    unless msg =~ /\[INFO|WARN|ERROR\]/
+    unless msg =~ /\[(INFO|WARN|ERROR)\]/
       return "[WARN] #{msg}"
     end
     msg

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -28,7 +28,7 @@ describe DataIntegrityChecksJob do
       allow(checker).to receive(:report?).and_call_original
       allow(checker).to receive(:report).and_call_original
     end
-    allow(slack_service).to receive(:send_notification).and_return(true)
+    allow(slack_service).to receive(:send_notification) { |msg| @slack_msg = msg }
 
     @emitted_gauges = []
     allow(DataDogService).to receive(:emit_gauge) do |args|
@@ -96,6 +96,7 @@ describe DataIntegrityChecksJob do
         expect(expired_async_jobs_checker).to have_received(:report?).once
         expect(expired_async_jobs_checker).to have_received(:report).once
         expect(slack_service).to have_received(:send_notification)
+        expect(@slack_msg).to match(/^\[WARN\]/)
       end
     end
 


### PR DESCRIPTION
Fix the double `[WARN] [INFO]` labeling.