### PR TITLE
Remove errant reload when bulk assigning tasks

### DIFF
--- a/app/controllers/bulk_task_assignments_controller.rb
+++ b/app/controllers/bulk_task_assignments_controller.rb
@@ -5,9 +5,13 @@ class BulkTaskAssignmentsController < TasksController
     bulk_task_assignment = BulkTaskAssignment.new(*bulk_task_assignment_params)
     return invalid_record_error(bulk_task_assignment) unless bulk_task_assignment.valid?
 
-    tasks = bulk_task_assignment.process
+    bulk_task_assignment.process
 
-    render json: json_tasks(tasks)
+    render json: { queue_config: QueueConfig.new(assignee: organization).to_hash }
+  end
+
+  def organization
+    Organization.find_by(url: params[:bulk_task_assignment][:organization_url])
   end
 
   private

--- a/client/app/queue/components/BulkAssignModal.jsx
+++ b/client/app/queue/components/BulkAssignModal.jsx
@@ -13,7 +13,7 @@ import { setActiveOrganization, requestSave } from '../uiReducer/uiActions';
 import LoadingScreen from '../../components/LoadingScreen';
 import { LOGO_COLORS } from '../../constants/AppConstants';
 import COPY from '../../../COPY';
-import WindowUtil from '../../util/WindowUtil';
+import { setQueueConfig } from '../QueueActions';
 
 const BULK_ASSIGN_ISSUE_COUNT = [5, 10, 20, 30, 40, 50];
 
@@ -82,9 +82,9 @@ class BulkAssignModal extends React.PureComponent {
       detail: 'Please go to your individual queue to see any self assigned tasks'
     };
 
-    return this.props.requestSave('/bulk_task_assignments', { data }, successMessage).then(() => {
+    return this.props.requestSave('/bulk_task_assignments', { data }, successMessage).then((resp) => {
       this.props.history.push(`/organizations/${this.organizationUrl()}`);
-      WindowUtil.reloadWithPOST();
+      this.props.setQueueConfig(resp.body.queue_config);
     }).
       catch(() => {
         // handle the error
@@ -229,7 +229,8 @@ BulkAssignModal.propTypes = {
   history: PropTypes.object,
   location: PropTypes.object,
   onCancel: PropTypes.func,
-  requestSave: PropTypes.func
+  requestSave: PropTypes.func,
+  setQueueConfig: PropTypes.func
 };
 
 const mapStateToProps = (state) => {
@@ -245,7 +246,8 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => (
   bindActionCreators({
     setActiveOrganization,
-    requestSave
+    requestSave,
+    setQueueConfig
   }, dispatch));
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(BulkAssignModal));

--- a/spec/controllers/bulk_task_assignments_controller_spec.rb
+++ b/spec/controllers/bulk_task_assignments_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe BulkTaskAssignmentsController, :postgres, type: :controller do
           get :create, params: { bulk_task_assignment: params }
           expect(response.status).to eq 200
           response_body = JSON.parse(response.body)
-          expect(response_body["data"].size).to eq 2
+          expect(response_body["queue_config"]["tabs"][1]["tasks"].count).to eq 2
         end
       end
 

--- a/spec/controllers/bulk_task_assignments_controller_spec.rb
+++ b/spec/controllers/bulk_task_assignments_controller_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe BulkTaskAssignmentsController, :postgres, type: :controller do
           get :create, params: { bulk_task_assignment: params }
           expect(response.status).to eq 200
           response_body = JSON.parse(response.body)
+          expect(response_body["queue_config"]["tabs"][0]["tasks"].count).to eq 0
           expect(response_body["queue_config"]["tabs"][1]["tasks"].count).to eq 2
+          expect(response_body["queue_config"]["tabs"][2]["tasks"].count).to eq 0
+          expect(response_body["queue_config"]["tabs"][3]["tasks"].count).to eq 0
         end
       end
 

--- a/spec/feature/queue/bulk_task_assignment_spec.rb
+++ b/spec/feature/queue/bulk_task_assignment_spec.rb
@@ -19,11 +19,11 @@ RSpec.feature "Bulk task assignment", :postgres do
       number_of_tasks = options.find { |option| option.text =~ /3/ }
       number_of_tasks.click
       expect(page).to_not have_content("Please select a value")
-      submit = all("button", text: "Assign Tasks")[0]
+      submit = find("button", id: "Bulk-Assign-Tasks-button-id-1")
       submit.click
     end
 
-    it "is able to bulk assign tasks for the hearing management org", skip: "flake" do
+    it "is able to bulk assign tasks for the hearing management org" do
       3.times do
         create(:no_show_hearing_task)
       end
@@ -32,7 +32,7 @@ RSpec.feature "Bulk task assignment", :postgres do
       expect(page).to have_content("Bulk Assign Tasks")
 
       # Whem missing required fields
-      submit = all("button", text: "Assign Tasks")[0]
+      submit = find("button", id: "Bulk-Assign-Tasks-button-id-1")
       submit.click
       expect(page).to have_content("Please select a value")
       expect(page).to_not have_content("Loading")

--- a/spec/feature/queue/bulk_task_assignment_spec.rb
+++ b/spec/feature/queue/bulk_task_assignment_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Bulk task assignment", :postgres do
       assign_to.click
       task_type = options.find { |option| option.text =~ /No Show Hearing Task/ }
       task_type.click
-      number_of_tasks = options.find { |option| option.text =~ /3/ }
+      number_of_tasks = options.find { |option| option.text =~ /3 \(all available tasks\)/ }
       number_of_tasks.click
       expect(page).to_not have_content("Please select a value")
       submit = find("button", id: "Bulk-Assign-Tasks-button-id-1")
@@ -31,7 +31,7 @@ RSpec.feature "Bulk task assignment", :postgres do
       click_button(text: "Assign Tasks")
       expect(page).to have_content("Bulk Assign Tasks")
 
-      # Whem missing required fields
+      # When missing required fields
       submit = find("button", id: "Bulk-Assign-Tasks-button-id-1")
       submit.click
       expect(page).to have_content("Please select a value")


### PR DESCRIPTION
Resolves #11190

### Description
Pass queue config to the front end after bulk assigning tasks so that the page does not need a refresh

### Acceptance Criteria
- [ ] Page does not refresh automaticvally after bulk assigning tasks
- [ ] Task counts in their respective tabs are correct
- [ ] Flake passes!

### Testing Plan
1. Make BVATWARNER an admin
```ruby
OrganizationsUser.make_user_admin(HearingsManagement.singleton.users.first, HearingsManagement.singleton)
```
1. Log in as BVATWARNER and got to the hearings management page http://localhost:3000/organizations/hearings-management
1. Bulk assign tasks, keeping an eye on the tasks counts
1. Ensure the tasks appear in their proper tabs
1. Refresh the page and ensure it matches the tasks/counts shown before the refresh to ensure what's returned after bulk assign matches the hard pull after a refresh.

### User Facing Changes

 BEFORE REFRESH|AFTER REFRESH
 ---|---
![Screen Shot 2020-07-09 at 1 53 24 PM](https://user-images.githubusercontent.com/45575454/87075737-cdf53d80-c1ee-11ea-924b-dcf61e2aa3dc.png)|![Screen Shot 2020-07-09 at 1 53 38 PM](https://user-images.githubusercontent.com/45575454/87075746-d0579780-c1ee-11ea-9092-c400d5854e2b.png)