### PR TITLE
Add request throttling to VA.gov service

### DIFF
--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -37,6 +37,7 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
         geomatch_result = geomatch(appeal)
         record_geomatched_appeal(appeal.external_id, geomatch_result[:status])
       rescue Caseflow::Error::VaDotGovLimitError
+        Rails.logger.error("VA.gov returned a rate limit error")
         record_geomatched_appeal(appeal.external_id, "limit_error")
         break
       rescue StandardError => error

--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -310,9 +310,9 @@ class ExternalApi::VADotGovService
       request.headers = headers.merge(apikey: ENV["VA_DOT_GOV_API_KEY"])
 
       # Rate limit requests to VA.gov veteran verification API. This is meant to be an
-      # aggressive safety meausre because it's more costly (in terms of computing resources)
+      # aggressive safety measure because it's more costly (in terms of computing resources)
       # if we hit the rate limit. The assumption I'm making here is that since this data is
-      # cached, this *mandatory* sleep call won't be a *massive* increase to the average time
+      # cached, this *mandatory* sleep call won't be a massive increase to the average time
       # for each request.
       #
       # Rate Limit: https://developer.va.gov/explore/verification/docs/veteran_confirmation?version=current

--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -309,6 +309,19 @@ class ExternalApi::VADotGovService
       request.body = body.to_json unless body.nil?
       request.headers = headers.merge(apikey: ENV["VA_DOT_GOV_API_KEY"])
 
+      # Rate limit requests to VA.gov veteran verification API. This is meant to be an
+      # aggressive safety meausre because it's more costly (in terms of computing resources)
+      # if we hit the rate limit. The assumption I'm making here is that since this data is
+      # cached, this *mandatory* sleep call won't be a *massive* increase to the average time
+      # for each request.
+      #
+      # Rate Limit: https://developer.va.gov/explore/verification/docs/veteran_confirmation?version=current
+      #
+      # > We implemented basic rate limiting of 60 requests per minute. If you exceed this quota,
+      # > your request will return a 429 status code. You may petition for increased rate limits by
+      # > emailing and requests will be decided on a case by case basis.
+      sleep 1
+
       MetricsService.record("api.va.gov #{method.to_s.upcase} request to #{url}",
                             service: :va_dot_gov,
                             name: endpoint) do


### PR DESCRIPTION
Rate limiting was removed in https://github.com/department-of-veterans-affairs/caseflow/pull/12366, and caching was put in instead. Unfortunately, we are still running into a rate limit everytime we run the `FetchHearingLocationsForVeteransJob` job:

<img width="1373" alt="Screen Shot 2020-07-14 at 3 09 27 PM" src="https://user-images.githubusercontent.com/1298274/87466465-4a6b9000-c5e4-11ea-918e-3fd7ce2e76e2.png">

One complaint in #12366 was that the sleep call in `FetchHearingLocationsForVeteransJob` was related to a degradation in performance in the seed file. Moving the sleep call into the non-fake `ExternalApi::VADotGovService`, means that the sleep call won't be triggered in the dev environment.

### Description

 - Add request throttling to VA.gov service
