### PR TITLE
Rescue RecordNotUnique for BgsPowerOfAttorney

### DIFF
--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -92,6 +92,12 @@ class Claimant < CaseflowRecord
     BgsPowerOfAttorney.find_or_create_by_file_number(decision_review.veteran_file_number)
   rescue ActiveRecord::RecordInvalid # not found at BGS
     nil
+  rescue ActiveRecord::RecordNotUnique
+    # We've noticed that this error is thrown because of a race-condition
+    # where multiple processes are trying to create the same object.
+    # see: https://dsva.slack.com/archives/C3EAF3Q15/p1593726968095600 for investigation
+    # So a solution to this is to rescue the error and query it
+    BgsPowerOfAttorney.find_by(file_number: decision_review.veteran_file_number)
   end
 
   def bgs_address_service

--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -80,6 +80,12 @@ class PowerOfAttorney
     BgsPowerOfAttorney.find_or_create_by_file_number(file_number)
   rescue ActiveRecord::RecordInvalid # not found at BGS
     nil
+  rescue ActiveRecord::RecordNotUnique
+    # We've noticed that this error is thrown because of a race-condition
+    # where multiple processes are trying to create the same object.
+    # see: https://dsva.slack.com/archives/C3EAF3Q15/p1593726968095600 for investigation
+    # So a solution to this is to rescue the error and query it
+    BgsPowerOfAttorney.find_by(file_number: file_number)
   end
 
   def fetch_bgs_power_of_attorney_by_claimant_participant_id

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -160,6 +160,21 @@ describe Claimant, :postgres do
         expect(bgs_service).to have_received(:fetch_poas_by_participant_ids).once
       end
     end
+
+    context "when RecordNotUniqueError is thrown but BgsPowerOfAttorney object exists" do
+      let(:file_number_with_raised_error) { claimant.decision_review.veteran_file_number }
+      let!(:power_of_attorney) { BgsPowerOfAttorney.create(file_number: claimant.decision_review.veteran_file_number) }
+
+      before do
+        allow(BgsPowerOfAttorney).to receive(:find_or_create_by_claimant_participant_id).and_return(nil)
+        allow(BgsPowerOfAttorney).to receive(:find_or_create_by_file_number)
+          .with(file_number_with_raised_error).and_raise(ActiveRecord::RecordNotUnique.new)
+      end
+
+      it "returns BgsPowerOfAttorney" do
+        expect(subject).to eq power_of_attorney
+      end
+    end
   end
 
   context "#valid?" do

--- a/spec/models/power_of_attorney_spec.rb
+++ b/spec/models/power_of_attorney_spec.rb
@@ -73,6 +73,20 @@ describe PowerOfAttorney, :all_dbs do
     end
   end
 
+  context "when RecordNotUniqueError is thrown but BgsPowerOfAttorney object exists" do
+    let(:file_number_with_raised_error) { power_of_attorney.file_number }
+
+    before do
+      allow(BgsPowerOfAttorney).to receive(:find_or_create_by_file_number)
+        .with(file_number_with_raised_error).and_raise(ActiveRecord::RecordNotUnique.new)
+    end
+
+    it "returns BgsPowerOfAttorney object" do
+      expect(power_of_attorney.bgs_representative_name).to eq "Clarence Darrow"
+      expect(power_of_attorney.bgs_representative_address[:city]).to eq "SAN FRANCISCO"
+    end
+  end
+
   describe "error handling" do
     before do
       allow_any_instance_of(Fakes::BGSService).to receive(:find_address_by_participant_id).and_raise(Savon::Error)


### PR DESCRIPTION
### Description
The PR resolves [sentry error](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10200/events/68ef18c0d30140c4b1818ff3870ec6ba/) where `RecordNotUniqueError` is being thrown when trying to create `BgsPowerOfAttorney` object. We discovered that the issue is caused by a race condition where two simultaneous efforts are trying to create the same `BgsPowerOfAttorney` instance.
This is similar to [PR to rescue from RecordNotUnique error in UpdateCachedAppealsAttributesJob](https://github.com/department-of-veterans-affairs/caseflow/pull/14606)
[Slack thread for investigation](https://dsva.slack.com/archives/C3EAF3Q15/p1593726968095600)