### PR TITLE
Fix case details page by supplying attorney claimant relationship

### DIFF
--- a/app/models/attorney_claimant.rb
+++ b/app/models/attorney_claimant.rb
@@ -20,6 +20,10 @@ class AttorneyClaimant < Claimant
     false
   end
 
+  def relationship
+    "Attorney"
+  end
+
   private
 
   def find_power_of_attorney

--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -234,7 +234,7 @@ class DecisionIssue < CaseflowRecord
   end
 
   def dta_payee_code
-    decision_review.payee_code || prior_payee_code || decision_review.claimant.bgs_payee_code
+    decision_review.payee_code || prior_payee_code || decision_review.claimant&.bgs_payee_code
   end
 
   def find_remand_supplemental_claim

--- a/app/models/other_claimant.rb
+++ b/app/models/other_claimant.rb
@@ -7,4 +7,8 @@
 
 class OtherClaimant < Claimant
   validate { |claimant| OtherClaimantValidator.new(claimant).validate }
+
+  def relationship
+    "Other"
+  end
 end

--- a/app/serializers/intake/decision_review_serializer.rb
+++ b/app/serializers/intake/decision_review_serializer.rb
@@ -6,6 +6,12 @@ class Intake::DecisionReviewSerializer
 
   attribute :claimant, &:claimant_participant_id
   attribute :claimant_type
+  attribute :claimant_name do |object|
+    object.claimant.name
+  end
+  attribute :claimant_notes do |object|
+    object.claimant.notes
+  end
   attribute :veteran_is_not_claimant
   attribute :processed_in_caseflow, &:processed_in_caseflow?
   attribute :legacy_opt_in_approved

--- a/app/serializers/intake/decision_review_serializer.rb
+++ b/app/serializers/intake/decision_review_serializer.rb
@@ -7,10 +7,10 @@ class Intake::DecisionReviewSerializer
   attribute :claimant, &:claimant_participant_id
   attribute :claimant_type
   attribute :claimant_name do |object|
-    object.claimant.name
+    object.claimant&.name
   end
   attribute :claimant_notes do |object|
-    object.claimant.notes
+    object.claimant&.notes
   end
   attribute :veteran_is_not_claimant
   attribute :processed_in_caseflow, &:processed_in_caseflow?

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -257,6 +257,7 @@ RSpec.feature "Case details", :all_dbs do
         expect(page).to_not have_content("Regional Office")
       end
     end
+
     context "when veteran is in BGS" do
       let!(:appeal) do
         create(
@@ -302,6 +303,36 @@ RSpec.feature "Case details", :all_dbs do
         expect(page).to have_content(appeal.appellant_address_line_1)
         expect(page).to have_content(COPY::CASE_DETAILS_VETERAN_ADDRESS_SOURCE)
         expect(page).to_not have_content("Regional Office")
+      end
+    end
+
+    context "when appellant is an attorney" do
+      let(:bgs_atty) { create(:bgs_attorney) }
+      let(:appeal) do
+        create(
+          :appeal,
+          associated_judge: judge_user,
+          associated_attorney: attorney_user,
+          number_of_claimants: 0,
+          veteran_is_not_claimant: true
+        )
+      end
+      let!(:claimant) do
+        create(
+          :claimant,
+          decision_review: appeal,
+          type: "AttorneyClaimant",
+          participant_id: bgs_atty.participant_id
+        )
+      end
+
+      scenario "details view informs us that appellant's relationship to Veteran is attorney" do
+        visit "/queue/appeals/#{appeal.uuid}"
+
+        expect(page).to have_content("About the Veteran")
+        expect(page).to have_content("About the Appellant")
+        expect(page).to have_content("Name: #{claimant.name}")
+        expect(page).to have_content("Relation to Veteran: Attorney")
       end
     end
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -306,7 +306,7 @@ RSpec.feature "Case details", :all_dbs do
       end
     end
 
-    context "when appellant is an attorney" do
+    context "when appellant is an attorney or unlisted claimant" do
       let(:bgs_atty) { create(:bgs_attorney) }
       let(:appeal) do
         create(
@@ -317,22 +317,22 @@ RSpec.feature "Case details", :all_dbs do
           veteran_is_not_claimant: true
         )
       end
-      let!(:claimant) do
-        create(
-          :claimant,
-          decision_review: appeal,
-          type: "AttorneyClaimant",
-          participant_id: bgs_atty.participant_id
-        )
-      end
 
-      scenario "details view informs us that appellant's relationship to Veteran is attorney" do
-        visit "/queue/appeals/#{appeal.uuid}"
+      %w[Attorney Other].each do |claimant_type|
+        scenario "details view informs us that appellant's relationship to Veteran is #{claimant_type}" do
+          create(
+            :claimant,
+            decision_review: appeal,
+            type: "#{claimant_type}Claimant",
+            participant_id: bgs_atty.participant_id,
+            notes: (claimant_type == "Other") ? "sample notes" : nil
+          )
+          visit "/queue/appeals/#{appeal.uuid}"
 
-        expect(page).to have_content("About the Veteran")
-        expect(page).to have_content("About the Appellant")
-        expect(page).to have_content("Name: #{claimant.name}")
-        expect(page).to have_content("Relation to Veteran: Attorney")
+          expect(page).to have_content("About the Veteran")
+          expect(page).to have_content("About the Appellant")
+          expect(page).to have_content("Relation to Veteran: #{claimant_type}")
+        end
       end
     end
 


### PR DESCRIPTION
### Description
This PR ensures that all the new claimant subclasses have a `relationship` method, which fixes an error on the case detail page when it tries to display a non-BGS-related appellant.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Added a new case-details test for when claimant is an attorney

### Testing Plan
1. Visit `/intake`
1. Go through Intake with a known veteran, and establish an Appeal with an attorney claimant.
1. Visit `/search`
1. Do a search for the file number of that veteran
1. Visit the case details page and make sure everything looks right

### User Facing Changes
This PR fixes the "Appellant" section of the case details page, which will look like this:
<img width="949" src="https://user-images.githubusercontent.com/282869/89228028-d3a33080-d5ac-11ea-9e3f-1e55bd171c3f.png">