### PR TITLE
Do not chow cancelled tasks in completed tab

### DIFF
--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -58,7 +58,7 @@ class DecisionReviewsController < ApplicationController
 
   def completed_tasks
     apply_task_serializer(
-      business_line.tasks.recently_closed.includes([:assigned_to, :appeal]).order(closed_at: :desc).select(&:completed?)
+      business_line.tasks.recently_completed.includes([:assigned_to, :appeal]).order(closed_at: :desc).select(&:completed?)
     )
   end
 

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -77,7 +77,7 @@ class QueueTab
   end
 
   def recently_closed_tasks
-    Task.includes(*task_includes).visible_in_queue_table_view.where(assigned_to: assignee).recently_closed
+    Task.includes(*task_includes).visible_in_queue_table_view.where(assigned_to: assignee).recently_completed
   end
 
   def on_hold_task_children

--- a/app/models/queues/attorney_queue.rb
+++ b/app/models/queues/attorney_queue.rb
@@ -19,7 +19,7 @@ class AttorneyQueue
       end
     end
 
-    caseflow_tasks = user.tasks.includes(*task_includes).incomplete_or_recently_closed
+    caseflow_tasks = user.tasks.includes(*task_includes).incomplete_or_recently_completed
     (colocated_tasks_for_attorney_tasks + caseflow_tasks).flatten
   end
 

--- a/app/models/queues/generic_queue.rb
+++ b/app/models/queues/generic_queue.rb
@@ -15,7 +15,7 @@ class GenericQueue
   attr_reader :limit, :user
 
   def relevant_tasks
-    Task.incomplete_or_recently_closed.visible_in_queue_table_view
+    Task.incomplete_or_recently_completed.visible_in_queue_table_view
       .where(assigned_to: user)
       .includes(*task_includes)
       .order(created_at: :asc)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -60,9 +60,9 @@ class Task < CaseflowRecord
 
   scope :not_cancelled, -> { where.not(status: Constants.TASK_STATUSES.cancelled) }
 
-  scope :recently_closed, -> { closed.where(closed_at: (Time.zone.now - 1.week)..Time.zone.now) }
+  scope :recently_completed, -> { complete.where(closed_at: (Time.zone.now - 1.week)..Time.zone.now) }
 
-  scope :incomplete_or_recently_closed, -> { open.or(recently_closed) }
+  scope :incomplete_or_recently_completed, -> { open.or(recently_completed) }
 
   # Equivalent to .reject(&:hide_from_queue_table_view) but offloads that to the database.
   scope :visible_in_queue_table_view, lambda {

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -60,7 +60,7 @@ class Task < CaseflowRecord
 
   scope :not_cancelled, -> { where.not(status: Constants.TASK_STATUSES.cancelled) }
 
-  scope :recently_completed, -> { complete.where(closed_at: (Time.zone.now - 1.week)..Time.zone.now) }
+  scope :recently_completed, -> { completed.where(closed_at: (Time.zone.now - 1.week)..Time.zone.now) }
 
   scope :incomplete_or_recently_completed, -> { open.or(recently_completed) }
 


### PR DESCRIPTION
Resolves cancelled tasks showing up in user and org queues.

### Description
We (incorrectly) assumed user and org queues did not show cancelled tasks as the `recently_closed` scope was created before the concept of a cancelled task existed. When we introduced cancelled tasks, the scope was not updated to only select specifically completed tasks.

### Acceptance Criteria
- [ ] Cancelled tasks do not appear in a queue's completed tab

### Testing Plan
1. Log in a BVALSPORER
1. Cancel any task assigned to you
1. Confirm it doe not appear in your completed tab http://localhost:3000/queue?tab=completed_person&page=1
1. Confirm it does not appear in the vlj support completed tabhttp://localhost:3000/organizations/vlj-support?tab=completed&page=1

### User Facing Changes
 - [ ] Cancelled tasks do not appear in queue
