### PR TITLE
increase the query limit on the FetchHearingLocationForVeteransJob

### DIFF
--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -4,7 +4,7 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
   queue_with_priority :low_priority
   application_attr :hearing_schedule
 
-  QUERY_LIMIT = 500
+  QUERY_LIMIT = 750
   def create_schedule_hearing_tasks
     AppealRepository.create_schedule_hearing_tasks
   end

--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -309,19 +309,6 @@ class ExternalApi::VADotGovService
       request.body = body.to_json unless body.nil?
       request.headers = headers.merge(apikey: ENV["VA_DOT_GOV_API_KEY"])
 
-      # Rate limit requests to VA.gov veteran verification API. This is meant to be an
-      # aggressive safety measure because it's more costly (in terms of computing resources)
-      # if we hit the rate limit. The assumption I'm making here is that since this data is
-      # cached, this *mandatory* sleep call won't be a massive increase to the average time
-      # for each request.
-      #
-      # Rate Limit: https://developer.va.gov/explore/verification/docs/veteran_confirmation?version=current
-      #
-      # > We implemented basic rate limiting of 60 requests per minute. If you exceed this quota,
-      # > your request will return a 429 status code. You may petition for increased rate limits by
-      # > emailing and requests will be decided on a case by case basis.
-      sleep 1
-
       MetricsService.record("api.va.gov #{method.to_s.upcase} request to #{url}",
                             service: :va_dot_gov,
                             name: endpoint) do


### PR DESCRIPTION
### Description
The `FetchHearingLocationForVeteransJob` [starts at the beginning of each hour](https://github.com/department-of-veterans-affairs/appeals-lambdas/blob/master/async-jobs-trigger/serverless.yml#L98-L104), and runs for a little over 30 minutes. This PR increases the number of appeals the job considers by 50% so that the job will be able to process more appeals.

![Screen Shot 2020-07-17 at 7 57 32 AM](https://user-images.githubusercontent.com/45415133/87800824-bed04a00-c803-11ea-9a78-d9796b7e3df5.png)
