### PR TITLE
[Part 2] Populate age_aod column

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -19,6 +19,7 @@ class Api::V1::JobsController < Api::ApplicationController
     "prepare_establish_claim" => PrepareEstablishClaimTasksJob,
     "reassign_old_tasks" => ReassignOldTasksJob,
     "retrieve_documents_for_reader" => RetrieveDocumentsForReaderJob,
+    "set_appeal_age_aod" => SetAppealAgeAodJob,
     "stats_collector" => StatsCollectorJob,
     "sync_intake" => SyncIntakeJob,
     "sync_reviews" => SyncReviewsJob,

--- a/app/jobs/set_appeal_age_aod_job.rb
+++ b/app/jobs/set_appeal_age_aod_job.rb
@@ -2,7 +2,7 @@
 
 # Early morning job that checks if the claimant meets the Advance-On-Docket age criteria.
 # If criteria is satisfied, all active appeals associated with claimant will be marked as AOD.
-# This job only sets age_aod to true; it does not set it from true to false (see appeal.conditionally_set_age_aod).
+# This job only sets aod_based_on_age to true; it does not set it from true to false (see appeal.conditionally_set_age_aod).
 class SetAppealAgeAodJob < CaseflowJob
   include ActionView::Helpers::DateHelper
 
@@ -13,8 +13,7 @@ class SetAppealAgeAodJob < CaseflowJob
     appeals = non_aod_active_appeals.joins(claimants: :person).where("people.date_of_birth <= ?", 75.years.ago)
     detail_msg = "IDs of age-related AOD appeals: #{appeals.pluck(:id)}"
 
-    appeals.update_all(age_aod: true)
-    appeals.update_all(updated_at: Time.now.utc)
+    appeals.update_all(aod_based_on_age: true, updated_at: Time.now.utc)
 
     log_success(detail_msg)
   rescue StandardError => error
@@ -45,8 +44,8 @@ class SetAppealAgeAodJob < CaseflowJob
   private
 
   def non_aod_active_appeals
-    # `age_aod` is initially nil
-    # `age_aod` being false means that it was once true (in the case where the claimant's DOB was updated)
-    Appeal.active.where(age_aod: [nil, false])
+    # `aod_based_on_age` is initially nil
+    # `aod_based_on_age` being false means that it was once true (in the case where the claimant's DOB was updated)
+    Appeal.active.where(aod_based_on_age: [nil, false])
   end
 end

--- a/app/jobs/set_appeal_age_aod_job.rb
+++ b/app/jobs/set_appeal_age_aod_job.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Early morning job that checks if the claimant meets the Advance-On-Docket age criteria.
+# If criteria is satisfied, all active appeals associated with claimant will be marked as AOD.
+class SetAppealAgeAodJob < CaseflowJob
+  include ActionView::Helpers::DateHelper
+
+  def perform
+    RequestStore.store[:current_user] = User.system_user
+
+    # We expect there to be only one claimant on an appeal. Any claimant meeting the age criteria will cause AOD.
+    appeals = non_aod_active_appeals.joins(claimants: :person).where("people.date_of_birth <= ?", 75.years.ago)
+
+    appeals.update_all(age_aod: true)
+    appeals.update_all(updated_at: Time.now.utc)
+
+    log_success
+  rescue StandardError => error
+    log_error(self.class.name, error)
+  end
+
+  protected
+
+  def log_success
+    duration = time_ago_in_words(start_time)
+    msg = "#{self.class.name} completed after running for #{duration}."
+    Rails.logger.info(msg)
+
+    slack_service.send_notification("[INFO] #{msg}")
+  end
+
+  def log_error(collector_name, err)
+    duration = time_ago_in_words(start_time)
+    msg = "#{collector_name} failed after running for #{duration}. Fatal error: #{err.message}"
+    Rails.logger.info(msg)
+    Rails.logger.info(err.backtrace.join("\n"))
+
+    Raven.capture_exception(err, extra: { stats_collector_name: collector_name })
+
+    slack_service.send_notification("[ERROR] #{msg}")
+  end
+
+  private
+
+  def non_aod_active_appeals
+    Appeal.active.where.not(age_aod: true)
+  end
+end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -270,13 +270,13 @@ class Appeal < DecisionReview
   end
 
   def conditionally_set_age_aod
-    aod_based_on_age = claimant.person.advanced_on_docket_based_on_age? if claimant
+    aod_based_on_age = claimant&.advanced_on_docket_based_on_age?
     update(age_aod: aod_based_on_age) if age_aod != aod_based_on_age
   end
 
   def advanced_on_docket?
     conditionally_set_age_aod
-    claimant&.advanced_on_docket?(receipt_date)
+    age_aod || claimant&.advanced_on_docket_motion_granted?(receipt_date)
   end
 
   # Prefer aod? over aod going forward, as this function returns a boolean

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -276,6 +276,8 @@ class Appeal < DecisionReview
 
   def advanced_on_docket?
     conditionally_set_age_aod
+    # One of the AOD motion reasons is 'age'. Keep interrogation of any motions separate from `age_aod`,
+    # which reflects `claimant.advanced_on_docket_based_on_age?`.
     age_aod || claimant&.advanced_on_docket_motion_granted?(receipt_date)
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -34,7 +34,7 @@ class Appeal < DecisionReview
     "de_novo": "de_novo"
   }
 
-  after_create :conditionally_set_age_aod
+  after_create :conditionally_set_aod_based_on_age
 
   after_save :set_original_stream_data
 
@@ -269,16 +269,16 @@ class Appeal < DecisionReview
     nil
   end
 
-  def conditionally_set_age_aod
-    aod_based_on_age = claimant&.advanced_on_docket_based_on_age?
-    update(age_aod: aod_based_on_age) if age_aod != aod_based_on_age
+  def conditionally_set_aod_based_on_age
+    updated_aod_based_on_age = claimant&.advanced_on_docket_based_on_age?
+    update(aod_based_on_age: updated_aod_based_on_age) if aod_based_on_age != updated_aod_based_on_age
   end
 
   def advanced_on_docket?
-    conditionally_set_age_aod
-    # One of the AOD motion reasons is 'age'. Keep interrogation of any motions separate from `age_aod`,
+    conditionally_set_aod_based_on_age
+    # One of the AOD motion reasons is 'age'. Keep interrogation of any motions separate from `aod_based_on_age`,
     # which reflects `claimant.advanced_on_docket_based_on_age?`.
-    age_aod || claimant&.advanced_on_docket_motion_granted?(receipt_date)
+    aod_based_on_age || claimant&.advanced_on_docket_motion_granted?(receipt_date)
   end
 
   # Prefer aod? over aod going forward, as this function returns a boolean

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -34,6 +34,8 @@ class Appeal < DecisionReview
     "de_novo": "de_novo"
   }
 
+  after_create :conditionally_set_age_aod
+
   after_save :set_original_stream_data
 
   with_options on: :intake_review do
@@ -267,7 +269,13 @@ class Appeal < DecisionReview
     nil
   end
 
+  def conditionally_set_age_aod
+    aod_based_on_age = claimant&.person.advanced_on_docket_based_on_age?
+    update(age_aod: aod_based_on_age) if age_aod != aod_based_on_age
+  end
+
   def advanced_on_docket?
+    conditionally_set_age_aod
     claimant&.advanced_on_docket?(receipt_date)
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -270,7 +270,7 @@ class Appeal < DecisionReview
   end
 
   def conditionally_set_age_aod
-    aod_based_on_age = claimant&.person.advanced_on_docket_based_on_age?
+    aod_based_on_age = claimant.person.advanced_on_docket_based_on_age? if claimant
     update(age_aod: aod_based_on_age) if age_aod != aod_based_on_age
   end
 

--- a/app/models/attorney_claimant.rb
+++ b/app/models/attorney_claimant.rb
@@ -6,6 +6,18 @@
 class AttorneyClaimant < Claimant
   delegate :name, to: :bgs_attorney
 
+  def advanced_on_docket?(appeal_receipt_date)
+    false
+  end
+
+  def advanced_on_docket_based_on_age?
+    false
+  end
+
+  def advanced_on_docket_motion_granted?(appeal_receipt_date)
+    false
+  end
+
   private
 
   def find_power_of_attorney

--- a/app/models/attorney_claimant.rb
+++ b/app/models/attorney_claimant.rb
@@ -6,7 +6,7 @@
 class AttorneyClaimant < Claimant
   delegate :name, to: :bgs_attorney
 
-  def advanced_on_docket?(appeal_receipt_date)
+  def advanced_on_docket?(_appeal_receipt_date)
     false
   end
 
@@ -14,7 +14,7 @@ class AttorneyClaimant < Claimant
     false
   end
 
-  def advanced_on_docket_motion_granted?(appeal_receipt_date)
+  def advanced_on_docket_motion_granted?(_appeal_receipt_date)
     false
   end
 

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -44,6 +44,8 @@ class Claimant < CaseflowRecord
 
   delegate :date_of_birth,
            :advanced_on_docket?,
+           :advanced_on_docket_based_on_age?,
+           :advanced_on_docket_motion_granted?,
            :name,
            :first_name,
            :last_name,

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -44,9 +44,6 @@ class Claimant < CaseflowRecord
   end
 
   delegate :date_of_birth,
-           :advanced_on_docket?,
-           :advanced_on_docket_based_on_age?,
-           :advanced_on_docket_motion_granted?,
            :name,
            :first_name,
            :last_name,
@@ -62,6 +59,24 @@ class Claimant < CaseflowRecord
            :state,
            :zip,
            to: :bgs_address_service
+
+  def advanced_on_docket?(appeal_receipt_date)
+    return false if is_a?(AttorneyClaimant)
+
+    person&.advanced_on_docket?(appeal_receipt_date)
+  end
+
+  def advanced_on_docket_based_on_age?
+    return false if is_a?(AttorneyClaimant)
+
+    person&.advanced_on_docket_based_on_age?
+  end
+
+  def advanced_on_docket_motion_granted?(appeal_receipt_date)
+    return false if is_a?(AttorneyClaimant)
+
+    person&.advanced_on_docket_motion_granted?(appeal_receipt_date)
+  end
 
   private
 

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -44,6 +44,9 @@ class Claimant < CaseflowRecord
   end
 
   delegate :date_of_birth,
+           :advanced_on_docket?,
+           :advanced_on_docket_based_on_age?,
+           :advanced_on_docket_motion_granted?,
            :name,
            :first_name,
            :last_name,
@@ -59,24 +62,6 @@ class Claimant < CaseflowRecord
            :state,
            :zip,
            to: :bgs_address_service
-
-  def advanced_on_docket?(appeal_receipt_date)
-    return false if is_a?(AttorneyClaimant)
-
-    person&.advanced_on_docket?(appeal_receipt_date)
-  end
-
-  def advanced_on_docket_based_on_age?
-    return false if is_a?(AttorneyClaimant)
-
-    person&.advanced_on_docket_based_on_age?
-  end
-
-  def advanced_on_docket_motion_granted?(appeal_receipt_date)
-    return false if is_a?(AttorneyClaimant)
-
-    person&.advanced_on_docket_motion_granted?(appeal_receipt_date)
-  end
 
   private
 

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -2,6 +2,7 @@
 
 ##
 # The Claimant model associates a claimant to a decision review.
+# There are several subclasses, such as VeteranClaimant, DependentClaimant, and AttorneyClaimant.
 
 class Claimant < CaseflowRecord
   include HasDecisionReviewUpdatedSince

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -49,7 +49,7 @@ class Person < CaseflowRecord
   end
 
   def advanced_on_docket?(appeal_receipt_date)
-    advanced_on_docket_based_on_age? || advanced_on_docket_motion_granted?
+    advanced_on_docket_based_on_age? || advanced_on_docket_motion_granted?(appeal_receipt_date)
   end
 
   def date_of_birth

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -49,7 +49,7 @@ class Person < CaseflowRecord
   end
 
   def advanced_on_docket?(appeal_receipt_date)
-    advanced_on_docket_based_on_age? || AdvanceOnDocketMotion.granted_for_person?(id, appeal_receipt_date)
+    advanced_on_docket_based_on_age? || advanced_on_docket_motion_granted?
   end
 
   def date_of_birth
@@ -103,6 +103,10 @@ class Person < CaseflowRecord
 
   def advanced_on_docket_based_on_age?
     date_of_birth && date_of_birth < 75.years.ago
+  end
+
+  def advanced_on_docket_motion_granted?(appeal_receipt_date)
+    AdvanceOnDocketMotion.granted_for_person?(id, appeal_receipt_date)
   end
 
   def found?

--- a/spec/jobs/set_appeal_age_aod_job_spec.rb
+++ b/spec/jobs/set_appeal_age_aod_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe SetAppealAgeAodJob, :postgres do
+  include_context "Metrics Reports"
+
+  # rubocop:disable Metrics/LineLength
+  let(:report) do
+    "[INFO] SetAppealAgeAodJob completed after running for less than a minute."
+  end
+  # rubocop:enable Metrics/LineLength
+
+  describe "#perform" do
+    before do
+      allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| @slack_msg = first_arg }
+    end
+
+    it "sends message" do
+      described_class.perform_now
+
+      expect(@slack_msg).to eq(report)
+    end
+  end
+end

--- a/spec/jobs/set_appeal_age_aod_job_spec.rb
+++ b/spec/jobs/set_appeal_age_aod_job_spec.rb
@@ -10,7 +10,7 @@ describe SetAppealAgeAodJob, :postgres do
   # rubocop:enable Metrics/LineLength
 
   describe "#perform" do
-    let(:appeal) { create(:appeal, :with_schedule_hearing_tasks) }
+    let(:non_aod_appeal) { create(:appeal, :with_schedule_hearing_tasks) }
 
     let(:age_aod_appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_age) }
     let(:motion_aod_appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_motion) }
@@ -22,8 +22,8 @@ describe SetAppealAgeAodJob, :postgres do
       allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| @slack_msg = first_arg }
     end
 
-    it "sets age_aod for only active appeals with a claimant that satisfies the age criteria" do
-      expect(appeal.active?).to eq(true)
+    it "sets aod_based_on_age for only active appeals with a claimant that satisfies the age criteria" do
+      expect(non_aod_appeal.active?).to eq(true)
       expect(age_aod_appeal.active?).to eq(true)
       expect(motion_aod_appeal.active?).to eq(true)
       expect(inactive_age_aod_appeal.active?).to eq(false)
@@ -32,13 +32,13 @@ describe SetAppealAgeAodJob, :postgres do
       described_class.perform_now
       expect(@slack_msg).to include(success_msg)
 
-      # `age_aod` will be nil
-      # `age_aod` being false means that it was once true (in the case where the claimant's DOB was updated)
-      expect(appeal.reload.age_aod).not_to eq(true)
-      expect(inactive_age_aod_appeal.reload.age_aod).not_to eq(true)
+      # `aod_based_on_age` will be nil
+      # `aod_based_on_age` being false means that it was once true (in the case where the claimant's DOB was updated)
+      expect(non_aod_appeal.reload.aod_based_on_age).not_to eq(true)
+      expect(inactive_age_aod_appeal.reload.aod_based_on_age).not_to eq(true)
 
-      expect(age_aod_appeal.reload.age_aod).to eq(true)
-      expect(motion_aod_appeal.reload.age_aod).to eq(false)
+      expect(age_aod_appeal.reload.aod_based_on_age).to eq(true)
+      expect(motion_aod_appeal.reload.aod_based_on_age).to eq(false)
     end
 
     context "when the entire job fails" do

--- a/spec/jobs/set_appeal_age_aod_job_spec.rb
+++ b/spec/jobs/set_appeal_age_aod_job_spec.rb
@@ -10,14 +10,35 @@ describe SetAppealAgeAodJob, :postgres do
   # rubocop:enable Metrics/LineLength
 
   describe "#perform" do
+    let(:appeal) { create(:appeal, :with_schedule_hearing_tasks) }
+
+    let(:age_aod_appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_age) }
+    let(:motion_aod_appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_motion) }
+
+    let(:inactive_age_aod_appeal) { create(:appeal, :advanced_on_docket_due_to_age) }
+    let(:cancelled_age_aod_appeal) { create(:appeal, :advanced_on_docket_due_to_age, :cancelled) }
+
     before do
       allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| @slack_msg = first_arg }
     end
 
-    it "sends message" do
-      described_class.perform_now
+    it "sets age_aod for only active appeals with a claimant that satisfies the age criteria" do
+      expect(appeal.active?).to eq(true)
+      expect(age_aod_appeal.active?).to eq(true)
+      expect(motion_aod_appeal.active?).to eq(true)
+      expect(inactive_age_aod_appeal.active?).to eq(false)
+      expect(cancelled_age_aod_appeal.active?).to eq(false)
 
+      described_class.perform_now
       expect(@slack_msg).to eq(report)
+
+      # `age_aod` will be nil
+      # `age_aod` being false means that it was once true (in the case where the claimant's DOB was updated)
+      expect(appeal.reload.age_aod).not_to eq(true)
+      expect(inactive_age_aod_appeal.reload.age_aod).not_to eq(true)
+
+      expect(age_aod_appeal.reload.age_aod).to eq(true)
+      expect(motion_aod_appeal.reload.age_aod).to eq(false)
     end
   end
 end

--- a/spec/jobs/set_appeal_age_aod_job_spec.rb
+++ b/spec/jobs/set_appeal_age_aod_job_spec.rb
@@ -59,7 +59,7 @@ describe SetAppealAgeAodJob, :postgres do
         slack_msg = ""
         allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
 
-        allow_any_instance_of(described_class).to receive(:non_aod_active_appeals).and_raise(error_msg)
+        allow_any_instance_of(described_class).to receive(:appeals_to_set_age_based_aod).and_raise(error_msg)
         described_class.perform_now
 
         expected_msg = "#{described_class.name} failed after running for .*. Fatal error: #{error_msg}"

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -460,7 +460,7 @@ describe Appeal, :all_dbs do
 
       it "returns true" do
         expect(appeal.advanced_on_docket?).to eq(true)
-        expect(appeal.age_aod).to eq(true)
+        expect(appeal.aod_based_on_age).to eq(true)
       end
     end
 
@@ -469,7 +469,7 @@ describe Appeal, :all_dbs do
 
       it "returns false" do
         expect(appeal.advanced_on_docket?).to eq(false)
-        expect(appeal.age_aod).to eq(false)
+        expect(appeal.aod_based_on_age).to eq(false)
       end
     end
 
@@ -478,7 +478,7 @@ describe Appeal, :all_dbs do
 
       it "returns true" do
         expect(appeal.advanced_on_docket?).to eq(true)
-        expect(appeal.age_aod).to eq(false)
+        expect(appeal.aod_based_on_age).to eq(false)
       end
     end
   end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -455,23 +455,30 @@ describe Appeal, :all_dbs do
   end
 
   context "#advanced_on_docket?" do
-    context "when a claimant is advanced_on_docket?" do
-      let(:appeal) do
-        create(:appeal, claimants: [create(:claimant, :advanced_on_docket_due_to_age)])
-      end
+    context "when a claimant is advanced_on_docket? due to age" do
+      let(:appeal) { create(:appeal, claimants: [create(:claimant, :advanced_on_docket_due_to_age)]) }
 
       it "returns true" do
         expect(appeal.advanced_on_docket?).to eq(true)
+        expect(appeal.age_aod).to eq(true)
       end
     end
 
-    context "when no claimant is advanced_on_docket?" do
-      let(:appeal) do
-        create(:appeal)
-      end
+    context "when no claimant is advanced_on_docket? due to age" do
+      let(:appeal) { create(:appeal) }
 
       it "returns false" do
         expect(appeal.advanced_on_docket?).to eq(false)
+        expect(appeal.age_aod).to eq(false)
+      end
+    end
+
+    context "when a claimant is advanced_on_docket? due to motion" do
+      let(:appeal) { create(:appeal, :advanced_on_docket_due_to_motion) }
+
+      it "returns true" do
+        expect(appeal.advanced_on_docket?).to eq(true)
+        expect(appeal.age_aod).to eq(false)
       end
     end
   end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -122,6 +122,7 @@ describe Claimant, :postgres do
 
       it "returns true" do
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(true)
+        expect(claimant.advanced_on_docket_based_on_age?).to eq(false)
         expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(true)
       end
     end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -104,27 +104,61 @@ describe Claimant, :postgres do
   end
 
   context "#advanced_on_docket?" do
-    context "when claimant is over 75 years old" do
+
+    context "when claimant satisfies AOD age criteria" do
+      let(:claimant) { create(:claimant, :advanced_on_docket_due_to_age) }
+
       it "returns true" do
-        claimant = create(:claimant, :advanced_on_docket_due_to_age)
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(true)
         expect(claimant.advanced_on_docket_based_on_age?).to eq(true)
       end
     end
 
     context "when claimant has motion granted" do
-      it "returns true" do
-        claimant = create(:claimant)
-        create(:advance_on_docket_motion, person_id: claimant.person.id, granted: true)
+      let(:claimant) { create(:claimant) }
 
+      before do
+        create(:advance_on_docket_motion, person_id: claimant.person.id, granted: true)
+      end
+
+      it "returns true" do
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(true)
         expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(true)
       end
     end
 
     context "when claimant is younger than 75 years old and has no motion granted" do
+      let(:claimant) { create(:claimant) }
+
       it "returns false" do
-        claimant = create(:claimant)
+        expect(claimant.advanced_on_docket?(1.year.ago)).to eq(false)
+        expect(claimant.advanced_on_docket_based_on_age?).to eq(false)
+        expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(false)
+      end
+    end
+
+    context "when claimant satisfies AOD age criteria and has motion granted" do
+      let(:claimant) { create(:claimant, :advanced_on_docket_due_to_age) }
+
+      before do
+        create(:advance_on_docket_motion, person_id: claimant.person.id, granted: true)
+      end
+
+      it "returns true" do
+        expect(claimant.advanced_on_docket?(1.year.ago)).to eq(true)
+        expect(claimant.advanced_on_docket_based_on_age?).to eq(true)
+        expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(true)
+      end
+    end
+
+    context "when AttorneyClaimant satisfies AOD age criteria and has motion granted" do
+      let(:claimant) { create(:claimant, :advanced_on_docket_due_to_age, type: "AttorneyClaimant") }
+
+      before do
+        create(:advance_on_docket_motion, person_id: claimant.person.id, granted: true)
+      end
+
+      it "returns false" do
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(false)
         expect(claimant.advanced_on_docket_based_on_age?).to eq(false)
         expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(false)

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -104,7 +104,6 @@ describe Claimant, :postgres do
   end
 
   context "#advanced_on_docket?" do
-
     context "when claimant satisfies AOD age criteria" do
       let(:claimant) { create(:claimant, :advanced_on_docket_due_to_age) }
 

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -108,6 +108,7 @@ describe Claimant, :postgres do
       it "returns true" do
         claimant = create(:claimant, :advanced_on_docket_due_to_age)
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(true)
+        expect(claimant.advanced_on_docket_based_on_age?).to eq(true)
       end
     end
 
@@ -117,6 +118,7 @@ describe Claimant, :postgres do
         create(:advance_on_docket_motion, person_id: claimant.person.id, granted: true)
 
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(true)
+        expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(true)
       end
     end
 
@@ -124,6 +126,8 @@ describe Claimant, :postgres do
       it "returns false" do
         claimant = create(:claimant)
         expect(claimant.advanced_on_docket?(1.year.ago)).to eq(false)
+        expect(claimant.advanced_on_docket_based_on_age?).to eq(false)
+        expect(claimant.advanced_on_docket_motion_granted?(1.year.ago)).to eq(false)
       end
     end
   end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -203,8 +203,16 @@ describe Claimant, :postgres do
       end
     end
 
-    context "when claimant is attorney" do
+    context "when claimant is AttorneyClaimant" do
       let(:claimant) { create(:claimant, :advanced_on_docket_due_to_age, type: "AttorneyClaimant") }
+
+      before do
+        create(:bgs_attorney, participant_id: claimant.participant_id, name: "JOHN SMITH")
+      end
+
+      it "returns name of AttorneyClaimant" do
+        expect(claimant.name).to eq "JOHN SMITH"
+      end
 
       it "returns BgsPowerOfAttorney" do
         expect(subject).to be_a BgsPowerOfAttorney

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -202,6 +202,14 @@ describe Claimant, :postgres do
         expect(bgs_service).to have_received(:fetch_poas_by_participant_ids).once
       end
     end
+
+    context "when claimant is attorney" do
+      let(:claimant) { create(:claimant, :advanced_on_docket_due_to_age, type: "AttorneyClaimant") }
+
+      it "returns BgsPowerOfAttorney" do
+        expect(subject).to be_a BgsPowerOfAttorney
+      end
+    end
   end
 
   context "#valid?" do


### PR DESCRIPTION
Resolves #14637

[Part 1](https://github.com/department-of-veterans-affairs/caseflow/pull/14763)

### Description
Only for AMA appeals -- AOD status of legacy appeals can be found in VACOLS.
Add and use `Appeal.conditionally_set_aod_based_on_age` method to set the new `aod_based_on_age` table column when loaded by the user.
Add a job to set `aod_based_on_age` nightly for claimants who meet the age criteria.

### Acceptance Criteria
- [x] When `aod_based_on_age` is true, the appeal should show the AOD label/badge in the UI.
- [x] `aod_based_on_age` is true when `appeal.claimant.advanced_on_docket_based_on_age?` is true, after `appeal.advanced_on_docket?` is called.
- [x] After job is run, all active appeals associated with claimants age 75 and over will be marked as AOD (i.e., `aod_based_on_age` is true).

### Testing Plan
1. `rails db:migrate`
2. In Rails console, check the value of `aod_based_on_age` before and after changing things that would affect (and not affect) `aod_based_on_age` (also check the UI for an AOD label):
```ruby
> a=FactoryBot.create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_age)
> a.uuid
=> "64881a96-49a5-4442-b7d4-41eea483eee0" # Use this to check the UI at http://localhost:3000/queue/appeals/64881a96-49a5-4442-b7d4-41eea483eee0
> a.aod_based_on_age
=> nil
> a.advanced_on_docket?
=> true
> a.aod_based_on_age
=> true

> a.claimant.person.update(date_of_birth: 74.years.ago)
=> true
> a.aod_based_on_age
=> true
> a.advanced_on_docket?
=> false
> a.aod_based_on_age
=> false

> a2=FactoryBot.create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_age)
> a2.id
=> 708
> a2.uuid
=> "bccc4d86-ace1-41ce-99cf-cf013292b130"  # Use this to check the UI at http://localhost:3000/queue/appeals/bccc4d86-ace1-41ce-99cf-cf013292b130
> a2.aod_based_on_age
=> nil
> SetAppealAgeAodJob.new.perform_now
Performing SetAppealAgeAodJob (Job ID: fe8ff15c-6057-43f8-9b8c-594f4b4122d7) from Shoryuken(default)
SetAppealAgeAodJob completed after running for less than a minute.
IDs of age-related AOD appeals: [24, 708]
Performed SetAppealAgeAodJob (Job ID: fe8ff15c-6057-43f8-9b8c-594f4b4122d7) from Shoryuken(default) in 169.88ms
=> nil
```

Remember to `rake db:rollback` when done.

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

