### PR TITLE
Update issue sync error copy

### DIFF
--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -86,8 +86,10 @@ module IssueUpdater
 
   def fail_if_count_mismatch!
     if (issues || []).count != appeal.undecided_issues.count
-      msg = "Number of issues in the request does not match the number in the database"
-      fail Caseflow::Error::AttorneyJudgeCheckoutError, message: msg
+      title = "Issues have fallen out of sync"
+      msg = "The number of issues with decisions does not match the number of issues in the database. Please refresh " \
+            "the page and submit your decision again."
+      fail Caseflow::Error::AttorneyJudgeCheckoutError, message: msg, title: title
     end
   end
 

--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -86,9 +86,8 @@ module IssueUpdater
 
   def fail_if_count_mismatch!
     if (issues || []).count != appeal.undecided_issues.count
-      title = "Issues have fallen out of sync"
-      msg = "The number of issues with decisions does not match the number of issues in the database. Please refresh " \
-            "the page and submit your decision again."
+      title = "The issues are out of sync"
+      msg = "The issues on this case have changed. Please refresh the page and submit your decision again."
       fail Caseflow::Error::AttorneyJudgeCheckoutError, message: msg, title: title
     end
   end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -171,6 +171,7 @@ module Caseflow::Error
     def initialize(args)
       @code = args[:code] || 400
       @message = args[:message]
+      @title = args[:title]
     end
   end
 


### PR DESCRIPTION
### Description
Provides a more descriptive and actionable error for when issues on the front end do not match the issues in vacols

### Testing Plan
1. Log in as bvaabshire and go through judge checkout for any legacy appeal with issues
1. Before hitting "submit", delete some issues on the back end
   ```ruby
   vacols_id = "2520489"
   vacols_sequence_ids = LegacyAppeal.find_by(vacols_id: vacols_id).issues.map(&:vacols_sequence_id)
   vacols_sequence_ids.each do |id|
     Issue.delete_in_vacols!(vacols_id: vacols_id, vacols_sequence_id: id)
   end
   LegacyAppeal.find_by(vacols_id: vacols_id).issues.count
   => 0
   ```
1. Hit submit, notice new error copy.
   
### User Facing Changes

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-06-22 at 12 19 29 PM](https://user-images.githubusercontent.com/45575454/85313826-99f7e980-b486-11ea-9bd7-0a82498e2014.png)|![Screen Shot 2020-06-22 at 2 20 54 PM](https://user-images.githubusercontent.com/45575454/85322041-adf61800-b493-11ea-99f8-7b0eb703ea2e.png)

