### PR TITLE
Fix BGS POA test flake caused by sharing Redis state

### DIFF
--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -65,11 +65,11 @@ describe BgsPowerOfAttorney do
 
     context "when concurrent calls cause a race condition" do
       let(:concurrency) { 4 }
-      let(:pid) { "456" }
+      let(:pid) { "7108346" }
       let(:file_number) { "fn" }
       let(:bgs_record) do
         {
-          claimant_participant_id: "123",
+          claimant_participant_id: "1738055",
           participant_id: pid,
           file_number: file_number,
           representative_name: "some",

--- a/spec/models/power_of_attorney_spec.rb
+++ b/spec/models/power_of_attorney_spec.rb
@@ -46,7 +46,7 @@ describe PowerOfAttorney, :all_dbs do
 
     context "by claimant_participant_id" do
       let(:power_of_attorney) do
-        PowerOfAttorney.new(vacols_id: vacols_case.bfkey, claimant_participant_id: "123")
+        PowerOfAttorney.new(vacols_id: vacols_case.bfkey, claimant_participant_id: "8345701")
       end
 
       it "returns BGS values" do


### PR DESCRIPTION
### Description
Two tangentially-related specs (both around fetching POA data from BGS) were causing the tests to fail if the second one hit Redis state set by the first one.

e.g. https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/33002/workflows/630f377d-a044-484d-baa9-a32bb1a32e1f/jobs/121269/steps

This fixes that by just using test IDs with more entropy. Perhaps we can think of a more systematic and less convention-reliant fix in the BEWG?

### Testing Plan
```bundle exec rspec spec/models/*pow*```
was the most reliable way I found of reproducing the failure. This command now succeeds for me locally.