### PR TITLE
Fix missing method error for capture_exception

### DIFF
--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -315,7 +315,7 @@ class LegacyHearing < CaseflowRecord
       self.class.repository.load_vacols_data(self)
       true
     rescue Caseflow::Error::VacolsRecordNotFound => error
-      capture_exception(error)
+      Raven.capture_exception(error)
       false
     end
   end


### PR DESCRIPTION
From production:

```
NoMethodError (undefined method `capture_exception' for #<LegacyHearing...>)
app/models/legacy_hearing.rb:318:in `rescue in vacols_hearing_exists?'
```

### Description

Use `Raven.capture_exception`
