### PR TITLE
Reassigning LegacyAppeal drafting to another attorney clears overtime status

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -31,5 +31,5 @@ Please explain the changes you made here.
 * [ ] Column comments updated
 * [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
 * [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
-* [ ] DB schema docs updated with `make docs`
+* [ ] DB schema docs updated with `make docs` (after running `make migrate`)
 * [ ] #appeals-schema notified with summary and link to this PR

--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -117,6 +117,9 @@ class LegacyTasksController < ApplicationController
 
     return invalid_record_error(task) unless task.valid?
 
+    # Remove overtime status of an appeal when reassigning to another attorney
+    appeal.overtime = false if appeal.overtime?
+
     render json: {
       task: json_task(AttorneyLegacyTask.from_vacols(
                         task.last_case_assignment,

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -274,6 +274,9 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
           "appeal_id": @appeal.id
         }
       end
+      before do
+        @appeal = create(:legacy_appeal, vacols_case: create(:case, staff: @staff_user))
+      end
 
       it "fails because the current user is not a judge" do
         patch :update, params: { tasks: params, id: "3615398-2018-04-18" }

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -295,7 +295,7 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       before do
         FeatureToggle.enable!(:overtime_revamp)
         @appeal = create(:legacy_appeal, vacols_case: create(:case, staff: @staff_user))
-        @appeal.update!(overtime:  true)
+        @appeal.update!(overtime: true)
       end
       after { FeatureToggle.disable!(:overtime_revamp) }
 

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -270,7 +270,8 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       let(:role) { :attorney_role }
       let(:params) do
         {
-          "assigned_to_id": user.id
+          "assigned_to_id": user.id,
+          "appeal_id": @appeal.id
         }
       end
 
@@ -284,7 +285,8 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       let(:role) { :judge_role }
       let(:params) do
         {
-          "assigned_to_id": attorney.id
+          "assigned_to_id": attorney.id,
+          "appeal_id": @appeal.id
         }
       end
       before do
@@ -306,7 +308,8 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       context "when attorney is not found" do
         let(:params) do
           {
-            "assigned_to_id": 7_777_777_777
+            "assigned_to_id": 7_777_777_777,
+            "appeal_id": @appeal.id
           }
         end
 


### PR DESCRIPTION
Resolves #14366 

### Description
Legacy Appeals assigned to an attorney for drafting marked for overtime will have that overtime status cleared if reassigned to another attorney

### Acceptance Criteria
- [ ] OT status is cleared for:
  - Legacy Appeals
    - Assigned to an attorney for drafting
    - Marked for overtime
  - that are then: Reassigned to another attorney

### Testing Plan
1. Checkout master
1. Exit all db access and run `make reset`
1. Disable DAS deprecation: `FeatureToggle.disable!(:legacy_das_deprecation)`
1. Sign in as Abshire and navigate to the [assign queue](http://localhost:3000/queue/BVAAABSHIRE/assign)
1. Mark Legacy Appeal `Evangeline R Mac Gyver` as OT, assign the case to Attorney Reanna
1. Navigate to the assign queue and click Attorney Reanna's work queue
1. Reassign the  `Evangeline R Mac Gyver` case to Lela 
   - [ ] OT status retained
1. checkout this branch! 
1. Reassign the  `Evangeline R Mac Gyver` case to Reanna
   - [ ] OT status removed