### PR TITLE
Fix how updated_by gets assigned

### DIFF
--- a/app/models/concerns/updated_by_user_concern.rb
+++ b/app/models/concerns/updated_by_user_concern.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module UpdatedByUserConcern
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :updated_by, class_name: "User", optional: true
+
+    before_save :assign_updated_by_user
+  end
+
+  private
+
+  def assign_updated_by_user
+    return if RequestStore.store[:current_user] == User.system_user && updated_by.present?
+
+    self.updated_by = RequestStore.store[:current_user] if RequestStore.store[:current_user].present?
+  end
+end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -6,12 +6,12 @@ class Hearing < CaseflowRecord
   include HearingTimeConcern
   include HearingLocationConcern
   include HasSimpleAppealUpdatedSince
+  include UpdatedByUserConcern
 
   belongs_to :hearing_day
   belongs_to :appeal
   belongs_to :judge, class_name: "User"
   belongs_to :created_by, class_name: "User"
-  belongs_to :updated_by, class_name: "User"
   has_one :transcription, -> { order(created_at: :desc) }
   has_many :hearing_views, as: :hearing
   has_one :hearing_location, as: :hearing
@@ -42,7 +42,6 @@ class Hearing < CaseflowRecord
   after_create :update_fields_from_hearing_day
   before_create :check_available_slots, unless: :override_full_hearing_day_validation
   before_create :assign_created_by_user
-  before_update :assign_updated_by_user
 
   attr_accessor :override_full_hearing_day_validation
 
@@ -212,9 +211,5 @@ class Hearing < CaseflowRecord
 
   def assign_created_by_user
     self.created_by ||= RequestStore[:current_user]
-  end
-
-  def assign_updated_by_user
-    self.updated_by ||= RequestStore[:current_user]
   end
 end

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -5,11 +5,12 @@
 # Caseflow DB. For now all schedule data is sent to the
 # VACOLS DB (Aug 2018 implementation).
 class HearingDay < CaseflowRecord
+  include UpdatedByUserConcern
+
   acts_as_paranoid
 
   belongs_to :judge, class_name: "User"
   belongs_to :created_by, class_name: "User"
-  belongs_to :updated_by, class_name: "User"
   has_many :hearings
 
   class HearingDayHasChildrenRecords < StandardError; end
@@ -37,8 +38,7 @@ class HearingDay < CaseflowRecord
     "America/Anchorage" => 8
   }.freeze
 
-  before_create :assign_created_and_updated_by_user
-  before_update :assign_updated_by_user
+  before_create :assign_created_by_user
   after_update :update_children_records
 
   # Validates if the judge id maps to an actual record.
@@ -138,13 +138,8 @@ class HearingDay < CaseflowRecord
 
   private
 
-  def assign_created_and_updated_by_user
+  def assign_created_by_user
     self.created_by ||= RequestStore[:current_user]
-    assign_updated_by_user
-  end
-
-  def assign_updated_by_user
-    self.updated_by ||= RequestStore[:current_user]
   end
 
   def update_children_records

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -21,7 +21,7 @@ class VirtualHearing < CaseflowRecord
 
   belongs_to :hearing, polymorphic: true
   belongs_to :created_by, class_name: "User"
-  
+
   # Tracks the progress of the job that creates the virtual hearing in Pexip.
   has_one :establishment, class_name: "VirtualHearingEstablishment"
 

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -8,6 +8,7 @@ class LegacyHearing < CaseflowRecord
   include HasVirtualHearing
   include HearingLocationConcern
   include HearingTimeConcern
+  include UpdatedByUserConcern
 
   # When these instance variable getters are called, first check if we've
   # fetched the values from VACOLS. If not, first fetch all values and save them
@@ -28,7 +29,6 @@ class LegacyHearing < CaseflowRecord
   belongs_to :appeal, class_name: "LegacyAppeal"
   belongs_to :user # the judge
   belongs_to :created_by, class_name: "User"
-  belongs_to :updated_by, class_name: "User"
   has_many :hearing_views, as: :hearing
   has_many :appeal_stream_snapshots, foreign_key: :hearing_id
   has_one :hearing_location, as: :hearing
@@ -52,7 +52,6 @@ class LegacyHearing < CaseflowRecord
   delegate :timezone, :name, to: :regional_office, prefix: true
 
   before_create :assign_created_by_user
-  before_update :assign_updated_by_user
 
   CO_HEARING = "Central"
   VIDEO_HEARING = "Video"
@@ -323,9 +322,5 @@ class LegacyHearing < CaseflowRecord
 
   def assign_created_by_user
     self.created_by ||= RequestStore[:current_user]
-  end
-
-  def assign_updated_by_user
-    self.updated_by ||= RequestStore[:current_user]
   end
 end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -388,17 +388,19 @@ RSpec.describe HearingsController, type: :controller do
       expect(subject.status).to eq 200
     end
 
-    shared_examples_for "returns the correct hearing time in EST" do
+    shared_examples_for "returns the correct hearing time in EST" do |expected_time|
       it "returns the correct hearing time in EST", :aggregate_failures do
         body = JSON.parse(subject.body)
 
         expect(body["data"]["regional_office_timezone"]).to eq(expected_time_zone)
-        expect(body["data"]["scheduled_time_string"]).to eq("08:30")
-        expect(body["data"]["scheduled_for"]).to eq("#{hearing.hearing_day.scheduled_for}T08:30:00.000#{utc_offset}")
+        expect(body["data"]["scheduled_time_string"]).to eq(expected_time)
+        expect(body["data"]["scheduled_for"]).to eq(
+          "#{hearing.hearing_day.scheduled_for}T#{expected_time}:00.000#{utc_offset}"
+        )
       end
     end
 
-    it_should_behave_like "returns the correct hearing time in EST"
+    it_should_behave_like "returns the correct hearing time in EST", "08:30"
 
     context "for user on west coast" do
       let!(:user) do
@@ -407,7 +409,7 @@ RSpec.describe HearingsController, type: :controller do
         )
       end
 
-      it_should_behave_like "returns the correct hearing time in EST"
+      it_should_behave_like "returns the correct hearing time in EST", "05:30"
     end
   end
 


### PR DESCRIPTION
Resolves #14205

### Description

  * Create concern to standardize how `updated_by` gets set

### Acceptance Criteria
- [x]  save the current user whenever an update is done
- [x] use before_save instead of before_update to set the value, so it'll be set on create as well
- [x] don't save a nil value if RequestStore[:current_user] isn't set (see the implementation in the VirtualHearing model)
- [x] verify that this change won't invalidate assumptions we're making as we use updated_by elsewhere in the code (for example, in the Hearing model, we're using the timezone of the updated_by user to convert hearing times)
