### PR TITLE
Fix Styling Issue with Tab Panels

### DIFF
--- a/client/app/components/tabs/Tabs.module.scss
+++ b/client/app/components/tabs/Tabs.module.scss
@@ -2,9 +2,11 @@
   :local(.tab-panel) {
     opacity: 0;
     transition: opacity 0.15s linear;
+    display: none;
 
     &.active {
       opacity: 1;
+      display: block;
     }
 
     &.full-width {


### PR DESCRIPTION
### Description
This just restores a couple of missing styles to fix a layout issue with tab panels when not using `mountOnEnter` / `unmountOnExit`

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Visible tabs don't get vertically offset due to hidden tabs
