### PR TITLE
Add search attorney endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "console_tree_renderer", git: "https://github.com/department-of-veterans-aff
 gem "ddtrace"
 gem "dogstatsd-ruby"
 gem "fast_jsonapi"
+gem "fuzzy_match"
 gem "govdelivery-tms", require: "govdelivery/tms/mail/delivery_method"
 gem "holidays", "~> 6.4"
 gem "icalendar"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,6 +247,7 @@ GEM
     foreman (0.85.0)
       thor (~> 0.19.1)
     formatador (0.2.5)
+    fuzzy_match (2.1.0)
     get_process_mem (0.2.4)
       ffi (~> 1.0)
     git (1.5.0)
@@ -630,6 +631,7 @@ DEPENDENCIES
   fast_jsonapi
   fasterer
   foreman
+  fuzzy_match
   govdelivery-tms
   guard-rspec
   holidays (~> 6.4)

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -63,7 +63,10 @@ class IntakesController < ApplicationController
   end
 
   def attorneys
-    render json: AttorneySearch.new(params[:query]).fetch_attorneys.map(&:name)
+    results = AttorneySearch.new(params[:query]).fetch_attorneys.map do |attorney|
+      attorney.as_json.extract!("name", "participant_id")
+    end
+    render json: results
   end
 
   def error

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -62,6 +62,10 @@ class IntakesController < ApplicationController
     }, status: :bad_request
   end
 
+  def attorneys
+    render json: AttorneySearch.new(params[:query]).fetch_attorneys.map(&:name)
+  end
+
   def error
     intake.save_error!(code: params[:error_code])
     render json: {}

--- a/app/services/attorney_search.rb
+++ b/app/services/attorney_search.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "fuzzy_match"
+
+class AttorneySearch
+  attr_accessor :first_letters
+  attr_reader :query_text
+
+  def initialize(query_text)
+    @query_text = query_text
+  end
+
+  def fetch_attorneys
+    return [] if first_letters.empty?
+
+    candidates_by_name = {}
+    first_letter_candidates.each do |atty|
+      (candidates_by_name[atty.name] ||= []) << atty
+    end
+    top_names = top_matched_names(candidates_by_name.keys)
+    top_names.map { |name| candidates_by_name[name] }.flatten
+  end
+
+  private
+
+  def first_letters
+    @first_letters ||= begin
+      query_text.split().map { |word| word[0] }.select { |ch| ch.match(/[a-zA-Z]/) }
+    end
+  end
+
+  # get all attorneys from PG that have first-letter matches against the query text
+  def first_letter_candidates
+    @first_letter_candidates ||= begin
+      regexes = first_letters.map { |ch| "\\m" + ch } # \m is POSIX regex for start-of-word
+      where = (["name ~* ?"] * regexes.length).join(" AND ")
+      BgsAttorney.where(where, *regexes)
+    end
+  end
+
+  def top_matched_names(haystack)
+    return [] if haystack.empty?
+
+    # maps each name in haystack to [name, Dice's coefficient, Levenshtein distance]
+    results = FuzzyMatch.new(haystack).find_all_with_score(query_text)
+    results.select { |res| res[1] >= results[0][1] * 0.5 }.map(&:first)
+  end
+end

--- a/app/services/attorney_search.rb
+++ b/app/services/attorney_search.rb
@@ -3,7 +3,9 @@
 require "fuzzy_match"
 
 class AttorneySearch
-  attr_accessor :first_letters
+  # only return results scoring at least this fraction of the top score
+  RELATIVE_SCORE_THRESHOLD = 0.5
+
   attr_reader :query_text
 
   def initialize(query_text)
@@ -11,14 +13,23 @@ class AttorneySearch
   end
 
   def fetch_attorneys
-    return [] if first_letters.empty?
-
     candidates_by_name = {}
     first_letter_candidates.each do |atty|
       (candidates_by_name[atty.name] ||= []) << atty
     end
     top_names = top_matched_names(candidates_by_name.keys)
     top_names.map { |name| candidates_by_name[name] }.flatten
+  end
+
+  # get all attorneys from PG that have first-letter matches against the query text
+  def first_letter_candidates
+    return [] if first_letters.empty?
+
+    @first_letter_candidates ||= begin
+      regexes = first_letters.map { |ch| "\\m" + ch } # \m is POSIX regex for start-of-word
+      where = (["name ~* ?"] * regexes.length).join(" AND ")
+      BgsAttorney.where(where, *regexes)
+    end
   end
 
   private
@@ -29,20 +40,12 @@ class AttorneySearch
     end
   end
 
-  # get all attorneys from PG that have first-letter matches against the query text
-  def first_letter_candidates
-    @first_letter_candidates ||= begin
-      regexes = first_letters.map { |ch| "\\m" + ch } # \m is POSIX regex for start-of-word
-      where = (["name ~* ?"] * regexes.length).join(" AND ")
-      BgsAttorney.where(where, *regexes)
-    end
-  end
-
   def top_matched_names(haystack)
     return [] if haystack.empty?
 
     # maps each name in haystack to [name, Dice's coefficient, Levenshtein distance]
     results = FuzzyMatch.new(haystack).find_all_with_score(query_text)
-    results.select { |res| res[1] >= results[0][1] * 0.5 }.map(&:first)
+    threshold = results[0][1] * RELATIVE_SCORE_THRESHOLD
+    results.select { |res| res[1] >= threshold }.map(&:first)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,6 +180,7 @@ Rails.application.routes.draw do
 
   scope path: '/intake' do
     get "/", to: 'intakes#index'
+    get "/attorneys", to: 'intakes#attorneys'
     get "/manager", to: 'intake_manager#index'
     get "/manager/flagged_for_review", to: 'intake_manager#flagged_for_review'
     get "/manager/users/:user_css_id", to: 'intake_manager#user_stats'

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -193,4 +193,17 @@ RSpec.describe IntakesController, :postgres do
       end
     end
   end
+
+  describe "#attorneys" do
+    it "returns the names and participant IDs of matching attorneys" do
+      create(:bgs_attorney, name: "JOHN SMITH", participant_id: "123")
+      create(:bgs_attorney, name: "KEANU REEVES", participant_id: "456")
+
+      get :attorneys, params: { query: "JON SMITH" }
+      resp = JSON.parse(response.body, symbolize_names: true)
+      expect(resp).to eq [
+        {"name": "JOHN SMITH", "participant_id": "123"}
+      ]
+    end
+  end
 end

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe IntakesController, :postgres do
       get :attorneys, params: { query: "JON SMITH" }
       resp = JSON.parse(response.body, symbolize_names: true)
       expect(resp).to eq [
-        {"name": "JOHN SMITH", "participant_id": "123"}
+        { "name": "JOHN SMITH", "participant_id": "123" }
       ]
     end
   end

--- a/spec/services/attorney_search_spec.rb
+++ b/spec/services/attorney_search_spec.rb
@@ -1,12 +1,64 @@
 # frozen_string_literal: true
 
 describe AttorneySearch do
-  describe "#fetch_attorneys" do
-    subject { AttorneySearch.new(query_text).fetch_attorneys.map(&:name) }
+  let(:names) {
+    [
+      "JOHN SMITH",
+      "MARILEE NIKOLAUS IV",
+      "HUGH JACKMAN",
+      "JAYMIE SMITHAM V",
+      "BOYCE KOSS SR.",
+      "ZELLA D'AMORE JR.",
+      "TAINA TERRANCE-KLEIN",
+      "JOHN SMITH"
+    ]
+  }
+  let!(:attorneys) { names.map { |name| create(:bgs_attorney, name: name) } }
+  let(:search) { AttorneySearch.new(query_text) }
+
+  describe "#first_letter_candidates" do
+    subject { search.first_letter_candidates.map(&:name) }
 
     context "no words are provided" do
       let(:query_text) { "123 _no_words" }
       it { is_expected.to be_empty }
+    end
+
+    context "one word matches multiple first letters" do
+      let(:query_text) { "JONATHAN" }
+      it {
+        is_expected.to contain_exactly(
+          "JOHN SMITH",
+          "HUGH JACKMAN",
+          "JAYMIE SMITHAM V",
+          "ZELLA D'AMORE JR.",
+          "JOHN SMITH"
+        )
+      }
+    end
+  end
+
+  describe "#fetch_attorneys" do
+    subject { search.fetch_attorneys.map(&:name) }
+
+    context "query matches one name exactly" do
+      let(:query_text) { "HUGH JACKMAN" }
+      it { is_expected.to contain_exactly("HUGH JACKMAN") }
+    end
+
+    context "query matches a duplicate name" do
+      let(:query_text) { "JON SMITHY" }
+      it { is_expected.to start_with("JOHN SMITH", "JOHN SMITH") }
+    end
+
+    context "query approximately matches a name with apostrophe and abbreviation" do
+      let(:query_text) { "ZELDA DAMORE JR" }
+      it { is_expected.to start_with("ZELLA D'AMORE JR.") }
+    end
+
+    context "query approximately matches a hyphenated name" do
+      let(:query_text) { "TAINA TERRENCE KLEIN" }
+      it { is_expected.to start_with("TAINA TERRANCE-KLEIN") }
     end
   end
 end

--- a/spec/services/attorney_search_spec.rb
+++ b/spec/services/attorney_search_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+describe AttorneySearch do
+  describe "#fetch_attorneys" do
+    subject { AttorneySearch.new(query_text).fetch_attorneys.map(&:name) }
+
+    context "no words are provided" do
+      let(:query_text) { "123 _no_words" }
+      it { is_expected.to be_empty }
+    end
+  end
+end

--- a/spec/services/attorney_search_spec.rb
+++ b/spec/services/attorney_search_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe AttorneySearch do
-  let(:names) {
+  let(:names) do
     [
       "JOHN SMITH",
       "MARILEE NIKOLAUS IV",
@@ -12,12 +12,12 @@ describe AttorneySearch do
       "TAINA TERRANCE-KLEIN",
       "JOHN SMITH"
     ]
-  }
+  end
   let!(:attorneys) { names.map { |name| create(:bgs_attorney, name: name) } }
   let(:search) { AttorneySearch.new(query_text) }
 
-  describe "#first_letter_candidates" do
-    subject { search.first_letter_candidates.map(&:name) }
+  describe "#candidates" do
+    subject { search.candidates.map(&:name) }
 
     context "no words are provided" do
       let(:query_text) { "123 _no_words" }


### PR DESCRIPTION
Connects #14132 

### Description
This PR implements a new `/intake/attorneys` endpoint, to be used by the searchable dropdown in the `Add Claimant` modal.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] New endpoint that returns a list of attorneys matching free-text input
- [ ] Each attorney should be returned with a full name and a unique identifier (most likely a Participant ID)
- [ ] The matching algorithm should run in under 1 second (ideally much less) when tested in prod.

### Testing Plan
1. Added a new file of tests for the new service class
2. Added a small controller test to make sure serialization is working right
3. To test manually, log in as an intake user, make sure the DB is seeded, and hit `/intake/attorneys?query=random+name`
