### PR TITLE
Add stub implementations of all claimant subclasses

### DIFF
--- a/app/models/attorney_claimant.rb
+++ b/app/models/attorney_claimant.rb
@@ -4,4 +4,17 @@
 # An attorney can be a claimant when contesting attorney fees.
 
 class AttorneyClaimant < Claimant
+  delegate :name, to: :bgs_attorney
+
+  private
+
+  def find_power_of_attorney
+    find_power_of_attorney_by_pid
+  end
+
+  def bgs_attorney
+    @bgs_attorney ||= begin
+      BgsAttorney.find_by_participant_id(participant_id)
+    end
+  end
 end

--- a/app/models/bgs_related_claimant.rb
+++ b/app/models/bgs_related_claimant.rb
@@ -3,5 +3,20 @@
 class BgsRelatedClaimant < Claimant
   include AssociatedBgsRecord
 
-  bgs_attr_accessor :relationship
+  def fetch_bgs_record
+    general_info = bgs.fetch_claimant_info_by_participant_id(participant_id)
+    name_info = bgs.fetch_person_info(participant_id)
+
+    general_info.merge(name_info)
+  end
+
+  def bgs_payee_code
+    return unless bgs_record
+
+    bgs_record[:payee_code]
+  end
+
+  def bgs_record
+    @bgs_record ||= try_and_retry_bgs_record
+  end
 end

--- a/app/models/bgs_related_claimant.rb
+++ b/app/models/bgs_related_claimant.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class BgsRelatedClaimant < Claimant
+  include AssociatedBgsRecord
+
+  bgs_attr_accessor :relationship
+end

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -60,23 +60,6 @@ class Claimant < CaseflowRecord
            :zip,
            to: :bgs_address_service
 
-  def fetch_bgs_record
-    general_info = bgs.fetch_claimant_info_by_participant_id(participant_id)
-    name_info = bgs.fetch_person_info(participant_id)
-
-    general_info.merge(name_info)
-  end
-
-  def bgs_payee_code
-    return unless bgs_record
-
-    bgs_record[:payee_code]
-  end
-
-  def bgs_record
-    @bgs_record ||= try_and_retry_bgs_record
-  end
-
   private
 
   def find_power_of_attorney

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -4,13 +4,10 @@
 # The Claimant model associates a claimant to a decision review.
 
 class Claimant < CaseflowRecord
-  include AssociatedBgsRecord
   include HasDecisionReviewUpdatedSince
 
   belongs_to :decision_review, polymorphic: true
   belongs_to :person, primary_key: :participant_id, foreign_key: :participant_id
-
-  bgs_attr_accessor :relationship
 
   validate { |claimant| ClaimantValidator.new(claimant).validate }
   validates :participant_id,

--- a/app/models/dependent_claimant.rb
+++ b/app/models/dependent_claimant.rb
@@ -4,4 +4,5 @@
 # Dependent claimants are when the veteran's child, spouse, or parent are listed as a decision review's claimant.
 
 class DependentClaimant < BgsRelatedClaimant
+  bgs_attr_accessor :relationship
 end

--- a/app/models/dependent_claimant.rb
+++ b/app/models/dependent_claimant.rb
@@ -3,5 +3,5 @@
 ##
 # Dependent claimants are when the veteran's child, spouse, or parent are listed as a decision review's claimant.
 
-class DependentClaimant < Claimant
+class DependentClaimant < BgsRelatedClaimant
 end

--- a/app/models/other_claimant.rb
+++ b/app/models/other_claimant.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+##
+# OtherClaimant is used when none of Veteran, Dependent, or Attorney claimant is applicable, largely
+# due to not having a canonical BGS source for the claimant's participant ID.
+# Currently used for attorney fee cases when the attorney isn't found in the BGS attorney database.
+
+class OtherClaimant < Claimant
+end

--- a/app/models/veteran_claimant.rb
+++ b/app/models/veteran_claimant.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class VeteranClaimant < BgsRelatedClaimant
+  bgs_attr_accessor :relationship
 end

--- a/app/models/veteran_claimant.rb
+++ b/app/models/veteran_claimant.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-class VeteranClaimant < Claimant
+class VeteranClaimant < BgsRelatedClaimant
 end

--- a/spec/factories/claimant.rb
+++ b/spec/factories/claimant.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
       # & date_of_birth is populated
       claimant.person&.date_of_birth
 
-      if claimant.type == "VeteranClaimant"
+      if claimant.decision_review&.veteran&.participant_id == claimant.participant_id
         veteran = claimant.decision_review.veteran
         claimant.person.update!(first_name: veteran.first_name, last_name: veteran.last_name)
       end

--- a/spec/factories/claimant.rb
+++ b/spec/factories/claimant.rb
@@ -6,6 +6,19 @@ FactoryBot.define do
     sequence(:participant_id)
     association :decision_review, factory: :appeal
 
+    initialize_with do
+      klass = attributes[:type]&.constantize
+      decision_review = attributes[:decision_review]
+      if decision_review
+        klass ||= (decision_review.veteran_is_not_claimant ? DependentClaimant : VeteranClaimant)
+      end
+      klass ||= VeteranClaimant
+      if klass == VeteranClaimant
+        attributes[:participant_id] ||= decision_review&.veteran&.participant_id
+      end
+      klass.new(**attributes)
+    end
+
     trait :advanced_on_docket_due_to_age do
       after(:create) do |claimant, _evaluator|
         claimant.person.update!(date_of_birth: 76.years.ago)
@@ -17,12 +30,9 @@ FactoryBot.define do
       # & date_of_birth is populated
       claimant.person&.date_of_birth
 
-      if claimant.decision_review&.veteran&.participant_id == claimant.participant_id
-        claimant.type = "VeteranClaimant"
+      if claimant.type == "VeteranClaimant"
         veteran = claimant.decision_review.veteran
         claimant.person.update!(first_name: veteran.first_name, last_name: veteran.last_name)
-      else
-        claimant.type = "DependentClaimant"
       end
     end
   end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -3,10 +3,9 @@
 describe Claimant, :postgres do
   let(:name) { nil }
   let(:relationship_to_veteran) { nil }
+  let(:payee_code) { nil }
   let(:claimant_info) do
-    {
-      relationship: relationship_to_veteran
-    }
+    { relationship: relationship_to_veteran, payee_code: payee_code }
   end
 
   let(:name_info) do
@@ -42,6 +41,7 @@ describe Claimant, :postgres do
       let(:first_name) { "HARRY" }
       let(:last_name) { "POTTER" }
       let(:relationship_to_veteran) { "SON" }
+      let(:payee_code) { "12" }
       let(:address_line_1) { "4 Privet Dr" }
       let(:address_line_2) { "Little Whinging" }
       let(:city) { "Washington" }
@@ -66,6 +66,7 @@ describe Claimant, :postgres do
       it "returns BGS attributes when accessed through instance" do
         expect(claimant.name).to eq "Harry Potter"
         expect(claimant.relationship).to eq relationship_to_veteran
+        expect(claimant.bgs_payee_code).to eq payee_code
         expect(claimant.address_line_1).to eq address_line_1
         expect(claimant.address_line_2).to eq address_line_2
         expect(claimant.city).to eq city

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -36,7 +36,7 @@ describe Claimant, :postgres do
   end
 
   context "lazy loading instance attributes from BGS" do
-    let(:claimant) { create(:claimant) }
+    let(:claimant) { create(:claimant, type: "DependentClaimant") }
 
     context "when claimant exists in BGS" do
       let(:first_name) { "HARRY" }

--- a/spec/models/decision_issue_spec.rb
+++ b/spec/models/decision_issue_spec.rb
@@ -364,7 +364,7 @@ describe DecisionIssue, :postgres do
 
       context "when no supplemental claim matches decision issue" do
         let(:veteran) { create(:veteran) }
-        let(:decision_review) { create(:appeal, number_of_claimants: 1, veteran_file_number: veteran.file_number) }
+        let(:decision_review) { create(:appeal, number_of_claimants: 1, veteran_file_number: veteran.file_number, veteran_is_not_claimant: true) }
         let!(:decision_document) { create(:decision_document, decision_date: decision_date, appeal: decision_review) }
 
         context "when there is a prior claim by the same claimant on the same veteran" do
@@ -390,7 +390,7 @@ describe DecisionIssue, :postgres do
 
         context "when there is no prior claim by the claimant" do
           context "when there is a bgs payee code" do
-            before { allow_any_instance_of(Claimant).to receive(:bgs_payee_code).and_return("12") }
+            before { allow_any_instance_of(DependentClaimant).to receive(:bgs_payee_code).and_return("12") }
 
             it "creates a new supplemental claim" do
               expect(subject).to have_attributes(
@@ -408,7 +408,7 @@ describe DecisionIssue, :postgres do
           end
 
           context "when there is no bgs payee code" do
-            before { allow_any_instance_of(Claimant).to receive(:bgs_payee_code).and_return(nil) }
+            before { allow_any_instance_of(DependentClaimant).to receive(:bgs_payee_code).and_return(nil) }
 
             it "raises an error" do
               expect { subject }.to raise_error(DecisionIssue::AppealDTAPayeeCodeError)

--- a/spec/models/decision_issue_spec.rb
+++ b/spec/models/decision_issue_spec.rb
@@ -364,7 +364,14 @@ describe DecisionIssue, :postgres do
 
       context "when no supplemental claim matches decision issue" do
         let(:veteran) { create(:veteran) }
-        let(:decision_review) { create(:appeal, number_of_claimants: 1, veteran_file_number: veteran.file_number, veteran_is_not_claimant: true) }
+        let(:decision_review) do
+          create(
+            :appeal,
+            number_of_claimants: 1,
+            veteran_file_number: veteran.file_number,
+            veteran_is_not_claimant: true
+          )
+        end
         let!(:decision_document) { create(:decision_document, decision_date: decision_date, appeal: decision_review) }
 
         context "when there is a prior claim by the same claimant on the same veteran" do


### PR DESCRIPTION
Connects #14503 

### Description
This PR breaks out the four subclasses of Claimant with stub implementations. The intention here is to enable parallel work on each of the subclasses, while keeping it bare-bones enough that existing Veteran/Dependent claimant records have the same BGS-based implementation as usual.

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.