### PR TITLE
Fix Raven error when logging stats collector exceptions

### DIFF
--- a/app/jobs/stats_collector_job.rb
+++ b/app/jobs/stats_collector_job.rb
@@ -105,7 +105,7 @@ class StatsCollectorJob < CaseflowJob
     Rails.logger.info(msg)
     Rails.logger.info(err.backtrace.join("\n"))
 
-    Raven.capture_exception(err, [:stats_collector_name] => collector_name)
+    Raven.capture_exception(err, extra: { stats_collector_name: collector_name })
 
     slack_service.send_notification("[ERROR] #{msg}")
   end


### PR DESCRIPTION
@yoomlam, let me know if this was the original intention, to include the name of the stats collector as additional Sentry context under the key `stats_collector_name`.

From looking at our other code, as well as the Raven codebase, this is done by passing an arbitrary hash to the `extra` option in capture_exception.

[Example](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10735/) of a Sentry alert caused by this attempt to log a Sentry alert 😅 