### PR TITLE
Restrict bulk assign to admins of org

### DIFF
--- a/app/controllers/organizations/tasks_controller.rb
+++ b/app/controllers/organizations/tasks_controller.rb
@@ -9,7 +9,8 @@ class Organizations::TasksController < OrganizationsController
       organization_name: organization.name,
       id: organization.id,
       is_vso: organization.is_a?(::Representative),
-      queue_config: QueueConfig.new(assignee: organization).to_hash
+      queue_config: QueueConfig.new(assignee: organization).to_hash,
+      user_can_bulk_assign: organization.admins.include?(current_user)
     }
   end
 

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -9,7 +9,7 @@ class BulkTaskAssignment
   validate :organization_exists
   validate :regional_office_is_valid
   validate :assigned_to_part_of_organization
-  validate :assigned_by_part_of_organization
+  validate :assigned_by_admin_of_organization
   validate :organization_can_bulk_assign
 
   attr_accessor :assigned_to_id, :assigned_by, :organization_url, :task_type, :regional_office, :task_count
@@ -92,10 +92,10 @@ class BulkTaskAssignment
     errors.add(:assigned_to, "does not belong to organization with url #{organization_url}")
   end
 
-  def assigned_by_part_of_organization
-    return if organization&.users&.include?(assigned_by)
+  def assigned_by_admin_of_organization
+    return if organization&.admins&.include?(assigned_by)
 
-    errors.add(:assigned_by, "does not belong to organization with url #{organization_url}")
+    errors.add(:assigned_by, "is not admin of organization with url #{organization_url}")
   end
 
   def organization_can_bulk_assign

--- a/client/app/queue/OrganizationQueueLoadingScreen.jsx
+++ b/client/app/queue/OrganizationQueueLoadingScreen.jsx
@@ -31,10 +31,11 @@ class OrganizationQueueLoadingScreen extends React.PureComponent {
             id,
             organization_name: organizationName,
             is_vso: isVso,
+            user_can_bulk_assign: userCanBulkAssign,
             queue_config: queueConfig
           } = response.body;
 
-          this.props.setActiveOrganization(id, organizationName, isVso);
+          this.props.setActiveOrganization(id, organizationName, isVso, userCanBulkAssign);
           this.props.setQueueConfig(queueConfig);
         }
       ).

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -97,7 +97,7 @@ class QueueTableBuilder extends React.PureComponent {
       label: sprintf(tabConfig.label, totalTaskCount),
       page: <React.Fragment>
         <p className="cf-margin-top-0">{tabConfig.description}</p>
-        { tabConfig.allow_bulk_assign && <BulkAssignButton /> }
+        { this.props.userCanBulkAssign && tabConfig.allow_bulk_assign && <BulkAssignButton /> }
         <QueueTable
           key={tabConfig.name}
           columns={this.columnsFromConfig(config, tabConfig, tasks)}
@@ -131,7 +131,8 @@ class QueueTableBuilder extends React.PureComponent {
 const mapStateToProps = (state) => {
   return ({
     config: state.queue.queueConfig,
-    organizations: state.ui.organizations
+    organizations: state.ui.organizations,
+    userCanBulkAssign: state.ui.activeOrganization.userCanBulkAssign
   });
 };
 
@@ -144,7 +145,8 @@ QueueTableBuilder.propTypes = {
     table_title: PropTypes.string,
     active_tab_index: PropTypes.number
   }),
-  requireDasRecord: PropTypes.bool
+  requireDasRecord: PropTypes.bool,
+  userCanBulkAssign: PropTypes.bool
 };
 
 export default (connect(mapStateToProps)(QueueTableBuilder));

--- a/client/app/queue/uiReducer/uiActions.js
+++ b/client/app/queue/uiReducer/uiActions.js
@@ -155,12 +155,13 @@ export const setOrganizations = (organizations) => ({
   payload: { organizations }
 });
 
-export const setActiveOrganization = (id, name, isVso) => ({
+export const setActiveOrganization = (id, name, isVso, userCanBulkAssign) => ({
   type: ACTIONS.SET_ACTIVE_ORGANIZATION,
   payload: {
     id,
     name,
-    isVso
+    isVso,
+    userCanBulkAssign
   }
 });
 

--- a/client/app/queue/uiReducer/uiReducer.js
+++ b/client/app/queue/uiReducer/uiReducer.js
@@ -215,7 +215,8 @@ const workQueueUiReducer = (state = initialState, action = {}) => {
       activeOrganization: {
         id: { $set: action.payload.id },
         name: { $set: action.payload.name },
-        isVso: { $set: action.payload.isVso }
+        isVso: { $set: action.payload.isVso },
+        userCanBulkAssign: { $set: action.payload.userCanBulkAssign }
       }
     });
   case ACTIONS.SET_HEARING_DAY:

--- a/spec/controllers/bulk_task_assignments_controller_spec.rb
+++ b/spec/controllers/bulk_task_assignments_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe BulkTaskAssignmentsController, :postgres, type: :controller do
 
       it "should return tasks" do
         organization.users << assigned_to
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         get :create, params: { bulk_task_assignment: params }
         expect(response.status).to eq 200
         response_body = JSON.parse(response.body)

--- a/spec/controllers/organizations/tasks_controller_spec.rb
+++ b/spec/controllers/organizations/tasks_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Organizations::TasksController, :all_dbs, type: :controller do
         expect(response.status).to eq(200)
         response_body = JSON.parse(response.body)
 
-        expect(response_body.keys).to match_array(%w[organization_name id is_vso queue_config])
+        expect(response_body.keys).to match_array(%w[organization_name id is_vso queue_config user_can_bulk_assign])
       end
     end
 

--- a/spec/feature/queue/bulk_task_assignment_spec.rb
+++ b/spec/feature/queue/bulk_task_assignment_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Bulk task assignment", :postgres do
   let(:user) { create(:user) }
 
   before do
-    org.add_user(user)
+    OrganizationsUser.make_user_admin(user, org)
     User.authenticate!(user: user)
   end
 
@@ -165,6 +165,21 @@ RSpec.feature "Bulk task assignment", :postgres do
       # Sort the regional offices we expect to see by city name.
       sorted_regional_offices = regional_offices.map { |ro| RegionalOffice::CITIES[ro][:city] }.sort
       expect(regional_office_options).to eq(sorted_regional_offices)
+    end
+  end
+
+  context "when the user is not an admin" do
+    before do
+      user = create(:user)
+      org.add_user(user)
+      User.authenticate!(user: user)
+    end
+
+    it "does not show the bulk assign button" do
+      visit(org.path)
+
+      expect(page).to have_content(org.name)
+      expect(page).to have_no_content(COPY::BULK_ASSIGN_BUTTON_TEXT)
     end
   end
 end

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -62,7 +62,7 @@ describe BulkTaskAssignment, :postgres do
       end
     end
 
-    fcontext "when assigned to user does not belong to organization" do
+    context "when assigned to user does not belong to organization" do
       let(:assignee) { create(:user) }
       let(:error) { "does not belong to organization with url #{organization.url}" }
       let(:error_sym) { :assigned_to }
@@ -88,15 +88,10 @@ describe BulkTaskAssignment, :postgres do
 
     context "when organization is not valid" do
       let(:organization_url) { 1234 }
+      let(:error) { "could not find an organization with url #{organization_url}" }
+      let(:error_sym) { :organization_url }
 
-      it "does not bulk assigns tasks" do
-        OrganizationsUser.make_user_admin(assigned_by, organization)
-        organization.users << assigned_to
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq false
-        error = ["could not find an organization with url #{organization_url}"]
-        expect(bulk_assignment.errors[:organization_url]).to eq error
-      end
+      it_behaves_like "invalid bulk assign"
     end
 
     context "when organization cannot bulk assign" do

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -70,7 +70,6 @@ describe BulkTaskAssignment, :postgres do
       it_behaves_like "invalid bulk assign"
     end
 
-
     context "when assigned by user is not admin of organization" do
       let(:assigned_by_param) { create(:user) }
       let(:error) { "is not admin of organization with url #{organization.url}" }

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -49,7 +49,7 @@ describe BulkTaskAssignment, :postgres do
 
     context "when assigned to user does not belong to organization" do
       it "does not bulk assigns tasks" do
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq false
         error = ["does not belong to organization with url #{organization.url}"]
@@ -62,7 +62,7 @@ describe BulkTaskAssignment, :postgres do
 
       it "does not bulk assigns tasks" do
         organization.users << assigned_to
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq false
         error = ["could not find regional office: #{regional_office}"]
@@ -70,7 +70,7 @@ describe BulkTaskAssignment, :postgres do
       end
     end
 
-    context "when there are legacy apeals and regional office is passed" do
+    context "when there are legacy appeals and regional office is passed" do
       let(:regional_office) { "RO17" }
       let(:legacy_appeal) { create(:legacy_appeal, closest_regional_office: regional_office) }
       let!(:no_show_hearing_task_with_legacy_appeal) do
@@ -84,7 +84,7 @@ describe BulkTaskAssignment, :postgres do
         no_show_hearing_task2.appeal.update(closest_regional_office: regional_office)
         no_show_hearing_task3.appeal.update(closest_regional_office: "RO19")
         organization.users << assigned_to
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         count_before = Task.count
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq true
@@ -108,7 +108,7 @@ describe BulkTaskAssignment, :postgres do
       let(:task_type) { "UnknownTaskType" }
 
       it "does not bulk assigns tasks" do
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         organization.users << assigned_to
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq false
@@ -121,7 +121,7 @@ describe BulkTaskAssignment, :postgres do
       let(:organization_url) { 1234 }
 
       it "does not bulk assigns tasks" do
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         organization.users << assigned_to
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq false
@@ -134,7 +134,7 @@ describe BulkTaskAssignment, :postgres do
       let(:organization_url) { create(:organization).url }
 
       it "does not bulk assigns tasks" do
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         organization.users << assigned_to
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq false
@@ -143,12 +143,12 @@ describe BulkTaskAssignment, :postgres do
       end
     end
 
-    context "when assigned by user does not belong to organization" do
+    context "when assigned by user is not admin of organization" do
       it "does not bulk assigns tasks" do
         organization.users << assigned_to
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq false
-        error = ["does not belong to organization with url #{organization.url}"]
+        error = ["is not admin of organization with url #{organization.url}"]
         expect(bulk_assignment.errors[:assigned_by]).to eq error
       end
     end
@@ -156,7 +156,7 @@ describe BulkTaskAssignment, :postgres do
     context "when all attributes are present" do
       it "bulk assigns tasks" do
         organization.users << assigned_to
-        organization.users << assigned_by
+        OrganizationsUser.make_user_admin(assigned_by, organization)
         count_before = Task.count
         bulk_assignment = BulkTaskAssignment.new(params)
         expect(bulk_assignment.valid?).to eq true

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -47,74 +47,43 @@ describe BulkTaskAssignment, :postgres do
     let(:task_count) { 2 }
     let(:regional_office) { nil }
 
-    context "when assigned to user does not belong to organization" do
-      it "does not bulk assigns tasks" do
-        OrganizationsUser.make_user_admin(assigned_by, organization)
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq false
-        error = ["does not belong to organization with url #{organization.url}"]
-        expect(bulk_assignment.errors[:assigned_to]).to eq error
+    let(:assigner) { assigned_by }
+    let(:assignee) { assigned_to }
+
+    shared_examples "invalid bulk assign" do
+      context "when assigned by user is not admin of organization" do
+        it "does not bulk assigns tasks" do
+          OrganizationsUser.make_user_admin(assigner, organization)
+          organization.users << assignee
+          bulk_assignment = BulkTaskAssignment.new(params)
+          expect(bulk_assignment.valid?).to eq false
+          expect(bulk_assignment.errors[error_sym]).to eq [error]
+        end
       end
+    end
+
+    fcontext "when assigned to user does not belong to organization" do
+      let(:assignee) { create(:user) }
+      let(:error) { "does not belong to organization with url #{organization.url}" }
+      let(:error_sym) { :assigned_to }
+
+      it_behaves_like "invalid bulk assign"
     end
 
     context "when regional office is not valid" do
       let(:regional_office) { "Not Valid" }
+      let(:error) { "could not find regional office: #{regional_office}" }
+      let(:error_sym) { :regional_office }
 
-      it "does not bulk assigns tasks" do
-        organization.users << assigned_to
-        OrganizationsUser.make_user_admin(assigned_by, organization)
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq false
-        error = ["could not find regional office: #{regional_office}"]
-        expect(bulk_assignment.errors[:regional_office]).to eq error
-      end
-    end
-
-    context "when there are legacy appeals and regional office is passed" do
-      let(:regional_office) { "RO17" }
-      let(:legacy_appeal) { create(:legacy_appeal, closest_regional_office: regional_office) }
-      let!(:no_show_hearing_task_with_legacy_appeal) do
-        create(:no_show_hearing_task,
-               appeal: legacy_appeal,
-               assigned_to: organization,
-               created_at: 2.days.ago)
-      end
-
-      it "filters by regional office" do
-        no_show_hearing_task2.appeal.update(closest_regional_office: regional_office)
-        no_show_hearing_task3.appeal.update(closest_regional_office: "RO19")
-        organization.users << assigned_to
-        OrganizationsUser.make_user_admin(assigned_by, organization)
-        count_before = Task.count
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq true
-        result = bulk_assignment.process
-        expect(Task.count).to eq count_before + 2
-        expect(result.count).to eq 2
-        task_with_ama_appeal = result.find { |task| task.appeal == no_show_hearing_task2.appeal }
-        expect(task_with_ama_appeal.assigned_to).to eq assigned_to
-        expect(task_with_ama_appeal.type).to eq "NoShowHearingTask"
-        expect(task_with_ama_appeal.assigned_by).to eq assigned_by
-        expect(task_with_ama_appeal.parent_id).to eq no_show_hearing_task2.id
-
-        task_with_legacy_appeal = result.find { |task| task.appeal == legacy_appeal }
-        expect(task_with_legacy_appeal.assigned_to).to eq assigned_to
-        expect(task_with_legacy_appeal.type).to eq "NoShowHearingTask"
-        expect(task_with_legacy_appeal.assigned_by).to eq assigned_by
-      end
+      it_behaves_like "invalid bulk assign"
     end
 
     context "when task type is not valid" do
       let(:task_type) { "UnknownTaskType" }
+      let(:error) { "#{task_type} is not a valid task type" }
+      let(:error_sym) { :task_type }
 
-      it "does not bulk assigns tasks" do
-        OrganizationsUser.make_user_admin(assigned_by, organization)
-        organization.users << assigned_to
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq false
-        error = ["#{task_type} is not a valid task type"]
-        expect(bulk_assignment.errors[:task_type]).to eq error
-      end
+      it_behaves_like "invalid bulk assign"
     end
 
     context "when organization is not valid" do
@@ -132,25 +101,18 @@ describe BulkTaskAssignment, :postgres do
 
     context "when organization cannot bulk assign" do
       let(:organization_url) { create(:organization).url }
+      let(:error) { "with url #{organization_url} cannot bulk assign tasks" }
+      let(:error_sym) { :organization }
 
-      it "does not bulk assigns tasks" do
-        OrganizationsUser.make_user_admin(assigned_by, organization)
-        organization.users << assigned_to
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq false
-        error = ["with url #{organization_url} cannot bulk assign tasks"]
-        expect(bulk_assignment.errors[:organization]).to eq error
-      end
+      it_behaves_like "invalid bulk assign"
     end
 
     context "when assigned by user is not admin of organization" do
-      it "does not bulk assigns tasks" do
-        organization.users << assigned_to
-        bulk_assignment = BulkTaskAssignment.new(params)
-        expect(bulk_assignment.valid?).to eq false
-        error = ["is not admin of organization with url #{organization.url}"]
-        expect(bulk_assignment.errors[:assigned_by]).to eq error
-      end
+      let(:assigner) { create(:user) }
+      let(:error) { "is not admin of organization with url #{organization.url}" }
+      let(:error_sym) { :assigned_by }
+
+      it_behaves_like "invalid bulk assign"
     end
 
     context "when all attributes are present" do
@@ -168,6 +130,40 @@ describe BulkTaskAssignment, :postgres do
         expect(result.first.assigned_by).to eq assigned_by
         expect(result.first.appeal).to eq no_show_hearing_task1.appeal
         expect(result.first.parent_id).to eq no_show_hearing_task1.id
+      end
+
+      context "when there are legacy appeals and regional office is passed" do
+        let(:regional_office) { "RO17" }
+        let(:legacy_appeal) { create(:legacy_appeal, closest_regional_office: regional_office) }
+        let!(:no_show_hearing_task_with_legacy_appeal) do
+          create(:no_show_hearing_task,
+                 appeal: legacy_appeal,
+                 assigned_to: organization,
+                 created_at: 2.days.ago)
+        end
+
+        it "filters by regional office" do
+          no_show_hearing_task2.appeal.update(closest_regional_office: regional_office)
+          no_show_hearing_task3.appeal.update(closest_regional_office: "RO19")
+          organization.users << assigned_to
+          OrganizationsUser.make_user_admin(assigned_by, organization)
+          count_before = Task.count
+          bulk_assignment = BulkTaskAssignment.new(params)
+          expect(bulk_assignment.valid?).to eq true
+          result = bulk_assignment.process
+          expect(Task.count).to eq count_before + 2
+          expect(result.count).to eq 2
+          task_with_ama_appeal = result.find { |task| task.appeal == no_show_hearing_task2.appeal }
+          expect(task_with_ama_appeal.assigned_to).to eq assigned_to
+          expect(task_with_ama_appeal.type).to eq "NoShowHearingTask"
+          expect(task_with_ama_appeal.assigned_by).to eq assigned_by
+          expect(task_with_ama_appeal.parent_id).to eq no_show_hearing_task2.id
+
+          task_with_legacy_appeal = result.find { |task| task.appeal == legacy_appeal }
+          expect(task_with_legacy_appeal.assigned_to).to eq assigned_to
+          expect(task_with_legacy_appeal.type).to eq "NoShowHearingTask"
+          expect(task_with_legacy_appeal.assigned_by).to eq assigned_by
+        end
       end
     end
   end


### PR DESCRIPTION
Bumps #14124

### Description
Only allows admins of an org to bulk assign tasks

### Acceptance Criteria
- [x] Only admin users of organizations are can see bulk assign button
- [x] Only admin users are able to bulk assign tasks to themselves or another team member

### Testing Plan
1. Sign in as BVATWARNER and go to /organizations/hearings-management
1. Confirm no bulk assign button
1. Make BVATWARNER an admin
   ```ruby
   OrganizationsUser.make_user_admin(User.find_by(css_id: "BVATWARNER"), HearingsManagement.singleton)
   ```
1. Ensure can complete bulk assign

### User Facing Changes
 - [x] Only admins can see the bulk assign button

 ADMIN|NON ADMIN
 ---|---
![Screen Shot 2020-06-10 at 5 56 47 PM](https://user-images.githubusercontent.com/45575454/84322890-ca18c180-ab43-11ea-96ad-026a7f141d07.png)|![Screen Shot 2020-06-10 at 5 56 34 PM](https://user-images.githubusercontent.com/45575454/84322891-ca18c180-ab43-11ea-956b-d29308c1d8ff.png)
