### PR TITLE
Replace log_error with Raven.capture_message

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -311,7 +311,7 @@ class Appeal < DecisionReview
     begin
       TimezoneService.address_to_timezone(appellant_address).identifier
     rescue StandardError => error
-      Raven.capture_message(error)
+      Raven.capture_exception(error)
       nil
     end
   end
@@ -325,7 +325,7 @@ class Appeal < DecisionReview
     begin
       TimezoneService.address_to_timezone(rep_address).identifier
     rescue StandardError => error
-      Raven.capture_message(error)
+      Raven.capture_exception(error)
       nil
     end
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -311,7 +311,7 @@ class Appeal < DecisionReview
     begin
       TimezoneService.address_to_timezone(appellant_address).identifier
     rescue StandardError => error
-      log_error(error)
+      Raven.capture_message(error)
       nil
     end
   end
@@ -325,7 +325,7 @@ class Appeal < DecisionReview
     begin
       TimezoneService.address_to_timezone(rep_address).identifier
     rescue StandardError => error
-      log_error(error)
+      Raven.capture_message(error)
       nil
     end
   end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -231,7 +231,7 @@ class LegacyAppeal < CaseflowRecord
     begin
       TimezoneService.address_to_timezone(address).identifier
     rescue StandardError => error
-      Raven.capture_message(error)
+      Raven.capture_exception(error)
       nil
     end
   end
@@ -245,7 +245,7 @@ class LegacyAppeal < CaseflowRecord
     begin
       TimezoneService.address_to_timezone(address).identifier
     rescue StandardError => error
-      Raven.capture_message(error)
+      Raven.capture_exception(error)
       nil
     end
   end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -231,7 +231,7 @@ class LegacyAppeal < CaseflowRecord
     begin
       TimezoneService.address_to_timezone(address).identifier
     rescue StandardError => error
-      log_error(error)
+      Raven.capture_message(error)
       nil
     end
   end
@@ -245,7 +245,7 @@ class LegacyAppeal < CaseflowRecord
     begin
       TimezoneService.address_to_timezone(address).identifier
     rescue StandardError => error
-      log_error(error)
+      Raven.capture_message(error)
       nil
     end
   end


### PR DESCRIPTION
# Description
Fixes sentry error when resolving a timezone for a missing country: https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/11034/?referrer=webhooks_plugin

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Comment line 450 of `app/models/appeal.rb`
1. Shadow user `BVASYELLOW`
1. Navigate to the hearings schedule and choose a Central Hearing: http://localhost:3000/hearings/schedule
1. Ensure that the hearing loads without issues
1. Click the 'Edit hearing details' link
1. Change the type to Virtual and ensure that the timezone is empty
