### PR TITLE
Remove 'Special' from all user facing case movement copy

### DIFF
--- a/app/models/tasks/special_case_movement_task.rb
+++ b/app/models/tasks/special_case_movement_task.rb
@@ -39,14 +39,14 @@ class SpecialCaseMovementTask < Task
     #   This may change as we add more 'from' scenarios
     if !parent.is_a?(DistributionTask)
       fail(Caseflow::Error::InvalidParentTask,
-           message: "Special Case Movement must have a Distribution task parent")
+           message: "Case Movement task must have a Distribution task parent")
     end
   end
 
   def verify_user_organization
     if !SpecialCaseMovementTeam.singleton.user_has_access?(assigned_by)
       fail(Caseflow::Error::ActionForbiddenError,
-           message: "Special Case Movement restricted to Special Case Movement Team members")
+           message: "Case Movement restricted to Case Movement Team members")
     end
   end
 end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -304,7 +304,7 @@
   "CANCEL_FOREIGN_VETERANS_CASE_TASK_MODAL_TITLE": "Cancel hearing request",
   "CANCEL_FOREIGN_VETERANS_CASE_TASK_MODAL_DETAIL": "Canceling this hearing request will release it to a hearing coordinator for review. A 90 day evidence hold may still apply to this case.",
 
-  "SPECIAL_CASE_MOVEMENT_MODAL_TITLE": "Special Case Movement",
+  "SPECIAL_CASE_MOVEMENT_MODAL_TITLE": "Case Movement",
   "SPECIAL_CASE_MOVEMENT_MODAL_DETAIL": "This action overrides the normal case distribution process and immediately assigns the appeal to the judge selected.",
   "SPECIAL_CASE_MOVEMENT_MODAL_SELECTOR_PLACEHOLDER": "Select a judge",
 

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -165,7 +165,7 @@
     "value": "modal/end_hold"
   },
   "SPECIAL_CASE_MOVEMENT": {
-    "label": "Special Case Movement: Advance to judge",
+    "label": "Case Movement: Advance to judge",
     "value": "modal/special_case_movement",
     "func": "special_case_movement_data"
   },

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -130,8 +130,8 @@ module Caseflow::Error
     def initialize(args)
       @code = args[:code] || 500
       @appeal_id = args[:appeal_id] || nil
-      @message = args[:message] || "Appeal #{@appeal_id} must be in Case Storage and not have blocking Mail Tasks for"\
-                                   " Special Case Movement"
+      @message = args[:message] || "Appeal #{@appeal_id} must be in Case Storage and not have blocking Mail Tasks to "\
+                                   "be elligable for Case Movement"
     end
   end
 

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -130,8 +130,9 @@ module Caseflow::Error
     def initialize(args)
       @code = args[:code] || 500
       @appeal_id = args[:appeal_id] || nil
+      @title = "This appeal cannot be advanced to a judge"
       @message = args[:message] || "Appeal #{@appeal_id} must be in Case Storage and not have blocking Mail Tasks to "\
-                                   "be elligable for Case Movement"
+                                   "be eligible for Case Movement"
     end
   end
 


### PR DESCRIPTION
Resolves #14182

### Description
Please explain the changes you made here.

### Acceptance Criteria
- [ ] The phrase "_Special_ case movement" is never shown to a user

### Testing Plan
1. Sign in as a CM user (BVARDUNKLE)
1. Search for any case ready for distribution (search 321321321)
1. Select "Advance to judge" in task action dropdown (Note no "Special")
1. Note no "Special" in modal

### User Facing Changes
CONTEXT|BEFORE|AFTER
 ---|---|---
Task dropdown|![Screen Shot 2020-05-20 at 10 51 51 AM](https://user-images.githubusercontent.com/45575454/82466754-cb982200-9a8e-11ea-88f0-ce756617c9f2.png)|![Screen Shot 2020-05-20 at 11 37 17 AM](https://user-images.githubusercontent.com/45575454/82466777-d0f56c80-9a8e-11ea-8849-d8721258e17c.png)
Modal|![Screen Shot 2020-05-20 at 10 52 01 AM](https://user-images.githubusercontent.com/45575454/82466807-d94da780-9a8e-11ea-9097-e37c086ea68e.png)|![Screen Shot 2020-05-20 at 11 37 25 AM](https://user-images.githubusercontent.com/45575454/82466828-de125b80-9a8e-11ea-9564-22c73d3a1152.png)
Errors|![Screen Shot 2020-05-20 at 11 36 20 AM](https://user-images.githubusercontent.com/45575454/82466886-f4b8b280-9a8e-11ea-9658-a85b7bed1c19.png)|![Screen Shot 2020-05-20 at 11 37 44 AM](https://user-images.githubusercontent.com/45575454/82466902-f84c3980-9a8e-11ea-82d2-bcb62648e74c.png)