### PR TITLE
Enable Reader's accordion side bar to expand

### DIFF
--- a/client/app/reader/SideBarIssueTags.jsx
+++ b/client/app/reader/SideBarIssueTags.jsx
@@ -42,6 +42,7 @@ class SideBarIssueTags extends PureComponent {
         name="tags"
         label="Select or tag issues"
         multi
+        dropdownStyling={{ position: 'relative' }}
         creatable
         options={generateOptionsFromTags(this.props.tagOptions)}
         placeholder=""

--- a/client/app/styles/react/_select-dropdown.scss
+++ b/client/app/styles/react/_select-dropdown.scss
@@ -55,7 +55,6 @@ $cf-select-text-color: #323a45;
 
   .cf-select__menu {
     border-radius: 0;
-    position: relative;
 
     .cf-select__menu-list {
       .cf-select__option {

--- a/client/app/styles/react/_select-dropdown.scss
+++ b/client/app/styles/react/_select-dropdown.scss
@@ -55,6 +55,7 @@ $cf-select-text-color: #323a45;
 
   .cf-select__menu {
     border-radius: 0;
+    position: relative;
 
     .cf-select__menu-list {
       .cf-select__option {


### PR DESCRIPTION
Resolves [Support issues reporting that Reader's accordion side bar to expand vertically](https://dsva.slack.com/archives/CJL810329/p1594299202465300)

[Solution](https://dsva.slack.com/archives/CJL810329/p1594308929481400?thread_ts=1594307320.477100&cid=CJL810329) offered by JC

### Description
Set `position: 'relative'` for SearchableDropdown component within only the SideBarIssueTags component so that Reader's accordion side bar will expand vertically to show the `cf-select__menu` popup element when it appears.

We do not want to change it globally since the popup element would push down other elements, which would be jarring for the user.

### Acceptance Criteria
- [ ] Reader's accordion side bar will expand when user starts typing a known tag label

### Testing Plan
1. Go to a document in Reader (e.g., http://localhost:3000/reader/appeal/3575931/documents/5)
2. Add a few tags by typing in the input box under 'Issue tags'
3. Start typing one of the added tags; a popup should appear below the input box and the accordion section should expand downward to allow user to see the entire popup

### User Facing Changes
 - [x] Screenshots of UI changes

 BEFORE|AFTER
 ---|---
![image](https://user-images.githubusercontent.com/55255674/87067189-5668e380-c1d9-11ea-8c67-22505ffd181c.png) | <img width="334" alt="image" src="https://user-images.githubusercontent.com/55255674/87067323-831cfb00-c1d9-11ea-9805-38ba3c1d68f3.png">




