### PR TITLE
Updated regex in StringUtil.parseLinks

### DIFF
--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -92,7 +92,7 @@ const StringUtil = {
   parseLinks(str = '', { target = '_blank' } = {}) {
     // From https://code.tutsplus.com/tutorials/8-regular-expressions-you-should-know--net-6149
     // eslint-disable-next-line no-useless-escape
-    const regex = /((https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?)/gi;
+    const regex = /((https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?)(?=\s)/gi;
 
     return DOMPurify.sanitize(str.replace(regex, `<a href="$&" ${target ? `target="${target}"` : ''}>$&</a>`));
   },

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -91,10 +91,15 @@ const StringUtil = {
 
   parseLinks(str = '', { target = '_blank' } = {}) {
     // From https://code.tutsplus.com/tutorials/8-regular-expressions-you-should-know--net-6149
-    // eslint-disable-next-line no-useless-escape
-    const regex = /((https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?)(?=\s)/gi;
+    // eslint-disable-next-line
+    const regex = /((?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?)/gi;
 
-    return DOMPurify.sanitize(str.replace(regex, `<a href="$&" ${target ? `target="${target}"` : ''}>$&</a>`));
+    return DOMPurify.sanitize(
+      str.replace(
+        regex,
+        `<a href="$&" ${target ? `target="${target}"` : ''}>$&</a>`
+      )
+    );
   },
 
   // Replace newline ("\n") characters with React-friendly <br /> elements
@@ -113,7 +118,7 @@ const StringUtil = {
         </React.Fragment>
       );
     });
-  }
+  },
 };
 
 export default StringUtil;

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -95,6 +95,9 @@ const StringUtil = {
    * @param {object} options allows setting of target
    */
   parseLinks(str = '', { target = '_blank' } = {}) {
+    // Original regex from https://code.tutsplus.com/tutorials/8-regular-expressions-you-should-know--net-6149
+    // Modified by @nanotone to better deal with whitespace:
+    // https://github.com/department-of-veterans-affairs/caseflow/pull/14788
     // eslint-disable-next-line
     const regex = /(https?:\/\/|\b)[-\da-z.]+\.[a-z]{2,6}\/\S*/gi;
 

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -89,17 +89,25 @@ const StringUtil = {
     return str.toLowerCase().replace(/\W+/g, '_');
   },
 
+  /**
+   * Parses an input string to wrap URLs in HTML anchor tags
+   * @param {string} str input string
+   * @param {object} options allows setting of target
+   */
   parseLinks(str = '', { target = '_blank' } = {}) {
-    // From https://gist.github.com/dperini/729294
     // eslint-disable-next-line
-    const regex = /((?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?)/gi;
+    const regex = /(https?:\/\/|\b)[-\da-z.]+\.[a-z]{2,6}\/\S*/gi;
 
-    return DOMPurify.sanitize(
-      str.replace(
-        regex,
-        `<a href="$&" ${target ? `target="${target}"` : ''}>$&</a>`
-      )
+    // Add anchor tags
+    const replaced = str.replace(
+      regex,
+      `<a href="$&" ${target ? `target="${target}"` : ''}>$&</a>`
     );
+
+    // Sanitize, but ensure we allow `target` attribute
+    return DOMPurify.sanitize(replaced, {
+      ADD_ATTR: ['target'],
+    });
   },
 
   // Replace newline ("\n") characters with React-friendly <br /> elements

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -90,7 +90,7 @@ const StringUtil = {
   },
 
   parseLinks(str = '', { target = '_blank' } = {}) {
-    // From https://code.tutsplus.com/tutorials/8-regular-expressions-you-should-know--net-6149
+    // From https://gist.github.com/dperini/729294
     // eslint-disable-next-line
     const regex = /((?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z0-9\u00a1-\uffff][a-z0-9\u00a1-\uffff_-]{0,62})?[a-z0-9\u00a1-\uffff]\.)+(?:[a-z\u00a1-\uffff]{2,}\.?))(?::\d{2,5})?(?:[/?#]\S*)?)/gi;
 

--- a/client/app/util/StringUtil.js
+++ b/client/app/util/StringUtil.js
@@ -92,7 +92,7 @@ const StringUtil = {
   parseLinks(str = '', { target = '_blank' } = {}) {
     // From https://code.tutsplus.com/tutorials/8-regular-expressions-you-should-know--net-6149
     // eslint-disable-next-line no-useless-escape
-    const regex = /(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/gi;
+    const regex = /((https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?)/gi;
 
     return DOMPurify.sanitize(str.replace(regex, `<a href="$&" ${target ? `target="${target}"` : ''}>$&</a>`));
   },

--- a/client/test/app/util/StringUtil.test.js
+++ b/client/test/app/util/StringUtil.test.js
@@ -13,7 +13,8 @@ describe('StringUtil', () => {
       for (const link of links) {
         const input = `foo ${link} bar`;
         const output = StringUtil.parseLinks(input);
-        const expected = `foo <a href="${link}">${link}</a> bar`;
+
+        const expected = `foo <a target="_blank" href="${link}">${link}</a> bar`;
 
         expect(output).toBe(expected);
       }
@@ -23,7 +24,19 @@ describe('StringUtil', () => {
       for (const link of links) {
         const input = `foo\n${link}\nbar`;
         const output = StringUtil.parseLinks(input);
-        const expected = `foo\n<a href="${link}">${link}</a>\nbar`;
+        const expected = `foo\n<a target="_blank" href="${link}">${link}</a>\nbar`;
+
+        expect(output).toBe(expected);
+      }
+    });
+
+    test('allows a custom target', () => {
+      const options = { target: '' };
+
+      for (const link of links) {
+        const input = `foo ${link} bar`;
+        const output = StringUtil.parseLinks(input, options);
+        const expected = `foo <a href="${link}">${link}</a> bar`;
 
         expect(output).toBe(expected);
       }

--- a/client/test/app/util/StringUtil.test.js
+++ b/client/test/app/util/StringUtil.test.js
@@ -11,7 +11,7 @@ describe('StringUtil', () => {
 
     test('within other text, surrounded by spaces', () => {
       for (const link of links) {
-        const input = `foo ${links[0]} bar`;
+        const input = `foo ${link} bar`;
         const output = StringUtil.parseLinks(input);
         const expected = `foo <a href="${link}">${link}</a> bar`;
 

--- a/client/test/app/util/StringUtil.test.js
+++ b/client/test/app/util/StringUtil.test.js
@@ -6,22 +6,27 @@ describe('StringUtil', () => {
     const uuid = uuidv4();
     const links = [
       `https://appeals.cf.ds.va.gov/reader/appeal/${uuid}/documents/42416990`,
+      `https://appeals.cf.ds.va.gov/reader/appeal/${uuid}/documents/42416990?foo=bar`,
     ];
 
     test('within other text, surrounded by spaces', () => {
-      const input = `foo ${links[0]} bar`;
-      const output = StringUtil.parseLinks(input);
-      const expected = `foo <a href="${links[0]}">${links[0]}</a> bar`;
+      for (const link of links) {
+        const input = `foo ${links[0]} bar`;
+        const output = StringUtil.parseLinks(input);
+        const expected = `foo <a href="${link}">${link}</a> bar`;
 
-      expect(output).toBe(expected);
+        expect(output).toBe(expected);
+      }
     });
 
     test('within other text, surrounded by new lines', () => {
-      const input = `foo\n${links[0]}\nbar`;
-      const output = StringUtil.parseLinks(input);
-      const expected = `foo\n<a href="${links[0]}">${links[0]}</a>\nbar`;
+      for (const link of links) {
+        const input = `foo\n${link}\nbar`;
+        const output = StringUtil.parseLinks(input);
+        const expected = `foo\n<a href="${link}">${link}</a>\nbar`;
 
-      expect(output).toBe(expected);
+        expect(output).toBe(expected);
+      }
     });
   });
 });

--- a/client/test/app/util/StringUtil.test.js
+++ b/client/test/app/util/StringUtil.test.js
@@ -1,0 +1,27 @@
+import StringUtil from 'app/util/StringUtil';
+import { v4 as uuidv4 } from 'uuid';
+
+describe('StringUtil', () => {
+  describe('parseLinks', () => {
+    const uuid = uuidv4();
+    const links = [
+      `https://appeals.cf.ds.va.gov/reader/appeal/${uuid}/documents/42416990`,
+    ];
+
+    test('within other text, surrounded by spaces', () => {
+      const input = `foo ${links[0]} bar`;
+      const output = StringUtil.parseLinks(input);
+      const expected = `foo <a href="${links[0]}">${links[0]}</a> bar`;
+
+      expect(output).toBe(expected);
+    });
+
+    test('within other text, surrounded by new lines', () => {
+      const input = `foo\n${links[0]}\nbar`;
+      const output = StringUtil.parseLinks(input);
+      const expected = `foo\n<a href="${links[0]}">${links[0]}</a>\nbar`;
+
+      expect(output).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
### Description
This adjusts the regex used in the `parseLinks` function from frontend `StringUtil.js` and adds a couple of Jest tests.

### Background
- [Slack thread](https://dsva.slack.com/archives/CQNPUG8EQ/p1595964938014300)

The previous version was crashing when it encountered a newline char at the end of what should be the parsed URL:
```
motion:\nhttps://appeals.cf.ds.va.gov/reader/appeal/526e114b-af2d-4bc2-90ec-1ab1da0176b1/documents/42416990\nfoo
```

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Strings are properly parsed without crashing

