### PR TITLE
Bump kaminari

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,8 @@ gem "fuzzy_match"
 gem "govdelivery-tms", require: "govdelivery/tms/mail/delivery_method"
 gem "holidays", "~> 6.4"
 gem "icalendar"
-gem "kaminari"
+# CVE-2020-11082
+gem "kaminari", "~> 1.2.1"
 gem "moment_timezone-rails"
 # Rails 6 has native support for multiple dbs, so prefer that over multiverse after upgrade.
 # https://github.com/ankane/multiverse#upgrading-to-rails-6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,18 +297,18 @@ GEM
       multi_json (~> 1.0)
       therubyracer (~> 0.12.1)
     json (2.3.0)
-    kaminari (1.1.1)
+    kaminari (1.2.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.1.1)
-      kaminari-activerecord (= 1.1.1)
-      kaminari-core (= 1.1.1)
-    kaminari-actionview (1.1.1)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
       actionview
-      kaminari-core (= 1.1.1)
-    kaminari-activerecord (1.1.1)
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
       activerecord
-      kaminari-core (= 1.1.1)
-    kaminari-core (1.1.1)
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kramdown (1.17.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -637,7 +637,7 @@ DEPENDENCIES
   holidays (~> 6.4)
   icalendar
   jshint
-  kaminari
+  kaminari (~> 1.2.1)
   meta_request
   moment_timezone-rails
   multiverse


### PR DESCRIPTION
Resolves linting errors on master

```
$ bundle exec rake security
Name: kaminari
Version: 1.1.1
Advisory: CVE-2020-11082
Criticality: Unknown
URL: https://github.com/kaminari/kaminari/security/advisories/GHSA-r5jw-62xg-j433
Title: Cross-Site Scripting in Kaminari via `original_script_name` parameter
Solution: upgrade to >= 1.2.1
```