### PR TITLE
Add priority flag to distributions

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -38,7 +38,7 @@ class DistributionsController < ApplicationController
 
   def render_errors(error)
     errors = error.record.errors.details.values.flatten.map { |error_details| error_details[:error] }
-    return render_single(pending_distribution) if errors.include? :pending_distribution
+    return render_single(pending_distributions.first) if errors.include? :pending_distribution
 
     render_403_error(errors)
   end
@@ -101,8 +101,8 @@ class DistributionsController < ApplicationController
     end
   end
 
-  def pending_distribution
-    Distribution.pending_for_judge(judge).first
+  def pending_distributions
+    Distribution.pending_for_judge(judge)
   end
 
   def judge

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -102,7 +102,7 @@ class DistributionsController < ApplicationController
   end
 
   def pending_distribution
-    Distribution.pending_for_judge(judge)
+    Distribution.pending_for_judge(judge).first
   end
 
   def judge

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -9,8 +9,8 @@ class Distribution < CaseflowRecord
 
   validates :judge, presence: true
   validate :validate_user_is_judge, on: :create
-  validate :validate_number_of_unassigned_cases, on: :create
-  validate :validate_days_waiting_of_unassigned_cases, on: :create
+  validate :validate_number_of_unassigned_cases, on: :create, unless: :priority?
+  validate :validate_days_waiting_of_unassigned_cases, on: :create, unless: :priority?
   validate :validate_judge_has_no_pending_distributions, on: :create
 
   enum status: { pending: "pending", started: "started", error: "error", completed: "completed" }
@@ -22,7 +22,7 @@ class Distribution < CaseflowRecord
 
   class << self
     def pending_for_judge(judge)
-      find_by(status: %w[pending started], judge: judge)
+      where(status: %w[pending started], judge: judge)
     end
   end
 
@@ -74,7 +74,7 @@ class Distribution < CaseflowRecord
   end
 
   def validate_judge_has_no_pending_distributions
-    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge)
+    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge).where(priority: priority)
   end
 
   def judge_tasks

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -9,8 +9,8 @@ class Distribution < CaseflowRecord
 
   validates :judge, presence: true
   validate :validate_user_is_judge, on: :create
-  validate :validate_number_of_unassigned_cases, on: :create, unless: :priority?
-  validate :validate_days_waiting_of_unassigned_cases, on: :create, unless: :priority?
+  validate :validate_number_of_unassigned_cases, on: :create, unless: :priority_push?
+  validate :validate_days_waiting_of_unassigned_cases, on: :create, unless: :priority_push?
   validate :validate_judge_has_no_pending_distributions, on: :create
 
   enum status: { pending: "pending", started: "started", error: "error", completed: "completed" }
@@ -74,7 +74,9 @@ class Distribution < CaseflowRecord
   end
 
   def validate_judge_has_no_pending_distributions
-    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge).where(priority: priority).exists?
+    if self.class.pending_for_judge(judge).where(priority_push: priority_push).exists?
+      errors.add(:judge, :pending_distribution)
+    end
   end
 
   def judge_tasks

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -74,7 +74,7 @@ class Distribution < CaseflowRecord
   end
 
   def validate_judge_has_no_pending_distributions
-    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge).where(priority: priority)
+    errors.add(:judge, :pending_distribution) if self.class.pending_for_judge(judge).where(priority: priority).exists?
   end
 
   def judge_tasks

--- a/db/migrate/20200713173228_add_priority_to_distributions.rb
+++ b/db/migrate/20200713173228_add_priority_to_distributions.rb
@@ -1,0 +1,10 @@
+class AddPriorityToDistributions < ActiveRecord::Migration[5.2]
+  def up
+    add_column :distributions, :priority, :boolean, comment: "Whether or not this distribution was a priority appeals only push to judges via weekly job (not requested)"
+    change_column_default :distributions, :priority, false
+  end
+
+  def down
+    remove_column :distributions, :priority
+  end
+end

--- a/db/migrate/20200713173228_add_priority_to_distributions.rb
+++ b/db/migrate/20200713173228_add_priority_to_distributions.rb
@@ -1,10 +1,10 @@
 class AddPriorityToDistributions < ActiveRecord::Migration[5.2]
   def up
-    add_column :distributions, :priority, :boolean, comment: "Whether or not this distribution was a priority appeals only push to judges via weekly job (not requested)"
-    change_column_default :distributions, :priority, false
+    add_column :distributions, :priority_push, :boolean, comment: "Whether or not this distribution is a priority-appeals-only push to judges via a weekly job (not manually requested)"
+    change_column_default :distributions, :priority_push, false
   end
 
   def down
-    remove_column :distributions, :priority
+    remove_column :distributions, :priority_push
   end
 end

--- a/db/migrate/20200713174152_backfill_distribution_priority.rb
+++ b/db/migrate/20200713174152_backfill_distribution_priority.rb
@@ -3,7 +3,7 @@ class BackfillDistributionPriority < ActiveRecord::Migration[5.2]
 
   def change
     Distribution.unscoped.in_batches do |relation|
-      relation.update_all priority: false
+      relation.update_all priority_push: false
       sleep(0.1)
     end
   end

--- a/db/migrate/20200713174152_backfill_distribution_priority.rb
+++ b/db/migrate/20200713174152_backfill_distribution_priority.rb
@@ -1,0 +1,10 @@
+class BackfillDistributionPriority < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    Distribution.unscoped.in_batches do |relation|
+      relation.update_all priority: false
+      sleep(0.1)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -844,7 +844,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_174152) do
     t.boolean "military_sexual_trauma", default: false, comment: "Military Sexual Trauma (MST)"
     t.boolean "mustard_gas", default: false
     t.boolean "national_cemetery_administration", default: false
-    t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues; added belatedly"
+    t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues; column added belatedly"
     t.boolean "nonrating_issue", default: false
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -439,7 +439,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_174152) do
     t.datetime "created_at", null: false
     t.datetime "errored_at", comment: "when the Distribution job suffered an error"
     t.integer "judge_id"
-    t.boolean "priority", default: false, comment: "Whether or not this distribution was a priority appeals only push to judges via weekly job (not requested)"
+    t.boolean "priority_push", default: false, comment: "Whether or not this distribution is a priority-appeals-only push to judges via a weekly job (not manually requested)"
     t.datetime "started_at", comment: "when the Distribution job commenced"
     t.json "statistics"
     t.string "status"
@@ -844,7 +844,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_174152) do
     t.boolean "military_sexual_trauma", default: false, comment: "Military Sexual Trauma (MST)"
     t.boolean "mustard_gas", default: false
     t.boolean "national_cemetery_administration", default: false
-    t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues, added belatedly"
+    t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues; added belatedly"
     t.boolean "nonrating_issue", default: false
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_012721) do
+ActiveRecord::Schema.define(version: 2020_07_13_174152) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -439,6 +439,7 @@ ActiveRecord::Schema.define(version: 2020_07_07_012721) do
     t.datetime "created_at", null: false
     t.datetime "errored_at", comment: "when the Distribution job suffered an error"
     t.integer "judge_id"
+    t.boolean "priority", default: false, comment: "Whether or not this distribution was a priority appeals only push to judges via weekly job (not requested)"
     t.datetime "started_at", comment: "when the Distribution job commenced"
     t.json "statistics"
     t.string "status"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -323,7 +323,7 @@ distributions,created_at,datetime ∗,x,,,,,
 distributions,errored_at,datetime,,,,,,when the Distribution job suffered an error
 distributions,id,integer (8) PK,x,x,,,,
 distributions,judge_id,integer FK,,,x,,,
-distributions,priority,boolean,,,,,,Whether or not this distribution was a priority appeals only push to judges via weekly job (not requested)
+distributions,priority_push,boolean,,,,,,Whether or not this distribution is a priority-appeals-only push to judges via a weekly job (not manually requested)
 distributions,started_at,datetime,,,,,,when the Distribution job commenced
 distributions,statistics,json,,,,,,
 distributions,status,string,,,,,,

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -323,6 +323,7 @@ distributions,created_at,datetime ∗,x,,,,,
 distributions,errored_at,datetime,,,,,,when the Distribution job suffered an error
 distributions,id,integer (8) PK,x,x,,,,
 distributions,judge_id,integer FK,,,x,,,
+distributions,priority,boolean,,,,,,Whether or not this distribution was a priority appeals only push to judges via weekly job (not requested)
 distributions,started_at,datetime,,,,,,when the Distribution job commenced
 distributions,statistics,json,,,,,,
 distributions,status,string,,,,,,
@@ -687,18 +688,18 @@ legacy_issues,vacols_sequence_id,integer ∗,x,,,,,The sequence ID of the lega
 legacy_issue_optins,,,,,,,,"When a VACOLS issue from a legacy appeal is opted-in to AMA, this table keeps track of the related request_issue, and the status of processing the opt-in, or rollback if the request issue is removed from a Decision Review."
 legacy_issue_optins,created_at,datetime ∗,x,,,,,"When a Request Issue is connected to a VACOLS issue on a legacy appeal, and the Veteran has agreed to withdraw their legacy appeals, a legacy_issue_optin is created at the time the Decision Review is successfully intaken. This is used to indicate that the legacy issue should subsequently be opted into AMA in VACOLS. "
 legacy_issue_optins,error,string,,,,,,
+legacy_issue_optins,folder_decision_date,date,,,,,,Decision date on case record folder
 legacy_issue_optins,id,integer (8) PK,x,x,,,,
 legacy_issue_optins,legacy_issue_id,integer (8) FK,,,x,,x,"The legacy issue being opted in, which connects to the request issue"
 legacy_issue_optins,optin_processed_at,datetime,,,,,,"The timestamp for when the opt-in was successfully processed, meaning it was updated in VACOLS as opted into AMA."
 legacy_issue_optins,original_disposition_code,string,,,,,,The original disposition code of the VACOLS issue being opted in. Stored in case the opt-in is rolled back.
 legacy_issue_optins,original_disposition_date,date,,,,,,The original disposition date of the VACOLS issue being opted in. Stored in case the opt-in is rolled back.
+legacy_issue_optins,original_legacy_appeal_decision_date,date,,,,,,The original disposition date of a legacy appeal being opted in
+legacy_issue_optins,original_legacy_appeal_disposition_code,string,,,,,,The original disposition code of legacy appeal being opted in
 legacy_issue_optins,request_issue_id,integer (8) ∗ FK,x,,x,,x,The request issue connected to the legacy VACOLS issue that has been opted in.
 legacy_issue_optins,rollback_created_at,datetime,,,,,,"Timestamp for when the connected request issue is removed from a Decision Review during edit, indicating that the opt-in needs to be rolled back."
 legacy_issue_optins,rollback_processed_at,datetime,,,,,,Timestamp for when a rolled back opt-in has successfully finished being rolled back.
 legacy_issue_optins,updated_at,datetime ∗,x,,,,x,Automatically populated when the record is updated.
-legacy_issue_optins,original_legacy_appeal_decision_date,datetime,,,,,,The original disposition date of a legacy appeal being opted in.
-legacy_issue_optins,original_legacy_appeal_disposition_code,string,,,,,,The original disposition code of legacy appeal being opted in.
-legacy_issue_optins,folder_decision_date,date,,,,,,Decision date on case record folder.
 messages,,,,,,,,
 messages,created_at,datetime ∗,x,,,,,
 messages,detail_id,integer FK,,,x,,x,ID of the related object

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -417,10 +417,10 @@ describe Distribution, :all_dbs do
       end
     end
 
-    subject { Distribution.create(judge: user, priority: priority) }
+    subject { Distribution.create(judge: user, priority_push: priority_push) }
 
     let(:user) { judge }
-    let(:priority) { false }
+    let(:priority_push) { false }
 
     context "existing Distribution record with status pending" do
       let!(:existing_distribution) { create(:distribution, judge: judge) }
@@ -430,8 +430,8 @@ describe Distribution, :all_dbs do
         expect(subject.errors.details[:judge]).to include(error: :pending_distribution)
       end
 
-      context "when the priority is not the same" do
-        let!(:existing_distribution) { create(:distribution, judge: judge, priority: true) }
+      context "when the priority_push is not the same" do
+        let!(:existing_distribution) { create(:distribution, judge: judge, priority_push: true) }
 
         it_behaves_like "passes validations"
       end
@@ -445,8 +445,8 @@ describe Distribution, :all_dbs do
         expect(subject.errors.details[:judge]).to include(error: :pending_distribution)
       end
 
-      context "when the priority is not the same" do
-        let!(:existing_distribution) { create(:distribution, judge: judge, status: :started, priority: true) }
+      context "when the priority_push is not the same" do
+        let!(:existing_distribution) { create(:distribution, judge: judge, status: :started, priority_push: true) }
 
         it_behaves_like "passes validations"
       end
@@ -483,8 +483,8 @@ describe Distribution, :all_dbs do
         expect(subject.errors.details[:judge]).to include(error: :too_many_unassigned_cases)
       end
 
-      context "when priority is true" do
-        let(:priority) { true }
+      context "when priority_push is true" do
+        let(:priority_push) { true }
 
         it_behaves_like "passes validations"
       end
@@ -498,8 +498,8 @@ describe Distribution, :all_dbs do
         expect(subject.errors.details[:judge]).to include(error: :unassigned_cases_waiting_too_long)
       end
 
-      context "when priority is true" do
-        let(:priority) { true }
+      context "when priority_push is true" do
+        let(:priority_push) { true }
 
         it_behaves_like "passes validations"
       end
@@ -513,8 +513,8 @@ describe Distribution, :all_dbs do
         expect(subject.errors.details[:judge]).to include(error: :unassigned_cases_waiting_too_long)
       end
 
-      context "when priority is true" do
-        let(:priority) { true }
+      context "when priority_push is true" do
+        let(:priority_push) { true }
 
         it_behaves_like "passes validations"
       end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -410,7 +410,7 @@ describe Distribution, :all_dbs do
     end
   end
 
-  fcontext "validations" do
+  context "validations" do
     subject { Distribution.create(judge: user, priority: priority) }
 
     let(:user) { judge }
@@ -482,7 +482,7 @@ describe Distribution, :all_dbs do
       end
 
       context "when priority is true" do
-        let(:priority) { false }
+        let(:priority) { true }
 
         it "is valid" do
           expect(subject.valid?).to be true
@@ -500,7 +500,7 @@ describe Distribution, :all_dbs do
       end
 
       context "when priority is true" do
-        let(:priority) { false }
+        let(:priority) { true }
 
         it "is valid" do
           expect(subject.valid?).to be true
@@ -518,7 +518,7 @@ describe Distribution, :all_dbs do
       end
 
       context "when priority is true" do
-        let(:priority) { false }
+        let(:priority) { true }
 
         it "is valid" do
           expect(subject.valid?).to be true

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -411,6 +411,12 @@ describe Distribution, :all_dbs do
   end
 
   context "validations" do
+    shared_examples "passes validations" do
+      it "is valid" do
+        expect(subject.valid?).to be true
+      end
+    end
+
     subject { Distribution.create(judge: user, priority: priority) }
 
     let(:user) { judge }
@@ -427,9 +433,7 @@ describe Distribution, :all_dbs do
       context "when the priority is not the same" do
         let!(:existing_distribution) { create(:distribution, judge: judge, priority: true) }
 
-        it "does not prevent a new Distribution record" do
-          expect(subject.valid?).to be true
-        end
+        it_behaves_like "passes validations"
       end
     end
 
@@ -444,9 +448,7 @@ describe Distribution, :all_dbs do
       context "when the priority is not the same" do
         let!(:existing_distribution) { create(:distribution, judge: judge, status: :started, priority: true) }
 
-        it "does not prevent a new Distribution record" do
-          expect(subject.valid?).to be true
-        end
+        it_behaves_like "passes validations"
       end
     end
 
@@ -484,10 +486,7 @@ describe Distribution, :all_dbs do
       context "when priority is true" do
         let(:priority) { true }
 
-        it "is valid" do
-          expect(subject.valid?).to be true
-          expect(subject.errors.details).not_to have_key(:judge)
-        end
+        it_behaves_like "passes validations"
       end
     end
 
@@ -502,10 +501,7 @@ describe Distribution, :all_dbs do
       context "when priority is true" do
         let(:priority) { true }
 
-        it "is valid" do
-          expect(subject.valid?).to be true
-          expect(subject.errors.details).not_to have_key(:judge)
-        end
+        it_behaves_like "passes validations"
       end
     end
 
@@ -520,10 +516,7 @@ describe Distribution, :all_dbs do
       context "when priority is true" do
         let(:priority) { true }
 
-        it "is valid" do
-          expect(subject.valid?).to be true
-          expect(subject.errors.details).not_to have_key(:judge)
-        end
+        it_behaves_like "passes validations"
       end
     end
   end


### PR DESCRIPTION
Bumps #14604

### Description
Allows us to signify a distribution includes only priority cases pushed to a judge. Will allow us to filter by priority when calculating fairness for number of cases pushed to judges. Also allows us to skip some validations that we do not care about when pushing cases to judges.

### Acceptance Criteria
- [ ] Distributions can be created with a priority flag
- [ ] Validation for too_many_unassigned_cases is skipped when priority is true
- [ ] Validation for unassigned_cases_waiting_too_long is skipped when priority is true
- [ ] Validation for pending_distribution only checks for pending distributions of the same priority (a judge can have a pending distribution that they requested while still receiving a push priority case

### Database Changes
*Only for Schema Changes*

* [x] Column comments updated
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] DB schema docs updated with `make docs`
* [x] #appeals-schema notified with summary and link to this PR
