### PR TITLE
Properly clear overtime success message

### DIFF
--- a/client/app/queue/CaseDetailsLoadingScreen.jsx
+++ b/client/app/queue/CaseDetailsLoadingScreen.jsx
@@ -11,9 +11,20 @@ import USER_ROLE_TYPES from '../../constants/USER_ROLE_TYPES';
 import COPY from '../../COPY';
 import PropTypes from 'prop-types';
 
+import {
+  resetErrorMessages,
+  resetSuccessMessages,
+  resetSaveState
+} from './uiReducer/uiActions';
 import { onReceiveAppealDetails, onReceiveTasks, setAttorneysOfJudge, fetchAllAttorneys } from './QueueActions';
 
 class CaseDetailsLoadingScreen extends React.PureComponent {
+  componentWillUnmount = () => {
+    this.props.resetSaveState();
+    this.props.resetSuccessMessages();
+    this.props.resetErrorMessages();
+  }
+
   loadActiveAppealAndTask = () => {
     const {
       appealId,
@@ -110,7 +121,10 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
   onReceiveTasks,
   onReceiveAppealDetails,
   setAttorneysOfJudge,
-  fetchAllAttorneys
+  fetchAllAttorneys,
+  resetErrorMessages,
+  resetSuccessMessages,
+  resetSaveState
 }, dispatch);
 
 CaseDetailsLoadingScreen.propTypes = {
@@ -122,7 +136,10 @@ CaseDetailsLoadingScreen.propTypes = {
   appealDetails: PropTypes.object,
   onReceiveAppealDetails: PropTypes.func,
   setAttorneysOfJudge: PropTypes.func,
-  fetchAllAttorneys: PropTypes.func
+  fetchAllAttorneys: PropTypes.func,
+  resetErrorMessages: PropTypes.func,
+  resetSuccessMessages: PropTypes.func,
+  resetSaveState: PropTypes.func
 };
 
 export default (connect(mapStateToProps, mapDispatchToProps)(CaseDetailsLoadingScreen));

--- a/client/app/queue/SetOvertimeStatusModal.jsx
+++ b/client/app/queue/SetOvertimeStatusModal.jsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -41,6 +41,10 @@ export const SetOvertimeStatusModal = (props) => {
         props.setOvertime(externalId, resp.body.work_mode.overtime);
       });
   };
+
+  useEffect(() => {
+    props.resetSuccessMessages();
+  }, []);
 
   return (
     <React.Fragment>

--- a/client/app/queue/components/StartHoldModal.jsx
+++ b/client/app/queue/components/StartHoldModal.jsx
@@ -4,7 +4,6 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { onReceiveAmaTasks } from '../QueueActions';
 import QueueFlowModal from './QueueFlowModal';
-import { requestSave } from '../uiReducer/uiActions';
 import SearchableDropdown from '../../components/SearchableDropdown';
 import TextField from '../../components/TextField';
 import TextareaField from '../../components/TextareaField';
@@ -21,6 +20,11 @@ import {
   COLOCATED_HOLD_DURATIONS
 } from '../constants';
 import { withRouter } from 'react-router-dom';
+import {
+  requestSave,
+  resetErrorMessages,
+  resetSuccessMessages,
+} from '../uiReducer/uiActions';
 
 class StartHoldModal extends React.Component {
   constructor(props) {
@@ -32,6 +36,11 @@ class StartHoldModal extends React.Component {
       instructions: ''
     };
   }
+
+  componentDidMount = () => {
+    this.props.resetSuccessMessages();
+    this.props.resetErrorMessages();
+  };
 
   holdLength = () => this.state.hold === CUSTOM_HOLD_DURATION_TEXT ? this.state.customHold : this.state.hold;
 
@@ -111,6 +120,8 @@ StartHoldModal.propTypes = {
   highlightFormItems: PropTypes.bool,
   onReceiveAmaTasks: PropTypes.func,
   requestSave: PropTypes.func,
+  resetSuccessMessages: PropTypes.func,
+  resetErrorMessages: PropTypes.func,
   task: PropTypes.shape({
     taskId: PropTypes.string
   })
@@ -124,6 +135,8 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({
   requestSave,
+  resetErrorMessages,
+  resetSuccessMessages,
   onReceiveAmaTasks
 }, dispatch);
 


### PR DESCRIPTION
Resolves #14667 

### Description
Properly clears the Success message so it doesn't appear on the next modal (un/mark OT, place on hold) or back on the Queue

### Acceptance Criteria
- [ ]  The success banner does not remain after clicking out of the case details page
- [ ] The success banner does not remain after clicking the Mark Case as OT link again.
- [ ] [BONUS] The success banner does not remain after selecting "Place task on hold"

### Testing Plan
1. Sign in as a Judge (abshire works) and load your queue - click into a legacy case
1. Mark the case as overtime
   - [ ] Banner appears
1. Open the modal to Unmark case as overtime
   - [ ] Confirm banner does _not_ move to the modal
1. Confirm removal over overtime
   - [ ] Banner appears
1. Click Queue at the top of the page to load your queue
   - [ ] Banner does not reappear on `/queue`
1. Click into an AMA case
1. Mark the case as overtime
   - [ ] Banner appears
1. Select the dropdown action `Put Task On Hold`
   - [ ] Confirm banner does _not_ move to the modal

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

SCREEN | BEFORE|AFTER
---|---|---
Overtime Modal | ![OT modal - before](https://user-images.githubusercontent.com/6129479/87686785-ed421c80-c752-11ea-9ca0-d4350ca68c11.gif) | ![OT modal](https://user-images.githubusercontent.com/6129479/87686790-eddab300-c752-11ea-82ef-43a4ef548b7e.gif)
Queue | ![case list - before](https://user-images.githubusercontent.com/6129479/87686805-f4692a80-c752-11ea-9b09-c6f1e83b57f2.gif) | ![case list](https://user-images.githubusercontent.com/6129479/87686809-f59a5780-c752-11ea-85fa-31e98cb6f3a8.gif)
Place On Hold Modal | ![on hold modal - before](https://user-images.githubusercontent.com/6129479/87686835-fd59fc00-c752-11ea-9963-fc0c79874c99.gif) | ![on hold modal](https://user-images.githubusercontent.com/6129479/87686836-fdf29280-c752-11ea-9875-2084f4151835.gif)

