### PR TITLE
Intake | Use instance's zip_code during validation

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -195,10 +195,10 @@ class Veteran < CaseflowRecord
   alias gender sex
 
   def validate_zip_code
-    # This regex validation checks for that zip code is 5 characters long
-    zip_code = bgs_record&.[](:zip_code)
+    return unless zip_code
 
-    if zip_code && country == "USA"
+    if country == "USA"
+      # This regex validation checks for that zip code is 5 characters long
       errors.add(:zip_code, "invalid_zip_code") unless zip_code&.match?(/^(?=(\D*\d){5}\D*$)/)
     end
   end


### PR DESCRIPTION
Related #11942

### Description
There's currently a bug impacting a user during intake/edit.  It's related to this Sentry Alert:
https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/11262/?referrer=webhooks_plugin

When validating the zip code, use the instance method for zip code which may have memoized data.  There's an inconsistent error happening, either Review not editable or Something went wrong.  We think it might be related to different instances being accessed.

Not sure if this is a fix, still may continue to investigate.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...