### PR TITLE
[PART 2] Perform "caseflow" reassign of attorney tasks

### DIFF
--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -96,6 +96,9 @@ class LegacyTasksController < ApplicationController
     # update the location to the assigned judge.
     QueueRepository.update_location_to_judge(appeal.vacols_id, assigned_to)
 
+    # Remove overtime status of an appeal when reassigning to a judge
+    appeal.overtime = false if appeal.overtime?
+
     render json: {
       task: json_task(AttorneyLegacyTask.from_vacols(
                         VACOLS::CaseAssignment.latest_task_for_appeal(appeal.vacols_id),

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -517,6 +517,8 @@ class Task < CaseflowRecord
 
     update_with_instructions(status: Constants.TASK_STATUSES.cancelled, instructions: reassign_params[:instructions])
 
+    appeal.overtime = false if appeal.overtime? && reassign_clears_overtime?
+
     [sibling, self, sibling.children].flatten
   end
 
@@ -591,6 +593,10 @@ class Task < CaseflowRecord
     return nil unless record
 
     User.find_by_id(record.whodunnit)
+  end
+
+  def reassign_clears_overtime?
+    false
   end
 
   private

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -503,15 +503,13 @@ class Task < CaseflowRecord
   end
 
   def reassign(reassign_params, current_user)
-    sibling = Task.create!(
-      attributes.merge(
-        id: nil,
-        assigned_by_id: self.class.child_assigned_by_id(parent, current_user),
-        assigned_to: self.class.child_task_assignee(parent, reassign_params),
-        instructions: flattened_instructions(reassign_params),
-        status: Constants.TASK_STATUSES.assigned
-      )
-    )
+    sibling = dup.tap do |task|
+      task.assigned_by_id = self.class.child_assigned_by_id(parent, current_user)
+      task.assigned_to = self.class.child_task_assignee(parent, reassign_params)
+      task.instructions = flattened_instructions(reassign_params)
+      task.status = Constants.TASK_STATUSES.assigned
+      task.save!
+    end
 
     # Preserve the open children and status of the old task
     children.select(&:stays_with_reassigned_parent?).each { |child| child.update!(parent_id: sibling.id) }

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -12,8 +12,6 @@ class AttorneyTask < Task
 
   validate :assigned_by_role_is_valid, if: :will_save_change_to_assigned_by_id?
   validate :assigned_to_role_is_valid, if: :will_save_change_to_assigned_to_id?
-  validate :child_attorney_tasks_are_completed, on: :create
-
 
   def available_actions(user)
     if can_be_moved_by_user?(user)
@@ -68,12 +66,6 @@ class AttorneyTask < Task
     # The judge who is assigned the parent review task, the assigning judge, and SpecialCaseMovementTeam members can
     # cancel or reassign this task
     parent.assigned_to == user || assigned_by == user || user&.can_act_on_behalf_of_judges?
-  end
-
-  def child_attorney_tasks_are_completed
-    if parent&.children_attorney_tasks&.open&.any?
-      errors.add(:parent, "has open child tasks")
-    end
   end
 
   def assigned_to_role_is_valid

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -48,6 +48,10 @@ class AttorneyTask < Task
     super || completed?
   end
 
+  def reassign_clears_overtime?
+    true
+  end
+
   def send_back_to_judge_assign!
     transaction do
       cancelled!

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -41,4 +41,8 @@ class JudgeTask < Task
   def previous_task
     children_attorney_tasks.order(:assigned_at).last
   end
+
+  def reassign_clears_overtime?
+    true
+  end
 end

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -9,13 +9,13 @@ import COPY from '../../COPY';
 
 import { taskById, appealWithDetailSelector } from './selectors';
 
-import { onReceiveAmaTasks, legacyReassignToJudge } from './QueueActions';
+import { onReceiveAmaTasks, legacyReassignToJudge, setOvertime } from './QueueActions';
 
 import SearchableDropdown from '../components/SearchableDropdown';
 import TextareaField from '../components/TextareaField';
 import QueueFlowModal from './components/QueueFlowModal';
 
-import { requestPatch, requestSave } from './uiReducer/uiActions';
+import { requestPatch, requestSave, resetSuccessMessages } from './uiReducer/uiActions';
 
 import { taskActionData } from './utils';
 
@@ -58,6 +58,8 @@ class AssignToView extends React.Component {
       instructions: existingInstructions
     };
   }
+
+  componentDidMount = () => this.props.resetSuccessMessages();
 
   validateForm = () => {
     return this.state.selectedValue !== null && this.state.instructions !== '';
@@ -145,6 +147,9 @@ class AssignToView extends React.Component {
 
     return this.props.requestPatch(`/tasks/${task.taskId}`, payload, successMsg).then((resp) => {
       this.props.onReceiveAmaTasks(resp.body.tasks.data);
+      if (task.type === 'JudgeAssignTask') {
+        this.props.setOvertime(task.externalAppealId, false);
+      }
     });
   };
 
@@ -241,7 +246,8 @@ class AssignToView extends React.Component {
 
 AssignToView.propTypes = {
   appeal: PropTypes.shape({
-    externalId: PropTypes.string
+    externalId: PropTypes.string,
+    id: PropTypes.string
   }),
   assigneeAlreadySelected: PropTypes.bool,
   highlightFormItems: PropTypes.bool,
@@ -254,8 +260,12 @@ AssignToView.propTypes = {
   task: PropTypes.shape({
     instructions: PropTypes.string,
     taskId: PropTypes.string,
-    availableActions: PropTypes.arrayOf(PropTypes.object)
-  })
+    availableActions: PropTypes.arrayOf(PropTypes.object),
+    externalAppealId: PropTypes.string,
+    type: PropTypes.string
+  }),
+  setOvertime: PropTypes.func,
+  resetSuccessMessages: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -274,7 +284,9 @@ const mapDispatchToProps = (dispatch) =>
       requestPatch,
       requestSave,
       onReceiveAmaTasks,
-      legacyReassignToJudge
+      legacyReassignToJudge,
+      setOvertime,
+      resetSuccessMessages
     },
     dispatch
   );

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -216,7 +216,7 @@ const editAppeal = (appealId, attributes) => ({
 
 export const setOvertime = (appealId, overtime) => ({
   type: ACTIONS.SET_OVERTIME,
-  payload: { 
+  payload: {
     appealId,
     overtime
   }
@@ -495,9 +495,11 @@ export const reassignTasksToUser = ({
     params = {
       data: {
         task: {
-          type: 'AttorneyTask',
-          assigned_to_id: assigneeId,
-          instructions
+          reassign: {
+            assigned_to_id: assigneeId,
+            assigned_to_type: 'User',
+            instructions
+          }
         }
       }
     };

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -220,7 +220,7 @@ export const setOvertime = (appealId, overtime) => ({
     appealId,
     overtime
   }
-})
+});
 
 export const deleteTask = (taskId) => ({
   type: ACTIONS.DELETE_TASK,
@@ -534,6 +534,8 @@ export const reassignTasksToUser = ({
       dispatch(decrementTaskCountForAttorney({
         id: previousAssigneeId
       }));
+
+      dispatch(setOvertime(oldTask.externalAppealId, false));
     });
 }));
 
@@ -557,6 +559,8 @@ export const legacyReassignToJudge = ({
       dispatch(onReceiveTasks(_.pick(allTasks, ['tasks', 'amaTasks'])));
 
       dispatch(showSuccessMessage(successMessage));
+
+      dispatch(setOvertime(oldTask.externalAppealId, false));
     });
 }));
 

--- a/client/app/queue/components/AssignToAttorneyWidget.jsx
+++ b/client/app/queue/components/AssignToAttorneyWidget.jsx
@@ -47,6 +47,8 @@ class AssignToAttorneyWidget extends React.PureComponent {
     };
   }
 
+  componentDidMount = () => this.props.resetSuccessMessages();
+
   validAssignee = () => {
     const { selectedAssignee } = this.props;
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -897,6 +897,64 @@ describe Task, :all_dbs do
         end
       end
     end
+
+    context "When the appeal has not been marked for overtime" do
+      let!(:appeal) { create(:appeal) }
+      let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
+
+      before { FeatureToggle.enable!(:overtime_revamp) }
+      after { FeatureToggle.disable!(:overtime_revamp) }
+
+      it "does not create a new work mode for the appeal" do
+        expect(appeal.work_mode.nil?).to be true
+        subject
+        expect(appeal.work_mode.nil?).to be true
+      end
+    end
+
+    context "When the appeal has been marked for overtime" do
+      shared_examples "clears overtime" do
+        it "sets overtime to false" do
+          expect(appeal.overtime?).to be true
+          subject
+          expect(appeal.overtime?).to be false
+        end
+      end
+
+      let!(:appeal) { create(:appeal) }
+      let(:task) { create(:ama_task, appeal: appeal.reload) }
+
+      before do
+        appeal.overtime = true
+        FeatureToggle.enable!(:overtime_revamp)
+      end
+      after { FeatureToggle.disable!(:overtime_revamp) }
+
+      context "when the task type is not a judge or attorney task" do
+        it "does not clear the overtime status" do
+          expect(appeal.overtime?).to be true
+          subject
+          expect(appeal.overtime?).to be true
+        end
+      end
+
+      context "when the task is a judge task" do
+        let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
+
+        it_behaves_like "clears overtime"
+      end
+
+      context "when the task is an attorney task" do
+        let(:judge) { create(:user, :judge) }
+        let(:attorney) { create(:user, :attorney) }
+        let(:new_assignee) { create(:user, :attorney) }
+        let(:task) { create(:ama_attorney_rewrite_task, assigned_to: attorney, assigned_by: judge, appeal: appeal) }
+
+        subject { task.reassign(params, judge) }
+
+        it_behaves_like "clears overtime"
+      end
+    end
   end
 
   describe ".verify_org_task_unique" do

--- a/spec/models/tasks/attorney_task_spec.rb
+++ b/spec/models/tasks/attorney_task_spec.rb
@@ -34,42 +34,6 @@ describe AttorneyTask, :all_dbs do
       )
     end
 
-    context "there are no sibling tasks" do
-      it "is valid" do
-        expect(subject.valid?).to eq true
-      end
-    end
-
-    context "there is a completed sibling task" do
-      before do
-        create(:ama_attorney_task,
-               :completed,
-               assigned_to: attorney,
-               assigned_by: assigning_judge,
-               parent: parent)
-      end
-
-      it "is valid" do
-        expect(subject.valid?).to eq true
-      end
-    end
-
-    context "there is an uncompleted sibling task" do
-      before do
-        create(
-          :ama_attorney_task,
-          assigned_to: attorney,
-          assigned_by: assigning_judge,
-          parent: parent
-        )
-      end
-
-      it "is not valid" do
-        expect(subject.valid?).to eq false
-        expect(subject.errors.messages[:parent].first).to eq "has open child tasks"
-      end
-    end
-
     context "when the assigner is invalid" do
       let!(:assigning_judge_staff) { create(:staff, sdomainid: assigning_judge.css_id, sattyid: nil) }
       it "fails" do


### PR DESCRIPTION
Resolves #14225

PART 2 in stack to implement #14366
PART 1  #14448 
PART 3 #14453

### Description
User proper reassign params when reassigning an attorney task. Ensure's we're cancelling the original attorney task and creating a new one

### Acceptance Criteria
- [x] Upon reassign, old atty task is cancelled and new atty task is created

### Testing Plan
1. BVAAABSHIRE's assign page and assign an ama case to an attorney.
1. Check the tree
```ruby
Appeal 686 (evidence_submission)   ID   STATUS   ASGN_BY     ASGN_TO     UPDATED_AT
└── RootTask                       2051 on_hold              Bva         2020-05-22 14:50:22 UTC
    └── JudgeDecisionReviewTask    2052 on_hold              BVAAABSHIRE 2020-05-22 14:50:22 UTC
        └── AttorneyTask           2053 assigned BVAAABSHIRE BVAEERDMAN  2020-05-22 14:50:22 UTC
```
1. Either from the attorney queue in the judge assign page or from case details, reassign the case to another attorney
1. Check the tree
```ruby
Appeal 686 (evidence_submission)   ID   STATUS    ASGN_BY     ASGN_TO     UPDATED_AT
└── RootTask                       2051 on_hold               Bva         2020-05-22 14:50:22 UTC
    └── JudgeDecisionReviewTask    2052 on_hold               BVAAABSHIRE 2020-05-22 14:50:22 UTC
        ├── AttorneyTask           2053 cancelled BVAAABSHIRE BVAEERDMAN  2020-06-02 20:21:39 UTC
        └── AttorneyTask           2537 assigned  BVARDUNKLE  BVALSHIELDS 2020-05-22 14:50:22 UTC
```
1. Original task is cancelled, new task is opened.


### User Facing Changes
 - [ ] NONE