### PR TITLE
Tomas/add bgs power of attorney file number index

### DIFF
--- a/db/migrate/20200521135553_add_bgs_power_of_attorney_file_number_index.rb
+++ b/db/migrate/20200521135553_add_bgs_power_of_attorney_file_number_index.rb
@@ -1,0 +1,5 @@
+class AddBgsPowerOfAttorneyFileNumberIndex < Caseflow::Migration
+  def change
+    add_safe_index :bgs_power_of_attorneys, :file_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_200111) do
+ActiveRecord::Schema.define(version: 2020_05_21_135553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,6 +182,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_200111) do
     t.datetime "updated_at", null: false, comment: "Standard created_at/updated_at timestamps"
     t.index ["claimant_participant_id", "file_number"], name: "bgs_poa_pid_fn_unique_idx", unique: true
     t.index ["created_at"], name: "index_bgs_power_of_attorneys_on_created_at"
+    t.index ["file_number"], name: "index_bgs_power_of_attorneys_on_file_number"
     t.index ["last_synced_at"], name: "index_bgs_power_of_attorneys_on_last_synced_at"
     t.index ["poa_participant_id"], name: "index_bgs_power_of_attorneys_on_poa_participant_id"
     t.index ["representative_name"], name: "index_bgs_power_of_attorneys_on_representative_name"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1052,7 +1052,7 @@ veterans,ssn,string,,,,,x,The cached Social Security Number
 veterans,updated_at,datetime,,,,,x,
 virtual_hearings,,,,,,,,
 virtual_hearings,alias,string,,,,,x,Alias for conference in Pexip
-virtual_hearings,alias_with_host,string,,,,,x,Alias for conference in pexip with client_host
+virtual_hearings,alias_with_host,string,,,,,,Alias for conference in pexip with client_host
 virtual_hearings,conference_deleted,boolean ∗,x,,,,,Whether or not the conference was deleted from Pexip
 virtual_hearings,conference_id,integer,,,,,x,ID of conference from Pexip
 virtual_hearings,created_at,datetime ∗,x,,,,,

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1052,7 +1052,7 @@ veterans,ssn,string,,,,,x,The cached Social Security Number
 veterans,updated_at,datetime,,,,,x,
 virtual_hearings,,,,,,,,
 virtual_hearings,alias,string,,,,,x,Alias for conference in Pexip
-virtual_hearings,alias_with_host,string,,,,,,Alias for conference in pexip with client_host
+virtual_hearings,alias_with_host,string,,,,,x,Alias for conference in pexip with client_host
 virtual_hearings,conference_deleted,boolean ∗,x,,,,,Whether or not the conference was deleted from Pexip
 virtual_hearings,conference_id,integer,,,,,x,ID of conference from Pexip
 virtual_hearings,created_at,datetime ∗,x,,,,,


### PR DESCRIPTION
### Description
Adds an index for `file_number` on `BgsPowerOfAttorney` records.

### Database Changes
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
