### PR TITLE
Refactor in prep for BlockedCaseMovement

### DIFF
--- a/app/models/tasks/special_case_movement_task.rb
+++ b/app/models/tasks/special_case_movement_task.rb
@@ -8,7 +8,7 @@ class SpecialCaseMovementTask < Task
   before_create :verify_parent_task_type,
                 :verify_user_organization,
                 :verify_appeal_distributable
-  after_create :close_and_create_judge_task
+  after_create :distribute_to_judge
 
   def self.label
     COPY::CASE_MOVEMENT_TASK_LABEL
@@ -16,7 +16,7 @@ class SpecialCaseMovementTask < Task
 
   private
 
-  def close_and_create_judge_task
+  def distribute_to_judge
     Task.transaction do
       JudgeAssignTask.create!(appeal: appeal,
                               parent: appeal.root_task,

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -78,7 +78,8 @@ module Seeds
           )
         )
       end
-      # Create AMA tasks ready for distribution
+
+      # Create AMA appeals ready for distribution
       (1..30).each do |num|
         vet_file_number = format("3213213%<num>02d", num: num)
         create(
@@ -95,6 +96,39 @@ module Seeds
         )
       end
 
+      # Create AMA appeals blocked for distribution due to Evidence Window
+      (1..30).each do |num|
+        vet_file_number = format("4324324%<num>02d", num: num)
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          number_of_claimants: 1,
+          active_task_assigned_at: Time.zone.now,
+          veteran_file_number: vet_file_number,
+          docket_type: Constants.AMA_DOCKETS.evidence_submission,
+          closest_regional_office: "RO17",
+          request_issues: create_list(
+            :request_issue, 2, :nonrating, notes: notes
+          )
+        )
+      end
+
+      # Create AMA appeals blocked for distribution due to blocking mail
+      (1..30).each do |num|
+        vet_file_number = format("4324334%<num>02d", num: num)
+        create(
+          :appeal,
+          :mail_blocking_distribution,
+          number_of_claimants: 1,
+          active_task_assigned_at: Time.zone.now,
+          veteran_file_number: vet_file_number,
+          docket_type: Constants.AMA_DOCKETS.direct_review,
+          closest_regional_office: "RO17",
+          request_issues: create_list(
+            :request_issue, 2, :nonrating, notes: notes
+          )
+        )
+      end
       LegacyAppeal.create(vacols_id: "2096907", vbms_id: "228081153S")
       LegacyAppeal.create(vacols_id: "2226048", vbms_id: "213912991S")
       LegacyAppeal.create(vacols_id: "2249056", vbms_id: "608428712S")

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -192,6 +192,22 @@ FactoryBot.define do
     end
 
     ## Appeal with a realistic task tree
+    ## The appeal would be ready for distribution by the ACD except there is a blocking mail task
+    ## Leaves incorrectly open & incomplete Hearing / Evidence Window task branches
+    ## for those dockets
+    trait :mail_blocking_distribution do
+      ready_for_distribution
+      after(:create) do |appeal, _evaluator|
+        distribution_task = appeal.tasks.active.detect { |task| task.is_a?(DistributionTask) }
+        create(
+          :extension_request_mail_task,
+          appeal: appeal,
+          parent: distribution_task
+        )
+      end
+    end
+
+    ## Appeal with a realistic task tree
     ## The appeal is assigned to a Judge for a decision
     ## Leaves incorrectly open & incomplete Hearing / Evidence Window task branches
     ## for those dockets. Strongly suggest you provide a judge.

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -474,6 +474,12 @@ FactoryBot.define do
         assigned_by { nil }
       end
 
+      factory :extension_request_mail_task, class: ExtensionRequestMailTask do
+        parent { create(:root_task, appeal: appeal) }
+        assigned_to { MailTeam.singleton }
+        assigned_by { nil }
+      end
+
       factory :judge_address_motion_to_vacate_task, class: JudgeAddressMotionToVacateTask do
         parent { create(:vacate_motion_mail_task, appeal: appeal) }
       end


### PR DESCRIPTION
Part of a stack for #14260 

Part 1: #14964
Part 2: this PR

### Description
 - Rename the `after_create` method on SpecialCaseMovement
 - Create factory for _actually_ blocking distribution MailTask
 - Create factory for appeal with realistic task tree that is blocked for distribution by a mail task
 - Create seed data for appeals with a blocked distribution (30 with open Evidence Window, 30 with a blocking mail task)

### Acceptance Criteria
- [ ] `make reset` runs without error
- [ ] there are dev cases with Evidence Window
- [ ] there are dev cases with Blocking Mail tasks

### Testing Plan
1. `make reset`
1. Sign in as a CaseMovement User `BVARDUNKLE`
1. Search for a veteran with an ID between `432432401` - `432432430`
1. Click their appeal for `Tom Brady`
1. Confirm appeal is at Evidence Window
1. Search for a veteran with an ID between `432433401` - `432433430`
1. Click their appeal for `Tom Brady`
1. Confirm appeal is at Distribution with a Blocking Mail task
