### PR TITLE
Updates ruby gem to include Edit EP Claim Labels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "activerecord-import"
 gem "acts_as_tree"
 # BGS
 
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "ca870f0b543406b8d7a6be93ca7b3ed1797bacbf"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "128938e80b083588164233b1db91ea7b677a2627"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "business_time", "~> 0.9.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,8 +47,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: ca870f0b543406b8d7a6be93ca7b3ed1797bacbf
-  ref: ca870f0b543406b8d7a6be93ca7b3ed1797bacbf
+  revision: 128938e80b083588164233b1db91ea7b677a2627
+  ref: 128938e80b083588164233b1db91ea7b677a2627
   specs:
     bgs (0.2)
       httpclient
@@ -618,7 +618,8 @@ GEM
     uniform_notifier (1.12.1)
     validates_email_format_of (1.6.3)
       i18n
-    wasabi (3.5.0)
+    wasabi (3.6.1)
+      addressable
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
     webdrivers (4.1.2)


### PR DESCRIPTION
Connects #14888
connects https://github.com/department-of-veterans-affairs/ruby-bgs/pull/108

### Description
Please explain the changes you made here.

We'd like to implement the BGS service for updating claims, in order to use it for Edit EP claim labels. This should allow us to update the EP type code without losing any work that's happened so far on the claim. Updating the claim label should automatically re-route the claim in VBMS.