### PR TITLE
Remove volatile updated_at version from EPE cache key

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -285,6 +285,10 @@ class EndProductEstablishment < CaseflowRecord
     source.request_issues.where(end_product_establishment_id: id)
   end
 
+  def associated_rating_cache_key
+    "end_product_establishments/#{id}/associated_rating"
+  end
+
   def associated_rating
     @associated_rating ||= fetch_associated_rating
   end
@@ -420,7 +424,7 @@ class EndProductEstablishment < CaseflowRecord
   end
 
   def fetch_associated_rating
-    Rails.cache.fetch("#{cache_key}/associated_rating", expires_in: 3.hours) do
+    Rails.cache.fetch(associated_rating_cache_key, expires_in: 3.hours) do
       potential_decision_ratings.find do |rating|
         rating.associated_end_products.any? { |end_product| end_product.claim_id == reference_id }
       end

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -1110,7 +1110,7 @@ describe EndProductEstablishment, :postgres do
         ]
       end
 
-      let(:cache_key) { "#{end_product_establishment.cache_key}/associated_rating" }
+      let(:cache_key) { end_product_establishment.associated_rating_cache_key }
 
       before do
         end_product_establishment.save!


### PR DESCRIPTION
Connects #14472 

### Description
Revisiting this caching of an EPE's associated rating. In practice, the default `cache_key` ended up being too unstable to last anywhere near 3 hours, since it looks like

```end_product_establishments/105536-20200616201254357238```

where the second string of numbers is essentially `updated_at`. ([citation](https://api.rubyonrails.org/classes/ActiveRecord/Integration.html#method-i-cache_key))

While working with our problematic EPE in prod console, I saw two versions just 12 minutes apart (seemingly related to `last_synced_at` getting updated).

This PR essentially removes the timestamp from the cache key format.

### Testing Plan
1. Try this cache key out in prod 😩 