### PR TITLE
Fix undefined method update_vacols_location for nil:NilClass on dangling legacy appeals

### DIFF
--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -36,7 +36,7 @@ class NightlySyncsJob < CaseflowJob
       else
         # if we have tasks and no case_record, then we need to cancel all the tasks,
         # but we do not delete the dangling LegacyAppeal record.
-        legacy_appeal.tasks.open.each(&:cancelled!)
+        legacy_appeal.tasks.open.where(parent_id: nil).each(&:cancel_task_and_child_subtasks)
       end
     end
     datadog_report_time_segment(segment: "sync_cases_from_vacols", start_time: start_time)

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -52,7 +52,7 @@ describe NightlySyncsJob, :all_dbs do
         end
       end
 
-      fcontext "with open hearing tasks" do
+      context "with open hearing tasks" do
         let!(:legacy_appeal) { create(:legacy_appeal, :with_schedule_hearing_tasks) }
 
         it "cancels all open tasks and leaves the legacy appeal intact without throwing an error" do

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -51,6 +51,17 @@ describe NightlySyncsJob, :all_dbs do
           expect(legacy_appeal.reload.tasks.open).to be_empty
         end
       end
+
+      fcontext "with open hearing tasks" do
+        let!(:legacy_appeal) { create(:legacy_appeal, :with_schedule_hearing_tasks) }
+
+        it "cancels all open tasks and leaves the legacy appeal intact without throwing an error" do
+          subject
+
+          expect(legacy_appeal.reload).to_not be_nil
+          expect(legacy_appeal.reload.tasks.open).to be_empty
+        end
+      end
     end
 
     context "open DecisionReviewTasks" do


### PR DESCRIPTION
Resolves [this](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10772/?referrer=webhooks_plugin) sentry alert

### Description
When we find a dangling legacy appeal (we have an appeal in caseflow but the vacols record has been deleted) we cancel all open tasks on the appeal. This triggers a callback on hearing tasks that tries updates the vacols location of the appeal (which causes as error as there is no case record to update the location on).

### Acceptance Criteria
- [ ] Hearing tasks on dangling legacy appeals are cancelled without an error
