### PR TITLE
Fix fetch_person_by_ssn normalization

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -53,7 +53,7 @@ class Person < CaseflowRecord
   end
 
   def date_of_birth
-    cached_or_fetched_from_bgs(attr_name: :date_of_birth, bgs_attr: :birth_date)&.to_date
+    cached_or_fetched_from_bgs(attr_name: :date_of_birth)&.to_date
   end
 
   def first_name
@@ -140,6 +140,10 @@ class Person < CaseflowRecord
     bgs_record[:date_of_birth] = bgs_record.dig(:brthdy_dt)&.to_date
     bgs_record[:ssn] ||= bgs_record.dig(:ssn_nbr) || ssn
     bgs_record[:participant_id] ||= bgs_record.dig(:ptcpnt_id)
+    bgs_record[:first_name] ||= bgs_record.dig(:first_nm)
+    bgs_record[:last_name] ||= bgs_record.dig(:last_nm)
+    bgs_record[:middle_name] ||= bgs_record.dig(:middle_nm)
+    bgs_record[:email_address] ||= bgs_record.dig(:email_addr)
     bgs_record
   end
 end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -56,7 +56,7 @@ describe Person, :postgres do
 
   describe ".find_or_create_by_ssn" do
     before do
-      allow_any_instance_of(BGSService).to receive(:fetch_person_by_ssn) { bgs_person }
+      allow_any_instance_of(BGSService).to receive(:fetch_person_by_ssn) { bgs_person_by_ssn }
       allow_any_instance_of(BGSService).to receive(:fetch_person_info) { bgs_person }
     end
 
@@ -72,6 +72,17 @@ describe Person, :postgres do
         email_address: "cathy.smith@caseflow.gov"
       }
     end
+    let(:bgs_person_by_ssn) do
+      {
+        brthdy_dt: bgs_person[:birth_date],
+        first_nm: bgs_person[:first_name],
+        middle_nm: bgs_person[:middle_name],
+        last_nm: bgs_person[:last_name],
+        ssn_nbr: ssn,
+        ptcpnt_id: participant_id,
+        email_addr: bgs_person[:email_address]
+      }
+    end
     let(:participant_id) { known_fake_participant_id }
     let(:ssn) { "666001234" }
 
@@ -81,6 +92,9 @@ describe Person, :postgres do
       it "creates Person record" do
         expect(subject).to be_a Person
         expect(subject.participant_id).to eq participant_id
+        expect(subject.first_name).to eq "Cathy"
+        expect(subject.email_address).to eq bgs_person[:email_address]
+        expect(subject.date_of_birth.to_s).to eq("1998-09-05")
       end
     end
 


### PR DESCRIPTION
Observed while running UpdateCachedAppealsAttributesJob live in production, we were not caching all the BGS attributes when fetching by ssn.

This fixes that, with test showing the difference in the attribute names returned by `fetch_person_info` vs `fetch_person_by_ssn`.