### PR TITLE
Removed marked complete task action

### DIFF
--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -12,6 +12,7 @@ class BvaDispatchTask < Task
     if assigned_to == user || parent.task_is_assigned_to_organization_user_administers?(user)
       actions.unshift(Constants.TASK_ACTIONS.DISPATCH_RETURN_TO_JUDGE.to_h)
       actions.delete(Constants.TASK_ACTIONS.ASSIGN_TO_TEAM.to_h)
+      actions.delete(Constants.TASK_ACTIONS.MARK_COMPLETE.to_h)
     end
 
     actions


### PR DESCRIPTION
Resolves #14869 

### Description
Added new action deletion method to remove "Mark Task Complete".

### Acceptance Criteria
- [ ] BvaDispatchTasks cannot be marked complete by anyone through the caseflow task action dropdown

### Testing Plan
1. Sign in as BVADispatch user White.
2. Navigate to your queue.
3. Select a case.
4. Confirm the action is not there.
5. Sign in as BVADispatch admin Black.
6. Navigate to the team assigned queue.
7. Repeat steps 3. and 4.
