### PR TITLE
Use appeal.undecided_issues.count for legacy appeals

### DIFF
--- a/app/models/serializers/work_queue/task_column_serializer.rb
+++ b/app/models/serializers/work_queue/task_column_serializer.rb
@@ -74,7 +74,7 @@ class WorkQueue::TaskColumnSerializer
     columns = [Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name]
 
     if serialize_attribute?(params, columns)
-      object.appeal.number_of_issues
+      object.appeal.is_a?(LegacyAppeal) ? object.appeal.undecided_issues.count : object.appeal.number_of_issues
     end
   end
 

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -105,7 +105,7 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :issue_count do |object|
-    object.appeal.number_of_issues
+    object.appeal.is_a?(LegacyAppeal) ? object.appeal.undecided_issues.count : object.appeal.number_of_issues
   end
 
   attribute :external_hearing_id do |object|

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -693,7 +693,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
         expect(task["attributes"]["available_actions"].size).to eq 2
 
-        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(13)
+        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(14)
       end
     end
 


### PR DESCRIPTION
Resolves bug detailed [here](https://github.com/department-of-veterans-affairs/caseflow/issues/14142#issuecomment-662580905)

### Description
Fixes bug based on investigation [here](https://github.com/department-of-veterans-affairs/caseflow/issues/14142#issuecomment-662582976)

### Acceptance Criteria
- [x] Number of issues  for legacy appeals is correct in queue
   - [x] on initial load
   - [x] after filtering

### Testing Plan
1. Log in a steve casper
1. Ensure user pagination is on
   ```ruby
   FeatureToggle.enabled?(:user_queue_pagination, user: User.first)
   => true
   ```
1. Go to http://localhost:3000/queue?tab=on_hold_person and confirm legacy case issue counts are not all "1"
1. Filter by legacy docket and confirm the same as well

### User Facing Changes
 - [ ] issue counts in queue are correct for legacy appeals rather than just "1"

 BEFORE|AFTER
 ---|---
![Screen Shot 2020-07-22 at 3 14 39 PM](https://user-images.githubusercontent.com/45575454/88220058-7a441480-cc30-11ea-874b-a39d67c7dee1.png)|![Screen Shot 2020-07-22 at 3 27 21 PM](https://user-images.githubusercontent.com/45575454/88220065-7d3f0500-cc30-11ea-8ea7-95666d3f62a4.png)
![Screen Shot 2020-07-22 at 3 32 33 PM](https://user-images.githubusercontent.com/45575454/88220130-95af1f80-cc30-11ea-9d6d-1075d80c91fa.png)|![Screen Shot 2020-07-22 at 3 25 02 PM](https://user-images.githubusercontent.com/45575454/88220133-98117980-cc30-11ea-904e-17f4bc744295.png)
