### PR TITLE
Enable single-option new claimant relationship dropdown

### DIFF
--- a/client/app/intake/components/AddClaimantModal.jsx
+++ b/client/app/intake/components/AddClaimantModal.jsx
@@ -14,7 +14,6 @@ import TextareaField from '../../components/TextareaField';
 
 const relationshipOpts = [
   { label: 'Attorney (previously or currently)', value: 'attorney' },
-  { label: 'Other', value: 'other' },
 ];
 
 const fetchAttorneys = async (search = '') => {
@@ -117,7 +116,6 @@ export const AddClaimantModal = ({
         value={relationship}
         options={relationshipOpts}
         debounce={250}
-        readOnly
         strongLabel
       />
       <SearchableDropdown

--- a/client/app/intake/components/AddClaimantModal.jsx
+++ b/client/app/intake/components/AddClaimantModal.jsx
@@ -80,7 +80,7 @@ export const AddClaimantModal = ({
         onSubmit({
           name: claimant?.label,
           participantId: claimant?.value,
-          claimantType: relationship?.value,
+          claimantType: (unlistedClaimant ? 'other' : 'attorney'),
           claimantNotes,
         }),
       disabled: isInvalid,
@@ -91,12 +91,6 @@ export const AddClaimantModal = ({
     if (!unlistedClaimant) {
       setClaimantNotes('');
     }
-
-    // For now, this can only be either 'attorney' or 'other';
-    // will need to change logic when others are available
-    setRelationship(
-      unlistedClaimant ? relationshipOpts[1] : relationshipOpts[0]
-    );
   }, [unlistedClaimant]);
 
   return (

--- a/client/test/app/intake/components/AddClaimantModal.test.js
+++ b/client/test/app/intake/components/AddClaimantModal.test.js
@@ -100,7 +100,7 @@ describe('AddClaimantModal', () => {
       expect(screen.queryByLabelText(/notes.*/i)).toBeTruthy();
     });
 
-    it('should change relationship field if "claimant not listed" is selected', async () => {
+    it('should not change relationship field if "claimant not listed" is selected', async () => {
       const { container } = render(
         <AddClaimantModal
           onSearch={performQuery}
@@ -120,7 +120,7 @@ describe('AddClaimantModal', () => {
 
       userEvent.click(screen.getByLabelText(/claimant not listed/i));
 
-      expect(queryByText(/other/i)).toBeTruthy();
+      expect(queryByText(/attorney/i)).toBeTruthy();
     });
   });
 

--- a/client/test/app/intake/components/__snapshots__/AddClaimantModal.test.js.snap
+++ b/client/test/app/intake/components/__snapshots__/AddClaimantModal.test.js.snap
@@ -80,34 +80,49 @@ exports[`AddClaimantModal renders correctly 1`] = `
                   class="cf-select"
                 >
                   <div
-                    class="cf-select--is-disabled css-14jk2my-container"
+                    class=" css-2b097c-container"
                   >
                     <div
-                      class="cf-select__control cf-select__control--is-disabled css-1fhf3k1-control"
+                      class="cf-select__control css-yk16xz-control"
                     >
                       <div
                         class="cf-select__value-container cf-select__value-container--has-value css-g1d714-ValueContainer"
                       >
                         <div
-                          class="cf-select__single-value cf-select__single-value--is-disabled css-107lb6w-singleValue"
+                          class="cf-select__single-value css-1uccc91-singleValue"
                         >
                           Attorney (previously or currently)
                         </div>
-                        <input
-                          aria-autocomplete="list"
-                          class="css-62g3xt-dummyInput"
-                          disabled=""
-                          id="relationship"
-                          readonly=""
-                          tabindex="0"
-                          value=""
-                        />
+                        <div
+                          class="css-81nyic-Input"
+                        >
+                          <div
+                            class="cf-select__input"
+                            style="display: inline-block;"
+                          >
+                            <input
+                              aria-autocomplete="list"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              autocorrect="off"
+                              id="relationship"
+                              spellcheck="false"
+                              style="box-sizing: content-box; width: 2px; border: 0px; opacity: 1; outline: 0; padding: 0px;"
+                              tabindex="0"
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                            />
+                          </div>
+                        </div>
                       </div>
                       <div
                         class="cf-select__indicators css-1hb7zxy-IndicatorsContainer"
                       >
                         <span
-                          class="cf-select__indicator-separator css-109onse-indicatorSeparator"
+                          class="cf-select__indicator-separator css-1okebmr-indicatorSeparator"
                         />
                         <div
                           aria-hidden="true"


### PR DESCRIPTION
Connects #14948 

### Description
As per dogfooding learnings, this PR updates the add claimant modal to be in line with our preference for an active single-option dropdown over a grayed-out dropdown.

### Acceptance Criteria
- [x] "Claimant's relationship to the Veteran" field is not grayed-out
- [x] The drop-down result defaults to "Attorney (previously or currently)"
- [x] A user can open the drop-down, but the only option they see is "Attorney (previously or currently)"

### Testing Plan
1. As a BVA Intake user, start an intake for a veteran.
2. Select Yes for "Is the claimant someone other than the Veteran?" and click "Add Claimant"
3. Verify all AC.

### User Facing Changes
Before this change:
<img width="462" src="https://user-images.githubusercontent.com/282869/90157161-5ff6e580-dd5b-11ea-955a-0ce0c19ef6cc.png">

After this change:
<img width="459" src="https://user-images.githubusercontent.com/282869/90157192-6dac6b00-dd5b-11ea-964d-8e4a9460568d.png">

Verifying that there is only one option (Claimant name menu is visible at bottom):
<img width="460" src="https://user-images.githubusercontent.com/282869/90157381-aa786200-dd5b-11ea-94f4-9f49bfa68108.png">

