### PR TITLE
Remove build:storybook from build:production

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
     "pretty:format": "yarn run pretty --write",
     "build": "webpack --config webpack.config.js",
     "build:test": "NODE_ENV=test yarn run build",
-    "build:production": "NODE_ENV=production yarn run build && yarn run build:storybook",
+    "build:production": "NODE_ENV=production yarn run build",
     "dev:clear-build": "rm ../app/assets/javascripts/*webpack* || true",
     "dev": "yarn run dev:clear-build && NODE_ENV=development yarn run build -w",
     "dev:hot": "yarn run dev:clear-build && NODE_ENV=development node webpack-hot-server.js",


### PR DESCRIPTION
### Description
Removes `build:storybook` from `build:production` script so that we can build it only in demo environment

### Acceptance Criteria
- [ ] Code compiles correctly
