### PR TITLE
Add `build:demo` Script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN DD_INSTALL_ONLY=true DD_AGENT_MAJOR_VERSION=7 DD_API_KEY=$(cat config/datado
 RUN bundle install && \
     cd client && \
     yarn install && \
-    yarn run build:production && \
+    yarn run build:demo && \
     chmod +x /caseflow/docker-bin/startup.sh && \
     rm -rf docker-bin
 

--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "build": "webpack --config webpack.config.js",
     "build:test": "NODE_ENV=test yarn run build",
     "build:production": "NODE_ENV=production yarn run build",
+    "build:demo": "NODE_ENV=production yarn run build && yarn run build:storybook",
     "dev:clear-build": "rm ../app/assets/javascripts/*webpack* || true",
     "dev": "yarn run dev:clear-build && NODE_ENV=development yarn run build -w",
     "dev:hot": "yarn run dev:clear-build && NODE_ENV=development node webpack-hot-server.js",


### PR DESCRIPTION
### Description
This adds separate `build:demo` script that (currently) mirrors `build:production`, but also includes `build:storybook`. This allows greater flexibility in the future for customizing things for the demo environment.

### Acceptance Criteria
- [ ] Code compiles correctly
