### PR TITLE
Add BGS method and job for syncing attorneys

### DIFF
--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -50,7 +50,9 @@ class NightlySyncsJob < CaseflowJob
   end
 
   def sync_bgs_attorneys
+    start_time = Time.zone.now
     BgsAttorney.sync_bgs_attorneys
+    datadog_report_time_segment(segment: "sync_bgs_attorneys", start_time: start_time)
   end
 
   def dangling_legacy_appeals

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -12,6 +12,7 @@ class NightlySyncsJob < CaseflowJob
     sync_vacols_users
     sync_vacols_cases
     sync_decision_review_tasks
+    sync_bgs_attorneys
 
     datadog_report_runtime(metric_group_name: "nightly_syncs_job")
   end
@@ -46,6 +47,10 @@ class NightlySyncsJob < CaseflowJob
     checker = DecisionReviewTasksForInactiveAppealsChecker.new
     checker.call
     checker.buffer.map { |task_id| Task.find(task_id).cancelled! }
+  end
+
+  def sync_bgs_attorneys
+    BgsAttorney.sync_bgs_attorneys
   end
 
   def dangling_legacy_appeals

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -156,6 +156,8 @@ class WarmBgsCachesJob < CaseflowJob
   end
 
   def warm_attorney_address_caches
+    start_time = Time.zone.now
     BgsAttorney.all.each(&:warm_address_cache)
+    datadog_report_time_segment(segment: "warm_attorney_address_caches", start_time: start_time)
   end
 end

--- a/app/jobs/warm_bgs_caches_job.rb
+++ b/app/jobs/warm_bgs_caches_job.rb
@@ -12,6 +12,7 @@ class WarmBgsCachesJob < CaseflowJob
     warm_participant_caches
     warm_veteran_attribute_caches
     warm_people_caches
+    warm_attorney_address_caches
 
     datadog_report_runtime(metric_group_name: "warm_bgs_caches_job")
   end
@@ -152,5 +153,9 @@ class WarmBgsCachesJob < CaseflowJob
       end
     end
     veterans_updated
+  end
+
+  def warm_attorney_address_caches
+    BgsAttorney.all.each(&:warm_address_cache)
   end
 end

--- a/app/models/bgs_attorney.rb
+++ b/app/models/bgs_attorney.rb
@@ -19,6 +19,6 @@ class BgsAttorney < CaseflowRecord
   end
 
   def warm_address_cache
-    BgsAddressService.new(participant_id: participant_id).fetch_bgs_record
+    BgsAddressService.new(participant_id: participant_id).fetch_bgs_record(force: true)
   end
 end

--- a/app/models/bgs_attorney.rb
+++ b/app/models/bgs_attorney.rb
@@ -19,6 +19,6 @@ class BgsAttorney < CaseflowRecord
   end
 
   def warm_address_cache
-    BgsAddressService.new(participant_id: participant_id).fetch_bgs_record(force: true)
+    BgsAddressService.new(participant_id: participant_id).refresh_cached_bgs_record
   end
 end

--- a/app/models/bgs_attorney.rb
+++ b/app/models/bgs_attorney.rb
@@ -4,16 +4,21 @@
 # who might not already be associated with a record (hence the use of a different model/table)
 
 class BgsAttorney < CaseflowRecord
-  include AssociatedBgsRecord
   include BgsService
 
   class BgsAttorneyNotFound < StandardError; end
 
   class << self
-    def fetch_bgs_attorneys
-      # Implement connection to existing BGS service method
-      # client.data.find_power_of_attorneys
-      # bgs.find_power_of_attorneys
+    def sync_bgs_attorneys
+      now = Time.zone.now
+      bgs.fetch_poas_list.each do |hash|
+        atty = find_or_initialize_by(participant_id: hash[:ptcpnt_id])
+        atty.update!(name: hash[:nm], record_type: hash[:org_type_nm], last_synced_at: now)
+      end
     end
+  end
+
+  def warm_address_cache
+    BgsAddressService.new(participant_id: participant_id).fetch_bgs_record
   end
 end

--- a/app/models/bgs_attorney.rb
+++ b/app/models/bgs_attorney.rb
@@ -11,7 +11,7 @@ class BgsAttorney < CaseflowRecord
   class << self
     def sync_bgs_attorneys
       now = Time.zone.now
-      bgs.fetch_poas_list.each do |hash|
+      bgs.poas_list.each do |hash|
         atty = find_or_initialize_by(participant_id: hash[:ptcpnt_id])
         atty.update!(name: hash[:nm], record_type: hash[:org_type_nm], last_synced_at: now)
       end

--- a/app/services/bgs_address_service.rb
+++ b/app/services/bgs_address_service.rb
@@ -40,9 +40,9 @@ class BgsAddressService
     }
   end
 
-  def fetch_bgs_record
+  def fetch_bgs_record(force: false)
     cache_key = self.class.cache_key_for_participant_id(participant_id)
-    Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+    Rails.cache.fetch(cache_key, expires_in: 24.hours, force: force) do
       bgs.find_address_by_participant_id(participant_id)
     rescue Savon::Error
       # If there is no address for this participant id then we get an error.

--- a/app/services/bgs_address_service.rb
+++ b/app/services/bgs_address_service.rb
@@ -40,15 +40,23 @@ class BgsAddressService
     }
   end
 
-  def fetch_bgs_record(force: false)
-    cache_key = self.class.cache_key_for_participant_id(participant_id)
-    Rails.cache.fetch(cache_key, expires_in: 24.hours, force: force) do
+  def cache_key
+    self.class.cache_key_for_participant_id(participant_id)
+  end
+
+  def fetch_bgs_record
+    Rails.cache.fetch(cache_key, expires_in: 24.hours) do
       bgs.find_address_by_participant_id(participant_id)
     rescue Savon::Error
       # If there is no address for this participant id then we get an error.
       # catch it and return an empty array
       nil
     end
+  end
+
+  def refresh_cached_bgs_record
+    Rails.cache.delete(cache_key)
+    fetch_bgs_record
   end
 
   def bgs

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -187,14 +187,17 @@ class ExternalApi::BGSService
     get_limited_poas_hash_from_bgs(bgs_limited_poas)
   end
 
+  def poas_list
+    @poas_list ||= fetch_poas_list
+  end
+
   def fetch_poas_list
     DBService.release_db_connections
-    @poas_list ||=
-      MetricsService.record("BGS: fetch list of poas",
-                            service: :bgs,
-                            name: "data.find_power_of_attorneys") do
-        client.data.find_power_of_attorneys
-      end
+    MetricsService.record("BGS: fetch list of poas",
+                          service: :bgs,
+                          name: "data.find_power_of_attorneys") do
+      client.data.find_power_of_attorneys
+    end
   end
 
   def find_address_by_participant_id(participant_id)

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -187,6 +187,16 @@ class ExternalApi::BGSService
     get_limited_poas_hash_from_bgs(bgs_limited_poas)
   end
 
+  def fetch_poas_list
+    DBService.release_db_connections
+    @poas_list ||=
+      MetricsService.record("BGS: fetch list of poas",
+                            service: :bgs,
+                            name: "data.find_power_of_attorneys") do
+        client.data.find_power_of_attorneys
+      end
+  end
+
   def find_address_by_participant_id(participant_id)
     finder = ExternalApi::BgsAddressFinder.new(participant_id: participant_id, client: client)
     @addresses[participant_id] ||= finder.mailing_address || finder.addresses.last

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -317,7 +317,7 @@ class Fakes::BGSService
     result.empty? ? nil : result
   end
 
-  def fetch_poas_list
+  def poas_list
     [
       { ptcpnt_id: "12345678", nm: "NANCY BAUMBACH", org_type_nm: "POA Attorney" },
       { ptcpnt_id: "55114884", nm: "RICH TREUTING SR.", org_type_nm: "POA Agent" },

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -317,6 +317,16 @@ class Fakes::BGSService
     result.empty? ? nil : result
   end
 
+  def fetch_poas_list
+    [
+      { ptcpnt_id: "12345678", nm: "NANCY BAUMBACH", org_type_nm: "POA Attorney" },
+      { ptcpnt_id: "55114884", nm: "RICH TREUTING SR.", org_type_nm: "POA Agent" },
+      { ptcpnt_id: "56242925", nm: "MADELINE JENKINS", org_type_nm: "POA Attorney" },
+      { ptcpnt_id: "21543986", nm: "ACADIA VETERAN SERVICES", org_type_nm: "POA State Organization" },
+      { ptcpnt_id: "56154689", nm: "RANDALL KOHLER III", org_type_nm: "POA Attorney" }
+    ]
+  end
+
   # TODO: add more test cases
   def find_address_by_participant_id(participant_id)
     address = (self.class.address_records || {})[participant_id]

--- a/spec/models/bgs_attorney_spec.rb
+++ b/spec/models/bgs_attorney_spec.rb
@@ -10,7 +10,14 @@ describe BgsAttorney, :all_dbs do
 
       it "upserts all fetched attorneys" do
         subject
-        expect(BgsAttorney.all.map(&:name).sort).to eq ["ACADIA VETERAN SERVICES", "JANE DOE", "MADELINE JENKINS", "NANCY BAUMBACH", "RANDALL KOHLER III", "RICH TREUTING SR."]
+        expect(BgsAttorney.all.map(&:name).sort).to eq [
+          "ACADIA VETERAN SERVICES",
+          "JANE DOE",
+          "MADELINE JENKINS",
+          "NANCY BAUMBACH",
+          "RANDALL KOHLER III",
+          "RICH TREUTING SR."
+        ]
       end
     end
   end

--- a/spec/models/bgs_attorney_spec.rb
+++ b/spec/models/bgs_attorney_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+describe BgsAttorney, :all_dbs do
+  describe "#sync_bgs_attorneys" do
+    subject { BgsAttorney.sync_bgs_attorneys }
+
+    context "when some participant ids are already stored" do
+      let!(:atty1) { create(:bgs_attorney, participant_id: "12345678", name: "JOHN SMITH") }
+      let!(:atty2) { create(:bgs_attorney, participant_id: "12345679", name: "JANE DOE") }
+
+      it "upserts all fetched attorneys" do
+        subject
+        expect(BgsAttorney.all.map(&:name).sort).to eq ["ACADIA VETERAN SERVICES", "JANE DOE", "MADELINE JENKINS", "NANCY BAUMBACH", "RANDALL KOHLER III", "RICH TREUTING SR."]
+      end
+    end
+  end
+
+  describe "#warm_address_cache" do
+    let(:bgs_address_service) { BgsAddressService.new }
+    let(:atty) { create(:bgs_attorney, participant_id: "12345678", name: "JOHN SMITH") }
+
+    before do
+      allow(BgsAddressService).to receive(:new).and_return(bgs_address_service)
+      allow(bgs_address_service).to receive(:fetch_bgs_record).and_call_original
+    end
+
+    subject { atty.warm_address_cache }
+
+    it "fetches the attorney's address from BGS" do
+      subject
+      expect(BgsAddressService).to have_received(:new).with(participant_id: "12345678")
+      expect(bgs_address_service).to have_received(:fetch_bgs_record).once
+    end
+  end
+end

--- a/spec/models/bgs_attorney_spec.rb
+++ b/spec/models/bgs_attorney_spec.rb
@@ -30,7 +30,7 @@ describe BgsAttorney, :all_dbs do
 
     before do
       allow(BgsAddressService).to receive(:new).and_return(bgs_address_service)
-      allow(bgs_address_service).to receive(:fetch_bgs_record).and_call_original
+      allow(bgs_address_service).to receive(:refresh_cached_bgs_record).and_call_original
     end
 
     subject { atty.warm_address_cache }
@@ -38,7 +38,7 @@ describe BgsAttorney, :all_dbs do
     it "fetches the attorney's address from BGS" do
       subject
       expect(BgsAddressService).to have_received(:new).with(participant_id: pid)
-      expect(bgs_address_service).to have_received(:fetch_bgs_record).once
+      expect(bgs_address_service).to have_received(:refresh_cached_bgs_record).once
       expect(Rails.cache.fetch(cache_key)).not_to be_nil
     end
   end

--- a/spec/models/bgs_attorney_spec.rb
+++ b/spec/models/bgs_attorney_spec.rb
@@ -23,8 +23,10 @@ describe BgsAttorney, :all_dbs do
   end
 
   describe "#warm_address_cache" do
-    let(:bgs_address_service) { BgsAddressService.new }
-    let(:atty) { create(:bgs_attorney, participant_id: "12345678", name: "JOHN SMITH") }
+    let(:pid) { "12345678" }
+    let(:bgs_address_service) { BgsAddressService.new(participant_id: pid) }
+    let(:atty) { create(:bgs_attorney, participant_id: pid, name: "JOHN SMITH") }
+    let(:cache_key) { BgsAddressService.cache_key_for_participant_id(pid) }
 
     before do
       allow(BgsAddressService).to receive(:new).and_return(bgs_address_service)
@@ -35,8 +37,9 @@ describe BgsAttorney, :all_dbs do
 
     it "fetches the attorney's address from BGS" do
       subject
-      expect(BgsAddressService).to have_received(:new).with(participant_id: "12345678")
+      expect(BgsAddressService).to have_received(:new).with(participant_id: pid)
       expect(bgs_address_service).to have_received(:fetch_bgs_record).once
+      expect(Rails.cache.fetch(cache_key)).not_to be_nil
     end
   end
 end

--- a/spec/services/bgs_address_service_spec.rb
+++ b/spec/services/bgs_address_service_spec.rb
@@ -22,23 +22,22 @@ describe BgsAddressService do
     end
   end
 
-  describe "#fetch_bgs_record" do
+  describe "#refresh_cached_bgs_record" do
     let(:address_service) { BgsAddressService.new(participant_id: "1234") }
     let(:bgs) { double("BGSService") }
 
-    context "when forcing a fetch" do
-      before do
-        allow(address_service).to receive(:bgs).and_return(bgs)
-        allow(bgs).to receive(:find_address_by_participant_id).and_return({ "some": "address" })
-      end
+    before do
+      allow(address_service).to receive(:bgs).and_return(bgs)
+      allow(bgs).to receive(:find_address_by_participant_id).and_return(some: "address")
+    end
 
-      it "ignores any existing cache key" do
-        2.times do
-          address_service.fetch_bgs_record(force: false)
-          address_service.fetch_bgs_record(force: true)
-        end
-        expect(bgs).to have_received(:find_address_by_participant_id).thrice
+    it "deletes and re-caches any existing key" do
+      2.times do
+        address_service.fetch_bgs_record
+        address_service.refresh_cached_bgs_record
+        address_service.fetch_bgs_record
       end
+      expect(bgs).to have_received(:find_address_by_participant_id).thrice
     end
   end
 end

--- a/spec/services/bgs_address_service_spec.rb
+++ b/spec/services/bgs_address_service_spec.rb
@@ -21,4 +21,24 @@ describe BgsAddressService do
       expect(BgsAddressService.fetch_cached_addresses(%w[123 456 789])).to eq(addresses)
     end
   end
+
+  describe "#fetch_bgs_record" do
+    let(:address_service) { BgsAddressService.new(participant_id: "1234") }
+    let(:bgs) { double("BGSService") }
+
+    context "when forcing a fetch" do
+      before do
+        allow(address_service).to receive(:bgs).and_return(bgs)
+        allow(bgs).to receive(:find_address_by_participant_id).and_return({ "some": "address" })
+      end
+
+      it "ignores any existing cache key" do
+        2.times do
+          address_service.fetch_bgs_record(force: false)
+          address_service.fetch_bgs_record(force: true)
+        end
+        expect(bgs).to have_received(:find_address_by_participant_id).thrice
+      end
+    end
+  end
 end


### PR DESCRIPTION
Connects #14294 

### Description
This PR implements a BGSService method (and the corresponding method in Fakes) for fetching a list of attorneys from BGS, as well as recurring job logic for kicking off this fetch.

### Acceptance Criteria
- [ ] The Caseflow DB is populated with BGS attorney data
- [ ] A new job for populating is created and run nightly

### Testing Plan
1. Added new BgsAttorney spec file