### PR TITLE
Change cavc column to us_court_of_appeals_for_veterans_claims

### DIFF
--- a/app/controllers/special_issues_controller.rb
+++ b/app/controllers/special_issues_controller.rb
@@ -49,7 +49,8 @@ class SpecialIssuesController < ApplicationController
               :foreign_pension_dic_mexico_central_and_south_america_caribb,
               :us_territory_claim_american_samoa_guam_northern_mariana_isla,
               :us_territory_claim_puerto_rico_and_virgin_islands,
-              :burn_pit, :military_sexual_trauma, :blue_water, :us_court_of_appeals_for_veterans_claims, :no_special_issues)
+              :burn_pit, :military_sexual_trauma, :blue_water, 
+              :us_court_of_appeals_for_veterans_claims, :no_special_issues)
   end
 
   def record_not_found

--- a/app/controllers/special_issues_controller.rb
+++ b/app/controllers/special_issues_controller.rb
@@ -49,7 +49,7 @@ class SpecialIssuesController < ApplicationController
               :foreign_pension_dic_mexico_central_and_south_america_caribb,
               :us_territory_claim_american_samoa_guam_northern_mariana_isla,
               :us_territory_claim_puerto_rico_and_virgin_islands,
-              :burn_pit, :military_sexual_trauma, :blue_water, 
+              :burn_pit, :military_sexual_trauma, :blue_water,
               :us_court_of_appeals_for_veterans_claims, :no_special_issues)
   end
 

--- a/app/controllers/special_issues_controller.rb
+++ b/app/controllers/special_issues_controller.rb
@@ -49,7 +49,7 @@ class SpecialIssuesController < ApplicationController
               :foreign_pension_dic_mexico_central_and_south_america_caribb,
               :us_territory_claim_american_samoa_guam_northern_mariana_isla,
               :us_territory_claim_puerto_rico_and_virgin_islands,
-              :burn_pit, :military_sexual_trauma, :blue_water, :cavc, :no_special_issues)
+              :burn_pit, :military_sexual_trauma, :blue_water, :us_court_of_appeals_for_veterans_claims, :no_special_issues)
   end
 
   def record_not_found

--- a/db/migrate/20200728172002_rename_special_issues_cavc_column.rb
+++ b/db/migrate/20200728172002_rename_special_issues_cavc_column.rb
@@ -1,0 +1,7 @@
+class RenameSpecialIssuesCavcColumn < ActiveRecord::Migration[5.2]
+  def change
+    safety_assured do 
+      rename_column :special_issue_lists, :cavc, :us_court_of_appeals_for_veterans_claims
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_15_144822) do
+ActiveRecord::Schema.define(version: 2020_07_28_172002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1198,7 +1198,6 @@ ActiveRecord::Schema.define(version: 2020_07_15_144822) do
     t.string "appeal_type"
     t.boolean "blue_water", default: false, comment: "Blue Water"
     t.boolean "burn_pit", default: false, comment: "Burn Pit"
-    t.boolean "cavc", default: false, comment: "US Court of Appeals for Veterans Claims (CAVC)"
     t.boolean "contaminated_water_at_camp_lejeune", default: false
     t.datetime "created_at"
     t.boolean "dic_death_or_accrued_benefits_united_states", default: false
@@ -1222,6 +1221,7 @@ ActiveRecord::Schema.define(version: 2020_07_15_144822) do
     t.boolean "rice_compliance", default: false
     t.boolean "spina_bifida", default: false
     t.datetime "updated_at"
+    t.boolean "us_court_of_appeals_for_veterans_claims", default: false, comment: "US Court of Appeals for Veterans Claims (CAVC)"
     t.boolean "us_territory_claim_american_samoa_guam_northern_mariana_isla", default: false
     t.boolean "us_territory_claim_philippines", default: false
     t.boolean "us_territory_claim_puerto_rico_and_virgin_islands", default: false

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -916,7 +916,6 @@ special_issue_lists,appeal_id,integer (8) FK,,,x,,x,
 special_issue_lists,appeal_type,string,,,,,x,
 special_issue_lists,blue_water,boolean,,,,,,Blue Water
 special_issue_lists,burn_pit,boolean,,,,,,Burn Pit
-special_issue_lists,cavc,boolean,,,,,,US Court of Appeals for Veterans Claims (CAVC)
 special_issue_lists,contaminated_water_at_camp_lejeune,boolean,,,,,,
 special_issue_lists,created_at,datetime,,,,,,
 special_issue_lists,dic_death_or_accrued_benefits_united_states,boolean,,,,,,
@@ -941,6 +940,7 @@ special_issue_lists,radiation,boolean,,,,,,
 special_issue_lists,rice_compliance,boolean,,,,,,
 special_issue_lists,spina_bifida,boolean,,,,,,
 special_issue_lists,updated_at,datetime,,,,,x,
+special_issue_lists,us_court_of_appeals_for_veterans_claims,boolean,,,,,,US Court of Appeals for Veterans Claims (CAVC)
 special_issue_lists,us_territory_claim_american_samoa_guam_northern_mariana_isla,boolean,,,,,,
 special_issue_lists,us_territory_claim_philippines,boolean,,,,,,
 special_issue_lists,us_territory_claim_puerto_rico_and_virgin_islands,boolean,,,,,,


### PR DESCRIPTION
### Description
Renamed the `:cavc` field in the `special_issues_lists` table to `us_court_of_appeals_for_veterans_claims` to ensure it's being saved properly

### Acceptance Criteria
- [ ] US Court of Appeals for Veterans Claims (CAVC) properly updates in redux state
- [ ] US Court of Appeals for Veterans Claims (CAVC) properly saves in `special_issue_list` on appeal

### Testing Plan
1. Go to localhost:3000/queue as BVAAABSHIRE
2. Select an AMA appeal
3. Choose "Decision Ready for Review" from the actions
4. On the Select special issues view, ensure that `us_court_of_appeals_for_veterans_claims` loads in the specialIssues state
5. Interact with the checkbox and ensure that the state properly updates
6. Hit Continue and ensure in the rails console that whichever state you left the special issues is properly saved on the appeal

### Database Changes
*Only for Schema Changes*

* [x] Timestamps (created_at, updated_at) for new tables - 2020_07_28_172002
* [x] Column comments updated
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
