### PR TITLE
Sort rating_issue_serializer

### DIFF
--- a/app/serializers/intake/rating_issue_serializer.rb
+++ b/app/serializers/intake/rating_issue_serializer.rb
@@ -4,18 +4,18 @@ class Intake::RatingIssueSerializer
   include FastJsonapi::ObjectSerializer
   set_id(&:reference_id)
 
-  attribute :participant_id
-  attribute :reference_id
-  attribute :decision_text
-  attribute :promulgation_date
-  attribute :profile_date
-  attribute :ramp_claim_id
-  attribute :rba_contentions_data
-  attribute :diagnostic_code
-  attribute :benefit_type
-  attribute :subject_text
-  attribute :percent_number
   attribute :associated_end_products do |object|
     object.associated_end_products.map(&:serialize)
   end
+  attribute :benefit_type
+  attribute :decision_text
+  attribute :diagnostic_code
+  attribute :participant_id
+  attribute :percent_number
+  attribute :profile_date
+  attribute :promulgation_date
+  attribute :ramp_claim_id
+  attribute :rba_contentions_data
+  attribute :reference_id
+  attribute :subject_text
 end


### PR DESCRIPTION
sort rating_issue_serializer attributes just as fields are sorted in the rating_issue model
sorted with an emacs macro
double checked by hand