### PR TITLE
Tomas/14620 fix virtual hearing mailer spec

### DIFF
--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -70,7 +70,7 @@ describe VirtualHearingMailer do
   context "for judge" do
     include_context "ama_hearing"
 
-    let!(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:judge] }
+    let(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:judge] }
 
     describe "#cancellation" do
       include_context "cancellation_email"
@@ -103,219 +103,59 @@ describe VirtualHearingMailer do
     # legacy hearing is scheduled at 11:30am in the regional office's time zone
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "2:30pm EST" }
 
-    ama_times = expected_ama_times
-    legacy_times = expected_legacy_times
-    types = [:confirmation, :updated_time_confirmation]
-    recipient_title = MailRecipient::RECIPIENT_TITLES[:judge]
-
-    types = [:cancellation, :confirmation, :updated_time_confirmation] if types.nil?
-
     context "with ama hearing" do
       include_context "ama_hearing"
 
-      expected_eastern = ama_times[:expected_eastern]
-      expected_pacific = ama_times[:expected_pacific]
+      expected_eastern = expected_ama_times[:expected_eastern]
+      expected_pacific = expected_ama_times[:expected_pacific]
 
-      if types.include? :cancellation
-        describe "#cancellation" do
-          include_context "cancellation_email"
+      describe "#confirmation" do
+        include_context "confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
+        end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
 
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "has the correct time in the email" do
+            # judge time in the email will always be in central office time (ET)
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          end
+        it "displays central office time (ET)" do
+          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
 
-      if types.include? :confirmation
-        describe "#confirmation" do
-          include_context "confirmation_email"
+      describe "#updated_time_confirmation" do
+        include_context "updated_time_confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          end
-
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
-          end
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
-      end
 
-      if types.include? :updated_time_confirmation
-        describe "#updated_time_confirmation" do
-          include_context "updated_time_confirmation_email"
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
-
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            # judge time in the email will always be in central office time (ET)
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
-          end
-
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          end
+        it "displays central office time (ET)" do
+          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
     end
@@ -323,252 +163,74 @@ describe VirtualHearingMailer do
     context "with legacy hearing" do
       include_context "legacy_hearing"
 
-      expected_eastern = legacy_times[:expected_eastern]
-      expected_pacific = legacy_times[:expected_pacific]
+      expected_eastern = expected_legacy_times[:expected_eastern]
+      expected_pacific = expected_legacy_times[:expected_pacific]
 
-      if types.include? :cancellation
-        describe "#cancellation" do
-          include_context "cancellation_email"
+      describe "#confirmation" do
+        include_context "confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
+        end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
 
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "has the correct time in the email" do
+            # judge time in the email will always be in central office time (ET)
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          end
+        it "displays central office time (ET)" do
+          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
 
-      if types.include? :confirmation
-        describe "#confirmation" do
-          include_context "confirmation_email"
+      describe "#updated_time_confirmation" do
+        include_context "updated_time_confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          end
-
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
-          end
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
-      end
 
-      if types.include? :updated_time_confirmation
-        describe "#updated_time_confirmation" do
-          include_context "updated_time_confirmation_email"
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
-
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            # judge time in the email will always be in central office time (ET)
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
-          end
-
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          end
+        it "displays central office time (ET)" do
+          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
     end
 
-    recipient = MailRecipient::RECIPIENT_TITLES[:judge]
-
     describe "#confirmation" do
       include_context "confirmation_email"
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-        describe "#link" do
-          it "is host link" do
-            expect(subject.html_part.body).to include(virtual_hearing.host_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.host_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.host_pin}&role=host"
-            )
-          end
-        end
-      end
-
-      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+      describe "#link" do
+        it "is host link" do
+          expect(subject.html_part.body).to include(virtual_hearing.host_link)
         end
 
-        describe "#link" do
-          it "is guest link" do
-            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.guest_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.guest_pin}&role=guest"
-            )
-          end
+        it "is in correct format" do
+          expect(virtual_hearing.host_link).to eq(
+            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+            "pin=#{virtual_hearing.host_pin}&role=host"
+          )
         end
       end
     end
@@ -576,40 +238,17 @@ describe VirtualHearingMailer do
     describe "#updated_time_confirmation" do
       include_context "updated_time_confirmation_email"
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-        describe "#link" do
-          it "is host link" do
-            expect(subject.html_part.body).to include(virtual_hearing.host_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.host_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.host_pin}&role=host"
-            )
-          end
-        end
-      end
-
-      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+      describe "#link" do
+        it "is host link" do
+          expect(subject.html_part.body).to include(virtual_hearing.host_link)
         end
 
-        describe "#link" do
-          it "is guest link" do
-            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.guest_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.guest_pin}&role=guest"
-            )
-          end
+        it "is in correct format" do
+          expect(virtual_hearing.host_link).to eq(
+            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+            "pin=#{virtual_hearing.host_pin}&role=host"
+          )
         end
       end
     end
@@ -618,7 +257,7 @@ describe VirtualHearingMailer do
   context "for appellant" do
     include_context "ama_hearing"
 
-    let!(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:appellant] }
+    let(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:appellant] }
 
     describe "#cancellation" do
       include_context "cancellation_email"
@@ -652,216 +291,122 @@ describe VirtualHearingMailer do
     # legacy hearing is scheduled at 11:30am in the regional office's time zone
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am PST" }
 
-    ama_times = expected_ama_times
-    legacy_times = expected_legacy_times
-    types = [:cancellation, :confirmation, :updated_time_confirmation]
-    recipient_title = MailRecipient::RECIPIENT_TITLES[:appellant]
-
     context "with ama hearing" do
       include_context "ama_hearing"
 
-      expected_eastern = ama_times[:expected_eastern]
-      expected_pacific = ama_times[:expected_pacific]
+      expected_eastern = expected_ama_times[:expected_eastern]
+      expected_pacific = expected_ama_times[:expected_pacific]
 
-      if types.include? :cancellation
-        describe "#cancellation" do
-          include_context "cancellation_email"
+      describe "#cancellation" do
+        include_context "cancellation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "appellant_tz is present" do
+          before do
+            virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "appellant_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :confirmation
-        describe "#confirmation" do
-          include_context "confirmation_email"
+      describe "#confirmation" do
+        include_context "confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "appellant_tz is present" do
+          before do
+            virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
+        end
 
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "appellant_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :updated_time_confirmation
-        describe "#updated_time_confirmation" do
-          include_context "updated_time_confirmation_email"
+      describe "#updated_time_confirmation" do
+        include_context "updated_time_confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "appellant_tz is present" do
+          before do
+            virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "appellant_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
@@ -870,253 +415,142 @@ describe VirtualHearingMailer do
     context "with legacy hearing" do
       include_context "legacy_hearing"
 
-      expected_eastern = legacy_times[:expected_eastern]
-      expected_pacific = legacy_times[:expected_pacific]
+      expected_eastern = expected_legacy_times[:expected_eastern]
+      expected_pacific = expected_legacy_times[:expected_pacific]
 
-      if types.include? :cancellation
-        describe "#cancellation" do
-          include_context "cancellation_email"
+      describe "#cancellation" do
+        include_context "cancellation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "appellant_tz is present" do
+          before do
+            virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "appellant_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :confirmation
-        describe "#confirmation" do
-          include_context "confirmation_email"
+      describe "#confirmation" do
+        include_context "confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "appellant_tz is present" do
+          before do
+            virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
+        end
 
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "appellant_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :updated_time_confirmation
-        describe "#updated_time_confirmation" do
-          include_context "updated_time_confirmation_email"
+      describe "#updated_time_confirmation" do
+        include_context "updated_time_confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "appellant_tz is present" do
+          before do
+            virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "appellant_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
     end
 
-
-    recipient = MailRecipient::RECIPIENT_TITLES[:appellant]
-
     describe "#confirmation" do
       include_context "confirmation_email"
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-        describe "#link" do
-          it "is host link" do
-            expect(subject.html_part.body).to include(virtual_hearing.host_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.host_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.host_pin}&role=host"
-            )
-          end
-        end
+      it "has the test link" do
+        expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
       end
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+      describe "#link" do
+        it "is guest link" do
+          expect(subject.html_part.body).to include(virtual_hearing.guest_link)
         end
 
-        describe "#link" do
-          it "is guest link" do
-            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.guest_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.guest_pin}&role=guest"
-            )
-          end
+        it "is in correct format" do
+          expect(virtual_hearing.guest_link).to eq(
+            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+            "pin=#{virtual_hearing.guest_pin}&role=guest"
+          )
         end
       end
     end
@@ -1124,40 +558,21 @@ describe VirtualHearingMailer do
     describe "#updated_time_confirmation" do
       include_context "updated_time_confirmation_email"
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-        describe "#link" do
-          it "is host link" do
-            expect(subject.html_part.body).to include(virtual_hearing.host_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.host_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.host_pin}&role=host"
-            )
-          end
-        end
+      it "has the test link" do
+        expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
       end
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+      describe "#link" do
+        it "is guest link" do
+          expect(subject.html_part.body).to include(virtual_hearing.guest_link)
         end
 
-        describe "#link" do
-          it "is guest link" do
-            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.guest_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.guest_pin}&role=guest"
-            )
-          end
+        it "is in correct format" do
+          expect(virtual_hearing.guest_link).to eq(
+            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+            "pin=#{virtual_hearing.guest_pin}&role=guest"
+          )
         end
       end
     end
@@ -1208,7 +623,7 @@ describe VirtualHearingMailer do
   context "for representative" do
     include_context "ama_hearing"
 
-    let!(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:representative] }
+    let(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:representative] }
 
     describe "#cancellation" do
       include_context "cancellation_email"
@@ -1242,216 +657,122 @@ describe VirtualHearingMailer do
     # legacy hearing is scheduled at 11:30am in the regional office's time zone
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am PST" }
 
-    ama_times = expected_ama_times
-    legacy_times = expected_legacy_times
-    types = [:cancellation, :confirmation, :updated_time_confirmation]
-    recipient_title = MailRecipient::RECIPIENT_TITLES[:representative]
-
     context "with ama hearing" do
       include_context "ama_hearing"
 
-      expected_eastern = ama_times[:expected_eastern]
-      expected_pacific = ama_times[:expected_pacific]
+      expected_eastern = expected_ama_times[:expected_eastern]
+      expected_pacific = expected_ama_times[:expected_pacific]
 
-      if types.include? :cancellation
-        describe "#cancellation" do
-          include_context "cancellation_email"
+      describe "#cancellation" do
+        include_context "cancellation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "representative_tz is present" do
+          before do
+            virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "representative_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :confirmation
-        describe "#confirmation" do
-          include_context "confirmation_email"
+      describe "#confirmation" do
+        include_context "confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "representative_tz is present" do
+          before do
+            virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
+        end
 
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "representative_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :updated_time_confirmation
-        describe "#updated_time_confirmation" do
-          include_context "updated_time_confirmation_email"
+      describe "#updated_time_confirmation" do
+        include_context "updated_time_confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "representative_tz is present" do
+          before do
+            virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "representative_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
@@ -1460,253 +781,142 @@ describe VirtualHearingMailer do
     context "with legacy hearing" do
       include_context "legacy_hearing"
 
-      expected_eastern = legacy_times[:expected_eastern]
-      expected_pacific = legacy_times[:expected_pacific]
+      expected_eastern = expected_legacy_times[:expected_eastern]
+      expected_pacific = expected_legacy_times[:expected_pacific]
 
-      if types.include? :cancellation
-        describe "#cancellation" do
-          include_context "cancellation_email"
+      describe "#cancellation" do
+        include_context "cancellation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "representative_tz is present" do
+          before do
+            virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "representative_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :confirmation
-        describe "#confirmation" do
-          include_context "confirmation_email"
+      describe "#confirmation" do
+        include_context "confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "representative_tz is present" do
+          before do
+            virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
+        end
 
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "representative_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
 
-      if types.include? :updated_time_confirmation
-        describe "#updated_time_confirmation" do
-          include_context "updated_time_confirmation_email"
+      describe "#updated_time_confirmation" do
+        include_context "updated_time_confirmation_email"
 
-          context "regional office is in eastern timezone" do
-            let(:regional_office) { nyc_ro_eastern }
+        context "regional office is in eastern timezone" do
+          let(:regional_office) { nyc_ro_eastern }
 
-            it "has the correct time in the email" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
+          it "has the correct time in the email" do
+            expect(subject.html_part.body).to include(expected_eastern)
+          end
+        end
+
+        context "regional office is in pacific timezone" do
+          let(:regional_office) { oakland_ro_pacific }
+
+          it "has the correct time in the email" do
+            # always show regional office time regardless of recipient
+            expect(subject.html_part.body).to include("8:30am PST")
+          end
+        end
+
+        describe "representative_tz is present" do
+          before do
+            virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+            hearing.reload
           end
 
-          context "regional office is in pacific timezone" do
-            let(:regional_office) { oakland_ro_pacific }
-
-            it "has the correct time in the email" do
-              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-                # judge time in the email will always be in central office time (ET)
-                expect(subject.html_part.body).to include(expected_pacific)
-              else
-                # always show regional office time regardless of recipient
-                expect(subject.html_part.body).to include("8:30am PST")
-              end
-            end
+          it "displays pacific standard time (PT)" do
+            expect(subject.html_part.body).to include(expected_pacific)
           end
+        end
 
-          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-            it "displays central office time (ET)" do
-              expect(subject.html_part.body).to include(expected_eastern)
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-            describe "appellant_tz is present" do
-              before do
-                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "appellant_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
-          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-            describe "representative_tz is present" do
-              before do
-                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-                hearing.reload
-              end
-
-              it "displays pacific standard time (PT)" do
-                expect(subject.html_part.body).to include(expected_pacific)
-              end
-            end
-
-            describe "representative_tz is not present" do
-              it "displays eastern standard time (ET)" do
-                expect(subject.html_part.body).to include(expected_eastern)
-              end
-            end
+        describe "representative_tz is not present" do
+          it "displays eastern standard time (ET)" do
+            expect(subject.html_part.body).to include(expected_eastern)
           end
         end
       end
     end
 
-
-    recipient = MailRecipient::RECIPIENT_TITLES[:representative]
-
     describe "#confirmation" do
       include_context "confirmation_email"
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-        describe "#link" do
-          it "is host link" do
-            expect(subject.html_part.body).to include(virtual_hearing.host_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.host_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.host_pin}&role=host"
-            )
-          end
-        end
+      it "has the test link" do
+        expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
       end
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+      describe "#link" do
+        it "is guest link" do
+          expect(subject.html_part.body).to include(virtual_hearing.guest_link)
         end
 
-        describe "#link" do
-          it "is guest link" do
-            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.guest_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.guest_pin}&role=guest"
-            )
-          end
+        it "is in correct format" do
+          expect(virtual_hearing.guest_link).to eq(
+            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+            "pin=#{virtual_hearing.guest_pin}&role=guest"
+          )
         end
       end
     end
@@ -1714,40 +924,21 @@ describe VirtualHearingMailer do
     describe "#updated_time_confirmation" do
       include_context "updated_time_confirmation_email"
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-        describe "#link" do
-          it "is host link" do
-            expect(subject.html_part.body).to include(virtual_hearing.host_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.host_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.host_pin}&role=host"
-            )
-          end
-        end
+      it "has the test link" do
+        expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
       end
 
-      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+      describe "#link" do
+        it "is guest link" do
+          expect(subject.html_part.body).to include(virtual_hearing.guest_link)
         end
 
-        describe "#link" do
-          it "is guest link" do
-            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-          end
-
-          it "is in correct format" do
-            expect(virtual_hearing.guest_link).to eq(
-              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-              "pin=#{virtual_hearing.guest_pin}&role=guest"
-            )
-          end
+        it "is in correct format" do
+          expect(virtual_hearing.guest_link).to eq(
+            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+            "pin=#{virtual_hearing.guest_pin}&role=guest"
+          )
         end
       end
     end

--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -11,18 +11,12 @@ describe VirtualHearingMailer do
       regional_office: regional_office
     )
   end
-  let(:virtual_hearing) do
-    create(
-      :virtual_hearing,
-      hearing: hearing
-    )
-  end
-
+  let(:virtual_hearing) { create(:virtual_hearing, hearing: hearing) }
   let(:recipient_title) { nil }
   let(:recipient) { MailRecipient.new(name: "LastName", email: "email@test.com", title: recipient_title) }
   let(:pexip_url) { "fake.va.gov" }
 
-  shared_context "ama hearing" do
+  shared_context "ama_hearing" do
     let(:hearing) do
       create(
         :hearing,
@@ -33,7 +27,7 @@ describe VirtualHearingMailer do
     end
   end
 
-  shared_context "legacy hearing" do
+  shared_context "legacy_hearing" do
     let(:hearing) do
       hearing_date = Time.use_zone("America/New_York") { Time.zone.now.change(hour: 11, min: 30) }
       case_hearing = create(
@@ -52,15 +46,15 @@ describe VirtualHearingMailer do
     end
   end
 
-  shared_context "cancellation email" do
+  shared_context "cancellation_email" do
     subject { VirtualHearingMailer.cancellation(mail_recipient: recipient, virtual_hearing: virtual_hearing) }
   end
 
-  shared_context "confirmation email" do
+  shared_context "confirmation_email" do
     subject { VirtualHearingMailer.confirmation(mail_recipient: recipient, virtual_hearing: virtual_hearing) }
   end
 
-  shared_context "updated time confirmation email" do
+  shared_context "updated_time_confirmation_email" do
     subject do
       VirtualHearingMailer.updated_time_confirmation(mail_recipient: recipient, virtual_hearing: virtual_hearing)
     end
@@ -73,365 +67,1731 @@ describe VirtualHearingMailer do
     stub_const("ENV", "PEXIP_CLIENT_HOST" => pexip_url)
   end
 
-  shared_examples_for "sends an email" do
-    it "sends an email" do
-      expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
-    end
-  end
-
-  shared_examples_for "doesn't send an email" do
-    it "doesn't send an email" do
-      expect { subject.deliver_now! }.to_not(change { ActionMailer::Base.deliveries.count })
-    end
-  end
-
-  shared_examples_for "doesn't send a cancellation email" do
-    describe "#cancellation" do
-      include_context "cancellation email"
-
-      it_behaves_like "doesn't send an email"
-    end
-  end
-
-  shared_examples_for "sends a cancellation email" do
-    describe "#cancellation" do
-      include_context "cancellation email"
-
-      it_behaves_like "sends an email"
-    end
-  end
-
-  shared_examples_for "sends a confirmation email" do
-    describe "#confirmation" do
-      include_context "confirmation email"
-
-      it_behaves_like "sends an email"
-    end
-  end
-
-  shared_examples_for "sends an updated time confirmation email" do
-    describe "#updated_time_confirmation" do
-      include_context "updated time confirmation email"
-
-      it_behaves_like "sends an email"
-    end
-  end
-
-  shared_examples_for "sends all email types" do
-    it_behaves_like "sends a cancellation email"
-    it_behaves_like "sends a confirmation email"
-    it_behaves_like "sends an updated time confirmation email"
-  end
-
-  shared_examples_for "email body has the right times based on regional_office" do
-    |expected_eastern, expected_pacific, recipient_title|
-    context "regional office is in eastern timezone" do
-      let(:regional_office) { nyc_ro_eastern }
-
-      it "has the correct time in the email" do
-        expect(subject.html_part.body).to include(expected_eastern)
-      end
-    end
-
-    context "regional office is in pacific timezone" do
-      let(:regional_office) { oakland_ro_pacific }
-
-      it "has the correct time in the email" do
-        if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-          # judge time in the email will always be in central office time (ET)
-          expect(subject.html_part.body).to include(expected_pacific)
-        else
-          # always show regional office time regardless of recipient
-          expect(subject.html_part.body).to include("8:30am PST")
-        end
-      end
-    end
-  end
-
-  shared_examples_for "email body has right time for recipient" do |expected_eastern, expected_pacific, recipient_title|
-    if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
-      it "displays central office time (ET)" do
-        expect(subject.html_part.body).to include(expected_eastern)
-      end
-    elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
-      describe "appellant_tz is present" do
-        before do
-          virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
-          hearing.reload
-        end
-
-        it "displays pacific standard time (PT)" do
-          expect(subject.html_part.body).to include(expected_pacific)
-        end
-      end
-
-      describe "appellant_tz is not present" do
-        it "displays eastern standard time (ET)" do
-          expect(subject.html_part.body).to include(expected_eastern)
-        end
-      end
-    elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
-      describe "representative_tz is present" do
-        before do
-          virtual_hearing.update!(representative_tz: "America/Los_Angeles")
-          hearing.reload
-        end
-
-        it "displays pacific standard time (PT)" do
-          expect(subject.html_part.body).to include(expected_pacific)
-        end
-      end
-
-      describe "representative_tz is not present" do
-        it "displays eastern standard time (ET)" do
-          expect(subject.html_part.body).to include(expected_eastern)
-        end
-      end
-    end
-  end
-
-  shared_examples_for "email body has the right times for types" do
-    |expected_eastern, expected_pacific, types, recipient_title|
-    if types.include? :cancellation
-      describe "#cancellation" do
-        include_context "cancellation email"
-
-        it_behaves_like(
-          "email body has the right times based on regional_office",
-          expected_eastern,
-          expected_pacific,
-          recipient_title
-        )
-        it_behaves_like "email body has right time for recipient", expected_eastern, expected_pacific, recipient_title
-      end
-    end
-
-    if types.include? :confirmation
-      describe "#confirmation" do
-        include_context "confirmation email"
-
-        it_behaves_like(
-          "email body has the right times based on regional_office",
-          expected_eastern,
-          expected_pacific,
-          recipient_title
-        )
-        it_behaves_like "email body has right time for recipient", expected_eastern, expected_pacific, recipient_title
-      end
-    end
-
-    if types.include? :updated_time_confirmation
-      describe "#updated_time_confirmation" do
-        include_context "updated time confirmation email"
-
-        it_behaves_like(
-          "email body has the right times based on regional_office",
-          expected_eastern,
-          expected_pacific,
-          recipient_title
-        )
-        it_behaves_like "email body has right time for recipient", expected_eastern, expected_pacific, recipient_title
-      end
-    end
-  end
-
-  # ama_times & legacy_times are in the format { expected_eastern: "10:30 EST", expected_pacific: "7:30 PST" }
-  # expected_eastern is the time displayed in the email body when the regional office is in the eastern time zone
-  # expected_pacific is the time displayed in the email body when the regional office is in the pacific time zone
-  shared_examples_for "email body has the right times with ama and legacy hearings" do
-    |ama_times, legacy_times, types, recipient_title|
-    types = [:cancellation, :confirmation, :updated_time_confirmation] if types.nil?
-
-    context "with ama hearing" do
-      include_context "ama hearing"
-
-      it_behaves_like(
-        "email body has the right times for types",
-        ama_times[:expected_eastern],
-        ama_times[:expected_pacific],
-        types,
-        recipient_title
-      )
-    end
-
-    context "with legacy hearing" do
-      include_context "legacy hearing"
-
-      it_behaves_like(
-        "email body has the right times for types",
-        legacy_times[:expected_eastern],
-        legacy_times[:expected_pacific],
-        types,
-        recipient_title
-      )
-    end
-  end
-
-  shared_examples_for "email body has the correct link" do |recipient|
-    if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
-      describe "#link" do
-        it "is host link" do
-          expect(subject.html_part.body).to include(virtual_hearing.host_link)
-        end
-
-        it "is in correct format" do
-          expect(virtual_hearing.host_link).to eq(
-            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-            "pin=#{virtual_hearing.host_pin}&role=host"
-          )
-        end
-      end
-    end
-
-    if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
-       recipient == MailRecipient::RECIPIENT_TITLES[:representative]
-      it "has the test link" do
-        expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
-      end
-
-      describe "#link" do
-        it "is guest link" do
-          expect(subject.html_part.body).to include(virtual_hearing.guest_link)
-        end
-
-        it "is in correct format" do
-          expect(virtual_hearing.guest_link).to eq(
-            "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-            "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
-            "pin=#{virtual_hearing.guest_pin}&role=guest"
-          )
-        end
-      end
-    end
-  end
-
-  shared_examples_for "email body has the correct link for types" do |recipient|
-    describe "#confirmation" do
-      include_context "confirmation email"
-
-      it_behaves_like "email body has the correct link", recipient
-    end
-
-    describe "#updated_time_confirmation" do
-      include_context "updated time confirmation email"
-
-      it_behaves_like "email body has the correct link", recipient
-    end
-  end
-
-  shared_examples_for "email body has correct hearing location" do
-    describe "hearing_location is not nil" do
-      it "shows correct hearing location" do
-        expect(subject.html_part.body).to include(hearing.location.full_address)
-        expect(subject.html_part.body).to include(hearing.hearing_location.name)
-      end
-    end
-
-    describe "hearing_location is nil" do
-      it "shows correct hearing location" do
-        hearing.update!(hearing_location: nil)
-        expect(subject.html_part.body).to include(hearing.regional_office.full_address)
-        expect(subject.html_part.body).to include(hearing.regional_office.name)
-      end
-    end
-  end
-
-  shared_examples_for "cancellation email body has the correct hearing location" do
-    describe "#cancellation" do
-      include_context "cancellation email"
-
-      context "with legacy hearing" do
-        include_context "legacy hearing"
-
-        it_behaves_like "email body has correct hearing location"
-      end
-
-      context "with ama hearing" do
-        include_context "ama hearing"
-
-        it_behaves_like "email body has correct hearing location"
-      end
-    end
-  end
-
   context "for judge" do
-    include_context "ama hearing"
+    include_context "ama_hearing"
 
     let!(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:judge] }
 
-    it_behaves_like "doesn't send a cancellation email"
-    it_behaves_like "sends a confirmation email"
-    it_behaves_like "sends an updated time confirmation email"
+    describe "#cancellation" do
+      include_context "cancellation_email"
+
+      it "doesn't send an email" do
+        expect { subject.deliver_now! }.to_not(change { ActionMailer::Base.deliveries.count })
+      end
+    end
+
+    describe "#confirmation" do
+      include_context "confirmation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
+
+    describe "#updated_time_confirmation" do
+      include_context "updated_time_confirmation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
 
     # we expect the judge to always see the hearing time in central office (eastern) time zone
 
     # ama hearing is scheduled at 8:30am in the regional office's time zone
-    expected_ama_times = {
-      expected_eastern: "8:30am EST",
-      expected_pacific: "11:30am EST"
-    }
-    # legacy hearing is scheduled at 11:30am in the central office's time zone (eastern)
+    expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "11:30am EST" }
+    # legacy hearing is scheduled at 11:30am in the regional office's time zone
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "2:30pm EST" }
-    it_behaves_like(
-      "email body has the right times with ama and legacy hearings",
-      expected_ama_times,
-      expected_legacy_times,
-      [:confirmation, :updated_time_confirmation],
-      MailRecipient::RECIPIENT_TITLES[:judge]
-    )
-    it_behaves_like("email body has the correct link for types", MailRecipient::RECIPIENT_TITLES[:judge])
+
+    ama_times = expected_ama_times
+    legacy_times = expected_legacy_times
+    types = [:confirmation, :updated_time_confirmation]
+    recipient_title = MailRecipient::RECIPIENT_TITLES[:judge]
+
+    types = [:cancellation, :confirmation, :updated_time_confirmation] if types.nil?
+
+    context "with ama hearing" do
+      include_context "ama_hearing"
+
+      expected_eastern = ama_times[:expected_eastern]
+      expected_pacific = ama_times[:expected_pacific]
+
+      if types.include? :cancellation
+        describe "#cancellation" do
+          include_context "cancellation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :confirmation
+        describe "#confirmation" do
+          include_context "confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :updated_time_confirmation
+        describe "#updated_time_confirmation" do
+          include_context "updated_time_confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "with legacy hearing" do
+      include_context "legacy_hearing"
+
+      expected_eastern = legacy_times[:expected_eastern]
+      expected_pacific = legacy_times[:expected_pacific]
+
+      if types.include? :cancellation
+        describe "#cancellation" do
+          include_context "cancellation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :confirmation
+        describe "#confirmation" do
+          include_context "confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :updated_time_confirmation
+        describe "#updated_time_confirmation" do
+          include_context "updated_time_confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    recipient = MailRecipient::RECIPIENT_TITLES[:judge]
+
+    describe "#confirmation" do
+      include_context "confirmation_email"
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
+        describe "#link" do
+          it "is host link" do
+            expect(subject.html_part.body).to include(virtual_hearing.host_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.host_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.host_pin}&role=host"
+            )
+          end
+        end
+      end
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
+         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
+        it "has the test link" do
+          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+        end
+
+        describe "#link" do
+          it "is guest link" do
+            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.guest_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.guest_pin}&role=guest"
+            )
+          end
+        end
+      end
+    end
+
+    describe "#updated_time_confirmation" do
+      include_context "updated_time_confirmation_email"
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
+        describe "#link" do
+          it "is host link" do
+            expect(subject.html_part.body).to include(virtual_hearing.host_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.host_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.host_pin}&role=host"
+            )
+          end
+        end
+      end
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
+         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
+        it "has the test link" do
+          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+        end
+
+        describe "#link" do
+          it "is guest link" do
+            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.guest_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.guest_pin}&role=guest"
+            )
+          end
+        end
+      end
+    end
   end
 
   context "for appellant" do
-    include_context "ama hearing"
+    include_context "ama_hearing"
 
     let!(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:appellant] }
 
-    it_behaves_like "sends all email types"
+    describe "#cancellation" do
+      include_context "cancellation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
+
+    describe "#confirmation" do
+      include_context "confirmation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
+
+    describe "#updated_time_confirmation" do
+      include_context "updated_time_confirmation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
 
     # we expect the appellant to always see the hearing time in the regional office time zone
     # unless appellant_tz in VirtualHearing is set
 
     # ama hearing is scheduled at 8:30am in the regional office's time zone
     expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "5:30am PST" }
-    # legacy hearing is scheduled at 11:30am in the central office's time zone (eastern)
+    # legacy hearing is scheduled at 11:30am in the regional office's time zone
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am PST" }
-    it_behaves_like(
-      "email body has the right times with ama and legacy hearings",
-      expected_ama_times,
-      expected_legacy_times,
-      nil,
-      MailRecipient::RECIPIENT_TITLES[:appellant]
-    )
 
-    it_behaves_like("email body has the correct link for types", MailRecipient::RECIPIENT_TITLES[:appellant])
-    it_behaves_like("cancellation email body has the correct hearing location")
+    ama_times = expected_ama_times
+    legacy_times = expected_legacy_times
+    types = [:cancellation, :confirmation, :updated_time_confirmation]
+    recipient_title = MailRecipient::RECIPIENT_TITLES[:appellant]
+
+    context "with ama hearing" do
+      include_context "ama_hearing"
+
+      expected_eastern = ama_times[:expected_eastern]
+      expected_pacific = ama_times[:expected_pacific]
+
+      if types.include? :cancellation
+        describe "#cancellation" do
+          include_context "cancellation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :confirmation
+        describe "#confirmation" do
+          include_context "confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :updated_time_confirmation
+        describe "#updated_time_confirmation" do
+          include_context "updated_time_confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "with legacy hearing" do
+      include_context "legacy_hearing"
+
+      expected_eastern = legacy_times[:expected_eastern]
+      expected_pacific = legacy_times[:expected_pacific]
+
+      if types.include? :cancellation
+        describe "#cancellation" do
+          include_context "cancellation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :confirmation
+        describe "#confirmation" do
+          include_context "confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :updated_time_confirmation
+        describe "#updated_time_confirmation" do
+          include_context "updated_time_confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+    recipient = MailRecipient::RECIPIENT_TITLES[:appellant]
+
+    describe "#confirmation" do
+      include_context "confirmation_email"
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
+        describe "#link" do
+          it "is host link" do
+            expect(subject.html_part.body).to include(virtual_hearing.host_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.host_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.host_pin}&role=host"
+            )
+          end
+        end
+      end
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
+         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
+        it "has the test link" do
+          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+        end
+
+        describe "#link" do
+          it "is guest link" do
+            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.guest_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.guest_pin}&role=guest"
+            )
+          end
+        end
+      end
+    end
+
+    describe "#updated_time_confirmation" do
+      include_context "updated_time_confirmation_email"
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
+        describe "#link" do
+          it "is host link" do
+            expect(subject.html_part.body).to include(virtual_hearing.host_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.host_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.host_pin}&role=host"
+            )
+          end
+        end
+      end
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
+         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
+        it "has the test link" do
+          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+        end
+
+        describe "#link" do
+          it "is guest link" do
+            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.guest_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.guest_pin}&role=guest"
+            )
+          end
+        end
+      end
+    end
+
+    describe "#cancellation" do
+      include_context "cancellation_email"
+
+      context "with legacy hearing" do
+        include_context "legacy_hearing"
+
+        describe "hearing_location is not nil" do
+          it "shows correct hearing location" do
+            expect(subject.html_part.body).to include(hearing.location.full_address)
+            expect(subject.html_part.body).to include(hearing.hearing_location.name)
+          end
+        end
+
+        describe "hearing_location is nil" do
+          it "shows correct hearing location" do
+            hearing.update!(hearing_location: nil)
+            expect(subject.html_part.body).to include(hearing.regional_office.full_address)
+            expect(subject.html_part.body).to include(hearing.regional_office.name)
+          end
+        end
+      end
+
+      context "with ama hearing" do
+        include_context "ama_hearing"
+
+        describe "hearing_location is not nil" do
+          it "shows correct hearing location" do
+            expect(subject.html_part.body).to include(hearing.location.full_address)
+            expect(subject.html_part.body).to include(hearing.hearing_location.name)
+          end
+        end
+
+        describe "hearing_location is nil" do
+          it "shows correct hearing location" do
+            hearing.update!(hearing_location: nil)
+            expect(subject.html_part.body).to include(hearing.regional_office.full_address)
+            expect(subject.html_part.body).to include(hearing.regional_office.name)
+          end
+        end
+      end
+    end
   end
 
   context "for representative" do
-    include_context "ama hearing"
+    include_context "ama_hearing"
 
     let!(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:representative] }
 
-    it_behaves_like "sends all email types"
+    describe "#cancellation" do
+      include_context "cancellation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
+
+    describe "#confirmation" do
+      include_context "confirmation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
+
+    describe "#updated_time_confirmation" do
+      include_context "updated_time_confirmation_email"
+
+      it "sends an email" do
+        expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
+      end
+    end
 
     # we expect the representative to always see the hearing time in the regional office time zone
     # unless representative_tz in VirtualHearing is set
 
     # ama hearing is scheduled at 8:30am in the regional office's time zone
     expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "5:30am PST" }
-    # legacy hearing is scheduled at 11:30am in the central office's time zone (eastern)
+    # legacy hearing is scheduled at 11:30am in the regional office's time zone
     expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am PST" }
 
-    it_behaves_like(
-      "email body has the right times with ama and legacy hearings",
-      expected_ama_times,
-      expected_legacy_times,
-      nil,
-      MailRecipient::RECIPIENT_TITLES[:representative]
-    )
-    it_behaves_like("email body has the correct link for types", MailRecipient::RECIPIENT_TITLES[:representative])
-    it_behaves_like("cancellation email body has the correct hearing location")
+    ama_times = expected_ama_times
+    legacy_times = expected_legacy_times
+    types = [:cancellation, :confirmation, :updated_time_confirmation]
+    recipient_title = MailRecipient::RECIPIENT_TITLES[:representative]
+
+    context "with ama hearing" do
+      include_context "ama_hearing"
+
+      expected_eastern = ama_times[:expected_eastern]
+      expected_pacific = ama_times[:expected_pacific]
+
+      if types.include? :cancellation
+        describe "#cancellation" do
+          include_context "cancellation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :confirmation
+        describe "#confirmation" do
+          include_context "confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :updated_time_confirmation
+        describe "#updated_time_confirmation" do
+          include_context "updated_time_confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "with legacy hearing" do
+      include_context "legacy_hearing"
+
+      expected_eastern = legacy_times[:expected_eastern]
+      expected_pacific = legacy_times[:expected_pacific]
+
+      if types.include? :cancellation
+        describe "#cancellation" do
+          include_context "cancellation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :confirmation
+        describe "#confirmation" do
+          include_context "confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+
+      if types.include? :updated_time_confirmation
+        describe "#updated_time_confirmation" do
+          include_context "updated_time_confirmation_email"
+
+          context "regional office is in eastern timezone" do
+            let(:regional_office) { nyc_ro_eastern }
+
+            it "has the correct time in the email" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          end
+
+          context "regional office is in pacific timezone" do
+            let(:regional_office) { oakland_ro_pacific }
+
+            it "has the correct time in the email" do
+              if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+                # judge time in the email will always be in central office time (ET)
+                expect(subject.html_part.body).to include(expected_pacific)
+              else
+                # always show regional office time regardless of recipient
+                expect(subject.html_part.body).to include("8:30am PST")
+              end
+            end
+          end
+
+          if recipient_title == MailRecipient::RECIPIENT_TITLES[:judge]
+            it "displays central office time (ET)" do
+              expect(subject.html_part.body).to include(expected_eastern)
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:appellant]
+            describe "appellant_tz is present" do
+              before do
+                virtual_hearing.update!(appellant_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "appellant_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          elsif recipient_title == MailRecipient::RECIPIENT_TITLES[:representative]
+            describe "representative_tz is present" do
+              before do
+                virtual_hearing.update!(representative_tz: "America/Los_Angeles")
+                hearing.reload
+              end
+
+              it "displays pacific standard time (PT)" do
+                expect(subject.html_part.body).to include(expected_pacific)
+              end
+            end
+
+            describe "representative_tz is not present" do
+              it "displays eastern standard time (ET)" do
+                expect(subject.html_part.body).to include(expected_eastern)
+              end
+            end
+          end
+        end
+      end
+    end
+
+
+    recipient = MailRecipient::RECIPIENT_TITLES[:representative]
+
+    describe "#confirmation" do
+      include_context "confirmation_email"
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
+        describe "#link" do
+          it "is host link" do
+            expect(subject.html_part.body).to include(virtual_hearing.host_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.host_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.host_pin}&role=host"
+            )
+          end
+        end
+      end
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
+         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
+        it "has the test link" do
+          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+        end
+
+        describe "#link" do
+          it "is guest link" do
+            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.guest_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.guest_pin}&role=guest"
+            )
+          end
+        end
+      end
+    end
+
+    describe "#updated_time_confirmation" do
+      include_context "updated_time_confirmation_email"
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:judge]
+        describe "#link" do
+          it "is host link" do
+            expect(subject.html_part.body).to include(virtual_hearing.host_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.host_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.host_pin}&role=host"
+            )
+          end
+        end
+      end
+
+      if recipient == MailRecipient::RECIPIENT_TITLES[:appellant] ||
+         recipient == MailRecipient::RECIPIENT_TITLES[:representative]
+        it "has the test link" do
+          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient))
+        end
+
+        describe "#link" do
+          it "is guest link" do
+            expect(subject.html_part.body).to include(virtual_hearing.guest_link)
+          end
+
+          it "is in correct format" do
+            expect(virtual_hearing.guest_link).to eq(
+              "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+              "conference=#{virtual_hearing.formatted_alias_or_alias_with_host}&" \
+              "pin=#{virtual_hearing.guest_pin}&role=guest"
+            )
+          end
+        end
+      end
+    end
+
+    describe "#cancellation" do
+      include_context "cancellation_email"
+
+      context "with legacy hearing" do
+        include_context "legacy_hearing"
+
+        describe "hearing_location is not nil" do
+          it "shows correct hearing location" do
+            expect(subject.html_part.body).to include(hearing.location.full_address)
+            expect(subject.html_part.body).to include(hearing.hearing_location.name)
+          end
+        end
+
+        describe "hearing_location is nil" do
+          it "shows correct hearing location" do
+            hearing.update!(hearing_location: nil)
+            expect(subject.html_part.body).to include(hearing.regional_office.full_address)
+            expect(subject.html_part.body).to include(hearing.regional_office.name)
+          end
+        end
+      end
+
+      context "with ama hearing" do
+        include_context "ama_hearing"
+
+        describe "hearing_location is not nil" do
+          it "shows correct hearing location" do
+            expect(subject.html_part.body).to include(hearing.location.full_address)
+            expect(subject.html_part.body).to include(hearing.hearing_location.name)
+          end
+        end
+
+        describe "hearing_location is nil" do
+          it "shows correct hearing location" do
+            hearing.update!(hearing_location: nil)
+            expect(subject.html_part.body).to include(hearing.regional_office.full_address)
+            expect(subject.html_part.body).to include(hearing.regional_office.name)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/mailers/virtual_hearing_mailer_spec.rb
+++ b/spec/mailers/virtual_hearing_mailer_spec.rb
@@ -71,16 +71,20 @@ describe VirtualHearingMailer do
     let(:recipient_title) { MailRecipient::RECIPIENT_TITLES[:judge] }
 
     # we expect the judge to always see the hearing time in central office (eastern) time zone
+
     # ama hearing is scheduled at 8:30am in the regional office's time zone
-    expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "11:30am EST" }
+    expected_ama_times = {
+      ro_and_recipient_both_eastern: "8:30am EST",
+      ro_pacific_recipient_eastern: "11:30am EST"
+    }
     # legacy hearing is scheduled at 11:30am in the regional office's time zone
-    expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "2:30pm EST" }
+    expected_legacy_times = {
+      ro_and_recipient_both_eastern: "11:30am EST",
+      ro_pacific_recipient_eastern: "2:30pm EST"
+    }
 
     context "with ama hearing" do
       include_context "ama_hearing"
-
-      expected_eastern = expected_ama_times[:expected_eastern]
-      expected_pacific = expected_ama_times[:expected_pacific]
 
       describe "#cancellation" do
         include_context "cancellation_email"
@@ -115,7 +119,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -124,12 +128,8 @@ describe VirtualHearingMailer do
 
           it "has the correct time in the email" do
             # judge time in the email will always be in central office time (ET)
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_pacific_recipient_eastern])
           end
-        end
-
-        it "displays central office time (ET)" do
-          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
 
@@ -158,7 +158,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -167,21 +167,14 @@ describe VirtualHearingMailer do
 
           it "has the correct time in the email" do
             # judge time in the email will always be in central office time (ET)
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_pacific_recipient_eastern])
           end
-        end
-
-        it "displays central office time (ET)" do
-          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
     end
 
     context "with legacy hearing" do
       include_context "legacy_hearing"
-
-      expected_eastern = expected_legacy_times[:expected_eastern]
-      expected_pacific = expected_legacy_times[:expected_pacific]
 
       describe "#confirmation" do
         include_context "confirmation_email"
@@ -190,7 +183,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -199,12 +192,8 @@ describe VirtualHearingMailer do
 
           it "has the correct time in the email" do
             # judge time in the email will always be in central office time (ET)
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_pacific_recipient_eastern])
           end
-        end
-
-        it "displays central office time (ET)" do
-          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
 
@@ -215,7 +204,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -224,12 +213,8 @@ describe VirtualHearingMailer do
 
           it "has the correct time in the email" do
             # judge time in the email will always be in central office time (ET)
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_pacific_recipient_eastern])
           end
-        end
-
-        it "displays central office time (ET)" do
-          expect(subject.html_part.body).to include(expected_eastern)
         end
       end
     end
@@ -242,15 +227,20 @@ describe VirtualHearingMailer do
     # unless appellant_tz in VirtualHearing is set
 
     # ama hearing is scheduled at 8:30am in the regional office's time zone
-    expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "5:30am PST" }
+    expected_ama_times = {
+      ro_and_recipient_both_eastern: "8:30am EST",
+      ro_and_recipient_both_pacific: "8:30am PST",
+      ro_eastern_recipient_pacific: "5:30am PST"
+    }
     # legacy hearing is scheduled at 11:30am in the regional office's time zone
-    expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am PST" }
+    expected_legacy_times = {
+      ro_and_recipient_both_eastern: "11:30am EST",
+      ro_and_recipient_both_pacific: "11:30am PST",
+      ro_eastern_recipient_pacific: "8:30am PST"
+    }
 
     context "with ama hearing" do
       include_context "ama_hearing"
-
-      expected_eastern = expected_ama_times[:expected_eastern]
-      expected_pacific = expected_ama_times[:expected_pacific]
 
       describe "#cancellation" do
         include_context "cancellation_email"
@@ -278,7 +268,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -286,8 +276,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -298,13 +287,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "appellant_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -316,11 +305,11 @@ describe VirtualHearingMailer do
           expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
         end
 
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
-        end
-
         describe "#link" do
+          it "has the test link" do
+            expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
+          end
+
           it "is guest link" do
             expect(subject.html_part.body).to include(virtual_hearing.guest_link)
           end
@@ -338,7 +327,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -346,8 +335,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -358,13 +346,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "appellant_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -376,11 +364,11 @@ describe VirtualHearingMailer do
           expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
         end
 
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
-        end
-
         describe "#link" do
+          it "has the test link" do
+            expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
+          end
+
           it "is guest link" do
             expect(subject.html_part.body).to include(virtual_hearing.guest_link)
           end
@@ -398,7 +386,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -406,8 +394,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -418,13 +405,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "appellant_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -433,9 +420,6 @@ describe VirtualHearingMailer do
     context "with legacy hearing" do
       include_context "legacy_hearing"
 
-      expected_eastern = expected_legacy_times[:expected_eastern]
-      expected_pacific = expected_legacy_times[:expected_pacific]
-
       describe "#cancellation" do
         include_context "cancellation_email"
 
@@ -458,7 +442,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -466,8 +450,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -478,13 +461,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "appellant_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -496,7 +479,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -504,8 +487,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -516,13 +498,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "appellant_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -534,7 +516,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -542,8 +524,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -554,13 +535,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "appellant_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -574,15 +555,20 @@ describe VirtualHearingMailer do
     # unless representative_tz in VirtualHearing is set
 
     # ama hearing is scheduled at 8:30am in the regional office's time zone
-    expected_ama_times = { expected_eastern: "8:30am EST", expected_pacific: "5:30am PST" }
+    expected_ama_times = {
+      ro_and_recipient_both_eastern: "8:30am EST",
+      ro_and_recipient_both_pacific: "8:30am PST",
+      ro_eastern_recipient_pacific: "5:30am PST"
+    }
     # legacy hearing is scheduled at 11:30am in the regional office's time zone
-    expected_legacy_times = { expected_eastern: "11:30am EST", expected_pacific: "11:30am PST" }
+    expected_legacy_times = {
+      ro_and_recipient_both_eastern: "11:30am EST",
+      ro_and_recipient_both_pacific: "11:30am PST",
+      ro_eastern_recipient_pacific: "8:30am PST"
+    }
 
     context "with ama hearing" do
       include_context "ama_hearing"
-
-      expected_eastern = expected_ama_times[:expected_eastern]
-      expected_pacific = expected_ama_times[:expected_pacific]
 
       describe "#cancellation" do
         include_context "cancellation_email"
@@ -610,7 +596,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -618,8 +604,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -630,13 +615,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "representative_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -648,11 +633,11 @@ describe VirtualHearingMailer do
           expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
         end
 
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
-        end
-
         describe "#link" do
+          it "has the test link" do
+            expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
+          end
+
           it "is guest link" do
             expect(subject.html_part.body).to include(virtual_hearing.guest_link)
           end
@@ -670,7 +655,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -678,8 +663,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -690,13 +674,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "representative_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -708,11 +692,11 @@ describe VirtualHearingMailer do
           expect { subject.deliver_now! }.to change { ActionMailer::Base.deliveries.count }.by 1
         end
 
-        it "has the test link" do
-          expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
-        end
-
         describe "#link" do
+          it "has the test link" do
+            expect(subject.html_part.body).to include(virtual_hearing.test_link(recipient_title))
+          end
+
           it "is guest link" do
             expect(subject.html_part.body).to include(virtual_hearing.guest_link)
           end
@@ -730,7 +714,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -738,8 +722,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -750,13 +733,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "representative_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_ama_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -765,9 +748,6 @@ describe VirtualHearingMailer do
     context "with legacy hearing" do
       include_context "legacy_hearing"
 
-      expected_eastern = expected_legacy_times[:expected_eastern]
-      expected_pacific = expected_legacy_times[:expected_pacific]
-
       describe "#cancellation" do
         include_context "cancellation_email"
 
@@ -790,7 +770,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -798,8 +778,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -810,13 +789,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "representative_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -828,7 +807,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -836,8 +815,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -848,13 +826,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "representative_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
       end
@@ -866,7 +844,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { nyc_ro_eastern }
 
           it "has the correct time in the email" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
 
@@ -874,8 +852,7 @@ describe VirtualHearingMailer do
           let(:regional_office) { oakland_ro_pacific }
 
           it "has the correct time in the email" do
-            # always show regional office time regardless of recipient
-            expect(subject.html_part.body).to include("8:30am PST")
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_pacific])
           end
         end
 
@@ -886,13 +863,13 @@ describe VirtualHearingMailer do
           end
 
           it "displays pacific standard time (PT)" do
-            expect(subject.html_part.body).to include(expected_pacific)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_eastern_recipient_pacific])
           end
         end
 
         describe "representative_tz is not present" do
           it "displays eastern standard time (ET)" do
-            expect(subject.html_part.body).to include(expected_eastern)
+            expect(subject.html_part.body).to include(expected_legacy_times[:ro_and_recipient_both_eastern])
           end
         end
       end


### PR DESCRIPTION
Resolves #14620

Stacked on PR #14577

### Description
Resolves test failures in `spec/mailers/virtual_hearing_mailer_spec.rb` which started on a recent merge with the `master` branch. In order to fix the failures, I had to completely reformat the test file, removing shared examples, which satisfies the requirements of #14620.

### How to review
I reorganized the test file in the first three commits of this PR, and fixed the errors in the 4th. To see just the fixes, look at [changes introduced in the 4th commit](https://github.com/department-of-veterans-affairs/caseflow/commit/38fc4a184b89264fa127496c2a6f094a2fc98c9c) only.


