### PR TITLE
Remove extra "to"

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -76,7 +76,7 @@
   "TASK_SNAPSHOT_REMOVE_OVERTIME_SUCCESS": "%s's case has been removed from overtime status",
   "TASK_SNAPSHOT_REMOVE_OVERTIME_SUCCESS_DETAIL": "The \"OT\" label has been removed from this case and will no longer be visible to judges and attorneys",
   "TASK_SNAPSHOT_MARK_AS_OVERTIME_HEADER": "Mark case as overtime",
-  "TASK_SNAPSHOT_MARK_AS_OVERTIME_CONFIRMATION": "This case does not have an overtime status. Do you want to  to mark this case for overtime?",
+  "TASK_SNAPSHOT_MARK_AS_OVERTIME_CONFIRMATION": "This case does not have an overtime status. Do you want to mark this case for overtime?",
   "TASK_SNAPSHOT_MARK_AS_OVERTIME_SUCCESS": "%s's case has been marked for overtime",
   "TASK_SNAPSHOT_MARK_AS_OVERTIME_SUCCESS_DETAIL": "A new \"OT\" label has been added to the case and will be visible to all judges and attorneys",
   "TASK_SNAPSHOT_OVERTIME_LABEL": "Overtime Status",


### PR DESCRIPTION
Resolves copy error found in dogfooding

### Description
removed errant "to"

### Acceptance Criteria
- [x] Modal shows copy stipulated by design in #13415

### Testing Plan
1. Sign in as a judge
1. Go to your queue
1. Select a case
1. Click "Mark this case as overtime"
1. Check copy matches the below

### User Facing Changes

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-07-09 at 10 44 35 AM](https://user-images.githubusercontent.com/45575454/87054794-8c09ce80-c1d1-11ea-816d-44fdfd4a0a63.png)|![Screen Shot 2020-07-09 at 10 44 15 AM](https://user-images.githubusercontent.com/45575454/87054799-8c09ce80-c1d1-11ea-80da-1fbe3fdb1e67.png)
