### PR TITLE
Fix issue where recipients on virtual hearing alert was incorrect

### DIFF
--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -252,18 +252,6 @@ class BaseHearingUpdateForm
     email_changed && !virtual_hearing_cancelled? && !virtual_hearing_created?
   end
 
-  def email_change_type
-    if virtual_hearing_attributes&.key?(:appellant_email) && virtual_hearing_attributes&.key?(:representative_email)
-      "CHANGED_APPELLANT_AND_POA_EMAIL"
-    elsif virtual_hearing_attributes&.key?(:appellant_email)
-      "CHANGED_APPELLANT_EMAIL"
-    elsif virtual_hearing_attributes&.key?(:representative_email)
-      "CHANGED_POA_EMAIL"
-    elsif judge_id.present?
-      "CHANGED_VLJ_EMAIL"
-    end
-  end
-
   def change_type
     if virtual_hearing_created?
       "CHANGED_TO_VIRTUAL"
@@ -272,7 +260,7 @@ class BaseHearingUpdateForm
     elsif only_time_updated_or_timezone_updated?
       "CHANGED_HEARING_TIME"
     elsif only_emails_updated?
-      email_change_type
+      "CHANGED_EMAIL"
     end
   end
 
@@ -303,13 +291,15 @@ class BaseHearingUpdateForm
     nested_alert = VirtualHearingUserAlertBuilder.new(
       change_type: change_type,
       alert_type: :info,
-      hearing: hearing
+      appeal: hearing.appeal,
+      virtual_hearing_updates: virtual_hearing_updates
     ).call.to_hash
 
     nested_alert[:next] = VirtualHearingUserAlertBuilder.new(
       change_type: change_type,
       alert_type: :success,
-      hearing: hearing
+      appeal: hearing.appeal,
+      virtual_hearing_updates: virtual_hearing_updates
     ).call.to_hash
 
     @virtual_hearing_alert = nested_alert

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -291,14 +291,14 @@ class BaseHearingUpdateForm
     nested_alert = VirtualHearingUserAlertBuilder.new(
       change_type: change_type,
       alert_type: :info,
-      appeal: hearing.appeal,
+      hearing: hearing,
       virtual_hearing_updates: virtual_hearing_updates
     ).call.to_hash
 
     nested_alert[:next] = VirtualHearingUserAlertBuilder.new(
       change_type: change_type,
       alert_type: :success,
-      appeal: hearing.appeal,
+      hearing: hearing,
       virtual_hearing_updates: virtual_hearing_updates
     ).call.to_hash
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -738,27 +738,15 @@
     },
     "CHANGED_FROM_VIRTUAL": {
       "TITLE": "We're updating %s's hearing type",
-      "MESSAGE": "Emails to the %{recipients_except_vlj} are in progress."
+      "MESSAGE": "Emails to the %{recipients} are in progress."
     },
-    "CHANGED_APPELLANT_AND_POA_EMAIL": {
+    "CHANGED_EMAIL": {
       "TITLE": "We're emailing the invite to %s's hearing",
-      "MESSAGE": "Emails to the %{appellant_title} and POA / Representative are in progress."
-    },
-    "CHANGED_APPELLANT_EMAIL": {
-      "TITLE": "We're emailing the invite to %s's hearing",
-      "MESSAGE": "Email to %{appellant_title} is in progress."
-    },
-    "CHANGED_POA_EMAIL": {
-      "TITLE": "We're emailing the invite to %s's hearing",
-      "MESSAGE": "Email to POA / Representative is in progress."
-    },
-    "CHANGED_VLJ_EMAIL": {
-      "TITLE": "We're emailing the invite to %s's hearing",
-      "MESSAGE": "Email to VLJ is in progress."
+      "MESSAGE": "Email to %{recipients} is in progress."
     },
     "CHANGED_HEARING_TIME": {
       "TITLE": "We're updating the hearing time of %s's hearing",
-      "MESSAGE": "Emails to the %{recipients_except_vlj} are in progress."
+      "MESSAGE": "Emails to the %{recipients} are in progress."
     }
   },
 
@@ -769,27 +757,15 @@
     },
     "CHANGED_FROM_VIRTUAL": {
       "TITLE": "You have successfully updated the type of %s's hearing.",
-      "MESSAGE": "Email notifications were sent to the %{recipients_except_vlj}."
+      "MESSAGE": "Email notifications were sent to the %{recipients}."
     },
-    "CHANGED_APPELLANT_AND_POA_EMAIL": {
-      "TITLE": "You have successfully emailed the invite to %s's virtual hearing.",
-      "MESSAGE": ""
-    },
-    "CHANGED_APPELLANT_EMAIL": {
-      "TITLE": "You have successfully emailed the invite to %s's virtual hearing.",
-      "MESSAGE": ""
-    },
-    "CHANGED_POA_EMAIL": {
-      "TITLE": "You have successfully emailed the invite to %s's virtual hearing.",
-      "MESSAGE": ""
-    },
-    "CHANGED_VLJ_EMAIL": {
+    "CHANGED_EMAIL": {
       "TITLE": "You have successfully emailed the invite to %s's virtual hearing.",
       "MESSAGE": ""
     },
     "CHANGED_HEARING_TIME": {
       "TITLE": "You have successfully updated the time of %s's virtual hearing",
-      "MESSAGE": "Email notifications were sent to the %{recipients_except_vlj}."
+      "MESSAGE": "Email notifications were sent to the %{recipients}."
     }
   },
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -738,7 +738,7 @@
     },
     "CHANGED_FROM_VIRTUAL": {
       "TITLE": "We're updating %s's hearing type",
-      "MESSAGE": "Emails to the %{recipients} are in progress."
+      "MESSAGE": "Emails to the %{recipients_except_vlj} are in progress."
     },
     "CHANGED_EMAIL": {
       "TITLE": "We're emailing the invite to %s's hearing",
@@ -746,7 +746,7 @@
     },
     "CHANGED_HEARING_TIME": {
       "TITLE": "We're updating the hearing time of %s's hearing",
-      "MESSAGE": "Emails to the %{recipients} are in progress."
+      "MESSAGE": "Emails to the %{recipients_except_vlj} are in progress."
     }
   },
 
@@ -757,7 +757,7 @@
     },
     "CHANGED_FROM_VIRTUAL": {
       "TITLE": "You have successfully updated the type of %s's hearing.",
-      "MESSAGE": "Email notifications were sent to the %{recipients}."
+      "MESSAGE": "Email notifications were sent to the %{recipients_except_vlj}."
     },
     "CHANGED_EMAIL": {
       "TITLE": "You have successfully emailed the invite to %s's virtual hearing.",
@@ -765,7 +765,7 @@
     },
     "CHANGED_HEARING_TIME": {
       "TITLE": "You have successfully updated the time of %s's virtual hearing",
-      "MESSAGE": "Email notifications were sent to the %{recipients}."
+      "MESSAGE": "Email notifications were sent to the %{recipients_except_vlj}."
     }
   },
 

--- a/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
+++ b/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Editing virtual hearing information on daily Docket", :all_dbs do
       expect(page).to have_content(
         format(
           COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_HEARING_TIME"]["MESSAGE"],
-          recipients_except_vlj: "Veteran and POA / Representative"
+          recipients: "Veteran and POA / Representative"
         )
       )
 
@@ -143,7 +143,7 @@ RSpec.feature "Editing virtual hearing information on daily Docket", :all_dbs do
       expect(page).to have_content(
         format(
           COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_HEARING_TIME"]["MESSAGE"],
-          recipients_except_vlj: "Veteran and POA / Representative"
+          recipients: "Veteran and POA / Representative"
         )
       )
 

--- a/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
+++ b/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature "Editing virtual hearing information on daily Docket", :all_dbs do
       expect(page).to have_content(
         format(
           COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_HEARING_TIME"]["MESSAGE"],
-          recipients: "Veteran and POA / Representative"
+          recipients_except_vlj: "Veteran and POA / Representative"
         )
       )
 
@@ -143,7 +143,7 @@ RSpec.feature "Editing virtual hearing information on daily Docket", :all_dbs do
       expect(page).to have_content(
         format(
           COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_HEARING_TIME"]["MESSAGE"],
-          recipients: "Veteran and POA / Representative"
+          recipients_except_vlj: "Veteran and POA / Representative"
         )
       )
 


### PR DESCRIPTION
Resolves #14992 

### Description

WIP

### Acceptance Criteria
- [ ]  Ensure that in progress alert copy is correct after editing timezones
- [ ]  Ensure that success alert copy is correct after editing timezones

### Testing Plan

Try changing:
- POA and Appellant email
- POA or Appellant email
- POA and Appellant timezone
- POA or Appellant timezone
- POA timezone and Appellant email
- POA email and Appellant timezone


### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy 
* [ ] Write a separate story (within the same file) for each discrete variation of the component

### Database Changes
*Only for Schema Changes*

* [ ] Timestamps (created_at, updated_at) for new tables
* [ ] Column comments updated
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] DB schema docs updated with `make docs` (after running `make migrate`)
* [ ] #appeals-schema notified with summary and link to this PR
