### PR TITLE
Set modal instructions to empty string instead of null

### DIFF
--- a/client/app/queue/components/AssignToAttorneyWidget.jsx
+++ b/client/app/queue/components/AssignToAttorneyWidget.jsx
@@ -40,7 +40,7 @@ class AssignToAttorneyWidget extends React.PureComponent {
     super(props);
 
     this.state = {
-      instructions: this.props.isModal ? this.props.selectedTasks[0].instructions : null
+      instructions: this.props.isModal ? this.props.selectedTasks[0].instructions : ""
     };
   }
 

--- a/client/app/queue/components/AssignToAttorneyWidget.jsx
+++ b/client/app/queue/components/AssignToAttorneyWidget.jsx
@@ -40,7 +40,7 @@ class AssignToAttorneyWidget extends React.PureComponent {
     super(props);
 
     this.state = {
-      instructions: this.props.isModal ? this.props.selectedTasks[0].instructions : ""
+      instructions: this.props.isModal ? this.props.selectedTasks[0].instructions : ''
     };
   }
 


### PR DESCRIPTION
Resolves several recent Sentry alerts:
* https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10314
* https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10315

### Description
Replace setting `instructions` to `null` with empty string to avoid errors when accessing it: 
https://github.com/department-of-veterans-affairs/caseflow/blob/fa38c46894a9ba9c1ec7b7488d884cb51e8a1f58/client/app/queue/components/AssignToAttorneyWidget.jsx#L79

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Expect no further Sentry alerts like those mentioned above.
