### PR TITLE
Backend of BlockedCaseMovement

### DIFF
--- a/app/models/tasks/special_case_movement/blocked_special_case_movement_task.rb
+++ b/app/models/tasks/special_case_movement/blocked_special_case_movement_task.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+##
+# Task to record on the appeal that the special case movement manually assigned the case outside of automatic
+#   case distribution and intentionally cancelled any tasks that were blocking distribution
+
+class BlockedSpecialCaseMovementTask < SpecialCaseMovementTask
+  private
+
+  def distribute_to_judge
+    Task.transaction do
+      super
+      cancel_tasks_blocking_distribution
+    end
+  end
+
+  def cancel_tasks_blocking_distribution
+    parent.cancel_descendants
+  end
+
+  def verify_appeal_distributable
+    if DistributionTask.open.where(appeal: appeal).empty?
+      fail(Caseflow::Error::IneligibleForBlockedSpecialCaseMovement, appeal_id: appeal.id)
+    end
+  end
+end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -124,6 +124,17 @@ module Caseflow::Error
     end
   end
 
+  class IneligibleForBlockedSpecialCaseMovement < SerializableError
+    attr_accessor :appeal_id
+
+    def initialize(args)
+      @code = args[:code] || 500
+      @appeal_id = args[:appeal_id] || nil
+      @title = "This appeal cannot be advanced to a judge"
+      @message = args[:message] || "Appeal #{@appeal_id} must be in Case Storage to be eligible for Case Movement"
+    end
+  end
+
   class IneligibleForSpecialCaseMovement < SerializableError
     attr_accessor :appeal_id
 

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -131,7 +131,7 @@ module Caseflow::Error
       @code = args[:code] || 500
       @appeal_id = args[:appeal_id] || nil
       @title = "This appeal cannot be advanced to a judge"
-      @message = args[:message] || "Appeal #{@appeal_id} must be in Case Storage to be eligible for Case Movement"
+      @message = args[:message] || "Appeal #{@appeal_id} must be waiting to be distributed be eligible for Case Movement"
     end
   end
 

--- a/spec/models/tasks/special_case_movement/blocked_special_case_movement_task_spec.rb
+++ b/spec/models/tasks/special_case_movement/blocked_special_case_movement_task_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require_relative "../special_case_movement_shared_examples"
+
+describe BlockedSpecialCaseMovementTask do
+  describe ".create" do
+    context "with Case Movement Team user" do
+      let(:cm_user) { create(:user) }
+
+      subject do
+        BlockedSpecialCaseMovementTask.create!(appeal: appeal,
+                                               assigned_to: cm_user,
+                                               assigned_by: cm_user,
+                                               parent: dist_task)
+      end
+
+      before do
+        SpecialCaseMovementTeam.singleton.add_user(cm_user)
+      end
+
+      shared_examples "cancelled distribution children" do
+        it "cancel any open distribution descendants" do
+          dist_task = appeal.tasks.open.where(type: DistributionTask.name).first
+          open_tasks = dist_task.descendants.select(&:open?) - [dist_task]
+          expect { subject }.not_to raise_error
+          open_tasks.each do |task|
+            expect(task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          end
+        end
+      end
+
+      context "appeal ready for distribution" do
+        let(:appeal) do
+          create(:appeal,
+                 :with_post_intake_tasks,
+                 docket_type: Constants.AMA_DOCKETS.direct_review)
+        end
+        let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
+
+        context "with no blocking tasks" do
+          it_behaves_like "successful creation"
+        end
+
+        it_behaves_like "appeal has a nonblocking mail task"
+
+        context "with (dispatch) blocking mail task" do
+          before do
+            # TODO: this _should_ not cancel after we finish
+            # https://github.com/department-of-veterans-affairs/caseflow/issues/14057
+            # Distribution Blocking. Update this test to properly pass then!
+            create(:congressional_interest_mail_task,
+                   appeal: appeal,
+                   parent: dist_task)
+          end
+          it_behaves_like "successful creation"
+          it_behaves_like "cancelled distribution children"
+        end
+
+        context "with a (distribution) blocking mail task" do
+          before do
+            create(:extension_request_mail_task,
+                   appeal: appeal,
+                   parent: dist_task)
+          end
+          it_behaves_like "successful creation"
+          it_behaves_like "cancelled distribution children"
+        end
+      end
+
+      context "appeal at the evidence window state" do
+        let(:appeal) do
+          create(:appeal,
+                 :with_post_intake_tasks,
+                 docket_type: Constants.AMA_DOCKETS.evidence_submission)
+        end
+        let(:dist_task) { appeal.tasks.open.where(type: DistributionTask.name).first }
+
+        context "with distribution task on_hold" do
+          it_behaves_like "successful creation"
+          it_behaves_like "cancelled distribution children"
+        end
+
+        it_behaves_like "wrong parent task type provided"
+      end
+
+      it_behaves_like "appeal past distribution" do
+        let(:expected_error) { Caseflow::Error::IneligibleForBlockedSpecialCaseMovement }
+      end
+    end
+
+    it_behaves_like "non Case Movement user provided"
+  end
+end

--- a/spec/models/tasks/special_case_movement/blocked_special_case_movement_task_spec.rb
+++ b/spec/models/tasks/special_case_movement/blocked_special_case_movement_task_spec.rb
@@ -47,7 +47,8 @@ describe BlockedSpecialCaseMovementTask do
           before do
             # TODO: this _should_ not cancel after we finish
             # https://github.com/department-of-veterans-affairs/caseflow/issues/14057
-            # Distribution Blocking. Update this test to properly pass then!
+            # Distribution Blocking. Update this test then, either to properly pass, or remove
+            # completely if no longer distinguishing
             create(:congressional_interest_mail_task,
                    appeal: appeal,
                    parent: dist_task)

--- a/spec/models/tasks/special_case_movement_shared_examples.rb
+++ b/spec/models/tasks/special_case_movement_shared_examples.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Shared examples for both SpecialCaseMovementTask and BlockedSpecialCaseMovementTask
+
+shared_examples "successful creation" do
+  it "should create the SCM task and JudgeAssign task" do
+    expect { subject }.not_to raise_error
+    scm_task =  appeal.tasks.where(type: described_class.name).first
+    expect(scm_task.status).to eq(Constants.TASK_STATUSES.completed)
+    judge_task = appeal.tasks.open.where(type: JudgeAssignTask.name).first
+    expect(judge_task.status).to eq(Constants.TASK_STATUSES.assigned)
+  end
+end
+
+shared_examples "appeal has a nonblocking mail task" do
+  before do
+    create(:aod_motion_mail_task,
+           appeal: appeal,
+           parent: appeal.root_task)
+  end
+  it_behaves_like "successful creation"
+  it "still has the open mail task" do
+    aod_mail_task = AodMotionMailTask.where(appeal: appeal).first
+    expect(aod_mail_task.open?).to eq(true)
+    expect { subject }.not_to raise_error
+    expect(aod_mail_task.reload.open?).to eq(true)
+  end
+end
+
+shared_examples "wrong parent task type provided" do
+  context "with the evidence window task as parent" do
+    let(:evidence_window_task) { appeal.tasks.open.where(type: EvidenceSubmissionWindowTask.name).first }
+
+    subject do
+      described_class.create!(appeal: appeal,
+                              assigned_to: cm_user,
+                              assigned_by: cm_user,
+                              parent: evidence_window_task)
+    end
+
+    it "should error with wrong parent type" do
+      expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask)
+    end
+  end
+end
+
+shared_examples "appeal past distribution" do
+  context "appeal at the judge already" do
+    let(:appeal) do
+      create(:appeal,
+             :assigned_to_judge,
+             docket_type: Constants.AMA_DOCKETS.direct_review)
+    end
+    let(:dist_task) { appeal.tasks.where(type: DistributionTask.name).first }
+
+    subject do
+      described_class.create!(appeal: appeal,
+                              assigned_to: cm_user,
+                              assigned_by: cm_user,
+                              parent: dist_task)
+    end
+
+    it "should error with appeal not distributable" do
+      expect { subject }.to raise_error(expected_error)
+    end
+  end
+end
+
+shared_examples "non Case Movement user provided" do
+  context "with a non-CaseMovement user" do
+    let(:user) { create(:user) }
+    let(:appeal) do
+      create(:appeal,
+             :with_post_intake_tasks,
+             docket_type: Constants.AMA_DOCKETS.direct_review)
+    end
+    let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
+
+    subject do
+      described_class.create!(appeal: appeal,
+                              assigned_to: user,
+                              assigned_by: user,
+                              parent: dist_task)
+    end
+
+    it "should error with user error" do
+      expect { subject }.to raise_error(Caseflow::Error::ActionForbiddenError)
+    end
+  end
+end

--- a/spec/models/tasks/special_case_movement_spec.rb
+++ b/spec/models/tasks/special_case_movement_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-describe SpecialCaseMovementTask, :postgres do
+require_relative "special_case_movement_shared_examples"
+
+describe SpecialCaseMovementTask do
   describe ".create" do
     context "with Case Movement Team user" do
       let(:cm_user) { create(:user) }
@@ -25,18 +27,14 @@ describe SpecialCaseMovementTask, :postgres do
         let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
 
         context "with no blocking tasks" do
-          it "should create the SCM task and JudgeAssign task" do
-            expect { subject }.not_to raise_error
-            scm_task =  appeal.tasks.where(type: SpecialCaseMovementTask.name).first
-            expect(scm_task.status).to eq(Constants.TASK_STATUSES.completed)
-            judge_task = appeal.tasks.open.where(type: JudgeAssignTask.name).first
-            expect(judge_task.status).to eq(Constants.TASK_STATUSES.assigned)
-          end
+          it_behaves_like "successful creation"
         end
+
+        it_behaves_like "appeal has a nonblocking mail task"
 
         context "with blocking mail task" do
           before do
-            create(:congressional_interest_mail_task,
+            create(:extension_request_mail_task,
                    appeal: appeal,
                    parent: appeal.root_task)
           end
@@ -44,17 +42,6 @@ describe SpecialCaseMovementTask, :postgres do
             expect { subject }.to raise_error do |error|
               expect(error).to be_a(Caseflow::Error::IneligibleForSpecialCaseMovement)
             end
-          end
-        end
-
-        context "with a nonblocking mail task" do
-          before do
-            create(:aod_motion_mail_task,
-                   appeal: appeal,
-                   parent: appeal.root_task)
-          end
-          it "shouldn't error with appeal not ready" do
-            expect { subject }.not_to raise_error
           end
         end
       end
@@ -76,42 +63,14 @@ describe SpecialCaseMovementTask, :postgres do
           end
         end
 
-        context "with the evidence window task as parent" do
-          let(:evidence_window_task) { appeal.tasks.open.where(type: EvidenceSubmissionWindowTask.name).first }
+        it_behaves_like "wrong parent task type provided"
+      end
 
-          subject do
-            SpecialCaseMovementTask.create!(appeal: appeal,
-                                            assigned_to: cm_user,
-                                            assigned_by: cm_user,
-                                            parent: evidence_window_task)
-          end
-
-          it "should error with wrong parent type" do
-            expect { subject }.to raise_error(Caseflow::Error::InvalidParentTask)
-          end
-        end
+      it_behaves_like "appeal past distribution" do
+        let(:expected_error) { Caseflow::Error::IneligibleForSpecialCaseMovement }
       end
     end
 
-    context "with regular user" do
-      let(:user) { create(:user) }
-      let(:appeal) do
-        create(:appeal,
-               :with_post_intake_tasks,
-               docket_type: Constants.AMA_DOCKETS.direct_review)
-      end
-      let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
-
-      subject do
-        SpecialCaseMovementTask.create!(appeal: appeal,
-                                        assigned_to: user,
-                                        assigned_by: user,
-                                        parent: dist_task)
-      end
-
-      it "should error with user error" do
-        expect { subject }.to raise_error(Caseflow::Error::ActionForbiddenError)
-      end
-    end
+    it_behaves_like "non Case Movement user provided"
   end
 end


### PR DESCRIPTION
Part of a stack for #14260 

Part 1: #14967
Part 2:  this PR

### Description
Subclasses the SpecialCaseMovement task and overrides functions to allow for movement on any case with an `open` DistributionTask, and cancels any Distribution blocking tasks that were open underneath the Distribution 

### Acceptance Criteria
 - [ ] Please put this work behind the feature toggle: cm_move_with_blocking_tasks
    - I am not certain this is necessary. Would appreciate reviewer's thoughts
 - [x] This feature should be accessible to the following user groups: CM Team Members
 - [x] CM team members can cancel "blocking tasks" to advance a case to a VLJ
 - [ ] CM team members cannot cancel "Blocking for dispatch only" tasks
    - This will be true after the completion of #14056 - but not until then. We should confirm in Dogfooding

### Testing Plan

1. Create an appeal at Evidence Window on the console
```ruby
appeal_at_ew = FactoryBot.create(
  :appeal,
  :with_post_intake_tasks,
  number_of_claimants: 1,
  active_task_assigned_at: Time.zone.now,
  veteran_file_number: 888999888,
  docket_type: Constants.AMA_DOCKETS.evidence_submission,
  closest_regional_office: "RO17",
  request_issues: FactoryBot.create_list(
    :request_issue, 2, :nonrating, notes: "notes"
  )
)
```
1. Create an appeal at Blocked Distribution by Mail on the console
```ruby
appeal_at_mail_blocked_dist = FactoryBot.create(
  :appeal,
  :mail_blocking_distribution,
  number_of_claimants: 1,
  active_task_assigned_at: Time.zone.now,
  veteran_file_number: 999888999,
  docket_type: Constants.AMA_DOCKETS.direct_review,
  closest_regional_office: "RO17",
  request_issues: FactoryBot.create_list(
    :request_issue, 2, :nonrating, notes: "notes"
  )
)
```
1. Run the EvidenceWindow appeal
```
appeal = appeal_at_ew
dist_task = DistributionTask.find_by(appeal: appeal)
BlockedSpecialCaseMovementTask.create( appeal: appeal,
                                       assigned_to: User.find_by_css_id("BVAAABSHIRE"),
                                       assigned_by: User.find_by_css_id("BVARDUNKLE"),
                                       parent: dist_task)
```
1. Confirm the case is at Judge Assign with completed distribution and case momvement, and a cancelled evidence window.
1. Repeat with the Mail Blocked Appeal

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.
