### PR TITLE
bump puma 3.12.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "pg", platforms: :ruby
 # Application server: Puma
 # Puma was chosen because it handles load of 40+ concurrent users better than Unicorn and Passenger
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
-gem "puma", "~> 3.12.4"
+gem "puma", "~> 3.12.6"
 gem "rack", "~> 2.2.0"
 gem "rails", "5.2.4.3"
 # Used to colorize output for rake tasks

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "pg", platforms: :ruby
 # Application server: Puma
 # Puma was chosen because it handles load of 40+ concurrent users better than Unicorn and Passenger
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
+# We are not yet at version 4.x because we have not tested.
 gem "puma", "~> 3.12.6"
 gem "rack", "~> 2.2.0"
 gem "rails", "5.2.4.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.1.1)
-    puma (3.12.4)
+    puma (3.12.6)
     rack (2.2.2)
     rack-contrib (2.1.0)
       rack (~> 2.0)
@@ -651,7 +651,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
-  puma (~> 3.12.4)
+  puma (~> 3.12.6)
   rack (~> 2.2.0)
   rails (= 5.2.4.3)
   rails-erd


### PR DESCRIPTION
Upgrading `puma` per this advisory:

```
Name: puma
Version: 3.12.4
Advisory: CVE-2020-11077
Criticality: Unknown
URL: https://github.com/puma/puma/security/advisories/GHSA-w64w-qqph-5gxm
Title: HTTP Smuggling via Transfer-Encoding Header in Puma
Solution: upgrade to ~> 3.12.6, >= 4.3.5
```