### PR TITLE
Fix TypeError vetNameFromAppeal(app/queue/AssignToView) on veteran info 500

### DIFF
--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -25,14 +25,6 @@ const selectedAction = (props) => {
   return actionData.selected ? actionData.options.find((option) => option.value === actionData.selected.id) : null;
 };
 
-const vetNameFromAppeal = (appeal) => {
-  const {
-    veteranInfo: { veteran }
-  } = appeal;
-
-  return veteran.full_name;
-};
-
 const getAction = (props) => {
   return props.task && props.task.availableActions.length > 0 ? selectedAction(props) : null;
 };
@@ -95,7 +87,7 @@ class AssignToView extends React.Component {
 
     const pulacCerulloSuccessMessage = {
       title: COPY.PULAC_CERULLO_SUCCESS_TITLE,
-      detail: sprintf(COPY.PULAC_CERULLO_SUCCESS_DETAIL, vetNameFromAppeal(appeal))
+      detail: sprintf(COPY.PULAC_CERULLO_SUCCESS_DETAIL, appeal.veteranFullName)
     };
 
     if (isReassignAction) {
@@ -265,7 +257,8 @@ AssignToView.propTypes = {
     type: PropTypes.string
   }),
   setOvertime: PropTypes.func,
-  resetSuccessMessages: PropTypes.func
+  resetSuccessMessages: PropTypes.func,
+  veteranFullName: PropTypes.string
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -239,7 +239,8 @@ class AssignToView extends React.Component {
 AssignToView.propTypes = {
   appeal: PropTypes.shape({
     externalId: PropTypes.string,
-    id: PropTypes.string
+    id: PropTypes.string,
+    veteranFullName: PropTypes.string
   }),
   assigneeAlreadySelected: PropTypes.bool,
   highlightFormItems: PropTypes.bool,
@@ -257,8 +258,7 @@ AssignToView.propTypes = {
     type: PropTypes.string
   }),
   setOvertime: PropTypes.func,
-  resetSuccessMessages: PropTypes.func,
-  veteranFullName: PropTypes.string
+  resetSuccessMessages: PropTypes.func
 };
 
 const mapStateToProps = (state, ownProps) => {


### PR DESCRIPTION
Resolves [this](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10747/?referrer=webhooks_plugin) sentry alert

### Description
When the veteran info endpoint returns an error, we try to pull the veteran's info from an undefinded object. We have the veteran full name on the appeal object anyway. This change updates the PULAC_CERULLO_SUCCESS_DETAIL to pull the full name of the vet from the appeal. This will front end failures due to back end 500s on veteran information.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1.[ Update veteran endpoint to return an error](https://github.com/department-of-veterans-affairs/caseflow/blob/ba8b8ad060d7d37c1c38a7df1eefd0fc41c411b6/app/controllers/appeals_controller.rb#L84)
  ```ruby
  def veteran
    fail Caseflow::Error::ActionForbiddenError
  end
  ```
1. Log in as bvaaaabshire
1. Go to your queue and select any ama case
1. Make this appeal's stream 'vacate'
   ```ruby
   Appeal.find_by(uuid: "c55d8fca-a632-49c8-bb3b-f9a46092511e").vacate!
   Appeal.find_by(uuid: "c55d8fca-a632-49c8-bb3b-f9a46092511e").vacate?
   => true
   ```
1. Select "Notify Litigation Support of Possible Conflict of Jurisdiction" from the dropdown
1. Ensure the request submits successfully and the veteran's name appears in the success banner.

### User Facing Changes
 - [ ] NONE

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-06-22 at 1 21 14 PM](https://user-images.githubusercontent.com/45575454/85316767-489e2900-b48b-11ea-8518-6cd22a0bafa5.png)|![Screen Shot 2020-06-22 at 1 21 14 PM](https://user-images.githubusercontent.com/45575454/85316767-489e2900-b48b-11ea-8518-6cd22a0bafa5.png)