### PR TITLE
Fix regression with POA missing cache

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -88,7 +88,7 @@ detectors:
       - Seeds::Users#create_aod_user_and_tasks
       - SyncReviewsJob
       - TaskTimerJob
-      - UpdateCachedAppealsAttributesJob#assignees_for_vacols_id
+      - UpdateCachedAppealsAttributesJob
       - UserReporter#report_user_related_records
       - User#current_case_assignments_with_views
       - User#appeal_has_task_assigned_to_user?
@@ -143,6 +143,7 @@ detectors:
       - RequestIssue
       - BulkTaskReassignment
       - Task
+      - UpdateCachedAppealsAttributesJob
   TooManyConstants:
     exclude:
       - Fakes::BGSServicePOA

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -111,7 +111,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
         closest_regional_office_city: regional_office ? regional_office[:city] : COPY::UNKNOWN_REGIONAL_OFFICE,
         closest_regional_office_key: regional_office ? appeal.closest_regional_office : COPY::UNKNOWN_REGIONAL_OFFICE,
         docket_type: appeal.docket_name, # "legacy"
-        power_of_attorney_name: bgs_poa.representative_name || appeal.representative_name,
+        power_of_attorney_name: (bgs_poa&.representative_name || appeal.representative_name),
         suggested_hearing_location: appeal.suggested_hearing_location&.formatted_location
       }
     end


### PR DESCRIPTION
### Description

Fixes regression introduced in #13922 with the advent of the BgsPowerOfAttorney AR model.

We were skipping our local db cache and always making BGS calls, which slowed the job down to take hours instead of minutes.
