### PR TITLE
Handle server error in daily docket

### DIFF
--- a/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocketRow.jsx
@@ -186,6 +186,11 @@ class DailyDocketRow extends React.Component {
     return this.props.
       saveHearing(this.props.hearing.externalId, hearingChanges).
       then((response) => {
+        // false is returned from DailyDocketContainer in case of error
+        if (!response) {
+          return;
+        }
+
         const alerts = response.body?.alerts;
 
         if (alerts.hearing) {


### PR DESCRIPTION
Resolves #14187

- return if server returns an error in `saveHearing` in `DailyDocketRow` to prevent the frontend from breaking when server returns error
