### PR TITLE
AppealsWithClosedRootTaskOpenChildrenQuery

### DIFF
--- a/app/queries/appeals_with_closed_root_task_open_children_query.rb
+++ b/app/queries/appeals_with_closed_root_task_open_children_query.rb
@@ -12,10 +12,15 @@ class AppealsWithClosedRootTaskOpenChildrenQuery
   end
 
   def appeal_ids_for_closed_root_tasks
-    Task.select(:appeal_id).where(appeal_type: "Appeal").where(type: RootTask.name, status: Task.closed_statuses)
+    Task.select(:appeal_id)
+      .where(appeal_type: "Appeal")
+      .where(type: RootTask.name, status: Task.closed_statuses)
   end
 
   def appeal_ids_for_open_tasks
-    Task.select(:appeal_id).where(appeal_type: "Appeal").where.not(type: RootTask.name).where(status: Task.open_statuses)
+    Task.select(:appeal_id)
+      .where(appeal_type: "Appeal")
+      .where.not(type: RootTask.name)
+      .where(status: Task.open_statuses)
   end
 end

--- a/app/queries/appeals_with_closed_root_task_open_children_query.rb
+++ b/app/queries/appeals_with_closed_root_task_open_children_query.rb
@@ -17,9 +17,8 @@ class AppealsWithClosedRootTaskOpenChildrenQuery
   end
 
   def appeal_ids_for_open_tasks
-    Task.select(:appeal_id)
+    Task.open.select(:appeal_id)
       .where(appeal_type: "Appeal")
       .where.not(type: RootTask.name)
-      .where(status: Task.open_statuses)
   end
 end

--- a/app/queries/appeals_with_closed_root_task_open_children_query.rb
+++ b/app/queries/appeals_with_closed_root_task_open_children_query.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AppealsWithClosedRootTaskOpenChildrenQuery
+  def call
+    appeals_with_open_child_tasks_and_closed_root_tasks
+  end
+
+  private
+
+  def appeals_with_open_child_tasks_and_closed_root_tasks
+    Appeal.established.where(id: appeal_ids_for_closed_root_tasks).where(id: appeal_ids_for_open_tasks)
+  end
+
+  def appeal_ids_for_closed_root_tasks
+    Task.select(:appeal_id).where(appeal_type: "Appeal").where(type: RootTask.name, status: Task.closed_statuses)
+  end
+
+  def appeal_ids_for_open_tasks
+    Task.select(:appeal_id).where(appeal_type: "Appeal").where.not(type: RootTask.name).where(status: Task.open_statuses)
+  end
+end

--- a/app/queries/appeals_with_closed_root_task_open_children_query.rb
+++ b/app/queries/appeals_with_closed_root_task_open_children_query.rb
@@ -12,9 +12,8 @@ class AppealsWithClosedRootTaskOpenChildrenQuery
   end
 
   def appeal_ids_for_closed_root_tasks
-    Task.select(:appeal_id)
+    RootTask.closed.select(:appeal_id)
       .where(appeal_type: "Appeal")
-      .where(type: RootTask.name, status: Task.closed_statuses)
   end
 
   def appeal_ids_for_open_tasks

--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -2,12 +2,17 @@
 
 class StuckAppealsChecker < DataIntegrityChecker
   def call
-    return unless stuck_appeals.count > 0
+    return if stuck_appeals.count == 0 && appeals_maybe_not_closed.count == 0
 
-    add_to_report "Stuck Appeals: #{stuck_appeals.count} reported by AppealsWithNoTasksOrAllTasksOnHoldQuery"
+    add_to_report "AppealsWithNoTasksOrAllTasksOnHoldQuery: #{stuck_appeals.count}"
+    add_to_report "AppealsWithClosedRootTaskOpenChildrenQuery: #{appeals_maybe_not_closed.count}"
   end
 
   private
+
+  def appeals_maybe_not_closed
+    @appeals_maybe_not_closed ||= AppealsWithClosedRootTaskOpenChildrenQuery.new.call
+  end
 
   def stuck_appeals
     @stuck_appeals ||= AppealsWithNoTasksOrAllTasksOnHoldQuery.new.call

--- a/spec/services/stuck_appeals_checker_spec.rb
+++ b/spec/services/stuck_appeals_checker_spec.rb
@@ -20,13 +20,19 @@ describe StuckAppealsChecker, :postgres do
     create(:bva_dispatch_task, :completed, appeal: appeal)
     appeal
   end
+  let!(:appeal_with_closed_root_open_child) do
+    appeal = create(:appeal, :with_post_intake_tasks)
+    appeal.root_task.completed!
+    appeal
+  end
 
   describe "#call" do
     it "reports 3 appeals stuck" do
       subject.call
 
       expect(subject.report?).to eq(true)
-      expect(subject.report).to match(/^Stuck Appeals: 3 reported/)
+      expect(subject.report).to match(/AppealsWithNoTasksOrAllTasksOnHoldQuery: 3/)
+      expect(subject.report).to match(/AppealsWithClosedRootTaskOpenChildrenQuery: 1/)
     end
   end
 end


### PR DESCRIPTION
connects #14255 

### Description
Expand definition of "stuck" appeal to include those that appear to be closed (via their root task) but where there are open child tasks.