### PR TITLE
Release CM users acting on behalf of judges

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -154,10 +154,9 @@ class TasksController < ApplicationController
   end
 
   def verify_view_access
-    return true if user == current_user || Judge.new(current_user).attorneys.include?(user)
-
-    return true if FeatureToggle.enabled?(:scm_view_judge_assign_queue) &&
-                   current_user.member_of_organization?(SpecialCaseMovementTeam.singleton)
+    return true if user == current_user ||
+                   Judge.new(current_user).attorneys.include?(user) ||
+                   current_user.can_act_on_behalf_of_judges?
 
     fail Caseflow::Error::ActionForbiddenError, message: "Only accessible by members of the Case Movement Team."
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -347,7 +347,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def can_act_on_behalf_of_judges?
-    member_of_organization?(SpecialCaseMovementTeam.singleton) && FeatureToggle.enabled?(:scm_view_judge_assign_queue)
+    member_of_organization?(SpecialCaseMovementTeam.singleton)
   end
 
   def show_regional_office_in_queue?

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -56,11 +56,7 @@ describe DistributionsController, :all_dbs do
         end
 
         context "but scm is enabled" do
-          before do
-            FeatureToggle.enable!(:scm_view_judge_assign_queue)
-            SpecialCaseMovementTeam.singleton.add_user(authed_user)
-          end
-          after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
+          before { SpecialCaseMovementTeam.singleton.add_user(authed_user) }
 
           it "renders the created distribution as json" do
             subject

--- a/spec/controllers/judge_assign_tasks_controller_spec.rb
+++ b/spec/controllers/judge_assign_tasks_controller_spec.rb
@@ -69,11 +69,7 @@ RSpec.describe JudgeAssignTasksController, :all_dbs do
       context "when the assigner is a member of the scm team" do
         let(:user) { create(:user) }
 
-        before do
-          SpecialCaseMovementTeam.singleton.add_user(user)
-          FeatureToggle.enable!(:scm_view_judge_assign_queue)
-        end
-        after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
+        before { SpecialCaseMovementTeam.singleton.add_user(user) }
 
         it_behaves_like "attorney task assignment"
       end

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -135,10 +135,8 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       before do
         current_user = create(:user).tap { |scm_user| SpecialCaseMovementTeam.singleton.add_user(scm_user) }
         User.stub = current_user
-        FeatureToggle.enable!(:scm_view_judge_assign_queue)
         @appeal = create(:legacy_appeal, vacols_case: create(:case, staff: @staff_user))
       end
-      after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
 
       it "should be successful" do
         params = {

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -750,14 +750,10 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
       before do
         scm_user = create(:user)
         SpecialCaseMovementTeam.singleton.add_user(scm_user)
-        FeatureToggle.enable!(:scm_view_judge_assign_queue)
         User.authenticate!(user: judge_user)
         DatabaseRequestCounter.enable
       end
-      after do
-        FeatureToggle.disable!(:scm_view_judge_assign_queue)
-        DatabaseRequestCounter.disable
-      end
+      after { DatabaseRequestCounter.disable }
 
       it_behaves_like "judge view legacy tasks"
     end

--- a/spec/feature/queue/scm_judge_assignment_spec.rb
+++ b/spec/feature/queue/scm_judge_assignment_spec.rb
@@ -25,11 +25,7 @@ RSpec.feature "SCM Team access to judge movement features", :all_dbs do
 
     SpecialCaseMovementTeam.singleton.add_user(scm_user)
     User.authenticate!(user: current_user)
-
-    FeatureToggle.enable!(:scm_view_judge_assign_queue)
   end
-
-  after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
 
   context "Non-SCM user should not see judge assign queue page if they are not the judge" do
     context "logged in user is some user" do
@@ -120,11 +116,7 @@ RSpec.feature "SCM Team access to judge movement features", :all_dbs do
         allow_any_instance_of(DirectReviewDocket).to receive(:weight).and_return(10)
         allow_any_instance_of(DirectReviewDocket).to receive(:nonpriority_receipts_per_year).and_return(100)
         allow(Docket).to receive(:nonpriority_decisions_per_year).and_return(1000)
-
-        FeatureToggle.enable!(:scm_view_judge_assign_queue)
       end
-
-      after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
 
       scenario "on ama appeals" do
         step "request cases" do

--- a/spec/models/legacy_tasks/judge_legacy_task_spec.rb
+++ b/spec/models/legacy_tasks/judge_legacy_task_spec.rb
@@ -90,9 +90,6 @@ describe JudgeLegacyTask, :postgres do
       context "when the user is on the special case movement team" do
         let(:user) { create(:user).tap { |scm_user| SpecialCaseMovementTeam.singleton.add_user(scm_user) } }
 
-        before { FeatureToggle.enable!(:scm_view_judge_assign_queue) }
-        after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
-
         it "returns only case movement actions" do
           expect(subject).to match_array [
             Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -33,9 +33,6 @@ describe JudgeTask, :all_dbs do
         create(:user).tap { |scm_user| SpecialCaseMovementTeam.singleton.add_user(scm_user) }
       end
 
-      before { FeatureToggle.enable!(:scm_view_judge_assign_queue) }
-      after { FeatureToggle.disable!(:scm_view_judge_assign_queue) }
-
       context "in the assign phase" do
         it "should return the Case Management assignment actions along with attorneys" do
           expect(subject).to eq(


### PR DESCRIPTION
Releases CM users acting on behalf of judges

### Description
Pulls all mention of `FeatureToggle.enabled?(:scm_view_judge_assign_queue)`

### Acceptance Criteria
- [x] #12424 AC without feature toggle
- [x] no mention of scm_view_judge_assign_queue in code base

### Testing Plan
1. Turn off the `scm_view_judge_assign_queue` toggle with `FeatureToggle.disable!(:scm_view_judge_assign_queue)`
1. Run through testing plans for #12424