### PR TITLE
Fix display of non-vet claimants on non-comp DR tasks

### DIFF
--- a/app/models/serializers/work_queue/decision_review_task_serializer.rb
+++ b/app/models/serializers/work_queue/decision_review_task_serializer.rb
@@ -24,7 +24,9 @@ class WorkQueue::DecisionReviewTaskSerializer
     return "self" unless decision_review(object).veteran_is_not_claimant
 
     claimant = claimant_with_name(object)
-    claimant&.relationship.presence || claimant.class.name.delete_suffix("Claimant")
+    return "Unknown" if claimant.nil?
+
+    claimant.relationship.presence || claimant.class.name.delete_suffix("Claimant")
   end
 
   attribute :claimant do |object|

--- a/app/models/serializers/work_queue/decision_review_task_serializer.rb
+++ b/app/models/serializers/work_queue/decision_review_task_serializer.rb
@@ -24,7 +24,7 @@ class WorkQueue::DecisionReviewTaskSerializer
     return "self" unless decision_review(object).veteran_is_not_claimant
 
     claimant = claimant_with_name(object)
-    claimant.try(:relationship).present? ? claimant.relationship : "claimant"
+    claimant&.relationship.presence || claimant.class.name.delete_suffix("Claimant")
   end
 
   attribute :claimant do |object|

--- a/spec/models/serializers/work_queue/decision_review_task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/decision_review_task_serializer_spec.rb
@@ -34,12 +34,12 @@ describe WorkQueue::DecisionReviewTaskSerializer, :postgres do
         create(:higher_level_review, veteran_file_number: veteran.file_number, veteran_is_not_claimant: true)
       end
 
-      it "returns placeholder 'claimant'" do
+      it "returns placeholder 'Unknown'" do
         serializable_hash = {
           id: task.id.to_s,
           type: :decision_review_task,
           attributes: {
-            claimant: { name: "claimant", relationship: "claimant" },
+            claimant: { name: "claimant", relationship: "Unknown" },
             appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0, activeRequestIssues: [] },
             veteran_participant_id: veteran.participant_id,
             assigned_on: task.assigned_at,
@@ -69,12 +69,12 @@ describe WorkQueue::DecisionReviewTaskSerializer, :postgres do
               veteran_is_not_claimant: true)
       end
 
-      it "returns placeholder 'claimant'" do
+      it "returns relationship based on claimant class" do
         serializable_hash = {
           id: task.id.to_s,
           type: :decision_review_task,
           attributes: {
-            claimant: { name: claimant.name, relationship: "claimant" },
+            claimant: { name: claimant.name, relationship: "Veteran" },
             appeal: { id: hlr.id.to_s, isLegacyAppeal: false, issueCount: 0, activeRequestIssues: [] },
             veteran_participant_id: veteran.participant_id,
             assigned_on: task.assigned_at,


### PR DESCRIPTION
Connects #11301 

### Description
This PR fixes a rare bug in displaying non-veteran claimants' relationship on decision review task pages. It occurs only when the claimant's BGS record has a `nil` relationship. The task mentioned in the original ticket, 248934, is one such instance in prod.

### Acceptance Criteria
- [x] Relationship type shows up on non-compensation queue task page

### Testing Plan
- `DecisionReviewTask.find(248934).ui_hash[:claimant]` is the expression in question
  - Running it on original code produces `{:name=>"REDACTED", :relationship=>"claimant"}`
  - Patch `WorkQueue::DecisionReviewTaskSerializer.claimant_relationship` with the diff of this PR
  - Running it on patched code produces `{:name=>"REDACTED", :relationship=>"Dependent"}`
- Alternatively, if we can find an instance of this missing data in UAT, deploying this branch to UAT should fix it.