### PR TITLE
[PART 2] Allow transcription tasks to be assigned to users

### DIFF
--- a/app/models/tasks/transcription_task.rb
+++ b/app/models/tasks/transcription_task.rb
@@ -3,11 +3,17 @@
 class TranscriptionTask < Task
   before_create :check_parent_type
 
+  VALID_PARENT_TYPES = [
+    AssignHearingDispositionTask,
+    MissingHearingTranscriptsColocatedTask,
+    TranscriptionTask
+  ].freeze
+
   def check_parent_type
-    unless parent.is_a?(AssignHearingDispositionTask) || parent.is_a?(MissingHearingTranscriptsColocatedTask)
+    unless VALID_PARENT_TYPES.any? { |type| parent.is_a?(type) }
       fail(
         Caseflow::Error::InvalidParentTask,
-        message: "TranscriptionTask parents must be AssignHearingDispositionTask/MissingHearingTranscriptsColocatedTask"
+        message: "TranscriptionTask parents must be #{VALID_PARENT_TYPES.map(&:name).join(" or ")}"
       )
     end
   end

--- a/app/models/tasks/transcription_task.rb
+++ b/app/models/tasks/transcription_task.rb
@@ -13,7 +13,7 @@ class TranscriptionTask < Task
     unless VALID_PARENT_TYPES.any? { |type| parent.is_a?(type) }
       fail(
         Caseflow::Error::InvalidParentTask,
-        message: "TranscriptionTask parents must be #{VALID_PARENT_TYPES.map(&:name).join(" or ")}"
+        message: "TranscriptionTask parents must be #{VALID_PARENT_TYPES.map(&:name).join(' or ')}"
       )
     end
   end

--- a/spec/models/tasks/transcription_task_spec.rb
+++ b/spec/models/tasks/transcription_task_spec.rb
@@ -9,6 +9,52 @@ describe TranscriptionTask, :postgres do
 
   let(:transcription_user) { create(:user) }
 
+  context "check_parent_type" do
+    let(:parent_task_type) { :hearing_task }
+    let(:grand_parent_task_type) { :assign_hearing_disposition_task }
+    let(:grand_parent_task) { create(grand_parent_task_type) }
+    let(:parent_task) { create(parent_task_type, parent: grand_parent_task) }
+    let(:child_task) { create(:transcription_task, parent: parent_task) }
+
+    before { allow_any_instance_of(Task).to receive(:automatically_assign_org_task?).and_return(false) }
+
+    subject { child_task }
+
+    shared_examples "valid parent type" do
+      it "does not throw an error" do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    it "throws an error" do
+      expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask, "TranscriptionTask parents must be " \
+        "AssignHearingDispositionTask or MissingHearingTranscriptsColocatedTask or TranscriptionTask")
+    end
+
+    context "when the task type is valid" do
+      context "transcription_task" do
+        let(:parent_task_type) { :transcription_task }
+
+        it_behaves_like "valid parent type"
+      end
+
+      context "assign_hearing_disposition_task" do
+        let(:grand_parent_task_type) { :hearing_task }
+        let(:parent_task_type) { :assign_hearing_disposition_task }
+
+        it_behaves_like "valid parent type"
+      end
+
+      context "missing_hearing_transcripts_colocated_task" do
+        let(:parent_task) { create(:ama_colocated_task, :missing_hearing_transcripts, parent: grand_parent_task) }
+
+        before { allow_any_instance_of(Task).to receive(:verify_org_task_unique).and_return(nil) }
+
+        it_behaves_like "valid parent type"
+      end
+    end
+  end
+
   context "#update_from_params" do
     context "When cancelled" do
       let(:update_params) do

--- a/spec/models/tasks/transcription_task_spec.rb
+++ b/spec/models/tasks/transcription_task_spec.rb
@@ -14,21 +14,23 @@ describe TranscriptionTask, :postgres do
     let(:grand_parent_task_type) { :assign_hearing_disposition_task }
     let(:grand_parent_task) { create(grand_parent_task_type) }
     let(:parent_task) { create(parent_task_type, parent: grand_parent_task) }
-    let(:child_task) { create(:transcription_task, parent: parent_task) }
 
     before { allow_any_instance_of(Task).to receive(:automatically_assign_org_task?).and_return(false) }
 
-    subject { child_task }
+    subject { create(:transcription_task, parent: parent_task) }
 
     shared_examples "valid parent type" do
       it "does not throw an error" do
         expect { subject }.not_to raise_error
+        expect(parent_task.children.length).to eq 1
+        expect(parent_task.children.first.type).to eq TranscriptionTask.name
       end
     end
 
-    it "throws an error" do
+    it "throws an error because parent task type is invalid" do
       expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask, "TranscriptionTask parents must be " \
         "AssignHearingDispositionTask or MissingHearingTranscriptsColocatedTask or TranscriptionTask")
+      expect(parent_task.children.length).to eq 0
     end
 
     context "when the task type is valid" do
@@ -48,7 +50,8 @@ describe TranscriptionTask, :postgres do
       context "missing_hearing_transcripts_colocated_task" do
         let(:parent_task) { create(:ama_colocated_task, :missing_hearing_transcripts, parent: grand_parent_task) }
 
-        before { allow_any_instance_of(Task).to receive(:verify_org_task_unique).and_return(nil) }
+        # missing_hearing_transcripts automatically create a child transcription task
+        subject { create(parent_task_type, parent: grand_parent_task) }
 
         it_behaves_like "valid parent type"
       end


### PR DESCRIPTION
Resolves [this](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10745) sentry alert

### Description
Allows the parents of transcription tasks to be transcription tasks!

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Make a transcription admin
   ```ruby
   OrganizationsUser.make_user_admin(TranscriptionTeam.singleton.users.first, TranscriptionTeam.singleton)
   ```
1. Make some transcription tasks
   ```ruby
   RequestStore[:current_user] = User.system_user
   20.times { |i| FactoryBot.create(:colocated_task, :missing_hearing_transcripts, assigned_to: TranscriptionTeam.singleton, assigned_by: User.first, appeal: LegacyAppeal.find(i + 1)) }
   ```
1. Log in as TRANSCRIPTION_USER
1. Go to the transcription queue by going to the users queue, clicking the switch views dropdown, and selecting transcription team
1. Ensure the user can bulk assign tasks
![Screen Shot 2020-06-19 at 12 36 35 PM](https://user-images.githubusercontent.com/45575454/85157541-9e739680-b229-11ea-9527-fdddfa90fb5a.png)
![Screen Shot 2020-06-19 at 12 37 10 PM](https://user-images.githubusercontent.com/45575454/85157556-a0d5f080-b229-11ea-9a72-59a19a9b88e6.png)
![Screen Shot 2020-06-19 at 12 36 48 PM](https://user-images.githubusercontent.com/45575454/85157566-a3384a80-b229-11ea-9ec1-aa7944919309.png)


### NOTE
The odd refresh is a known error: #11190