### PR TITLE
No ETL sweeper alert unless more than 20 records affected

### DIFF
--- a/app/jobs/etl_builder_job.rb
+++ b/app/jobs/etl_builder_job.rb
@@ -23,7 +23,7 @@ class ETLBuilderJob < CaseflowJob
     swept = ETL::Sweeper.new.call
     datadog_report_time_segment(segment: "etl_sweeper", start_time: start)
 
-    return unless swept > 0
+    return unless swept > 20 # big enough to warrant reality check
 
     msg = "[INFO] ETL swept up #{swept} deleted records -- see logs for details"
     slack_service.send_notification(msg, "ETL::Sweeper", SLACK_CHANNEL)

--- a/spec/jobs/etl_builder_job_spec.rb
+++ b/spec/jobs/etl_builder_job_spec.rb
@@ -51,17 +51,32 @@ describe ETLBuilderJob, :etl, :all_dbs do
       end
     end
 
-    context "when deleted row is swept up" do
+    context "when one deleted row is swept up" do
       before do
         ETL::Builder.new.full
         Appeal.last.delete
         Appeal.last.touch
       end
 
-      it "sends INFO message to slack" do
+      it "does not send INFO message to slack" do
         Timecop.travel(1.hour.ago) { subject }
 
-        expect(@slack_msg).to include("[INFO] ETL swept up 1 deleted records")
+        expect(@slack_msg).to be_nil
+      end
+
+      context "when more than 20 rows swept up" do
+        before do
+          20.times { create(:appeal) }
+          ETL::Builder.new.full
+          Appeal.delete_all
+          create(:appeal)
+        end
+
+        it "sends INFO message to slack" do
+          Timecop.travel(1.hour.ago) { subject }
+
+          expect(@slack_msg).to match(/\[INFO\] ETL swept up \d+ deleted records/)
+        end
       end
     end
   end


### PR DESCRIPTION
Quiets the noise in the #appeals-delta slack channel.