### PR TITLE
Reinstate db:migration:redo check in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,8 +188,8 @@ jobs:
       - run:
           name: Database setup
           command: |
-            ~/project/ci-bin/capture-log "DB=etl bundle exec rake db:create db:schema:load db:migrate"
-            ~/project/ci-bin/capture-log "bundle exec rake db:create db:schema:load db:migrate"
+            ~/project/ci-bin/capture-log "DB=etl bundle exec rake db:create db:schema:load db:migrate:redo"
+            ~/project/ci-bin/capture-log "bundle exec rake db:create db:schema:load db:migrate:redo"
 
       - run:
           name: Wait for FACOLS to be ready


### PR DESCRIPTION
### Description
The db:migration:redo rake task is shorthand for rolling back the latest migration, and then re-applying it. This allows us to check for syntax errors and other loudly-failing migration-time errors in CI. It was removed in #13768 which squashed away all migrations at the time, and we forgot to reinstate it.