### PR TITLE
Intake | G Code | Store original legacy appeal data in case of rollback

### DIFF
--- a/db/migrate/20200702015739_add_original_legacy_appeal_to_legacy_issue_optins.rb
+++ b/db/migrate/20200702015739_add_original_legacy_appeal_to_legacy_issue_optins.rb
@@ -1,0 +1,7 @@
+class AddOriginalLegacyAppealToLegacyIssueOptins < ActiveRecord::Migration[5.2]
+  def change
+    add_column :legacy_issue_optins, :original_legacy_appeal_disposition_code, :string, comment: "The original disposition code of legacy appeal being opted in"
+    add_column :legacy_issue_optins, :original_legacy_appeal_decision_date, :date, comment: "The original disposition date of a legacy appeal being opted in"
+    add_column :legacy_issue_optins, :folder_date_time_of_decision, :datetime, comment: "Date/Time of decision"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_154526) do
+ActiveRecord::Schema.define(version: 2020_07_02_015739) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -331,7 +331,7 @@ ActiveRecord::Schema.define(version: 2020_06_30_154526) do
     t.datetime "created_at"
     t.bigint "decision_review_id", comment: "The ID of the decision review the claimant is on."
     t.string "decision_review_type", comment: "The type of decision review the claimant is on."
-    t.text "notes", comment: "This is a notes field for adding claimant not listed and any supplementary information outside of unlisted claimant."
+    t.text "notes", comment: "Notes why a claimant is not listed."
     t.string "participant_id", null: false, comment: "The participant ID of the claimant."
     t.string "payee_code", comment: "The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
     t.string "type", default: "Claimant", comment: "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."
@@ -884,10 +884,13 @@ ActiveRecord::Schema.define(version: 2020_06_30_154526) do
   create_table "legacy_issue_optins", comment: "When a VACOLS issue from a legacy appeal is opted-in to AMA, this table keeps track of the related request_issue, and the status of processing the opt-in, or rollback if the request issue is removed from a Decision Review.", force: :cascade do |t|
     t.datetime "created_at", null: false, comment: "When a Request Issue is connected to a VACOLS issue on a legacy appeal, and the Veteran has agreed to withdraw their legacy appeals, a legacy_issue_optin is created at the time the Decision Review is successfully intaken. This is used to indicate that the legacy issue should subsequently be opted into AMA in VACOLS. "
     t.string "error"
+    t.datetime "folder_date_time_of_decision", comment: "Date/Time of decision"
     t.bigint "legacy_issue_id", comment: "The legacy issue being opted in, which connects to the request issue"
     t.datetime "optin_processed_at", comment: "The timestamp for when the opt-in was successfully processed, meaning it was updated in VACOLS as opted into AMA."
     t.string "original_disposition_code", comment: "The original disposition code of the VACOLS issue being opted in. Stored in case the opt-in is rolled back."
     t.date "original_disposition_date", comment: "The original disposition date of the VACOLS issue being opted in. Stored in case the opt-in is rolled back."
+    t.date "original_legacy_appeal_decision_date", comment: "The original disposition date of a legacy appeal being opted in"
+    t.string "original_legacy_appeal_disposition_code", comment: "The original disposition code of legacy appeal being opted in"
     t.bigint "request_issue_id", null: false, comment: "The request issue connected to the legacy VACOLS issue that has been opted in."
     t.datetime "rollback_created_at", comment: "Timestamp for when the connected request issue is removed from a Decision Review during edit, indicating that the opt-in needs to be rolled back."
     t.datetime "rollback_processed_at", comment: "Timestamp for when a rolled back opt-in has successfully finished being rolled back."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -331,7 +331,7 @@ ActiveRecord::Schema.define(version: 2020_07_02_015739) do
     t.datetime "created_at"
     t.bigint "decision_review_id", comment: "The ID of the decision review the claimant is on."
     t.string "decision_review_type", comment: "The type of decision review the claimant is on."
-    t.text "notes", comment: "Notes why a claimant is not listed."
+    t.text "notes", comment: "This is a notes field for adding claimant not listed and any supplementary information outside of unlisted claimant."
     t.string "participant_id", null: false, comment: "The participant ID of the claimant."
     t.string "payee_code", comment: "The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
     t.string "type", default: "Claimant", comment: "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -691,6 +691,9 @@ legacy_issue_optins,request_issue_id,integer (8) ∗ FK,x,,x,,x,The request is
 legacy_issue_optins,rollback_created_at,datetime,,,,,,"Timestamp for when the connected request issue is removed from a Decision Review during edit, indicating that the opt-in needs to be rolled back."
 legacy_issue_optins,rollback_processed_at,datetime,,,,,,Timestamp for when a rolled back opt-in has successfully finished being rolled back.
 legacy_issue_optins,updated_at,datetime ∗,x,,,,x,Automatically populated when the record is updated.
+legacy_issue_optins,original_legacy_appeal_decision_date,datetime,,,,,,The original disposition date of a legacy appeal being opted in.
+legacy_issue_optins,original_legacy_appeal_disposition_code,string,,,,,,The original disposition code of legacy appeal being opted in.
+legacy_issue_optins,folder_date_time_of_decision,datetime,,,,,,Date/Time of decision.
 messages,,,,,,,,
 messages,created_at,datetime ∗,x,,,,,
 messages,detail_id,integer FK,,,x,,x,ID of the related object


### PR DESCRIPTION
Connects #14500
### Description
This pr adds columns to the legacy issue opt-in table
### Acceptance Criteria
- [ ] Add columns to the legacy issue opt-in table:
  - [ ] Original legacy appeal disposition (bfdc) using the letter code (e.g. "G" instead of "Failure to respond")
  - [ ] Original legacy appeal decision date (bfddec)
  - [ ] Folder Date/Time of Decision (tidcls)


### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Database Changes
* legacy issue opt-in table*

* [x] Adds Original legacy appeal disposition (bfdc), Original legacy appeal decision date (bfddec), and Folder Date/Time of Decision (tidcls) to  legacy issue opt-in table
* [ ] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR

