### PR TITLE
Write hearing type to VACOLS when converting legacy hearings

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -103,6 +103,8 @@ class Hearing < CaseflowRecord
     HEARING_TYPES[request_type.to_sym]
   end
 
+  alias original_request_type request_type
+
   def assigned_to_vso?(user)
     appeal.tasks.any? do |task|
       task.type == TrackVeteranTask.name &&

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -32,6 +32,8 @@ class BaseHearingUpdateForm
 
       add_virtual_hearing_alert if show_virtual_hearing_progress_alerts?
     end
+
+    after_update_hearing
   end
 
   def hearing_alerts
@@ -45,6 +47,8 @@ class BaseHearingUpdateForm
   protected
 
   def update_hearing; end
+
+  def after_update_hearing; end
 
   def hearing_updates; end
 

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -22,6 +22,8 @@ class BaseHearingUpdateForm
 
         virtual_hearing_changed = true
       end
+
+      after_update_hearing
     end
 
     if virtual_hearing_changed
@@ -32,8 +34,6 @@ class BaseHearingUpdateForm
 
       add_virtual_hearing_alert if show_virtual_hearing_progress_alerts?
     end
-
-    after_update_hearing
   end
 
   def hearing_alerts

--- a/app/models/hearings/forms/legacy_hearing_update_form.rb
+++ b/app/models/hearings/forms/legacy_hearing_update_form.rb
@@ -12,6 +12,14 @@ class LegacyHearingUpdateForm < BaseHearingUpdateForm
     HearingRepository.load_vacols_data(hearing)
   end
 
+  def after_update_hearing
+    if virtual_hearing_created?
+      hearing.update_request_type_in_vacols(VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:virtual])
+    elsif virtual_hearing_cancelled?
+      hearing.update_request_type_in_vacols(hearing.original_request_type)
+    end
+  end
+
   private
 
   def hearing_updates

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -175,7 +175,7 @@ class VirtualHearing < CaseflowRecord
   end
 
   def associated_hearing_is_video
-    if hearing.request_type != HearingDay::REQUEST_TYPES[:video]
+    if hearing.original_request_type != HearingDay::REQUEST_TYPES[:video]
       errors.add(:hearing, "must be a video hearing")
     end
   end

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -47,9 +47,9 @@ class LegacyHearing < CaseflowRecord
   vacols_attr_accessor :scheduled_for
 
   # request_type is the current value of HEARSCHED.HEARING_TYPE in VACOLS, but one
-  # should use original_request_type or readable_request_type to make sure we
-  # consistently get the value we expect, as we are now writing to this field in
-  # VACOLS when we convert a legacy hearing to and from virtual.
+  # should use original_request_type to make sure we consistently get the value we
+  # expect, as we are now writing to this field in VACOLS when we convert a legacy
+  # hearing to and from virtual.
   vacols_attr_accessor :request_type
 
   vacols_attr_accessor :venue_key, :vacols_record, :disposition

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -44,7 +44,15 @@ class LegacyHearing < CaseflowRecord
   # scheduled_for is the correct hearing date and time in Eastern Time for travel
   # board and video hearings, or in the user's (Hearing Coordinator) time zone for
   # central hearings; the transformation happens in HearingMapper.datetime_based_on_type
-  vacols_attr_accessor :scheduled_for, :request_type, :venue_key, :vacols_record, :disposition
+  vacols_attr_accessor :scheduled_for
+
+  # request_type is the current value of HEARSCHED.HEARING_TYPE in VACOLS, but one
+  # should use original_request_type or readable_request_type to make sure we
+  # consistently get the value we expect, as we are now writing to this field in
+  # VACOLS when we convert a legacy hearing to and from virtual.
+  vacols_attr_accessor :request_type
+
+  vacols_attr_accessor :venue_key, :vacols_record, :disposition
   vacols_attr_accessor :aod, :hold_open, :transcript_requested, :notes, :add_on
   vacols_attr_accessor :transcript_sent_date, :appeal_vacols_id
   vacols_attr_accessor :representative_name, :hearing_day_vacols_id
@@ -120,8 +128,8 @@ class LegacyHearing < CaseflowRecord
   end
 
   def hearing_day_id_refers_to_vacols_row?
-    (request_type == HearingDay::REQUEST_TYPES[:central] && scheduled_for.to_date < Date.new(2019, 1, 1)) ||
-      (request_type == HearingDay::REQUEST_TYPES[:video] && scheduled_for.to_date < Date.new(2019, 4, 1))
+    (original_request_type == HearingDay::REQUEST_TYPES[:central] && scheduled_for.to_date < Date.new(2019, 1, 1)) ||
+      (original_request_type == HearingDay::REQUEST_TYPES[:video] && scheduled_for.to_date < Date.new(2019, 4, 1))
   end
 
   def hearing_day_id
@@ -147,7 +155,7 @@ class LegacyHearing < CaseflowRecord
   # There is a constraint within the `HearingRepository` context that means that calling
   # `LegacyHearing#regional_office_Key` triggers an unnecessary call to VACOLS.
   def regional_office_key
-    if request_type == HearingDay::REQUEST_TYPES[:travel] || hearing_day.nil?
+    if original_request_type == HearingDay::REQUEST_TYPES[:travel] || hearing_day.nil?
       return (venue_key || appeal&.regional_office_key)
     end
 
@@ -155,7 +163,7 @@ class LegacyHearing < CaseflowRecord
   end
 
   def request_type_location
-    if request_type == HearingDay::REQUEST_TYPES[:central]
+    if original_request_type == HearingDay::REQUEST_TYPES[:central]
       "Board of Veterans' Appeals in Washington, DC"
     elsif venue
       venue[:label]
@@ -226,7 +234,7 @@ class LegacyHearing < CaseflowRecord
   end
 
   def readable_location
-    if request_type == LegacyHearing::CO_HEARING
+    if original_request_type == HearingDay::REQUEST_TYPES[:central]
       return "Washington, DC"
     end
 
@@ -234,7 +242,11 @@ class LegacyHearing < CaseflowRecord
   end
 
   def readable_request_type
-    Hearing::HEARING_TYPES[request_type.to_sym]
+    Hearing::HEARING_TYPES[original_request_type.to_sym]
+  end
+
+  def original_request_type
+    original_vacols_request_type.presence || request_type
   end
 
   cache_attribute :cached_number_of_documents do

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -233,6 +233,19 @@ class LegacyHearing < CaseflowRecord
     end
   end
 
+  def update_request_type_in_vacols(new_request_type)
+    if VACOLS::CaseHearing::HEARING_TYPES.exclude? new_request_type
+      fail HearingMapper::InvalidRequestTypeError, "\"#{new_request_type}\" is not a valid request type."
+    end
+
+    # update original_vacols_request_type if request_type is not virtual
+    if request_type != VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:virtual]
+      update!(original_vacols_request_type: request_type)
+    end
+
+    update_caseflow_and_vacols(request_type: new_request_type)
+  end
+
   def readable_location
     if original_request_type == HearingDay::REQUEST_TYPES[:central]
       return "Washington, DC"

--- a/db/migrate/20200908050443_add_original_vacols_request_type_to_legacy_hearing.rb
+++ b/db/migrate/20200908050443_add_original_vacols_request_type_to_legacy_hearing.rb
@@ -1,0 +1,5 @@
+class AddOriginalVacolsRequestTypeToLegacyHearing < Caseflow::Migration
+  def change
+    add_column :legacy_hearings, :original_vacols_request_type, :string, comment: "The original request type of the hearing in VACOLS, before it was changed to Virtual"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_04_140217) do
+ActiveRecord::Schema.define(version: 2020_09_08_050443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -872,6 +872,7 @@ ActiveRecord::Schema.define(version: 2020_09_04_140217) do
     t.bigint "created_by_id", comment: "The ID of the user who created the Legacy Hearing"
     t.bigint "hearing_day_id", comment: "The hearing day the hearing will take place on"
     t.string "military_service", comment: "Periods and circumstances of military service"
+    t.string "original_vacols_request_type", comment: "The original request type of the hearing in VACOLS, before it was changed to Virtual"
     t.boolean "prepped", comment: "Determines whether the judge has checked the hearing as prepped"
     t.text "summary", comment: "Summary of hearing"
     t.datetime "updated_at", comment: "Timestamp when record was last updated."

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -669,6 +669,7 @@ legacy_hearings,created_by_id,integer (8) FK,,,x,,x,The ID of the user who creat
 legacy_hearings,hearing_day_id,integer (8),,,,,x,The hearing day the hearing will take place on
 legacy_hearings,id,integer (8) PK,x,x,,,,
 legacy_hearings,military_service,string,,,,,,Periods and circumstances of military service
+legacy_hearings,original_vacols_request_type,string,,,,,,"The original request type of the hearing in VACOLS, before it was changed to Virtual"
 legacy_hearings,prepped,boolean,,,,,,Determines whether the judge has checked the hearing as prepped
 legacy_hearings,summary,text,,,,,,Summary of hearing
 legacy_hearings,updated_at,datetime,,,,,x,Timestamp when record was last updated.
@@ -975,7 +976,6 @@ tasks,assigned_at,datetime,,,,,,
 tasks,assigned_by_id,integer FK,,,x,,,
 tasks,assigned_to_id,integer ∗ FK,x,,x,,x,
 tasks,assigned_to_type,string ∗,x,,,,x,
-tasks,cancelled_by_id,integer,,,,,,ID of user that cancelled the task. Backfilled from versions table. Can be nil if task was cancelled before this column was added or if there is no user logged in when the task is cancelled
 tasks,closed_at,datetime,,,,,,
 tasks,created_at,datetime ∗,x,,,,,
 tasks,id,integer (8) PK,x,x,,,,


### PR DESCRIPTION
Resolves #15065

### Description
Support for writing request type (or HEARSCHED.HEARING_TYPE) to VACOLS when converting legacy hearings to and from virtual.

### Database Changes

* [x] Column comments updated
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
