### PR TITLE
Remove case from judge and attorney queue when scheduling hearing

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -153,7 +153,7 @@ class ColocatedTask < Task
   def update_location_in_vacols
     if saved_change_to_status? &&
        !open? &&
-       all_tasks_closed_for_appeal? &&
+       all_colocated_tasks_closed_for_appeal? &&
        appeal_in_caseflow_vacols_location? &&
        assigned_to.is_a?(Organization)
       AppealRepository.update_location!(appeal, vacols_location)
@@ -172,7 +172,7 @@ class ColocatedTask < Task
     assigned_by.vacols_uniq_id
   end
 
-  def all_tasks_closed_for_appeal?
+  def all_colocated_tasks_closed_for_appeal?
     appeal.tasks.open.select { |task| task.is_a?(ColocatedTask) }.none?
   end
 

--- a/app/models/tasks/schedule_hearing_colocated_task.rb
+++ b/app/models/tasks/schedule_hearing_colocated_task.rb
@@ -48,6 +48,6 @@ class ScheduleHearingColocatedTask < ColocatedTask
     parent = DistributionTask.create!(appeal: appeal, parent: appeal.root_task)
     ScheduleHearingTask.create!(appeal: appeal, parent: parent)
     JudgeTask.open.where(appeal: appeal).find_each(&:cancel_task_and_child_subtasks)
-    DistributedCase.find_by(case_id: appeal.uuid).update!(case_id: "#{appeal.uuid}-attempt1")
+    DistributedCase.find_by(case_id: appeal.uuid)&.update!(case_id: "#{appeal.uuid}-attempt1")
   end
 end

--- a/app/models/tasks/schedule_hearing_colocated_task.rb
+++ b/app/models/tasks/schedule_hearing_colocated_task.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ScheduleHearingColocatedTask < ColocatedTask
-  after_update :send_to_hearings_branch, if: :just_completed?
+  after_update :send_to_hearings_branch, if: :just_completed_ama_organization_task?
 
   def self.label
     Constants.CO_LOCATED_ADMIN_ACTIONS.schedule_hearing
@@ -36,11 +36,10 @@ class ScheduleHearingColocatedTask < ColocatedTask
     LegacyAppeal::LOCATION_CODES[:schedule_hearing]
   end
 
-  def just_completed?
+  def just_completed_ama_organization_task?
     appeal_type.eql?(Appeal.name) &&
       saved_change_to_status? &&
       completed? &&
-      all_tasks_closed_for_appeal? &&
       assigned_to.is_a?(Organization)
   end
 

--- a/app/models/tasks/schedule_hearing_colocated_task.rb
+++ b/app/models/tasks/schedule_hearing_colocated_task.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ScheduleHearingColocatedTask < ColocatedTask
-  after_update :create_schedule_hearing_task_on_completion
+  after_update :send_to_hearings_branch, if: :just_completed?
 
   def self.label
     Constants.CO_LOCATED_ADMIN_ACTIONS.schedule_hearing
@@ -36,13 +36,18 @@ class ScheduleHearingColocatedTask < ColocatedTask
     LegacyAppeal::LOCATION_CODES[:schedule_hearing]
   end
 
-  def create_schedule_hearing_task_on_completion
-    if appeal_type.eql?(Appeal.name) &&
-       saved_change_to_status? &&
-       completed? &&
-       all_tasks_closed_for_appeal? &&
-       assigned_to.is_a?(Organization)
-      ScheduleHearingTask.create!(appeal: appeal, parent: appeal.root_task)
-    end
+  def just_completed?
+    appeal_type.eql?(Appeal.name) &&
+      saved_change_to_status? &&
+      completed? &&
+      all_tasks_closed_for_appeal? &&
+      assigned_to.is_a?(Organization)
+  end
+
+  def send_to_hearings_branch
+    parent = DistributionTask.create!(appeal: appeal, parent: appeal.root_task)
+    ScheduleHearingTask.create!(appeal: appeal, parent: parent)
+    JudgeTask.open.where(appeal: appeal).find_each(&:cancel_task_and_child_subtasks)
+    DistributedCase.find_by(case_id: appeal.uuid).update!(case_id: "#{appeal.uuid}-attempt1")
   end
 end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -179,14 +179,6 @@ FactoryBot.define do
     trait :assigned_to_judge do
       ready_for_distribution
       after(:create) do |appeal, evaluator|
-        DistributedCase.create!(
-          distribution: create(:distribution, judge: evaluator.associated_judge),
-          ready_at: Time.zone.now,
-          docket: appeal.docket_type,
-          priority: false,
-          case_id: appeal.uuid,
-          task: appeal.tasks.where(type: DistributionTask.name).first
-        )
         JudgeAssignTask.create!(appeal: appeal,
                                 parent: appeal.root_task,
                                 assigned_at: evaluator.active_task_assigned_at,

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -179,6 +179,14 @@ FactoryBot.define do
     trait :assigned_to_judge do
       ready_for_distribution
       after(:create) do |appeal, evaluator|
+        DistributedCase.create!(
+          distribution: create(:distribution, judge: evaluator.associated_judge),
+          ready_at: Time.zone.now,
+          docket: appeal.docket_type,
+          priority: false,
+          case_id: appeal.uuid,
+          task: appeal.tasks.where(type: DistributionTask.name).first
+        )
         JudgeAssignTask.create!(appeal: appeal,
                                 parent: appeal.root_task,
                                 assigned_at: evaluator.active_task_assigned_at,

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -769,7 +769,9 @@ feature "Task queue", :all_dbs do
           find("div", class: "Select-option", text: Constants.TASK_ACTIONS.SCHEDULE_HEARING_SEND_TO_TEAM.label).click
           find("button", text: "Send case").click
           expect(page).to have_content("Bob Smith's case has been sent to the Confirm schedule hearing team")
-          expect(appeal.tasks.pluck(:type)).to include(ScheduleHearingTask.name, HearingTask.name)
+          expect(appeal.tasks.pluck(:type)).to include(
+            ScheduleHearingTask.name, HearingTask.name, DistributionTask.name
+          )
         end
       end
     end

--- a/spec/models/tasks/schedule_hearing_colocated_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_colocated_task_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+describe ScheduleHearingColocatedTask, :all_dbs do
+  fdescribe ".completed!" do
+    let(:appeal) { create(:appeal, :at_attorney_drafting) }
+    let(:parent) { AttorneyTask.find_by(appeal: appeal) }
+    let!(:schedule_hearing_colocated_task) { create(:colocated_task, :schedule_hearing, appeal: appeal, parent: parent) }
+
+    subject { schedule_hearing_colocated_task.completed! }
+
+    it "should send the appeal back to the hearings branch" do
+      expect(DistributionTask.where(appeal: appeal).count).to eq 1
+      expect(HearingTask.where(appeal: appeal).count).to eq 0
+      expect(ScheduleHearingTask.where(appeal: appeal).count).to eq 0
+      expect(DistributionTask.where(appeal: appeal).count).to eq 1
+      expect(JudgeDecisionReviewTask.find_by(appeal: appeal).status).to eq Task.statuses[:on_hold]
+      expect(AttorneyTask.find_by(appeal: appeal).status).to eq Task.statuses[:on_hold]
+      expect(ScheduleHearingColocatedTask.find_by(appeal: appeal).status).to eq Task.statuses[:assigned]
+      distributed_case = DistributedCase.find_by(case_id: appeal.uuid)
+      expect(distributed_case.case_id).to eq appeal.uuid
+
+      subject
+
+      expect(DistributionTask.where(appeal: appeal).count).to eq 2
+      expect(HearingTask.where(appeal: appeal).count).to eq 1
+      expect(ScheduleHearingTask.where(appeal: appeal).count).to eq 1
+      expect(JudgeDecisionReviewTask.find_by(appeal: appeal).status).to eq Task.statuses[:cancelled]
+      expect(AttorneyTask.find_by(appeal: appeal).status).to eq Task.statuses[:cancelled]
+      expect(ScheduleHearingColocatedTask.find_by(appeal: appeal).status).to eq Task.statuses[:completed]
+      expect(distributed_case.reload.case_id).to eq "#{appeal.uuid}-attempt1"
+    end
+  end
+end

--- a/spec/models/tasks/schedule_hearing_colocated_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_colocated_task_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe ScheduleHearingColocatedTask, :all_dbs do
-  fdescribe ".completed!" do
+  describe ".completed!" do
     let(:appeal) { create(:appeal, :at_attorney_drafting) }
     let(:parent) { AttorneyTask.find_by(appeal: appeal) }
     let!(:schedule_hearing_colocated_task) { create(:colocated_task, :schedule_hearing, appeal: appeal, parent: parent) }


### PR DESCRIPTION
Bumps #9781

### Description
Removes a case from a judge or attorneys queue when scheduling a hearing. Makes the case ready to be redistributed as well.

### Acceptance Criteria
- [x] When a schedule hearing colocated task is completed
   - [x] The judge or attorney task parent is cancelled
   - [x] A hearing and schedule hearing task are created under a distribution task
   - [x] The previous distributed case is updated to allow for a redistribution

### Testing Plan
1. Log in as BVATWARNER
1. Go to the hearings management queue
1. Select an AMA Confirm Schedule Hearing task and confirm the appeal needs a schedule hearing task created
   ```ruby
   appeal = Appeal.find_by_uuid("63f6662d-4ddd-4091-bff5-5606bc2a95b9")
   judge = JudgeTask.find_by(appeal: appeal).assigned_to
   JudgeAssignTask.open.where(assigned_to: judge).each(&:cancelled!)
   Distribution.pending_for_judge(judge).destroy
   DistributedCase.create!(
     distribution: FactoryBot.create(:distribution, judge: judge),
     ready_at: Time.zone.now,
     docket: appeal.docket_type,
     priority: false,
     case_id: appeal.uuid,
     task: appeal.tasks.first
   )
   appeal.treee
   Appeal 547 (evidence_submission)              ID   STATUS   ASGN_BY     ASGN_TO            UPDATED_AT
   └── RootTask                                  1452 on_hold              Bva                2020-06-12 14:02:18 UTC
       └── JudgeDecisionReviewTask               1453 on_hold  CSS_ID610   BVAAABSHIRE        2020-06-12 14:02:19 UTC
           └── AttorneyTask                      1454 on_hold  BVAAABSHIRE BVASCASPER1        2020-06-12 14:02:19 UTC
               └── ScheduleHearingColocatedTask  1455 assigned BVASCASPER1 HearingsManagement 2020-06-12 14:02:19 UTC
1. Confirm the ac
```ruby
appeal.reload.treee
Appeal 547 (evidence_submission)              ID   STATUS    ASGN_BY     ASGN_TO            UPDATED_AT
└── RootTask                                  1452 on_hold               Bva                2020-06-12 14:02:18 UTC
    ├── JudgeDecisionReviewTask               1453 cancelled CSS_ID610   BVAAABSHIRE        2020-06-12 14:02:19 UTC
    │   └── AttorneyTask                      1454 cancelled BVAAABSHIRE BVASCASPER1        2020-06-22 21:27:22 UTC
    │       └── ScheduleHearingColocatedTask  1455 completed BVASCASPER1 HearingsManagement 2020-06-22 21:27:22 UTC
    └── DistributionTask                      2747 on_hold               Bva                2020-06-22 21:27:22 UTC
        └── HearingTask                       2748 on_hold               Bva                2020-06-22 21:27:22 UTC
            └── ScheduleHearingTask           2749 assigned              Bva                2020-06-22 21:27:22 UTC
DistributedCase.find_by("case_id LIKE ?", "%#{appeal.uuid}%").case_id
=> "63f6662d-4ddd-4091-bff5-5606bc2a95b9-attempt1"
```