### PR TITLE
Add method for fetching multiple cached BGS addresses

### DIFF
--- a/app/services/bgs_address_service.rb
+++ b/app/services/bgs_address_service.rb
@@ -8,6 +8,22 @@ class BgsAddressService
 
   bgs_attr_accessor :address_line_1, :address_line_2, :address_line_3, :city, :country, :state, :zip
 
+  class << self
+    def cache_key_for_participant_id(participant_id)
+      "bgs-participant-address-#{participant_id}"
+    end
+
+    def participant_id_from_cache_key(key)
+      key.split("-")[-1]
+    end
+
+    def fetch_cached_addresses(participant_ids)
+      keys = participant_ids.map { |id| cache_key_for_participant_id(id) }
+      addresses = Rails.cache.read_multi(*keys)
+      Hash[addresses.map { |k, v| [participant_id_from_cache_key(k), v] }]
+    end
+  end
+
   def address
     return nil unless found?
 
@@ -25,7 +41,7 @@ class BgsAddressService
   end
 
   def fetch_bgs_record
-    cache_key = "bgs-participant-address-#{participant_id}"
+    cache_key = self.class.cache_key_for_participant_id(participant_id)
     Rails.cache.fetch(cache_key, expires_in: 24.hours) do
       bgs.find_address_by_participant_id(participant_id)
     rescue Savon::Error

--- a/spec/services/bgs_address_service_spec.rb
+++ b/spec/services/bgs_address_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+describe BgsAddressService do
+  describe "#participant_id_from_cache_key" do
+    it "extracts a participant ID from a cache key" do
+      participant_id = "123456"
+      cache_key = BgsAddressService.cache_key_for_participant_id(participant_id)
+      expect(BgsAddressService.participant_id_from_cache_key(cache_key)).to eq(participant_id)
+    end
+  end
+
+  describe "#fetch_cached_addresses" do
+    it "retrieves only cached addresses" do
+      addresses = {
+        "123" => {"address": "address one"},
+        "456" => {"address": "address two"}
+      }
+      addresses.each do |pid, value|
+        Rails.cache.write(BgsAddressService.cache_key_for_participant_id(pid), value)
+      end
+      expect(BgsAddressService.fetch_cached_addresses(["123", "456", "789"])).to eq(addresses)
+    end
+  end
+end

--- a/spec/services/bgs_address_service_spec.rb
+++ b/spec/services/bgs_address_service_spec.rb
@@ -12,13 +12,13 @@ describe BgsAddressService do
   describe "#fetch_cached_addresses" do
     it "retrieves only cached addresses" do
       addresses = {
-        "123" => {"address": "address one"},
-        "456" => {"address": "address two"}
+        "123" => { "address": "address one" },
+        "456" => { "address": "address two" }
       }
       addresses.each do |pid, value|
         Rails.cache.write(BgsAddressService.cache_key_for_participant_id(pid), value)
       end
-      expect(BgsAddressService.fetch_cached_addresses(["123", "456", "789"])).to eq(addresses)
+      expect(BgsAddressService.fetch_cached_addresses(%w[123 456 789])).to eq(addresses)
     end
   end
 end


### PR DESCRIPTION
Connects #14132 

### Description
This adds a few class methods to `BgsAddressService`, notably a `#fetch_cached_addresses` to fetch multiple cached addresses in one round-trip to Redis. A future PR will make use of this method to "join" addresses to a list of attorney names from Postgres, on participant ID.

### Testing Plan
1. Added new rspec file for `BgsAddressService`