### PR TITLE
Show inline errors for full page video to virtual

### DIFF
--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -14,6 +14,7 @@ import {
   RESET_HEARING,
   RESET_VIRTUAL_HEARING
 } from '../contexts/HearingsFormContext';
+import { HearingsUserContext } from '../contexts/HearingsUserContext';
 import { deepDiff, pollVirtualHearingData, getChanges, getAppellantTitleForHearing } from '../utils';
 import { inputFix } from './details/style';
 import {
@@ -37,6 +38,9 @@ import VirtualHearingModal from './VirtualHearingModal';
 const HearingDetails = (props) => {
   // Map the state and dispatch to relevant names
   const { state: { initialHearing, hearing, formsUpdated }, dispatch } = useContext(HearingsFormContext);
+
+  // Pull out feature flag
+  const { userUseFullPageVideoToVirtual } = useContext(HearingsUserContext);
 
   // Create the update hearing dispatcher
   const updateHearing = updateHearingDispatcher(hearing, dispatch);
@@ -165,7 +169,7 @@ const HearingDetails = (props) => {
       // Set the state with the error
       setLoading(false);
 
-      if (code === 1002 && hearing?.readableRequestType === 'Video') {
+      if (code === 1002 && hearing?.readableRequestType === 'Video' && !userUseFullPageVideoToVirtual) {
         // 1002 is returned with an invalid email. rethrow respError, then re-catch it in VirtualHearingModal
         setError(msg);
         throw respError;
@@ -174,7 +178,7 @@ const HearingDetails = (props) => {
       // Remove the validation string from th error
       const messages = msg.split(':')[1];
 
-      // Set inline errors if not Video because it doesnt use the VirtualHearingModal
+      // Set inline errors for hearing conversion page
       const errors = messages.split(',').reduce((list, message) => ({
         ...list,
         [(/Representative/).test(message) ? 'representativeEmail' : 'appellantEmail']:


### PR DESCRIPTION
Resolves #15009

### Description
- Update `Details` component to show inline errors for full page video to virtual conversion

### Acceptance Criteria
- [x]  Invalid email validation errors display inline instead of in a banner
- [x] Verify that validation errors that are no longer relevant are not shown

### Testing Plan
1. Enable feature toggle on rails console`FeatureToggle.enable!(:full_page_video_to_virtual, users: [User.find_by(css_id: "BVASYELLOW")])`
2. Login as `BVASYELLOW`
3. Go to http://localhost:3000/hearings/schedule and pick a video hearing day
4. Convert the hearing day to `Virtual` 
5. Enter invalid emails and see inline errors
