### PR TITLE
Properly checks User for Overtime feature

### DIFF
--- a/app/controllers/work_modes_controller.rb
+++ b/app/controllers/work_modes_controller.rb
@@ -24,7 +24,7 @@ class WorkModesController < ApplicationController
   end
 
   def validate_modification_access_to_overtime
-    fail(Caseflow::Error::ActionForbiddenError) unless FeatureToggle.enabled?(:overtime_revamp)
+    fail(Caseflow::Error::ActionForbiddenError) unless FeatureToggle.enabled?(:overtime_revamp, user: current_user)
 
     unless current_user.judge? && current_user_is_assigned_to_appeal?
       msg = "Only judges assigned to this appeal can toggle overtime status"

--- a/app/models/concerns/taskable.rb
+++ b/app/models/concerns/taskable.rb
@@ -20,7 +20,7 @@ module Taskable
   end
 
   def overtime?
-    return !!work_mode&.overtime if FeatureToggle.enabled?(:overtime_revamp)
+    return !!work_mode&.overtime if FeatureToggle.enabled?(:overtime_revamp, user: RequestStore.store[:current_user])
 
     false
   end

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -115,7 +115,7 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :attorney_case_rewrite_details do |object|
-    if FeatureToggle.enabled?(:overtime_revamp)
+    if FeatureToggle.enabled?(:overtime_revamp, user: RequestStore.store[:current_user])
       {
         note_from_attorney: object.latest_attorney_case_review&.note,
         untimely_evidence: object.latest_attorney_case_review&.untimely_evidence

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -115,7 +115,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def can_view_overtime_status?
-    (attorney_in_vacols? || judge_in_vacols?) && FeatureToggle.enabled?(:overtime_revamp)
+    (attorney_in_vacols? || judge_in_vacols?) && FeatureToggle.enabled?(:overtime_revamp, user: self)
   end
 
   def vacols_uniq_id


### PR DESCRIPTION
### Description
Makes sure we're checking the user specific feature toggle for `overtime_revamp`

### Acceptance Criteria
- [x] Testing user can see their own marked OT cases
- [x] Testing user can see cases marked OT by others
- [x] Non-enabled users cannot see cases marked OT

### Testing Plan
1. Setup the OT flag:
   ```ruby
   FeatureToggle.disable!(:overtime_revamp)
   FeatureToggle.enable!(:overtime_revamp, users: ["BVAAABSHIRE", "BVASCASPER1"])

   FeatureToggle.enabled?(:overtime_revamp)
   => false
   FeatureToggle.enable!(:overtime_revamp, users: ["BVAAABSHIRE"])
   => true
   FeatureToggle.enable!(:overtime_revamp, users: ["BVASCASPER1"])
   => true
   ```
2. Sign in as Abshire & navigate to your assign queue, select a case
   - [ ] You have the `Overtime Status` section & link
3. Mark the case as overtime
   - [ ] Does not error
   - [ ] the OT badge appears at the top of the case details
4. Go back to the Assign Queue
   - [ ] the OT badge appears on the case
5. Assign the case to BVASCASPER1
6. Sign in as Casper & navigate to your queue
   - [ ] the OT badge appears on the case
7. Click into case details
   - [ ] the OT badge appears at the top of the case details
   - [ ] You _do not have_ have the `Overtime Status` section & link
8. Save the case URL. Sign in as BVAGSPORER & navigate to the case.
   - [ ] the OT badge _does not appear_ appears at the top of the case details
   - [ ] You _do not have_ have the `Overtime Status` section & link
9. Sign back in as BVAAABSHIRE, navigate to the case, remove OT status
   - [ ] does not error
   - [ ] OT badge disappears
10. Mark it OT again
    - [ ] Does not error
    - [ ] the OT badge appears at the top of the case details
