### PR TITLE
Set Sentry application for PostDecisionMotions endpoints

### DIFF
--- a/app/controllers/post_decision_motions_controller.rb
+++ b/app/controllers/post_decision_motions_controller.rb
@@ -3,6 +3,10 @@
 class PostDecisionMotionsController < ApplicationController
   before_action :verify_task_access, only: [:create, :return_to_lit_support, :return_to_judge]
 
+  def set_application
+    RequestStore.store[:application] = "queue"
+  end
+
   def create
     motion_updater = PostDecisionMotionUpdater.new(task, motion_params)
     motion_updater.process


### PR DESCRIPTION
### Description
Rails errors from PostDecisionMotionsController are getting sent by Sentry to #appeals-app-alerts (e.g. [this one](https://dsva.slack.com/archives/C4JECDLSE/p1592849542480500)).

For starters, PDMC should set its `application` for Sentry. In the future, we may also want to consider adding a new application for PDMs in sentry-to-slack/handler.js so that they can more easily be routed to 🦊.