### PR TITLE
Prioritize AOD and CAVC cases during Bulk Assignment

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -333,6 +333,10 @@ class Appeal < DecisionReview
     veteran_middle_name&.first
   end
 
+  def cavc?
+    false if cavc == "not implemented for AMA"
+  end
+
   def cavc
     "not implemented for AMA"
   end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -89,13 +89,8 @@ class LegacyAppeal < CaseflowRecord
   end
 
   # To match Appeals AOD behavior
-  def aod?
-    aod
-  end
-
-  def advanced_on_docket?
-    aod
-  end
+  alias aod? aod
+  alias advanced_on_docket? aod
 
   cache_attribute :dic do
     issues.map(&:dic).include?(true)
@@ -784,6 +779,8 @@ class LegacyAppeal < CaseflowRecord
   def cavc
     type == "Court Remand"
   end
+
+  alias cavc? cavc
 
   # Adding anything to this to_hash can trigger a lazy load which slows down
   # welcome gate dramatically. Don't add anything to it without also adding it to

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Assign multiple cases, which are selected based on parameters.
+# Cases are prioritized in the following order:
+#   - CAVC AOD Cases
+#   - AOD Cases
+#   - CAVC Cases
+#   - remaining cases
 class BulkTaskAssignment
   include ActiveModel::Model
 

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -53,22 +53,15 @@ class BulkTaskAssignment
   end
 
   def prioritized_tasks(tasks)
-    remaining_tasks = tasks
-    prioritized_tasks = []
+    task_count = tasks.count
+    task_with_initial_priority = tasks.each_with_index.map { |task, i| [task, task_count - i] }
 
-    prioritized_tasks += remaining_tasks.select { |t| t.appeal.cavc? && t.appeal.aod? }
-    remaining_tasks -= prioritized_tasks
-
-    prioritized_tasks += remaining_tasks.select { |t| t.appeal.aod? }
-    remaining_tasks -= prioritized_tasks
-
-    prioritized_tasks += remaining_tasks.select { |t| t.appeal.cavc? }
-    remaining_tasks -= prioritized_tasks
-
-    # pp prioritized_tasks, remaining_tasks
-    prioritized_tasks += remaining_tasks
-
-    prioritized_tasks
+    prioritized_tasks_with_priority = task_with_initial_priority.sort_by do |task, priority|
+      priority += task_count**3 if task.appeal.aod?
+      priority += task_count**2 if task.appeal.cavc?
+      -priority
+    end
+    prioritized_tasks_with_priority.map(&:first)
   end
 
   def assigned_to

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -54,7 +54,7 @@ class BulkTaskAssignment
 
   def prioritized_tasks(tasks)
     task_count = tasks.count
-    task_with_initial_priority = tasks.each_with_index.map { |task, i| [task, task_count - i] }
+    task_with_initial_priority = tasks.each_with_index.map { |task, index| [task, task_count - index] }
 
     prioritized_tasks_with_priority = task_with_initial_priority.sort_by do |task, priority|
       priority += task_count**3 if task.appeal.aod?

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -59,15 +59,22 @@ class BulkTaskAssignment
   end
 
   def prioritized_tasks(tasks)
-    task_count = tasks.count
-    task_with_initial_priority = tasks.each_with_index.map { |task, index| [task, task_count - index] }
+    remaining_tasks = tasks
+    prioritized_tasks = []
 
-    prioritized_tasks_with_priority = task_with_initial_priority.sort_by do |task, priority|
-      priority += task_count**3 if task.appeal.aod?
-      priority += task_count**2 if task.appeal.cavc?
-      -priority
-    end
-    prioritized_tasks_with_priority.map(&:first)
+    prioritized_tasks += remaining_tasks.select { |t| t.appeal.cavc? && t.appeal.aod? }
+    remaining_tasks -= prioritized_tasks
+
+    prioritized_tasks += remaining_tasks.select { |t| t.appeal.aod? }
+    remaining_tasks -= prioritized_tasks
+
+    prioritized_tasks += remaining_tasks.select { |t| t.appeal.cavc? }
+    remaining_tasks -= prioritized_tasks
+
+    # pp prioritized_tasks, remaining_tasks
+    prioritized_tasks += remaining_tasks
+
+    prioritized_tasks
   end
 
   def assigned_to

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -59,22 +59,15 @@ class BulkTaskAssignment
   end
 
   def prioritized_tasks(tasks)
-    remaining_tasks = tasks
-    prioritized_tasks = []
+    task_count = tasks.count
+    task_with_initial_priority = tasks.each_with_index.map { |task, i| [task, task_count - i] }
 
-    prioritized_tasks += remaining_tasks.select { |t| t.appeal.cavc? && t.appeal.aod? }
-    remaining_tasks -= prioritized_tasks
-
-    prioritized_tasks += remaining_tasks.select { |t| t.appeal.aod? }
-    remaining_tasks -= prioritized_tasks
-
-    prioritized_tasks += remaining_tasks.select { |t| t.appeal.cavc? }
-    remaining_tasks -= prioritized_tasks
-
-    # pp prioritized_tasks, remaining_tasks
-    prioritized_tasks += remaining_tasks
-
-    prioritized_tasks
+    prioritized_tasks_with_priority = task_with_initial_priority.sort_by do |task, priority|
+      priority += task_count**3 if task.appeal.aod?
+      priority += task_count**2 if task.appeal.cavc?
+      -priority
+    end
+    prioritized_tasks_with_priority.map(&:first)
   end
 
   def assigned_to

--- a/app/workflows/bulk_task_assignment.rb
+++ b/app/workflows/bulk_task_assignment.rb
@@ -60,7 +60,7 @@ class BulkTaskAssignment
 
   def prioritized_tasks(tasks)
     task_count = tasks.count
-    task_with_initial_priority = tasks.each_with_index.map { |task, i| [task, task_count - i] }
+    task_with_initial_priority = tasks.each_with_index.map { |task, index| [task, task_count - index] }
 
     prioritized_tasks_with_priority = task_with_initial_priority.sort_by do |task, priority|
       priority += task_count**3 if task.appeal.aod?

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -164,12 +164,7 @@ describe BulkTaskAssignment, :postgres do
         subject { BulkTaskAssignment.new(params).process }
 
         it "sorts priority appeals first" do
-          pp Task.active.map { |t| [t.appeal.id, t.appeal.class.name, t.appeal.aod?, t.appeal.cavc?] }
-          Task.active.order(:created_at).map { |t| t.appeal.treee }
-
           prioritized_tasks = subject
-          pp prioritized_tasks.map { |t| [t.appeal.id, t.appeal.class.name, t.appeal.aod?, t.appeal.cavc?] }
-          prioritized_tasks.map { |t| t.appeal.treee }
           expect(prioritized_tasks.first(4).map(&:appeal)).to eq(expected_appeal_ordering)
 
           appeals_of_returned_tasks = prioritized_tasks.map(&:appeal)

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -136,10 +136,7 @@ describe BulkTaskAssignment, :postgres do
       end
 
       def create_no_show_hearing_task_for_appeal(appeal, creation_time = 1.day.ago)
-        create(:no_show_hearing_task,
-               appeal: appeal,
-               assigned_to: organization,
-               created_at: creation_time)
+        create(:no_show_hearing_task, appeal: appeal, assigned_to: organization, created_at: creation_time)
       end
 
       context "when there are priority appeals" do

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -161,12 +161,7 @@ describe BulkTaskAssignment, :postgres do
         subject { BulkTaskAssignment.new(params).process }
 
         it "sorts priority appeals first" do
-          pp Task.active.map { |t| [t.appeal.id, t.appeal.class.name, t.appeal.aod?, t.appeal.cavc?] }
-          Task.active.order(:created_at).map { |t| t.appeal.treee }
-
           prioritized_tasks = subject
-          pp prioritized_tasks.map { |t| [t.appeal.id, t.appeal.class.name, t.appeal.aod?, t.appeal.cavc?] }
-          prioritized_tasks.map { |t| t.appeal.treee }
           expect(prioritized_tasks.first(4).map(&:appeal)).to eq(expected_appeal_ordering)
 
           appeals_of_returned_tasks = prioritized_tasks.map(&:appeal)

--- a/spec/workflows/bulk_task_assignment_spec.rb
+++ b/spec/workflows/bulk_task_assignment_spec.rb
@@ -161,7 +161,12 @@ describe BulkTaskAssignment, :postgres do
         subject { BulkTaskAssignment.new(params).process }
 
         it "sorts priority appeals first" do
+          pp Task.active.map { |t| [t.appeal.id, t.appeal.class.name, t.appeal.aod?, t.appeal.cavc?] }
+          Task.active.order(:created_at).map { |t| t.appeal.treee }
+
           prioritized_tasks = subject
+          pp prioritized_tasks.map { |t| [t.appeal.id, t.appeal.class.name, t.appeal.aod?, t.appeal.cavc?] }
+          prioritized_tasks.map { |t| t.appeal.treee }
           expect(prioritized_tasks.first(4).map(&:appeal)).to eq(expected_appeal_ordering)
 
           appeals_of_returned_tasks = prioritized_tasks.map(&:appeal)


### PR DESCRIPTION
Resolves #14781

### Description
Prioritize associated cases before bulk assigning tasks.

### Acceptance Criteria
- [ ] Code compiles correctly

Cases are prioritized in the following order for Bulk Assign: 
1. CAVC AOD Cases
2. AOD Cases
3. CAVC Cases
4. Regular appeal stream

### Testing Plan
(See #14501, #14510, and #14523 for reference.)
1. Make BVATWARNER an admin so that the bulk "Assign tasks" button appears
   ```ruby
   OrganizationsUser.make_user_admin(User.find_by(css_id: "BVATWARNER"), HearingsManagement.singleton)
   ```
1. Sign in as BVATWARNER and go to `/organizations/hearings-management`
1. Make some cases AOD or CAVC
   * grant AOD Motion per case -- do [this](https://github.com/department-of-veterans-affairs/caseflow/issues/14085#issuecomment-675689095) as AOD_USER (in an incognito window to avoid logging out BVATWARNER)
   * create a CAVC case (is there a better way?):
      ```ruby
      corres=FactoryBot.create(:correspondent, stafkey:"777");
      folder=FactoryBot.create(:folder, ticknum: "000100777");
      vcase= FactoryBot.create(:case, :type_cavc_remand, :assigned, user: User.find_by(css_id: "BVATWARNER"), correspondent: corres, folder: folder);
      appeal=FactoryBot.create(:legacy_appeal, vacols_case: vcase);

      ht=FactoryBot.create(:hearing_task, appeal: appeal, assigned_by: nil);
      ahdt=FactoryBot.create(:assign_hearing_disposition_task, parent: ht, assigned_by: nil);
      FactoryBot.create(:no_show_hearing_task, parent: ahdt, assigned_by: nil);
      ```
   * create AOD CAVC case (by combining the procedures above)
1. As BVATWARNER, refresh the `/organizations/hearings-management` page to see AOD and CAVC cases
1. Perform bulk "Assign tasks" with "No Show Hearing Task" type and ensure priority cases are assigned first (see the "Assigned" tab)


