### PR TITLE
Add UserAlerts to CaseDetailsView

### DIFF
--- a/client/app/components/UserAlerts.jsx
+++ b/client/app/components/UserAlerts.jsx
@@ -2,67 +2,64 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import _, { uniq } from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { removeAlertsWithTimestamps } from './common/actions';
 import Alert from './Alert';
 
 const ALERT_EXPIRATION = 30000;
 
-class UserAlerts extends React.Component {
-
-  componentDidMount () {
-    setTimeout(this.removeExpiredAlerts, ALERT_EXPIRATION);
-  }
-
-  componentDidUpdate () {
-    setTimeout(this.removeExpiredAlerts, ALERT_EXPIRATION);
-  }
-
-  removeExpiredAlerts = () => {
+const UserAlerts = ({ alerts, removeAlertsWithTimestamps }) => {
+  const removeExpiredAlerts = () => {
     const currentTime = Date.now();
-    const { alerts } = this.props;
 
-    const expiredAlertTimestamps = alerts.filter((alert) => (
-      (currentTime - alert.timestamp) >= ALERT_EXPIRATION
-    )).map((alert) => alert.timestamp);
+    const expiredAlertTimestamps = alerts.
+      filter((alert) => (
+        (currentTime - alert.timestamp) >= ALERT_EXPIRATION
+      )).
+      map((alert) => alert.timestamp);
 
     if (expiredAlertTimestamps.length > 0) {
-      this.props.removeAlertsWithTimestamps(uniq(expiredAlertTimestamps));
+      removeAlertsWithTimestamps(uniq(expiredAlertTimestamps));
     }
+  };
+
+  useEffect(
+    () => {
+      setTimeout(removeExpiredAlerts, ALERT_EXPIRATION);
+    },
+    [alerts]
+  );
+
+  if (_.isUndefined(alerts) || _.isNull(alerts) || _.isEmpty(alerts)) {
+    return null;
   }
 
-  render () {
-    const { alerts } = this.props;
-
-    if (_.isUndefined(alerts) || _.isNull(alerts) || _.isEmpty(alerts)) {
-      return null;
-    }
-
-    return (
-      <div className="cf-alerts-container cf-margin-bottom-2rem">
-        {alerts.map(({ type, message, title, timestamp }, index) => (
-          <Alert type={type}
-            message={
-              message ? <div
-                className="cf-margin-top-1rem cf-margin-bottom-1rem"
-                dangerouslySetInnerHTML={{ __html: message }} /> : null
-            }
-            title={title}
-            key={`alert-${timestamp}-${index}`} />
-        ))}
-      </div>
-    );
-  }
-}
+  return (
+    <div className="cf-alerts-container cf-margin-bottom-2rem">
+      {alerts.map(({ type, message, title, timestamp }, index) => (
+        <Alert type={type}
+          message={
+            message ? <div
+              className="cf-margin-top-1rem cf-margin-bottom-1rem"
+              dangerouslySetInnerHTML={{ __html: message }} /> : null
+          }
+          title={title}
+          key={`alert-${timestamp}-${index}`} />
+      ))}
+    </div>
+  );
+};
 
 UserAlerts.propTypes = {
-  alerts: PropTypes.arrayOf(PropTypes.shape({
-    type: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
-    message: PropTypes.string,
-    title: PropTypes.string,
-    timestamp: PropTypes.integer
-  })),
+  alerts: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.oneOf(['success', 'info', 'warning', 'error']),
+      message: PropTypes.string,
+      title: PropTypes.string,
+      timestamp: PropTypes.integer
+    })
+  ),
   removeAlertsWithTimestamps: PropTypes.func
 };
 

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -1,34 +1,33 @@
+import { bindActionCreators } from 'redux';
+import { connect, useSelector } from 'react-redux';
 import { css } from 'glamor';
+import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
+import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
-import { connect, useSelector } from 'react-redux';
 import _ from 'lodash';
-import { bindActionCreators } from 'redux';
-
-import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
-
-import Alert from '../components/Alert';
-import AppellantDetail from './AppellantDetail';
-import VeteranDetail from './VeteranDetail';
-import VeteranCasesView from './VeteranCasesView';
-import CaseHearingsDetail from './CaseHearingsDetail';
-import PowerOfAttorneyDetail from './PowerOfAttorneyDetail';
-import CaseTitle from './CaseTitle';
-import CaseTitleDetails from './CaseTitleDetails';
-import TaskSnapshot from './TaskSnapshot';
-import CaseDetailsIssueList from './components/CaseDetailsIssueList';
-import StickyNavContentArea from './StickyNavContentArea';
-import { resetErrorMessages, resetSuccessMessages, setHearingDay } from './uiReducer/uiActions';
-import CaseTimeline from './CaseTimeline';
-import { getQueryParams } from '../util/QueryParamsUtil';
 
 import { CATEGORIES, TASK_ACTIONS } from './constants';
 import { COLORS } from '../constants/AppConstants';
-import COPY from '../../COPY';
-import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
-
 import { appealWithDetailSelector, getAllTasksForAppeal } from './selectors';
+import { clearAlerts } from '../components/common/actions';
+import { getQueryParams } from '../util/QueryParamsUtil';
 import { needsPulacCerulloAlert } from './pulacCerullo';
+import { resetErrorMessages, resetSuccessMessages, setHearingDay } from './uiReducer/uiActions';
+import Alert from '../components/Alert';
+import AppellantDetail from './AppellantDetail';
+import COPY from '../../COPY';
+import CaseDetailsIssueList from './components/CaseDetailsIssueList';
+import CaseHearingsDetail from './CaseHearingsDetail';
+import CaseTimeline from './CaseTimeline';
+import CaseTitle from './CaseTitle';
+import CaseTitleDetails from './CaseTitleDetails';
+import PowerOfAttorneyDetail from './PowerOfAttorneyDetail';
+import StickyNavContentArea from './StickyNavContentArea';
+import TaskSnapshot from './TaskSnapshot';
+import UserAlerts from '../components/UserAlerts';
+import VeteranCasesView from './VeteranCasesView';
+import VeteranDetail from './VeteranDetail';
 
 // TODO: Pull this horizontal rule styling out somewhere.
 const horizontalRuleStyling = css({
@@ -65,6 +64,7 @@ export const CaseDetailsView = (props) => {
     // the modal to show error messages without them being cleared by the CaseDetailsView.
     if (!modalIsOpen) {
       props.resetErrorMessages();
+      props.clearAlerts();
     }
 
     const { hearingDate, regionalOffice } = getQueryParams(window.location.search);
@@ -95,6 +95,7 @@ export const CaseDetailsView = (props) => {
           </Alert>
         </div>
       )}
+      {!modalIsOpen && <UserAlerts />}
       <AppSegment filledBackground>
         <CaseTitle appeal={appeal} />
         <CaseTitleDetails
@@ -151,6 +152,7 @@ CaseDetailsView.propTypes = {
 const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
+      clearAlerts,
       resetErrorMessages,
       resetSuccessMessages,
       setHearingDay


### PR DESCRIPTION
Resolves #14893

### Description

WIP

### Acceptance Criteria

- [ ]  Ensure case details page can handle receiving and polling for virtual hearings status notifications

### Testing Plan

WIP

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy 
* [ ] Write a separate story (within the same file) for each discrete variation of the component