### PR TITLE
Fix bug with blank receipt date error not showing

### DIFF
--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -43,8 +43,8 @@ export const isCorrection = (isRating, intakeData) => {
 
 export const getReceiptDateError = (responseErrorCodes, state) => (
   {
-    in_future:
-      'Receipt date cannot be in the future.',
+    blank: 'Please enter a valid receipt date.',
+    in_future: 'Receipt date cannot be in the future.',
     before_ramp: 'Receipt Date cannot be earlier than RAMP start date, 11/01/2017.',
     before_ama: `Receipt Date cannot be prior to ${formatDateStr(DATES.AMA_ACTIVATION)}.`,
     before_ramp_receipt_date: 'Receipt date cannot be earlier than the original ' +

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -13,19 +13,20 @@ feature "Intake Review Page", :postgres do
   end
   let(:benefit_type) { "compensation" }
 
-  describe "Validating receipt date not before ama" do
+  describe "Validating receipt date not blank or before AMA" do
     before { FeatureToggle.enable!(:use_ama_activation_date) }
 
-    it "shows correct error with AMA date" do
-      start_higher_level_review(veteran)
+    it "shows correct error with blank or pre-AMA dates" do
+      start_higher_level_review(veteran, receipt_date: nil)
       visit "/intake"
       expect(page).to have_current_path("/intake/review_request")
+      click_intake_continue
+
+      expect(page).to have_content("Please enter a valid receipt date.")
       fill_in "What is the Receipt Date of this form?", with: "01/01/2019"
       click_intake_continue
 
-      expect(page).to have_content(
-        "Receipt Date cannot be prior to 02/19/2019."
-      )
+      expect(page).to have_content("Receipt Date cannot be prior to 02/19/2019.")
     end
   end
 


### PR DESCRIPTION
Connects #14906 

### Description
Quick bug fix to reinstate an error message for blank receipt dates.

### Acceptance Criteria
- [x] Show an error message to the user if they attempt to submit the intake "Review" form without filling the receipt date field

### Testing Plan
1. Start an intake and attempt to submit for review without selecting a receipt date.
2. Verify that the appropriate error message is displayed.
3. Added (back?) in a feature test.