### PR TITLE
migration to add appeal_type column

### DIFF
--- a/app/models/vbms_uploaded_document.rb
+++ b/app/models/vbms_uploaded_document.rb
@@ -6,9 +6,17 @@ class VbmsUploadedDocument < CaseflowRecord
   belongs_to :appeal, optional: false
   validates :document_type, presence: true
 
+  before_create :temporarily_set_appeal_type
+
   attribute :file, :string
 
   def cache_file
     UploadDocumentToVbms.new(document: self).cache_file
+  end
+
+  private
+
+  def temporarily_set_appeal_type
+    self.appeal_type = Appeal.name
   end
 end

--- a/db/migrate/20200813235013_add_appeal_type_column_to_vbms_uploaded_documents.rb
+++ b/db/migrate/20200813235013_add_appeal_type_column_to_vbms_uploaded_documents.rb
@@ -1,0 +1,5 @@
+class AddAppealTypeColumnToVbmsUploadedDocuments < ActiveRecord::Migration[5.2]
+  def change
+    add_column :vbms_uploaded_documents, :appeal_type, :string, comment: "'Appeal' or 'LegacyAppeal'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_172002) do
+ActiveRecord::Schema.define(version: 2020_08_13_235013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1359,6 +1359,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_172002) do
 
   create_table "vbms_uploaded_documents", force: :cascade do |t|
     t.bigint "appeal_id", null: false
+    t.string "appeal_type", comment: "'Appeal' or 'LegacyAppeal'"
     t.datetime "attempted_at"
     t.datetime "canceled_at", comment: "Timestamp when job was abandoned"
     t.datetime "created_at", null: false

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1042,6 +1042,7 @@ user_quotas,updated_at,datetime ∗,x,,,,x,
 user_quotas,user_id,integer ∗ FK,x,,x,,x,
 vbms_uploaded_documents,,,,,,,,
 vbms_uploaded_documents,appeal_id,integer (8) ∗ FK,x,,x,,x,
+vbms_uploaded_documents,appeal_type,string,,,,,,'Appeal' or 'LegacyAppeal'
 vbms_uploaded_documents,attempted_at,datetime,,,,,,
 vbms_uploaded_documents,canceled_at,datetime,,,,,,Timestamp when job was abandoned
 vbms_uploaded_documents,created_at,datetime ∗,x,,,,,


### PR DESCRIPTION
Connects #14971 

### Description
Adds an `appeal_type` column to the `vbms_uploaded_documents` table. I will manually populate this column with a default value. Follow-on PRs connected to #14971 will use the column to implement a polymorphic appeal association on the `VbmsUploadedDocument` model, make the column non-nullable, and add an index.

### Database Changes
* ~~Timestamps (created_at, updated_at) for new tables~~ (n/a)
* [x] Column comments updated
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* ~~Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)~~ (in a follow-on PR)
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
