### PR TITLE
Add exponential retries to error handling

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -21,16 +21,16 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
     )
   end
 
-  retry_on(IncompleteError, attempts: 5, wait: :exponentially_longer) do |job, exception|
+  retry_on(IncompleteError, attempts: 10, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
   end
 
-  retry_on(VirtualHearingNotCreatedError, attempts: 5, wait: :exponentially_longer) do |job, exception|
+  retry_on(VirtualHearingNotCreatedError, attempts: 10, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
   end
 
   # Retry if Pexip returns an invalid response.
-  retry_on(Caseflow::Error::PexipApiError, attempts: 5, wait: :exponentially_longer) do |job, exception|
+  retry_on(Caseflow::Error::PexipApiError, attempts: 10, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
 
     kwargs = job.arguments.first

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -21,16 +21,16 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
     )
   end
 
-  retry_on(IncompleteError, attempts: 5) do |job, exception|
+  retry_on(IncompleteError, attempts: 5, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
   end
 
-  retry_on(VirtualHearingNotCreatedError, attempts: 5) do |job, exception|
+  retry_on(VirtualHearingNotCreatedError, attempts: 5, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
   end
 
   # Retry if Pexip returns an invalid response.
-  retry_on Caseflow::Error::PexipApiError, attempts: 5 do |job, exception|
+  retry_on(Caseflow::Error::PexipApiError, attempts: 5, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
 
     kwargs = job.arguments.first

--- a/app/jobs/virtual_hearings/delete_conferences_job.rb
+++ b/app/jobs/virtual_hearings/delete_conferences_job.rb
@@ -15,7 +15,7 @@ class VirtualHearings::DeleteConferencesJob < VirtualHearings::ConferenceJob
     )
   end
 
-  retry_on(DeleteConferencesJobFailure, attempts: 5) do |job, exception|
+  retry_on(DeleteConferencesJobFailure, attempts: 5, wait: :exponentially_longer) do |job, exception|
     Rails.logger.error("#{job.class.name} (#{job.job_id}) failed with error: #{exception}")
 
     extra = {

--- a/spec/jobs/virtual_hearings/create_conference_job_spec.rb
+++ b/spec/jobs/virtual_hearings/create_conference_job_spec.rb
@@ -96,7 +96,7 @@ describe VirtualHearings::CreateConferenceJob do
           end
         end.to(
           have_performed_job(VirtualHearings::CreateConferenceJob)
-            .exactly(5)
+            .exactly(10)
             .times
         )
       end
@@ -114,7 +114,7 @@ describe VirtualHearings::CreateConferenceJob do
       end
 
       it "job goes back on queue and logs if error", :aggregate_failures do
-        expect(Rails.logger).to receive(:error).exactly(6).times
+        expect(Rails.logger).to receive(:error).exactly(11).times
 
         expect do
           perform_enqueued_jobs do
@@ -122,7 +122,7 @@ describe VirtualHearings::CreateConferenceJob do
           end
         end.to(
           have_performed_job(VirtualHearings::CreateConferenceJob)
-            .exactly(5)
+            .exactly(10)
             .times
         )
 
@@ -174,7 +174,7 @@ describe VirtualHearings::CreateConferenceJob do
           end
         end.to(
           have_performed_job(VirtualHearings::CreateConferenceJob)
-            .exactly(5)
+            .exactly(10)
             .times
         )
       end


### PR DESCRIPTION
Resolves https://dsva.slack.com/archives/C3EAF3Q15/p1594894688082500

The `CreateConferenceJob` isn't being retried at the intervals specified in the Shoryuken initializer:

https://github.com/department-of-veterans-affairs/caseflow/blob/17bf10c7169e5c24dd76ffcd8701c5b23f3a1ef8/config/initializers/shoryuken.rb#L5-L6

### Description

- Increases the number of retries from 5 to 10
- Adds exponential backoff to wait time inbetween retries (documented here: https://edgeapi.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html)
