### PR TITLE
Add reminder to check migrate:rollback

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,8 @@ Please explain the changes you made here.
 
 * [ ] Timestamps (created_at, updated_at) for new tables
 * [ ] Column comments updated
+* [ ] Verify that `migrate:rollback` works as desired ([reason](https://stackoverflow.com/questions/10365129/rails-migrations-self-up-and-self-down-versus-change))
 * [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
-* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, and unique constraints)
+* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
 * [ ] DB schema docs updated with `make docs` (after running `make migrate`)
 * [ ] #appeals-schema notified with summary and link to this PR

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -29,7 +29,7 @@ Please explain the changes you made here.
 
 * [ ] Timestamps (created_at, updated_at) for new tables
 * [ ] Column comments updated
-* [ ] Verify that `migrate:rollback` works as desired ([reason](https://stackoverflow.com/questions/10365129/rails-migrations-self-up-and-self-down-versus-change))
+* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
 * [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
 * [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
 * [ ] DB schema docs updated with `make docs` (after running `make migrate`)


### PR DESCRIPTION
### Description
Prompted by [this Slack convo](https://dsva.slack.com/archives/CHNHVHZ2T/p1594752659005000?thread_ts=1594749387.003500&cid=CHNHVHZ2T), add a reminder to check that `migrate:rollback` works as expected.
Rails infers the `up` and `down` operation from defined `change` functions but if you want ensure it does it right, use `up`/`down` explicitly.

### Acceptance Criteria
- [ ] Instructions are clear
