### PR TITLE
Add benefit type validation on when adding decision issues

### DIFF
--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -158,11 +158,12 @@ class SelectDispositionsView extends React.PureComponent {
     });
   }
 
+  validBenefitType = (benefitType) => Object.keys(BENEFIT_TYPES).includes(benefitType);
+
   validate = () => {
     const { decisionIssue } = this.state;
 
-    return decisionIssue.benefit_type && decisionIssue.disposition &&
-      decisionIssue.description;
+    return this.validBenefitType(decisionIssue.benefit_type) && decisionIssue.disposition && decisionIssue.description;
   }
 
   saveDecision = () => {
@@ -374,6 +375,8 @@ class SelectDispositionsView extends React.PureComponent {
           name="Benefit type"
           placeholder={COPY.DECISION_ISSUE_MODAL_BENEFIT_TYPE}
           hideLabel
+          errorMessage={highlightModal && !this.validBenefitType(decisionIssue.benefit_type) ?
+            'This field is required' : null}
           value={decisionIssue.benefit_type}
           options={_.map(BENEFIT_TYPES, (value, key) => ({ label: value,
             value: key }))}


### PR DESCRIPTION
Resolves #13164

### Description
This sentry alert is being thrown because 'unidentified' decision issues are being passed to the back end, where they fail validation. This add validation to the front end so the user can know where their mistake is before they try to completed checkout. 

### Acceptance Criteria
- [ ] Benefit type is a required field when completing judge/attorney checkout

### Testing Plan
1. Log in as a judge or an attorney and go to any ama appeal waiting for your decision
1. Update one of the request issues to have an "unidentified" benefit type
   ```ruby
   appeal = Appeal.find_by(uuid: "184c9236-bf5c-4168-b431-7aebce98bdab")
   appeal.request_issues.first.update!(benefit_type: "unidentified")
   ```
1. Go through your checkout flow by selecting "Decision ready for (review|dispatch)"
1. When adding a disposition for the issue with the "unidentified" benefit type, confirm this dropdown is not populated and will show an error if the user tries to submit without selecting a valid benefit type.
![Screen Shot 2020-06-23 at 11 45 00 AM](https://user-images.githubusercontent.com/45575454/85426183-21596180-b548-11ea-8060-4ee1c7431b57.png)
![Screen Shot 2020-06-23 at 11 45 14 AM](https://user-images.githubusercontent.com/45575454/85426191-23bbbb80-b548-11ea-8f5c-194486bfdef1.png)
