### PR TITLE
Add EndProductChangeValidator for calculating edit eligibility

### DIFF
--- a/app/workflows/end_product_change_validator.rb
+++ b/app/workflows/end_product_change_validator.rb
@@ -54,7 +54,7 @@ class EndProductChangeValidator
   end
 
   def disallowed_disposition_change?
-    ["board_remand", "dta_error", "difference_of_opinion"].any? do |disp|
+    %w[board_remand dta_error difference_of_opinion].any? do |disp|
       old_hash[:disposition_type] == disp && new_hash[:disposition_type] != disp
     end
   end

--- a/app/workflows/end_product_change_validator.rb
+++ b/app/workflows/end_product_change_validator.rb
@@ -31,7 +31,6 @@ class EndProductChangeValidator
     !(claim_family_change? ||
       source_review_change? ||
       fiduciary? ||
-      disallowed_board_grant_change? ||
       disallowed_disposition_change?)
   end
 
@@ -49,12 +48,8 @@ class EndProductChangeValidator
     [old_hash[:benefit_type], new_hash[:benefit_type]].include?("fiduciary")
   end
 
-  def disallowed_board_grant_change?
-    old_code.start_with?("030BG") && !new_code.start_with?("030BG")
-  end
-
   def disallowed_disposition_change?
-    %w[board_remand dta_error difference_of_opinion].any? do |disp|
+    %w[allowed board_remand dta_error difference_of_opinion].any? do |disp|
       old_hash[:disposition_type] == disp && new_hash[:disposition_type] != disp
     end
   end

--- a/app/workflows/end_product_change_validator.rb
+++ b/app/workflows/end_product_change_validator.rb
@@ -28,7 +28,11 @@ class EndProductChangeValidator
   end
 
   def code_change_allowed?
-    !(claim_family_change? || source_review_change? || fiduciary? || disallowed_disposition_change?)
+    !(claim_family_change? ||
+      source_review_change? ||
+      fiduciary? ||
+      disallowed_board_grant_change? ||
+      disallowed_disposition_change?)
   end
 
   private
@@ -43,6 +47,10 @@ class EndProductChangeValidator
 
   def fiduciary?
     [old_hash[:benefit_type], new_hash[:benefit_type]].include?("fiduciary")
+  end
+
+  def disallowed_board_grant_change?
+    old_code.start_with?("030BG") && !new_code.start_with?("030BG")
   end
 
   def disallowed_disposition_change?

--- a/app/workflows/end_product_change_validator.rb
+++ b/app/workflows/end_product_change_validator.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class EndProductChangeValidator
+  class << self
+    def claim_types
+      Constants.EP_CLAIM_TYPES.to_h
+    end
+
+    def eligible_new_codes(code)
+      eligible_new_codes_hash(code).keys.map(&:to_s)
+    end
+
+    def eligible_new_codes_hash(code)
+      claim_types.select do |new_code, _val|
+        new_code = new_code.to_s
+        new_code != code && EndProductChangeValidator.new(code, new_code).code_change_allowed?
+      end
+    end
+  end
+
+  attr_reader :old_code, :old_hash, :new_code, :new_hash
+
+  def initialize(old_code, new_code)
+    @old_code = old_code
+    @new_code = new_code
+    @old_hash = EndProductChangeValidator.claim_types[old_code.to_sym]
+    @new_hash = EndProductChangeValidator.claim_types[new_code.to_sym]
+  end
+
+  def code_change_allowed?
+    !(claim_family_change? || source_review_change? || fiduciary? || disallowed_disposition_change?)
+  end
+
+  private
+
+  def claim_family_change?
+    old_hash[:family] != new_hash[:family]
+  end
+
+  def source_review_change?
+    old_hash[:review_type] != new_hash[:review_type]
+  end
+
+  def fiduciary?
+    [old_hash[:benefit_type], new_hash[:benefit_type]].include?("fiduciary")
+  end
+
+  def disallowed_disposition_change?
+    ["board_remand", "dta_error", "difference_of_opinion"].any? do |disp|
+      old_hash[:disposition_type] == disp && new_hash[:disposition_type] != disp
+    end
+  end
+end

--- a/spec/workflows/end_product_change_validator_spec.rb
+++ b/spec/workflows/end_product_change_validator_spec.rb
@@ -40,7 +40,7 @@ describe EndProductChangeValidator do
       let(:code) { "030BGR" }
 
       it "allows changes only to other BGE codes" do
-        expect(subject.keys).to all start_with("030BG")
+        expect(subject.values).to all include(disposition_type: "allowed")
       end
     end
 

--- a/spec/workflows/end_product_change_validator_spec.rb
+++ b/spec/workflows/end_product_change_validator_spec.rb
@@ -36,6 +36,14 @@ describe EndProductChangeValidator do
       end
     end
 
+    context "when original code is for a remand" do
+      let(:code) { "030BGR" }
+
+      it "allows changes only to other BGE codes" do
+        expect(subject.keys).to all start_with("030BG")
+      end
+    end
+
     context "when original code is for a DTA claim" do
       let(:code) { "040HDENR" }
 

--- a/spec/workflows/end_product_change_validator_spec.rb
+++ b/spec/workflows/end_product_change_validator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe EndProductChangeValidator do
+  describe "#eligible_new_codes_hash" do
+    subject { EndProductChangeValidator.eligible_new_codes_hash(code) }
+
+    context "when original code is in the 040 family" do
+      let(:code) { "040SCNRPMC" }
+      
+      it "allows changes only to other 040 codes" do
+        expect(subject.values).to all include(family: "040")
+      end
+    end
+
+    context "when original code is for an HLR" do
+      let(:code) { "030HLRR" }
+
+      it "allows changes only to other HLR codes" do
+        expect(subject.values).to all include(review_type: "higher_level_review")
+      end
+    end
+
+    context "when original code is for fiduciary benefit type" do
+      let(:code) { "040SCRFID" }
+
+      it "allows no changes" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "when original code is for a remand" do
+      let(:code) { "040BDENR" }
+
+      it "allows changes only to other remand codes" do
+        expect(subject.values).to all include(disposition_type: "board_remand")
+      end
+    end
+
+    context "when original code is for a DTA claim" do
+      let(:code) { "040HDENR" }
+
+      it "allows changes only to other DTA codes" do
+        expect(subject.values).to all include(disposition_type: "dta_error")
+      end
+    end
+
+    context "when original code is for a DOO claim" do
+      let(:code) { "930AHNRCPMC" }
+
+      it "allows changes only to other DOO codes" do
+        expect(subject.values).to all include(disposition_type: "difference_of_opinion")
+      end
+    end
+  end
+end

--- a/spec/workflows/end_product_change_validator_spec.rb
+++ b/spec/workflows/end_product_change_validator_spec.rb
@@ -6,7 +6,7 @@ describe EndProductChangeValidator do
 
     context "when original code is in the 040 family" do
       let(:code) { "040SCNRPMC" }
-      
+
       it "allows changes only to other 040 codes" do
         expect(subject.values).to all include(family: "040")
       end


### PR DESCRIPTION
Connects #15113

### Description
This PR adds a new workflow, EndProductChangeValidator, that calculates the new EP codes an existing code is allowed to change to.

### Acceptance Criteria
- [ ] Add a method to EndProductEstablishment that can calculate the eligible new codes, based on the current end product establishment code
- Exclusions:
  - [x] Changes between different families (040 / 030 / 930)
  - [x] Changes between different source review types (SC / HLR / Appeal)
  - [ ] ~End Product codes not currently supported in Caseflow~
  - [x] Remand to a non-remand
  - [x] Board grant effectuation to a non-board grant effectuation
  - [x] Fiduciary claims
  - [x] DTA claims to a non-DTA claim
  - [x] DOO claims to a non-DOO claim
- [x] Update documentation: [End product codes](https://github.com/department-of-veterans-affairs/caseflow/wiki/End-product-codes)

### Testing Plan
1. New spec file added. Check it out; I'm pretty happy with the way I was able to structure the examples and expectations.
2. Play around with the class in Rails console. It's pretty straightforward, as it has no dependencies or integrations outside of the constants file. Example:

```ruby
> EndProductChangeValidator.eligible_new_codes("030BGR")
=> ["030BGNRPMC", "030BGRNR", "030BGRPMC"]
> EndProductChangeValidator.eligible_new_codes_hash("030BGR")
=> {:"030BGNRPMC"=>
  {:offical_label=>"PMC Board Grant nonrating",
   :benefit_type=>"pension",
...
```