### PR TITLE
Fix bug preventing selection of deceased vet's dependent claimant

### DIFF
--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -83,7 +83,7 @@ export const SelectClaimant = (props) => {
     veteranIsNotClaimant,
     attorneyFees
   ]);
-  const handleVeteranIsNotClaimant = (value) => {
+  const handleVeteranIsNotClaimantChange = (value) => {
     const boolValue = convertStringToBoolean(value);
 
     setVeteranIsNotClaimant(boolValue);
@@ -149,7 +149,7 @@ export const SelectClaimant = (props) => {
     // disable veteran claimant option if veteran is deceased
     veteranClaimantOptions = BOOLEAN_RADIO_OPTIONS_DISABLED_FALSE;
     // set claimant value to someone other than the veteran
-    handleVeteranIsNotClaimant('true');
+    setVeteranIsNotClaimant(true);
   }
 
   return (
@@ -160,7 +160,7 @@ export const SelectClaimant = (props) => {
         strongLabel
         vertical
         options={veteranClaimantOptions}
-        onChange={handleVeteranIsNotClaimant}
+        onChange={handleVeteranIsNotClaimantChange}
         errorMessage={veteranIsNotClaimantError}
         value={veteranIsNotClaimant === null ? null : veteranIsNotClaimant.toString()}
       />

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -427,6 +427,9 @@ def check_deceased_veteran_cant_be_payee
   # verify that veteran cannot be selected
   expect(page.has_no_content?("00 - Veteran")).to eq(true)
   expect(page).to have_content("10 - Spouse")
+
+  find("label", text: "Bob Vance, Spouse", match: :prefer_exact).click
+  expect(find(".cf-select__value-container")).to have_content("10 - Spouse")
 end
 
 # rubocop: disable Metrics/AbcSize


### PR DESCRIPTION
### Description
This PR fixes a bug I introduced in #14648 that prevents Intake users from selecting dependent claimants when the veteran is deceased.

The bug is caused by ascribing two distinct intentions to the `handleVeteranIsNotClaimant` function: the user clicking on `yes`/`no` for whether the claimant is the veteran, and setting the corresponding Redux state under the hood. The `deceased` conditional intends the latter but the function implements the former -- therefore I've added the word `Change` to the function name.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Intake user can select dependent claimant for a deceased veteran

### Testing Plan
- Manual test:
  - Start a claim review intake (HLR or SC)
  - Make sure the selected veteran has a `date_of_death` set in the DB
  - On the review screen, make sure the deceased veteran can't be selected, and their dependent(s) can.
- Added a check in the deceased veteran spec for selecting a dependent claimant.

### User Facing Changes
No real changes, but this is what the UI looks like with the bug preventing claimant selection:
<img width="509" src="https://user-images.githubusercontent.com/282869/88844161-42991780-d1b0-11ea-8306-a8b71a668554.png">

And with the bug fixed (just business as usual):
<img width="482" src="https://user-images.githubusercontent.com/282869/88844184-49c02580-d1b0-11ea-9768-2995bf2b3dae.png">
