### PR TITLE
Legacy cases with blocking mail records or diaries are not ready to be distributed

### DIFF
--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -144,8 +144,11 @@ class VACOLS::CaseDocket < VACOLS::Record
       select count(*) N, PRIORITY, READY
       from (
         select case when BFAC = '7' or nvl(AOD_DIARIES.CNT, 0) + nvl(AOD_HEARINGS.CNT, 0) > 0 then 1 else 0 end as PRIORITY,
-          case when BFCURLOC in ('81', '83') then 1 else 0 end as READY
+          case when BFCURLOC in ('81', '83') and MAIL_BLOCKS_DISTRIBUTION = 0 and DIARY_BLOCKS_DISTRIBUTION = 0
+            then 1 else 0 end as READY
         from BRIEFF
+        #{JOIN_MAIL_BLOCKS_DISTRIBUTION}
+        #{JOIN_DIARY_BLOCKS_DISTRIBUTION}
         left join (
           select TSKTKNM, count(*) CNT
           from ASSIGN

--- a/spec/factories/vacols/mail.rb
+++ b/spec/factories/vacols/mail.rb
@@ -6,12 +6,14 @@ FactoryBot.define do
 
     trait :blocking do
       mltype { "03" }
-      mlcompdate { nil }
     end
 
-    trait :non_blocking do
-      mltype { "03" }
+    trait :completed do
       mlcompdate { Time.zone.now.to_date }
+    end
+
+    trait :incomplete do
+      mlcompdate { nil }
     end
   end
 end

--- a/spec/factories/vacols/mail.rb
+++ b/spec/factories/vacols/mail.rb
@@ -3,5 +3,15 @@
 FactoryBot.define do
   factory :mail, class: VACOLS::Mail do
     mltype { "02" }
+
+    trait :blocking do
+      mltype { "03" }
+      mlcompdate { nil }
+    end
+
+    trait :non_blocking do
+      mltype { "03" }
+      mlcompdate { Time.zone.now.to_date }
+    end
   end
 end

--- a/spec/models/vacols/case_docket_spec.rb
+++ b/spec/models/vacols/case_docket_spec.rb
@@ -92,7 +92,7 @@ describe VACOLS::CaseDocket, :all_dbs do
            folder: build(:folder, tinum: postcavc_ready_case_docket_number, titrnum: "123456789S"))
   end
 
-  let!(:aod_unready_case_due_to_location) do
+  let!(:aod_case_unready_due_to_location) do
     create(:case,
            :aod,
            bfd19: 1.year.ago,
@@ -101,7 +101,7 @@ describe VACOLS::CaseDocket, :all_dbs do
            bfcurloc: "55")
   end
 
-  let!(:aod_unready_case_due_to_blocking_mail) do
+  let!(:aod_case_unready_due_to_blocking_mail) do
     create(:case,
            :aod,
            bfd19: 1.year.ago,
@@ -444,7 +444,7 @@ describe VACOLS::CaseDocket, :all_dbs do
     end
 
     it "does not distribute non-ready or nonpriority cases" do
-      expect(aod_unready_case_due_to_location.reload.bfcurloc).to eq("55")
+      expect(aod_case_unready_due_to_location.reload.bfcurloc).to eq("55")
       expect(nonpriority_ready_case.reload.bfcurloc).to eq("81")
     end
 

--- a/spec/models/vacols/case_docket_spec.rb
+++ b/spec/models/vacols/case_docket_spec.rb
@@ -45,13 +45,15 @@ describe VACOLS::CaseDocket, :all_dbs do
 
   let(:another_nonpriority_ready_case_docket_number) { "1801002" }
   let!(:another_nonpriority_ready_case) do
-    create(:case,
-           bfd19: 1.year.ago,
-           bfac: "1",
-           bfmpro: "ACT",
-           bfcurloc: "83",
-           bfdloout: 1.day.ago,
-           folder: build(:folder, tinum: another_nonpriority_ready_case_docket_number, titrnum: "123456789S"))
+    create(
+      :case,
+      bfd19: 1.year.ago,
+      bfac: "1",
+      bfmpro: "ACT",
+      bfcurloc: "83",
+      bfdloout: 1.day.ago,
+      folder: build(:folder, tinum: another_nonpriority_ready_case_docket_number, titrnum: "123456789S")
+    ).tap { |vacols_case| create(:mail, :non_blocking, mlfolder: vacols_case.bfkey) }
   end
 
   let!(:nonpriority_unready_case) do
@@ -90,7 +92,7 @@ describe VACOLS::CaseDocket, :all_dbs do
            folder: build(:folder, tinum: postcavc_ready_case_docket_number, titrnum: "123456789S"))
   end
 
-  let!(:aod_unready_case) do
+  let!(:aod_unready_case_due_to_location) do
     create(:case,
            :aod,
            bfd19: 1.year.ago,
@@ -99,11 +101,20 @@ describe VACOLS::CaseDocket, :all_dbs do
            bfcurloc: "55")
   end
 
+  let!(:aod_unready_case_due_to_blocking_mail) do
+    create(:case,
+           :aod,
+           bfd19: 1.year.ago,
+           bfac: "1",
+           bfmpro: "ACT",
+           bfcurloc: "81").tap { |vacols_case| create(:mail, :blocking, mlfolder: vacols_case.bfkey) }
+  end
+
   context ".counts_by_priority_and_readiness" do
     subject { VACOLS::CaseDocket.counts_by_priority_and_readiness }
     it "creates counts grouped by priority and readiness" do
       expect(subject).to match_array([
-                                       { "n" => 1, "priority" => 1, "ready" => 0 },
+                                       { "n" => 2, "priority" => 1, "ready" => 0 },
                                        { "n" => 2, "priority" => 1, "ready" => 1 },
                                        { "n" => 1, "priority" => 0, "ready" => 0 },
                                        { "n" => 2, "priority" => 0, "ready" => 1 }
@@ -433,7 +444,7 @@ describe VACOLS::CaseDocket, :all_dbs do
     end
 
     it "does not distribute non-ready or nonpriority cases" do
-      expect(aod_unready_case.reload.bfcurloc).to eq("55")
+      expect(aod_unready_case_due_to_location.reload.bfcurloc).to eq("55")
       expect(nonpriority_ready_case.reload.bfcurloc).to eq("81")
     end
 

--- a/spec/models/vacols/case_docket_spec.rb
+++ b/spec/models/vacols/case_docket_spec.rb
@@ -53,7 +53,7 @@ describe VACOLS::CaseDocket, :all_dbs do
       bfcurloc: "83",
       bfdloout: 1.day.ago,
       folder: build(:folder, tinum: another_nonpriority_ready_case_docket_number, titrnum: "123456789S")
-    ).tap { |vacols_case| create(:mail, :non_blocking, mlfolder: vacols_case.bfkey) }
+    ).tap { |vacols_case| create(:mail, :blocking, :completed, mlfolder: vacols_case.bfkey) }
   end
 
   let!(:nonpriority_unready_case) do
@@ -107,7 +107,7 @@ describe VACOLS::CaseDocket, :all_dbs do
            bfd19: 1.year.ago,
            bfac: "1",
            bfmpro: "ACT",
-           bfcurloc: "81").tap { |vacols_case| create(:mail, :blocking, mlfolder: vacols_case.bfkey) }
+           bfcurloc: "81").tap { |vacols_case| create(:mail, :blocking, :incomplete, mlfolder: vacols_case.bfkey) }
   end
 
   context ".counts_by_priority_and_readiness" do


### PR DESCRIPTION
Resolves discrepancy detailed https://github.com/department-of-veterans-affairs/caseflow/issues/14752#issuecomment-665986693

### Description
Ensures we take blocking mail records and diary records into account when counting a legacy case as "ready"

### Acceptance Criteria
- [x] counts_by_priority_and_readiness matches number of ready priority cases 
