### PR TITLE
Check for veteran record where ssn is stored as file number

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -351,7 +351,7 @@ class Veteran < CaseflowRecord
       begin
         # Only make request to BGS if finding by file number is nil
         veteran = find_by(file_number: file_number) ||
-          find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
+         find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
       rescue BGS::ShareError
         false
       end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -352,7 +352,6 @@ class Veteran < CaseflowRecord
         # Only make request to BGS if finding by file number is nil
         veteran = find_by(file_number: file_number) ||
           find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
-
       rescue BGS::ShareError
         false
       end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -348,15 +348,15 @@ class Veteran < CaseflowRecord
     end
 
     def find_by_file_number_and_sync(file_number, sync_name: false)
-      begin
-        # Only make request to BGS if finding by file number is nil
-        veteran = find_by(file_number: file_number) ||
-          find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
-      rescue BGS::ShareError
-        false
-      end
+      veteran = begin
+            # Only make request to BGS if finding by file number is nil
+            find_by(file_number: file_number) ||
+              find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
+          rescue BGS::ShareError
+            nil
+          end
 
-      return nil unless veteran
+      return nil unless veteran.present?
 
       # Check to see if veteran is accessible to make sure bgs_record is
       # a hash and not :not_found. Also if it's not found, bgs_record returns

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -349,8 +349,8 @@ class Veteran < CaseflowRecord
 
     def find_by_file_number_and_sync(file_number, sync_name: false)
       begin
+        # Only make request to BGS if finding by file number is nil
         veteran = find_by(file_number: file_number) ||
-          # Only make request to BGS if finding by file number is nil
           find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
       rescue BGS::ShareError
         false

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -349,7 +349,9 @@ class Veteran < CaseflowRecord
 
     def find_by_file_number_and_sync(file_number, sync_name: false)
       begin
-        veteran = find_by(file_number: file_number) || find_by(file_number: bgs.fetch_veteran_info(file_number)[:ssn])
+        veteran = find_by(file_number: file_number) ||
+          # Only make request to BGS if finding by file number is nil
+          find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
       rescue BGS::ShareError
         false
       end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -351,7 +351,8 @@ class Veteran < CaseflowRecord
       begin
         # Only make request to BGS if finding by file number is nil
         veteran = find_by(file_number: file_number) ||
-         find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
+          find_by(file_number: bgs.fetch_veteran_info(file_number)&.dig(:ssn))
+
       rescue BGS::ShareError
         false
       end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -324,8 +324,8 @@ class Veteran < CaseflowRecord
 
     def find_or_create_by_file_number_or_ssn(file_number_or_ssn, sync_name: false)
       if file_number_or_ssn.to_s.length == 9
-        find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
-          find_by_file_number_and_sync(file_number_or_ssn, sync_name: sync_name) ||
+        find_by_file_number_and_sync(file_number_or_ssn, sync_name: sync_name) ||
+          find_or_create_by_ssn(file_number_or_ssn, sync_name: sync_name) ||
           find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)
       else
         find_or_create_by_file_number(file_number_or_ssn, sync_name: sync_name)

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -77,7 +77,7 @@ feature "Appeal Edit issues", :all_dbs do
   scenario "allows adding/removing issues" do
     visit "appeals/#{appeal.uuid}/edit/"
 
-    expect(page).to have_content("#{nonrating_request_issue.description}")
+    expect(page).to have_content(nonrating_request_issue.description)
 
     # remove an issue
     click_remove_intake_issue_dropdown(nonrating_request_issue.description)

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -77,7 +77,7 @@ feature "Appeal Edit issues", :all_dbs do
   scenario "allows adding/removing issues" do
     visit "appeals/#{appeal.uuid}/edit/"
 
-    expect(page).to have_content("2. #{nonrating_request_issue.description}")
+    expect(page).to have_content("#{nonrating_request_issue.description}")
 
     # remove an issue
     click_remove_intake_issue_dropdown(nonrating_request_issue.description)

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -667,7 +667,7 @@ describe Veteran, :all_dbs do
       end
 
       context "veteran saved in Caseflow with SSN as filenumber" do
-        let!(:veteran_by_ssn) { create(:veteran, file_number: ssn, ssn: ssn)}
+        let!(:veteran_by_ssn) { create(:veteran, file_number: ssn, ssn: ssn) }
 
         before do
           veteran.destroy! # leaves it in BGS

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -665,6 +665,20 @@ describe Veteran, :all_dbs do
       it "fetches based on SSN" do
         expect(described_class.find_or_create_by_file_number_or_ssn(ssn)).to eq(veteran)
       end
+
+      context "veteran saved in Caseflow with SSN as filenumber" do
+        let!(:veteran_by_ssn) { create(:veteran, file_number: ssn, ssn: ssn)}
+
+        before do
+          veteran.destroy! # leaves it in BGS
+        end
+
+        it "finds the veteran based on SSN and does not create a duplicate" do
+          expect(described_class.find_or_create_by_file_number_or_ssn(ssn)).to eq(veteran_by_ssn)
+          expect(described_class.find_or_create_by_file_number_or_ssn(file_number)).to eq(veteran_by_ssn)
+          expect(Veteran.where(ssn: ssn).count).to eq 1
+        end
+      end
     end
 
     context "does not exist in BGS" do


### PR DESCRIPTION
connects #14079

### Description
This updates the veteran model when finding or creating a veteran by file number **OR** ssn.

Previously, if the veteran was saved with the SSN as the file_number, and a user searched by file_number, it would create a new record instead of finding the record saved by SSN.