### PR TITLE
Don't throw error when validating nil doc id

### DIFF
--- a/app/validators/legacy_attorney_case_review_document_id_validator.rb
+++ b/app/validators/legacy_attorney_case_review_document_id_validator.rb
@@ -4,13 +4,24 @@ module LegacyAttorneyCaseReviewDocumentIdValidator
   extend ActiveSupport::Concern
 
   def valid_document_id?
+    return false if document_id.nil?
+
     if draft_decision_work_product?
       return document_id.match?(new_decision_regex) || document_id.match?(old_decision_regex)
     end
 
     return document_id.match?(vha_regex) if vha_work_product?
 
-    document_id.match?(ime_regex) if ime_work_product?
+    return document_id.match?(ime_regex) if ime_work_product?
+
+    document_id_matches_any?
+  end
+
+  def document_id_matches_any?
+    document_id.match?(new_decision_regex) ||
+      document_id.match?(old_decision_regex) ||
+      document_id.match?(vha_regex) ||
+      document_id.match?(ime_regex)
   end
 
   def draft_decision_work_product?

--- a/spec/models/queues/legacy_work_queue_spec.rb
+++ b/spec/models/queues/legacy_work_queue_spec.rb
@@ -45,7 +45,7 @@ describe LegacyWorkQueue, :all_dbs do
     context "when it is an acting judge" do
       let(:role) { :attorney_judge_role }
 
-      fit "returns attorney tasks for cases with invalid doc ids, but judge task for cases with a valid doc id" do
+      it "returns attorney tasks for cases with invalid doc ids, but judge task for cases with a valid doc id" do
         expect(subject.length).to eq(4)
         expect(subject[0].class).to eq(AttorneyLegacyTask)
         expect(subject[1].class).to eq(JudgeLegacyDecisionReviewTask)

--- a/spec/models/queues/legacy_work_queue_spec.rb
+++ b/spec/models/queues/legacy_work_queue_spec.rb
@@ -17,7 +17,8 @@ describe LegacyWorkQueue, :all_dbs do
             work_product: "DEC"
           )
         ),
-        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user, document_id: "NONE"))
+        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user, document_id: "NONE")),
+        create(:legacy_appeal, vacols_case: create(:case, :assigned, user: user, document_id: nil))
       ]
     end
 
@@ -27,7 +28,7 @@ describe LegacyWorkQueue, :all_dbs do
       let(:role) { :attorney_role }
 
       it "returns tasks" do
-        expect(subject.length).to eq(3)
+        expect(subject.length).to eq(4)
         expect(subject[0].class).to eq(AttorneyLegacyTask)
       end
     end
@@ -36,7 +37,7 @@ describe LegacyWorkQueue, :all_dbs do
       let(:role) { :judge_role }
 
       it "returns tasks" do
-        expect(subject.length).to eq(3)
+        expect(subject.length).to eq(4)
         expect(subject[0].class).to eq(JudgeLegacyDecisionReviewTask)
       end
     end
@@ -44,11 +45,12 @@ describe LegacyWorkQueue, :all_dbs do
     context "when it is an acting judge" do
       let(:role) { :attorney_judge_role }
 
-      it "returns attorney tasks for cases with invalid doc ids, but judge task for cases with a valid doc id" do
-        expect(subject.length).to eq(3)
+      fit "returns attorney tasks for cases with invalid doc ids, but judge task for cases with a valid doc id" do
+        expect(subject.length).to eq(4)
         expect(subject[0].class).to eq(AttorneyLegacyTask)
         expect(subject[1].class).to eq(JudgeLegacyDecisionReviewTask)
         expect(subject[2].class).to eq(AttorneyLegacyTask)
+        expect(subject[3].class).to eq(AttorneyLegacyTask)
       end
     end
   end


### PR DESCRIPTION
Resolves `NoMethodError: undefined method `match?' for nil:NilClass` for acting judges

### Description
Some doc ids are nil. Do not try to validate nil document ids. Also, on occasion, we have a nil work product (about 1% of decass records) If this work product is nil, validate the document id on all matchers.

### Testing Plan
1. On master
```ruby
appeal = LegacyAppeal.last
VACOLS::Decass.where(defolder: appeal.vacols_id).update_all(dedocid: nil)
appeal.reload.vacols_case_review.document_id
=> nil
appeal.reload.vacols_case_review.valid_document_id?
NoMethodError: undefined method `match?' for nil:NilClass
```
1. Pull this branch
```ruby
reload!
appeal = LegacyAppeal.last
appeal.reload.vacols_case_review.document_id
=> nil
appeal.reload.vacols_case_review.valid_document_id?
=> false
```