### PR TITLE
Fix Cannot read property 'length' of undefined in QueueTableBuilder

### DIFF
--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -54,7 +54,7 @@ class QueueTableBuilder extends React.PureComponent {
       [QUEUE_CONFIG.INDIVIDUALLY_COMPLETED_TASKS_TAB_NAME]: this.props.completedTasks
     };
 
-    return mapper[tabName];
+    return mapper[tabName] || [];
   }
 
   filterValuesForColumn = (column) => column && column.filterable && column.filter_options;


### PR DESCRIPTION
Resolves [this](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10744/?referrer=webhooks_plugin) sentry alert. Resolves #14439

### Description
There is an odd transitional state where queue table builder is called  before queue loading screen. This fixes the white screen of death, but not the root cause

### Acceptance Criteria
- [ ] Judge user can navigate from their attorney assign queue to their own queue through the navigation bar without a white screen of death.

### Testing Plan
1. Log in as BVAAASHIRE
1. Navigate to your assign queue for a specific attorney (http://localhost:3000/queue/BVAAABSHIRE/assign/71)
1. Click “Queue” in the navigation bar
1. No white screen of death