### PR TITLE
Add Sentry event id to UpdateCachedAppealsAttributesJob alert

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -205,13 +205,14 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
   def log_error(start_time, err)
     duration = time_ago_in_words(start_time)
     msg = "UpdateCachedAppealsAttributesJob failed after running for #{duration}. Fatal error: #{err.message}"
-    slack_msg = "[ERROR] UpdateCachedAppealsAttributesJob failed after running for #{duration}. See Sentry for error"
 
     Rails.logger.info(msg)
     Rails.logger.info(err.backtrace.join("\n"))
 
     Raven.capture_exception(err)
 
+    slack_msg = "[ERROR] UpdateCachedAppealsAttributesJob failed after running for #{duration}. "\
+                "See Sentry event #{Raven.last_event_id}"
     slack_service.send_notification(slack_msg) # do not leak PII
 
     datadog_report_runtime(metric_group_name: METRIC_GROUP_NAME)

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -91,7 +91,7 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
 
       UpdateCachedAppealsAttributesJob.perform_now
 
-      expected_msg = "UpdateCachedAppealsAttributesJob failed after running for .*. See Sentry for error"
+      expected_msg = "UpdateCachedAppealsAttributesJob failed after running for .*. See Sentry event .*"
 
       expect(slack_msg).to match(/#{expected_msg}/)
     end


### PR DESCRIPTION
@pkarman -- I might be missing something, but it seems pretty hard to find a sentry alert for a job failure, as searching the exception class name returns no results. Hence, this PR.