### PR TITLE
Acting judges: restore on-hold and completed tabs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -321,7 +321,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def queue_tabs
-    return [assigned_tasks_tab] if judge_in_vacols?
+    return [assigned_tasks_tab] if judge_in_vacols? and not attorney_in_vacols?
 
     [
       assigned_tasks_tab,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -321,7 +321,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def queue_tabs
-    return [assigned_tasks_tab] if judge_in_vacols? and not attorney_in_vacols?
+    return [assigned_tasks_tab] if judge_in_vacols? && !attorney_in_vacols?
 
     [
       assigned_tasks_tab,


### PR DESCRIPTION
Resolves: The “On Hold” or “Complete” queue has disappeared for Attorneys.

### Description
This seems to be happening for acting judges. Regular attorneys' queues still have all 3 tabs. 

Acting judges return true for both `judge_in_vacols?` and `attorney_in_vacols?`.

I was able to replicate on dev. For attorneys who are acting judges, their Queue page appears like a regular judge's Queue page. Their Queue page should look like other attorneys.

[Slack convo](https://dsva.slack.com/archives/CHX8FMP28/p1591213452044800)

### Acceptance Criteria
- [x] Code compiles correctly and tests pass

### User Facing Changes

 BEFORE|AFTER
 ---|---
<img width="827" alt="image" src="https://user-images.githubusercontent.com/55255674/83684795-41cb7700-a5ad-11ea-8ea7-458fad16d52c.png"> | <img width="827" alt="image" src="https://user-images.githubusercontent.com/55255674/83684751-28c2c600-a5ad-11ea-8910-9bd3a17cbc03.png">

The before screenshot looks like a judge's Queue page.