### PR TITLE
RoundRobin should only consider visible tasks

### DIFF
--- a/app/models/round_robin_task_distributor.rb
+++ b/app/models/round_robin_task_distributor.rb
@@ -15,7 +15,12 @@ class RoundRobinTaskDistributor
 
   def latest_task
     # Use id as a proxy for created_at since the id field is already indexed.
-    task_class.where(assigned_to: assignee_pool).order(id: :desc).first
+    # Request .visible_in_queue_table_view to avoid TimedHoldTask or similar tasks
+    task_class
+      .visible_in_queue_table_view
+      .where(assigned_to: assignee_pool)
+      .order(id: :desc)
+      .first
   end
 
   def last_assignee

--- a/spec/models/round_robin_task_distributor_spec.rb
+++ b/spec/models/round_robin_task_distributor_spec.rb
@@ -39,6 +39,18 @@ describe RoundRobinTaskDistributor, :all_dbs do
         expect(Task.all.max_by(&:created_at).assigned_to_type).to eq(Organization.name)
       end
     end
+
+    context "when a TimedHoldTask task is most recent task" do
+      let!(:task) { create(:task, assigned_to: assignee) }
+      let!(:timed_hold_task) do
+        create(:timed_hold_task, assigned_to: assignee_pool[assignee_index - 1])
+      end
+
+      it "should return the most recent non-TimedHoldTask assigned" do
+        expect(round_robin_distributor.latest_task.id).to eq(task.id)
+        expect(Task.all.max_by(&:created_at).id).to eq(timed_hold_task.id)
+      end
+    end
   end
 
   describe ".next_assignee" do


### PR DESCRIPTION
Connects #14084 

### Description
The introduction of TimedHoldTasks introduced a hidden bug in Round Robin Distributions that assumed any type of Task was valid for consideration. When users placed a case assigned to them on hold, it bumped to round robin to them. 

This PR addresses this issue by asserting that Round Robin logic should only consider user-visible Tasks.

### Acceptance Criteria
- [x] Tests pass
- [x] Running RoundRobin cycles correctly through the users

### Testing Plan
Helper Function; set on console:
```
def assign_round_robins(round_robin_distributor)
    tasks = []
    8.times do |appeal|
       appeal = FactoryBot.create(:appeal, :with_post_intake_tasks)
       task = Task.create!(appeal: appeal, parent: appeal.root_task, assigned_to: round_robin_distributor.next_assignee, status: "assigned", type: "ColocatedTask", assigned_by: User.last)
    tasks.push(task)
    end
    return tasks.pluck(:assigned_to_id)
end
```
On master:
1. Create an assignee pool of users
  ` assignee_pool = User.first(4)`
1. Create round robin distributor with type Task and the assignee pool.
  `round_robin_distributor = RoundRobinTaskDistributor.new(assignee_pool: assignee_pool, task_class: Task)`
    1. Run through several assignments, confirm RoundRobin behavior looping through the list of assignees
    `assign_round_robins(round_robin_distributor)`
        - [x] RoundRobin loops through the users
         - note the last user id!
    1. assigned a TimedHoldTask to one of the assignee users out-of-flow (i.e.; if the last user is 1, assign to 3)
    `TimedHoldTask.create!(appeal: Appeal.first, parent: Appeal.first.root_task, assigned_to: User.find( OUTOFORDERID ), status: "assigned", assigned_by: User.last, days_on_hold: 15)`
    1. run the RoundRobin again, confirm the bug and see we jumped out of the RoundRobin flow and assigned based on the TimedHoldTask assignee
    `assign_round_robins(round_robin_distributor)`
        - [x] RoundRobin assigns to the user following the TimedHoldTask assignee, not next RoundRobin assignment

On PR:
1. create assignee pool
  ` assignee_pool = User.first(4)`
1. create round robin distributor with type Task.
  `round_robin_distributor = RoundRobinTaskDistributor.new(assignee_pool: assignee_pool, task_class: Task)`
    1. run through several assignemnts, confirm RoundRobin behavior
    `assign_round_robins(round_robin_distributor)`
        - [x] RoundRobin loops through the users
        - Note the last user id!
    1. assigned a THT to a user out-of-flow (i.e.; if the last user is 1, assign to 3)
    `TimedHoldTask.create!(appeal: Appeal.first, parent: Appeal.first.root_task, assigned_to: User.find( OUTOFORDERID ), status: "assigned", assigned_by: User.last, days_on_hold: 15)`
    1. run the RoundRobin again 
    `assign_round_robins(round_robin_distributor)`
      - [x] confirm continuation of previous RoundRobin flow, not a jump to the user following TimedHoldTask user

### User Facing Changes
None

### Code Documentation Updates
- [ ]  Add note to [Auto Task Distribution](https://github.com/department-of-veterans-affairs/caseflow/wiki/Automatic-Task-Distribution#vlj-support-round-robin)