### PR TITLE
[Part 3] Update recipient role in email sent event if veteran

### DIFF
--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -115,12 +115,18 @@ class VirtualHearings::SendEmail
 
   # :nocov:
   def create_sent_hearing_email_event(recipient, external_id)
+    # The "appellant" title is used in the email and is consistent whether or not the
+    # veteran is or isn't the appellant, but the email event can be more specific.
+    recipient_is_veteran = (
+      recipient.title.eq?(MailRecipient::RECIPIENT_TITLES[:appellant]) &&
+      !appeal.appellant_is_not_veteran
+    )
     SentHearingEmailEvent.create!(
       hearing: hearing,
       email_type: type,
       email_address: recipient.email,
       external_message_id: external_id,
-      recipient_role: recipient.title.downcase,
+      recipient_role: recipient_is_veteran ? "veteran" : recipient.title.downcase,
       sent_by: virtual_hearing.updated_by
     )
   rescue StandardError => error

--- a/app/jobs/virtual_hearings/send_email.rb
+++ b/app/jobs/virtual_hearings/send_email.rb
@@ -118,7 +118,7 @@ class VirtualHearings::SendEmail
     # The "appellant" title is used in the email and is consistent whether or not the
     # veteran is or isn't the appellant, but the email event can be more specific.
     recipient_is_veteran = (
-      recipient.title.eq?(MailRecipient::RECIPIENT_TITLES[:appellant]) &&
+      recipient.title == MailRecipient::RECIPIENT_TITLES[:appellant] &&
       !appeal.appellant_is_not_veteran
     )
     SentHearingEmailEvent.create!(

--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -40,8 +40,10 @@ class SentHearingEmailEvent < CaseflowRecord
     case recipient_role
     when "judge"
       "VLJ Email"
-    when "appellant", "veteran"
+    when "appellant"
       "Appellant Email"
+    when "veteran"
+      "Veteran Email"
     when "representative"
       "POA/Representative Email"
     else

--- a/client/app/styles/react/_select-dropdown.scss
+++ b/client/app/styles/react/_select-dropdown.scss
@@ -19,6 +19,10 @@ $cf-select-text-color: #323a45;
       .cf-select__indicators {
         opacity: 0.35;
       }
+
+      input {
+        margin: 0;
+      }
     }
 
     .cf-select__value-container {

--- a/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
+++ b/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature "Editing virtual hearing information on daily Docket", :all_dbs do
     expect(events.where(sent_by_id: current_user.id).count).to eq 3
     expect(events.where(email_type: "updated_time_confirmation").count).to eq 3
     expect(events.where(email_address: hearing.virtual_hearing.appellant_email).count).to eq 1
-    expect(events.where(recipient_role: "appellant").count).to eq 1
+    expect(events.sent_to_appellant.count).to eq 1
     expect(events.where(email_address: hearing.virtual_hearing.representative_email).count).to eq 1
     expect(events.where(recipient_role: "representative").count).to eq 1
     expect(events.where(email_address: hearing.virtual_hearing.judge_email).count).to eq 1

--- a/spec/feature/hearings/virtual_hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/virtual_hearings/hearing_details_spec.rb
@@ -163,7 +163,7 @@ RSpec.feature "Editing Virtual Hearings from Hearing Details" do
       expect(events.where(sent_by_id: current_user.id).count).to eq 2
       expect(events.where(email_type: "confirmation").count).to eq 2
       expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
-      expect(events.where(recipient_role: "appellant").count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
       expect(events.where(email_address: pre_loaded_rep_email).count).to eq 1
       expect(events.where(recipient_role: "representative").count).to eq 1
 
@@ -415,7 +415,7 @@ RSpec.feature "Editing Virtual Hearings from Hearing Details" do
       expect(events.where(sent_by_id: current_user.id).count).to eq 2
       expect(events.where(email_type: "confirmation").count).to eq 2
       expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
-      expect(events.where(recipient_role: "appellant").count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
       expect(events.where(email_address: fill_in_rep_email).count).to eq 1
       expect(events.where(recipient_role: "representative").count).to eq 1
 
@@ -508,7 +508,7 @@ RSpec.feature "Editing Virtual Hearings from Hearing Details" do
       expect(events.where(sent_by_id: current_user.id).count).to eq 1
       expect(events.where(email_type: "confirmation").count).to eq 1
       expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
-      expect(events.where(recipient_role: "appellant").count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
 
       # Check the Email Notification History
       check_email_event_table(hearing, 1)
@@ -578,7 +578,7 @@ RSpec.feature "Editing Virtual Hearings from Hearing Details" do
       expect(events.where(sent_by_id: current_user.id).count).to eq 1
       expect(events.where(email_type: "updated_time_confirmation").count).to eq 1
       expect(events.where(email_address: central_virtual_hearing.appellant_email).count).to eq 1
-      expect(events.where(recipient_role: "appellant").count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
 
       # Check the Email Notification History
       check_email_event_table(central_hearing, 1)
@@ -614,7 +614,7 @@ RSpec.feature "Editing Virtual Hearings from Hearing Details" do
       expect(events.where(sent_by_id: current_user.id).count).to eq 2
       expect(events.where(email_type: "updated_time_confirmation").count).to eq 2
       expect(events.where(email_address: central_virtual_hearing.appellant_email).count).to eq 1
-      expect(events.where(recipient_role: "appellant").count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
       expect(events.where(email_address: central_virtual_hearing.representative_email).count).to eq 1
       expect(events.where(recipient_role: "representative").count).to eq 1
 
@@ -652,7 +652,7 @@ RSpec.feature "Editing Virtual Hearings from Hearing Details" do
       expect(events.where(sent_by_id: current_user.id).count).to eq 2
       expect(events.where(email_type: "confirmation").count).to eq 2
       expect(events.where(email_address: central_virtual_hearing.appellant_email).count).to eq 1
-      expect(events.where(recipient_role: "appellant").count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
       expect(events.where(email_address: fill_in_rep_email).count).to eq 1
       expect(events.where(recipient_role: "representative").count).to eq 1
 

--- a/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
+++ b/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
@@ -51,7 +51,7 @@ describe VirtualHearings::DeleteConferencesJob do
         expect(events.where(sent_by_id: virtual_hearing.updated_by_id).count).to eq 2
         expect(events.where(email_type: "cancellation").count).to eq 2
         expect(events.where(email_address: virtual_hearing.appellant_email).count).to eq 1
-        expect(events.where(recipient_role: "appellant").count).to eq 1
+        expect(events.sent_to_appellant.count).to eq 1
         expect(events.where(email_address: virtual_hearing.representative_email).count).to eq 1
         expect(events.where(recipient_role: "representative").count).to eq 1
         expect(events.where(recipient_role: "judge").count).to eq 0


### PR DESCRIPTION
Part of #14852 resolutions to #14840

### Description

- Updates naming for recipient role when create an email sent event if the veteran is the appellant
