### PR TITLE
Make docket range job idempotent

### DIFF
--- a/app/jobs/docket_range_job.rb
+++ b/app/jobs/docket_range_job.rb
@@ -3,21 +3,31 @@
 # job that sets appeals that are in docket range for the upcoming month
 
 class DocketRangeJob < ApplicationJob
+  class << self
+    def end_of_time_period
+      one_month_from_now.end_of_month
+    end
+
+    def one_month_from_now
+      Time.zone.now + 1.month
+    end
+
+    def number_of_days_in_next_month_from_now
+      Time.days_in_month(one_month_from_now.month, one_month_from_now.year).days
+    end
+  end
+
   queue_with_priority :low_priority
 
   def perform
-    DocketCoordinator.new
-      .upcoming_appeals_in_range(number_of_days_in_next_month_from_now)
-      .update(docket_range_date: one_month_from_now.end_of_month)
-  end
-
-  private
-
-  def one_month_from_now
-    Time.zone.now + 1.month
-  end
-
-  def number_of_days_in_next_month_from_now
-    Time.days_in_month(one_month_from_now.month, one_month_from_now.year).days
+    DocketCoordinator
+      .new
+      .upcoming_appeals_in_range(
+        self.class.number_of_days_in_next_month_from_now,
+        self.class.end_of_time_period
+      )
+      .update(
+        docket_range_date: self.class.end_of_time_period
+      )
   end
 end

--- a/app/models/docket_coordinator.rb
+++ b/app/models/docket_coordinator.rb
@@ -92,7 +92,7 @@ class DocketCoordinator
     dockets[:hearing]
       .appeals(priority: false)
       .where(docket_range_date: [nil, end_of_time_period])
-      .order('docket_range_date DESC NULLS LAST')
+      .order("docket_range_date DESC NULLS LAST")
       .limit(target)
   end
 

--- a/app/models/docket_coordinator.rb
+++ b/app/models/docket_coordinator.rb
@@ -80,9 +80,20 @@ class DocketCoordinator
 
   # Determines which non-priority appeals to schedule for a hearing for a given
   # time period in DAYS.
-  def upcoming_appeals_in_range(time_period)
+  #
+  # @param time_period [Numeric] The number of days in the time period
+  # @param end_of_time_period [Date] The date of last day in the time period
+  #
+  # @return [ActiveRecord::Relation]
+  #   The appeals that should be scheduled in the given time period
+  def upcoming_appeals_in_range(time_period, end_of_time_period)
     target = target_number_of_ama_hearings(time_period)
-    dockets[:hearing].appeals(priority: false).where(docket_range_date: nil).limit(target)
+
+    dockets[:hearing]
+      .appeals(priority: false)
+      .where(docket_range_date: [nil, end_of_time_period])
+      .order('docket_range_date DESC NULLS LAST')
+      .limit(target)
   end
 
   def priority_count

--- a/spec/jobs/docket_range_job_spec.rb
+++ b/spec/jobs/docket_range_job_spec.rb
@@ -1,23 +1,28 @@
 # frozen_string_literal: true
 
-require "faker"
-
-describe DocketRangeJob, :postgres do
+describe DocketRangeJob do
   describe "#perform" do
     let(:today) { Time.zone.now }
     let(:docket_coord) { DocketCoordinator.new }
+    let(:appeals_with_nil_docket_range_date) { 16 }
+    let(:target_number_of_appeals) { 15 }
+
     before do
+      docket_range_date = Time.utc(today.year, today.month, 1)
+
       30.times do |index|
-        create(:appeal,
-               :with_post_intake_tasks,
-               docket_range_date: (index < 16) ? nil : Time.utc(today.year, today.month, 1))
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          docket_range_date: (index < appeals_with_nil_docket_range_date) ? nil : docket_range_date
+        )
       end
 
       allow(DocketCoordinator).to receive(:new)
         .and_return(docket_coord)
 
       allow(docket_coord).to receive(:target_number_of_ama_hearings)
-        .and_return(15)
+        .and_return(target_number_of_appeals)
 
       allow(docket_coord.dockets[:hearing]).to receive(:appeals)
         .and_return(Appeal.all)
@@ -25,9 +30,44 @@ describe DocketRangeJob, :postgres do
 
     it "adds docket_range_date to last 15 appeals" do
       DocketRangeJob.perform_now
-      expected_date = (today + 1.month).end_of_month
-      appeals = Appeal.where(docket_range_date: expected_date)
-      expect(appeals.count).to eq(15)
+
+      appeals = Appeal.where(docket_range_date: DocketRangeJob.end_of_time_period)
+      expect(appeals.count).to eq(target_number_of_appeals)
+    end
+
+    it "results do not change when job is run multiple times" do
+      DocketRangeJob.perform_now
+      DocketRangeJob.perform_now
+      DocketRangeJob.perform_now
+
+      appeals = Appeal.where(docket_range_date: DocketRangeJob.end_of_time_period)
+      expect(appeals.count).to eq(target_number_of_appeals)
+    end
+
+    it "covers untouched appeals in next month" do
+      DocketRangeJob.perform_now
+
+      expect(
+        Appeal
+          .where(docket_range_date: DocketRangeJob.end_of_time_period)
+          .count
+      ).to eq(target_number_of_appeals)
+
+      # Ensure if job starts next month, it will modify a different set of appeals
+      Timecop.freeze((today + 1.month).beginning_of_month) do
+        DocketRangeJob.perform_now
+
+        expect(
+          Appeal
+            .where(docket_range_date: DocketRangeJob.end_of_time_period)
+            .count
+        ).to eq(appeals_with_nil_docket_range_date - target_number_of_appeals)
+      end
+
+      # Ensure all appeals have docket_range_job field populated
+      expect(
+        Appeal.where.not(docket_range_date: nil).count
+      ).to eq(30)
     end
   end
 end

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -93,7 +93,7 @@ describe DocketCoordinator do
         :with_post_intake_tasks,
         docket_type: Constants.AMA_DOCKETS.direct_review,
         receipt_date: (days_before_goal_due + 1).days.ago,
-        target_decision_date: (days_to_decision_goal - days_before_goal_due - 1).days.from_now
+        target_decision_date: (days_to_decision_goal - days_before_goal_due + 35).days.from_now
       )
     end
   end
@@ -198,7 +198,7 @@ describe DocketCoordinator do
     let(:nonpriority_decisions_per_year) { 1340 }
     let(:nonpriority_legacy_count) { 80 }
 
-    it "uses the pacesetting direct review proportion", skip: "change to 90 day window invalidates these numbers" do
+    it "uses the pacesetting direct review proportion" do
       expect(docket_coordinator.docket_proportions).to include(
         legacy: 0.8,
         evidence_submission: 0.05,

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -75,10 +75,10 @@ describe DocketCoordinator do
     (0...due_direct_review_count).map do
       create(
         :appeal,
-         :with_post_intake_tasks,
-         docket_type: Constants.AMA_DOCKETS.direct_review,
-         receipt_date: 11.months.ago,
-         target_decision_date: 1.month.from_now
+        :with_post_intake_tasks,
+        docket_type: Constants.AMA_DOCKETS.direct_review,
+        receipt_date: 11.months.ago,
+        target_decision_date: 1.month.from_now
       )
     end
   end


### PR DESCRIPTION
Resolves #14455

Setup cronjob: https://github.com/department-of-veterans-affairs/appeals-lambdas/pull/71

### Description

  * Update job to look search for appeals that already have a docket range set in the current period
  * Add tests related to running the `DocketRangeJob` multiple times

> Do we need to backfill any appeals? What are the implications?

I don't think so. Basically any un-worked appeal should get grouped together for the next month's docket.

### Acceptance Criteria
- [ ] The job is modified to be idempotent
- [ ] The job is scheduled to run once at the end of each month
- [ ] Run the job once manually to account for when it should've run at the end of May