### PR TITLE
Intake | Use iso8601 datetime for fetching ratings

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -251,7 +251,10 @@ class ExternalApi::BGSService
                            end_date = #{end_date}",
                           service: :bgs,
                           name: "rating.find_by_participant_id_and_date_range") do
-      client.rating.find_by_participant_id_and_date_range(participant_id, start_date, end_date)
+      client.rating.find_by_participant_id_and_date_range(
+        participant_id,
+        start_date.to_datetime.iso8601,
+        end_date.to_datetime.iso8601)
     end
   end
 

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -254,7 +254,8 @@ class ExternalApi::BGSService
       client.rating.find_by_participant_id_and_date_range(
         participant_id,
         start_date.to_datetime.iso8601,
-        end_date.to_datetime.iso8601)
+        end_date.to_datetime.iso8601
+      )
     end
   end
 


### PR DESCRIPTION
### Description
BGS has changed date input formats for the RatingComparisonEJB service, so we are updating our input dates to match, which is converting them to datetimes in the ISO8601 format.