### PR TITLE
Allow demo/dev CM users to assign legacy cases to attorneys

### DIFF
--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -41,10 +41,12 @@ module Seeds
       special_case_movement_user = User.create(css_id: "BVARDUNKLE",
                                                station_id: 101,
                                                full_name: "Rosalie SpecialCaseMovement Dunkle")
+      FactoryBot.create(:staff, user: special_case_movement_user)
       SpecialCaseMovementTeam.singleton.add_user(special_case_movement_user)
       special_case_movement_admin = User.create(css_id: "BVAGBEEKMAN",
                                                 station_id: 101,
                                                 full_name: "Bryan SpecialCaseMovementAdmin Beekman")
+      FactoryBot.create(:staff, user: special_case_movement_admin)
       OrganizationsUser.make_user_admin(special_case_movement_admin, SpecialCaseMovementTeam.singleton)
       bva_intake_admin = User.create(css_id: "BVADWISE", station_id: 101, full_name: "Deborah BvaIntakeAdmin Wise")
       OrganizationsUser.make_user_admin(bva_intake_admin, BvaIntake.singleton)


### PR DESCRIPTION
Resolves #14195 

### Description

This PR prevents the `Validation failed: Deadusr can't be blank` error referenced in the above issue which was preventing demo/dev env CM users from assigning legacy cases to attorneys.

### Acceptance Criteria
- [ ] CM user can successfully assign a legacy case to an attorney

### Testing Plan
1. Ensure that the das depreciation feature is off: 
`FeatureToggle.disable!(:legacy_das_deprecation)`
2. Login as either of the CM users -  BVAGBEEKMAN or BVARDUNKLE
3. Go to http://localhost:3000/queue/BVAAABSHIRE/assign
4. Select a legacy case
5. Attempt to assign the case to an attorney

Oops, you get an error!

Now open up your console
```ruby
# Running this you will see the CM user is missing the required Staff record
VACOLS::Staff.find_by_sdomainid("BVAGBEEKMAN")
=> nil

# Now run this to give the CM user the staff record
FactoryBot.create(:staff, user:User.find_by(css_id: "BVAGBEEKMAN"))
=> #<VACOLS::Staff:0x00007fee8085b490

# Run that first command again to find that pesky Staff record now exists
=> #<VACOLS::Staff:0x00007fee928644e8
```

Rerun the Testing Plan and see that you can now assign the legacy case to the attorney! 🎉 

### User Facing Changes

#### BEFORE

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/18618189/84081429-eda90400-a9ab-11ea-9d93-ec79888f9991.gif)

#### AFTER

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/18618189/84194404-fc0a2500-aa6a-11ea-8659-8ef5ad05f7b7.gif)
