### PR TITLE
Veteran date of death

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -146,6 +146,7 @@ detectors:
       - BulkTaskReassignment
       - Task
       - UpdateCachedAppealsAttributesJob
+      - Veteran
   TooManyConstants:
     exclude:
       - Fakes::BGSServicePOA

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -387,7 +387,7 @@ class Veteran < CaseflowRecord
   end
 
   def cached_attributes_updatable?
-    accessible? && bgs_record.is_a?(Hash) && stale_attributes?
+    accessible? && bgs_record_found? && stale_attributes?
   end
 
   def deceased?

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -139,9 +139,13 @@ class Veteran < CaseflowRecord
   end
 
   def access_error
-    @access_error ||= nil if bgs_record.is_a?(Hash)
+    @access_error ||= nil if bgs_record_found?
   rescue BGS::ShareError => error
     error.message
+  end
+
+  def bgs_record_found?
+    bgs_record.is_a?(Hash)
   end
 
   # When two Veteran records get merged for data clean up, it can lead to multiple active phone numbers
@@ -167,7 +171,7 @@ class Veteran < CaseflowRecord
   end
 
   def incident_flash?
-    bgs_record.is_a?(Hash) && bgs_record[:block_cadd_ind] == "S"
+    bgs_record_found? && bgs_record[:block_cadd_ind] == "S"
   end
 
   # Postal code might be stored in address line 3 for international addresses
@@ -240,11 +244,11 @@ class Veteran < CaseflowRecord
   end
 
   def ssn
-    super || (bgs_record.is_a?(Hash) ? bgs_record[:ssn] : nil)
+    super || (bgs_record_found? ? bgs_record[:ssn] : nil)
   end
 
   def date_of_death
-    super || (bgs_record.is_a?(Hash) ? bgs_record[:date_of_death] : nil)
+    super || (bgs_record_found? ? bgs_record[:date_of_death] : nil)
   end
 
   def address

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -269,15 +269,19 @@ class Veteran < CaseflowRecord
 
   def stale?
     (first_name.nil? || last_name.nil? || self[:ssn].nil? || self[:participant_id].nil? ||
-      email_address.nil? || self[:date_of_death].nil?)
+      email_address.nil?)
   end
 
   def stale_attributes?
     return false unless accessible? && bgs_record.is_a?(Hash)
 
     is_stale = stale?
-    is_stale ||= CACHED_BGS_ATTRIBUTES.any? { |local_attr, bgs_attr| self[local_attr] != bgs_record[bgs_attr] }
+    is_stale ||= stale_bgs_attributes?
     is_stale
+  end
+
+  def stale_bgs_attributes?
+    CACHED_BGS_ATTRIBUTES.any? { |local_attr, bgs_attr| self[local_attr] != bgs_record[bgs_attr] }
   end
 
   def update_cached_attributes!
@@ -383,7 +387,7 @@ class Veteran < CaseflowRecord
   end
 
   def deceased?
-    !date_of_death.nil?
+    date_of_death.present?
   end
 
   def alive?
@@ -458,7 +462,7 @@ class Veteran < CaseflowRecord
   def vbms_attributes
     self.class.bgs_attributes \
       - [:military_postal_type_code, :military_post_office_type_code, :ptcpnt_id] \
-      + [:file_number, :address_type, :first_name, :last_name, :name_suffix, :ssn]
+      + [:file_number, :address_type, :first_name, :last_name, :name_suffix, :ssn, :date_of_death]
   end
 
   def military_address?

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -401,6 +401,7 @@ class Veteran < CaseflowRecord
   def unload_bgs_record
     @bgs_record_loaded = false
     @bgs_record = nil
+    self
   end
 
   private

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -14,7 +14,7 @@ class Veteran < CaseflowRecord
   bgs_attr_accessor :ptcpnt_id, :sex, :address_line1, :address_line2,
                     :address_line3, :city, :state, :country, :zip_code,
                     :military_postal_type_code, :military_post_office_type_code,
-                    :service, :date_of_birth, :date_of_death, :email_address
+                    :service, :date_of_birth, :email_address
 
   with_options if: :alive? do
     validates :address_line1, :country, presence: true, on: :bgs
@@ -55,6 +55,7 @@ class Veteran < CaseflowRecord
 
   # key is local attribute name; value is corresponding bgs attribute name
   CACHED_BGS_ATTRIBUTES = {
+    date_of_death: :date_of_death,
     first_name: :first_name,
     last_name: :last_name,
     middle_name: :middle_name,
@@ -242,6 +243,10 @@ class Veteran < CaseflowRecord
     super || (bgs_record.is_a?(Hash) ? bgs_record[:ssn] : nil)
   end
 
+  def date_of_death
+    super || (bgs_record.is_a?(Hash) ? bgs_record[:date_of_death] : nil)
+  end
+
   def address
     @address ||= Address.new(
       address_line_1: address_line1,
@@ -264,7 +269,7 @@ class Veteran < CaseflowRecord
 
   def stale?
     (first_name.nil? || last_name.nil? || self[:ssn].nil? || self[:participant_id].nil? ||
-      email_address.nil?)
+      email_address.nil? || self[:date_of_death].nil?)
   end
 
   def stale_attributes?

--- a/db/migrate/20200518200111_add_veteran_date_of_death.rb
+++ b/db/migrate/20200518200111_add_veteran_date_of_death.rb
@@ -1,0 +1,5 @@
+class AddVeteranDateOfDeath < ActiveRecord::Migration[5.2]
+  def change
+    add_column :veterans, :date_of_death, :date, comment: "Date of Death reported by BGS, cached locally"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_13_140953) do
+ActiveRecord::Schema.define(version: 2020_05_18_200111) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1368,6 +1368,7 @@ ActiveRecord::Schema.define(version: 2020_05_13_140953) do
   create_table "veterans", force: :cascade do |t|
     t.string "closest_regional_office"
     t.datetime "created_at"
+    t.date "date_of_death", comment: "Date of Death reported by BGS, cached locally"
     t.string "file_number", null: false
     t.string "first_name"
     t.string "last_name"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -109,13 +109,13 @@ available_hearing_locations,state,string,,,,,,
 available_hearing_locations,updated_at,datetime ∗,x,,,,x,
 available_hearing_locations,veteran_file_number,string,,,,,x,
 available_hearing_locations,zip_code,string,,,,,,
-bgs_attorneys,,,,,,,,Attorney data cached from BGS — used for claimants
+bgs_attorneys,,,,,,,,Cache of unique BGS attorney data — used for adding claimants to cases pulled from POA data
 bgs_attorneys,created_at,datetime ∗,x,,,,x,Standard created_at/updated_at timestamps
 bgs_attorneys,id,integer (8) PK,x,x,,,,
 bgs_attorneys,last_synced_at,datetime,,,,,x,The last time BGS was checked
 bgs_attorneys,name,string ∗,x,,,,x,Name
 bgs_attorneys,participant_id,string ∗,x,,,,x,Participant ID
-bgs_attorneys,record_type,string ∗,x,,,,,"Possible types: POA State Organization,POA National Organization,POA Attorney,POA Agent,POA Local/Regional Organization"
+bgs_attorneys,record_type,string ∗,x,,,,,"Known types: POA State Organization, POA National Organization, POA Attorney, POA Agent, POA Local/Regional Organization"
 bgs_attorneys,updated_at,datetime ∗,x,,,,x,Standard created_at/updated_at timestamps
 bgs_power_of_attorneys,,,,,,,,Power of Attorney (POA) cached from BGS
 bgs_power_of_attorneys,authzn_change_clmant_addrs_ind,string,,,,,,Authorization for POA to change claimant address
@@ -1040,6 +1040,7 @@ vbms_uploaded_documents,uploaded_to_vbms_at,datetime,,,,,,
 veterans,,,,,,,,
 veterans,closest_regional_office,string,,,,,,
 veterans,created_at,datetime,,,,,,
+veterans,date_of_death,date,,,,,,"Date of Death reported by BGS, cached locally"
 veterans,file_number,string ∗,x,,,,x,
 veterans,first_name,string ∗,x,,,,,
 veterans,id,integer (8) PK,x,x,,,,
@@ -1070,7 +1071,7 @@ virtual_hearings,representative_email_sent,boolean ∗,x,,,,,Whether or not a 
 virtual_hearings,request_cancelled,boolean,,,,,,Determines whether the user has cancelled the virtual hearing request
 virtual_hearings,updated_at,datetime ∗,x,,,,x,
 virtual_hearings,updated_by_id,integer (8) FK,,,x,,x,The ID of the user who most recently updated the virtual hearing
-virtual_hearings,veteran_email,string ∗,x,,,,,Veteran's email address
+virtual_hearings,veteran_email,string,,,,,,Veteran's email address
 virtual_hearings,veteran_email_sent,boolean ∗,x,,,,,Whether or not a notification email was sent to the veteran
 virtual_hearing_establishments,,,,,,,,
 virtual_hearing_establishments,attempted_at,datetime,,,,,,Async timestamp for most recent attempt to run.

--- a/lib/generators/veteran.rb
+++ b/lib/generators/veteran.rb
@@ -98,6 +98,7 @@ class Generators::Veteran
                   first_name: attrs[:first_name],
                   last_name: attrs[:last_name],
                   middle_name: attrs[:middle_name],
+                  date_of_death: attrs[:date_of_death],
                   name_suffix: attrs[:suffix_name])
     end
   end

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe IntakesController, :postgres do
         expect(vet).to_not be_nil
         expect(vet.first_name).to eq "Ed"
         expect(vet.last_name).to eq "Merica"
-        expect(bgs).to have_received(:fetch_veteran_info).exactly(2).times
+        expect(bgs).to have_received(:fetch_veteran_info).exactly(3).times
       end
     end
 

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -37,7 +37,7 @@ FactoryBot.define do
           file_number: veteran.file_number,
           ssn: veteran.ssn,
           email_address: evaluator.email_address,
-          date_of_death: evaluator.date_of_death,
+          date_of_death: veteran.date_of_death,
           # both for compatability
           ptcpnt_id: veteran.participant_id,
           participant_id: veteran.participant_id

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     name_suffix { "II" }
     ssn { Generators::Random.unique_ssn }
     email_address { "#{first_name}.#{last_name}@test.com" }
+    date_of_death { nil }
 
     transient do
       bgs_veteran_record do
@@ -36,6 +37,7 @@ FactoryBot.define do
           file_number: veteran.file_number,
           ssn: veteran.ssn,
           email_address: evaluator.email_address,
+          date_of_death: evaluator.date_of_death,
           # both for compatability
           ptcpnt_id: veteran.participant_id,
           participant_id: veteran.participant_id

--- a/spec/models/ramp_election_spec.rb
+++ b/spec/models/ramp_election_spec.rb
@@ -133,7 +133,7 @@ describe RampElection, :postgres do
             limited_poa_access: nil,
             status_type_code: "PEND"
           },
-          veteran_hash: veteran.reload.to_vbms_hash,
+          veteran_hash: veteran.unload_bgs_record.reload.to_vbms_hash,
           user: nil
         )
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -762,7 +762,7 @@ describe Veteran, :all_dbs do
     let(:middle_name) { "Q" }
     let(:name_suffix) { "Esq" }
     let(:ssn) { "666000000" }
-    let(:date_of_death) { "12/31/2019" }
+    let(:date_of_death) { "2019-12-31" }
     let(:bgs_first_name) { first_name }
     let(:bgs_last_name) { last_name }
     let(:bgs_middle_name) { middle_name }
@@ -791,9 +791,25 @@ describe Veteran, :all_dbs do
 
     subject { veteran.stale_attributes? }
 
+    before do
+      veteran.unload_bgs_record # force it to reload from BGS
+    end
+
     context "no difference" do
       it "is false" do
         is_expected.to eq(false)
+      end
+    end
+
+    context "date_of_death does not match BGS" do
+      let(:bgs_date_of_death) { "2020-01-02" }
+
+      before do
+        Fakes::BGSService.edit_veteran_record(veteran.file_number, :date_of_death, bgs_date_of_death)
+      end
+
+      it "is true" do
+        is_expected.to eq(true)
       end
     end
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -6,7 +6,8 @@ describe Veteran, :all_dbs do
       file_number: "44556677",
       first_name: "June",
       last_name: "Juniper",
-      name_suffix: name_suffix
+      name_suffix: name_suffix,
+      date_of_death: date_of_death
     )
   end
 
@@ -35,6 +36,7 @@ describe Veteran, :all_dbs do
       state: state,
       country: country,
       date_of_birth: date_of_birth,
+      date_of_death: date_of_death,
       zip_code: zip_code,
       military_post_office_type_code: military_post_office_type_code,
       military_postal_type_code: military_postal_type_code,
@@ -52,6 +54,7 @@ describe Veteran, :all_dbs do
   let(:address_line3) { "Daisies" }
   let(:date_of_birth) { "12/21/1989" }
   let(:service) { [{ branch_of_service: "army" }] }
+  let(:date_of_death) { "12/31/2019" }
   let(:ssn) { "123456789" }
 
   context ".find_or_create_by_file_number" do
@@ -183,6 +186,7 @@ describe Veteran, :all_dbs do
         state: "CA",
         country: "USA",
         date_of_birth: "12/21/1989",
+        date_of_death: "12/31/2019",
         zip_code: "94117",
         military_post_office_type_code: "DPO",
         military_postal_type_code: "AE",
@@ -231,6 +235,7 @@ describe Veteran, :all_dbs do
         state: "CA",
         country: "USA",
         date_of_birth: "12/21/1989",
+        date_of_death: date_of_death,
         zip_code: "94117",
         military_post_office_type_code: "DPO",
         military_postal_type_code: "AE"
@@ -239,6 +244,7 @@ describe Veteran, :all_dbs do
   end
 
   context "#to_vbms_hash" do
+    let(:date_of_death) { nil }
     subject { veteran.to_vbms_hash }
 
     it "returns the correct values" do
@@ -756,11 +762,13 @@ describe Veteran, :all_dbs do
     let(:middle_name) { "Q" }
     let(:name_suffix) { "Esq" }
     let(:ssn) { "666000000" }
+    let(:date_of_death) { "12/31/2019" }
     let(:bgs_first_name) { first_name }
     let(:bgs_last_name) { last_name }
     let(:bgs_middle_name) { middle_name }
     let(:bgs_name_suffix) { name_suffix }
     let(:bgs_ssn) { ssn }
+    let(:bgs_date_of_death) { date_of_death }
     let!(:veteran) do
       create(
         :veteran,
@@ -769,12 +777,14 @@ describe Veteran, :all_dbs do
         middle_name: middle_name,
         name_suffix: name_suffix,
         ssn: ssn,
+        date_of_death: date_of_death,
         bgs_veteran_record: {
           first_name: bgs_first_name,
           last_name: bgs_last_name,
           middle_name: bgs_middle_name,
           name_suffix: bgs_name_suffix,
-          ssn: bgs_ssn
+          ssn: bgs_ssn,
+          date_of_death: bgs_date_of_death
         }
       )
     end
@@ -782,7 +792,9 @@ describe Veteran, :all_dbs do
     subject { veteran.stale_attributes? }
 
     context "no difference" do
-      it { is_expected.to eq(false) }
+      it "is false" do
+        is_expected.to eq(false)
+      end
     end
 
     context "first_name is nil" do

--- a/spec/requests/api/v3/decision_review/contestable_issues_controller_spec.rb
+++ b/spec/requests/api/v3/decision_review/contestable_issues_controller_spec.rb
@@ -8,7 +8,7 @@ describe Api::V3::DecisionReview::ContestableIssuesController, :postgres, type: 
   end
 
   describe "#index" do
-    let(:veteran) { create(:veteran) }
+    let(:veteran) { create(:veteran).unload_bgs_record }
 
     let!(:api_key) do
       ApiKey.create!(consumer_name: "ApiV3 Test Consumer").key_string

--- a/spec/services/duplicate_veteran_participant_id_finder_spec.rb
+++ b/spec/services/duplicate_veteran_participant_id_finder_spec.rb
@@ -22,7 +22,7 @@ describe DuplicateVeteranParticipantIDFinder, :postgres do
   before do
     allow(bgs_client).to receive(:people) { people_service }
     allow(people_service).to receive(:find_by_ssn) do
-     { ptcpnt_id: second_participant_id }
+      { ptcpnt_id: second_participant_id }
     end
     allow(bgs).to receive(:fetch_veteran_info).with(file_number) { bgs_veteran_record }
     allow(BGSService).to receive(:new) { bgs }

--- a/spec/services/duplicate_veteran_participant_id_finder_spec.rb
+++ b/spec/services/duplicate_veteran_participant_id_finder_spec.rb
@@ -1,21 +1,38 @@
 # frozen_string_literal: true
 
 describe DuplicateVeteranParticipantIDFinder, :postgres do
-  it "returns duplicate participant IDs" do
-    stub_const("BGSService", ExternalApi::BGSService)
-    RequestStore[:current_user] = create(:user)
+  let(:bgs) { ExternalApi::BGSService.new(client: bgs_client) }
+  let(:bgs_client) { double("bgs") }
+  let(:people_service) { double("people") }
+  let(:ssn) { "987654321" }
+  let(:file_number) { "111111111S" }
+  let(:participant_id) { "123456" }
+  let(:second_participant_id) { "765432" }
+  let(:veteran) do
+    create(:veteran, ssn: ssn, participant_id: participant_id, file_number: file_number)
+  end
+  let(:bgs_veteran_record) do
+    {
+      ptcpnt_id: participant_id,
+      file_number: file_number,
+      ssn: ssn
+    }
+  end
 
-    ssn = "987654321"
-    file_number = "111111111S"
-    participant_id = "123456"
-    second_participant_id = "765432"
-    veteran = create(:veteran, ssn: ssn, participant_id: participant_id, file_number: file_number)
+  before do
+    allow(bgs_client).to receive(:people) { people_service }
+    allow(people_service).to receive(:find_by_ssn) do
+     { ptcpnt_id: second_participant_id }
+    end
+    allow(bgs).to receive(:fetch_veteran_info).with(file_number) { bgs_veteran_record }
+    allow(BGSService).to receive(:new) { bgs }
+  end
 
-    allow(Veteran).to receive(:find_or_create_by_file_number).and_return(veteran)
-    allow(veteran).to receive(:fetch_bgs_record).and_return({})
-    allow_any_instance_of(BGS::PersonWebService).to receive(:find_by_ssn).and_return(ptcpnt_id: second_participant_id)
+  describe "#call" do
+    subject { described_class.new(veteran: veteran).call }
 
-    pids = DuplicateVeteranParticipantIDFinder.new(veteran: veteran).call
-    expect(pids).to match_array [participant_id, second_participant_id]
+    it "returns duplicate participant IDs" do
+      expect(subject).to match_array [participant_id, second_participant_id]
+    end
   end
 end


### PR DESCRIPTION
connects #13213 #12651 

### Description
Creates new column `date_of_death` on the Veteran model to cache that value from BGS.

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
