### PR TITLE
Allow users to access special issues page

### DIFF
--- a/app/models/tasks/judge_decision_review_task.rb
+++ b/app/models/tasks/judge_decision_review_task.rb
@@ -10,7 +10,7 @@ class JudgeDecisionReviewTask < JudgeTask
     return [] unless assigned_to == user
 
     judge_checkout_label = if ama?
-                             ama_judge_actions
+                             ama_judge_actions(user)
                            else
                              Constants.TASK_ACTIONS.JUDGE_LEGACY_CHECKOUT.to_h
                            end
@@ -46,8 +46,10 @@ class JudgeDecisionReviewTask < JudgeTask
 
   private
 
-  def ama_judge_actions
-    return Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SP_ISSUES.to_h if FeatureToggle.enabled?(:special_issues_revamp)
+  def ama_judge_actions(user)
+    if FeatureToggle.enabled?(:special_issues_revamp, user: user)
+      return Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SP_ISSUES.to_h
+    end
 
     Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h
   end

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -322,17 +322,19 @@ class TaskActionRepository
 
     def review_decision_draft(task, user)
       action = Constants.TASK_ACTIONS.REVIEW_LEGACY_DECISION.to_h
-      action = select_ama_review_decision_action(task) if task.ama?
+      action = select_ama_review_decision_action(task, user) if task.ama?
 
       TaskActionHelper.build_hash(action, task, user).merge(returns_complete_hash: true)
     end
 
     private
 
-    def select_ama_review_decision_action(task)
+    def select_ama_review_decision_action(task, user)
       return Constants.TASK_ACTIONS.REVIEW_VACATE_DECISION.to_h if task.appeal.vacate?
 
-      return Constants.TASK_ACTIONS.REVIEW_AMA_DECISION_SP_ISSUES.to_h if FeatureToggle.enabled?(:special_issues_revamp)
+      if FeatureToggle.enabled?(:special_issues_revamp, user: user)
+        return Constants.TASK_ACTIONS.REVIEW_AMA_DECISION_SP_ISSUES.to_h
+      end
 
       Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h
     end

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -485,7 +485,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
     end
 
     context "Special issue validation" do
-      before { FeatureToggle.enable!(:special_issues_revamp) }
+      before { FeatureToggle.enable!(:special_issues_revamp, users: [current_user.css_id]) }
       after { FeatureToggle.disable!(:special_issues_revamp) }
 
       let!(:task) do

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
     end
 
     context "when special_issues_revamp feature is enabled" do
-      before { FeatureToggle.enable!(:special_issues_revamp) }
+      before { FeatureToggle.enable!(:special_issues_revamp, users: [attorney_user.css_id]) }
       after { FeatureToggle.disable!(:special_issues_revamp) }
       scenario "submits draft decision" do
         visit "/queue"
@@ -452,7 +452,7 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
       let(:case_issues) { create_list(:case_issue, 4, with_notes: true) }
 
       context "when :special_issues_revamp feature enabled" do
-        before { FeatureToggle.enable!(:special_issues_revamp) }
+        before { FeatureToggle.enable!(:special_issues_revamp, users: [attorney_user.css_id]) }
         after { FeatureToggle.disable!(:special_issues_revamp) }
 
         scenario "no special issue chosen" do

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -87,7 +87,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
     end
 
     context "when special_issues_revamp feature is enabled" do
-      before { FeatureToggle.enable!(:special_issues_revamp) }
+      before { FeatureToggle.enable!(:special_issues_revamp, users: [judge_user.css_id]) }
       after { FeatureToggle.disable!(:special_issues_revamp) }
       scenario "starts dispatch checkout flow" do
         visit "/queue"


### PR DESCRIPTION
Resolves bug where [pilot users could not access the special issues page](https://dsva.slack.com/archives/CJL810329/p1595868875347600)

### Description
Checks that a toggle is enabled for a user, as it has only been enabled for our pilot users

### Acceptance Criteria
- [x] When feature is enabled for one user, that user can see the special issues page when checking out an appeal

### Testing Plan
1. Log in as bvaaabshire and go to their queue
2. Select an ama appeal that needs a decision review and go to case details
3. Disable feature toggle
   ```ruby
   FeatureToggle.disable!(:special_issues_revamp)
   FeatureToggle.enabled?(:special_issues_revamp, user: User.third)
   => false
   ```
4. Click "Ready for dispatch" and notice you are dropped on the dispositions page
5. Enable the feature only for the user
   ```ruby
   FeatureToggle.enable!(:special_issues_revamp, users: [User.third.css_id])
   FeatureToggle.enabled?(:special_issues_revamp)
   => false
   ```
6. Reload the page and repeat step 4, notice you are dropped on the special issues page
7. Complete checkout
8. Ensure special issues were saved
   ```ruby
   appeal  = Appeal.find_by(uuid: "")
   appeal.special_issue_list.as_json.values.any? { |val| val == true }
   ```


### User Facing Changes
 - [x] users with the feature toggle enabled will be dropped on the special issues page when checking out an ama appeal
