### PR TITLE
Cache finalized decision issues before receipt date on instance

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -423,11 +423,13 @@ class Appeal < DecisionReview
   def finalized_decision_issues_before_receipt_date
     return [] unless receipt_date
 
-    DecisionIssue.includes(:decision_review).where(participant_id: veteran.participant_id)
-      .select(&:finalized?)
-      .select do |issue|
-        issue.approx_decision_date && issue.approx_decision_date < receipt_date
-      end
+    @finalized_decision_issues_before_receipt_date ||= begin
+      DecisionIssue.includes(:decision_review).where(participant_id: veteran.participant_id)
+        .select(&:finalized?)
+        .select do |issue|
+          issue.approx_decision_date && issue.approx_decision_date < receipt_date
+        end
+    end
   end
 
   def create_business_line_tasks!

--- a/app/models/claim_review.rb
+++ b/app/models/claim_review.rb
@@ -68,11 +68,13 @@ class ClaimReview < DecisionReview
   def finalized_decision_issues_before_receipt_date
     return [] unless receipt_date
 
-    DecisionIssue.where(participant_id: veteran.participant_id, benefit_type: benefit_type)
-      .select(&:finalized?)
-      .select do |issue|
-        issue.approx_decision_date && issue.approx_decision_date < receipt_date
-      end
+    @finalized_decision_issues_before_receipt_date ||= begin
+      DecisionIssue.where(participant_id: veteran.participant_id, benefit_type: benefit_type)
+        .select(&:finalized?)
+        .select do |issue|
+          issue.approx_decision_date && issue.approx_decision_date < receipt_date
+        end
+    end
   end
 
   # Save issues and assign it the appropriate end product establishment.


### PR DESCRIPTION
Related to the 🦇 issue in #14472:
- [🦇 thread](https://dsva.slack.com/archives/CHX8FMP28/p1591277936051900)
- [🦊 thread](https://dsva.slack.com/archives/C54QCEHAL/p1591281463495000)

### Description
The SupplementalClaim in question was also taking forever to calculate and serialize contestable issues -- over 1 minute.

- It turns out that it has 423 contestable rating issues or decisions.
- For each of these, the `ContestableIssueGenerator` checks for a decision issue duplicate by calling back to the SC for prior finalized decision issues.
- The SC as 27 potential issues to check, each of which loads _its_ own SC (via `approx_decision_date`). None of these are cached.

All in all, the contestable issues serializer was hitting the DB about 10k extra times.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Manually tested by patching in Rails console and rerunning `sc.contestable_issues` -- elapsed time dropped to about 1 second.