### PR TITLE
Default to empty string for instructions

### DIFF
--- a/client/app/queue/components/AssignToAttorneyWidget.jsx
+++ b/client/app/queue/components/AssignToAttorneyWidget.jsx
@@ -43,7 +43,7 @@ class AssignToAttorneyWidget extends React.PureComponent {
     super(props);
 
     this.state = {
-      instructions: this.props.isModal ? this.props.selectedTasks[0].instructions : ''
+      instructions: (this.props.isModal ? this.props.selectedTasks[0].instructions : null) || ''
     };
   }
 


### PR DESCRIPTION
Resolves Sentry alert: https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10660/?referrer=webhooks_plugin

Error:

```
TypeError

Cannot read property 'length' of undefined
```

### Description

- Always default to empty string for instructions