### PR TITLE
add diagnostic code for 7632

### DIFF
--- a/client/constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json
+++ b/client/constants/DIAGNOSTIC_CODE_DESCRIPTIONS.json
@@ -2055,6 +2055,10 @@
     "staff_description": "Endometriosis",
     "status_description": "endometriosis"
   },
+  "7632": {
+    "staff_description": "Female Sexual Arousal Disorder (FSAD)",
+    "status_description": "female sexual arousal disorder"
+  },
   "7699": {
     "staff_description": "Other gynecological or breast disability",
     "status_description": "gynecological or breast disability"


### PR DESCRIPTION
Resolves the issue described here: https://dsva.slack.com/archives/CHX8FMP28/p1599047514117800

### Description

Add diagnostic code for 7632

Found diagnostic code description by doing the following:

```
> codes = BGSService.new.client.share_standard_data.find_diagnostic_codes
> codes[:return][:types].select { |c| c[:code] == '7632' }
```