### PR TITLE
Change sign in URL, add return_to URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -153,7 +153,7 @@ class ApplicationController < ApplicationBaseController
     if current_user.present?
       urls.append(title: "Sign Out", link: url_for(controller: "/sessions", action: "destroy"), border: true)
     else
-      urls.append(title: "Sign In", link: url_for("/login"), border: true)
+      urls.append(title: "Sign In", link: url_for("/search"), border: true)
     end
 
     urls

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,13 +15,14 @@ class SessionsController < ApplicationController
       session["return_to"] = request.original_url
       return redirect_to(sso_url)
     end
+    return redirect_to(sso_url) unless current_user
 
     # In order to use Caseflow, we need to know what regional office (RO) the user is from.
     # CSS will give us the station office ID. Some station office IDs correspond to multiple
     # RO IDs. In this case, we present a list of ROs to the user and ask which one they are.
     # :nocov:
     unless current_user.ro_is_ambiguous_from_station_office?
-      redirect_to(root_path)
+      redirect_to(session["return_to"] || root_path)
       return
     end
     # :nocov:

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,18 +9,19 @@ class SessionsController < ApplicationController
     if Rails.application.config.sso_service_disabled
       return render "errors/500", layout: "application", status: :service_unavailable
     end
+
     # :nocov:
-
-    session["return_to"] = request.original_url
-
-    return redirect_to(sso_url) unless current_user
+    unless current_user
+      session["return_to"] = request.original_url
+      return redirect_to(sso_url)
+    end
 
     # In order to use Caseflow, we need to know what regional office (RO) the user is from.
     # CSS will give us the station office ID. Some station office IDs correspond to multiple
     # RO IDs. In this case, we present a list of ROs to the user and ask which one they are.
     # :nocov:
     unless current_user.ro_is_ambiguous_from_station_office?
-      redirect_to(session["return_to"] || root_path)
+      redirect_to(root_path)
       return
     end
     # :nocov:

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,6 @@ class SessionsController < ApplicationController
       session["return_to"] = request.original_url
       return redirect_to(sso_url)
     end
-    return redirect_to(sso_url) unless current_user
 
     # In order to use Caseflow, we need to know what regional office (RO) the user is from.
     # CSS will give us the station office ID. Some station office IDs correspond to multiple

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,6 +11,8 @@ class SessionsController < ApplicationController
     end
     # :nocov:
 
+    session["return_to"] = request.original_url
+
     return redirect_to(sso_url) unless current_user
 
     # In order to use Caseflow, we need to know what regional office (RO) the user is from.

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -144,6 +144,7 @@ RSpec.feature "Login", :all_dbs do
       visit "/help"
 
       click_on "Menu"
+      expect(page).to have_link("Sign In", href: "/search")
       click_on "Sign In"
 
       expect(current_path).to eq("/fake-login-page")


### PR DESCRIPTION
### Description
This is in response to a Batteam issue. When users are trying to login to Caseflow, they are redirected to the eFolder app instead of the Caseflow app.  If they don't have eFolder access they are getting not authorized screen.  This PR is to redirect them back to Caseflow, in one place by adding the return to URL, and another by changing the link on the "Sign in" button.

Slack threads:
https://dsva.slack.com/archives/CHX8FMP28/p1590603820436400
https://dsva.slack.com/archives/CHX8FMP28/p1590615449453000