### PR TITLE
Use request_type instead of readabale_request_type to determine RO

### DIFF
--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -95,7 +95,7 @@ export default class DailyDocket extends React.Component {
 
     // for Central hearing days, return 'C'
     // Otherwise assume it's a video hearing day and return RO key
-    return dailyDocket.requestType === 'C' ? 'C' : dailyDocket.regionalOfficeKey
+    return dailyDocket.requestType === 'C' ? 'C' : dailyDocket.regionalOfficeKey;
   };
 
   openDispositionModal = ({ hearing, fromDisposition, toDisposition, onConfirm, onCancel }) => {

--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -93,7 +93,9 @@ export default class DailyDocket extends React.Component {
   getRegionalOffice = () => {
     const { dailyDocket } = this.props;
 
-    return dailyDocket.readableRequestType === 'Central' ? 'C' : dailyDocket.regionalOfficeKey;
+    // for Central hearing days, return 'C'
+    // Otherwise assume it's a video hearing day and return RO key
+    return dailyDocket.requestType === 'C' ? 'C' : dailyDocket.regionalOfficeKey
   };
 
   openDispositionModal = ({ hearing, fromDisposition, toDisposition, onConfirm, onCancel }) => {


### PR DESCRIPTION
### Description
#### Background
This PR fixes an issue with central dockets where [these sentrey errors](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/11573/?referrer=webhooks_plugin) started popping up because we were fetching hearing locations on daily docket with `regionalOffice=null`. This `regionalOffice` was getting set to `null` by this [logic](https://github.com/department-of-veterans-affairs/caseflow/blob/e6279de98591de6b6a5fa7657c0769c00715b963/client/app/hearings/components/dailyDocket/DailyDocket.jsx#L96) because we were using `readableRequestType` from hearingDay object which now returns `Central`, `Central, Virtual`, or `Virtual` as central hearings are being converted to virtual since the release of this feature to some hearings users ([slack request](https://dsva.slack.com/archives/C3EAF3Q15/p1599238807134300)).

#### Fix
The fix was to keep `readableRequestType` only for displaying to users and instead use `requestType` (which is currently either `C` or `V`) to  determine the `regionalOffice` for a hearing day. 

#### Reference
[Slack thread for discussion](https://dsva.slack.com/archives/C01155MJGF2/p1600128301012900)

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

#### BEFORE
<img width="861" alt="Screen Shot 2020-09-15 at 1 29 48 PM" src="https://user-images.githubusercontent.com/20735998/93244662-13d30280-f758-11ea-85aa-742de2182485.png"> 

#### AFTER
<img width="833" alt="Screen Shot 2020-09-15 at 1 30 01 PM" src="https://user-images.githubusercontent.com/20735998/93244683-1afa1080-f758-11ea-9f3a-c3ad7a5d8727.png">



### Testing Plan
1. Enable feature toggle on rails console`FeatureToggle.enable!(:schedule_virtual_hearings_for_central, users: [User.find_by(css_id: "BVASYELLOW")])`
2. Login as `BVASYELLOW`
3. Go to http://localhost:3000/hearings/schedule and pick a central hearing day with 2 or more hearings
4. Convert a hearing to `Virtual` 
5. Go back to daily docket and notice that the hearing locations are fetched without errors