### PR TITLE
Add index for claimant_participant_id on BgsPowerOfAttorney table

### DIFF
--- a/db/migrate/20200521202239_add_claimant_participation_id_index_to_bgs_power_of_attorney.rb
+++ b/db/migrate/20200521202239_add_claimant_participation_id_index_to_bgs_power_of_attorney.rb
@@ -1,0 +1,5 @@
+class AddClaimantParticipationIdIndexToBgsPowerOfAttorney < Caseflow::Migration
+  def change
+    add_safe_index :bgs_power_of_attorneys, :claimant_participant_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_21_135553) do
+ActiveRecord::Schema.define(version: 2020_05_21_202239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -181,6 +181,7 @@ ActiveRecord::Schema.define(version: 2020_05_21_135553) do
     t.string "representative_type", null: false, comment: "POA type"
     t.datetime "updated_at", null: false, comment: "Standard created_at/updated_at timestamps"
     t.index ["claimant_participant_id", "file_number"], name: "bgs_poa_pid_fn_unique_idx", unique: true
+    t.index ["claimant_participant_id"], name: "index_bgs_power_of_attorneys_on_claimant_participant_id"
     t.index ["created_at"], name: "index_bgs_power_of_attorneys_on_created_at"
     t.index ["file_number"], name: "index_bgs_power_of_attorneys_on_file_number"
     t.index ["last_synced_at"], name: "index_bgs_power_of_attorneys_on_last_synced_at"


### PR DESCRIPTION
This is the second index, following @tomas-nava’s PR #14361, that was identified as causing high CPU usage.

### Description
Adds an index for `claimant_participant_id` on `BgsPowerOfAttorney` table.

It's being queried here:
https://github.com/department-of-veterans-affairs/caseflow/blob/ec6565b97a1d81fa49afb7fef5c64549af8630ef/app/models/bgs_power_of_attorney.rb#L42

### Database Changes
* [x] Appropriate indexes added 
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR