### PR TITLE
Remove extra tab stops in Reader Document View

### DIFF
--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -106,6 +106,7 @@ export class PdfFile extends React.PureComponent {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(nextProps) {
     if (nextProps.isVisible !== this.props.isVisible) {
       this.currentPage = 0;
@@ -481,11 +482,41 @@ export class PdfFile extends React.PureComponent {
 }
 
 PdfFile.propTypes = {
+  clearDocumentLoadError: PropTypes.object,
+  clearPdfDocument: PropTypes.object,
+  currentMatchIndex: PropTypes.object,
+  documentId: PropTypes.number.isRequired,
+  documentType: PropTypes.string,
+  file: PropTypes.string.isRequired,
+  isVisible: PropTypes.bool,
+  jumpToPageNumber: PropTypes.number,
+  loadError: PropTypes.bool,
+  matchesPerPage: PropTypes.array,
+  onPageChange: PropTypes.func,
+  onScrollToComment: PropTypes.func,
+  pageDimensions: PropTypes.func,
   pdfDocument: PropTypes.object,
-  setDocScrollPosition: PropTypes.func,
+  pdfWorker: PropTypes.string,
+  resetJumpToPage: PropTypes.func,
+  rotation: PropTypes.number,
+  scale: PropTypes.number,
   scrollToComment: PropTypes.shape({
-    id: PropTypes.number
-  })
+    id: PropTypes.number,
+    page: PropTypes.number
+  }),
+  scrollTop: PropTypes.number,
+  searchText: PropTypes.string,
+  setDocumentLoadError: PropTypes.func,
+  setDocScrollPosition: PropTypes.func,
+  setPageDimensions: PropTypes.func,
+  setPdfDocument: PropTypes.func,
+  showPlaceAnnotationIcon: PropTypes.func,
+  sidebarHidden: PropTypes.bool,
+  startPlacingAnnotation: PropTypes.func,
+  togglePdfSidebar: PropTypes.func,
+  updateSearchIndexPage: PropTypes.func,
+  updateSearchRelativeIndex: PropTypes.func,
+  windowingOverscan: PropTypes.number
 };
 
 const mapDispatchToProps = (dispatch) => ({

--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -469,6 +469,7 @@ export class PdfFile extends React.PureComponent {
             columnWidth={this.getColumnWidth}
             columnCount={this.columnCount}
             scale={this.props.scale}
+            tabIndex={-1}
           />;
         }
       }

--- a/client/app/reader/PdfFile.jsx
+++ b/client/app/reader/PdfFile.jsx
@@ -469,7 +469,7 @@ export class PdfFile extends React.PureComponent {
             columnWidth={this.getColumnWidth}
             columnCount={this.columnCount}
             scale={this.props.scale}
-            tabIndex={-1}
+            tabIndex={this.props.isVisible ? 0 : -1}
           />;
         }
       }

--- a/client/app/styles/react/_search_bar.scss
+++ b/client/app/styles/react/_search_bar.scss
@@ -99,6 +99,7 @@
 
   &.hidden {
     top: 0;
+    display: none;
   }
 }
 // scss-lint:disable PropertyCount

--- a/spec/feature/reader/reader_spec.rb
+++ b/spec/feature/reader/reader_spec.rb
@@ -1232,10 +1232,10 @@ RSpec.feature "Reader", :all_dbs do
 
     scenario "Show and Hide Document Searchbar with Keyboard" do
       visit "/reader/appeal/#{appeal.vacols_id}/documents/#{documents[0].id}"
-      search_bar = find(".cf-search-bar")
 
       find("body").send_keys [:meta, "f"]
 
+      search_bar = find(".cf-search-bar")
       expect(search_bar).not_to match_css(".hidden")
 
       find("body").send_keys [:escape]


### PR DESCRIPTION
Resolves #12245

### Description
Remove extra tab stops:
1. for search bar when it is hidden and
2. for the PDF view, i.e.,`ReactVirtualized__Grid` elements (`Grid` React components within `PdfFile`)

See https://github.com/department-of-veterans-affairs/caseflow/issues/12245#issuecomment-644406955

### Acceptance Criteria
- [x] Code compiles correctly
- [ ] Tab stops flow from search icon to the PDF to the bottom of PDF viewer when search bar is hidden
- [ ] Tab stops flow from search icon to search bar elements when search bar is visible
- [ ] Reader's keyboard shortcuts still work

### Testing Plan
1. Log in as attorney
2. Go to their queue and click one of the "View docs" links for an appeal
3. Use keyboard to tab to the search (magnifying glass) icon. Continue to press Tab to see the next selection/focus.
   * Try clicking on the search icon to open the search panel; then pressing Tab.
   * Try Shift-Tab to go backwards.

All Tab keyboard navigation should move the current focus to a reasonable element.

### User Facing Changes

The current focused element should always be visible with a dotted outline. 

