### PR TITLE
Fix error when receiving an empty hearing location payload for legacy hearings

### DIFF
--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -35,7 +35,7 @@ class LegacyHearing < CaseflowRecord
   has_many :email_events, class_name: "SentHearingEmailEvent", foreign_key: :hearing_id
 
   alias_attribute :location, :hearing_location
-  accepts_nested_attributes_for :hearing_location
+  accepts_nested_attributes_for :hearing_location, reject_if: proc { |attributes| attributes.blank? }
 
   # this is used to cache appeal stream for hearings
   # when fetched intially.


### PR DESCRIPTION
Applies #14457 to legacy hearing too

### Description

Applies the fix made In #14457 to legacy hearings
