### PR TITLE
Avoid triggering extra VACOLS call for hearing when mapping data

### DIFF
--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -117,6 +117,10 @@ class LegacyHearing < CaseflowRecord
     @hearing_day ||= HearingDay.find_by_id(hearing_day_id)
   end
 
+  # The logic for this method is mirrored in `HearingRepository#regional_office_for_scheduled_timezone`.
+  #
+  # There is a constraint within the `HearingRepository` context that means that calling
+  # `LegacyHearing#regional_office_Key` triggers an unnecessary call to VACOLS.
   def regional_office_key
     if request_type == HearingDay::REQUEST_TYPES[:travel] || hearing_day.nil?
       return (venue_key || appeal&.regional_office_key)

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -142,9 +142,38 @@ class HearingRepository
       end
     end
 
+    # Gets the regional office to use when mapping the VACOLS hearing date to
+    # the local scheduled time.
+    #
+    # @note Avoid triggering an indirect additional VACOLS load by avoiding calls to the
+    #   `hearing` parameter.
+    #
+    # @note This mirrors `LegacyHearing#regional_office_key`, but is designed to avoid
+    #   calls to any VACOLS accessors because those would trigger an additional
+    #   query to VACOLS.
+    #
+    #   The only call here that has the potential to trigger a VACOLS query is
+    #   the call to `LegacyHearing#hearing_day`, which can make a call to VACOLS
+    #   if the value is not cached in Caseflow.
+    #
+    # @param hearing       [LegacyHearing] an uninitialized Caseflow legacy hearing
+    # @param vacols_record [VACOLS::CaseHearing] a VACOLS case hearing
+    #
+    # @return [RegionalOffice]
+    #   A hash of setter names on a `LegacyHearing` to values
+    def regional_office_for_scheduled_timezone(hearing, vacols_record)
+      ro_key = if vacols_record.hearing_type == HearingDay::REQUEST_TYPES[:travel] || hearing.hearing_day.nil?
+                 vacols_record.hearing_venue || vacols_record.bfregoff
+               else
+                 hearing.hearing_day&.regional_office || "C"
+               end
+
+      RegionalOffice.find!(ro_key) if ro_key.present?
+    end
+
     # Maps attributes on a VACOLS case hearing to attributes on a Caseflow legacy hearing.
     #
-    # @note Avoid triggering an indirect additional VACOLS load by avoiding calls to the 
+    # @note Avoid triggering an indirect additional VACOLS load by avoiding calls to the
     #   `hearing` parameter.
     #
     # @param hearing       [LegacyHearing] an uninitialized Caseflow legacy hearing
@@ -155,23 +184,12 @@ class HearingRepository
     #
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def vacols_attributes(hearing, vacols_record)
-      # This mirrors `LegacyHearing#regional_office_key`, but is designed to avoid
-      # calls to any VACOLS accessors because those would trigger an additional
-      # query to VACOLS.
-      #
-      # The only call here that has the potential to trigger a VACOLS query is
-      # the call to `LegacyHearing#hearing_day`, which can make a call to VACOLS
-      # if the value is not cached in Caseflow.
-      ro_key = if vacols_record.hearing_type == HearingDay::REQUEST_TYPES[:travel] || hearing.hearing_day.nil?
-                 vacols_record.hearing_venue || vacols_record.bfregoff
-               else
-                 hearing.hearing_day&.regional_office || "C"
-               end
-      ro = RegionalOffice.find!(ro_key) if ro_key.present?
+      date = HearingMapper.datetime_based_on_type(
+        datetime: vacols_record.hearing_date,
+        regional_office: regional_office_for_scheduled_timezone(hearing, vacols_record),
+        type: vacols_record.hearing_type
+      )
 
-      date = HearingMapper.datetime_based_on_type(datetime: vacols_record.hearing_date,
-                                                  regional_office: ro,
-                                                  type: vacols_record.hearing_type)
       {
         vacols_record: vacols_record,
         appeal_vacols_id: vacols_record.folder_nr,


### PR DESCRIPTION
Resolves the issue described here: https://dsva.slack.com/archives/CHX8FMP28/p1594129148267500

### Description

  * Calls fo `LegacyHearing#regional_office_key/LegacyHearing#regional_office` trigger a call to VACOLS if the VACOLS record is not populated. This mirrors the logic in `HearingRepository#vacols_attributes` to avoid triggering that call to VACOLS.

