### PR TITLE
Log out should completely clear session remnants

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -52,6 +52,7 @@ class SessionsController < ApplicationController
 
   # :nocov:
   def destroy
+    session.delete("return_to")
     remove_user_from_session
     if session["global_admin"]
       add_user_to_session(session["global_admin"])

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -19,7 +19,7 @@
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
 
-  <%= env_javascript_include_tag(static: ['webpack-bundle'], skip_pipeline: Rails.env.test?,
+  <%= env_javascript_include_tag(static: ['webpack-bundle'],
                                  hot: ['http://localhost:3500/webpack-bundle.js']) %>
 
   <%= csrf_meta_tags %>

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -19,7 +19,7 @@
 
   <%= stylesheet_link_tag 'application', media: 'all' %>
 
-  <%= env_javascript_include_tag(static: ['webpack-bundle'],
+  <%= env_javascript_include_tag(static: ['webpack-bundle'], skip_pipeline: Rails.env.test?,
                                  hot: ['http://localhost:3500/webpack-bundle.js']) %>
 
   <%= csrf_meta_tags %>

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+describe SessionsController, type: :controller do
+  let(:user) { create(:user) }
+  let(:admin_user) { create(:user) }
+
+  describe "#destroy" do
+    context "normal user" do
+      before do
+        session["user"] = Fakes::AuthenticationService.get_user_session(user.id)
+        session["return_to"] = "foobar"
+      end
+
+      it "clears session and logs out user" do
+        get :destroy
+
+        expect(response).to redirect_to "/"
+        expect(session["return_to"]).to be_nil
+        expect(session["user"]).to be_nil
+      end
+    end
+
+    context "global admin" do
+      before do
+        session["global_admin"] = admin_user.id
+        session["user"] = Fakes::AuthenticationService.get_user_session(user.id)
+        session["return_to"] = "foobar"
+      end
+
+      it "restores sessionn to admin user" do
+        get :destroy
+
+        expect(response).to redirect_to "/test/users"
+        expect(session["return_to"]).to be_nil
+        expect(session["user"]["pg_user_id"]).to eq admin_user.id
+        expect(session["global_admin"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -27,7 +27,7 @@ describe SessionsController, type: :controller do
         session["return_to"] = "foobar"
       end
 
-      it "restores sessionn to admin user" do
+      it "restores session to admin user" do
         get :destroy
 
         expect(response).to redirect_to "/test/users"


### PR DESCRIPTION
It is possible for logout to not completely clear a session and confuse subsequent login redirects.

https://dsva.slack.com/archives/C2ZBKPMND/p1590667397111300