### PR TITLE
Fix issue when geomatching returns the San Antonio facility id for closest RO

### DIFF
--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -66,6 +66,7 @@ class VaDotGovAddressValidator
   def closest_regional_office
     @closest_regional_office ||= begin
       return unless closest_ro_response.success?
+      return "RO62" if closest_regional_office_facility_id_is_san_antonio?
 
       RegionalOffice
         .cities

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -66,6 +66,9 @@ class VaDotGovAddressValidator
   def closest_regional_office
     @closest_regional_office ||= begin
       return unless closest_ro_response.success?
+
+      # Note: In `ro_facility_ids_to_geomatch`, the San Antonio facility ID is passed
+      # as a valid RO for any veteran living in Texas.
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?
 
       RegionalOffice
@@ -118,6 +121,9 @@ class VaDotGovAddressValidator
     # veterans whose closest AHL is San Antonio should have Houston as the RO
     # even though Waco may be closer. This is a RO/AHL policy quirk.
     # see https://github.com/department-of-veterans-affairs/caseflow/issues/9858
+    #
+    # Note: In the logic to determine the closest RO, there is logic that maps this
+    # facility ID to the Houston RO.
     facility_ids << "vha_671BY" if veteran_lives_in_texas? # include San Antonio facility id
 
     facility_ids << "vba_372" if appeal_is_legacy_and_veteran_lives_in_va_or_md?

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -67,6 +67,10 @@ module VaDotGovAddressValidator::Validations
     (closest_regional_office == "RO60") ? "RO10" : closest_regional_office
   end
 
+  def closest_regional_office_facility_id_is_san_antonio?
+    closest_ro_facility_id == "vha_671BY"
+  end
+
   def appeal_is_legacy_and_veteran_requested_central_office?
     appeal.is_a?(LegacyAppeal) && appeal.hearing_request_type == :central_office
   end


### PR DESCRIPTION
https://sentry.ds.va.gov/department-of-veterans-affairs/caseflow/issues/10898/?referrer=webhooks_plugin

### Description

  * Adds back the special logic to handle the San Antonio facility id (https://github.com/department-of-veterans-affairs/caseflow/commit/7256ed42056709540caf0db2daa8a9a8e12fb815#diff-4d46d1ed8191ccd0e18528f719dbb32cL46)
