### PR TITLE
Handle BGS::AccountLocked error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "aasm", "4.11.0"
 gem "activerecord-import"
 gem "acts_as_tree"
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "53de789b61b9ee2d109f8901f3321b2b394be6da"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "eb402ebd17eb39cd13df3c21d749e1b598676324"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "aasm", "4.11.0"
 gem "activerecord-import"
 gem "acts_as_tree"
 # BGS
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "b6d05017344a861b4b858c037f8b277e25ea84f2"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "53de789b61b9ee2d109f8901f3321b2b394be6da"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: b6d05017344a861b4b858c037f8b277e25ea84f2
-  ref: b6d05017344a861b4b858c037f8b277e25ea84f2
+  revision: eb402ebd17eb39cd13df3c21d749e1b598676324
+  ref: eb402ebd17eb39cd13df3c21d749e1b598676324
   specs:
     bgs (0.2)
       httpclient

--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -7,7 +7,9 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
   skip_before_action :verify_authenticity_token, only: [:outcode]
 
   rescue_from BGS::AccountLocked do |_e|
-    render(json: { message: "Your account is locked. Please contact the VA Enterprise Service Desk to resolve this issue." }, status: :forbidden)
+    account_locked_error_msg = "Your account is locked. " \
+                               "Please contact the VA Enterprise Service Desk to resolve this issue."
+    render(json: { message: account_locked_error_msg }, status: :forbidden)
   end
 
   def list

--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -6,6 +6,10 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
 
   skip_before_action :verify_authenticity_token, only: [:outcode]
 
+  rescue_from BGS::AccountLocked do |_e|
+    render(json: { message: "Your account is locked.  Please contact your Security Officer" }, status: :forbidden)
+  end
+
   def list
     if file_number.present?
       render json: json_appeals(appeals_by_file_number)

--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -7,7 +7,7 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
   skip_before_action :verify_authenticity_token, only: [:outcode]
 
   rescue_from BGS::AccountLocked do |_e|
-    render(json: { message: "Your account is locked.  Please contact your Security Officer" }, status: :forbidden)
+    render(json: { message: "Your account is locked. Please contact the VA Enterprise Service Desk to resolve this issue." }, status: :forbidden)
   end
 
   def list

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
               get :details, params: params
               expect(response.status).to eq 403
               expect(JSON.parse(response.body)["message"])
-                .to eq "Your account is locked.  Please contact the VA Enterprise Service Desk to resolve this issue."
+                .to eq "Your account is locked. Please contact the VA Enterprise Service Desk to resolve this issue."
             end
           end
 

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
               get :details, params: params
               expect(response.status).to eq 403
               expect(JSON.parse(response.body)["message"])
-                .to eq "Your account is locked.  Please contact your Security Officer"
+                .to eq "Your account is locked.  Please contact the VA Enterprise Service Desk to resolve this issue."
             end
           end
 


### PR DESCRIPTION
Associated with https://github.com/department-of-veterans-affairs/ruby-bgs/pull/100

### Description
When BGS::AccountLocked occurs, return 403 instead of 500 error.

Too many 500 errors cause [PagerDuty alerts](https://dsva.slack.com/archives/C4JECDLSE/p1593618219014500).

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] No more [BGS::ShareError Sentry alerts](https://dsva.slack.com/archives/CD5DAQNCU/p1593615521117200) relating to "Your account is locked.  Please contact your Security Officer"
