### PR TITLE
[PART 3] Remove assignee_label from cached appeals

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -33,7 +33,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     appeals = Appeal.includes(:available_hearing_locations).where(id: open_appeals_from_tasks(Appeal.name))
     request_issues_to_cache = request_issue_counts_for_appeal_ids(appeals.pluck(:id))
     veteran_names_to_cache = veteran_names_for_file_numbers(appeals.pluck(:veteran_file_number))
-    appeal_assignees_to_cache = assignees_for_caseflow_appeal_ids(appeals.pluck(:id), Appeal.name)
 
     appeal_aod_status = aod_status_for_appeals(appeals)
     representative_names = representative_names_for_appeals(appeals)
@@ -43,7 +42,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       {
         appeal_id: appeal.id,
         appeal_type: Appeal.name,
-        assignee_label: appeal_assignees_to_cache[appeal.id],
         case_type: appeal.type,
         closest_regional_office_city: regional_office ? regional_office[:city] : COPY::UNKNOWN_REGIONAL_OFFICE,
         closest_regional_office_key: regional_office ? appeal.closest_regional_office : COPY::UNKNOWN_REGIONAL_OFFICE,
@@ -57,8 +55,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       }
     end
 
-    update_columns = [:assignee_label,
-                      :case_type,
+    update_columns = [:case_type,
                       :closest_regional_office_city,
                       :closest_regional_office_key,
                       :docket_type,
@@ -147,7 +144,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
       issue_counts_to_cache = issues_counts_for_vacols_folders(batch_vacols_ids)
       aod_status_to_cache = VACOLS::Case.aod(batch_vacols_ids)
-      appeal_assignees_to_cache = assignees_for_vacols_id(vacols_cases)
 
       correspondent_ids = vacols_folders.map { |folder| folder[:correspondent_id] }
       veteran_names_to_cache = veteran_names_for_correspondent_ids(correspondent_ids)
@@ -157,7 +153,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
         {
           vacols_id: folder[:vacols_id],
-          assignee_label: appeal_assignees_to_cache[folder[:vacols_id]],
           case_type: vacols_case[:status],
           docket_number: folder[:docket_number],
           issue_count: issue_counts_to_cache[folder[:vacols_id]] || 0,
@@ -166,7 +161,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         }
       end
 
-      update_columns = [:assignee_label, :docket_number, :issue_count, :veteran_name, :case_type, :is_aod]
+      update_columns = [:docket_number, :issue_count, :veteran_name, :case_type, :is_aod]
       CachedAppeal.import values_to_cache, on_duplicate_key_update: { conflict_target: [:vacols_id],
                                                                       columns: update_columns }
 
@@ -234,36 +229,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     end.to_h
   end
 
-  def assignees_for_caseflow_appeal_ids(appeal_ids, appeal_type)
-    active_appeals = caseflow_appeals_assignees(appeal_ids, appeal_type, Task.active)
-    on_hold_appeals = caseflow_appeals_assignees(appeal_ids, appeal_type, Task.on_hold)
-
-    on_hold_appeals.merge(active_appeals)
-  end
-
-  def assignees_for_vacols_id(vacols_cases)
-    # Grab statuses from input hash of VACOLS cases.
-    vacols_statuses = vacols_cases.keys.map do |vacols_id|
-      [vacols_id, vacols_cases[vacols_id][:location]]
-    end.to_h
-
-    # Grab the appeal_ids for the VACOLS cases in CASEFLOW status
-    caseflow_vacols_ids = vacols_statuses.select { |_key, value| value == "CASEFLOW" }.keys
-    caseflow_vacols_to_appeal_id = LegacyAppeal.where(vacols_id: caseflow_vacols_ids).pluck(:vacols_id, :id).to_h
-
-    # Lookup more detailed Caseflow location for CASEFLOW vacols status
-    caseflow_statuses_by_appeal_id = assignees_for_caseflow_appeal_ids(caseflow_vacols_to_appeal_id.values,
-                                                                       LegacyAppeal.name)
-    # Map back to VACOLS id
-    caseflow_statuses_by_vacol_id = {}
-    caseflow_vacols_to_appeal_id.each do |vacols_id, appeal_id|
-      caseflow_statuses_by_vacol_id[vacols_id] = caseflow_statuses_by_appeal_id[appeal_id]
-    end
-
-    # Overwrite VACOLS Caseflow location with Caseflow detailed location
-    vacols_statuses.merge(caseflow_statuses_by_vacol_id)
-  end
-
   def case_fields_for_vacols_ids(vacols_ids)
     # array of arrays will become hash with bfkey as key.
     # [
@@ -286,25 +251,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         }
       ]
     end.to_h
-  end
-
-  def caseflow_appeals_assignees(appeal_ids, appeal_type, tasks)
-    ordered_tasks = tasks
-      .visible_in_queue_table_view
-      .where(appeal_type: appeal_type, appeal_id: appeal_ids)
-      .order(:appeal_id, created_at: :desc)
-
-    first_task_assignees_per_caseflow_appeal(ordered_tasks)
-  end
-
-  def first_task_assignees_per_caseflow_appeal(tasks)
-    org_tasks = tasks.joins("left join organizations on tasks.assigned_to_id = organizations.id")
-      .where("tasks.assigned_to_type = 'Organization'").pluck(:created_at, :appeal_id, "organizations.name")
-    user_tasks = tasks.joins("left join users on tasks.assigned_to_id = users.id")
-      .where("tasks.assigned_to_type = 'User'").pluck(:created_at, :appeal_id, "users.css_id")
-
-    # Combine the user & org tasks, preferring the most recently created (last) task
-    (org_tasks + user_tasks).sort_by { |task| task[0] }.map { |task| task.drop(1) }.to_h
   end
 
   def issues_counts_for_vacols_folders(vacols_ids)

--- a/db/migrate/20200513002909_remove_assignee_label_from_cached_appeal.rb
+++ b/db/migrate/20200513002909_remove_assignee_label_from_cached_appeal.rb
@@ -1,0 +1,7 @@
+class RemoveAssigneeLabelFromCachedAppeal < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do
+      remove_column :cached_appeal_attributes, :assignee_label, :string, comment: "Queues will now use the actual task assignee rather than the appeal's assigned to location"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_29_184512) do
+ActiveRecord::Schema.define(version: 2020_05_13_002909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -201,7 +201,6 @@ ActiveRecord::Schema.define(version: 2020_04_29_184512) do
   create_table "cached_appeal_attributes", id: false, force: :cascade do |t|
     t.integer "appeal_id"
     t.string "appeal_type"
-    t.string "assignee_label", comment: "Who is currently most responsible for the appeal"
     t.string "case_type", comment: "The case type, i.e. original, post remand, CAVC remand, etc"
     t.string "closest_regional_office_city", comment: "Closest regional office to the veteran"
     t.string "closest_regional_office_key", comment: "Closest regional office to the veteran in 4 character key"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -141,7 +141,6 @@ board_grant_effectuations,updated_at,datetime,,,,,x,
 cached_appeal_attributes,,,,,,,,
 cached_appeal_attributes,appeal_id,integer,,,,,x,
 cached_appeal_attributes,appeal_type,string,,,,,x,
-cached_appeal_attributes,assignee_label,string,,,,,,Who is currently most responsible for the appeal
 cached_appeal_attributes,case_type,string,,,,,x,"The case type, i.e. original, post remand, CAVC remand, etc"
 cached_appeal_attributes,closest_regional_office_city,string,,,,,x,Closest regional office to the veteran
 cached_appeal_attributes,closest_regional_office_key,string,,,,,x,Closest regional office to the veteran in 4 character key

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -14,7 +14,7 @@ appeals,claimant_id,integer (8),,,,,x,claimants.id
 appeals,claimant_last_name,string,,,,,,people.last_name
 appeals,claimant_middle_name,string,,,,,,people.middle_name
 appeals,claimant_name_suffix,string,,,,,,people.name_suffix
-appeals,claimant_participant_id,string (20),,,,,x,claimants.participant_id
+appeals,claimant_participant_id,string (50),,,,,x,claimants.participant_id
 appeals,claimant_payee_code,string (20),,,,,,claimants.payee_code
 appeals,claimant_person_id,integer (8),,,,,x,people.id
 appeals,closest_regional_office,string (20),,,,,,The code for the regional office closest to the Veteran on the appeal.
@@ -44,7 +44,7 @@ appeals,veteran_participant_id,string (20),,,,,x,veterans.participant_id
 attorney_case_reviews,,,,,,,,Denormalized attorney_case_reviews
 attorney_case_reviews,appeal_id,integer (8) ∗,x,,,,x,tasks.appeal_id
 attorney_case_reviews,appeal_type,string ∗,x,,,,x,tasks.appeal_type
-attorney_case_reviews,attorney_css_id,string (20) ∗,x,,,,,users.css_id
+attorney_case_reviews,attorney_css_id,string (50) ∗,x,,,,,users.css_id
 attorney_case_reviews,attorney_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,attorney_id,integer (8) ∗,x,,,,x,attorney_case_reviews.attorney_id
 attorney_case_reviews,attorney_sattyid,string (20),,,,,,users.sattyid
@@ -57,7 +57,7 @@ attorney_case_reviews,overtime,boolean,,,,,,attorney_case_reviews.overtime
 attorney_case_reviews,review_created_at,datetime ∗,x,,,,x,attorney_case_reviews.created_at
 attorney_case_reviews,review_id,integer (8) ∗,x,,,,x,attorney_case_reviews.id
 attorney_case_reviews,review_updated_at,datetime ∗,x,,,,x,attorney_case_reviews.updated_at
-attorney_case_reviews,reviewing_judge_css_id,string (20) ∗,x,,,,,users.css_id
+attorney_case_reviews,reviewing_judge_css_id,string (50) ∗,x,,,,,users.css_id
 attorney_case_reviews,reviewing_judge_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,reviewing_judge_id,integer (8) ∗,x,,,,x,attorney_case_reviews.reviewing_judge_id
 attorney_case_reviews,reviewing_judge_sattyid,string (20),,,,,,users.sattyid
@@ -108,6 +108,75 @@ decision_issues,rating_issue_reference_id,integer (8),,,,,x,decision_issues.rati
 decision_issues,rating_profile_date,datetime,,,,,,decision_issues.rating_profile_date
 decision_issues,rating_promulgation_date,datetime,,,,,,decision_issues.rating_promulgation_date
 decision_issues,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
+hearings,,,,,,,,Denormalized hearings
+hearings,appeal_id,integer ∗,x,,,,x,ID of the associated Appeal
+hearings,bva_poc,string,,,,,,hearings.bva_poc
+hearings,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
+hearings,created_by_id,integer (8),,,,,,The ID of the user who created the Hearing
+hearings,created_by_user_css_id,string (50),,,,,,users.css_id
+hearings,created_by_user_full_name,string (255),,,,,,users.full_name
+hearings,created_by_user_sattyid,string (20),,,,,,users.sattyid
+hearings,disposition,string,,,,,,hearings.disposition
+hearings,evidence_window_waived,boolean,,,,,,hearings.evidence_window_waived
+hearings,hearing_created_at,datetime,,,,,x,hearings.created_at
+hearings,hearing_day_bva_poc,string,,,,,,hearing_days.bva_poc
+hearings,hearing_day_created_at,datetime,,,,,x,hearing_days.created_at
+hearings,hearing_day_created_by_id,integer (8),,,,,,The ID of the user who created the Hearing Day
+hearings,hearing_day_created_by_user_css_id,string (50),,,,,,users.css_id
+hearings,hearing_day_created_by_user_full_name,string (255),,,,,,users.full_name
+hearings,hearing_day_created_by_user_sattyid,string (20),,,,,,users.sattyid
+hearings,hearing_day_deleted_at,datetime,,,,,x,hearing_days.deleted_at
+hearings,hearing_day_id,integer,,,,,x,hearings.hearing_day_id
+hearings,hearing_day_judge_id,integer,,,,,,hearing_days.judge_id
+hearings,hearing_day_lock,boolean,,,,,,hearing_days.lock
+hearings,hearing_day_notes,text,,,,,,hearing_days.notes
+hearings,hearing_day_regional_office,string,,,,,,hearing_days.regional_office
+hearings,hearing_day_request_type,string,,,,,,hearing_days.request_type
+hearings,hearing_day_room,string,,,,,,The room at BVA where the hearing will take place
+hearings,hearing_day_scheduled_for,date,,,,,,hearing_days.scheduled_for
+hearings,hearing_day_updated_at,datetime,,,,,x,hearing_days.updated_at
+hearings,hearing_day_updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing Day
+hearings,hearing_day_updated_by_user_css_id,string (50),,,,,,users.css_id
+hearings,hearing_day_updated_by_user_full_name,string (255),,,,,,users.full_name
+hearings,hearing_day_updated_by_user_sattyid,string (20),,,,,,users.sattyid
+hearings,hearing_id,integer (8) ∗,x,,,,x,ID of the Hearing
+hearings,hearing_location_address,string,,,,,,hearing_locations.address
+hearings,hearing_location_city,string,,,,,,hearing_locations.city
+hearings,hearing_location_classification,string,,,,,,hearing_locations.classification
+hearings,hearing_location_created_at,datetime,,,,,x,hearing_locations.created_at
+hearings,hearing_location_distance,float,,,,,,hearing_locations.distance
+hearings,hearing_location_facility_id,string,,,,,,hearing_locations.facility_id
+hearings,hearing_location_facility_type,string,,,,,,hearing_locations.facility_type
+hearings,hearing_location_id,integer (8),,,,,x,hearing_locations.id
+hearings,hearing_location_name,string,,,,,,hearing_locations.name
+hearings,hearing_location_state,string,,,,,,hearing_locations.state
+hearings,hearing_location_updated_at,datetime,,,,,x,hearing_locations.updated_at
+hearings,hearing_location_zip_code,string,,,,,,hearing_locations.zip_code
+hearings,hearing_request_type,string ∗,x,,,,x,Calculated based on virtual_hearings and hearing_day.request_type
+hearings,hearing_updated_at,datetime,,,,,x,hearings.updated_at
+hearings,id,integer (8) PK,x,x,,,,
+hearings,judge_css_id,string,,,,,,users.css_id
+hearings,judge_full_name,string,,,,,,users.full_name
+hearings,judge_id,integer,,,,,x,hearings.judge_id
+hearings,judge_sattyid,string,,,,,,users.sattyid
+hearings,military_service,string,,,,,,hearings.military_service
+hearings,notes,string,,,,,,hearings.notes
+hearings,prepped,boolean,,,,,,hearings.prepped
+hearings,representative_name,string,,,,,,hearings.representative_name
+hearings,room,string,,,,,,hearings.room
+hearings,scheduled_time,time,,,,,,hearings.scheduled_time
+hearings,summary,text,,,,,,hearings.summary
+hearings,transcript_requested,boolean,,,,,,hearings.transcript_requested
+hearings,transcript_sent_date,date,,,,,,hearings.transcript_sent_date
+hearings,type,string,,,,,x,Hearing (AMA) or LegacyHearing
+hearings,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
+hearings,updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing
+hearings,updated_by_user_css_id,string (50),,,,,,users.css_id
+hearings,updated_by_user_full_name,string (255),,,,,,users.full_name
+hearings,updated_by_user_sattyid,string (20),,,,,,users.sattyid
+hearings,uuid,uuid,,,,,x,Unique identifier for the Hearing
+hearings,vacols_id,string,,,,,x,"When type=LegacyHearing, this column points at the VACOLS case id"
+hearings,witness,string,,,,,,hearings.witness
 organizations,,,,,,,,Copy of Organizations table
 organizations,created_at,datetime,,,,,x,
 organizations,id,integer (8) PK,x,x,,,,
@@ -135,21 +204,21 @@ people,id,integer (8) PK,x,x,,,,
 people,last_name,string (50),,,,,,"Person last name, cached from BGS"
 people,middle_name,string (50),,,,,,"Person middle name, cached from BGS"
 people,name_suffix,string (20),,,,,,"Person name suffix, cached from BGS"
-people,participant_id,string (20) ∗,x,,,,x,
+people,participant_id,string (50) ∗,x,,,,x,
 people,updated_at,datetime ∗,x,,,,x,
 tasks,,,,,,,,Denormalized Tasks with User/Organization
 tasks,appeal_id,integer (8) ∗ FK,x,,x,,x,tasks.appeal_id
 tasks,appeal_type,string ∗,x,,,,x,tasks.appeal_type
 tasks,assigned_at,datetime,,,,,,tasks.assigned_at
 tasks,assigned_by_id,integer (8),,,,,,tasks.assigned_by_id
-tasks,assigned_by_user_css_id,string (20),,,,,,users.css_id
+tasks,assigned_by_user_css_id,string (50),,,,,,users.css_id
 tasks,assigned_by_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_by_user_sattyid,string (20),,,,,,users.sattyid
 tasks,assigned_to_id,integer (8) ∗,x,,,,x,tasks.assigned_to_id
 tasks,assigned_to_org_name,string (255),,,,,,organizations.name
 tasks,assigned_to_org_type,string (50),,,,,,organizations.type
 tasks,assigned_to_type,string ∗,x,,,,x,tasks.assigned_to_type
-tasks,assigned_to_user_css_id,string (20),,,,,,users.css_id
+tasks,assigned_to_user_css_id,string (50),,,,,,users.css_id
 tasks,assigned_to_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_to_user_sattyid,string (20),,,,,,users.sattyid
 tasks,closed_at,datetime,,,,,,tasks.closed_at
@@ -167,7 +236,7 @@ tasks,task_updated_at,datetime,,,,,,tasks.updated_at
 tasks,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,,,,,,,,Combined Caseflow/VACOLS user lookups
 users,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-users,css_id,string (20) ∗,x,,,,,CSEM (Active Directory) username
+users,css_id,string (50) ∗,x,,,,,CSEM (Active Directory) username
 users,email,string (255),,,,,,CSEM email
 users,full_name,string (255),,,,,,CSEM full name
 users,id,integer (8) PK,x,x,,,,
@@ -186,3 +255,31 @@ users,stitle,string (16),,,,,,VACOLS cached_user_attributes.stitle
 users,svlj,string (1),,,,,,
 users,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,user_id,integer ∗,x,,,,x,ID of the User
+vha_decision_reviews,,,,,,,,VHA-specific decision reviews
+vha_decision_reviews,benefit_type,string ∗,x,,,,,"The benefit type selected by the Veteran on their form, also known as a Line of Business."
+vha_decision_reviews,closest_regional_office,string,,,,,x,The code for the regional office closest to the Veteran on the appeal.
+vha_decision_reviews,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
+vha_decision_reviews,decision_review_created_at,datetime,,,,,x,
+vha_decision_reviews,decision_review_id,integer (8) ∗,x,,,,x,ID of the Decision Review -- may be used as FK to decision_issues
+vha_decision_reviews,decision_review_remanded_id,integer (8),,,,,x,"If an Appeal or Higher Level Review decision is remanded, including Duty to Assist errors, it automatically generates a new Supplemental Claim.  If this Supplemental Claim was generated, then the ID of the original Decision Review with the remanded decision is stored here."
+vha_decision_reviews,decision_review_remanded_type,string,,,,,x,"The type of the Decision Review remanded if applicable, used with decision_review_remanded_id to as a composite key to identify the remanded Decision Review."
+vha_decision_reviews,decision_review_type,string ∗,x,,,,x,The type of the Decision Review -- may be used as FK to decision_issues
+vha_decision_reviews,decision_review_updated_at,datetime,,,,,x,
+vha_decision_reviews,docket_range_date,date,,,,,x,Date that appeal was added to hearing docket range.
+vha_decision_reviews,docket_type,string,,,,,x,"The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
+vha_decision_reviews,established_at,datetime,,,,,x,Timestamp for when the appeal has successfully been intaken into Caseflow by the user.
+vha_decision_reviews,establishment_processed_at,datetime,,,,,,Timestamp for when the End Product Establishments for the Decision Review successfully finished processing.
+vha_decision_reviews,establishment_submitted_at,datetime,,,,,,Timestamp for when the Higher Level Review was submitted by a Claims Assistant. This adds the End Product Establishment to a job to finish processing asynchronously.
+vha_decision_reviews,id,integer (8) PK,x,x,,,,
+vha_decision_reviews,informal_conference,boolean,,,,,x,Indicates whether a Veteran selected on their Higher Level Review form to have an informal conference. This creates a claimant letter and a tracked item in BGS.
+vha_decision_reviews,legacy_opt_in_approved,boolean,,,,,x,Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review.
+vha_decision_reviews,poa_participant_id,string,,,,,x,"Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
+vha_decision_reviews,receipt_date,date,,,,,x,The date that the Higher Level Review form was received by central mail. This is used to determine which issues are eligible to be appealed based on timeliness.  Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established.
+vha_decision_reviews,same_office,boolean,,,,,x,Whether the Veteran wants their issues to be reviewed by the same office where they were previously reviewed. This creates a special issue on all of the contentions created on this Higher Level Review.
+vha_decision_reviews,stream_docket_number,string,,,,,x,"Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
+vha_decision_reviews,stream_type,string,,,,,x,"When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
+vha_decision_reviews,target_decision_date,date,,,,,x,"If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
+vha_decision_reviews,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
+vha_decision_reviews,uuid,uuid ∗,x,,,,x,The universally unique identifier for the Decision Review
+vha_decision_reviews,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran that the Decision Review is for.
+vha_decision_reviews,veteran_is_not_claimant,boolean,,,,,x,"Indicates whether the Veteran is the claimant on the Decision Review form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."

--- a/docs/schema/etl.csv
+++ b/docs/schema/etl.csv
@@ -14,7 +14,7 @@ appeals,claimant_id,integer (8),,,,,x,claimants.id
 appeals,claimant_last_name,string,,,,,,people.last_name
 appeals,claimant_middle_name,string,,,,,,people.middle_name
 appeals,claimant_name_suffix,string,,,,,,people.name_suffix
-appeals,claimant_participant_id,string (50),,,,,x,claimants.participant_id
+appeals,claimant_participant_id,string (20),,,,,x,claimants.participant_id
 appeals,claimant_payee_code,string (20),,,,,,claimants.payee_code
 appeals,claimant_person_id,integer (8),,,,,x,people.id
 appeals,closest_regional_office,string (20),,,,,,The code for the regional office closest to the Veteran on the appeal.
@@ -44,7 +44,7 @@ appeals,veteran_participant_id,string (20),,,,,x,veterans.participant_id
 attorney_case_reviews,,,,,,,,Denormalized attorney_case_reviews
 attorney_case_reviews,appeal_id,integer (8) ∗,x,,,,x,tasks.appeal_id
 attorney_case_reviews,appeal_type,string ∗,x,,,,x,tasks.appeal_type
-attorney_case_reviews,attorney_css_id,string (50) ∗,x,,,,,users.css_id
+attorney_case_reviews,attorney_css_id,string (20) ∗,x,,,,,users.css_id
 attorney_case_reviews,attorney_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,attorney_id,integer (8) ∗,x,,,,x,attorney_case_reviews.attorney_id
 attorney_case_reviews,attorney_sattyid,string (20),,,,,,users.sattyid
@@ -57,7 +57,7 @@ attorney_case_reviews,overtime,boolean,,,,,,attorney_case_reviews.overtime
 attorney_case_reviews,review_created_at,datetime ∗,x,,,,x,attorney_case_reviews.created_at
 attorney_case_reviews,review_id,integer (8) ∗,x,,,,x,attorney_case_reviews.id
 attorney_case_reviews,review_updated_at,datetime ∗,x,,,,x,attorney_case_reviews.updated_at
-attorney_case_reviews,reviewing_judge_css_id,string (50) ∗,x,,,,,users.css_id
+attorney_case_reviews,reviewing_judge_css_id,string (20) ∗,x,,,,,users.css_id
 attorney_case_reviews,reviewing_judge_full_name,string (255) ∗,x,,,,,users.full_name
 attorney_case_reviews,reviewing_judge_id,integer (8) ∗,x,,,,x,attorney_case_reviews.reviewing_judge_id
 attorney_case_reviews,reviewing_judge_sattyid,string (20),,,,,,users.sattyid
@@ -108,75 +108,6 @@ decision_issues,rating_issue_reference_id,integer (8),,,,,x,decision_issues.rati
 decision_issues,rating_profile_date,datetime,,,,,,decision_issues.rating_profile_date
 decision_issues,rating_promulgation_date,datetime,,,,,,decision_issues.rating_promulgation_date
 decision_issues,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-hearings,,,,,,,,Denormalized hearings
-hearings,appeal_id,integer ∗,x,,,,x,ID of the associated Appeal
-hearings,bva_poc,string,,,,,,hearings.bva_poc
-hearings,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-hearings,created_by_id,integer (8),,,,,,The ID of the user who created the Hearing
-hearings,created_by_user_css_id,string (50),,,,,,users.css_id
-hearings,created_by_user_full_name,string (255),,,,,,users.full_name
-hearings,created_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,disposition,string,,,,,,hearings.disposition
-hearings,evidence_window_waived,boolean,,,,,,hearings.evidence_window_waived
-hearings,hearing_created_at,datetime,,,,,x,hearings.created_at
-hearings,hearing_day_bva_poc,string,,,,,,hearing_days.bva_poc
-hearings,hearing_day_created_at,datetime,,,,,x,hearing_days.created_at
-hearings,hearing_day_created_by_id,integer (8),,,,,,The ID of the user who created the Hearing Day
-hearings,hearing_day_created_by_user_css_id,string (50),,,,,,users.css_id
-hearings,hearing_day_created_by_user_full_name,string (255),,,,,,users.full_name
-hearings,hearing_day_created_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,hearing_day_deleted_at,datetime,,,,,x,hearing_days.deleted_at
-hearings,hearing_day_id,integer,,,,,x,hearings.hearing_day_id
-hearings,hearing_day_judge_id,integer,,,,,,hearing_days.judge_id
-hearings,hearing_day_lock,boolean,,,,,,hearing_days.lock
-hearings,hearing_day_notes,text,,,,,,hearing_days.notes
-hearings,hearing_day_regional_office,string,,,,,,hearing_days.regional_office
-hearings,hearing_day_request_type,string,,,,,,hearing_days.request_type
-hearings,hearing_day_room,string,,,,,,The room at BVA where the hearing will take place
-hearings,hearing_day_scheduled_for,date,,,,,,hearing_days.scheduled_for
-hearings,hearing_day_updated_at,datetime,,,,,x,hearing_days.updated_at
-hearings,hearing_day_updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing Day
-hearings,hearing_day_updated_by_user_css_id,string (50),,,,,,users.css_id
-hearings,hearing_day_updated_by_user_full_name,string (255),,,,,,users.full_name
-hearings,hearing_day_updated_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,hearing_id,integer (8) ∗,x,,,,x,ID of the Hearing
-hearings,hearing_location_address,string,,,,,,hearing_locations.address
-hearings,hearing_location_city,string,,,,,,hearing_locations.city
-hearings,hearing_location_classification,string,,,,,,hearing_locations.classification
-hearings,hearing_location_created_at,datetime,,,,,x,hearing_locations.created_at
-hearings,hearing_location_distance,float,,,,,,hearing_locations.distance
-hearings,hearing_location_facility_id,string,,,,,,hearing_locations.facility_id
-hearings,hearing_location_facility_type,string,,,,,,hearing_locations.facility_type
-hearings,hearing_location_id,integer (8),,,,,x,hearing_locations.id
-hearings,hearing_location_name,string,,,,,,hearing_locations.name
-hearings,hearing_location_state,string,,,,,,hearing_locations.state
-hearings,hearing_location_updated_at,datetime,,,,,x,hearing_locations.updated_at
-hearings,hearing_location_zip_code,string,,,,,,hearing_locations.zip_code
-hearings,hearing_request_type,string ∗,x,,,,x,Calculated based on virtual_hearings and hearing_day.request_type
-hearings,hearing_updated_at,datetime,,,,,x,hearings.updated_at
-hearings,id,integer (8) PK,x,x,,,,
-hearings,judge_css_id,string,,,,,,users.css_id
-hearings,judge_full_name,string,,,,,,users.full_name
-hearings,judge_id,integer,,,,,x,hearings.judge_id
-hearings,judge_sattyid,string,,,,,,users.sattyid
-hearings,military_service,string,,,,,,hearings.military_service
-hearings,notes,string,,,,,,hearings.notes
-hearings,prepped,boolean,,,,,,hearings.prepped
-hearings,representative_name,string,,,,,,hearings.representative_name
-hearings,room,string,,,,,,hearings.room
-hearings,scheduled_time,time,,,,,,hearings.scheduled_time
-hearings,summary,text,,,,,,hearings.summary
-hearings,transcript_requested,boolean,,,,,,hearings.transcript_requested
-hearings,transcript_sent_date,date,,,,,,hearings.transcript_sent_date
-hearings,type,string,,,,,x,Hearing (AMA) or LegacyHearing
-hearings,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-hearings,updated_by_id,integer (8),,,,,,The ID of the user who most recently updated the Hearing
-hearings,updated_by_user_css_id,string (50),,,,,,users.css_id
-hearings,updated_by_user_full_name,string (255),,,,,,users.full_name
-hearings,updated_by_user_sattyid,string (20),,,,,,users.sattyid
-hearings,uuid,uuid,,,,,x,Unique identifier for the Hearing
-hearings,vacols_id,string,,,,,x,"When type=LegacyHearing, this column points at the VACOLS case id"
-hearings,witness,string,,,,,,hearings.witness
 organizations,,,,,,,,Copy of Organizations table
 organizations,created_at,datetime,,,,,x,
 organizations,id,integer (8) PK,x,x,,,,
@@ -204,21 +135,21 @@ people,id,integer (8) PK,x,x,,,,
 people,last_name,string (50),,,,,,"Person last name, cached from BGS"
 people,middle_name,string (50),,,,,,"Person middle name, cached from BGS"
 people,name_suffix,string (20),,,,,,"Person name suffix, cached from BGS"
-people,participant_id,string (50) ∗,x,,,,x,
+people,participant_id,string (20) ∗,x,,,,x,
 people,updated_at,datetime ∗,x,,,,x,
 tasks,,,,,,,,Denormalized Tasks with User/Organization
 tasks,appeal_id,integer (8) ∗ FK,x,,x,,x,tasks.appeal_id
 tasks,appeal_type,string ∗,x,,,,x,tasks.appeal_type
 tasks,assigned_at,datetime,,,,,,tasks.assigned_at
 tasks,assigned_by_id,integer (8),,,,,,tasks.assigned_by_id
-tasks,assigned_by_user_css_id,string (50),,,,,,users.css_id
+tasks,assigned_by_user_css_id,string (20),,,,,,users.css_id
 tasks,assigned_by_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_by_user_sattyid,string (20),,,,,,users.sattyid
 tasks,assigned_to_id,integer (8) ∗,x,,,,x,tasks.assigned_to_id
 tasks,assigned_to_org_name,string (255),,,,,,organizations.name
 tasks,assigned_to_org_type,string (50),,,,,,organizations.type
 tasks,assigned_to_type,string ∗,x,,,,x,tasks.assigned_to_type
-tasks,assigned_to_user_css_id,string (50),,,,,,users.css_id
+tasks,assigned_to_user_css_id,string (20),,,,,,users.css_id
 tasks,assigned_to_user_full_name,string (255),,,,,,users.full_name
 tasks,assigned_to_user_sattyid,string (20),,,,,,users.sattyid
 tasks,closed_at,datetime,,,,,,tasks.closed_at
@@ -236,7 +167,7 @@ tasks,task_updated_at,datetime,,,,,,tasks.updated_at
 tasks,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,,,,,,,,Combined Caseflow/VACOLS user lookups
 users,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-users,css_id,string (50) ∗,x,,,,,CSEM (Active Directory) username
+users,css_id,string (20) ∗,x,,,,,CSEM (Active Directory) username
 users,email,string (255),,,,,,CSEM email
 users,full_name,string (255),,,,,,CSEM full name
 users,id,integer (8) PK,x,x,,,,
@@ -255,31 +186,3 @@ users,stitle,string (16),,,,,,VACOLS cached_user_attributes.stitle
 users,svlj,string (1),,,,,,
 users,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
 users,user_id,integer ∗,x,,,,x,ID of the User
-vha_decision_reviews,,,,,,,,VHA-specific decision reviews
-vha_decision_reviews,benefit_type,string ∗,x,,,,,"The benefit type selected by the Veteran on their form, also known as a Line of Business."
-vha_decision_reviews,closest_regional_office,string,,,,,x,The code for the regional office closest to the Veteran on the appeal.
-vha_decision_reviews,created_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-vha_decision_reviews,decision_review_created_at,datetime,,,,,x,
-vha_decision_reviews,decision_review_id,integer (8) ∗,x,,,,x,ID of the Decision Review -- may be used as FK to decision_issues
-vha_decision_reviews,decision_review_remanded_id,integer (8),,,,,x,"If an Appeal or Higher Level Review decision is remanded, including Duty to Assist errors, it automatically generates a new Supplemental Claim.  If this Supplemental Claim was generated, then the ID of the original Decision Review with the remanded decision is stored here."
-vha_decision_reviews,decision_review_remanded_type,string,,,,,x,"The type of the Decision Review remanded if applicable, used with decision_review_remanded_id to as a composite key to identify the remanded Decision Review."
-vha_decision_reviews,decision_review_type,string ∗,x,,,,x,The type of the Decision Review -- may be used as FK to decision_issues
-vha_decision_reviews,decision_review_updated_at,datetime,,,,,x,
-vha_decision_reviews,docket_range_date,date,,,,,x,Date that appeal was added to hearing docket range.
-vha_decision_reviews,docket_type,string,,,,,x,"The docket type selected by the Veteran on their appeal form, which can be hearing, evidence submission, or direct review."
-vha_decision_reviews,established_at,datetime,,,,,x,Timestamp for when the appeal has successfully been intaken into Caseflow by the user.
-vha_decision_reviews,establishment_processed_at,datetime,,,,,,Timestamp for when the End Product Establishments for the Decision Review successfully finished processing.
-vha_decision_reviews,establishment_submitted_at,datetime,,,,,,Timestamp for when the Higher Level Review was submitted by a Claims Assistant. This adds the End Product Establishment to a job to finish processing asynchronously.
-vha_decision_reviews,id,integer (8) PK,x,x,,,,
-vha_decision_reviews,informal_conference,boolean,,,,,x,Indicates whether a Veteran selected on their Higher Level Review form to have an informal conference. This creates a claimant letter and a tracked item in BGS.
-vha_decision_reviews,legacy_opt_in_approved,boolean,,,,,x,Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review.
-vha_decision_reviews,poa_participant_id,string,,,,,x,"Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
-vha_decision_reviews,receipt_date,date,,,,,x,The date that the Higher Level Review form was received by central mail. This is used to determine which issues are eligible to be appealed based on timeliness.  Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established.
-vha_decision_reviews,same_office,boolean,,,,,x,Whether the Veteran wants their issues to be reviewed by the same office where they were previously reviewed. This creates a special issue on all of the contentions created on this Higher Level Review.
-vha_decision_reviews,stream_docket_number,string,,,,,x,"Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
-vha_decision_reviews,stream_type,string,,,,,x,"When multiple appeals have the same docket number, they are differentiated by appeal stream type, depending on the work being done on each appeal."
-vha_decision_reviews,target_decision_date,date,,,,,x,"If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
-vha_decision_reviews,updated_at,datetime ∗,x,,,,x,Default created_at/updated_at for the ETL record
-vha_decision_reviews,uuid,uuid ∗,x,,,,x,The universally unique identifier for the Decision Review
-vha_decision_reviews,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran that the Decision Review is for.
-vha_decision_reviews,veteran_is_not_claimant,boolean,,,,,x,"Indicates whether the Veteran is the claimant on the Decision Review form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."

--- a/spec/factories/cached_appeals.rb
+++ b/spec/factories/cached_appeals.rb
@@ -8,7 +8,6 @@ FactoryBot.define do
     case_type { "Original" }
     is_aod { false }
     appeal_id { rand(1..9_999) }
-    assignee_label  { "BVAAABSHIRE" }
     vacols_id { nil }
   end
 end


### PR DESCRIPTION
Bumps #13914

PART 3 of stack
PART 1 #14263
PART 2 #14264

### Description
Removes assignee_label from cached appeals attributes table as it is no longer used

### Acceptance Criteria
- [x] Migration goes off without a hitch
- [x] `UpdateCachedAppealsAttributesJob` still runs correctly

### Testing Plan
1. Run migration
```bash
 bin/rails db:migrate RAILS_ENV=development
```
2. Confirm no errors
3. Run `UpdateCachedAppealsAttributesJob`
```ruby
UpdateCachedAppealsAttributesJob.perform_now
```
4. Confirm no errors

### Database Changes
* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR