### PR TITLE
Add Sentry ID from Raven to data integrity job Slack message

### DIFF
--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -32,7 +32,9 @@ class DataIntegrityChecksJob < CaseflowJob
     # don't retry via normal shoryuken, just log and move to next checker.
     rescue StandardError => error
       log_error(error, extra: { checker: klass })
-      slack_service.send_notification("Error running #{klass}", klass, checker.slack_channel)
+      slack_msg = "Error running #{klass}."
+      slack_msg += " See Sentry event #{Raven.last_event_id}" if Raven.last_event_id.present?
+      slack_service.send_notification(slack_msg, klass, checker.slack_channel)
     end
 
     datadog_report_runtime(metric_group_name: "data_integrity_checks_job")

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -112,8 +112,11 @@ describe DataIntegrityChecksJob do
       it "rescues error and logs to sentry and slack" do
         subject
 
-        expect(slack_service).to have_received(:send_notification)
-          .with("Error running ExpiredAsyncJobsChecker. See Sentry event sentry_12345", "ExpiredAsyncJobsChecker", "#appeals-foxtrot")
+        expect(slack_service).to have_received(:send_notification).with(
+          "Error running ExpiredAsyncJobsChecker. See Sentry event sentry_12345",
+          "ExpiredAsyncJobsChecker",
+          "#appeals-foxtrot"
+        )
         expect(@raven_called).to eq(true)
       end
     end

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -37,6 +37,7 @@ describe DataIntegrityChecksJob do
     end
 
     allow(Raven).to receive(:capture_exception) { @raven_called = true }
+    allow(Raven).to receive(:last_event_id) { @raven_called && "sentry_12345" }
   end
 
   describe "#perform" do
@@ -112,6 +113,7 @@ describe DataIntegrityChecksJob do
         subject
 
         expect(slack_service).to have_received(:send_notification)
+          .with("Error running ExpiredAsyncJobsChecker. See Sentry event sentry_12345", "ExpiredAsyncJobsChecker", "#appeals-foxtrot")
         expect(@raven_called).to eq(true)
       end
     end


### PR DESCRIPTION
### Description
Inspired by [this](https://dsva.slack.com/archives/CN3FQR4A1/p1599647433017300) exceptionally uninformative Slack message about some error with LegacyAppealsWithNoVacolsCase.

Modeled after #14536.