### PR TITLE
Show all attorneys in MTV dropdown for judges with no team

### DIFF
--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -152,9 +152,10 @@ class TaskActionRepository
 
     def address_motion_to_vacate_data(task, _user = nil)
       attorney = task.appeal.assigned_attorney
+      judge_attorneys = JudgeTeam.for_judge(task.assigned_to)&.attorneys
       {
         selected: attorney,
-        options: users_to_options(Attorney.list_all),
+        options: users_to_options([judge_attorneys.presence || Attorney.list_all, attorney].flatten.compact.uniq),
         type: PostDecisionMotion.name
       }
     end

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -154,7 +154,7 @@ class TaskActionRepository
       attorney = task.appeal.assigned_attorney
       {
         selected: attorney,
-        options: users_to_options([JudgeTeam.for_judge(task.assigned_to)&.attorneys, attorney].flatten.compact.uniq),
+        options: users_to_options(Attorney.list_all),
         type: PostDecisionMotion.name
       }
     end


### PR DESCRIPTION
Resolves issue where users cannot reassign a case to an attorney who didn't draft the decision to execute motion to vacate.

Returns allows users with no judge team or no attorneys on their judge team to select from all attorneys.

[Slack Thread](https://dsva.slack.com/archives/CHX8FMP28/p1599248554164500)

testing
```ruby
task = JudgeAddressMotionToVacateTask.active.first
team = JudgeTeam.for_judge(task.assigned_to)
team.attorneys.count
=> 4

task.available_actions_unwrapper(task.assigned_to).last[:data][:options].count
=> 4

OrganizationsUser.where(organization: team, user: team.attorneys).destroy_all
team.attorneys.count
=> 0
task.available_actions_unwrapper(task.assigned_to).last[:data][:options].count
=> 736

team.destroy
JudgeTeam.for_judge(task.assigned_to)
=> nil
task.available_actions_unwrapper(task.assigned_to).last[:data][:options].count
=> 736
```