### PR TITLE
sort IDT api documents

### DIFF
--- a/app/models/serializers/idt/v1/appeal_details_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_details_serializer.rb
@@ -97,7 +97,7 @@ class Idt::V1::AppealDetailsSerializer
   attribute :assigned_by, &:reviewing_judge_name
 
   attribute :documents do |object|
-    object.attorney_case_reviews.sort_by(&:created_at).reverse.map do |document|
+    object.attorney_case_reviews.sort_by(&:updated_at).reverse.map do |document|
       { written_by: document.written_by_name, document_id: document.document_id }
     end
   end

--- a/app/models/serializers/idt/v1/appeal_details_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_details_serializer.rb
@@ -97,7 +97,7 @@ class Idt::V1::AppealDetailsSerializer
   attribute :assigned_by, &:reviewing_judge_name
 
   attribute :documents do |object|
-    object.attorney_case_reviews.map do |document|
+    object.attorney_case_reviews.sort_by(&:created_at).reverse.map do |document|
       { written_by: document.written_by_name, document_id: document.document_id }
     end
   end

--- a/app/models/serializers/idt/v1/appeal_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_serializer.rb
@@ -26,7 +26,7 @@ class Idt::V1::AppealSerializer
   attribute :assigned_by, &:reviewing_judge_name
 
   attribute :documents do |object|
-    object.attorney_case_reviews.map do |document|
+    object.attorney_case_reviews.sort_by(&:created_at).reverse.map do |document|
       { written_by: document.written_by_name, document_id: document.document_id }
     end
   end

--- a/app/models/serializers/idt/v1/appeal_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_serializer.rb
@@ -26,7 +26,7 @@ class Idt::V1::AppealSerializer
   attribute :assigned_by, &:reviewing_judge_name
 
   attribute :documents do |object|
-    object.attorney_case_reviews.sort_by(&:created_at).reverse.map do |document|
+    object.attorney_case_reviews.sort_by(&:updated_at).reverse.map do |document|
       { written_by: document.written_by_name, document_id: document.document_id }
     end
   end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -174,8 +174,24 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
           ]
         end
 
-        let!(:case_review1) { create(:attorney_case_review, document_id: "17325093.1116", task_id: tasks.first.id) }
-        let!(:case_review2) { create(:attorney_case_review, document_id: "17325093.1117", task_id: tasks.first.id) }
+        let!(:case_review1) do
+          create(
+            :attorney_case_review,
+            created_at: Time.zone.now - 1.minute,
+            updated_at: Time.zone.now - 1.minute,
+            document_id: "17325093.1116",
+            task_id: tasks.first.id
+          )
+        end
+        let!(:case_review2) do
+          create(
+            :attorney_case_review,
+            created_at: Time.zone.now,
+            updated_at: Time.zone.now,
+            document_id: "17325093.1117",
+            task_id: tasks.first.id
+          )
+        end
 
         before do
           # cancel one, so it does not show up

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -174,8 +174,8 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
           ]
         end
 
-        let!(:case_review1) { create(:attorney_case_review, task_id: tasks.first.id) }
-        let!(:case_review2) { create(:attorney_case_review, task_id: tasks.first.id) }
+        let!(:case_review1) { create(:attorney_case_review, document_id: "17325093.1116", task_id: tasks.first.id) }
+        let!(:case_review2) { create(:attorney_case_review, document_id: "17325093.1117", task_id: tasks.first.id) }
 
         before do
           # cancel one, so it does not show up
@@ -210,13 +210,13 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
           expect(ama_appeals.first["attributes"]["assigned_by"]).to eq tasks.first.parent.assigned_to.full_name
           expect(ama_appeals.first["attributes"]["documents"].size).to eq 2
           expect(ama_appeals.first["attributes"]["documents"].first["written_by"])
-            .to eq case_review1.attorney.full_name
-          expect(ama_appeals.first["attributes"]["documents"].first["document_id"])
-            .to eq case_review1.document_id
-          expect(ama_appeals.first["attributes"]["documents"].second["written_by"])
             .to eq case_review2.attorney.full_name
-          expect(ama_appeals.first["attributes"]["documents"].second["document_id"])
+          expect(ama_appeals.first["attributes"]["documents"].first["document_id"])
             .to eq case_review2.document_id
+          expect(ama_appeals.first["attributes"]["documents"].second["written_by"])
+            .to eq case_review1.attorney.full_name
+          expect(ama_appeals.first["attributes"]["documents"].second["document_id"])
+            .to eq case_review1.document_id
         end
 
         it "returns active appeals associated with a file number" do


### PR DESCRIPTION
Resolves #14306

### Description
- sort list of documents returned by IDT API by desc `updated_at`
- modify old tests
