### PR TITLE
[PART 2] Show task assignee name in queue tables

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -33,7 +33,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     appeals = Appeal.includes(:available_hearing_locations).where(id: open_appeals_from_tasks(Appeal.name))
     request_issues_to_cache = request_issue_counts_for_appeal_ids(appeals.pluck(:id))
     veteran_names_to_cache = veteran_names_for_file_numbers(appeals.pluck(:veteran_file_number))
-    appeal_assignees_to_cache = assignees_for_caseflow_appeal_ids(appeals.pluck(:id), Appeal.name)
 
     appeal_aod_status = aod_status_for_appeals(appeals)
     representative_names = representative_names_for_appeals(appeals)
@@ -43,7 +42,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       {
         appeal_id: appeal.id,
         appeal_type: Appeal.name,
-        assignee_label: appeal_assignees_to_cache[appeal.id],
         case_type: appeal.type,
         closest_regional_office_city: regional_office ? regional_office[:city] : COPY::UNKNOWN_REGIONAL_OFFICE,
         closest_regional_office_key: regional_office ? appeal.closest_regional_office : COPY::UNKNOWN_REGIONAL_OFFICE,
@@ -57,8 +55,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       }
     end
 
-    update_columns = [:assignee_label,
-                      :case_type,
+    update_columns = [:case_type,
                       :closest_regional_office_city,
                       :closest_regional_office_key,
                       :docket_type,
@@ -147,7 +144,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
       issue_counts_to_cache = issues_counts_for_vacols_folders(batch_vacols_ids)
       aod_status_to_cache = VACOLS::Case.aod(batch_vacols_ids)
-      appeal_assignees_to_cache = assignees_for_vacols_id(vacols_cases)
 
       correspondent_ids = vacols_folders.map { |folder| folder[:correspondent_id] }
       veteran_names_to_cache = veteran_names_for_correspondent_ids(correspondent_ids)
@@ -157,7 +153,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
         {
           vacols_id: folder[:vacols_id],
-          assignee_label: appeal_assignees_to_cache[folder[:vacols_id]],
           case_type: vacols_case[:status],
           docket_number: folder[:docket_number],
           issue_count: issue_counts_to_cache[folder[:vacols_id]] || 0,
@@ -166,7 +161,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         }
       end
 
-      update_columns = [:assignee_label, :docket_number, :issue_count, :veteran_name, :case_type, :is_aod]
+      update_columns = [:docket_number, :issue_count, :veteran_name, :case_type, :is_aod]
       CachedAppeal.import values_to_cache, on_duplicate_key_update: { conflict_target: [:vacols_id],
                                                                       columns: update_columns }
 
@@ -234,36 +229,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     end.to_h
   end
 
-  def assignees_for_caseflow_appeal_ids(appeal_ids, appeal_type)
-    active_appeals = caseflow_appeals_assignees(appeal_ids, appeal_type, Task.active)
-    on_hold_appeals = caseflow_appeals_assignees(appeal_ids, appeal_type, Task.on_hold)
-
-    on_hold_appeals.merge(active_appeals)
-  end
-
-  def assignees_for_vacols_id(vacols_cases)
-    # Grab statuses from input hash of VACOLS cases.
-    vacols_statuses = vacols_cases.keys.map do |vacols_id|
-      [vacols_id, vacols_cases[vacols_id][:location]]
-    end.to_h
-
-    # Grab the appeal_ids for the VACOLS cases in CASEFLOW status
-    caseflow_vacols_ids = vacols_statuses.select { |_key, value| value == "CASEFLOW" }.keys
-    caseflow_vacols_to_appeal_id = LegacyAppeal.where(vacols_id: caseflow_vacols_ids).pluck(:vacols_id, :id).to_h
-
-    # Lookup more detailed Caseflow location for CASEFLOW vacols status
-    caseflow_statuses_by_appeal_id = assignees_for_caseflow_appeal_ids(caseflow_vacols_to_appeal_id.values,
-                                                                       LegacyAppeal.name)
-    # Map back to VACOLS id
-    caseflow_statuses_by_vacol_id = {}
-    caseflow_vacols_to_appeal_id.each do |vacols_id, appeal_id|
-      caseflow_statuses_by_vacol_id[vacols_id] = caseflow_statuses_by_appeal_id[appeal_id]
-    end
-
-    # Overwrite VACOLS Caseflow location with Caseflow detailed location
-    vacols_statuses.merge(caseflow_statuses_by_vacol_id)
-  end
-
   def case_fields_for_vacols_ids(vacols_ids)
     # array of arrays will become hash with bfkey as key.
     # [
@@ -286,25 +251,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         }
       ]
     end.to_h
-  end
-
-  def caseflow_appeals_assignees(appeal_ids, appeal_type, tasks)
-    ordered_tasks = tasks
-      .visible_in_queue_table_view
-      .where(appeal_type: appeal_type, appeal_id: appeal_ids)
-      .order(:appeal_id, created_at: :desc)
-
-    first_task_assignees_per_caseflow_appeal(ordered_tasks)
-  end
-
-  def first_task_assignees_per_caseflow_appeal(tasks)
-    org_tasks = tasks.joins("left join organizations on tasks.assigned_to_id = organizations.id")
-      .where("tasks.assigned_to_type = 'Organization'").pluck(:created_at, :appeal_id, "organizations.name")
-    user_tasks = tasks.joins("left join users on tasks.assigned_to_id = users.id")
-      .where("tasks.assigned_to_type = 'User'").pluck(:created_at, :appeal_id, "users.css_id")
-
-    # Combine the user & org tasks, preferring the most recently created (last) task
-    (org_tasks + user_tasks).sort_by { |task| task[0] }.map { |task| task.drop(1) }.to_h
   end
 
   def issues_counts_for_vacols_folders(vacols_ids)

--- a/app/models/queue_column.rb
+++ b/app/models/queue_column.rb
@@ -106,8 +106,7 @@ class QueueColumn
   end
 
   def assignee_options(tasks)
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause)
-      .group(:assignee_label).count.each_pair.map do |option, count|
+    tasks.with_assignees.group("assignees.display_name").count(:all).each_pair.map do |option, count|
       label = self.class.format_option_label(option, count)
       self.class.filter_option_hash(option, label)
     end

--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -136,14 +136,15 @@ class WorkQueue::TaskColumnSerializer
 
   attribute :assigned_to do |object, params|
     columns = [Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name]
+    assignee = object.assigned_to
 
     if serialize_attribute?(params, columns)
       {
-        css_id: object.assigned_to.try(:css_id),
-        is_organization: object.assigned_to.is_a?(Organization),
-        name: object.appeal.assigned_to_location,
-        type: object.assigned_to.class.name,
-        id: object.assigned_to.id
+        css_id: assignee.try(:css_id),
+        is_organization: assignee.is_a?(Organization),
+        name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
+        type: assignee.class.name,
+        id: assignee.id
       }
     else
       {

--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -142,7 +142,7 @@ class WorkQueue::TaskColumnSerializer
       {
         css_id: assignee.try(:css_id),
         is_organization: assignee.is_a?(Organization),
-        name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
+        name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
         type: assignee.class.name,
         id: assignee.id
       }

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -40,7 +40,7 @@ class WorkQueue::TaskSerializer
       css_id: assignee.try(:css_id),
       full_name: assignee.try(:full_name),
       is_organization: assignee.is_a?(Organization),
-      name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
+      name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
       type: assignee.class.name,
       id: assignee.id
     }

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -34,13 +34,15 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assigned_to do |object|
+    assignee = object.assigned_to
+
     {
-      css_id: object.assigned_to.try(:css_id),
-      is_organization: object.assigned_to.is_a?(Organization),
-      name: object.appeal.assigned_to_location,
-      full_name: object.assigned_to.try(:full_name),
-      type: object.assigned_to.class.name,
-      id: object.assigned_to.id
+      css_id: assignee.try(:css_id),
+      full_name: assignee.try(:full_name),
+      is_organization: assignee.is_a?(Organization),
+      name: assignee.is_a?(Organization) ? assignee.name : assignee.full_name,
+      type: assignee.class.name,
+      id: assignee.id
     }
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -179,14 +179,19 @@ class Task < CaseflowRecord
       )
     end
 
+    def assigners_table_clause
+      "(SELECT id, full_name AS display_name FROM users) AS assigners"
+    end
+
     def joins_with_assigners_clause
-      "LEFT JOIN (SELECT id, full_name AS display_name FROM users) AS assigners ON assigners.id = tasks.assigned_by_id"
+      "LEFT JOIN #{Task.assigners_table_clause} ON assigners.id = tasks.assigned_by_id"
     end
 
     def assignees_table_clause
       "(SELECT id, 'Organization' AS type, name AS display_name FROM organizations " \
-        "UNION " \
-      "SELECT id, 'User' AS type, full_name AS display_name FROM users) AS assignees"
+      "UNION " \
+      "SELECT id, 'User' AS type, full_name AS display_name FROM users)" \
+      "AS assignees"
     end
 
     def joins_with_assignees_clause

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -190,7 +190,7 @@ class Task < CaseflowRecord
     def assignees_table_clause
       "(SELECT id, 'Organization' AS type, name AS display_name FROM organizations " \
       "UNION " \
-      "SELECT id, 'User' AS type, full_name AS display_name FROM users)" \
+      "SELECT id, 'User' AS type, css_id AS display_name FROM users)" \
       "AS assignees"
     end
 

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -45,7 +45,7 @@ class TaskFilter
       when Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name
         "cached_appeal_attributes.case_type"
       when Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name
-        "cached_appeal_attributes.assignee_label"
+        "assignees.display_name"
       when Constants.QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME
         "cached_appeal_attributes.power_of_attorney_name"
       when Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME
@@ -67,7 +67,9 @@ class TaskFilter
   end
 
   def filtered_tasks
-    where_clause.empty? ? tasks : tasks.joins(CachedAppeal.left_join_from_tasks_clause).where(*where_clause)
+    return tasks if where_clause.empty?
+
+    tasks.with_assignees.with_cached_appeals.where(*where_clause)
   end
 
   # filter_params = ["col=docketNumberColumn&val=legacy|evidence_submission", "col=taskColumn&val=TranslationTask"]

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -26,7 +26,7 @@ class TaskSorter
 
     # Always join to the CachedAppeal and users tables because we sometimes need it, joining does not slow down the
     # application, and conditional logic to only join sometimes adds unnecessary complexity.
-    tasks.joins(CachedAppeal.left_join_from_tasks_clause).joins(left_join_from_users_clause).order(order_clause)
+    tasks.with_assignees.with_assigners.with_cached_appeals.order(order_clause)
   end
 
   private
@@ -67,16 +67,12 @@ class TaskSorter
   # postgres to use as a reference for sorting as a task's label is not stored in the database.
   def task_type_order_clause
     task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name)
-    task_type_sort_position = "type in '#{task_types_sorted_by_label.join(',')}'"
+    task_type_sort_position = "tasks.type in '#{task_types_sorted_by_label.join(',')}'"
     "position(#{task_type_sort_position}) #{sort_order}"
   end
 
   def assigner_order_clause
-    "substring(users.full_name,\'([a-zA-Z]+)$\') #{sort_order}"
-  end
-
-  def left_join_from_users_clause
-    "left join users on users.id = tasks.assigned_by_id"
+    "substring(assigners.display_name,\'([a-zA-Z]+)$\') #{sort_order}"
   end
 
   def column_is_valid

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -61,8 +61,8 @@
     "TASK_ASSIGNEE": {
       "filterable": true,
       "name": "assignedToColumn",
-      "sorting_table": "cached_appeal_attributes",
-      "sorting_columns": ["assignee_label"]
+      "sorting_table": "assignees",
+      "sorting_columns": ["display_name"]
     },
     "TASK_ASSIGNER": {
       "name": "completedToNameColumn"

--- a/db/migrate/20200513002909_remove_assignee_label_from_cached_appeal.rb
+++ b/db/migrate/20200513002909_remove_assignee_label_from_cached_appeal.rb
@@ -1,0 +1,7 @@
+class RemoveAssigneeLabelFromCachedAppeal < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      remove_column :cached_appeal_attributes, :assignee_label, :string, comment: "Queues will now use the actual task assignee rather than the appeal's assigned to location"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_29_184512) do
+ActiveRecord::Schema.define(version: 2020_05_13_002909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,7 +201,6 @@ ActiveRecord::Schema.define(version: 2020_04_29_184512) do
   create_table "cached_appeal_attributes", id: false, force: :cascade do |t|
     t.integer "appeal_id"
     t.string "appeal_type"
-    t.string "assignee_label", comment: "Who is currently most responsible for the appeal"
     t.string "case_type", comment: "The case type, i.e. original, post remand, CAVC remand, etc"
     t.string "closest_regional_office_city", comment: "Closest regional office to the veteran"
     t.string "closest_regional_office_key", comment: "Closest regional office to the veteran in 4 character key"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -141,7 +141,6 @@ board_grant_effectuations,updated_at,datetime,,,,,x,
 cached_appeal_attributes,,,,,,,,
 cached_appeal_attributes,appeal_id,integer,,,,,x,
 cached_appeal_attributes,appeal_type,string,,,,,x,
-cached_appeal_attributes,assignee_label,string,,,,,,Who is currently most responsible for the appeal
 cached_appeal_attributes,case_type,string,,,,,x,"The case type, i.e. original, post remand, CAVC remand, etc"
 cached_appeal_attributes,closest_regional_office_city,string,,,,,x,Closest regional office to the veteran
 cached_appeal_attributes,closest_regional_office_key,string,,,,,x,Closest regional office to the veteran in 4 character key

--- a/spec/factories/cached_appeals.rb
+++ b/spec/factories/cached_appeals.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     case_type { "Original" }
     is_aod { false }
     appeal_id { rand(1..9_999) }
-    assignee_label  { "BVAAABSHIRE" }
     vacols_id { nil }
   end
 end

--- a/spec/models/queue_column_spec.rb
+++ b/spec/models/queue_column_spec.rb
@@ -206,14 +206,12 @@ describe QueueColumn, :all_dbs do
 
     context "for the assignee column" do
       let(:column_name) { Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name }
-      let(:org_1) { create(:organization, name: "Org 1") }
-      let(:org_2) { create(:organization, name: "Org 2") }
-      let(:user_1) { create(:user, full_name: "User 1") }
-      let(:user_2) { create(:user, full_name: "User 2") }
-      let(:org_1_tasks) { Task.where(id: create_list(:task, 1, assigned_to: org_1).map(&:id)) }
-      let(:org_2_tasks) { Task.where(id: create_list(:task, 2, assigned_to: org_2).map(&:id)) }
-      let(:user_1_tasks) { Task.where(id: create_list(:task, 3, assigned_to: user_1).map(&:id)) }
-      let(:user_2_tasks) { Task.where(id: create_list(:task, 4, assigned_to: user_2).map(&:id)) }
+      let(:orgs) { create_list(:organization, 2) }
+      let(:users) { create_list(:user, 2) }
+      let(:org_1_tasks) { Task.where(id: create_list(:task, 1, assigned_to: orgs.first).map(&:id)) }
+      let(:org_2_tasks) { Task.where(id: create_list(:task, 2, assigned_to: orgs.second).map(&:id)) }
+      let(:user_1_tasks) { Task.where(id: create_list(:task, 3, assigned_to: users.first).map(&:id)) }
+      let(:user_2_tasks) { Task.where(id: create_list(:task, 4, assigned_to: users.second).map(&:id)) }
       let(:tasks) do
         Task.where(id: org_1_tasks.map(&:id) + org_2_tasks.map(&:id) + user_1_tasks.map(&:id) + user_2_tasks.map(&:id))
       end
@@ -221,7 +219,7 @@ describe QueueColumn, :all_dbs do
       it "returns an array with all present user names" do
         [org_1_tasks, org_2_tasks, user_1_tasks, user_2_tasks].each do |task_set|
           assignee = task_set.first.assigned_to
-          name = assignee.is_a?(Organization) ? assignee.name : assignee.full_name
+          name = assignee.is_a?(Organization) ? assignee.name : assignee.css_id
           option = QueueColumn.filter_option_hash(name, QueueColumn.format_option_label(name, task_set.count))
 
           expect(subject).to include(option)

--- a/spec/models/queue_column_spec.rb
+++ b/spec/models/queue_column_spec.rb
@@ -203,5 +203,30 @@ describe QueueColumn, :all_dbs do
         end
       end
     end
+
+    context "for the assignee column" do
+      let(:column_name) { Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name }
+      let(:org_1) { create(:organization, name: "Org 1") }
+      let(:org_2) { create(:organization, name: "Org 2") }
+      let(:user_1) { create(:user, full_name: "User 1") }
+      let(:user_2) { create(:user, full_name: "User 2") }
+      let(:org_1_tasks) { Task.where(id: create_list(:task, 1, assigned_to: org_1).map(&:id)) }
+      let(:org_2_tasks) { Task.where(id: create_list(:task, 2, assigned_to: org_2).map(&:id)) }
+      let(:user_1_tasks) { Task.where(id: create_list(:task, 3, assigned_to: user_1).map(&:id)) }
+      let(:user_2_tasks) { Task.where(id: create_list(:task, 4, assigned_to: user_2).map(&:id)) }
+      let(:tasks) do
+        Task.where(id: org_1_tasks.map(&:id) + org_2_tasks.map(&:id) + user_1_tasks.map(&:id) + user_2_tasks.map(&:id))
+      end
+
+      it "returns an array with all present user names" do
+        [org_1_tasks, org_2_tasks, user_1_tasks, user_2_tasks].each do |task_set|
+          assignee = task_set.first.assigned_to
+          name = assignee.is_a?(Organization) ? assignee.name : assignee.full_name
+          option = QueueColumn.filter_option_hash(name, QueueColumn.format_option_label(name, task_set.count))
+
+          expect(subject).to include(option)
+        end
+      end
+    end
   end
 end

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -378,9 +378,7 @@ describe TaskFilter, :all_dbs do
 
     context "when filtering by assignee" do
       let(:tasks_per_user) { 3 }
-      let(:users) do
-        [create(:user, full_name: "UserA"), create(:user, full_name: "UserB"), create(:user, full_name: "UserZ")]
-      end
+      let(:users) { create_list(:user, 3) }
       let(:first_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.first) }
       let(:second_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.second) }
       let(:third_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.third) }
@@ -402,9 +400,9 @@ describe TaskFilter, :all_dbs do
         end
       end
 
-      context "when filter includes the first user's name" do
+      context "when filter includes the first user's css_id" do
         let(:filter_params) do
-          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.full_name}"]
+          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.css_id}"]
         end
 
         it "returns only tasks where the closest regional office is Boston" do
@@ -412,10 +410,10 @@ describe TaskFilter, :all_dbs do
         end
       end
 
-      context "when filter includes the first and second users' names" do
+      context "when filter includes the first and second users' css_ids" do
         let(:filter_params) do
           ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&"\
-            "val=#{users.first.full_name}|#{users.second.full_name}"]
+            "val=#{users.first.css_id}|#{users.second.css_id}"]
         end
 
         it "returns tasks assigned to the first and second user" do

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -378,22 +378,13 @@ describe TaskFilter, :all_dbs do
 
     context "when filtering by assignee" do
       let(:tasks_per_user) { 3 }
-      let(:users) { create_list(:user, 3) }
+      let(:users) do
+        [create(:user, full_name: "UserA"), create(:user, full_name: "UserB"), create(:user, full_name: "UserZ")]
+      end
       let(:first_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.first) }
       let(:second_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.second) }
       let(:third_user_tasks) { create_list(:ama_task, tasks_per_user, assigned_to: users.third) }
       let(:all_tasks) { Task.where(id: (first_user_tasks + second_user_tasks + third_user_tasks).pluck(:id)) }
-
-      before do
-        all_tasks.each do |task|
-          create(
-            :cached_appeal,
-            appeal_type: task.appeal_type,
-            appeal_id: task.appeal.id,
-            assignee_label: task.appeal.assigned_to_location
-          )
-        end
-      end
 
       context "when filter_params is an empty array" do
         let(:filter_params) { [] }
@@ -411,20 +402,23 @@ describe TaskFilter, :all_dbs do
         end
       end
 
-      context "when filter includes the first user's css_id" do
-        let(:filter_params) { ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.css_id}"] }
+      context "when filter includes the first user's name" do
+        let(:filter_params) do
+          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.full_name}"]
+        end
 
         it "returns only tasks where the closest regional office is Boston" do
           expect(subject.map(&:id)).to match_array(first_user_tasks.map(&:id))
         end
       end
 
-      context "when filter includes Boston and Washington" do
+      context "when filter includes the first and second users' names" do
         let(:filter_params) do
-          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&val=#{users.first.css_id}|#{users.second.css_id}"]
+          ["col=#{Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name}&"\
+            "val=#{users.first.full_name}|#{users.second.full_name}"]
         end
 
-        it "returns tasks where the closest regional office is Boston or Washington" do
+        it "returns tasks assigned to the first and second user" do
           expect(subject.map(&:id)).to match_array((first_user_tasks + second_user_tasks).map(&:id))
         end
       end

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -233,19 +233,19 @@ describe TaskSorter, :all_dbs do
 
       context "when sorting by assigned to column" do
         let(:column_name) { Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name }
-        let(:org_1) { create(:organization, name: "Org B") }
-        let(:user_1) { create(:user, full_name: "User Z") }
-        let(:user_2) { create(:user, full_name: "User A") }
-        let(:org_1_task) { create(:task, assigned_to: org_1) }
-        let(:user_1_task) { create(:task, assigned_to: user_1) }
-        let(:user_2_task) { create(:task, assigned_to: user_2) }
+        let(:orgs) { create_list(:organization, 2) }
+        let(:users) { create_list(:user, 2) }
+        let(:org_1_task) { create(:task, assigned_to: orgs.first) }
+        let(:org_2_task) { create(:task, assigned_to: orgs.second) }
+        let(:user_1_task) { create(:task, assigned_to: users.first) }
+        let(:user_2_task) { create(:task, assigned_to: users.second) }
         let(:tasks) do
-          Task.where(id: [org_1_task, user_1_task, user_2_task])
+          Task.where(id: [org_1_task, org_2_task, user_1_task, user_2_task])
         end
 
         it "sorts by assigned to" do
           expected_order = tasks.sort_by do |task|
-            task.assigned_to.is_a?(User) ? task.assigned_to.full_name : task.assigned_to.name
+            task.assigned_to.is_a?(User) ? task.assigned_to.css_id : task.assigned_to.name
           end
           expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id))
         end

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -233,22 +233,20 @@ describe TaskSorter, :all_dbs do
 
       context "when sorting by assigned to column" do
         let(:column_name) { Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNEE.name }
-        let(:tasks) { Task.where(id: create_list(:ama_task, 5).pluck(:id)) }
-
-        before do
-          users = []
-          5.times do
-            users.push(create(:user, css_id: Faker::Name.unique.first_name))
-          end
-          tasks.each_with_index do |task, index|
-            user = users[index % 5]
-            task.update!(assigned_to_id: user.id)
-            create(:cached_appeal, appeal_id: task.appeal_id, assignee_label: user.css_id)
-          end
+        let(:org_1) { create(:organization, name: "Org B") }
+        let(:user_1) { create(:user, full_name: "User Z") }
+        let(:user_2) { create(:user, full_name: "User A") }
+        let(:org_1_task) { create(:task, assigned_to: org_1) }
+        let(:user_1_task) { create(:task, assigned_to: user_1) }
+        let(:user_2_task) { create(:task, assigned_to: user_2) }
+        let(:tasks) do
+          Task.where(id: [org_1_task, user_1_task, user_2_task])
         end
 
         it "sorts by assigned to" do
-          expected_order = tasks.sort_by { |task| task.appeal.assigned_to_location }
+          expected_order = tasks.sort_by do |task|
+            task.assigned_to.is_a?(User) ? task.assigned_to.full_name : task.assigned_to.name
+          end
           expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id))
         end
       end


### PR DESCRIPTION
Bumps #13914

PART 2 of stack
PART 1 #14263
PART 3 #14265

### Description
Rather than displaying an appeal's problematic assigned_to_location, show the actual task assignee in task tables.

### Acceptance Criteria
- [x] Task tables display the name of the org or the name of the user that is assigned the task
- [x] Organization queues
   - [x] Can sort by assignee name
   - [x] Can filter by assignee name
   - [x] Show the correct assignee filter options

### Testing Plan
#### Tasks assigned to users
1. Sign in as BVALSPORER
1. Navigate to the VLJ support queue http://localhost:3000/organizations/vlj-support
1. Confirm that assignee css_ids appear in the queue table
1. Confirm filter options look correct
1. Confirm filtering works
1. Confirm sorting works

#### Tasks assigned to organizations
1. Sign in as Jolly Postman
1. Navigate to any ama case (I searched for vet 321321321) and add 4 tasks (FOIA, AOD, change of addrress, and Congressional Interest)
1. Update all these tasks to be on hold
```ruby
uuid = ""
appeal = Appeal.find_by_uuid(uuid)
MailTask.where(appeal: appeal).each(&:on_hold!)
appeal.reload.treee
                                              ┌──────────────────────────────────────────────────────────────────────────────┐
Appeal 138 (direct_review) ────────────────── │ ID   │ STATUS  │ ASGN_BY       │ ASGN_TO           │ UPDATED_AT              │
└── RootTask                                  │ 352  │ on_hold │               │ Bva               │ 2020-05-07 16:00:44 UTC │
    ├── DistributionTask                      │ 353  │ on_hold │               │ Bva               │ 2020-05-13 00:46:14 UTC │
    │   ├── CongressionalInterestMailTask     │ 2623 │ on_hold │               │ MailTeam          │ 2020-05-13 00:46:14 UTC │
    │   │   └── CongressionalInterestMailTask │ 2624 │ on_hold │ JOLLY_POSTMAN │ LitigationSupport │ 2020-05-13 00:47:38 UTC │
    │   └── FoiaRequestMailTask               │ 2625 │ on_hold │               │ MailTeam          │ 2020-05-13 00:46:22 UTC │
    │       └── FoiaRequestMailTask           │ 2626 │ on_hold │ JOLLY_POSTMAN │ PrivacyTeam       │ 2020-05-13 00:47:38 UTC │
    ├── AodMotionMailTask                     │ 2627 │ on_hold │               │ MailTeam          │ 2020-05-13 00:46:35 UTC │
    │   └── AodMotionMailTask                 │ 2628 │ on_hold │ JOLLY_POSTMAN │ AodTeam           │ 2020-05-13 00:47:38 UTC │
    └── AddressChangeMailTask                 │ 2629 │ on_hold │               │ MailTeam          │ 2020-05-13 00:47:00 UTC │
        └── AddressChangeMailTask             │ 2630 │ on_hold │ JOLLY_POSTMAN │ Colocated         │ 2020-05-13 00:47:00 UTC │
            └── AddressChangeMailTask         │ 2631 │ on_hold │ JOLLY_POSTMAN │ BVALSPORER        │ 2020-05-13 00:47:38 UTC │
                                              └──────────────────────────────────────────────────────────────────────────────┘
```
1. Go to the mail queue's on hold tab http://localhost:3000/organizations/mail?tab=on_hold
1. Confirm that assignee org names appear in the queue table
1. Confirm filter options look correct
1. Confirm filtering works
1. Confirm sorting works

### User Facing Changes
 - [x] Queues show the actual assignees of each task (no one assignee for all tasks for one case)

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-12 at 8 53 39 PM](https://user-images.githubusercontent.com/45575454/81759614-2d56fb80-9493-11ea-9969-35b8a5ba09ff.png)|![Screen Shot 2020-05-12 at 8 52 41 PM](https://user-images.githubusercontent.com/45575454/81759607-292ade00-9493-11ea-984e-54edd4265aa5.png)

 - [x] Queues show the css_id of the user assignee, rather than a mix of user id or css_id?

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-12 at 8 55 59 PM](https://user-images.githubusercontent.com/45575454/81759681-5e373080-9493-11ea-958b-b6e9e79e773e.png)|<img width="973" alt="Screen Shot 2020-05-15 at 1 25 39 PM" src="https://user-images.githubusercontent.com/45575454/82078744-a7fc6280-96af-11ea-9e70-a0897a1dd51a.png">



 - [x] Queues do not show "Case Storage" unless they are actually assigned to BVA

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-12 at 9 00 31 PM](https://user-images.githubusercontent.com/45575454/81759811-b66e3280-9493-11ea-8e1c-737a69757bb8.png)|<img width="1024" alt="Screen Shot 2020-05-15 at 5 02 39 PM" src="https://user-images.githubusercontent.com/45575454/82095870-ebfe6000-96cd-11ea-8c1d-a0355f150698.png">
