### PR TITLE
Added Caching of Associated Rating for EPE

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -420,8 +420,10 @@ class EndProductEstablishment < CaseflowRecord
   end
 
   def fetch_associated_rating
-    potential_decision_ratings.find do |rating|
-      rating.associated_end_products.any? { |end_product| end_product.claim_id == reference_id }
+    Rails.cache.fetch("epe_associated_rating/#{end_product.claim_id}", expires_in: 3.hours) do
+      potential_decision_ratings.find do |rating|
+        rating.associated_end_products.any? { |end_product| end_product.claim_id == reference_id }
+      end
     end
   end
 

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -420,7 +420,7 @@ class EndProductEstablishment < CaseflowRecord
   end
 
   def fetch_associated_rating
-    Rails.cache.fetch("epe_associated_rating/#{end_product.claim_id}", expires_in: 3.hours) do
+    Rails.cache.fetch("#{cache_key}/associated_rating", expires_in: 3.hours) do
       potential_decision_ratings.find do |rating|
         rating.associated_end_products.any? { |end_product| end_product.claim_id == reference_id }
       end

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -1081,12 +1081,13 @@ describe EndProductEstablishment, :postgres do
 
     context "when many potential ratings" do
       let(:reference_id) { "reference-id" }
-      let(:other_epe) do 
-        create(:end_product_establishment,
+      let(:other_epe) do
+        create(
+          :end_product_establishment,
           veteran_file_number: veteran_file_number,
-          established_at: end_product_establishment.established_at + 2.day,
+          established_at: end_product_establishment.established_at + 2.days,
           code: "040SCR"
-        ) 
+        )
       end
 
       let(:associated_claims) do

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -1115,7 +1115,7 @@ describe EndProductEstablishment, :postgres do
         end_product_establishment.save!
       end
 
-      it "caches the associated end product" do
+      it "caches the associated rating for the given EPE" do
         expect(Rails.cache.exist?(cache_key)).to eq(false)
         # If caching works, this should only get called once
         expect(PromulgatedRating).to receive(:fetch_in_range).once.and_call_original


### PR DESCRIPTION
Connects #14472

### Description
This adds caching in `EndProductEstablishment.fetch_associated_rating` to increase performance when doing lookups.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Associated rating for EPE is cached
