### PR TITLE
Show error message that's triggered when opening modal

### DIFF
--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -56,10 +56,16 @@ export const CaseDetailsView = (props) => {
   const success = useSelector((state) => state.ui.messages.success);
   const error = useSelector((state) => state.ui.messages.error);
   const veteranCaseListIsVisible = useSelector((state) => state.ui.veteranCaseListIsVisible);
+  const modalIsOpen = window.location.pathname.includes('modal');
 
   useEffect(() => {
     window.analyticsEvent(CATEGORIES.QUEUE_TASK, TASK_ACTIONS.VIEW_APPEAL_INFO);
-    props.resetErrorMessages();
+
+    // Prevent error messages from being reset if a modal is being displayed. This allows
+    // the modal to show error messages without them being cleared by the CaseDetailsView.
+    if (!modalIsOpen) {
+      props.resetErrorMessages();
+    }
 
     const { hearingDate, regionalOffice } = getQueryParams(window.location.search);
 
@@ -72,8 +78,6 @@ export const CaseDetailsView = (props) => {
   }, []);
 
   const doPulacCerulloReminder = useMemo(() => needsPulacCerulloAlert(appeal, tasks), [appeal, tasks]);
-
-  const modalIsOpen = window.location.pathname.includes('modal');
 
   return (
     <React.Fragment>

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -37,7 +37,7 @@ class AssignHearingModal extends React.PureComponent {
   }
 
   componentDidMount = () => {
-    const { appeal, openHearing } = this.props;
+    const { openHearing } = this.props;
 
     if (openHearing) {
       this.props.showErrorMessage({
@@ -100,9 +100,9 @@ class AssignHearingModal extends React.PureComponent {
       }
     };
 
-    return this.props
-      .requestPatch(`/tasks/${scheduleHearingTask.taskId}`, payload, this.getSuccessMsg())
-      .then(
+    return this.props.
+      requestPatch(`/tasks/${scheduleHearingTask.taskId}`, payload, this.getSuccessMsg()).
+      then(
         () => {
           history.goBack();
 
@@ -192,7 +192,7 @@ class AssignHearingModal extends React.PureComponent {
     return (
       <QueueFlowModal
         submit={this.completeScheduleHearingTask}
-        submitDisabled={!!openHearing}
+        submitDisabled={Boolean(openHearing)}
         validateForm={this.validateForm}
         title="Schedule Veteran"
         button="Schedule"

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -37,7 +37,7 @@ class AssignHearingModal extends React.PureComponent {
   }
 
   componentDidMount = () => {
-    const { openHearing } = this.props;
+    const { appeal, openHearing } = this.props;
 
     if (openHearing) {
       this.props.showErrorMessage({
@@ -189,13 +189,10 @@ class AssignHearingModal extends React.PureComponent {
     const { showErrorMessages, showFullHearingDayWarning } = this.state;
     const { address_line_1: addressLine1, city, state, zip } = appeal.appellantAddress || {};
 
-    if (openHearing) {
-      return null;
-    }
-
     return (
       <QueueFlowModal
         submit={this.completeScheduleHearingTask}
+        submitDisabled={!!openHearing}
         validateForm={this.validateForm}
         title="Schedule Veteran"
         button="Schedule"
@@ -210,15 +207,21 @@ class AssignHearingModal extends React.PureComponent {
               {COPY.SCHEDULE_VETERAN_FULL_HEARING_DAY_MESSAGE_DETAIL}
             </Alert>
           }
-          <p>
-            Veteran Address<br />
-            {addressLine1}<br />
-            {`${city}, ${state} ${zip}`}
-          </p>
-          <AssignHearingForm
-            appeal={appeal}
-            showErrorMessages={showErrorMessages}
-            {...this.getInitialValues()} />
+          {
+            !openHearing &&
+            <React.Fragment>
+              <p>
+                Veteran Address<br />
+                {addressLine1}<br />
+                {`${city}, ${state} ${zip}`}
+              </p>
+              <AssignHearingForm
+                appeal={appeal}
+                showErrorMessages={showErrorMessages}
+                {...this.getInitialValues()}
+              />
+            </React.Fragment>
+          }
         </div>
       </QueueFlowModal>
     );

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -56,7 +56,7 @@ class AssignHearingModal extends React.PureComponent {
 
   toggleFullHearingDayWarning = () => {
     const { assignHearingForm, hearingDay } = this.props;
-    const selectedHearingDay = (assignHearingForm || {}).hearingDay || hearingDay;
+    const selectedHearingDay = assignHearingForm?.hearingDay || hearingDay;
 
     if (!selectedHearingDay) {
       return;
@@ -66,10 +66,6 @@ class AssignHearingModal extends React.PureComponent {
       showFullHearingDayWarning: selectedHearingDay.filledSlots >= selectedHearingDay.totalSlots
     });
   }
-
-  submit = () => {
-    return this.completeScheduleHearingTask();
-  };
 
   validateForm = () => {
     const { assignHearingForm, openHearing } = this.props;
@@ -104,26 +100,30 @@ class AssignHearingModal extends React.PureComponent {
       }
     };
 
-    return this.props.requestPatch(`/tasks/${scheduleHearingTask.taskId}`, payload, this.getSuccessMsg()).
-      then(() => {
-        history.goBack();
-        this.resetAppealDetails();
+    return this.props
+      .requestPatch(`/tasks/${scheduleHearingTask.taskId}`, payload, this.getSuccessMsg())
+      .then(
+        () => {
+          history.goBack();
 
-      }, () => {
-        if (appeal.isLegacyAppeal) {
-          this.props.showErrorMessage({
-            title: 'No Available Slots',
-            detail: 'Could not find any available slots for this regional office and hearing day combination. ' +
-                    'Please select a different date.'
-          });
-        } else {
-          this.props.showErrorMessage({
-            title: 'No Hearing Day',
-            detail: 'Until April 1st hearing days for AMA appeals need to be created manually. ' +
-                    'Please contact the Caseflow Team for assistance.'
-          });
+          this.resetAppealDetails();
+        },
+        () => {
+          if (appeal.isLegacyAppeal) {
+            this.props.showErrorMessage({
+              title: 'No Available Slots',
+              detail: 'Could not find any available slots for this regional office and hearing day combination. ' +
+                      'Please select a different date.'
+            });
+          } else {
+            this.props.showErrorMessage({
+              title: 'No Hearing Day',
+              detail: 'Until April 1st hearing days for AMA appeals need to be created manually. ' +
+                      'Please contact the Caseflow Team for assistance.'
+            });
+          }
         }
-      });
+      );
   }
 
   resetAppealDetails = () => {
@@ -195,7 +195,7 @@ class AssignHearingModal extends React.PureComponent {
 
     return (
       <QueueFlowModal
-        submit={this.submit}
+        submit={this.completeScheduleHearingTask}
         validateForm={this.validateForm}
         title="Schedule Veteran"
         button="Schedule"
@@ -226,6 +226,7 @@ class AssignHearingModal extends React.PureComponent {
 }
 
 AssignHearingModal.propTypes = {
+  // The open hearing for an appeal (if it exists).
   openHearing: PropTypes.shape({
     date: PropTypes.string
   }),

--- a/client/app/queue/components/QueueFlowModal.jsx
+++ b/client/app/queue/components/QueueFlowModal.jsx
@@ -53,7 +53,7 @@ class QueueFlowModal extends React.PureComponent {
   };
 
   render = () => {
-    const { title, button, children, error, success } = this.props;
+    const { title, button, children, error, success, submitDisabled } = this.props;
 
     return (
       <Modal
@@ -67,6 +67,7 @@ class QueueFlowModal extends React.PureComponent {
           {
             classNames: ['usa-button-secondary', 'usa-button-hover', 'usa-button-warning'],
             name: button,
+            disabled: submitDisabled,
             loading: this.state.loading,
             onClick: this.submit
           }
@@ -84,6 +85,7 @@ class QueueFlowModal extends React.PureComponent {
 QueueFlowModal.defaultProps = {
   button: COPY.MODAL_SUBMIT_BUTTON,
   pathAfterSubmit: '/queue',
+  submitDisabled: false,
   title: ''
 };
 
@@ -97,6 +99,7 @@ QueueFlowModal.propTypes = {
   pathAfterSubmit: PropTypes.string,
   // submit should return a promise on which .then() can be called
   submit: PropTypes.func,
+  submitDisabled: PropTypes.bool,
   validateForm: PropTypes.func,
   saveSuccessful: PropTypes.bool,
   success: PropTypes.object,

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -177,6 +177,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
     end
     let(:incarcerated_veteran_task_instructions) { "Incarcerated veteran task instructions" }
     let(:contested_claimant_task_instructions) { "Contested claimant task instructions" }
+    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_ama_appeals }
 
     before { cache_appeals }
 

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
+RSpec.feature "Schedule Veteran For A Hearing" do
   let!(:current_user) do
     user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
     User.authenticate!(user: user)
@@ -561,7 +561,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       )
     end
 
-    scenario "shows an error message in the schedule veteran's modal", focus: true do
+    scenario "shows an error message in the schedule veteran's modal" do
       visit "queue/appeals/#{appeal.external_id}"
       # Expected dropdowns on page:
       #   [0] - Assign disposition task

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
   end
 
   let(:other_user) { create(:user) }
+  let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
 
   before do
     HearingsManagement.singleton.add_user(current_user)
@@ -32,11 +33,8 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
     let(:appellant_appeal_link_text) do
       "#{legacy_appeal.appellant[:first_name]} #{legacy_appeal.appellant[:last_name]} | #{veteran.file_number}"
     end
-    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
 
-    before do
-      cache_appeals
-    end
+    before { cache_appeals }
 
     def navigate_to_schedule_veteran_modal
       visit "hearings/schedule/assign"
@@ -49,6 +47,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
       expect(page).to have_content("Time")
     end
+
     scenario "address from BGS is displayed in schedule veteran modal" do
       navigate_to_schedule_veteran_modal
 
@@ -58,6 +57,7 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
         "#{FakeConstants.BGS_SERVICE.DEFAULT_STATE} #{FakeConstants.BGS_SERVICE.DEFAULT_ZIP}"
       )
     end
+
     scenario "Schedule Veteran for central hearing" do
       navigate_to_schedule_veteran_modal
       # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
@@ -108,7 +108,6 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       )
     end
     let!(:veteran) { create(:veteran, file_number: "123456789") }
-    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
 
     scenario "Schedule Veteran for video" do
       cache_appeals
@@ -178,11 +177,8 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
     end
     let(:incarcerated_veteran_task_instructions) { "Incarcerated veteran task instructions" }
     let(:contested_claimant_task_instructions) { "Contested claimant task instructions" }
-    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_ama_appeals }
 
-    before do
-      cache_appeals
-    end
+    before { cache_appeals }
 
     scenario "Can create multiple admin actions and reassign them" do
       visit "hearings/schedule/assign"
@@ -473,7 +469,6 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
       )
     end
     let!(:veteran5) { create(:veteran, file_number: "523454787") }
-    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
 
     scenario "Verify docket order is CVAC, AOD, then regular." do
       cache_appeals

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -533,6 +533,46 @@ RSpec.feature "Schedule Veteran For A Hearing", :all_dbs do
     end
   end
 
+  context "With an appeal where there is an open hearing" do
+    let(:regional_office) { "RO39" }
+    let(:hearing_day) do
+      create(
+        :hearing_day,
+        request_type: HearingDay::REQUEST_TYPES[:video],
+        scheduled_for: Time.zone.today + 160,
+        regional_office: regional_office
+      )
+    end
+    let(:appeal) do
+      create(
+        :appeal,
+        :hearing_docket,
+        :with_post_intake_tasks,
+        closest_regional_office: regional_office
+      )
+    end
+    let!(:hearing) do
+      create(
+        :hearing,
+        :with_tasks,
+        appeal: appeal,
+        hearing_day: hearing_day,
+        regional_office: regional_office
+      )
+    end
+
+    scenario "shows an error message in the schedule veteran's modal", focus: true do
+      visit "queue/appeals/#{appeal.external_id}"
+      # Expected dropdowns on page:
+      #   [0] - Assign disposition task
+      #   [1] - Schedule hearing task
+      within page.all(".cf-form-dropdown")[1] do
+        click_dropdown(text: "Schedule Veteran")
+      end
+      expect(page).to have_content("Open Hearing")
+    end
+  end
+
   context "No upcoming hearing days" do
     scenario "Show status message for empty upcoming hearing days" do
       visit "hearings/schedule/assign"


### PR DESCRIPTION
Resolves #14767

### Description

  * Display error on schedule hearing modal when there is an open hearing

### Acceptance Criteria
- [x]  Show error message on Case details

### User Facing Changes

<img width="1440" alt="Screen Shot 2020-07-30 at 12 27 38 PM" src="https://user-images.githubusercontent.com/1298274/88948596-1ccb4b80-d260-11ea-88ac-c9a763c94c9d.png">
