### PR TITLE
Batch request BGS power of attorney when calling update appeals attributes

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -229,13 +229,9 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
   # Builds a hash of appeal_id => rep name
   def representative_names_for_appeals(appeals)
-    claimants = Claimant.where(decision_review_id: appeals, decision_review_type: Appeal.name)
-    claimant_rep_hash = BgsPowerOfAttorney.where(claimant_participant_id: claimants.pluck(:participant_id)).map do |rep|
-      [rep.claimant_participant_id, rep.representative_name]
-    end.to_h
-    claimants.map do |claimant|
-      [claimant.decision_review_id, claimant_rep_hash[claimant.participant_id]]
-    end.to_h
+    Claimant.where(decision_review_id: appeals, decision_review_type: Appeal.name).joins(
+      "LEFT JOIN bgs_power_of_attorneys ON bgs_power_of_attorneys.claimant_participant_id = claimants.participant_id"
+    ).pluck("claimants.decision_review_id, bgs_power_of_attorneys.representative_name").to_h
   end
 
   def assignees_for_caseflow_appeal_ids(appeal_ids, appeal_type)

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -227,10 +227,14 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     ).pluck(:id)
   end
 
+  # Builds a hash of appeal_id => rep name
   def representative_names_for_appeals(appeals)
-    # builds a hash of appeal_id => rep name
-    Claimant.where(decision_review_id: appeals, decision_review_type: Appeal.name).map do |claimant|
-      [claimant.decision_review_id, claimant.representative_name]
+    claimants = Claimant.where(decision_review_id: appeals, decision_review_type: Appeal.name)
+    claimant_rep_hash = BgsPowerOfAttorney.where(claimant_participant_id: claimants.pluck(:participant_id)).map do |rep|
+      [rep.claimant_participant_id, rep.representative_name]
+    end.to_h
+    claimants.map do |claimant|
+      [claimant.decision_review_id, claimant_rep_hash[claimant.participant_id]]
     end.to_h
   end
 

--- a/spec/controllers/hearings/schedule_hearing_tasks_columns_controller_spec.rb
+++ b/spec/controllers/hearings/schedule_hearing_tasks_columns_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Hearings::ScheduleHearingTasksColumnsController, :all_dbs, type: 
         closest_regional_office: regional_office_key
       )
     end
+    let!(:poa) { create(:bgs_power_of_attorney, claimant_participant_id: appeal.claimant.participant_id) }
 
     let!(:hearing_location) do
       create(

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -652,6 +652,16 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       create(:schedule_hearing_task, appeal: appeal_three)
     end
 
+    def create_cached_poas
+      Appeal.all.each_with_index do |appeal, i|
+        create(
+          :bgs_power_of_attorney,
+          claimant_participant_id: appeal.claimant.participant_id,
+          representative_name: "Attorney #{i}"
+        )
+      end
+    end
+
     def navigate_to_ama_tab
       visit "hearings/schedule/assign"
       expect(page).to have_content("Regional Office")
@@ -722,19 +732,8 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
 
     context "Filter by PowerOfAttorneyName column" do
       before do
-        %w[1 2 3].each do |participant_id|
-          allow_any_instance_of(BGSService).to receive(:fetch_poas_by_participant_ids)
-            .with([participant_id]).and_return(
-              participant_id => {
-                file_number: participant_id * 8,
-                representative_type: "Attorney",
-                representative_name: "Attorney #{participant_id}",
-                participant_id: participant_id
-              }
-            )
-        end
-
         create_ama_appeals
+        create_cached_poas
         cache_appeals
         navigate_to_ama_tab
       end

--- a/spec/models/queue_tabs/assign_hearing_tab_spec.rb
+++ b/spec/models/queue_tabs/assign_hearing_tab_spec.rb
@@ -182,6 +182,8 @@ describe AssignHearingTab do
     let!(:task2) { create(:schedule_hearing_task, assigned_to: assignee, appeal: appeal) }
 
     describe ".power_of_attorney_name_options" do
+      before { create(:bgs_power_of_attorney, claimant_participant_id: appeal.claimant.participant_id) }
+
       subject { tab.power_of_attorney_name_options }
 
       it "returns correct options" do


### PR DESCRIPTION
Resolves some increased runtime in UpdateCachedAppealsAttributesJob. [_DataDog_](https://app.datadoghq.com/dashboard/t5t-exj-m32/cronjob-statistics?from_ts=1581784680000&fullscreen_section=overview&fullscreen_widget=4858424138530196&live=false&to_ts=1589557100283&fullscreen_start_ts=1581784680000&fullscreen_end_ts=1589557100283&fullscreen_paused=true)
<img width="895" alt="Screen Shot 2020-05-15 at 11 39 10 AM" src="https://user-images.githubusercontent.com/45575454/82069074-d3c41c00-96a0-11ea-9f78-729aa20421f8.png">

### Description
Resolves N+1 query on representatives for claimants

### Testing Plan
1. Test in dev
```ruby
# In dev - Master - Notice N calls to BgsPowerOfAttorney
Benchmark.measure { UpdateCachedAppealsAttributesJob.perform_now }
=> #<Benchmark::Tms:0x00007fc5f1c71758
 @cstime=0.023877000000000148,
 @cutime=0.021962999999999955,
 @label="",
 @real=6.24496799998451,
 @stime=0.4519979999999997,
 @total=3.4721700000000038,
 @utime=2.974332000000004>

# In dev - on branch - Notice 1 call to BgsPowerOfAttorney
Benchmark.measure { UpdateCachedAppealsAttributesJob.perform_now }
 => #<Benchmark::Tms:0x00007fcf8546f490
 @cstime=0.02260000000000001,
 @cutime=0.021063,
 @label="",
 @real=3.2325339999515563,
 @stime=0.11409400000000014,
 @total=1.711609000000001,
 @utime=1.553852000000001>
```
2. Test in prod
```ruby
# In prod - after caching (run twice)
claimants = Claimant.first(1000).reject { |claimant| claimant.decision_review.nil? }
Benchmark.measure do 
  claimants.map do |claimant|
    [claimant.decision_review_id, claimant.representative_name]
  end.to_h
end
=> #<Benchmark::Tms:0x000000000d6835a0 @label=""
  @real=4.471017775000291
  @cstime=0.0
  @cutime=0.0
  @stime=0.055988999999999844
  @utime=1.1426359999999995
  @total=1.1986249999999994>

Benchmark.measure do 
  claimant_rep_hash = BgsPowerOfAttorney.where(claimant_participant_id: claimants.pluck(:participant_id)).map do |rep|
    [rep.claimant_participant_id, rep.representative_name]
  end.to_h
  claimants.map do |claimant|
    [claimant.decision_review_id, claimant_rep_hash[claimant.participant_id]]
  end.to_h
end
=> #<Benchmark::Tms:0x000000000c9dcf18 @label=""
  @real=0.10690424299991719
  @cstime=0.0
  @cutime=0.0
  @stime=0.0
  @utime=0.0440320000000014
  @total=0.0440320000000014>
```