### PR TITLE
Relabel SCMTask in Queue table

### DIFF
--- a/app/models/tasks/special_case_movement_task.rb
+++ b/app/models/tasks/special_case_movement_task.rb
@@ -10,6 +10,10 @@ class SpecialCaseMovementTask < Task
                 :verify_appeal_distributable
   after_create :close_and_create_judge_task
 
+  def self.label
+    COPY::CASE_MOVEMENT_TASK_LABEL
+  end
+
   private
 
   def close_and_create_judge_task

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -523,6 +523,7 @@
   "UNAUTHORIZED_PAGE_ACCESS_MESSAGE": "You aren't authorized to use this part of Caseflow yet.",
   "CASE_DETAILS_LOADING_FAILURE_TITLE": "Unable to load this case",
 
+  "CASE_MOVEMENT_TASK_LABEL": "Case Movement",
   "JUDGE_ASSIGN_TASK_LABEL": "Assign",
   "JUDGE_DECISION_REVIEW_TASK_LABEL": "Review",
   "JUDGE_QUALITY_REVIEW_TASK_LABEL": "Quality review",

--- a/spec/feature/queue/special_case_movement_task_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
     SpecialCaseMovementTeam.singleton.add_user(scm_user)
     User.authenticate!(user: scm_user)
   end
-  describe "Special Case Movement Team Member" do
+  describe "Case Movement Team Member" do
     context "With the Appeal in the right state" do
       it "successfully assigns the task to judge" do
         visit("queue/appeals/#{appeal.external_id}")

--- a/spec/models/tasks/distribution_task_spec.rb
+++ b/spec/models/tasks/distribution_task_spec.rb
@@ -58,7 +58,7 @@ describe DistributionTask, :postgres do
       expect(distribution_task.available_actions(user).count).to eq(0)
     end
 
-    it "with Special Case Movement Team user has the Special Case Movement action" do
+    it "with Case Movement Team user has the Special Case Movement action" do
       expect(distribution_task.available_actions(scm_user).count).to eq(1)
     end
 

--- a/spec/models/tasks/distribution_task_spec.rb
+++ b/spec/models/tasks/distribution_task_spec.rb
@@ -58,7 +58,7 @@ describe DistributionTask, :postgres do
       expect(distribution_task.available_actions(user).count).to eq(0)
     end
 
-    it "with Case Movement Team user has the Special Case Movement action" do
+    it "with Case Movement Team user has the Case Movement action" do
       expect(distribution_task.available_actions(scm_user).count).to eq(1)
     end
 

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -28,7 +28,7 @@ describe JudgeTask, :all_dbs do
       end
     end
 
-    context "user is a Special Case Movement team member" do
+    context "user is a Case Movement team member" do
       let(:user) do
         create(:user).tap { |scm_user| SpecialCaseMovementTeam.singleton.add_user(scm_user) }
       end

--- a/spec/models/tasks/special_case_movement_spec.rb
+++ b/spec/models/tasks/special_case_movement_spec.rb
@@ -2,18 +2,18 @@
 
 describe SpecialCaseMovementTask, :postgres do
   describe ".create" do
-    context "with Special Case Movement Team user" do
-      let(:scm_user) { create(:user) }
+    context "with Case Movement Team user" do
+      let(:cm_user) { create(:user) }
 
       subject do
         SpecialCaseMovementTask.create!(appeal: appeal,
-                                        assigned_to: scm_user,
-                                        assigned_by: scm_user,
+                                        assigned_to: cm_user,
+                                        assigned_by: cm_user,
                                         parent: dist_task)
       end
 
       before do
-        SpecialCaseMovementTeam.singleton.add_user(scm_user)
+        SpecialCaseMovementTeam.singleton.add_user(cm_user)
       end
 
       context "appeal ready for distribution" do

--- a/spec/models/tasks/special_case_movement_spec.rb
+++ b/spec/models/tasks/special_case_movement_spec.rb
@@ -81,8 +81,8 @@ describe SpecialCaseMovementTask, :postgres do
 
           subject do
             SpecialCaseMovementTask.create!(appeal: appeal,
-                                            assigned_to: scm_user,
-                                            assigned_by: scm_user,
+                                            assigned_to: cm_user,
+                                            assigned_by: cm_user,
                                             parent: evidence_window_task)
           end
 


### PR DESCRIPTION
Resolves #14447 

### Description
Remove "Special" copy from all tabs in Queue table

### Acceptance Criteria
- [ ] Special Case Movement copy is updated to Case Movement on all tabs

### Testing Plan

1. Log in as BVARDUNKLE
2. Go to case search
3. Search for an appeal that is ready to be distributed (321321301 to 321321330)
4. Click into case details
5. Select “Case movement: Advance to judge”
6. Select a judge and hit submit
7. Go to your user’s queue
8. Click into the completed tab

Try assigning a case to Dunkle so that the case shows up in the Assigned and On hold tabs.

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/55255674/84796771-a380dd80-afbe-11ea-9e38-c92dd203c8ff.png"> | <img width="1000" alt="image" src="https://user-images.githubusercontent.com/55255674/84796343-22c1e180-afbe-11ea-9f09-0a3ebb6f80ff.png">
