### PR TITLE
Add ruby-prof gem for performance profiling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -128,6 +128,7 @@ group :development do
   gem "foreman"
   gem "meta_request"
   gem "rails-erd"
+  gem "ruby-prof", "~> 1.4"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,6 +533,7 @@ GEM
     ruby-graphviz (1.2.4)
     ruby-oci8 (2.2.7)
     ruby-plsql (0.7.1)
+    ruby-prof (1.4.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     ruby_parser (3.13.1)
@@ -711,6 +712,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   ruby-oci8 (~> 2.2)
+  ruby-prof (~> 1.4)
   sass-rails (~> 5.0)
   scss_lint
   sentry-raven

--- a/config/application.rb
+++ b/config/application.rb
@@ -63,6 +63,16 @@ module CaseflowCertification
     # it's a safe assumption we're running on us-gov-west-1
     ENV["AWS_REGION"] ||= "us-gov-west-1"
 
+    if Rails.env.development? && ENV["PERFORMANCE_PROFILE"].present?
+      config.middleware.use(
+        Rack::RubyProf,
+        path: './tmp/profile',
+        printers: {
+          ::RubyProf::CallTreePrinter => 'test-callgrind'
+        }
+      )
+    end
+
     # :nocov:
     if %w[development ssh_forwarding staging].include?(Rails.env)
       # configure pry


### PR DESCRIPTION
### Description

Adds `ruby-prof` for performance profiling

See wiki documentation for a general approach: https://github.com/department-of-veterans-affairs/caseflow/wiki/Backend-Performance-Profiling