### PR TITLE
Contested Claims | Attorney Fees | Migration to add notes to claimant table for unlisted claimants

### DIFF
--- a/db/migrate/20200617160206_add_notes_to_claimants.rb
+++ b/db/migrate/20200617160206_add_notes_to_claimants.rb
@@ -1,5 +1,5 @@
 class AddNotesToClaimants < ActiveRecord::Migration[5.2]
   def change
-    add_column :claimants, :notes, :text, comment: "Notes why a claimant is not listed."
+    add_column :claimants, :notes, :text, comment: "This is a notes field for adding claimant not listed and any supplementary information outside of unlisted claimant."
   end
 end

--- a/db/migrate/20200617160206_add_notes_to_claimants.rb
+++ b/db/migrate/20200617160206_add_notes_to_claimants.rb
@@ -1,0 +1,5 @@
+class AddNotesToClaimants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claimants, :notes, :text, comment: "Notes why a claimant is not listed."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_15_153543) do
+ActiveRecord::Schema.define(version: 2020_06_17_160206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -331,6 +331,7 @@ ActiveRecord::Schema.define(version: 2020_06_15_153543) do
     t.datetime "created_at"
     t.bigint "decision_review_id", comment: "The ID of the decision review the claimant is on."
     t.string "decision_review_type", comment: "The type of decision review the claimant is on."
+    t.text "notes", comment: "Notes why a claimant is not listed."
     t.string "participant_id", null: false, comment: "The participant ID of the claimant."
     t.string "payee_code", comment: "The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
     t.string "type", default: "Claimant", comment: "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -331,7 +331,7 @@ ActiveRecord::Schema.define(version: 2020_06_17_160206) do
     t.datetime "created_at"
     t.bigint "decision_review_id", comment: "The ID of the decision review the claimant is on."
     t.string "decision_review_type", comment: "The type of decision review the claimant is on."
-    t.text "notes", comment: "Notes why a claimant is not listed."
+    t.text "notes", comment: "This is a notes field for adding claimant not listed and any supplementary information outside of unlisted claimant."
     t.string "participant_id", null: false, comment: "The participant ID of the claimant."
     t.string "payee_code", comment: "The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
     t.string "type", default: "Claimant", comment: "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -242,6 +242,7 @@ claimants,id,integer (8) PK,x,x,,,,
 claimants,participant_id,string ∗ U,x,,,x,x,The participant ID of the claimant.
 claimants,payee_code,string,,,,,,"The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
 claimants,type,string,,,,,,"The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."
+claimants,notes,text,,,,,,"Notes why a claimant is not listed."
 claimants,updated_at,datetime,,,,,x,
 claims_folder_searches,,,,,,,,
 claims_folder_searches,appeal_id,integer FK,,,x,,x,

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -242,7 +242,7 @@ claimants,id,integer (8) PK,x,x,,,,
 claimants,participant_id,string ∗ U,x,,,x,x,The participant ID of the claimant.
 claimants,payee_code,string,,,,,,"The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
 claimants,type,string,,,,,,"The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."
-claimants,notes,text,,,,,,"Notes why a claimant is not listed."
+claimants,notes,text,,,,,,"This is a notes field for adding claimant not listed and any supplementary information outside of unlisted claimant."
 claimants,updated_at,datetime,,,,,x,
 claims_folder_searches,,,,,,,,
 claims_folder_searches,appeal_id,integer FK,,,x,,x,


### PR DESCRIPTION
Connects to  #14380 and pr #14487

### Description
This PR is a migration to add the  "notes" field for unlisted claimants where we do not have other data, and initially populates the type column with "Claimant".

### Acceptance Criteria
- [ ] Code compiles correctly

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
