### PR TITLE
handle legacy virtual hearing type from VACOLS

### DIFF
--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -76,6 +76,7 @@ module HearingMapper
       return "1" if type == :C
       return "2" if type == :T
       return "6" if type == :V
+      return "7" if type == :R
     end
 
     def representative_name_to_vacols_format(value)

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -70,6 +70,7 @@ class Hearing < CaseflowRecord
   attr_accessor :override_full_hearing_day_validation
 
   HEARING_TYPES = {
+    R: "Virtual",
     V: "Video",
     T: "Travel",
     C: "Central"

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -140,7 +140,7 @@ class VACOLS::Case < VACOLS::Record
       left join (
         select FOLDER_NR, count(*) CNT
         from HEARSCHED
-        where HEARING_TYPE IN ('C', 'T', 'V')
+        where HEARING_TYPE IN ('C', 'T', 'V', 'R')
           AND AOD IN ('G', 'Y')
         group by FOLDER_NR
       ) AOD_HEARINGS

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -83,7 +83,7 @@ class VACOLS::CaseDocket < VACOLS::Record
         first_value(BOARD_MEMBER) over (partition by TITRNUM, TINUM order by HEARING_DATE desc) VLJ
       from HEARSCHED
       inner join FOLDER on FOLDER.TICKNUM = HEARSCHED.FOLDER_NR
-      where HEARING_TYPE in ('C', 'T', 'V') and HEARING_DISP = 'H'
+      where HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H'
     ) VLJ_HEARINGS
       on VLJ_HEARINGS.VLJ not in ('000', '888', '999')
         and VLJ_HEARINGS.TITRNUM = BRIEFF.TITRNUM
@@ -158,7 +158,7 @@ class VACOLS::CaseDocket < VACOLS::Record
         left join (
           select FOLDER_NR, count(*) CNT
           from HEARSCHED
-          where HEARING_TYPE IN ('C', 'T', 'V')
+          where HEARING_TYPE IN ('C', 'T', 'V', 'R')
             AND AOD IN ('G', 'Y')
           group by FOLDER_NR
         ) AOD_HEARINGS on AOD_HEARINGS.FOLDER_NR = BFKEY
@@ -223,7 +223,7 @@ class VACOLS::CaseDocket < VACOLS::Record
         left join (
           select FOLDER_NR, count(*) CNT
           from HEARSCHED
-          where HEARING_TYPE IN ('C', 'T', 'V')
+          where HEARING_TYPE IN ('C', 'T', 'V', 'R')
             AND AOD IN ('G', 'Y')
           group by FOLDER_NR
         ) AOD_HEARINGS on AOD_HEARINGS.FOLDER_NR = BFKEY

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -12,7 +12,14 @@ class VACOLS::CaseHearing < VACOLS::Record
   has_one :staff, foreign_key: :sattyid, primary_key: :board_member
   has_one :brieff, foreign_key: :bfkey, primary_key: :folder_nr, class_name: "Case"
 
-  HEARING_TYPES = %w[V T C].freeze
+  HEARING_TYPE_LOOKUP = {
+    central: "C",
+    travel: "T",
+    video: "V",
+    virtual: "R"
+  }.freeze
+
+  HEARING_TYPES = HEARING_TYPE_LOOKUP.values.freeze
 
   HEARING_DISPOSITIONS = {
     H: Constants.HEARING_DISPOSITION_TYPES.held,

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -320,7 +320,7 @@ class AppealRepository
         .includes(:correspondent, :case_issues, :case_hearings, folder: [:outcoder]).reject do |case_record|
           case_record.case_hearings.any? do |hearing|
             # VACOLS contains non-BVA hearings information, we want to confirm the appeal has no scheduled BVA hearings
-            hearing.hearing_disp.nil? && HearingDay::REQUEST_TYPES.value?(hearing.hearing_type)
+            hearing.hearing_disp.nil? && VACOLS::CaseHearing::HEARING_TYPES.include?(hearing.hearing_type)
           end
         end
     end

--- a/local/vacols/vacols_copy_5_functions_dev.sql
+++ b/local/vacols/vacols_copy_5_functions_dev.sql
@@ -65,7 +65,7 @@ select count(*) into dcnt from assign
 
 hcnt := 0;
 select count(*) into hcnt from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y');
+  and hearing_type in ('C', 'T', 'V', 'R') and aod in ('G', 'Y');
 
 aodcnt := dcnt + hcnt;
 
@@ -102,7 +102,7 @@ select count(*) into dcnt from assign
 
 hcnt := 0;
 select count(*) into hcnt from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y');
+  and hearing_type in ('C', 'T', 'V', 'R') and aod in ('G', 'Y');
 
 aodcnt := dcnt + hcnt;
 
@@ -770,7 +770,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V') and hearing_disp in ('H', 'C', 'N');
+and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp in ('H', 'C', 'N');
 RETURN hrcnt;
 END;
 /
@@ -805,7 +805,7 @@ CURSOR DN_Cur is
   SELECT HEARING_DATE FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 BEGIN
 
@@ -828,7 +828,7 @@ CURSOR DN_Cur is
   SELECT HEARING_DATE FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and board_member = vlj and
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and board_member = vlj and
      HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 BEGIN
@@ -851,7 +851,7 @@ CURSOR DV_Cur is select hearing_disp || ' ' || to_char(hearing_date, 'mm/dd/yy')
  || ' ' || nvl(aod, 'N')|| ' ' || to_char(holddays, '999')
  into hrinfo from BRIEFF, HEARSCHED where
  bfkey = folder_nr and bfcorlid = appealid
- and hearing_type in ('C', 'T', 'V') order by hearing_date Desc;
+ and hearing_type in ('C', 'T', 'V', 'R') order by hearing_date Desc;
 
 BEGIN
 
@@ -869,7 +869,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')
+and hearing_type in ('C', 'T', 'V', 'R')
 and hearing_disp in ('H', 'C', 'N');
 RETURN hrcnt;
 END;
@@ -881,7 +881,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')
+and hearing_type in ('C', 'T', 'V', 'R')
 and hearing_disp in ('H');
 RETURN hrcnt;
 END;
@@ -900,7 +900,7 @@ CURSOR DN_Cur is
   SELECT to_char(hearing_date, 'mm/dd/yy'), hearing_type, board_member
    FROM HEARSCHED, FOLDER WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H'
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H'
      order by HEARING_DATE DESC;
 
 BEGIN
@@ -923,7 +923,7 @@ hrcnt number;
 
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')
+and hearing_type in ('C', 'T', 'V', 'R')
 and hearing_disp in ('H', 'C', 'N') and hearing_date > decdate;
 
 if hrcnt > 0 then
@@ -944,7 +944,7 @@ END;
 BEGIN
 select Max(hearing_date) into hrdate from hearsched
   where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V')
+  and hearing_type in ('C', 'T', 'V', 'R')
   and (hearing_disp = 'H' or hearing_disp = null)
   and (hearing_date > reqdate or reqdate is null);
 
@@ -958,7 +958,7 @@ END;
 
 BEGIN
 select max(to_char(holddays, '999'))  into hrinfo from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')  and hearing_disp in ('H', 'C', 'N');
+and hearing_type in ('C', 'T', 'V', 'R')  and hearing_disp in ('H', 'C', 'N');
 
 if hrinfo is null then
   hrinfo := '   ';
@@ -990,7 +990,7 @@ if inha = '1' or inha = '2' or inha = '6' then
 end if;
 
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V') and hearing_disp in ('H', 'C', 'N');
+and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp in ('H', 'C', 'N');
 
 if hrcnt > 0 then
   pending := 'N';
@@ -1009,7 +1009,7 @@ END;
 
 BEGIN
 select max(repname) into hrrep  from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') ;
+  and hearing_type in ('C', 'T', 'V', 'R') ;
 
 RETURN hrrep;
 END;
@@ -1023,7 +1023,7 @@ hrcnt number;
 
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and hearing_disp is null;
+  and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp is null;
 
 if hrcnt > 0 then
   sched := 'Y';
@@ -1045,7 +1045,7 @@ hrdate varchar2(8);
 BEGIN
 select hearing_type, to_char(hearing_date, 'mm/dd/yy') into hrtype, hrdate
   from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and hearing_disp is null;
+  and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp is null;
 
 hrinfo := hrtype || ' ' || hrdate;
 
@@ -1141,7 +1141,7 @@ tbcnt number;
 
 BEGIN
 select count(*) into tbcnt from HEARSCHED where folder_nr = folder
-  and hearing_type in ('C', 'V', 'T')
+  and hearing_type in ('C', 'T', 'V', 'R')
   and (hearing_disp is null or hearing_disp = 'H');
 
 if tbcnt > 0 then
@@ -1667,7 +1667,7 @@ CURSOR DN_Cur is
   SELECT BOARD_MEMBER FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 CURSOR BF_Cur is
   SELECT BFMEMID FROM BRIEFF, FOLDER
@@ -1706,7 +1706,7 @@ CURSOR DN_Cur is
   SELECT BOARD_MEMBER FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 CURSOR BF_Cur is
   SELECT BFMEMID FROM BRIEFF, FOLDER
@@ -1765,7 +1765,7 @@ mdate date;
 
 CURSOR Hr_Cur is SELECT BOARD_MEMBER, HEARING_DATE from  HEARSCHED, FOLDER
   where TICKNUM = FOLDER_NR and TITRNUM = in_appealid AND tinum = in_tinum and
-      HEARING_DISP = 'H' AND HEARING_TYPE in ('C', 'T', 'V') and
+      HEARING_DISP = 'H' AND HEARING_TYPE in ('C', 'T', 'V', 'R') and
       (HEARING_DATE >= in_dpdcn or in_dpdcn is null)
       order by HEARING_DATE DESC ;
       

--- a/local/vacols/vacols_copy_5_functions_dev.sql
+++ b/local/vacols/vacols_copy_5_functions_dev.sql
@@ -1125,6 +1125,7 @@ if team is null then team := '  '; end if;
 if    hrtype = 'C' then hrtype := 'Central Office';
 elsif hrtype = 'T' then hrtype := 'Travel Board  ';
 elsif hrtype = 'V' then hrtype := 'Video         ';
+elsif hrtype = 'R' then hrtype := 'Virtual       ';
 else  hrtype := ' ';
 end if;
 
@@ -1749,7 +1750,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder and
-  hearing_type in ('C', 'V') and hearing_date is not null and
+  hearing_type in ('C', 'V', 'R') and hearing_date is not null and
   board_member is not null and hearing_disp is null;
 RETURN hrcnt;
 END;
@@ -2430,7 +2431,7 @@ tbcnt number;
 
 BEGIN
 select count(*) into tbcnt from HEARSCHED where folder_nr = folder
-  and hearing_type in ('V', 'T')
+  and hearing_type in ('T', 'V', 'R')
   and (hearing_disp is null or hearing_disp = 'H');
 
 if tbcnt > 0 then

--- a/local/vacols/vacols_copy_5_functions_test.sql
+++ b/local/vacols/vacols_copy_5_functions_test.sql
@@ -1749,7 +1749,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder and
-  hearing_type in ('C', 'V') and hearing_date is not null and
+  hearing_type in ('C', 'V', 'R') and hearing_date is not null and
   board_member is not null and hearing_disp is null;
 RETURN hrcnt;
 END;
@@ -2430,7 +2430,7 @@ tbcnt number;
 
 BEGIN
 select count(*) into tbcnt from HEARSCHED where folder_nr = folder
-  and hearing_type in ('V', 'T')
+  and hearing_type in ('T', 'V', 'R')
   and (hearing_disp is null or hearing_disp = 'H');
 
 if tbcnt > 0 then

--- a/local/vacols/vacols_copy_5_functions_test.sql
+++ b/local/vacols/vacols_copy_5_functions_test.sql
@@ -65,7 +65,7 @@ select count(*) into dcnt from assign
 
 hcnt := 0;
 select count(*) into hcnt from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y');
+  and hearing_type in ('C', 'T', 'V', 'R') and aod in ('G', 'Y');
 
 aodcnt := dcnt + hcnt;
 
@@ -102,7 +102,7 @@ select count(*) into dcnt from assign
 
 hcnt := 0;
 select count(*) into hcnt from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and aod in ('G', 'Y');
+  and hearing_type in ('C', 'T', 'V', 'R') and aod in ('G', 'Y');
 
 aodcnt := dcnt + hcnt;
 
@@ -770,7 +770,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V') and hearing_disp in ('H', 'C', 'N');
+and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp in ('H', 'C', 'N');
 RETURN hrcnt;
 END;
 /
@@ -805,7 +805,7 @@ CURSOR DN_Cur is
   SELECT HEARING_DATE FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 BEGIN
 
@@ -828,7 +828,7 @@ CURSOR DN_Cur is
   SELECT HEARING_DATE FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and board_member = vlj and
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and board_member = vlj and
      HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 BEGIN
@@ -851,7 +851,7 @@ CURSOR DV_Cur is select hearing_disp || ' ' || to_char(hearing_date, 'mm/dd/yy')
  || ' ' || nvl(aod, 'N')|| ' ' || to_char(holddays, '999')
  into hrinfo from BRIEFF, HEARSCHED where
  bfkey = folder_nr and bfcorlid = appealid
- and hearing_type in ('C', 'T', 'V') order by hearing_date Desc;
+ and hearing_type in ('C', 'T', 'V', 'R') order by hearing_date Desc;
 
 BEGIN
 
@@ -869,7 +869,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')
+and hearing_type in ('C', 'T', 'V', 'R')
 and hearing_disp in ('H', 'C', 'N');
 RETURN hrcnt;
 END;
@@ -881,7 +881,7 @@ END;
   hrcnt number;
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')
+and hearing_type in ('C', 'T', 'V', 'R')
 and hearing_disp in ('H');
 RETURN hrcnt;
 END;
@@ -900,7 +900,7 @@ CURSOR DN_Cur is
   SELECT to_char(hearing_date, 'mm/dd/yy'), hearing_type, board_member
    FROM HEARSCHED, FOLDER WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H'
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H'
      order by HEARING_DATE DESC;
 
 BEGIN
@@ -923,7 +923,7 @@ hrcnt number;
 
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')
+and hearing_type in ('C', 'T', 'V', 'R')
 and hearing_disp in ('H', 'C', 'N') and hearing_date > decdate;
 
 if hrcnt > 0 then
@@ -944,7 +944,7 @@ END;
 BEGIN
 select Max(hearing_date) into hrdate from hearsched
   where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V')
+  and hearing_type in ('C', 'T', 'V', 'R')
   and (hearing_disp = 'H' or hearing_disp = null)
   and (hearing_date > reqdate or reqdate is null);
 
@@ -958,7 +958,7 @@ END;
 
 BEGIN
 select max(to_char(holddays, '999'))  into hrinfo from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V')  and hearing_disp in ('H', 'C', 'N');
+and hearing_type in ('C', 'T', 'V', 'R')  and hearing_disp in ('H', 'C', 'N');
 
 if hrinfo is null then
   hrinfo := '   ';
@@ -990,7 +990,7 @@ if inha = '1' or inha = '2' or inha = '6' then
 end if;
 
 select count(*) into hrcnt from hearsched where folder_nr = folder
-and hearing_type in ('C', 'T', 'V') and hearing_disp in ('H', 'C', 'N');
+and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp in ('H', 'C', 'N');
 
 if hrcnt > 0 then
   pending := 'N';
@@ -1009,7 +1009,7 @@ END;
 
 BEGIN
 select max(repname) into hrrep  from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') ;
+  and hearing_type in ('C', 'T', 'V', 'R') ;
 
 RETURN hrrep;
 END;
@@ -1023,7 +1023,7 @@ hrcnt number;
 
 BEGIN
 select count(*) into hrcnt from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and hearing_disp is null;
+  and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp is null;
 
 if hrcnt > 0 then
   sched := 'Y';
@@ -1045,7 +1045,7 @@ hrdate varchar2(8);
 BEGIN
 select hearing_type, to_char(hearing_date, 'mm/dd/yy') into hrtype, hrdate
   from hearsched where folder_nr = folder
-  and hearing_type in ('C', 'T', 'V') and hearing_disp is null;
+  and hearing_type in ('C', 'T', 'V', 'R') and hearing_disp is null;
 
 hrinfo := hrtype || ' ' || hrdate;
 
@@ -1141,7 +1141,7 @@ tbcnt number;
 
 BEGIN
 select count(*) into tbcnt from HEARSCHED where folder_nr = folder
-  and hearing_type in ('C', 'V', 'T')
+  and hearing_type in ('C', 'T', 'V', 'R')
   and (hearing_disp is null or hearing_disp = 'H');
 
 if tbcnt > 0 then
@@ -1667,7 +1667,7 @@ CURSOR DN_Cur is
   SELECT BOARD_MEMBER FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 CURSOR BF_Cur is
   SELECT BFMEMID FROM BRIEFF, FOLDER
@@ -1706,7 +1706,7 @@ CURSOR DN_Cur is
   SELECT BOARD_MEMBER FROM HEARSCHED, FOLDER
    WHERE TICKNUM = FOLDER_NR and
      (TITRNUM = appealid AND (tinum = docket or tinum is null))
-     and HEARING_TYPE in ('C', 'V', 'T') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
+     and HEARING_TYPE in ('C', 'T', 'V', 'R') and HEARING_DISP = 'H' order by HEARING_DATE DESC;
 
 CURSOR BF_Cur is
   SELECT BFMEMID FROM BRIEFF, FOLDER
@@ -1765,7 +1765,7 @@ mdate date;
 
 CURSOR Hr_Cur is SELECT BOARD_MEMBER, HEARING_DATE from  HEARSCHED, FOLDER
   where TICKNUM = FOLDER_NR and TITRNUM = in_appealid AND tinum = in_tinum and
-      HEARING_DISP = 'H' AND HEARING_TYPE in ('C', 'T', 'V') and
+      HEARING_DISP = 'H' AND HEARING_TYPE in ('C', 'T', 'V', 'R') and
       (HEARING_DATE >= in_dpdcn or in_dpdcn is null)
       order by HEARING_DATE DESC ;
       

--- a/spec/mappers/hearing_mapper_spec.rb
+++ b/spec/mappers/hearing_mapper_spec.rb
@@ -14,42 +14,49 @@ describe HearingMapper do
 
     context "when disposition is held and it is central office hearing" do
       let(:hearing_disp) { "H" }
-      let(:hearing_type) { HearingDay::REQUEST_TYPES[:central] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:central] }
 
       it { is_expected.to eq "1" }
     end
 
     context "when disposition is held and it is video hearing" do
       let(:hearing_disp) { "H" }
-      let(:hearing_type) { HearingDay::REQUEST_TYPES[:video] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:video] }
 
       it { is_expected.to eq "6" }
     end
 
     context "when disposition is held and it is travel board hearing" do
       let(:hearing_disp) { "H" }
-      let(:hearing_type) { HearingDay::REQUEST_TYPES[:travel] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:travel] }
 
       it { is_expected.to eq "2" }
     end
 
+    context "when disposition is held and it is a virtual hearing" do
+      let(:hearing_disp) { "H" }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:virtual] }
+
+      it { is_expected.to eq "7" }
+    end
+
     context "when disposition is postponed" do
       let(:hearing_disp) { "P" }
-      let(:hearing_type) { HearingDay::REQUEST_TYPES[:travel] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:travel] }
 
       it { is_expected.to eq nil }
     end
 
     context "when disposition is cancelled" do
       let(:hearing_disp) { "C" }
-      let(:hearing_type) { HearingDay::REQUEST_TYPES[:video] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:video] }
 
       it { is_expected.to eq "5" }
     end
 
     context "when disposition is not held" do
       let(:hearing_disp) { "N" }
-      let(:hearing_type) { HearingDay::REQUEST_TYPES[:central] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:central] }
 
       it { is_expected.to eq "5" }
     end
@@ -69,7 +76,7 @@ describe HearingMapper do
     let(:datetime) { Time.new(2013, 9, 5, 20, 0, 0, "-08:00") }
 
     context "when travel board" do
-      let(:type) { HearingDay::REQUEST_TYPES[:travel] }
+      let(:type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:travel] }
 
       it "uses a regional office timezone to set the zone" do
         expect(subject.day).to eq 5
@@ -79,7 +86,7 @@ describe HearingMapper do
     end
 
     context "when video" do
-      let(:type) { HearingDay::REQUEST_TYPES[:video] }
+      let(:type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:video] }
 
       it "uses a regional office timezone to set the zone" do
         expect(subject.day).to eq 5
@@ -89,7 +96,7 @@ describe HearingMapper do
     end
 
     context "when central_office" do
-      let(:type) { HearingDay::REQUEST_TYPES[:central] }
+      let(:type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:central] }
 
       it "does not use a regional office timezone" do
         expect(subject.day).to eq 6


### PR DESCRIPTION
Resolves #15078 
Resolves #15079

### Description
- Interpret a value of `'R'` in the VACOLS `hearsched.hearing_type` as an indication that the legacy hearing is virtual.
- Write `7` to `brieff.bfha` when a legacy hearing with this hearing type is held
