### PR TITLE
Split FeatureToggle Queue/Dispatch for New Contentions

### DIFF
--- a/app/views/dispatch/establish_claims/show.html.erb
+++ b/app/views/dispatch/establish_claims/show.html.erb
@@ -11,7 +11,7 @@
   feedbackUrl: feedback_url,
   buildDate: build_date,
   featureToggles: {
-    specialIssuesRevamp: FeatureToggle.enabled?(:special_issues_revamp, user: current_user)
+    specialIssuesRevamp: FeatureToggle.enabled?(:special_issues_revamp_dispatch, user: current_user)
   }
 }) %>
 <% end %>

--- a/client/app/establishClaim/selectors/index.js
+++ b/client/app/establishClaim/selectors/index.js
@@ -8,18 +8,18 @@ const getStationKey = (_, stationKey) => stationKey;
 
 export const getStationOfJurisdiction = createSelector(
   [getSpecialIssues, getStationKey],
-  (specialIssues, stationKey, special_issues_revamp) => {
+  (specialIssues, stationKey, special_issues_revamp_dispatch) => {
     let station = ARC_STATION_OF_JURISDICTION;
 
     // Go through the special issues, and for any regional issues, set SOJ to RO
-    specialIssueFilters(special_issues_revamp).regionalSpecialIssues().forEach((issue) => {
+    specialIssueFilters(special_issues_revamp_dispatch).regionalSpecialIssues().forEach((issue) => {
       if (specialIssues[issue.specialIssue]) {
         station = stationKey;
       }
     });
 
     // Go through all the special issues, this time looking for routed issues
-    specialIssueFilters(special_issues_revamp).routedSpecialIssues().forEach((issue) => {
+    specialIssueFilters(special_issues_revamp_dispatch).routedSpecialIssues().forEach((issue) => {
       if (specialIssues[issue.specialIssue]) {
         station = issue.stationOfJurisdiction.key;
       }

--- a/client/app/establishClaim/util/index.js
+++ b/client/app/establishClaim/util/index.js
@@ -12,11 +12,11 @@ export const formattedStationOfJurisdiction = (
   stationOfJurisdiction,
   regionalOfficeKey,
   regionalOfficeCities,
-  special_issues_revamp
+  special_issues_revamp_dispatch
 ) => {
   let suffix;
 
-  enabledSpecialIssues(special_issues_revamp).forEach((issue) => {
+  enabledSpecialIssues(special_issues_revamp_dispatch).forEach((issue) => {
     let issueKey = issue.stationOfJurisdiction && issue.stationOfJurisdiction.key;
 
     // If the assigned stationOfJurisdiction matches a routed special issue, use the

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -485,8 +485,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
     end
 
     context "Special issue validation" do
-      before { FeatureToggle.enable!(:special_issues_revamp, users: [current_user.css_id]) }
-      after { FeatureToggle.disable!(:special_issues_revamp) }
+      before { FeatureToggle.enable!(:special_issues_revamp_dispatch, users: [current_user.css_id]) }
+      after { FeatureToggle.disable!(:special_issues_revamp_dispatch) }
 
       let!(:task) do
         create(:establish_claim,


### PR DESCRIPTION
Bumps #13423 

### Description
Links the new contentions in Dispatch to a distinct FeatureToggle, allowing us to release only the changes to Queue

### Acceptance Criteria
- Enabling `:special_issues_revamp`
  - [x] Fully enables the new contention work in Queue
  - [x] Leaves Caseflow Dispatch unaffected
- [x] [Update the FeatureToggle docs](https://github.com/department-of-veterans-affairs/caseflow/wiki/Adding-a-Feature-Flag-with-FeatureToggle)

### Testing Plan
1. Both Toggles disabled
   `FeatureToggle.disable!(:special_issues_revamp)`
   `FeatureToggle.disable!(:special_issues_revamp_dispatch)`
   - [x] Attorney Checkout unchanged
   - [x] Judge Checkout unchanged
   - [x] Dispatch Claim Establishment unchanged
1. Enable `:special_issues_revamp` _only_
   `FeatureToggle.enable!(:special_issues_revamp)`
   `FeatureToggle.disable!(:special_issues_revamp_dispatch)`
   - [x] Attorney Checkout has new contentions & behavior
   - [x] Judge Checkout has new contentions & behavior
   - [x] Dispatch Claim Establishment unchanged

### User Facing Changes
None