### PR TITLE
Upgrade danger gem to 6.* to address CVE-2020-14001

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ group :test, :development, :demo do
   # Testing tools
   gem "capybara"
   gem "capybara-screenshot"
-  gem "danger", "~> 5.10"
+  gem "danger", "~> 6.0"
   gem "database_cleaner"
   gem "factory_bot_rails", "~> 4.8"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     childprocess (1.0.1)
       rake (< 13.0)
     choice (0.2.0)
-    claide (1.0.2)
+    claide (1.0.3)
     claide-plugins (0.9.2)
       cork
       nap
@@ -197,15 +197,16 @@ GEM
     crass (1.0.6)
     d3-rails (5.9.2)
       railties (>= 3.1)
-    danger (5.16.1)
+    danger (6.3.2)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (~> 0.9)
-      faraday-http-cache (~> 1.0)
-      git (~> 1.5)
-      kramdown (~> 1.5)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.6)
+      kramdown (~> 2.0)
+      kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
@@ -269,8 +270,8 @@ GEM
       i18n (>= 0.8)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.1)
-      faraday (~> 0.8)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fast_jsonapi (1.5)
@@ -285,7 +286,8 @@ GEM
     fuzzy_match (2.1.0)
     get_process_mem (0.2.4)
       ffi (~> 1.0)
-    git (1.5.0)
+    git (1.7.0)
+      rchardet (~> 1.8)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     govdelivery-tms (2.8.4)
@@ -345,7 +347,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.1)
     kaminari-core (1.2.1)
-    kramdown (1.17.0)
+    kramdown (2.3.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.19)
@@ -396,7 +401,8 @@ GEM
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.14.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     paper_trail (10.3.1)
@@ -460,6 +466,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rb-readline (0.5.5)
+    rchardet (1.8.0)
     react_on_rails (8.0.6)
       addressable
       connection_pool
@@ -489,6 +496,7 @@ GEM
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    rexml (3.2.4)
     roo (2.8.2)
       nokogiri (~> 1)
       rubyzip (>= 1.2.1, < 2.0.0)
@@ -560,9 +568,9 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
@@ -661,7 +669,7 @@ DEPENDENCIES
   connect_vbms!
   console_tree_renderer!
   countries
-  danger (~> 5.10)
+  danger (~> 6.0)
   database_cleaner
   ddtrace
   derailed_benchmarks


### PR DESCRIPTION
Addresses this [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2020-14001):

```
Name: kramdown                                                                                                                                                                                              
Version: 1.17.0                                                                                                                                                                                             
Advisory: CVE-2020-14001                                                                                                                                                                                    
Criticality: High                                                                                     
URL: https://github.com/advisories/GHSA-mqm2-cgpr-p4m6                                                
Title: Unintended read access in kramdown gem                                                         
Solution: upgrade to >= 2.3.0
```

Upgrading the Danger gem fixes this. Note: none of the affected gems are used in production.