### PR TITLE
Remove overtime status on case reassign

### DIFF
--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -96,6 +96,9 @@ class LegacyTasksController < ApplicationController
     # update the location to the assigned judge.
     QueueRepository.update_location_to_judge(appeal.vacols_id, assigned_to)
 
+    # Remove overtime status of an appeal when reassigning to a judge
+    appeal.overtime = false if appeal.overtime?
+
     render json: {
       task: json_task(AttorneyLegacyTask.from_vacols(
                         VACOLS::CaseAssignment.latest_task_for_appeal(appeal.vacols_id),

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -93,7 +93,7 @@ class TasksController < ApplicationController
   #   assigned_to_id: 23
   # }
   def update
-    tasks = task.update_from_params(update_params, current_user)
+    tasks = update_task
     tasks.each { |t| return invalid_record_error(t) unless t.valid? }
 
     tasks_to_return = (QueueForRole.new(user_role).create(user: current_user).tasks + tasks).uniq
@@ -107,6 +107,16 @@ class TasksController < ApplicationController
         "detail": error
       ]
     }, status: :bad_request
+  end
+
+  def update_task
+    if task.is_a?(AttorneyTask) && update_params[:status].eql?(Constants.TASK_STATUSES.cancelled)
+      task.verify_user_can_update!(current_user)
+
+      return task.send_back_to_judge_assign!
+    end
+
+    task.update_from_params(update_params, current_user)
   end
 
   def for_appeal

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -503,19 +503,23 @@ class Task < CaseflowRecord
   end
 
   def reassign(reassign_params, current_user)
-    sibling = dup.tap do |task|
-      task.assigned_by_id = self.class.child_assigned_by_id(parent, current_user)
-      task.assigned_to = self.class.child_task_assignee(parent, reassign_params)
-      task.instructions = flattened_instructions(reassign_params)
-      task.status = Constants.TASK_STATUSES.assigned
-      task.save!
-    end
+    sibling = Task.create!(
+      attributes.merge(
+        id: nil,
+        assigned_by_id: self.class.child_assigned_by_id(parent, current_user),
+        assigned_to: self.class.child_task_assignee(parent, reassign_params),
+        instructions: flattened_instructions(reassign_params),
+        status: Constants.TASK_STATUSES.assigned
+      )
+    )
 
     # Preserve the open children and status of the old task
     children.select(&:stays_with_reassigned_parent?).each { |child| child.update!(parent_id: sibling.id) }
     sibling.update!(status: status)
 
     update_with_instructions(status: Constants.TASK_STATUSES.cancelled, instructions: reassign_params[:instructions])
+
+    appeal.overtime = false if appeal.overtime? && reassign_clears_overtime?
 
     [sibling, self, sibling.children].flatten
   end
@@ -591,6 +595,10 @@ class Task < CaseflowRecord
     return nil unless record
 
     User.find_by_id(record.whodunnit)
+  end
+
+  def reassign_clears_overtime?
+    false
   end
 
   private

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -51,6 +51,10 @@ class AttorneyTask < Task
     super || completed?
   end
 
+  def reassign_clears_overtime?
+    true
+  end
+
   private
 
   def can_be_moved_by_user?(user)

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -41,4 +41,8 @@ class JudgeTask < Task
   def previous_task
     children_attorney_tasks.order(:assigned_at).last
   end
+
+  def reassign_clears_overtime?
+    true
+  end
 end

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -216,7 +216,7 @@ const editAppeal = (appealId, attributes) => ({
 
 export const setOvertime = (appealId, overtime) => ({
   type: ACTIONS.SET_OVERTIME,
-  payload: { 
+  payload: {
     appealId,
     overtime
   }
@@ -495,9 +495,11 @@ export const reassignTasksToUser = ({
     params = {
       data: {
         task: {
-          type: 'AttorneyTask',
-          assigned_to_id: assigneeId,
-          instructions
+          reassign: {
+            assigned_to_id: assigneeId,
+            assigned_to_type: 'User',
+            instructions
+          }
         }
       }
     };

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -691,6 +691,46 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
       expect(versions.length).to eq 1
     end
 
+    context "when cancelling a task" do
+      it "updates status to completed" do
+        patch :update, params: { task: { status: Constants.TASK_STATUSES.cancelled }, id: admin_action.id }
+        expect(response.status).to eq 200
+        response_body = JSON.parse(response.body)["tasks"]["data"]
+        expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.cancelled
+        expect(response_body.first["attributes"]["closed_at"]).to_not be nil
+      end
+
+      context "when the task is an attorney task" do
+        let(:judge) { create(:user, :judge) }
+        let(:attorney) { create(:user, :attorney) }
+        let(:judge_task) { create(:ama_judge_decision_review_task, assigned_to: judge) }
+        let(:attorney_task) do
+          create(:ama_attorney_task, assigned_to: attorney, assigned_by: judge, parent: judge_task)
+        end
+
+        before { User.stub = judge }
+
+        it "calls send_back_to_judge_assign!" do
+          patch :update, params: { task: { status: Constants.TASK_STATUSES.cancelled }, id: attorney_task.id }
+
+          expect(response.status).to eq 200
+          response_body = JSON.parse(response.body)["tasks"]["data"]
+
+          expect(response_body.first["attributes"]["type"]).to eq JudgeAssignTask.name
+          expect(response_body.first["attributes"]["status"]).to eq Constants.TASK_STATUSES.assigned
+          expect(response_body.first["attributes"]["assigned_to"]["id"]).to eq judge.id
+
+          expect(response_body.second["attributes"]["type"]).to eq AttorneyTask.name
+          expect(response_body.second["attributes"]["status"]).to eq Constants.TASK_STATUSES.cancelled
+          expect(response_body.second["attributes"]["closed_at"]).to_not be nil
+
+          expect(response_body.third["attributes"]["type"]).to eq JudgeDecisionReviewTask.name
+          expect(response_body.third["attributes"]["status"]).to eq Constants.TASK_STATUSES.cancelled
+          expect(response_body.third["attributes"]["closed_at"]).to_not be nil
+        end
+      end
+    end
+
     context "when some other user updates another user's task" do
       let(:assigned_by_user) { create(:user) }
       let!(:assigned_by_user_staff) { create(:staff, :attorney_role, sdomainid: assigned_by_user.css_id) }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -42,6 +42,22 @@ FactoryBot.define do
 
     trait :judge do
       roles { ["Hearing Prep"] }
+
+      after(:create) do |user, evaluator|
+        create(:staff, :judge_role, user: user)
+      end
+    end
+
+    trait :attorney do
+      after(:create) do |user, evaluator|
+        create(:staff, :attorney_role, user: user)
+      end
+    end
+
+    trait :acting_judge do
+      after(:create) do |user, evaluator|
+        create(:staff, :attorney_judge_role, user: user)
+      end
     end
 
     after(:create) do |user, evaluator|

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -897,6 +897,64 @@ describe Task, :all_dbs do
         end
       end
     end
+
+    context "When the appeal has not been marked for overtime" do
+      let!(:appeal) { create(:appeal) }
+      let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
+
+      before { FeatureToggle.enable!(:overtime_revamp) }
+      after { FeatureToggle.disable!(:overtime_revamp) }
+
+      it "does not create a new work mode for the appeal" do
+        expect(appeal.work_mode.nil?).to be true
+        subject
+        expect(appeal.work_mode.nil?).to be true
+      end
+    end
+
+    context "When the appeal has been marked for overtime" do
+      shared_examples "clears overtime" do
+        it "sets overtime to false" do
+          expect(appeal.overtime?).to be true
+          subject
+          expect(appeal.overtime?).to be false
+        end
+      end
+
+      let!(:appeal) { create(:appeal) }
+      let(:task) { create(:ama_task, appeal: appeal.reload) }
+
+      before do
+        appeal.overtime = true
+        FeatureToggle.enable!(:overtime_revamp)
+      end
+      after { FeatureToggle.disable!(:overtime_revamp) }
+
+      context "when the task type is not a judge or attorney task" do
+        it "does not clear the overtime status" do
+          expect(appeal.overtime?).to be true
+          subject
+          expect(appeal.overtime?).to be true
+        end
+      end
+
+      context "when the task is a judge task" do
+        let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
+
+        it_behaves_like "clears overtime"
+      end
+
+      context "when the task is an attorney task" do
+        let(:judge) { create(:user, :judge) }
+        let(:attorney) { create(:user, :attorney) }
+        let(:new_assignee) { create(:user, :attorney) }
+        let(:task) { create(:ama_attorney_rewrite_task, assigned_to: attorney, assigned_by: judge, appeal: appeal) }
+
+        subject { task.reassign(params, judge) }
+
+        it_behaves_like "clears overtime"
+      end
+    end
   end
 
   describe ".verify_org_task_unique" do

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -34,42 +34,6 @@ describe AttorneyTask, :all_dbs do
       )
     end
 
-    context "there are no sibling tasks" do
-      it "is valid" do
-        expect(subject.valid?).to eq true
-      end
-    end
-
-    context "there is a completed sibling task" do
-      before do
-        create(:ama_attorney_task,
-               :completed,
-               assigned_to: attorney,
-               assigned_by: assigning_judge,
-               parent: parent)
-      end
-
-      it "is valid" do
-        expect(subject.valid?).to eq true
-      end
-    end
-
-    context "there is an uncompleted sibling task" do
-      before do
-        create(
-          :ama_attorney_task,
-          assigned_to: attorney,
-          assigned_by: assigning_judge,
-          parent: parent
-        )
-      end
-
-      it "is not valid" do
-        expect(subject.valid?).to eq false
-        expect(subject.errors.messages[:parent].first).to eq "has open child tasks"
-      end
-    end
-
     context "when the assigner is invalid" do
       let!(:assigning_judge_staff) { create(:staff, sdomainid: assigning_judge.css_id, sattyid: nil) }
       it "fails" do
@@ -184,13 +148,13 @@ describe AttorneyTask, :all_dbs do
     end
   end
 
-  context "when cancelling the task" do
+  context ".send_back_to_judge_assign!" do
     let!(:attorney_task) { create(:ama_attorney_task, assigned_by: assigning_judge, parent: parent) }
 
-    subject { attorney_task.update!(status: Constants.TASK_STATUSES.cancelled) }
+    subject { attorney_task.send_back_to_judge_assign! }
 
     it "cancels the parent decision task and opens a judge assignment task" do
-      expect(subject).to be true
+      expect(subject.count).to eq 3
       expect(attorney_task.reload.status).to eq Constants.TASK_STATUSES.cancelled
       expect(parent.reload.status).to eq Constants.TASK_STATUSES.cancelled
       assign_task = appeal.tasks.find_by(type: JudgeAssignTask.name)


### PR DESCRIPTION
Resolves #14366

### Description
Removes the overtime status of appeal when an appeal is reassigned.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy 
* [ ] Write a separate story (within the same file) for each discrete variation of the component

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [ ] DB schema docs updated with `make docs`
* [ ] #appeals-schema notified with summary and link to this PR
