### PR TITLE
Add comment for legacy_hearings.vacols_id

### DIFF
--- a/db/migrate/20200615153543_add_legacy_hearing_vacols_id_comment.rb
+++ b/db/migrate/20200615153543_add_legacy_hearing_vacols_id_comment.rb
@@ -1,0 +1,5 @@
+class AddLegacyHearingVacolsIdComment < ActiveRecord::Migration[5.2]
+  def change
+    change_column_comment :legacy_hearings, :vacols_id, "Corresponds to VACOLS’ hearsched.hearing_pkseq"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_11_205900) do
+ActiveRecord::Schema.define(version: 2020_06_15_153543) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -870,7 +870,7 @@ ActiveRecord::Schema.define(version: 2020_06_11_205900) do
     t.datetime "updated_at", comment: "Timestamp when record was last updated."
     t.bigint "updated_by_id", comment: "The ID of the user who most recently updated the Legacy Hearing"
     t.integer "user_id"
-    t.string "vacols_id", null: false
+    t.string "vacols_id", null: false, comment: "Corresponds to VACOLS’ hearsched.hearing_pkseq"
     t.string "witness"
     t.index ["created_by_id"], name: "index_legacy_hearings_on_created_by_id"
     t.index ["hearing_day_id"], name: "index_legacy_hearings_on_hearing_day_id"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -669,7 +669,7 @@ legacy_hearings,summary,text,,,,,,
 legacy_hearings,updated_at,datetime,,,,,x,Timestamp when record was last updated.
 legacy_hearings,updated_by_id,integer (8) FK,,,x,,x,The ID of the user who most recently updated the Legacy Hearing
 legacy_hearings,user_id,integer FK,,,x,,x,
-legacy_hearings,vacols_id,string ∗,x,,,,x,
+legacy_hearings,vacols_id,string ∗,x,,,,x,Corresponds to VACOLS’ hearsched.hearing_pkseq
 legacy_hearings,witness,string,,,,,,
 legacy_issues,,,,,,,,"On an AMA decision review, when a veteran requests to review an issue that is already being contested on a legacy appeal, the legacy issue is connected to the request issue. If the veteran also chooses to opt their legacy issues into AMA and the issue is eligible to be transferred to AMA, the issues are closed in VACOLS through a legacy issue opt-in. This table stores the legacy issues connected to each request issue, and the record for opting them into AMA (if applicable)."
 legacy_issues,created_at,datetime ∗,x,,,,,Default created_at/updated_at


### PR DESCRIPTION
### Description
As suggested [here](https://dsva.slack.com/archives/CPEMQPVKR/p1591811688006800?thread_ts=1591803433.003900&cid=CPEMQPVKR), this PR adds a comment to state that Caseflow’s `legacy_hearings.vacols_id` corresponds to VACOLS’ `hearsched.hearing_pkseq`.
Mentioned in [dsva-vacols#124](https://github.com/department-of-veterans-affairs/dsva-vacols/issues/124#issuecomment-642171396)

### Acceptance Criteria
- [ ] Code compiles correctly

### Database Changes
*Only for Schema Changes*

* [x] Column comments updated
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
