### PR TITLE
Use task assignee name in queue tables

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -33,7 +33,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     appeals = Appeal.includes(:available_hearing_locations).where(id: open_appeals_from_tasks(Appeal.name))
     request_issues_to_cache = request_issue_counts_for_appeal_ids(appeals.pluck(:id))
     veteran_names_to_cache = veteran_names_for_file_numbers(appeals.pluck(:veteran_file_number))
-    appeal_assignees_to_cache = assignees_for_caseflow_appeal_ids(appeals.pluck(:id), Appeal.name)
 
     appeal_aod_status = aod_status_for_appeals(appeals)
     representative_names = representative_names_for_appeals(appeals)
@@ -43,7 +42,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       {
         appeal_id: appeal.id,
         appeal_type: Appeal.name,
-        assignee_label: appeal_assignees_to_cache[appeal.id],
         case_type: appeal.type,
         closest_regional_office_city: regional_office ? regional_office[:city] : COPY::UNKNOWN_REGIONAL_OFFICE,
         closest_regional_office_key: regional_office ? appeal.closest_regional_office : COPY::UNKNOWN_REGIONAL_OFFICE,
@@ -57,8 +55,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       }
     end
 
-    update_columns = [:assignee_label,
-                      :case_type,
+    update_columns = [:case_type,
                       :closest_regional_office_city,
                       :closest_regional_office_key,
                       :docket_type,
@@ -147,7 +144,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
       issue_counts_to_cache = issues_counts_for_vacols_folders(batch_vacols_ids)
       aod_status_to_cache = VACOLS::Case.aod(batch_vacols_ids)
-      appeal_assignees_to_cache = assignees_for_vacols_id(vacols_cases)
 
       correspondent_ids = vacols_folders.map { |folder| folder[:correspondent_id] }
       veteran_names_to_cache = veteran_names_for_correspondent_ids(correspondent_ids)
@@ -157,7 +153,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
         {
           vacols_id: folder[:vacols_id],
-          assignee_label: appeal_assignees_to_cache[folder[:vacols_id]],
           case_type: vacols_case[:status],
           docket_number: folder[:docket_number],
           issue_count: issue_counts_to_cache[folder[:vacols_id]] || 0,
@@ -166,7 +161,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         }
       end
 
-      update_columns = [:assignee_label, :docket_number, :issue_count, :veteran_name, :case_type, :is_aod]
+      update_columns = [:docket_number, :issue_count, :veteran_name, :case_type, :is_aod]
       CachedAppeal.import values_to_cache, on_duplicate_key_update: { conflict_target: [:vacols_id],
                                                                       columns: update_columns }
 
@@ -234,36 +229,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     end.to_h
   end
 
-  def assignees_for_caseflow_appeal_ids(appeal_ids, appeal_type)
-    active_appeals = caseflow_appeals_assignees(appeal_ids, appeal_type, Task.active)
-    on_hold_appeals = caseflow_appeals_assignees(appeal_ids, appeal_type, Task.on_hold)
-
-    on_hold_appeals.merge(active_appeals)
-  end
-
-  def assignees_for_vacols_id(vacols_cases)
-    # Grab statuses from input hash of VACOLS cases.
-    vacols_statuses = vacols_cases.keys.map do |vacols_id|
-      [vacols_id, vacols_cases[vacols_id][:location]]
-    end.to_h
-
-    # Grab the appeal_ids for the VACOLS cases in CASEFLOW status
-    caseflow_vacols_ids = vacols_statuses.select { |_key, value| value == "CASEFLOW" }.keys
-    caseflow_vacols_to_appeal_id = LegacyAppeal.where(vacols_id: caseflow_vacols_ids).pluck(:vacols_id, :id).to_h
-
-    # Lookup more detailed Caseflow location for CASEFLOW vacols status
-    caseflow_statuses_by_appeal_id = assignees_for_caseflow_appeal_ids(caseflow_vacols_to_appeal_id.values,
-                                                                       LegacyAppeal.name)
-    # Map back to VACOLS id
-    caseflow_statuses_by_vacol_id = {}
-    caseflow_vacols_to_appeal_id.each do |vacols_id, appeal_id|
-      caseflow_statuses_by_vacol_id[vacols_id] = caseflow_statuses_by_appeal_id[appeal_id]
-    end
-
-    # Overwrite VACOLS Caseflow location with Caseflow detailed location
-    vacols_statuses.merge(caseflow_statuses_by_vacol_id)
-  end
-
   def case_fields_for_vacols_ids(vacols_ids)
     # array of arrays will become hash with bfkey as key.
     # [
@@ -286,25 +251,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         }
       ]
     end.to_h
-  end
-
-  def caseflow_appeals_assignees(appeal_ids, appeal_type, tasks)
-    ordered_tasks = tasks
-      .visible_in_queue_table_view
-      .where(appeal_type: appeal_type, appeal_id: appeal_ids)
-      .order(:appeal_id, created_at: :desc)
-
-    first_task_assignees_per_caseflow_appeal(ordered_tasks)
-  end
-
-  def first_task_assignees_per_caseflow_appeal(tasks)
-    org_tasks = tasks.joins("left join organizations on tasks.assigned_to_id = organizations.id")
-      .where("tasks.assigned_to_type = 'Organization'").pluck(:created_at, :appeal_id, "organizations.name")
-    user_tasks = tasks.joins("left join users on tasks.assigned_to_id = users.id")
-      .where("tasks.assigned_to_type = 'User'").pluck(:created_at, :appeal_id, "users.css_id")
-
-    # Combine the user & org tasks, preferring the most recently created (last) task
-    (org_tasks + user_tasks).sort_by { |task| task[0] }.map { |task| task.drop(1) }.to_h
   end
 
   def issues_counts_for_vacols_folders(vacols_ids)

--- a/app/models/cached_appeal.rb
+++ b/app/models/cached_appeal.rb
@@ -2,10 +2,4 @@
 
 class CachedAppeal < CaseflowRecord
   self.table_name = "cached_appeal_attributes"
-
-  def self.left_join_from_tasks_clause
-    "left join #{CachedAppeal.table_name} "\
-    "on #{CachedAppeal.table_name}.appeal_id = #{Task.table_name}.appeal_id "\
-    "and #{CachedAppeal.table_name}.appeal_type = #{Task.table_name}.appeal_type"
-  end
 end

--- a/app/models/quality_review_case_selector.rb
+++ b/app/models/quality_review_case_selector.rb
@@ -17,7 +17,7 @@ class QualityReviewCaseSelector
       QualityReviewTask
         .not_cancelled
         .created_this_month
-        .where(assigned_to_type: Organization.name)
+        .assigned_to_organization
         .size >= MONTHLY_LIMIT_OF_QUAILITY_REVIEWS
     end
   end

--- a/app/models/queue_column.rb
+++ b/app/models/queue_column.rb
@@ -68,14 +68,13 @@ class QueueColumn
   private
 
   def case_type_options(tasks)
-    options = tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .group(:case_type).count.each_pair.map do |option, count|
+    options = tasks.with_cached_appeals.group(:case_type).count.each_pair.map do |option, count|
       label = self.class.format_option_label(option, count)
       self.class.filter_option_hash(option, label)
     end
 
     # Add the AOD option as the first option in the list.
-    aod_counts = tasks.joins(CachedAppeal.left_join_from_tasks_clause).group(:is_aod).count[true]
+    aod_counts = tasks.with_cached_appeals.group(:is_aod).count[true]
     if aod_counts
       aod_option_key = Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_AOD.key
       aod_option_label = self.class.format_option_label("AOD", aod_counts)
@@ -86,15 +85,14 @@ class QueueColumn
   end
 
   def docket_type_options(tasks)
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause).group(:docket_type).count.each_pair.map do |option, count|
+    tasks.with_cached_appeals.group(:docket_type).count.each_pair.map do |option, count|
       label = self.class.format_option_label(Constants::DOCKET_NAME_FILTERS[option], count)
       self.class.filter_option_hash(option, label)
     end
   end
 
   def regional_office_options(tasks)
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .group(:closest_regional_office_city).count.each_pair.map do |option, count|
+    tasks.with_cached_appeals.group(:closest_regional_office_city).count.each_pair.map do |option, count|
       label = self.class.format_option_label(option, count)
       self.class.filter_option_hash(option, label)
     end

--- a/app/models/queue_column.rb
+++ b/app/models/queue_column.rb
@@ -108,16 +108,7 @@ class QueueColumn
   end
 
   def assignee_options(tasks)
-    org_options = tasks.assigned_to_organization
-      .joins("INNER JOIN organizations ON tasks.assigned_to_id = organizations.id")
-      .group("organizations.name")
-      .count(:all)
-    user_options = tasks.assigned_to_user
-      .joins("INNER JOIN users ON tasks.assigned_to_id = users.id")
-      .group("users.full_name") # Confirm with design
-      .count(:all)
-
-    org_options.merge(user_options).each_pair.map do |option, count|
+    tasks.with_assignees.group("assignees.display_name").count(:all).each_pair.map do |option, count|
       label = self.class.format_option_label(option, count)
       self.class.filter_option_hash(option, label)
     end

--- a/app/models/queue_column.rb
+++ b/app/models/queue_column.rb
@@ -108,8 +108,16 @@ class QueueColumn
   end
 
   def assignee_options(tasks)
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .group(:assignee_label).count.each_pair.map do |option, count|
+    org_options = tasks.assigned_to_organization
+      .joins("INNER JOIN organizations ON tasks.assigned_to_id = organizations.id")
+      .group("organizations.name")
+      .count(:all)
+    user_options = tasks.assigned_to_user
+      .joins("INNER JOIN users ON tasks.assigned_to_id = users.id")
+      .group("users.full_name") # Confirm with design
+      .count(:all)
+
+    org_options.merge(user_options).each_pair.map do |option, count|
       label = self.class.format_option_label(option, count)
       self.class.filter_option_hash(option, label)
     end

--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -22,8 +22,8 @@ class AssignHearingTab
       ScheduleHearingTask
         .includes(*task_includes)
         .active
+        .with_cached_appeals
         .where(appeal_type: appeal_type)
-        .joins(CachedAppeal.left_join_from_tasks_clause)
 
     @tasks ||=
       if appeal_type == "LegacyAppeal"
@@ -85,16 +85,14 @@ class AssignHearingTab
   end
 
   def power_of_attorney_name_options
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .group(:power_of_attorney_name).count.each_pair.map do |option, count|
+    tasks.with_cached_appeals.group(:power_of_attorney_name).count.each_pair.map do |option, count|
       label = QueueColumn.format_option_label(option, count)
       QueueColumn.filter_option_hash(option, label)
     end
   end
 
   def suggested_location_options
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .group(:suggested_hearing_location).count.each_pair.map do |option, count|
+    tasks.with_cached_appeals.group(:suggested_hearing_location).count.each_pair.map do |option, count|
       label = QueueColumn.format_option_label(option, count)
       QueueColumn.filter_option_hash(option, label)
     end

--- a/app/models/queues/attorney_queue.rb
+++ b/app/models/queues/attorney_queue.rb
@@ -10,7 +10,7 @@ class AttorneyQueue
   # using assigned by user. We set status to being on_hold and placed_on_hold_at to assigned_at timestamp
   def tasks
     colocated_tasks_grouped = ColocatedTask.includes(*task_includes)
-      .open.where(assigned_by: user, assigned_to_type: Organization.name, appeal_type: LegacyAppeal.name)
+      .open.assigned_to_organization.where(assigned_by: user, appeal_type: LegacyAppeal.name)
       .order(:created_at).group_by(&:appeal_id)
     colocated_tasks_for_attorney_tasks = colocated_tasks_grouped.each_with_object([]) do |(_k, value), result|
       result << value.first.tap do |record|

--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -136,14 +136,15 @@ class WorkQueue::TaskColumnSerializer
 
   attribute :assigned_to do |object, params|
     columns = [Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name]
+    assignee = object.assigned_to
 
     if serialize_attribute?(params, columns)
       {
-        css_id: object.assigned_to.try(:css_id),
-        is_organization: object.assigned_to.is_a?(Organization),
-        name: object.appeal.assigned_to_location,
-        type: object.assigned_to.class.name,
-        id: object.assigned_to.id
+        css_id: assignee.try(:css_id),
+        is_organization: assignee.is_a?(Organization),
+        name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
+        type: assignee.class.name,
+        id: assignee.id
       }
     else
       {

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -34,13 +34,15 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assigned_to do |object|
+    assignee = object.assigned_to
+
     {
-      css_id: object.assigned_to.try(:css_id),
-      is_organization: object.assigned_to.is_a?(Organization),
-      name: object.appeal.assigned_to_location,
-      full_name: object.assigned_to.try(:full_name),
-      type: object.assigned_to.class.name,
-      id: object.assigned_to.id
+      css_id: assignee.try(:css_id),
+      full_name: assignee.try(:cssfull_name_id),
+      is_organization: assignee.is_a?(Organization),
+      name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
+      type: assignee.class.name,
+      id: assignee.id
     }
   end
 

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -38,7 +38,7 @@ class WorkQueue::TaskSerializer
 
     {
       css_id: assignee.try(:css_id),
-      full_name: assignee.try(:cssfull_name_id),
+      full_name: assignee.try(:full_name),
       is_organization: assignee.is_a?(Organization),
       name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
       type: assignee.class.name,

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -85,7 +85,7 @@ class Task < CaseflowRecord
 
   scope :with_assigners, -> { joins(Task.joins_with_assigners_clause) }
 
-  scope :with_cached_appeals, -> { joins(Task.joins_with_cached_appeals_clause)}
+  scope :with_cached_appeals, -> { joins(Task.joins_with_cached_appeals_clause) }
 
   ############################################################################################
   ## class methods

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -81,6 +81,10 @@ class Task < CaseflowRecord
 
   scope :assigned_to_organization, -> { where(assigned_to_type: Organization.name) }
 
+  scope :with_assignees, -> { joins(Task.joins_with_assignees_clause) }
+
+  scope :with_assigners, -> { joins(Task.joins_with_assigners_clause) }
+
   ############################################################################################
   ## class methods
   class << self
@@ -175,6 +179,21 @@ class Task < CaseflowRecord
         assigned_to: params[:assigned_to] || child_task_assignee(parent, params),
         instructions: params[:instructions]
       )
+    end
+
+    def joins_with_assigners_clause
+      "LEFT JOIN (SELECT id, full_name AS display_name FROM users) AS assigners ON assigners.id = tasks.assigned_by_id"
+    end
+
+    def assignees_table_clause
+      "(SELECT id, 'Organization' AS type, name AS display_name FROM organizations " \
+        "UNION " \
+      "SELECT id, 'User' AS type, full_name AS display_name FROM users) AS assignees"
+    end
+
+    def joins_with_assignees_clause
+      "INNER JOIN #{Task.assignees_table_clause} ON " \
+      "assignees.id = tasks.assigned_to_id AND assignees.type = tasks.assigned_to_type"
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -77,6 +77,10 @@ class Task < CaseflowRecord
                                  )
                                }
 
+  scope :assigned_to_user, -> { where(assigned_to_type: User.name) }
+
+  scope :assigned_to_organization, -> { where(assigned_to_type: Organization.name) }
+
   ############################################################################################
   ## class methods
   class << self

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -85,6 +85,8 @@ class Task < CaseflowRecord
 
   scope :with_assigners, -> { joins(Task.joins_with_assigners_clause) }
 
+  scope :with_cached_appeals, -> { joins(Task.joins_with_cached_appeals_clause)}
+
   ############################################################################################
   ## class methods
   class << self
@@ -194,6 +196,12 @@ class Task < CaseflowRecord
     def joins_with_assignees_clause
       "INNER JOIN #{Task.assignees_table_clause} ON " \
       "assignees.id = tasks.assigned_to_id AND assignees.type = tasks.assigned_to_type"
+    end
+
+    def joins_with_cached_appeals_clause
+      "left join #{CachedAppeal.table_name} "\
+      "on #{CachedAppeal.table_name}.appeal_id = #{Task.table_name}.appeal_id "\
+      "and #{CachedAppeal.table_name}.appeal_type = #{Task.table_name}.appeal_type"
     end
   end
 

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -45,7 +45,7 @@ class TaskFilter
       when Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name
         "cached_appeal_attributes.case_type"
       when Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name
-        "cached_appeal_attributes.assignee_label"
+        "assignees.display_name"
       when Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME
         "cached_appeal_attributes.power_of_attorney_name"
       when Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME
@@ -67,7 +67,9 @@ class TaskFilter
   end
 
   def filtered_tasks
-    where_clause.empty? ? tasks : tasks.joins(CachedAppeal.left_join_from_tasks_clause).where(*where_clause)
+    return tasks if where_clause.empty?
+
+    tasks.with_assignees.joins(CachedAppeal.left_join_from_tasks_clause).where(*where_clause)
   end
 
   # filter_params = ["col=docketNumberColumn&val=legacy|evidence_submission", "col=taskColumn&val=TranslationTask"]

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -69,7 +69,7 @@ class TaskFilter
   def filtered_tasks
     return tasks if where_clause.empty?
 
-    tasks.with_assignees.joins(CachedAppeal.left_join_from_tasks_clause).where(*where_clause)
+    tasks.with_assignees.with_cached_appeals.where(*where_clause)
   end
 
   # filter_params = ["col=docketNumberColumn&val=legacy|evidence_submission", "col=taskColumn&val=TranslationTask"]

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -26,10 +26,7 @@ class TaskSorter
 
     # Always join to the CachedAppeal and users tables because we sometimes need it, joining does not slow down the
     # application, and conditional logic to only join sometimes adds unnecessary complexity.
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .joins(left_join_from_users_clause)
-      .joins(join_assignees_clause)
-      .order(order_clause)
+    tasks.with_assignees.with_assigners.joins(CachedAppeal.left_join_from_tasks_clause).order(order_clause)
   end
 
   private
@@ -75,21 +72,7 @@ class TaskSorter
   end
 
   def assigner_order_clause
-    "substring(users.full_name,\'([a-zA-Z]+)$\') #{sort_order}"
-  end
-
-  def assignees_table
-    "(SELECT id, 'Organization' AS type, name AS assignee_label FROM organizations " \
-      "UNION " \
-    "SELECT id, 'User' AS type, full_name AS assignee_label FROM users) AS assignees"
-  end
-
-  def join_assignees_clause
-    "INNER JOIN #{assignees_table} ON assignees.id = tasks.assigned_to_id AND assignees.type = tasks.assigned_to_type"
-  end
-
-  def left_join_from_users_clause
-    "left join users on users.id = tasks.assigned_by_id"
+    "substring(assigners.display_name,\'([a-zA-Z]+)$\') #{sort_order}"
   end
 
   def column_is_valid

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -26,7 +26,10 @@ class TaskSorter
 
     # Always join to the CachedAppeal and users tables because we sometimes need it, joining does not slow down the
     # application, and conditional logic to only join sometimes adds unnecessary complexity.
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause).joins(left_join_from_users_clause).order(order_clause)
+    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
+      .joins(left_join_from_users_clause)
+      .joins(join_assignees_clause)
+      .order(order_clause)
   end
 
   private
@@ -73,6 +76,16 @@ class TaskSorter
 
   def assigner_order_clause
     "substring(users.full_name,\'([a-zA-Z]+)$\') #{sort_order}"
+  end
+
+  def assignees_table
+    "(SELECT id, 'Organization' AS type, name AS assignee_label FROM organizations " \
+      "UNION " \
+    "SELECT id, 'User' AS type, full_name AS assignee_label FROM users) AS assignees"
+  end
+
+  def join_assignees_clause
+    "INNER JOIN #{assignees_table} ON assignees.id = tasks.assigned_to_id AND assignees.type = tasks.assigned_to_type"
   end
 
   def left_join_from_users_clause

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -26,7 +26,7 @@ class TaskSorter
 
     # Always join to the CachedAppeal and users tables because we sometimes need it, joining does not slow down the
     # application, and conditional logic to only join sometimes adds unnecessary complexity.
-    tasks.with_assignees.with_assigners.joins(CachedAppeal.left_join_from_tasks_clause).order(order_clause)
+    tasks.with_assignees.with_assigners.with_cached_appeals.order(order_clause)
   end
 
   private

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -67,7 +67,7 @@ class TaskSorter
   # postgres to use as a reference for sorting as a task's label is not stored in the database.
   def task_type_order_clause
     task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name)
-    task_type_sort_position = "type in '#{task_types_sorted_by_label.join(',')}'"
+    task_type_sort_position = "tasks.type in '#{task_types_sorted_by_label.join(',')}'"
     "position(#{task_type_sort_position}) #{sort_order}"
   end
 

--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -83,7 +83,7 @@ class MailTask < Task
     end
 
     def most_recent_active_task_assignee(parent)
-      parent.appeal.tasks.open.where(assigned_to_type: User.name).order(:created_at).last&.assigned_to
+      parent.appeal.tasks.open.assigned_to_user.order(:created_at).last&.assigned_to
     end
   end
 

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -36,9 +36,8 @@ class TrackVeteranTask < Task
     new_task_count = 0
     closed_task_count = 0
 
-    tasks_to_sync = appeal.tasks.open.where(
-      type: [TrackVeteranTask.name, InformalHearingPresentationTask.name],
-      assigned_to_type: Organization.name
+    tasks_to_sync = appeal.tasks.open.assigned_to_organization.where(
+      type: [TrackVeteranTask.name, InformalHearingPresentationTask.name]
     )
     cached_representatives = tasks_to_sync.map(&:assigned_to)
     fresh_representatives = appeal.representatives

--- a/app/workflows/bulk_task_reassignment.rb
+++ b/app/workflows/bulk_task_reassignment.rb
@@ -254,7 +254,7 @@ class BulkTaskReassignment
   end
 
   def reassign_tasks_with_parent_org_tasks(tasks)
-    parents_assigned_to_orgs = Task.where(id: tasks.pluck(:parent_id), assigned_to_type: Organization.name)
+    parents_assigned_to_orgs = Task.assigned_to_organization.where(id: tasks.pluck(:parent_id))
     tasks_with_parent_org_tasks = tasks.where(parent: parents_assigned_to_orgs)
 
     parents_assigned_to_orgs.distinct.pluck(:assigned_to_id).each do |org_id|
@@ -310,7 +310,7 @@ class BulkTaskReassignment
 
   # Cancels all user tasks and makes the parent tasks available for manual reassignment
   def reassign_tasks_with_parent_user_tasks(tasks)
-    parents_assigned_to_users = Task.where(id: tasks.pluck(:parent_id), assigned_to_type: User.name)
+    parents_assigned_to_users = Task.assigned_to_user.where(id: tasks.pluck(:parent_id))
     tasks_with_parent_user_tasks = tasks.where(parent: parents_assigned_to_users)
 
     if tasks_with_parent_user_tasks.any?

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -60,9 +60,7 @@
     },
     "TASK_ASSIGNEE": {
       "filterable": true,
-      "name": "assignedToColumn",
-      "sorting_table": "cached_appeal_attributes",
-      "sorting_columns": ["assignee_label"]
+      "name": "assignedToColumn"
     },
     "TASK_ASSIGNER": {
       "name": "completedToNameColumn"

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -60,7 +60,9 @@
     },
     "TASK_ASSIGNEE": {
       "filterable": true,
-      "name": "assignedToColumn"
+      "name": "assignedToColumn",
+      "sorting_table": "assignees",
+      "sorting_columns": ["display_name"]
     },
     "TASK_ASSIGNER": {
       "name": "completedToNameColumn"

--- a/db/migrate/20200513002909_remove_assignee_label_from_cached_appeal.rb
+++ b/db/migrate/20200513002909_remove_assignee_label_from_cached_appeal.rb
@@ -1,0 +1,7 @@
+class RemoveAssigneeLabelFromCachedAppeal < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      remove_column :cached_appeal_attributes, :assignee_label, :string, comment: "Queues will now use the actual task assignee rather than the appeal's assigned to location"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_29_184512) do
+ActiveRecord::Schema.define(version: 2020_05_13_002909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,7 +201,6 @@ ActiveRecord::Schema.define(version: 2020_04_29_184512) do
   create_table "cached_appeal_attributes", id: false, force: :cascade do |t|
     t.integer "appeal_id"
     t.string "appeal_type"
-    t.string "assignee_label", comment: "Who is currently most responsible for the appeal"
     t.string "case_type", comment: "The case type, i.e. original, post remand, CAVC remand, etc"
     t.string "closest_regional_office_city", comment: "Closest regional office to the veteran"
     t.string "closest_regional_office_key", comment: "Closest regional office to the veteran in 4 character key"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -141,7 +141,6 @@ board_grant_effectuations,updated_at,datetime,,,,,x,
 cached_appeal_attributes,,,,,,,,
 cached_appeal_attributes,appeal_id,integer,,,,,x,
 cached_appeal_attributes,appeal_type,string,,,,,x,
-cached_appeal_attributes,assignee_label,string,,,,,,Who is currently most responsible for the appeal
 cached_appeal_attributes,case_type,string,,,,,x,"The case type, i.e. original, post remand, CAVC remand, etc"
 cached_appeal_attributes,closest_regional_office_city,string,,,,,x,Closest regional office to the veteran
 cached_appeal_attributes,closest_regional_office_key,string,,,,,x,Closest regional office to the veteran in 4 character key

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -14,7 +14,7 @@ appeals,claimant_id,integer (8),,,,,x,claimants.id
 appeals,claimant_last_name,string,,,,,,people.last_name
 appeals,claimant_middle_name,string,,,,,,people.middle_name
 appeals,claimant_name_suffix,string,,,,,,people.name_suffix
-appeals,claimant_participant_id,string (50),,,,,x,claimants.participant_id
+appeals,claimant_participant_id,string (20),,,,,x,claimants.participant_id
 appeals,claimant_payee_code,string (20),,,,,,claimants.payee_code
 appeals,claimant_person_id,integer (8),,,,,x,people.id
 appeals,closest_regional_office,string (20),,,,,,The code for the regional office closest to the Veteran on the appeal.
@@ -44,7 +44,7 @@ appeals,veteran_participant_id,string (20),,,,,x,veterans.participant_id
 attorney_case_reviews,,,,,,,,Denormalized attorney_case_reviews
 attorney_case_reviews,appeal_id,integer (8) ∗,x,,,,x,tasks.appeal_id
 attorney_case_reviews,appeal_type,string ∗,x,,,,x,tasks.appeal_type
-attorney_case_reviews,attorney_css_id,string (50) ∗,x,,,,,users.css_id
+attorney_case_reviews,attorney_css_id,string (20) ∗,x,,,,,users.css_id
 attorney_case_reviews,attorney_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,attorney_id,integer (8) ∗,x,,,,x,attorney_case_reviews.attorney_id
 attorney_case_reviews,attorney_sattyid,string (20),,,,,,users.sattyid
@@ -57,7 +57,7 @@ attorney_case_reviews,overtime,boolean,,,,,,attorney_case_reviews.overtime
 attorney_case_reviews,review_created_at,datetime ∗,x,,,,x,attorney_case_reviews.created_at
 attorney_case_reviews,review_id,integer (8) ∗,x,,,,x,attorney_case_reviews.id
 attorney_case_reviews,review_updated_at,datetime ∗,x,,,,x,attorney_case_reviews.updated_at
-attorney_case_reviews,reviewing_judge_css_id,string (50) ∗,x,,,,,users.css_id
+attorney_case_reviews,reviewing_judge_css_id,string (20) ∗,x,,,,,users.css_id
 attorney_case_reviews,reviewing_judge_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,reviewing_judge_id,integer (8) ∗,x,,,,x,attorney_case_reviews.reviewing_judge_id
 attorney_case_reviews,reviewing_judge_sattyid,string (20),,,,,,users.sattyid
@@ -108,75 +108,6 @@ decision_issues,rating_issue_reference_id,integer (8),,,,,x,decision_issues.rati
 decision_issues,rating_profile_date,datetime,,,,,,decision_issues.rating_profile_date
 decision_issues,rating_promulgation_date,datetime,,,,,,decision_issues.rating_promulgation_date
 decision_issues,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-hearings,,,,,,,,Denormalized hearings
-hearings,appeal_id,integer ∗,x,,,,x,ID of the associated Appeal
-hearings,bva_poc,string,,,,,,hearings.bva_poc
-hearings,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-hearings,created_by_id,integer (8),,,,,,The ID of the user who created the Hearing
-hearings,created_by_user_css_id,string (50),,,,,,users.css_id
-hearings,created_by_user_full_name,string (255),,,,,,users.full_name
-hearings,created_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,disposition,string,,,,,,hearings.disposition
-hearings,evidence_window_waived,boolean,,,,,,hearings.evidence_window_waived
-hearings,hearing_created_at,datetime,,,,,x,hearings.created_at
-hearings,hearing_day_bva_poc,string,,,,,,hearing_days.bva_poc
-hearings,hearing_day_created_at,datetime,,,,,x,hearing_days.created_at
-hearings,hearing_day_created_by_id,integer (8),,,,,,The ID of the user who created the Hearing Day
-hearings,hearing_day_created_by_user_css_id,string (50),,,,,,users.css_id
-hearings,hearing_day_created_by_user_full_name,string (255),,,,,,users.full_name
-hearings,hearing_day_created_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,hearing_day_deleted_at,datetime,,,,,x,hearing_days.deleted_at
-hearings,hearing_day_id,integer,,,,,x,hearings.hearing_day_id
-hearings,hearing_day_judge_id,integer,,,,,,hearing_days.judge_id
-hearings,hearing_day_lock,boolean,,,,,,hearing_days.lock
-hearings,hearing_day_notes,text,,,,,,hearing_days.notes
-hearings,hearing_day_regional_office,string,,,,,,hearing_days.regional_office
-hearings,hearing_day_request_type,string,,,,,,hearing_days.request_type
-hearings,hearing_day_room,string,,,,,,The room at BVA where the hearing will take place
-hearings,hearing_day_scheduled_for,date,,,,,,hearing_days.scheduled_for
-hearings,hearing_day_updated_at,datetime,,,,,x,hearing_days.updated_at
-hearings,hearing_day_updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing Day
-hearings,hearing_day_updated_by_user_css_id,string (50),,,,,,users.css_id
-hearings,hearing_day_updated_by_user_full_name,string (255),,,,,,users.full_name
-hearings,hearing_day_updated_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,hearing_id,integer (8) ∗,x,,,,x,ID of the Hearing
-hearings,hearing_location_address,string,,,,,,hearing_locations.address
-hearings,hearing_location_city,string,,,,,,hearing_locations.city
-hearings,hearing_location_classification,string,,,,,,hearing_locations.classification
-hearings,hearing_location_created_at,datetime,,,,,x,hearing_locations.created_at
-hearings,hearing_location_distance,float,,,,,,hearing_locations.distance
-hearings,hearing_location_facility_id,string,,,,,,hearing_locations.facility_id
-hearings,hearing_location_facility_type,string,,,,,,hearing_locations.facility_type
-hearings,hearing_location_id,integer (8),,,,,x,hearing_locations.id
-hearings,hearing_location_name,string,,,,,,hearing_locations.name
-hearings,hearing_location_state,string,,,,,,hearing_locations.state
-hearings,hearing_location_updated_at,datetime,,,,,x,hearing_locations.updated_at
-hearings,hearing_location_zip_code,string,,,,,,hearing_locations.zip_code
-hearings,hearing_request_type,string ∗,x,,,,x,Calculated based on virtual_hearings and hearing_day.request_type
-hearings,hearing_updated_at,datetime,,,,,x,hearings.updated_at
-hearings,id,integer (8) PK,x,x,,,,
-hearings,judge_css_id,string,,,,,,users.css_id
-hearings,judge_full_name,string,,,,,,users.full_name
-hearings,judge_id,integer,,,,,x,hearings.judge_id
-hearings,judge_sattyid,string,,,,,,users.sattyid
-hearings,military_service,string,,,,,,hearings.military_service
-hearings,notes,string,,,,,,hearings.notes
-hearings,prepped,boolean,,,,,,hearings.prepped
-hearings,representative_name,string,,,,,,hearings.representative_name
-hearings,room,string,,,,,,hearings.room
-hearings,scheduled_time,time,,,,,,hearings.scheduled_time
-hearings,summary,text,,,,,,hearings.summary
-hearings,transcript_requested,boolean,,,,,,hearings.transcript_requested
-hearings,transcript_sent_date,date,,,,,,hearings.transcript_sent_date
-hearings,type,string,,,,,x,Hearing (AMA) or LegacyHearing
-hearings,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-hearings,updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing
-hearings,updated_by_user_css_id,string (50),,,,,,users.css_id
-hearings,updated_by_user_full_name,string (255),,,,,,users.full_name
-hearings,updated_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,uuid,uuid,,,,,x,Unique identifier for the Hearing
-hearings,vacols_id,string,,,,,x,"When type=LegacyHearing, this column points at the VACOLS case id"
-hearings,witness,string,,,,,,hearings.witness
 organizations,,,,,,,,Copy of Organizations table
 organizations,created_at,datetime,,,,,x,
 organizations,id,integer (8) PK,x,x,,,,
@@ -204,21 +135,21 @@ people,id,integer (8) PK,x,x,,,,
 people,last_name,string (50),,,,,,"Person last name, cached from BGS"
 people,middle_name,string (50),,,,,,"Person middle name, cached from BGS"
 people,name_suffix,string (20),,,,,,"Person name suffix, cached from BGS"
-people,participant_id,string (50) ∗,x,,,,x,
+people,participant_id,string (20) ∗,x,,,,x,
 people,updated_at,datetime ∗,x,,,,x,
 tasks,,,,,,,,Denormalized Tasks with User/Organization
 tasks,appeal_id,integer (8) ∗ FK,x,,x,,x,tasks.appeal_id
 tasks,appeal_type,string ∗,x,,,,x,tasks.appeal_type
 tasks,assigned_at,datetime,,,,,,tasks.assigned_at
 tasks,assigned_by_id,integer (8),,,,,,tasks.assigned_by_id
-tasks,assigned_by_user_css_id,string (50),,,,,,users.css_id
+tasks,assigned_by_user_css_id,string (20),,,,,,users.css_id
 tasks,assigned_by_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_by_user_sattyid,string (20),,,,,,users.sattyid
 tasks,assigned_to_id,integer (8) ∗,x,,,,x,tasks.assigned_to_id
 tasks,assigned_to_org_name,string (255),,,,,,organizations.name
 tasks,assigned_to_org_type,string (50),,,,,,organizations.type
 tasks,assigned_to_type,string ∗,x,,,,x,tasks.assigned_to_type
-tasks,assigned_to_user_css_id,string (50),,,,,,users.css_id
+tasks,assigned_to_user_css_id,string (20),,,,,,users.css_id
 tasks,assigned_to_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_to_user_sattyid,string (20),,,,,,users.sattyid
 tasks,closed_at,datetime,,,,,,tasks.closed_at
@@ -236,7 +167,7 @@ tasks,task_updated_at,datetime,,,,,,tasks.updated_at
 tasks,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,,,,,,,,Combined Caseflow/VACOLS user lookups
 users,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-users,css_id,string (50) ∗,x,,,,,CSEM (Active Directory) username
+users,css_id,string (20) ∗,x,,,,,CSEM (Active Directory) username
 users,email,string (255),,,,,,CSEM email
 users,full_name,string (255),,,,,,CSEM full name
 users,id,integer (8) PK,x,x,,,,
@@ -255,31 +186,3 @@ users,stitle,string (16),,,,,,VACOLS cached_user_attributes.stitle
 users,svlj,string (1),,,,,,
 users,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,user_id,integer ∗,x,,,,x,ID of the User
-vha_decision_reviews,,,,,,,,VHA-specific decision reviews
-vha_decision_reviews,benefit_type,string ∗,x,,,,,"The benefit type selected by the Veteran on their form, also known as a Line of Business."
-vha_decision_reviews,closest_regional_office,string,,,,,x,The code for the regional office closest to the Veteran on the appeal.
-vha_decision_reviews,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-vha_decision_reviews,decision_review_created_at,datetime,,,,,x,
-vha_decision_reviews,decision_review_id,integer (8) ∗,x,,,,x,ID of the Decision Review -- may be used as FK to decision_issues
-vha_decision_reviews,decision_review_remanded_id,integer (8),,,,,x,"If an Appeal or Higher Level Review decision is remanded, including Duty to Assist errors, it automatically generates a new Supplemental Claim.  If this Supplemental Claim was generated, then the ID of the original Decision Review with the remanded decision is stored here."
-vha_decision_reviews,decision_review_remanded_type,string,,,,,x,"The type of the Decision Review remanded if applicable, used with decision_review_remanded_id to as a composite key to identify the remanded Decision Review."
-vha_decision_reviews,decision_review_type,string ∗,x,,,,x,The type of the Decision Review -- may be used as FK to decision_issues
-vha_decision_reviews,decision_review_updated_at,datetime,,,,,x,
-vha_decision_reviews,docket_range_date,date,,,,,x,Date that appeal was added to hearing docket range.
-vha_decision_reviews,docket_type,string,,,,,x,"The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
-vha_decision_reviews,established_at,datetime,,,,,x,Timestamp for when the appeal has successfully been intaken into Caseflow by the user.
-vha_decision_reviews,establishment_processed_at,datetime,,,,,,Timestamp for when the End Product Establishments for the Decision Review successfully finished processing.
-vha_decision_reviews,establishment_submitted_at,datetime,,,,,,Timestamp for when the Higher Level Review was submitted by a Claims Assistant. This adds the End Product Establishment to a job to finish processing asynchronously.
-vha_decision_reviews,id,integer (8) PK,x,x,,,,
-vha_decision_reviews,informal_conference,boolean,,,,,x,Indicates whether a Veteran selected on their Higher Level Review form to have an informal conference. This creates a claimant letter and a tracked item in BGS.
-vha_decision_reviews,legacy_opt_in_approved,boolean,,,,,x,Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review.
-vha_decision_reviews,poa_participant_id,string,,,,,x,"Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
-vha_decision_reviews,receipt_date,date,,,,,x,The date that the Higher Level Review form was received by central mail. This is used to determine which issues are eligible to be appealed based on timeliness.  Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established.
-vha_decision_reviews,same_office,boolean,,,,,x,Whether the Veteran wants their issues to be reviewed by the same office where they were previously reviewed. This creates a special issue on all of the contentions created on this Higher Level Review.
-vha_decision_reviews,stream_docket_number,string,,,,,x,"Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
-vha_decision_reviews,stream_type,string,,,,,x,"When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
-vha_decision_reviews,target_decision_date,date,,,,,x,"If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
-vha_decision_reviews,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-vha_decision_reviews,uuid,uuid ∗,x,,,,x,The universally unique identifier for the Decision Review
-vha_decision_reviews,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran that the Decision Review is for.
-vha_decision_reviews,veteran_is_not_claimant,boolean,,,,,x,"Indicates whether the Veteran is the claimant on the Decision Review form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."

--- a/spec/factories/cached_appeals.rb
+++ b/spec/factories/cached_appeals.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     case_type { "Original" }
     is_aod { false }
     appeal_id { rand(1..9_999) }
-    assignee_label  { "BVAAABSHIRE" }
     vacols_id { nil }
   end
 end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -447,12 +447,12 @@ feature "Task queue", :all_dbs do
     before do
       organization.add_user(organization_user)
       User.authenticate!(user: organization_user)
-      Task.on_hold.where(assigned_to_type: Organization.name, assigned_to_id: organization.id)
+      Task.on_hold.where(assigned_to: organization)
         .each_with_index do |task, idx|
           child_task = create(:ama_task, parent: task)
           child_task.update!(status: Constants.TASK_STATUSES.on_hold) if idx < on_hold_count
         end
-      Task.active.where(assigned_to_type: Organization.name, assigned_to_id: organization.id)
+      Task.active.where(assigned_to: organization)
         .take(foia_task_count).each { |task| task.update!(type: FoiaTask.name) }
     end
 

--- a/spec/models/queue_column_spec.rb
+++ b/spec/models/queue_column_spec.rb
@@ -203,5 +203,30 @@ describe QueueColumn, :all_dbs do
         end
       end
     end
+
+    context "for the assignee column" do
+      let(:column_name) { Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name }
+      let(:org_1) { create(:organization, name: "Org 1") }
+      let(:org_2) { create(:organization, name: "Org 2") }
+      let(:user_1) { create(:user, full_name: "User 1") }
+      let(:user_2) { create(:user, full_name: "User 2") }
+      let(:org_1_tasks) { Task.where(id: create_list(:task, 1, assigned_to: org_1).map(&:id)) }
+      let(:org_2_tasks) { Task.where(id: create_list(:task, 2, assigned_to: org_2).map(&:id)) }
+      let(:user_1_tasks) { Task.where(id: create_list(:task, 3, assigned_to: user_1).map(&:id)) }
+      let(:user_2_tasks) { Task.where(id: create_list(:task, 4, assigned_to: user_2).map(&:id)) }
+      let(:tasks) do
+        Task.where(id: org_1_tasks.map(&:id) + org_2_tasks.map(&:id) + user_1_tasks.map(&:id) + user_2_tasks.map(&:id))
+      end
+
+      it "returns an array with all present user names" do
+        [org_1_tasks, org_2_tasks, user_1_tasks, user_2_tasks].each do |task_set|
+          assignee = task_set.first.assigned_to
+          name = assignee.is_a?(Organization) ? assignee.name : assignee.full_name
+          option = QueueColumn.filter_option_hash(name, QueueColumn.format_option_label(name, task_set.count))
+
+          expect(subject).to include(option)
+        end
+      end
+    end
   end
 end

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -378,22 +378,13 @@ describe TaskFilter, :all_dbs do
 
     context "when filtering by assignee" do
       let(:tasks_per_user) { 3 }
-      let(:users) { create_list(:user, 3) }
+      let(:users) do
+        [create(:user, full_name: "UserA"), create(:user, full_name: "UserB"), create(:user, full_name: "UserZ")]
+      end
       let(:first_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.first) }
       let(:second_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.second) }
       let(:third_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.third) }
       let(:all_tasks) { Task.where(id: (first_user_tasks + second_user_tasks + third_user_tasks).pluck(:id)) }
-
-      before do
-        all_tasks.each do |task|
-          create(
-            :cached_appeal,
-            appeal_type: task.appeal_type,
-            appeal_id: task.appeal.id,
-            assignee_label: task.appeal.assigned_to_location
-          )
-        end
-      end
 
       context "when filter_params is an empty array" do
         let(:filter_params) { [] }
@@ -411,20 +402,23 @@ describe TaskFilter, :all_dbs do
         end
       end
 
-      context "when filter includes the first user's css_id" do
-        let(:filter_params) { ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.css_id}"] }
+      context "when filter includes the first user's name" do
+        let(:filter_params) do
+          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.full_name}"]
+        end
 
         it "returns only tasks where the closest regional office is Boston" do
           expect(subject.map(&:id)).to match_array(first_user_tasks.map(&:id))
         end
       end
 
-      context "when filter includes Boston and Washington" do
+      context "when filter includes the first and second users' names" do
         let(:filter_params) do
-          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.css_id}|#{users.second.css_id}"]
+          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&"\
+            "val=#{users.first.full_name}|#{users.second.full_name}"]
         end
 
-        it "returns tasks where the closest regional office is Boston or Washington" do
+        it "returns tasks assigned to the first and second user" do
           expect(subject.map(&:id)).to match_array((first_user_tasks + second_user_tasks).map(&:id))
         end
       end

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -233,22 +233,20 @@ describe TaskSorter, :all_dbs do
 
       context "when sorting by assigned to column" do
         let(:column_name) { Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name }
-        let(:tasks) { Task.where(id: create_list(:ama_task, 5).pluck(:id)) }
-
-        before do
-          users = []
-          5.times do
-            users.push(create(:user, css_id: Faker::Name.unique.first_name))
-          end
-          tasks.each_with_index do |task, index|
-            user = users[index % 5]
-            task.update!(assigned_to_id: user.id)
-            create(:cached_appeal, appeal_id: task.appeal_id, assignee_label: user.css_id)
-          end
+        let(:org_1) { create(:organization, name: "Org B") }
+        let(:user_1) { create(:user, full_name: "User Z") }
+        let(:user_2) { create(:user, full_name: "User A") }
+        let(:org_1_task) { create(:task, assigned_to: org_1) }
+        let(:user_1_task) { create(:task, assigned_to: user_1) }
+        let(:user_2_task) { create(:task, assigned_to: user_2) }
+        let(:tasks) do
+          Task.where(id: [org_1_task, user_1_task, user_2_task])
         end
 
         it "sorts by assigned to" do
-          expected_order = tasks.sort_by { |task| task.appeal.assigned_to_location }
+          expected_order = tasks.sort_by do |task|
+            task.assigned_to.is_a?(User) ? task.assigned_to.full_name : task.assigned_to.name
+          end
           expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id))
         end
       end

--- a/spec/workflows/bulk_task_reassignment_spec.rb
+++ b/spec/workflows/bulk_task_reassignment_spec.rb
@@ -259,7 +259,7 @@ describe BulkTaskReassignment, :all_dbs do
               end
               parent_tasks.each { |task| expect(task.reload.on_hold?).to eq true }
 
-              new_tasks = Task.open.where(assigned_to_type: User.name)
+              new_tasks = Task.open.assigned_to_user
               new_tasks.each do |task|
                 expect(task.instructions).to include format(COPY::BULK_REASSIGN_INSTRUCTIONS, "reassigned", user.css_id)
               end
@@ -284,7 +284,7 @@ describe BulkTaskReassignment, :all_dbs do
               end
               parent_tasks.each { |task| expect(task.reload.on_hold?).to eq true }
 
-              new_tasks = Task.open.where(assigned_to_type: User.name)
+              new_tasks = Task.open.assigned_to_user
               new_tasks.each do |task|
                 expect(task.instructions).to include format(COPY::BULK_REASSIGN_INSTRUCTIONS, "reassigned", user.css_id)
               end


### PR DESCRIPTION
Resolves #13914

### Description
Rather than caching an appeal's problematic assigned_to_location, show the actual task assignee in task tables

### Acceptance Criteria
- [ ] Task tables display the name of the org or the name of the user that is assigned the task
- [ ] Organization queues
   - [ ] Can sort by assignee name
   - [ ] Can filter by assignee name
   - [ ] Show the correct assignee filter options
- [ ] Clean migration
- [ ] `UpdateCachedAppealsAttributesJob` still runs correctly

### Testing Plan
#### Tasks assigned to users
1. Sign in as BVALSPORER
1. Navigate to the VLJ support queue http://localhost:3000/organizations/vlj-support
1. Confirm that assignee full names appear in the queue table
1. Confirm filter options look correct
1. Confirm filtering works
1. Confirm sorting works

#### Tasks assigned to organizations
1. Sign in as Jolly Postman
1. Navigate to any ama case (I searched for vet 321321321) and add 4 tasks (FOIA, AOD, change of addrress, and Congressional Interest)
1. Update all these tasks to be on hold
```ruby
uuid = ""
appeal = Appeal.find_by_uuid(uuid)
MailTask.where(appeal: appeal).each(&:on_hold!)
appeal.reload.treee
                                              ┌──────────────────────────────────────────────────────────────────────────────┐
Appeal 138 (direct_review) ────────────────── │ ID   │ STATUS  │ ASGN_BY       │ ASGN_TO           │ UPDATED_AT              │
└── RootTask                                  │ 352  │ on_hold │               │ Bva               │ 2020-05-07 16:00:44 UTC │
    ├── DistributionTask                      │ 353  │ on_hold │               │ Bva               │ 2020-05-13 00:46:14 UTC │
    │   ├── CongressionalInterestMailTask     │ 2623 │ on_hold │               │ MailTeam          │ 2020-05-13 00:46:14 UTC │
    │   │   └── CongressionalInterestMailTask │ 2624 │ on_hold │ JOLLY_POSTMAN │ LitigationSupport │ 2020-05-13 00:47:38 UTC │
    │   └── FoiaRequestMailTask               │ 2625 │ on_hold │               │ MailTeam          │ 2020-05-13 00:46:22 UTC │
    │       └── FoiaRequestMailTask           │ 2626 │ on_hold │ JOLLY_POSTMAN │ PrivacyTeam       │ 2020-05-13 00:47:38 UTC │
    ├── AodMotionMailTask                     │ 2627 │ on_hold │               │ MailTeam          │ 2020-05-13 00:46:35 UTC │
    │   └── AodMotionMailTask                 │ 2628 │ on_hold │ JOLLY_POSTMAN │ AodTeam           │ 2020-05-13 00:47:38 UTC │
    └── AddressChangeMailTask                 │ 2629 │ on_hold │               │ MailTeam          │ 2020-05-13 00:47:00 UTC │
        └── AddressChangeMailTask             │ 2630 │ on_hold │ JOLLY_POSTMAN │ Colocated         │ 2020-05-13 00:47:00 UTC │
            └── AddressChangeMailTask         │ 2631 │ on_hold │ JOLLY_POSTMAN │ BVALSPORER        │ 2020-05-13 00:47:38 UTC │
                                              └──────────────────────────────────────────────────────────────────────────────┘
```
1. Go to the mail queue's on hold tab http://localhost:3000/organizations/mail?tab=on_hold
1. Confirm that assignee org names appear in the queue table
1. Confirm filter options look correct
1. Confirm filtering works
1. Confirm sorting works

### User Facing Changes
 - [ ] Queues show the actual assignees of each task (no one assignee for all tasks for one case)

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-12 at 8 53 39 PM](https://user-images.githubusercontent.com/45575454/81759614-2d56fb80-9493-11ea-9969-35b8a5ba09ff.png)|![Screen Shot 2020-05-12 at 8 52 41 PM](https://user-images.githubusercontent.com/45575454/81759607-292ade00-9493-11ea-984e-54edd4265aa5.png)

 - [ ] Queues show the name of the user assignee, rather than a mix of user id or css_id?

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-12 at 8 56 16 PM](https://user-images.githubusercontent.com/45575454/81759679-5bd4d680-9493-11ea-9bd3-e41a3fc6ebba.png)|![Screen Shot 2020-05-12 at 8 55 59 PM](https://user-images.githubusercontent.com/45575454/81759681-5e373080-9493-11ea-958b-b6e9e79e773e.png)

 - [ ] Queues do not show "Case Storage" unless they are actually assigned to BVA

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-12 at 9 00 31 PM](https://user-images.githubusercontent.com/45575454/81759811-b66e3280-9493-11ea-8e1c-737a69757bb8.png)|![Screen Shot 2020-05-12 at 9 00 56 PM](https://user-images.githubusercontent.com/45575454/81759818-b8d08c80-9493-11ea-92d0-6bc9c039dcf6.png)


### Database Changes
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
