### PR TITLE
Fix field size in modals

### DIFF
--- a/client/app/components/Modal.jsx
+++ b/client/app/components/Modal.jsx
@@ -142,7 +142,7 @@ export default class Modal extends React.Component {
           </button>
           <div style={{ display: 'flex' }}>
             {icon && <i className={`fa fa-2x fa-${icon}`} {...iconStyling} />}
-            <div>
+            <div {...css({ flexGrow: 1 })}>
               <h1 id="modal_id-title">{title}</h1>
               <div {...modalTextStyling}>{children}</div>
             </div>


### PR DESCRIPTION
### Description

Introduced by #14065 

  * Adds flex-grow to expand the inner div to the full width of the flex box

### User Facing Changes

 BEFORE|AFTER
 ---|---
N/A | (ensuring that this is the same as in #14065) <img width="414" alt="Screen Shot 2020-05-27 at 2 41 21 PM" src="https://user-images.githubusercontent.com/1298274/83060151-05d26800-a029-11ea-931f-016d89fa0b04.png">
<img width="414" alt="Screen Shot 2020-05-27 at 2 44 07 PM" src="https://user-images.githubusercontent.com/1298274/83060268-2ef2f880-a029-11ea-9aa3-9dfef85abfa6.png"> | <img width="414" alt="Screen Shot 2020-05-27 at 2 42 29 PM" src="https://user-images.githubusercontent.com/1298274/83060253-27335400-a029-11ea-8f6f-87dc4e8fc7ce.png">
<img width="414" alt="Screen Shot 2020-05-27 at 2 44 36 PM" src="https://user-images.githubusercontent.com/1298274/83060307-3c0fe780-a029-11ea-8bc2-f4deea5afc56.png"> | <img width="414" alt="Screen Shot 2020-05-27 at 2 45 17 PM" src="https://user-images.githubusercontent.com/1298274/83060304-3b775100-a029-11ea-93a7-e9242961d63f.png">
