### PR TITLE
Upgrade React on Rails to 11.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ gem "rails", "5.2.4.3"
 # Used to colorize output for rake tasks
 gem "rainbow"
 # React
-gem "react_on_rails", "8.0.6"
+gem "react_on_rails", "11.3.0"
 gem "redis-namespace"
 gem "redis-rails", "~> 5.0.2"
 gem "request_store"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,7 +185,7 @@ GEM
     colored2 (3.1.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.6)
-    connection_pool (2.2.1)
+    connection_pool (2.2.3)
     cork (0.3.0)
       colored2 (~> 3.1)
     countries (3.0.1)
@@ -459,20 +459,19 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rb-readline (0.5.5)
     rchardet (1.8.0)
-    react_on_rails (8.0.6)
+    react_on_rails (11.3.0)
       addressable
       connection_pool
       execjs (~> 2.5)
       rails (>= 3.2)
-      rainbow (~> 2.2)
+      rainbow (~> 3.0)
     redis (4.0.1)
     redis-actionpack (5.0.2)
       actionpack (>= 4.0, < 6)
@@ -707,7 +706,7 @@ DEPENDENCIES
   rails-erd
   rainbow
   rb-readline
-  react_on_rails (= 8.0.6)
+  react_on_rails (= 11.3.0)
   redis-namespace
   redis-rails (~> 5.0.2)
   request_store

--- a/client/package.json
+++ b/client/package.json
@@ -102,7 +102,7 @@
     "react-highlight-words": "^0.8.0",
     "react-hot-loader": "^4.12.18",
     "react-markdown": "^4.2.2",
-    "react-on-rails": "^8.0.6",
+    "react-on-rails": "11.3.0",
     "react-polling": "^1.0.5",
     "react-redux": "^7.2.0",
     "react-router": "^5.1.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1815,6 +1815,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs2@^7.0.0":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.11.2.tgz#700a03945ebad0d31ba6690fc8a6bcc9040faa47"
+  integrity sha512-AC/ciV28adSSpEkBglONBWq4/Lvm6GAZuxIoyVtsnUpZMl0bxLtoChEnYAkP+47KyOCayZanojtflUEUJtR/6Q==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs2@^7.9.2":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.9.2.tgz#f11d074ff99b9b4319b5ecf0501f12202bf2bf4d"
@@ -14241,10 +14249,12 @@ react-markdown@^4.2.2:
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
 
-react-on-rails@^8.0.6:
-  version "8.0.6"
-  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-8.0.6.tgz#b0f30772a850dca6fa2c508576455557a2dd40ea"
-  integrity sha512-c/HLdDjmGRs+gyPFtdsdoj3JLym0Vkg7dIL9ujoyaUHL0rZibRivrvLjbjEXJgPWPN3cP2sttuXm3OcqVfC/jA==
+react-on-rails@11.3.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/react-on-rails/-/react-on-rails-11.3.0.tgz#edebfd4b98f1fa110e4d5ce92ef699d7dccf8fb2"
+  integrity sha512-3eyoZe+tysxdMy7IZ7Ca6gar268iX1NOJy7hJH8CW9dfNIFWbeWXTVa3G91wrt5xo2toWZLCoj51WcBWw0Rm3Q==
+  dependencies:
+    "@babel/runtime-corejs2" "^7.0.0"
 
 react-polling@^1.0.5:
   version "1.0.5"

--- a/config/initializers/react_on_rails.rb
+++ b/config/initializers/react_on_rails.rb
@@ -1,5 +1,7 @@
 # Shown below are the defaults for configuration
 ReactOnRails.configure do |config|
+  config.node_modules_location = "client"
+
   # Client bundles are configured in application.js
 
   # Directory where your generated assets go. All generated assets must go to the same directory.
@@ -18,16 +20,16 @@ ReactOnRails.configure do |config|
   # If you are using the ReactOnRails::TestHelper.configure_rspec_to_compile_assets(config)
   # with rspec then this controls what npm command is run
   # to automatically refresh your webpack assets on every test run.
-  config.npm_build_test_command = "yarn run build:test"
+  config.build_test_command = "yarn run build:test"
 
   # This configures the script to run to build the production assets by webpack. Set this to nil
   # if you don't want react_on_rails building this file for you.
   # This will set NODE_ENV=development necessary for source maps in DEMO
-  config.npm_build_production_command = if Rails.env.demo?
-                                          "yarn run build:demo"
-                                        else
-                                          "yarn run build:production"
-                                        end
+  config.build_production_command = if Rails.env.demo?
+                                      "yarn run build:demo"
+                                    else
+                                      "yarn run build:production"
+                                    end
 
   ################################################################################
   # CLIENT RENDERING OPTIONS
@@ -67,9 +69,6 @@ ReactOnRails.configure do |config|
   ################################################################################
   # MISCELLANEOUS OPTIONS
   ################################################################################
-
-  # The server render method - either ExecJS or NodeJS
-  config.server_render_method = "ExecJS"
 
   # Client js uses assets not digested by rails.
   # For any asset matching this regex, non-digested symlink will be created (what webpack's css wants)


### PR DESCRIPTION
Resolves #15017 

### Description

11.3.0 is not the most recent, but it's the most recent without and major breaking changes (05/24/2019). The version we were on was from 2017!

Notes: https://github.com/shakacode/react_on_rails/blob/master/CHANGELOG.md#1130---2019-05-24
