### PR TITLE
Rescue EE JSON errors to silence sentry alerts

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -21,7 +21,7 @@ class ApplicationJob < ActiveJob::Base
     attr_reader :app_name
   end
 
-  rescue_from VBMS::ClientError, BGS::ShareError do |error|
+  rescue_from Caseflow::Error::TransientError, VBMS::ClientError, BGS::ShareError do |error|
     capture_exception(error: error)
   end
 

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -36,14 +36,13 @@ class ExternalApi::EfolderService
       response_body = JSON.parse(response.body)
       response_body["documents"]
     rescue JSON::ParserError => error
-      handle_json_parser_error(error)
+      handle_json_parser_error(error, response)
     end
   end
 
-  def self.handle_json_parser_error(error)
-    if response.code != 200
-      # re-throw so we try again, but don't log to sentry
-      # these are likely 502 gateway errors from EE.
+  def self.handle_json_parser_error(error, response)
+    if response.code == 502
+      # re-throw so we try again, but don't log to sentry.
       fail Caseflow::Error::TransientError, message: response.body, code: response.code
     else
       fail error

--- a/app/services/external_api/efolder_service.rb
+++ b/app/services/external_api/efolder_service.rb
@@ -36,13 +36,17 @@ class ExternalApi::EfolderService
       response_body = JSON.parse(response.body)
       response_body["documents"]
     rescue JSON::ParserError => error
-      if response.code != 200
-        # re-throw so we try again, but don't log to sentry
-        # these are likely 502 gateway errors from EE.
-        raise Caseflow::Error::TransientError, message: response.body, code: response.body
-      else
-        raise error
-      end
+      handle_json_parser_error(error)
+    end
+  end
+
+  def self.handle_json_parser_error(error)
+    if response.code != 200
+      # re-throw so we try again, but don't log to sentry
+      # these are likely 502 gateway errors from EE.
+      fail Caseflow::Error::TransientError, message: response.body, code: response.code
+    else
+      fail error
     end
   end
 

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -20,6 +20,12 @@ module Caseflow::Error
     attr_accessor :code, :message, :title
   end
 
+  class TransientError < SerializableError
+    def ignorable?
+      true
+    end
+  end
+
   class EfolderError < SerializableError; end
   class DocumentRetrievalError < EfolderError; end
   class EfolderAccessForbidden < EfolderError; end

--- a/spec/jobs/fetch_efolder_document_count_job_spec.rb
+++ b/spec/jobs/fetch_efolder_document_count_job_spec.rb
@@ -2,28 +2,64 @@
 
 describe FetchEfolderDocumentCountJob do
   describe ".perform" do
-    before do
-      allow(ExternalApi::EfolderService).to receive(:fetch_document_count) { 10 }
+    let(:file_number) { "1234" }
+    let(:user) { double(:user) }
 
+    subject { FetchEfolderDocumentCountJob.perform_now(file_number: file_number, user: user) }
+
+    before do
       @emitted_gauges = []
       allow(DataDogService).to receive(:emit_gauge) do |args|
         @emitted_gauges.push(args)
       end
     end
 
-    let(:file_number) { "1234" }
-    let(:user) { double(:user) }
+    context "success" do
+      before do
+        allow(ExternalApi::EfolderService).to receive(:fetch_document_count) { 10 }
+      end
 
-    it "calls Efolder API service" do
-      doc_count = FetchEfolderDocumentCountJob.perform_now(file_number: file_number, user: user)
+      it "calls Efolder API service" do
+        doc_count = subject
 
-      expect(doc_count).to eq(10)
-      expect(@emitted_gauges.first).to include(
-        app_name: "caseflow_job",
-        metric_group: "efolder_fetch_document_count",
-        metric_name: "runtime",
-        metric_value: anything
-      )
+        expect(doc_count).to eq(10)
+        expect(@emitted_gauges.first).to include(
+          app_name: "caseflow_job",
+          metric_group: "efolder_fetch_document_count",
+          metric_name: "runtime",
+          metric_value: anything
+        )
+      end
+    end
+
+    context "eFolder returns error with invalid JSON" do
+      before do
+        allow(ExternalApi::EfolderService).to receive(:send_efolder_request) do
+          HTTPI::Response.new(502, {}, "<head><title>502 Bad Gateway</title></head>")
+        end
+
+        allow(Rails.logger).to receive(:error).and_call_original
+      end
+
+      it "throws ignorable error" do
+        subject
+
+        expect(@emitted_gauges).to eq([])
+        expect(Rails.logger).to have_received(:error).once
+      end
+    end
+
+    context "eFolder returns success with invalid JSON" do
+      before do
+        allow(ExternalApi::EfolderService).to receive(:send_efolder_request) do
+          HTTPI::Response.new(200, {}, "i am not json")
+        end
+      end
+
+      it "throws JSON error" do
+        expect { subject }.to raise_error(JSON::ParserError)
+        expect(@emitted_gauges).to eq([])
+      end
     end
   end
 end

--- a/spec/lib/caseflow/error_spec.rb
+++ b/spec/lib/caseflow/error_spec.rb
@@ -28,4 +28,18 @@ describe "Caseflow::Error" do
       end
     end
   end
+
+  describe "TransientError" do
+    let(:error_type) { Caseflow::Error::TransientError }
+
+    subject { fail error_type, message: "oops!" }
+
+    context ".ignorable?" do
+      it "acts like ignorable BGS or VBMS error" do
+        expect { subject }.to raise_error(error_type) do |error|
+          expect(error).to be_ignorable
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
See https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/9921/events/755143/

Resolves #13998

### Description
Treat EE invalid JSON as simple retry. We need to explore why nginx occasionally throws a 502 bad gateway, but we should treat EE as any other upstream service and handle failure more gracefully.
