### PR TITLE
Cancel descendants no longer cancels completed tasks

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -390,7 +390,7 @@ class Task < CaseflowRecord
   end
 
   def cancel_descendants
-    descendants.each { |desc| desc.update!(status: Constants.TASK_STATUSES.cancelled) }
+    descendants.select(&:open?).each { |desc| desc.update!(status: Constants.TASK_STATUSES.cancelled) }
   end
 
   def create_twin_of_type(_params)


### PR DESCRIPTION
### Description
Discovered a bug in Task `cancel_descendants` that marsk all tasks as cancelled rather than only the currently open ones. This PR corrects that :beetle: and adds a test for expected behavior

Currently this function is only used in one location, where the line before safely moved any open children out of the line of fire
https://github.com/department-of-veterans-affairs/caseflow/blob/7384ca900acdc7289e8edde04e872a9c736fe838/app/models/task.rb#L366-L369

### Acceptance Criteria
- [ ] Tests pass

### Testing Plan
1. Create an appeal at attorney drafting:
```
appeal = FactoryBot.create(:appeal, :at_attorney_drafting)
appeal.reload.treee(:id, :status, :updated_at, :closed_at)
                                         ┌──────────────────────────────────────────────────────────────────────┐
Appeal 732 (evidence_submission) ─────── │ ID   │ STATUS    │ UPDATED_AT              │ CLOSED_AT               │
└── RootTask                             │ 2224 │ on_hold   │ 2020-08-12 20:03:20 UTC │                         │
    ├── DistributionTask                 │ 2225 │ completed │ 2020-08-12 20:03:21 UTC │ 2020-08-12 20:03:21 UTC │
    │   └── EvidenceSubmissionWindowTask │ 2226 │ assigned  │ 2020-08-12 20:03:20 UTC │                         │
    ├── JudgeAssignTask                  │ 2227 │ completed │ 2020-08-12 20:03:21 UTC │ 2020-08-12 20:03:21 UTC │
    └── JudgeDecisionReviewTask          │ 2228 │ on_hold   │ 2020-08-12 20:03:21 UTC │                         │
        └── AttorneyTask                 │ 2229 │ assigned  │ 2020-08-12 20:03:21 UTC │                         │
                                         └──────────────────────────────────────────────────────────────────────┘
```
2. Call `cancel_descendants` on the root task
```
root_task_id = 2224
Task.find(root_task_id).cancel_descendants
```
3. Confirm only _previously open tasks_ are cancelled
```
appeal.reload.treee(:id, :status, :updated_at, :closed_at)
                                         ┌──────────────────────────────────────────────────────────────────────┐
Appeal 732 (evidence_submission) ─────── │ ID   │ STATUS    │ UPDATED_AT              │ CLOSED_AT               │
└── RootTask                             │ 2224 │ cancelled │ 2020-08-12 20:06:39 UTC │ 2020-08-12 20:06:39 UTC │
    ├── DistributionTask                 │ 2225 │ completed │ 2020-08-12 20:03:21 UTC │ 2020-08-12 20:03:21 UTC │
    │   └── EvidenceSubmissionWindowTask │ 2226 │ cancelled │ 2020-08-12 20:06:39 UTC │ 2020-08-12 20:06:39 UTC │
    ├── JudgeAssignTask                  │ 2227 │ completed │ 2020-08-12 20:03:21 UTC │ 2020-08-12 20:03:21 UTC │
    └── JudgeDecisionReviewTask          │ 2228 │ cancelled │ 2020-08-12 20:06:39 UTC │ 2020-08-12 20:06:39 UTC │
        └── AttorneyTask                 │ 2229 │ cancelled │ 2020-08-12 20:06:39 UTC │ 2020-08-12 20:06:39 UTC │
                                         └──────────────────────────────────────────────────────────────────────┘
```

### User Facing Changes
None