### PR TITLE
Ensure mail tasks assigned to the mail team get task instructions

### DIFF
--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -47,7 +47,8 @@ class MailTask < Task
           parent_task = create!(
             appeal: parent_task.appeal,
             parent_id: parent_if_blocking_task(parent_task).id,
-            assigned_to: MailTeam.singleton
+            assigned_to: MailTeam.singleton,
+            instructions: [params[:instructions]]
           )
         end
 

--- a/spec/models/tasks/mail_task_spec.rb
+++ b/spec/models/tasks/mail_task_spec.rb
@@ -11,7 +11,7 @@ describe MailTask, :postgres do
   describe ".create_from_params" do
     # Use AodMotionMailTask because we do create subclasses of MailTask, never MailTask itself.
     let(:task_class) { AodMotionMailTask }
-    let(:params) { { appeal: root_task.appeal, parent_id: root_task_id, type: task_class.name } }
+    let(:params) { { appeal: root_task.appeal, parent_id: root_task_id, type: task_class.name, instructions: "Test" } }
     let(:root_task_id) { root_task.id }
 
     context "when no root_task exists for appeal" do
@@ -30,11 +30,13 @@ describe MailTask, :postgres do
         mail_task = root_task.children[0]
         expect(mail_task.class).to eq(task_class)
         expect(mail_task.assigned_to).to eq(mail_team)
+        expect(mail_task.instructions).to eq(params[:instructions])
         expect(mail_task.children.length).to eq(1)
 
         child_task = mail_task.children[0]
         expect(child_task.class).to eq(task_class)
         expect(child_task.assigned_to).to eq(AodTeam.singleton)
+        expect(child_task.instructions).to eq(params[:instructions])
         expect(child_task.children.length).to eq(0)
       end
     end


### PR DESCRIPTION
### Description
Since #14070, we now show [active mail tasks assigned to the mail team in task snapshot](https://github.com/department-of-veterans-affairs/caseflow/pull/14070/files#diff-738d69bc1fa41b93704d5dcc4d805639R88). These tasks previously did not get created with instructions, so no instructions would appear in task snapshot. This fixes that. 

![Screen Shot 2020-05-11 at 4 10 44 PM](https://user-images.githubusercontent.com/45575454/81607100-213f4100-93a2-11ea-8f67-3022ce8422fc.png)


### Acceptance Criteria
- [ ] Mail tasks assigned to the mail team also have instructions provided upon creation

### Testing Plan
1. Sign in as jolly postman
2. Find a random case by searching for veteran "321321321" 
3. Click into case details and click "+Add a new task"
4. Add an evidence or argument task and add instructions
5. Press submit and ensure the task now shows instructions
