### PR TITLE
[PART 3] Remove overtime status of appeal if case is reassigned

### DIFF
--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -96,6 +96,9 @@ class LegacyTasksController < ApplicationController
     # update the location to the assigned judge.
     QueueRepository.update_location_to_judge(appeal.vacols_id, assigned_to)
 
+    # Remove overtime status of an appeal when reassigning to a judge
+    appeal.overtime = false if appeal.overtime?
+
     render json: {
       task: json_task(AttorneyLegacyTask.from_vacols(
                         VACOLS::CaseAssignment.latest_task_for_appeal(appeal.vacols_id),

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -517,6 +517,8 @@ class Task < CaseflowRecord
 
     update_with_instructions(status: Constants.TASK_STATUSES.cancelled, instructions: reassign_params[:instructions])
 
+    appeal.overtime = false if appeal.overtime? && reassign_clears_overtime?
+
     [sibling, self, sibling.children].flatten
   end
 
@@ -591,6 +593,10 @@ class Task < CaseflowRecord
     return nil unless record
 
     User.find_by_id(record.whodunnit)
+  end
+
+  def reassign_clears_overtime?
+    false
   end
 
   private

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -48,6 +48,10 @@ class AttorneyTask < Task
     super || completed?
   end
 
+  def reassign_clears_overtime?
+    true
+  end
+
   def send_back_to_judge_assign!
     transaction do
       cancelled!

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -41,4 +41,8 @@ class JudgeTask < Task
   def previous_task
     children_attorney_tasks.order(:assigned_at).last
   end
+
+  def reassign_clears_overtime?
+    true
+  end
 end

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -104,12 +104,6 @@ class AssignToView extends React.Component {
       requestSave('/tasks', payload, isPulacCerullo ? pulacCerulloSuccessMessage : assignTaskSuccessMessage).
       then((resp) => {
         this.props.onReceiveAmaTasks(resp.body.tasks.data);
-        if (taskType === 'JudgeAssignTask') {
-          this.props.setOvertime({
-            appealId: appeal.externalId,
-            overtime: false
-          });
-        }
       }).
       catch(() => {
         // handle the error from the frontend
@@ -153,6 +147,9 @@ class AssignToView extends React.Component {
 
     return this.props.requestPatch(`/tasks/${task.taskId}`, payload, successMsg).then((resp) => {
       this.props.onReceiveAmaTasks(resp.body.tasks.data);
+      if (task.type === 'JudgeAssignTask') {
+        this.props.setOvertime(task.externalAppealId, false);
+      }
     });
   };
 

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -102,9 +102,7 @@ class AssignToView extends React.Component {
 
     return this.props.
       requestSave('/tasks', payload, isPulacCerullo ? pulacCerulloSuccessMessage : assignTaskSuccessMessage).
-      then((resp) => {
-        this.props.onReceiveAmaTasks(resp.body.tasks.data);
-      }).
+      then((resp) => this.props.onReceiveAmaTasks(resp.body.tasks.data)).
       catch(() => {
         // handle the error from the frontend
       });

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -15,7 +15,7 @@ import SearchableDropdown from '../components/SearchableDropdown';
 import TextareaField from '../components/TextareaField';
 import QueueFlowModal from './components/QueueFlowModal';
 
-import { requestPatch, requestSave } from './uiReducer/uiActions';
+import { requestPatch, requestSave, resetSuccessMessages } from './uiReducer/uiActions';
 
 import { taskActionData } from './utils';
 
@@ -58,6 +58,8 @@ class AssignToView extends React.Component {
       instructions: existingInstructions
     };
   }
+
+  componentDidMount = () => this.props.resetSuccessMessages();
 
   validateForm = () => {
     return this.state.selectedValue !== null && this.state.instructions !== '';
@@ -262,7 +264,8 @@ AssignToView.propTypes = {
     externalAppealId: PropTypes.string,
     type: PropTypes.string
   }),
-  setOvertime: PropTypes.func
+  setOvertime: PropTypes.func,
+  resetSuccessMessages: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -282,7 +285,8 @@ const mapDispatchToProps = (dispatch) =>
       requestSave,
       onReceiveAmaTasks,
       legacyReassignToJudge,
-      setOvertime
+      setOvertime,
+      resetSuccessMessages
     },
     dispatch
   );

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -258,7 +258,9 @@ AssignToView.propTypes = {
   task: PropTypes.shape({
     instructions: PropTypes.string,
     taskId: PropTypes.string,
-    availableActions: PropTypes.arrayOf(PropTypes.object)
+    availableActions: PropTypes.arrayOf(PropTypes.object),
+    externalAppealId: PropTypes.string,
+    type: PropTypes.string
   }),
   setOvertime: PropTypes.func
 };

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -9,7 +9,7 @@ import COPY from '../../COPY';
 
 import { taskById, appealWithDetailSelector } from './selectors';
 
-import { onReceiveAmaTasks, legacyReassignToJudge } from './QueueActions';
+import { onReceiveAmaTasks, legacyReassignToJudge, setOvertime } from './QueueActions';
 
 import SearchableDropdown from '../components/SearchableDropdown';
 import TextareaField from '../components/TextareaField';
@@ -102,7 +102,15 @@ class AssignToView extends React.Component {
 
     return this.props.
       requestSave('/tasks', payload, isPulacCerullo ? pulacCerulloSuccessMessage : assignTaskSuccessMessage).
-      then((resp) => this.props.onReceiveAmaTasks(resp.body.tasks.data)).
+      then((resp) => {
+        this.props.onReceiveAmaTasks(resp.body.tasks.data);
+        if (taskType === 'JudgeAssignTask') {
+          this.props.setOvertime({
+            appealId: appeal.externalId,
+            overtime: false
+          });
+        }
+      }).
       catch(() => {
         // handle the error from the frontend
       });
@@ -241,7 +249,8 @@ class AssignToView extends React.Component {
 
 AssignToView.propTypes = {
   appeal: PropTypes.shape({
-    externalId: PropTypes.string
+    externalId: PropTypes.string,
+    id: PropTypes.string
   }),
   assigneeAlreadySelected: PropTypes.bool,
   highlightFormItems: PropTypes.bool,
@@ -255,7 +264,8 @@ AssignToView.propTypes = {
     instructions: PropTypes.string,
     taskId: PropTypes.string,
     availableActions: PropTypes.arrayOf(PropTypes.object)
-  })
+  }),
+  setOvertime: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -274,7 +284,8 @@ const mapDispatchToProps = (dispatch) =>
       requestPatch,
       requestSave,
       onReceiveAmaTasks,
-      legacyReassignToJudge
+      legacyReassignToJudge,
+      setOvertime
     },
     dispatch
   );

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -535,11 +535,7 @@ export const reassignTasksToUser = ({
         id: previousAssigneeId
       }));
 
-      debugger;
-      dispatch(setOvertime({
-        appealId: oldTask.externalAppealId,
-        overtime: false
-      }));
+      dispatch(setOvertime(oldTask.externalAppealId, false));
     });
 }));
 
@@ -564,10 +560,7 @@ export const legacyReassignToJudge = ({
 
       dispatch(showSuccessMessage(successMessage));
 
-      dispatch(setOvertime({
-        appealId: oldTask.externalAppealId,
-        overtime: false
-      }));
+      dispatch(setOvertime(oldTask.externalAppealId, false));
     });
 }));
 

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -220,7 +220,7 @@ export const setOvertime = (appealId, overtime) => ({
     appealId,
     overtime
   }
-})
+});
 
 export const deleteTask = (taskId) => ({
   type: ACTIONS.DELETE_TASK,
@@ -534,6 +534,12 @@ export const reassignTasksToUser = ({
       dispatch(decrementTaskCountForAttorney({
         id: previousAssigneeId
       }));
+
+      debugger;
+      dispatch(setOvertime({
+        appealId: oldTask.externalAppealId,
+        overtime: false
+      }));
     });
 }));
 
@@ -557,6 +563,11 @@ export const legacyReassignToJudge = ({
       dispatch(onReceiveTasks(_.pick(allTasks, ['tasks', 'amaTasks'])));
 
       dispatch(showSuccessMessage(successMessage));
+
+      dispatch(setOvertime({
+        appealId: oldTask.externalAppealId,
+        overtime: false
+      }));
     });
 }));
 

--- a/client/app/queue/components/AssignToAttorneyWidget.jsx
+++ b/client/app/queue/components/AssignToAttorneyWidget.jsx
@@ -47,6 +47,8 @@ class AssignToAttorneyWidget extends React.PureComponent {
     };
   }
 
+  componentDidMount = () => this.props.resetSuccessMessages();
+
   validAssignee = () => {
     const { selectedAssignee } = this.props;
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -897,6 +897,64 @@ describe Task, :all_dbs do
         end
       end
     end
+
+    context "When the appeal has not been marked for overtime" do
+      let!(:appeal) { create(:appeal) }
+      let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
+
+      before { FeatureToggle.enable!(:overtime_revamp) }
+      after { FeatureToggle.disable!(:overtime_revamp) }
+
+      it "does not create a new work mode for the appeal" do
+        expect(appeal.work_mode.nil?).to be true
+        subject
+        expect(appeal.work_mode.nil?).to be true
+      end
+    end
+
+    context "When the appeal has been marked for overtime" do
+      shared_examples "clears overtime" do
+        it "sets overtime to false" do
+          expect(appeal.overtime?).to be true
+          subject
+          expect(appeal.overtime?).to be false
+        end
+      end
+
+      let!(:appeal) { create(:appeal) }
+      let(:task) { create(:ama_task, appeal: appeal.reload) }
+
+      before do
+        appeal.overtime = true
+        FeatureToggle.enable!(:overtime_revamp)
+      end
+      after { FeatureToggle.disable!(:overtime_revamp) }
+
+      context "when the task type is not a judge or attorney task" do
+        it "does not clear the overtime status" do
+          expect(appeal.overtime?).to be true
+          subject
+          expect(appeal.overtime?).to be true
+        end
+      end
+
+      context "when the task is a judge task" do
+        let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
+
+        it_behaves_like "clears overtime"
+      end
+
+      context "when the task is an attorney task" do
+        let(:judge) { create(:user, :judge) }
+        let(:attorney) { create(:user, :attorney) }
+        let(:new_assignee) { create(:user, :attorney) }
+        let(:task) { create(:ama_attorney_rewrite_task, assigned_to: attorney, assigned_by: judge, appeal: appeal) }
+
+        subject { task.reassign(params, judge) }
+
+        it_behaves_like "clears overtime"
+      end
+    end
   end
 
   describe ".verify_org_task_unique" do


### PR DESCRIPTION
Resolves #14366

PART 3  in stack to implement #14366
PART 1  #14448
PART 2 #14452

### Description
If an appeal has been designated as "overtime approved" remove this status if the case is assigned to another judge or attorney.

### Acceptance Criteria
- [ ]  OT status is removed when a judge or case movement user reassigns a case to another judge
  - [ ] Ama
  - [ ] Legacy
- [ ] OT status is removed when a judge or case movement user reassigns an attorney task to another attorney
  - [ ] Ama

### Testing Plan
#### AMA Judge
1. Log in as bvaabshire
2. Mark an ama case as overtime
3. Reassign the case to another judge and go back to case details without refreshing
4. Ensure the case is no longer marked as overtime

#### AMA Attorney
1. Mark an ama case as overtime
1. Assign it to an attorney
1. Reassign the case to another attorney and go back to case details without refreshing
1. Ensure the case is no longer marked as overtime

#### Legacy Judge
1. Mark a legacy case as overtime
1. Reassign the case to another judge and go back to case details without refreshing
1. Ensure the case is no longer marked as overtime

### User Facing Changes
 - [ ] NONE