### PR TITLE
[PART 2] Allow user queues to be paginated

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -42,7 +42,7 @@ class TasksController < ApplicationController
   #      GET /tasks?user_id=xxx&role=attorney
   #      GET /tasks?user_id=xxx&role=judge
   def index
-    tasks = QueueForRole.new(user_role).create(user: user).tasks
+    tasks = user.use_task_pages_api? ? [] : QueueForRole.new(user_role).create(user: user).tasks
     render json: { tasks: json_tasks(tasks), queue_config: queue_config }
   end
 

--- a/app/models/task_pager.rb
+++ b/app/models/task_pager.rb
@@ -23,7 +23,7 @@ class TaskPager
   end
 
   def paged_tasks
-    sorted_tasks(filtered_tasks).page(page).per(TASKS_PER_PAGE)
+    @paged_tasks ||= sorted_tasks(filtered_tasks).page(page).per(TASKS_PER_PAGE)
   end
 
   def sorted_tasks(tasks)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -285,6 +285,10 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     administered_teams.select { |team| team.is_a?(JudgeTeam) }
   end
 
+  def non_administered_judge_teams
+    organizations_users.non_admin.where(organization: JudgeTeam.all)
+  end
+
   def user_info_for_idt
     self.class.user_repository.user_info_for_idt(css_id)
   end
@@ -312,6 +316,10 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     !!JudgeTeam.for_judge(self) || judge_in_vacols?
   end
 
+  def attorney?
+    non_administered_judge_teams.any? || attorney_in_vacols?
+  end
+
   def update_status!(new_status)
     transaction do
       if new_status.eql?(Constants.USER_STATUSES.inactive)
@@ -325,7 +333,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def use_task_pages_api?
-    false
+    FeatureToggle.enabled?(:user_queue_pagination, user: self) && !attorney? && !judge?
   end
 
   def queue_tabs
@@ -337,7 +345,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def self.default_active_tab
-    Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME
+    Constants.QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME
   end
 
   def assigned_tasks_tab

--- a/client/app/queue/AttorneyTaskListView.jsx
+++ b/client/app/queue/AttorneyTaskListView.jsx
@@ -73,6 +73,7 @@ class AttorneyTaskListView extends React.PureComponent {
         assignedTasks={this.props.workableTasks}
         onHoldTasks={this.props.onHoldTasks}
         completedTasks={this.props.completedTasks}
+        requireDasRecord
       />
     </AppSegment>;
   }
@@ -86,8 +87,7 @@ const mapStateToProps = (state) => {
       }
     },
     ui: {
-      messages,
-      organizations
+      messages
     }
   } = state;
 
@@ -97,7 +97,6 @@ const mapStateToProps = (state) => {
     completedTasks: completeTasksByAssigneeCssIdSelector(state),
     success: messages.success,
     error: messages.error,
-    organizations,
     taskDecision
   });
 };
@@ -124,7 +123,6 @@ AttorneyTaskListView.propTypes = {
   resetErrorMessages: PropTypes.func,
   showErrorMessage: PropTypes.func,
   onHoldTasks: PropTypes.array,
-  organizations: PropTypes.array,
   success: PropTypes.shape({
     title: PropTypes.string,
     detail: PropTypes.string

--- a/client/app/queue/ColocatedTaskListView.jsx
+++ b/client/app/queue/ColocatedTaskListView.jsx
@@ -50,11 +50,9 @@ const mapStateToProps = (state) => {
 
   return {
     success,
-    organizations: state.ui.organizations,
     assignedTasks: newTasksByAssigneeCssIdSelector(state),
     onHoldTasks: onHoldTasksByAssigneeCssIdSelector(state),
-    completedTasks: completeTasksByAssigneeCssIdSelector(state),
-    queueConfig: state.queue.queueConfig
+    completedTasks: completeTasksByAssigneeCssIdSelector(state)
   };
 };
 
@@ -71,7 +69,5 @@ ColocatedTaskListView.propTypes = {
   completedTasks: PropTypes.array,
   hideSuccessMessage: PropTypes.func,
   onHoldTasks: PropTypes.array,
-  organizations: PropTypes.array,
-  queueConfig: PropTypes.object,
   success: PropTypes.object
 };

--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -1,24 +1,13 @@
 import React from 'react';
-import _ from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { css } from 'glamor';
-import { sprintf } from 'sprintf-js';
 import PropTypes from 'prop-types';
 
-import BulkAssignButton from './components/BulkAssignButton';
-import TabWindow from '../components/TabWindow';
-import { docketNumberColumn, badgesColumn, detailsColumn, taskColumn, regionalOfficeColumn, issueCountColumn,
-  typeColumn, assignedToColumn, daysWaitingColumn, daysOnHoldColumn, readerLinkColumn, completedToNameColumn } from
-  './components/TaskTableColumns';
-
-import QueueTable from './QueueTable';
-import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
+import QueueTableBuilder from './QueueTableBuilder';
 import Alert from '../components/Alert';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
-import { tasksWithAppealsFromRawTasks } from './utils';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
-import { fullWidth } from './constants';
 
 const containerStyles = css({
   position: 'relative'
@@ -33,99 +22,8 @@ class OrganizationQueue extends React.PureComponent {
     this.props.clearCaseSelectSearch();
   }
 
-  calculateActiveTabIndex = (config) => {
-    const tabNames = config.tabs.map((tab) => {
-      return tab.name;
-    });
-    const { paginationOptions = {} } = this.props;
-    const activeTab = paginationOptions.tab || config.active_tab;
-    const index = _.indexOf(tabNames, activeTab);
-
-    return index === -1 ? 0 : index;
-  }
-
-  queueConfig = () => {
-    const config = this.props.queueConfig;
-
-    config.active_tab_index = this.calculateActiveTabIndex(config);
-
-    return config;
-  }
-
-  filterValuesForColumn = (column) => column && column.filterable && column.filter_options;
-
-  createColumnObject = (column, config, tasks) => {
-    const functionForColumn = {
-      badgesColumn: badgesColumn(tasks),
-      detailsColumn: detailsColumn(tasks, false, config.userRole),
-      taskColumn: taskColumn(tasks, this.filterValuesForColumn(column)),
-      regionalOfficeColumn: regionalOfficeColumn(tasks, this.filterValuesForColumn(column)),
-      typeColumn: typeColumn(tasks, this.filterValuesForColumn(column), false),
-      assignedToColumn: assignedToColumn(tasks, this.filterValuesForColumn(column)),
-      completedToNameColumn: completedToNameColumn(),
-      docketNumberColumn: docketNumberColumn(tasks, this.filterValuesForColumn(column), false),
-      daysWaitingColumn: daysWaitingColumn(false),
-      daysOnHoldColumn: daysOnHoldColumn(false),
-      readerLinkColumn: readerLinkColumn(false, true),
-      issueCountColumn: issueCountColumn(false)
-    };
-
-    return functionForColumn[column.name];
-  }
-
-  columnsFromConfig = (config, tabConfig, tasks) =>
-    tabConfig.columns.map((column) => this.createColumnObject(column, config, tasks));
-
-  taskTableTabFactory = (tabConfig, config) => {
-    const { paginationOptions = {} } = this.props;
-    const tasks = tasksWithAppealsFromRawTasks(tabConfig.tasks);
-    const cols = this.columnsFromConfig(config, tabConfig, tasks);
-    const totalTaskCount = tabConfig.total_task_count;
-
-    return {
-      label: sprintf(tabConfig.label, totalTaskCount),
-      page: <React.Fragment>
-        <p className="cf-margin-top-0">{tabConfig.description}</p>
-        { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
-        <QueueTable
-          key={tabConfig.name}
-          columns={cols}
-          rowObjects={tasks}
-          getKeyForRow={(_rowNumber, task) => task.uniqueId}
-          casesPerPage={config.tasks_per_page}
-          numberOfPages={tabConfig.task_page_count}
-          totalTaskCount={totalTaskCount}
-          taskPagesApiEndpoint={tabConfig.task_page_endpoint_base_path}
-          tabPaginationOptions={paginationOptions.tab === tabConfig.name && paginationOptions}
-          useTaskPagesApi
-          enablePagination
-        />
-      </React.Fragment>
-    };
-  }
-
-  tabsFromConfig = (config) => {
-    return config.tabs.map((tabConfig) => {
-      return this.taskTableTabFactory(tabConfig, config);
-    });
-  }
-
-  makeQueueComponents = (config) => {
-    return <div>
-      <h1 {...fullWidth}>{config.table_title}</h1>
-      <QueueOrganizationDropdown organizations={this.props.organizations} />
-
-      <TabWindow
-        name="tasks-organization-queue"
-        tabs={this.tabsFromConfig(config)}
-        defaultPage={config.active_tab_index}
-      />
-    </div>;
-  }
-
   render = () => {
     const { success, tasksAssignedByBulk } = this.props;
-    const body = this.makeQueueComponents(this.queueConfig());
 
     return <AppSegment filledBackground styling={containerStyles}>
       {success && <Alert type="success" title={success.title} message={success.detail} />}
@@ -139,7 +37,7 @@ class OrganizationQueue extends React.PureComponent {
           type="success"
           styling={alertStyling} />
       }
-      {body}
+      <QueueTableBuilder />
     </AppSegment>;
   };
 }
@@ -148,10 +46,8 @@ OrganizationQueue.propTypes = {
   clearCaseSelectSearch: PropTypes.func,
   onHoldTasks: PropTypes.array,
   organizations: PropTypes.array,
-  queueConfig: PropTypes.object,
   success: PropTypes.object,
-  tasksAssignedByBulk: PropTypes.object,
-  paginationOptions: PropTypes.object
+  tasksAssignedByBulk: PropTypes.object
 };
 
 const mapStateToProps = (state) => {
@@ -159,12 +55,8 @@ const mapStateToProps = (state) => {
 
   return {
     success,
-    userRole: state.ui.userRole,
-    organizationName: state.ui.activeOrganization.name,
-    organizationIsVso: state.ui.activeOrganization.isVso,
     organizations: state.ui.organizations,
-    tasksAssignedByBulk: state.queue.tasksAssignedByBulk,
-    queueConfig: state.queue.queueConfig
+    tasksAssignedByBulk: state.queue.tasksAssignedByBulk
   };
 };
 

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -277,7 +277,7 @@ class QueueApp extends React.PureComponent {
 
     return (
       <OrganizationQueueLoadingScreen urlToLoad={`${url}/tasks`}>
-        <OrganizationQueue {...this.props} paginationOptions={querystring.parse(window.location.search.slice(1))} />
+        <OrganizationQueue {...this.props} />
       </OrganizationQueueLoadingScreen>
     );
   };

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -660,7 +660,7 @@ HeaderRow.propTypes = FooterRow.propTypes = Row.propTypes = BodyRows.propTypes =
   useTaskPagesApi: PropTypes.bool,
   userReadableColumnNames: PropTypes.object,
   tabPaginationOptions: PropTypes.shape({
-    [QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM]: PropTypes.number,
+    [QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM]: PropTypes.string,
     [QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM]: PropTypes.string,
     [QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM]: PropTypes.string,
     [`${QUEUE_CONFIG.FILTER_COLUMN_REQUEST_PARAM}[]`]: PropTypes.arrayOf(PropTypes.string),

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -1,28 +1,51 @@
 import React from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { sprintf } from 'sprintf-js';
 import { connect } from 'react-redux';
+import querystring from 'querystring';
 
+import BulkAssignButton from './components/BulkAssignButton';
 import QueueTable from './QueueTable';
 import TabWindow from '../components/TabWindow';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
-import { completedToNameColumn, daysOnHoldColumn, daysWaitingColumn, detailsColumn, docketNumberColumn,
-  badgesColumn, issueCountColumn, readerLinkColumn, readerLinkColumnWithNewDocsIcon, regionalOfficeColumn,
-  taskColumn, taskCompletedDateColumn, typeColumn } from './components/TaskTableColumns';
+import { assignedToColumn, completedToNameColumn, daysOnHoldColumn, daysWaitingColumn, detailsColumn,
+  docketNumberColumn, badgesColumn, issueCountColumn, readerLinkColumn, readerLinkColumnWithNewDocsIcon,
+  regionalOfficeColumn, taskColumn, taskCompletedDateColumn, typeColumn } from './components/TaskTableColumns';
+import { tasksWithAppealsFromRawTasks } from './utils';
 
 import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
-import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import { fullWidth } from './constants';
 
 /**
- * A component to create a queue table's tabs and columns from a queue config and the user's tasks
- * The required props are:
+ * A component to create a queue table's tabs and columns from a queue config or the assignee's tasks
+ * The props are:
  * - @assignedTasks {array[object]} array of task objects to appear in the assigned tab
  * - @onHoldTasks {array[object]} array of task objects to appear in the on hold tab
  * - @completedTasks {array[object]} array of task objects to appear in the completed tab
  **/
 
 class QueueTableBuilder extends React.PureComponent {
+
+  paginationOptions = () => querystring.parse(window.location.search.slice(1));
+
+  calculateActiveTabIndex = (config) => {
+    const tabNames = config.tabs.map((tab) => {
+      return tab.name;
+    });
+    const activeTab = this.paginationOptions().tab || config.active_tab;
+    const index = _.indexOf(tabNames, activeTab);
+
+    return index === -1 ? 0 : index;
+  }
+
+  queueConfig = () => {
+    const { config } = this.props;
+
+    config.active_tab_index = this.calculateActiveTabIndex(config);
+
+    return config;
+  }
 
   tasksForTab = (tabName) => {
     const mapper = {
@@ -34,22 +57,26 @@ class QueueTableBuilder extends React.PureComponent {
     return mapper[tabName];
   }
 
+  filterValuesForColumn = (column) => column && column.filterable && column.filter_options;
+
   createColumnObject = (column, config, tasks) => {
-    const requireDasRecord = config.userRole === USER_ROLE_TYPES.attorney;
+    const { requireDasRecord } = this.props;
+    const filterOptions = this.filterValuesForColumn(column);
     const functionForColumn = {
-      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, false, requireDasRecord),
+      [QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name]: typeColumn(tasks, filterOptions, requireDasRecord),
+      [QUEUE_CONFIG.COLUMNS.BADGES.name]: badgesColumn(tasks),
       [QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name]: detailsColumn(tasks, requireDasRecord, config.userRole),
       [QUEUE_CONFIG.COLUMNS.DAYS_ON_HOLD.name]: daysOnHoldColumn(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(requireDasRecord),
-      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, false, requireDasRecord),
+      [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, filterOptions, requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(requireDasRecord, true),
-      [QUEUE_CONFIG.COLUMNS.BADGES.name]: badgesColumn(tasks),
       [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(requireDasRecord),
-      [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, false),
+      [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, filterOptions),
+      [QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name]: assignedToColumn(tasks, filterOptions),
       [QUEUE_CONFIG.COLUMNS.TASK_ASSIGNER.name]: completedToNameColumn(),
       [QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name]: taskCompletedDateColumn(),
-      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, false)
+      [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, filterOptions)
     };
 
     return functionForColumn[column.name];
@@ -59,17 +86,28 @@ class QueueTableBuilder extends React.PureComponent {
     (tabConfig.columns || []).map((column) => this.createColumnObject(column, config, tasks));
 
   taskTableTabFactory = (tabConfig, config) => {
-    const tasks = this.tasksForTab(tabConfig.name);
+    const paginationOptions = this.paginationOptions();
+    const tasks = config.use_task_pages_api ?
+      tasksWithAppealsFromRawTasks(tabConfig.tasks) :
+      this.tasksForTab(tabConfig.name);
+    const totalTaskCount = config.use_task_pages_api ? tabConfig.total_task_count : tasks.length;
 
     return {
-      label: sprintf(tabConfig.label, tasks.length),
+      label: sprintf(tabConfig.label, totalTaskCount),
       page: <React.Fragment>
         <p className="cf-margin-top-0">{tabConfig.description}</p>
+        { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
         <QueueTable
           key={tabConfig.name}
           columns={this.columnsFromConfig(config, tabConfig, tasks)}
           rowObjects={tasks}
           getKeyForRow={(_rowNumber, task) => task.uniqueId}
+          casesPerPage={config.tasks_per_page}
+          numberOfPages={tabConfig.task_page_count}
+          totalTaskCount={totalTaskCount}
+          taskPagesApiEndpoint={tabConfig.task_page_endpoint_base_path}
+          tabPaginationOptions={paginationOptions.tab === tabConfig.name && paginationOptions}
+          useTaskPagesApi={config.use_task_pages_api}
           enablePagination
         />
       </React.Fragment>
@@ -79,12 +117,12 @@ class QueueTableBuilder extends React.PureComponent {
   tabsFromConfig = (config) => (config.tabs || []).map((tabConfig) => this.taskTableTabFactory(tabConfig, config));
 
   render = () => {
-    const { config } = this.props;
+    const config = this.queueConfig();
 
     return <React.Fragment>
       <h1 {...fullWidth}>{config.table_title}</h1>
       <QueueOrganizationDropdown organizations={this.props.organizations} />
-      <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} />
+      <TabWindow name="tasks-tabwindow" tabs={this.tabsFromConfig(config)} defaultPage={config.active_tab_index} />
     </React.Fragment>;
   };
 }
@@ -102,8 +140,10 @@ QueueTableBuilder.propTypes = {
   onHoldTasks: PropTypes.array,
   completedTasks: PropTypes.array,
   config: PropTypes.shape({
-    table_title: PropTypes.string
-  })
+    table_title: PropTypes.string,
+    active_tab_index: PropTypes.number
+  }),
+  requireDasRecord: PropTypes.bool
 };
 
 export default (connect(mapStateToProps)(QueueTableBuilder));

--- a/client/test/karma/queue/ColocatedTaskListView-test.js
+++ b/client/test/karma/queue/ColocatedTaskListView-test.js
@@ -317,7 +317,7 @@ describe('ColocatedTaskListView', () => {
         }
     ],
     "tasks_per_page": 15,
-    "use_task_pages_api": true
+    "use_task_pages_api": false
 };
 
   /* eslint-disable no-unused-expressions */

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -197,6 +197,24 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
           expect(data.size).to be(1)
         end
+
+        context "when using task pages api" do
+          before do
+            expect(QueueForRole).not_to receive(:new)
+            allow_any_instance_of(User).to receive(:use_task_pages_api?).and_return(true)
+          end
+
+          it "gets tasks from task pager, not queue for role" do
+            get :index, params: { user_id: user.id, role: "unknown" }
+            expect(response.status).to eq 200
+
+            queue_for_role_tasks = JSON.parse(response.body)["tasks"]["data"]
+            expect(queue_for_role_tasks.size).to be(0)
+
+            paged_tasks = JSON.parse(response.body)["queue_config"]["tabs"].first["tasks"]
+            expect(paged_tasks.size).to be(1)
+          end
+        end
       end
 
       context "when a task is assignable" do

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -76,7 +76,7 @@ describe QueueConfig, :postgres do
         let(:assignee) { user }
 
         it "is the assigned tab" do
-          expect(subject[:active_tab]).to eq(Constants.QUEUE_CONFIG.ASSIGNED_TASKS_TAB_NAME)
+          expect(subject[:active_tab]).to eq(Constants.QUEUE_CONFIG.INDIVIDUALLY_ASSIGNED_TASKS_TAB_NAME)
         end
       end
     end
@@ -232,7 +232,8 @@ describe QueueConfig, :postgres do
           let!(:on_hold_tasks) { create_list(:ama_task, 5, :on_hold, assigned_to: assignee) }
           let!(:completed_tasks) { create_list(:ama_task, 7, :completed, assigned_to: assignee) }
 
-          before { allow(assignee).to receive(:use_task_pages_api?).and_return(true) }
+          before { FeatureToggle.enable!(:user_queue_pagination, users: [assignee.css_id]) }
+          after { FeatureToggle.disable!(:user_queue_pagination, users: [assignee.css_id]) }
 
           it "returns the tasks in the correct tabs" do
             tabs = subject


### PR DESCRIPTION
Part 2 of stack to bump #14142
[Part 1](https://github.com/department-of-veterans-affairs/caseflow/pull/14252)

## Description
Allows user queues to be paginated

## Testing
1. Log in as BVALSPORER
1. Pad your queue with some tasks
```ruby
3.times do 
  ColocatedTask.actions_assigned_to_colocated.map(&:to_sym).each do |action|
    appeal = FactoryBot.create(:appeal)
    parent = FactoryBot.create(
      :ama_task,
      assigned_to: User.first,
      assigned_by: User.first,
      appeal: appeal
    )
    task = FactoryBot.create(
      :ama_colocated_task,
      action,
      assigned_to: Colocated.singleton,
      appeal: appeal,
      assigned_by: User.first,
      parent_id: parent.id
    )
    task.children.first.on_hold!
  end
end
```
3. Enable pagination
```ruby
FeatureToggle.enable!(:user_queue_pagination, users: ["BVALSPORER"])
```
4. Test Pagination!

### Initial queue load only loads first page of tasks
With dev tools open, got to the user's queue
![Screen Shot 2020-05-12 at 3 58 34 PM](https://user-images.githubusercontent.com/45575454/81739509-7d20cd00-9469-11ea-8829-ec8cdb4ee8de.png)
- [x] This request for tasks only returns the first 15 tasks for each tab.
- [x] `total_task_count` and `task_page_count` are correct 
- [x] This request does not return all tasks assigned to the user in `tasks: { data: [] }`

### Filtering, sorting, paging, and switching tabs work
Try a combination of filtering and sorting to confirm the correct tasks are show. Bonus points for trying the same combination more than once and noticing the loading page is not shown because we're pulling from cached results. Each request should only return 15 tasks.
![Screen Shot 2020-05-12 at 4 44 16 PM](https://user-images.githubusercontent.com/45575454/81744429-36cf6c00-9471-11ea-86fe-228910c81f7c.png)


#### Sorting
![Screen Shot 2020-05-12 at 4 06 09 PM](https://user-images.githubusercontent.com/45575454/81740197-90806800-946a-11ea-9f44-8cb220782308.png)
![Screen Shot 2020-05-12 at 4 06 22 PM](https://user-images.githubusercontent.com/45575454/81740201-92e2c200-946a-11ea-9892-cc749ce49e3f.png)
- [x] Sorting on a column
   - [x] Displays the tasks in the correct order
   - [x] Affects tasks on higher number pages
   - [ ] Updates the address bar to show sorting (confirm this url is correct by bookmarking this page and clicking the bookmark. It should show the same order of tasks and the correct indicator of which column is being sorted http://localhost:3000/queue?tab=assigned_person&page=2&sort_by=taskColumn&order=desc)

#### Filtering
![Screen Shot 2020-05-12 at 4 14 55 PM](https://user-images.githubusercontent.com/45575454/81740949-c540ef00-946b-11ea-9d8a-402742983e91.png)
![Screen Shot 2020-05-12 at 4 15 06 PM](https://user-images.githubusercontent.com/45575454/81740961-c7a34900-946b-11ea-901b-f02e588ac87b.png)

- [x] Filtering on a column
   - [x] Displays the correctly filtered tasks
   - [x] Affects tasks on higher number pages
   - [x] Updates the address bar to show filtering (confirm this url is correct by bookmarking this page and clicking the bookmark. It should show the same filtered tasks and the correct indicator of which column is being filtered http://localhost:3000/queue?tab=on_hold_person&page=2&filter%5B%5D=col%3DtaskColumn%26val%3DAddressVerificationColocatedTask%7CExtensionColocatedTask%7CHearingClarificationColocatedTask%7CIhpColocatedTask)

### Paging
![Screen Shot 2020-05-12 at 4 12 27 PM](https://user-images.githubusercontent.com/45575454/81740826-932f8d00-946b-11ea-8e90-59195b1ca167.png)
![Screen Shot 2020-05-12 at 4 12 35 PM](https://user-images.githubusercontent.com/45575454/81740832-96c31400-946b-11ea-9143-d85551c630a3.png)
- [x] Going to a new page
    - [x] Preserves any filtering
    - [x] Preserves any sorting
    - [x] Displays the correct "showing tasks x of xx"
    - [ ] Updates the address bar to show paging (confirm this url is correct by bookmarking this page and clicking the bookmark. It should show the same page of tasks and the correct page indicator http://localhost:3000/queue?tab=on_hold_person&page=2)

### Changing tabs
![Screen Shot 2020-05-12 at 4 18 40 PM](https://user-images.githubusercontent.com/45575454/81741269-4b5d3580-946c-11ea-9fde-426b3cd115f7.png)
![Screen Shot 2020-05-12 at 4 18 53 PM](https://user-images.githubusercontent.com/45575454/81741274-4c8e6280-946c-11ea-8bbd-00a47d84726b.png)
- [x] Changing tabs
   - [x] Changes the tab (I ddon't know what you expected here
   - [x] Updates the address bar to show the updated tab (confirm this url is correct by bookmarking this page and clicking the bookmark. It should show the same tab of tasks and the correct tab indicator http://localhost:3000/queue?tab=on_hold_person&page=1)

### Any combinations of the above
- [ ] Go ahead, get crazy
- [ ] Incorrect combinations should update the page and address bar to the default (page 1, assigned tab, no sort, sort asc, no filter, correct filters) (Confirm the invalid URL is replaced with a valid one)
    - [x] [`?tab=INVALID_TAB_NAME`](http://localhost:3000/queue?tab=INVALID_TAB_NAME)
 `?tab=unassigned_person&page=1`
    - [x] [`?tab=assigned_person&page=20`](http://localhost:3000/queue?tab=assigned_person&page=1) 
  `?tab=assigned_person&page=1`
    - [x] [`?tab=assigned_person&page=-12`](http://localhost:3000/queue?tab=assigned_person&page=-12) 
  `?tab=assigned_person&page=1`
    - [x] [`?tab=assigned_person&page=1&sort_by=INVALID_COLUMN`](http://localhost:3000/queue?tab=assigned_person&page=1&sort_by=INVALID_COLUMN) 
  `?tab=assigned_person&page=1`
    - [x] [`?tab=assigned_person&page=1&sort_by=taskColumn&order=INVALID_SORT_ORDER`](http://localhost:3000/queue?tab=assigned_person&page=1&sort_by=taskColumn&order=INVALID_SORT_ORDER) 
  `?tab=assigned_person&page=1&sort_by=taskColumn&order=asc` (Notice the sort order is defaulted to asc)
    - [x] [`?tab=assigned_person&page=1&filter%5B%5D=col%3DINVALID_COLUMN_NAME%26val%3DAojColocatedTask`](http://localhost:3000/queue?tab=assigned_person&page=1&filter%5B%5D=col%3DINVALID_COLUMN_NAME%26val%3DAojColocatedTask) 
  `?tab=assigned_person&page=1`
    - [x] [`?tab=assigned_person&page=1&filter%5B%5D=col%3DtaskColumn%26val%3DINVALID_FILTER_VALUE`](http://localhost:3000/queue?tab=assigned_person&page=1&filter%5B%5D=col%3DtaskColumn%26val%3DINVALID_FILTER_VALUE) 
  `?tab=on_hold_person&page=1`
    - [x] [`?tab=on_hold_person&page=1&filter%5B%5D=col%3DtaskColumn%26val%3DAddressVerificationColocatedTask%7CINVALID_FILTER_VALUE`](http://localhost:3000/queue?tab=on_hold_person&page=1&filter%5B%5D=col%3DtaskColumn%26val%3DAddressVerificationColocatedTask%7CINVALID_FILTER_VALUE) 
  `?tab=on_hold_person&page=1&filter%5B%5D=col%3DtaskColumn%26val%3DAddressVerificationColocatedTask` (Notice correct filter is preserved)


## THINGS THAT SHOULD NOT HAVE CHANGED
 - [ ] The appearance and functionality of attorney queues

BEFORE|AFTER
---|---
![Screen Shot 2020-05-12 at 4 36 33 PM](https://user-images.githubusercontent.com/45575454/81742936-d808f300-946e-11ea-9f28-0e141f80d41f.png)|![Screen Shot 2020-05-12 at 4 37 32 PM](https://user-images.githubusercontent.com/45575454/81742977-ed7e1d00-946e-11ea-9511-8286d1ff5b9f.png)
![Screen Shot 2020-05-12 at 4 36 52 PM](https://user-images.githubusercontent.com/45575454/81742946-dc351080-946e-11ea-8fe7-db6d58ab69bf.png)|![Screen Shot 2020-05-12 at 4 37 39 PM](https://user-images.githubusercontent.com/45575454/81743001-f40c9480-946e-11ea-9b5d-4e8b744a2a0e.png)


 - [ ] The appearance and functionality of judge queues

BEFORE|AFTER
---|---
![Screen Shot 2020-05-12 at 4 35 04 PM](https://user-images.githubusercontent.com/45575454/81742799-a728be00-946e-11ea-9ac0-b7c89cdec383.png)|![Screen Shot 2020-05-12 at 4 35 34 PM](https://user-images.githubusercontent.com/45575454/81742812-ac860880-946e-11ea-96bf-3e1d9134b070.png)

 - [ ] The appearance and functionality of organization queues

BEFORE|AFTER
---|---
![Screen Shot 2020-05-12 at 4 33 28 PM](https://user-images.githubusercontent.com/45575454/81742614-60d35f00-946e-11ea-95cf-e95dd8db73ac.png) | ![Screen Shot 2020-05-12 at 4 33 44 PM](https://user-images.githubusercontent.com/45575454/81742626-64ff7c80-946e-11ea-9463-158789f852e7.png)

