### PR TITLE
Workaround VA SSL CA cert bug

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -93,6 +93,7 @@ detectors:
       - Seeds::Hearings
       - Seeds::Tasks#create_colocated_legacy_tasks
       - Seeds::Users#create_aod_user_and_tasks
+      - SlackService#http_service
       - SyncReviewsJob
       - TaskTimerJob
       - UpdateCachedAppealsAttributesJob

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -26,7 +26,13 @@ class SlackService
   private
 
   def http_service
-    HTTPClient.new
+    @http_service ||= begin
+      # we do not want the self-signed cert normally part of the HTTPClient CA chain.
+      client = HTTPClient.new
+      client.ssl_config.clear_cert_store
+      client.ssl_config.add_trust_ca(ENV["SSL_CERT_FILE"])
+      client
+    end
   end
 
   def pick_color(title, msg)

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -3,10 +3,14 @@
 describe SlackService do
   let(:slack_service) { SlackService.new(url: "http://www.example.com") }
   let(:http_agent) { double("http") }
+  let(:ssl_config) { double("ssl") }
 
   before do
     @http_params = nil
     allow(HTTPClient).to receive(:new) { http_agent }
+    allow(http_agent).to receive(:ssl_config) { ssl_config }
+    allow(ssl_config).to receive(:clear_cert_store) { true }
+    allow(ssl_config).to receive(:add_trust_ca) { true }
     allow(http_agent).to receive(:post) do |_url, params|
       @http_params = params
       "response"


### PR DESCRIPTION
See https://dsva.slack.com/archives/C2ZAMLK88/p1592833792309400

### Description

HTTPClient SSL config by default includes both `SSL_CERT_FILE` env var and its own self-signed certificate. Changes within the VA network in how TLS/SSL is handled started breaking on the self-signed CA cert. This change excludes it.