### PR TITLE
Temporarily remove pay grade validation

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -32,7 +32,6 @@ class Veteran < CaseflowRecord
     validate :validate_date_of_birth
     validate :validate_name_suffix
     validate :validate_zip_code
-    validate :validate_veteran_pay_grade
   end
 
   delegate :full_address, to: :address

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -596,7 +596,7 @@ feature "Intake", :all_dbs do
         end
       end
 
-      context "invalid pay grade" do
+      context "invalid pay grade", skip: "temporarily removing this validation" do
         let(:service) { [{ branch_of_service: "army", pay_grade: "not valid" }] }
         let(:veteran) do
           Generators::Veteran.build(


### PR DESCRIPTION
### Description
Turning off pay grade validation for now, it's erroring on the BGS fetch
[Sentry alert](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/11323/?referrer=webhooks_plugin)