### PR TITLE
Allow users to remove the last issue tag on a document

### DIFF
--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -44,16 +44,15 @@ export class SearchableDropdown extends React.Component {
      */
     if (!this.props.multi && Array.isArray(value) && value.length <= 0) {
       newValue = null;
+    } else if (this.props.multi && value === null) {
+      // Fix for https://github.com/JedWatson/react-select/issues/3632
+      newValue = [];
     }
     // don't set value in state if creatable is true
     if (!this.props.selfManageValueState) {
       this.setState({ value: this.props.clearOnSelect ? null : newValue });
     }
 
-    // Fix for https://github.com/JedWatson/react-select/issues/3632
-    if (this.props.multi && value === null) {
-      newValue = [];
-    }
     if (
       this.state.value &&
       newValue &&

--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -50,14 +50,18 @@ export class SearchableDropdown extends React.Component {
       this.setState({ value: this.props.clearOnSelect ? null : newValue });
     }
 
+    // Fix for https://github.com/JedWatson/react-select/issues/3632
+    if (this.props.multi && value === null) {
+      newValue = [];
+    }
     if (
       this.state.value &&
-      value &&
-      Array.isArray(value) &&
+      newValue &&
+      Array.isArray(newValue) &&
       Array.isArray(this.state.value) &&
-      value.length < this.state.value.length
+      newValue.length < this.state.value.length
     ) {
-      deletedValue = _.differenceWith(this.state.value, value, _.isEqual);
+      deletedValue = _.differenceWith(this.state.value, newValue, _.isEqual);
     }
     if (this.props.onChange) {
       this.props.onChange(newValue, deletedValue);


### PR DESCRIPTION
Resolves bug caused by https://github.com/JedWatson/react-select/issues/3632

### Description
When the final item in the multi select is removed, react-select returns null to [onChange](https://github.com/department-of-veterans-affairs/caseflow/blob/35d1d8bb058584bf2b2c868651cab72d57b05b68/client/app/components/SearchableDropdown.jsx#L34). However, we expect this to be an empty array. This adds a check to ensure that value is not null if if the react component is a multi select,

### Acceptance Criteria
- [ ] Users can remove the last issue tag on a document

### Testing Plan
1. Log in as a user with reader access
1. Go to reader and open a doc
1. Add an issue tag
1. Press the x on the individual tag
1. Reload the page
1. Ensure the tag is gone


### User Facing Changes

 BEFORE|AFTER
 ---|---
![ezgif-1-b87bc924b949](https://user-images.githubusercontent.com/45575454/87094869-acf01500-c20d-11ea-9ca9-69cef4f3c1e6.gif)|![ezgif-1-32d16ab9f8c0](https://user-images.githubusercontent.com/45575454/87094970-de68e080-c20d-11ea-8be1-d4c6d2198636.gif)
