### PR TITLE
Update postgres legacy appeals in batches

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -92,8 +92,6 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     cache_vacols_data_start = Time.zone.now
     cache_legacy_appeal_vacols_data(all_vacols_ids)
     datadog_report_time_segment(segment: "cache_legacy_appeal_vacols_data", start_time: cache_vacols_data_start)
-
-    increment_appeal_count(legacy_appeals.length, LegacyAppeal.name)
   end
 
   # rubocop:disable Metrics/MethodLength
@@ -125,6 +123,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
                                                                         :power_of_attorney_name,
                                                                         :suggested_hearing_location
                                                                       ] }
+      increment_appeal_count(batch_legacy_appeals.length, LegacyAppeal.name)
     end
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-VACOLS_BATCH_SIZE = 1000
+VACOLS_BATCH_SIZE = 1_000
 POSTGRES_BATCH_SIZE = 10_000
 
 class UpdateCachedAppealsAttributesJob < CaseflowJob

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 VACOLS_BATCH_SIZE = 1000
-POSTGRES_BATCH_SIZE = 10000
+POSTGRES_BATCH_SIZE = 10_000
 
 class UpdateCachedAppealsAttributesJob < CaseflowJob
   # For time_ago_in_words()


### PR DESCRIPTION
### Description
`UpdateCachedAppealsAttributesJob` has been timing out when updating Postgres legacy appeal data (see [example](https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/9357/?referrer=webhooks_plugin)). There's about 180k legacy appeals to update so I introduced a batch size of `10000` to see if that prevents the query from timing out

