### PR TITLE
Do not update contention if no contention exists

### DIFF
--- a/app/models/request_issue_contention.rb
+++ b/app/models/request_issue_contention.rb
@@ -6,7 +6,7 @@ class RequestIssueContention
   end
 
   delegate :contention_reference_id, :contention_removed_at, :contention_updated_at,
-           :edited_description, to: :request_issue
+           :edited_description, :end_product_establishment, to: :request_issue
 
   def vbms_contention
     return unless contention_reference_id
@@ -15,7 +15,7 @@ class RequestIssueContention
   end
 
   def update_text!
-    return unless contention_text_update_pending
+    return unless contention_reference_id && contention_text_update_pending
 
     fail EndProductEstablishment::ContentionNotFound, contention_reference_id unless vbms_contention
 

--- a/app/models/request_issue_contention.rb
+++ b/app/models/request_issue_contention.rb
@@ -6,7 +6,7 @@ class RequestIssueContention
   end
 
   delegate :contention_reference_id, :contention_removed_at, :contention_updated_at,
-           :edited_description, :end_product_establishment, to: :request_issue
+           :edited_description, to: :request_issue
 
   def vbms_contention
     return unless contention_reference_id

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -58,7 +58,7 @@ class RequestIssuesUpdate < CaseflowRecord
     review.end_product_establishments.each { |epe| epe.user = user } if review.processed_in_vbms?
 
     review.establish!
-    edited_issues.each { |issue| issue.end_product_establishment && RequestIssueContention.new(issue).update_text! }
+    edited_issues.each { |issue| issue.contention_reference_id && RequestIssueContention.new(issue).update_text! }
     potential_end_products_to_remove = []
     removed_or_withdrawn_issues.select(&:end_product_establishment).each do |request_issue|
       RequestIssueContention.new(request_issue).remove!

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -58,7 +58,7 @@ class RequestIssuesUpdate < CaseflowRecord
     review.end_product_establishments.each { |epe| epe.user = user } if review.processed_in_vbms?
 
     review.establish!
-    edited_issues.each { |issue| issue.contention_reference_id && RequestIssueContention.new(issue).update_text! }
+    edited_issues.each { |issue| RequestIssueContention.new(issue).update_text! }
     potential_end_products_to_remove = []
     removed_or_withdrawn_issues.select(&:end_product_establishment).each do |request_issue|
       RequestIssueContention.new(request_issue).remove!

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -58,7 +58,7 @@ class RequestIssuesUpdate < CaseflowRecord
     review.end_product_establishments.each { |epe| epe.user = user } if review.processed_in_vbms?
 
     review.establish!
-    edited_issues.each { |issue| RequestIssueContention.new(issue).update_text! }
+    edited_issues.each { |issue| issue.end_product_establishment && RequestIssueContention.new(issue).update_text! }
     potential_end_products_to_remove = []
     removed_or_withdrawn_issues.select(&:end_product_establishment).each do |request_issue|
       RequestIssueContention.new(request_issue).remove!

--- a/spec/models/request_issue_contention_spec.rb
+++ b/spec/models/request_issue_contention_spec.rb
@@ -54,6 +54,14 @@ describe RequestIssueContention, :postgres do
 
       it { is_expected.to be_falsey }
     end
+
+    context "when the request issue doesn't have a contention" do
+      let(:end_product_establishment) { nil }
+      let(:contention_reference_id) { nil }
+      let(:contention) { nil }
+
+      it { is_expected.to be_falsey }
+    end
   end
 
   context "#remove!" do

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -716,6 +716,7 @@ describe RequestIssuesUpdate, :all_dbs do
         edited_description: edited_description
       )
     end
+    let(:edited_issue_contention_id) { "3" }
 
     let!(:riu) do
       create(:request_issues_update, :requires_processing,
@@ -746,7 +747,7 @@ describe RequestIssuesUpdate, :all_dbs do
       Generators::Contention.build(
         claim_id: edited_issue.end_product_establishment.reference_id,
         text: "old request issue description",
-        id: "3",
+        id: edited_issue_contention_id,
         start_date: Time.zone.now,
         submit_date: 5.days.ago
       )

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -712,7 +712,7 @@ describe RequestIssuesUpdate, :all_dbs do
       create(
         :request_issue_with_epe,
         decision_review: review,
-        contention_reference_id: "3",
+        contention_reference_id: edited_issue_contention_id,
         edited_description: edited_description
       )
     end
@@ -769,6 +769,17 @@ describe RequestIssuesUpdate, :all_dbs do
       expect(review.end_product_establishments.map(&:user)).to_not include(riu.user)
       subject
       expect(review.end_product_establishments.map(&:user).uniq).to eq([riu.user])
+    end
+
+    context "when the request issue doesn't have a contention" do
+      let(:edited_issue_contention) { nil }
+      let(:edited_issue) { create(:request_issue, decision_review: review, edited_description: edited_description) }
+
+      it "does not try to update the contention in VBMS" do
+        expect(subject).to be_truthy
+        expect(Fakes::VBMSService).to_not have_received(:update_contention!)
+        expect(edited_issue.reload.contention_updated_at).to be nil
+      end
     end
   end
 


### PR DESCRIPTION
### Description
Request issues that do not have a contention on an end product do not need to have their contention updated. For example, request issues on appeals or non-compensation line of business reviews.  This is leading to the EndProductEstablishment::ContentionNotFound error.

This is impacting 6 request issue updates.

### Testing Plan
1. Test RequestIssuesUpdate.establish! and RequestIssueContention.update_text!