### PR TITLE
Build judge queues from config

### DIFF
--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -64,6 +64,19 @@ class QueueTab
       Constants.QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name
     ]
   end
+
+  def self.judge_review_column_names
+    [
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_ID.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name
+    ]
+  end
   # rubocop:enable Metrics/AbcSize
 
   private

--- a/app/models/queue_tab.rb
+++ b/app/models/queue_tab.rb
@@ -65,7 +65,7 @@ class QueueTab
     ]
   end
 
-  def self.judge_review_column_names
+  def self.judge_column_names
     [
       Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
       Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -22,7 +22,7 @@ class AssignedTasksTab < QueueTab
   # rubocop:disable Metrics/AbcSize
   def column_names
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
-    return QueueTab.judge_review_column_names if assignee.judge_in_vacols?
+    return QueueTab.judge_column_names if assignee.judge_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,

--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -22,6 +22,7 @@ class AssignedTasksTab < QueueTab
   # rubocop:disable Metrics/AbcSize
   def column_names
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
+    return QueueTab.judge_review_column_names if assignee.judge_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -321,6 +321,8 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def queue_tabs
+    return [assigned_tasks_tab] if judge_in_vacols?
+
     [
       assigned_tasks_tab,
       on_hold_tasks_tab,

--- a/client/app/queue/JudgeDecisionReviewTaskListView.jsx
+++ b/client/app/queue/JudgeDecisionReviewTaskListView.jsx
@@ -5,10 +5,10 @@ import { bindActionCreators } from 'redux';
 import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
 
-import TaskTable from './components/TaskTable';
-import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
+
+import QueueTableBuilder from './QueueTableBuilder';
 import Alert from '../components/Alert';
 
 import {
@@ -19,7 +19,6 @@ import {
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
 import { judgeDecisionReviewTasksSelector } from './selectors';
 
-import { fullWidth } from './constants';
 import COPY from '../../COPY';
 
 const containerStyles = css({
@@ -39,43 +38,22 @@ class JudgeDecisionReviewTaskListView extends React.PureComponent {
   };
 
   render = () => {
-    const {
-      messages,
-      organizations,
-      tasks
-    } = this.props;
-    const reviewableCount = tasks.length;
-    let tableContent;
-
-    if (reviewableCount === 0) {
-      tableContent = <p {...css({ textAlign: 'center',
-        marginTop: '3rem' })}>
-        {COPY.NO_CASES_IN_QUEUE_MESSAGE}<b><Link to="/search">{COPY.NO_CASES_IN_QUEUE_LINK_TEXT}</Link></b>.
-      </p>;
-    } else {
-      tableContent = <TaskTable
-        includeBadges
-        includeTask
-        includeDetailsLink
-        includeDocumentId
-        includeType
-        includeDocketNumber
-        includeIssueCount
-        includeDaysWaiting
-        tasks={this.props.tasks}
-      />;
-    }
+    const { tasks, error, success } = this.props;
+    const noCasesMessage = tasks.length === 0 ?
+      <p>
+        {COPY.NO_CASES_IN_QUEUE_MESSAGE}
+        <b><Link to="/search">{COPY.NO_CASES_IN_QUEUE_LINK_TEXT}</Link></b>.
+      </p> : '';
 
     return <AppSegment filledBackground styling={containerStyles}>
-      <h1 {...fullWidth}>{sprintf(COPY.JUDGE_CASE_REVIEW_TABLE_TITLE, reviewableCount)}</h1>
-      <QueueOrganizationDropdown organizations={organizations} />
-      {messages.error && <Alert type="error" title={messages.error.title}>
-        {messages.error.detail}
+      {error && <Alert type="error" title={error.title}>
+        {error.detail}
       </Alert>}
-      {messages.success && <Alert type="success" title={messages.success.title}>
-        {messages.success.detail || COPY.JUDGE_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
+      {success && <Alert type="success" title={success.title}>
+        {success.detail || COPY.ATTORNEY_QUEUE_TABLE_SUCCESS_MESSAGE_DETAIL}
       </Alert>}
-      {tableContent}
+      {noCasesMessage}
+      <QueueTableBuilder assignedTasks={tasks}/>
     </AppSegment>;
   };
 }
@@ -86,7 +64,6 @@ JudgeDecisionReviewTaskListView.propTypes = {
   resetSuccessMessages: PropTypes.func,
   resetErrorMessages: PropTypes.func,
   clearCaseSelectSearch: PropTypes.func,
-  organizations: PropTypes.array,
   messages: PropTypes.shape({
     error: PropTypes.shape({
       title: PropTypes.string,
@@ -108,7 +85,8 @@ const mapStateToProps = (state) => {
 
   return {
     tasks: judgeDecisionReviewTasksSelector(state),
-    messages
+    success: messages.success,
+    error: messages.error
   };
 };
 

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -9,8 +9,8 @@ import BulkAssignButton from './components/BulkAssignButton';
 import QueueTable from './QueueTable';
 import TabWindow from '../components/TabWindow';
 import QueueOrganizationDropdown from './components/QueueOrganizationDropdown';
-import { assignedToColumn, completedToNameColumn, daysOnHoldColumn, daysWaitingColumn, detailsColumn,
-  docketNumberColumn, badgesColumn, issueCountColumn, readerLinkColumn, readerLinkColumnWithNewDocsIcon,
+import { assignedToColumn, badgesColumn, completedToNameColumn, daysOnHoldColumn, daysWaitingColumn, detailsColumn,
+  docketNumberColumn, documentIdColumn, issueCountColumn, readerLinkColumn, readerLinkColumnWithNewDocsIcon,
   regionalOfficeColumn, taskColumn, taskCompletedDateColumn, typeColumn } from './components/TaskTableColumns';
 import { tasksWithAppealsFromRawTasks } from './utils';
 
@@ -70,6 +70,7 @@ class QueueTableBuilder extends React.PureComponent {
       [QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name]: daysWaitingColumn(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name]: docketNumberColumn(tasks, filterOptions, requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name]: readerLinkColumn(requireDasRecord, true),
+      [QUEUE_CONFIG.COLUMNS.DOCUMENT_ID.name]: documentIdColumn(),
       [QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]: issueCountColumn(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.READER_LINK_WITH_NEW_DOCS_ICON.name]: readerLinkColumnWithNewDocsIcon(requireDasRecord),
       [QUEUE_CONFIG.COLUMNS.REGIONAL_OFFICE.name]: regionalOfficeColumn(tasks, filterOptions),

--- a/client/app/queue/components/TaskTable.jsx
+++ b/client/app/queue/components/TaskTable.jsx
@@ -17,8 +17,7 @@ import QueueTable from '../QueueTable';
 import Checkbox from '../../components/Checkbox';
 import { docketNumberColumn, badgesColumn, detailsColumn, taskColumn, regionalOfficeColumn, daysWaitingColumn,
   issueCountColumn, typeColumn, assignedToColumn, readerLinkColumn, daysOnHoldColumn, completedToNameColumn,
-  taskCompletedDateColumn } from
-  './TaskTableColumns';
+  taskCompletedDateColumn, documentIdColumn } from './TaskTableColumns';
 
 import { setSelectionOfTaskOfUser } from '../QueueActions';
 import { hasDASRecord } from '../utils';
@@ -74,23 +73,7 @@ export class TaskTableUnconnected extends React.PureComponent {
   }
 
   caseDocumentIdColumn = () => {
-    return this.props.includeDocumentId ? {
-      header: COPY.CASE_LIST_TABLE_DOCUMENT_ID_COLUMN_TITLE,
-      valueFunction: (task) => {
-        const firstName = task.decisionPreparedBy ? task.decisionPreparedBy.firstName : task.assignedBy.firstName;
-        const lastName = task.decisionPreparedBy ? task.decisionPreparedBy.lastName : task.assignedBy.lastName;
-
-        if (!firstName) {
-          return task.documentId;
-        }
-
-        const nameAbbrev = `${firstName.substring(0, 1)}. ${lastName}`;
-
-        return <React.Fragment>
-          {task.documentId}<br />from {nameAbbrev}
-        </React.Fragment>;
-      }
-    } : null;
+    return this.props.includeDocumentId ? documentIdColumn(this.props.tasks) : null;
   }
 
   caseTypeColumn = () => {

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -57,6 +57,26 @@ export const docketNumberColumn = (tasks, filterOptions, requireDasRecord) => {
   };
 };
 
+export const documentIdColumn = (tasks) => {
+  return {
+    header: COPY.CASE_LIST_TABLE_DOCUMENT_ID_COLUMN_TITLE,
+    valueFunction: (task) => {
+      const firstName = task.decisionPreparedBy ? task.decisionPreparedBy.firstName : task.assignedBy.firstName;
+      const lastName = task.decisionPreparedBy ? task.decisionPreparedBy.lastName : task.assignedBy.lastName;
+
+      if (!firstName) {
+        return task.documentId;
+      }
+
+      const nameAbbrev = `${firstName.substring(0, 1)}. ${lastName}`;
+
+      return <React.Fragment>
+        {task.documentId}<br />from {nameAbbrev}
+      </React.Fragment>;
+    }
+  };
+}
+
 export const badgesColumn = () => {
   return {
     header: '',

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -41,6 +41,9 @@
     "DOCUMENT_COUNT_READER_LINK": {
       "name": "readerLinkColumn"
     },
+    "DOCUMENT_ID": {
+      "name": "documentIdColumn"
+    },
     "BADGES": {
       "name": "badgesColumn"
     },


### PR DESCRIPTION
Resolves #11700

### Description
Mirroring #11699, build judge queues from queue config.

### Acceptance Criteria
- [ ] Judge queue configurations are determined on the back end

### Testing Plan
1. Go to BVAAABSHIRE's queue
2. Ensure the columns/number of tasks are the same as on master
3. Ensure sorting and filtering work I guess?

### User Facing Changes

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-05-27 at 12 46 03 PM](https://user-images.githubusercontent.com/45575454/83049052-92285f00-a018-11ea-8ecf-39fd9c10b816.png)|![Screen Shot 2020-05-27 at 12 43 45 PM](https://user-images.githubusercontent.com/45575454/83049065-96547c80-a018-11ea-838e-036f4d67d1f3.png)
