### PR TITLE
Optimizations for Jest in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ jobs:
           command: |
             mkdir -p ~/test-results/jest
             pushd client
-            ~/project/ci-bin/capture-log "node_modules/.bin/jest --ci --reporters=default --reporters=jest-junit"
+            ~/project/ci-bin/capture-log "node_modules/.bin/jest --ci --reporters=default --reporters=jest-junit --maxWorkers=4"
 
       - run:
           name: Karma


### PR DESCRIPTION
### Description
This attempts to find better config params for running Jest under CircleCI to avoid timeout errors

### Background
- [CircleCI support center post](https://support.circleci.com/hc/en-us/articles/360038192673-NodeJS-Builds-or-Test-Suites-Fail-With-ENOMEM-or-a-Timeout)
- [Jest troubleshooting](https://jestjs.io/docs/en/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server)
- [CircleCI docs on instance types](https://circleci.com/docs/2.0/configuration-reference/#resource_class) (Our current config sets `resource_class` to `large`, so 4 vCPUs)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] JS tests pass in CircleCI w/o Timeouts

### Testing Plan
1. Keep running this in Circle, I guess?
