### PR TITLE
Remove eligible_due_to_date for aod motions

### DIFF
--- a/app/models/advance_on_docket_motion.rb
+++ b/app/models/advance_on_docket_motion.rb
@@ -17,9 +17,6 @@ class AdvanceOnDocketMotion < CaseflowRecord
   scope :granted, -> { where(granted: true) }
   scope :eligible_due_to_age, -> { age }
   scope :eligible_due_to_appeal, ->(appeal) { where(appeal: appeal).where.not(id: age) }
-  scope :eligible_due_to_date, lambda { |receipt_date|
-    where(created_at: receipt_date..DateTime::Infinity.new).where.not(id: age)
-  }
   scope :for_person, ->(person_id) { where(person_id: person_id) }
 
   class << self
@@ -28,8 +25,7 @@ class AdvanceOnDocketMotion < CaseflowRecord
     end
 
     def eligible_motions(person_id, appeal)
-      eligible_due_to_date(appeal.receipt_date)
-        .or(eligible_due_to_appeal(appeal))
+      eligible_due_to_appeal(appeal)
         .or(eligible_due_to_age)
         .for_person(person_id)
     end

--- a/spec/models/advance_on_docket_motion_spec.rb
+++ b/spec/models/advance_on_docket_motion_spec.rb
@@ -44,14 +44,6 @@ describe AdvanceOnDocketMotion, :postgres do
       end
     end
 
-    describe "#eligible_due_to_date" do
-      it "Returns all motions created after receipt date, but not age related motions" do
-        non_age_motions = described_class.where.not(id: described_class.age)
-        expect(described_class.eligible_due_to_date(1.day.ago).count).to eq non_age_motions.count / creation_dates.count
-        expect(described_class.eligible_due_to_date(31.days.ago).count).to eq non_age_motions.count
-      end
-    end
-
     describe "#eligible_due_to_appeal" do
       it "Returns all motions linked to the appeal, but not age related motions" do
         expect(described_class.eligible_due_to_appeal(appeals.first).pluck(:appeal_id).uniq).to eq [appeals.first.id]
@@ -118,7 +110,7 @@ describe AdvanceOnDocketMotion, :postgres do
       context "and the motion was granted after the appeal receipt date" do
         let(:appeal_receipt_date) { 30.days.ago }
 
-        it { is_expected.to be true }
+        it { is_expected.to be false }
       end
     end
   end


### PR DESCRIPTION
Resolves #14085

### Description
Remove old check that allowed a motion to be associated with an appeal because the motion was created after the appeal's receipt date. We have now [associated every motion with an appeal](https://github.com/department-of-veterans-affairs/caseflow/issues/14085#issuecomment-692347472) and this incorrect check should be removed.

### Acceptance Criteria
Appeals are only considered aod due to motion if there is an 
- [ ] age related motion that applies to any appeal with the same claimant
- [ ] any other reason related motion that applies to that exact appeal

### Testing Plan
1. Sign in as AOD_USER and find any non aod ama case
```ruby
appeal = Appeal.find_by(uuid: "173b6ce2-070c-4eec-a463-301f8f18c70e")
appeal.aod?
=> false
```
2. Find the "Edit" link next to the appeal stream type
1. Grant an AOD motion for any reason other than age
```ruby
appeal.aod?
=> true
```
4. Remove the appeal from the aod motion
```ruby
motion = AdvanceOnDocketMotion.find_by(appeal: appeal)
motion.update_attribute('appeal_id', nil)
AdvanceOnDocketMotion.find_by(appeal: appeal)
=> nil
appeal.aod?
=> false
AdvanceOnDocketMotion.first.created_at > appeal.receipt_date
=> true
```
5. Ensure aod does not show up in the ui by reloading case details