### PR TITLE
show correct am/pm on the central office time in the change virtual hearing time modal

### DIFF
--- a/client/app/hearings/components/VirtualHearingModal.jsx
+++ b/client/app/hearings/components/VirtualHearingModal.jsx
@@ -16,7 +16,7 @@ const getCentralOfficeTime = (hearing) => {
   return moment.
     tz(newTime, hearing.regionalOfficeTimezone).
     tz('America/New_York').
-    format('hh:mm');
+    format('HH:mm');
 };
 
 const formatTimeString = (hearing, timeWasEdited) => {


### PR DESCRIPTION
### Description
Fixes a bug where the central office time in the change virtual hearing time modal is always displayed in AM.

before:
![Screen Shot 2020-07-10 at 10 48 47 AM](https://user-images.githubusercontent.com/45415133/87183448-06eaec00-c29b-11ea-86bb-c2ad6edcebd6.png)

after:
![Screen Shot 2020-07-10 at 10 46 51 AM](https://user-images.githubusercontent.com/45415133/87183466-0b170980-c29b-11ea-9ccf-cd9ed8e3284f.png)
