### PR TITLE
Pass Sentry event ID to frontend for displaying Intake errors

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -66,6 +66,9 @@ class IntakesController < ApplicationController
       error_code: error.error_code,
       error_data: detail.end_product_base_modifier
     }, status: :bad_request
+  rescue StandardError => error
+    log_error(error)
+    render json: { error_code: "default", error_uuid: error_id }, status: :internal_server_error
   end
 
   def attorneys

--- a/client/app/intake/actions/intake.js
+++ b/client/app/intake/actions/intake.js
@@ -146,12 +146,14 @@ export const submitIntakeCompleteRequest = (intakeId, data) => (dispatch) => {
         const responseObject = error.response.body || {};
         const responseErrorCode = responseObject.error_code;
         const responseErrorData = responseObject.error_data;
+        const responseErrorUUID = responseObject.error_uuid;
 
         dispatch({
           type: ACTIONS.COMPLETE_INTAKE_FAIL,
           payload: {
             responseErrorCode,
-            responseErrorData
+            responseErrorData,
+            responseErrorUUID
           },
           meta: { analytics }
         });

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -151,7 +151,8 @@ class AddIssuesPage extends React.Component {
     }
 
     const requestState = intakeData.requestStatus.completeIntake || intakeData.requestStatus.requestIssuesUpdate;
-    const requestErrorCode = intakeData.requestStatus.completeIntakeErrorCode || intakeData.requestIssuesUpdateErrorCode;
+    const requestErrorCode =
+      intakeData.requestStatus.completeIntakeErrorCode || intakeData.requestIssuesUpdateErrorCode;
     const requestErrorUUID = intakeData.requestStatus.completeIntakeErrorUUID;
     const showInvalidVeteranError =
       !intakeData.veteranValid &&
@@ -325,7 +326,9 @@ class AddIssuesPage extends React.Component {
         )}
         <h1 className="cf-txt-c">{messageHeader}</h1>
 
-        {requestState === REQUEST_STATE.FAILED && <ErrorAlert errorCode={requestErrorCode} errorUUID={requestErrorUUID} />}
+        {requestState === REQUEST_STATE.FAILED && (
+          <ErrorAlert errorCode={requestErrorCode} errorUUID={requestErrorUUID} />
+        )}
 
         {showInvalidVeteranError && (
           <ErrorAlert errorCode="veteran_not_valid" errorData={intakeData.veteranInvalidFields} />

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -151,7 +151,8 @@ class AddIssuesPage extends React.Component {
     }
 
     const requestState = intakeData.requestStatus.completeIntake || intakeData.requestStatus.requestIssuesUpdate;
-    const requestErrorCode = intakeData.completeIntakeErrorCode || intakeData.requestIssuesUpdateErrorCode;
+    const requestErrorCode = intakeData.requestStatus.completeIntakeErrorCode || intakeData.requestIssuesUpdateErrorCode;
+    const requestErrorUUID = intakeData.requestStatus.completeIntakeErrorUUID;
     const showInvalidVeteranError =
       !intakeData.veteranValid &&
       _.some(
@@ -324,7 +325,7 @@ class AddIssuesPage extends React.Component {
         )}
         <h1 className="cf-txt-c">{messageHeader}</h1>
 
-        {requestState === REQUEST_STATE.FAILED && <ErrorAlert errorCode={requestErrorCode} />}
+        {requestState === REQUEST_STATE.FAILED && <ErrorAlert errorCode={requestErrorCode} errorUUID={requestErrorUUID} />}
 
         {showInvalidVeteranError && (
           <ErrorAlert errorCode="veteran_not_valid" errorData={intakeData.veteranInvalidFields} />

--- a/client/app/intake/pages/appeal/review.jsx
+++ b/client/app/intake/pages/appeal/review.jsx
@@ -53,7 +53,7 @@ class Review extends React.PureComponent {
     return <div>
       <h1>Review { veteranName }'s { FORM_TYPES.APPEAL.name }</h1>
 
-      { reviewIntakeError && <ErrorAlert /> }
+      { reviewIntakeError && <ErrorAlert {...reviewIntakeError} /> }
 
       <DateSelector
         name="receipt-date"
@@ -95,7 +95,7 @@ Review.propTypes = {
   docketTypeError: PropTypes.string,
   legacyOptInApproved: PropTypes.bool,
   legacyOptInApprovedError: PropTypes.string,
-  reviewIntakeError: PropTypes.string,
+  reviewIntakeError: PropTypes.object,
   setDocketType: PropTypes.func,
   setReceiptDate: PropTypes.func,
   setLegacyOptInApproved: PropTypes.func,

--- a/client/app/intake/pages/higherLevelReview/review.jsx
+++ b/client/app/intake/pages/higherLevelReview/review.jsx
@@ -55,7 +55,7 @@ class Review extends React.PureComponent {
     return <div>
       <h1>Review { veteranName }'s { FORM_TYPES.HIGHER_LEVEL_REVIEW.name }</h1>
 
-      { reviewIntakeError && <ErrorAlert /> }
+      { reviewIntakeError && <ErrorAlert {...reviewIntakeError} /> }
       { showInvalidVeteranError && <ErrorAlert errorCode="veteran_not_valid" errorData={veteranInvalidFields} /> }
 
       <BenefitType
@@ -123,7 +123,7 @@ Review.propTypes = {
   sameOfficeError: PropTypes.string,
   legacyOptInApproved: PropTypes.string,
   legacyOptInApprovedError: PropTypes.string,
-  reviewIntakeError: PropTypes.string,
+  reviewIntakeError: PropTypes.object,
   veteranValid: PropTypes.bool,
   veteranInvalidFields: PropTypes.object,
   setBenefitType: PropTypes.func,

--- a/client/app/intake/pages/supplementalClaim/review.jsx
+++ b/client/app/intake/pages/supplementalClaim/review.jsx
@@ -48,7 +48,7 @@ class Review extends React.PureComponent {
     return <div>
       <h1>Review { veteranName }'s { FORM_TYPES.SUPPLEMENTAL_CLAIM.name }</h1>
 
-      { reviewIntakeError && <ErrorAlert errorUUID={this.props.errorUUID} /> }
+      { reviewIntakeError && <ErrorAlert {...reviewIntakeError} /> }
       { showInvalidVeteranError &&
           <ErrorAlert
             errorUUID={this.props.errorUUID}
@@ -95,7 +95,7 @@ Review.propTypes = {
   sameOfficeError: PropTypes.string,
   legacyOptInApproved: PropTypes.string,
   legacyOptInApprovedError: PropTypes.string,
-  reviewIntakeError: PropTypes.string,
+  reviewIntakeError: PropTypes.object,
   veteranValid: PropTypes.bool,
   veteranInvalidFields: PropTypes.object,
   setBenefitType: PropTypes.func,

--- a/client/app/intake/reducers/appeal.js
+++ b/client/app/intake/reducers/appeal.js
@@ -194,7 +194,7 @@ export const appealReducer = (state = mapDataToInitialAppeal(), action) => {
           $set: REQUEST_STATE.FAILED
         },
         reviewIntakeError: {
-          $set: getPageError(action.payload.responseErrorCodes)
+          $set: getPageError(action.payload)
         }
       }
     });

--- a/client/app/intake/reducers/higherLevelReview.js
+++ b/client/app/intake/reducers/higherLevelReview.js
@@ -270,6 +270,9 @@ export const higherLevelReviewReducer = (state = mapDataToInitialHigherLevelRevi
         },
         completeIntakeErrorData: {
           $set: action.payload.responseErrorData
+        },
+        completeIntakeErrorUUID: {
+          $set: action.payload.responseErrorUUID
         }
       }
     });

--- a/client/app/intake/reducers/higherLevelReview.js
+++ b/client/app/intake/reducers/higherLevelReview.js
@@ -233,7 +233,7 @@ export const higherLevelReviewReducer = (state = mapDataToInitialHigherLevelRevi
           $set: REQUEST_STATE.FAILED
         },
         reviewIntakeError: {
-          $set: getPageError(action.payload.responseErrorCodes)
+          $set: getPageError(action.payload)
         }
       }
     });

--- a/client/app/intake/reducers/rampElection.js
+++ b/client/app/intake/reducers/rampElection.js
@@ -149,7 +149,7 @@ export const rampElectionReducer = (state = mapDataToInitialRampElection(), acti
           $set: REQUEST_STATE.FAILED
         },
         reviewIntakeError: {
-          $set: getPageError(action.payload.responseErrorCodes)
+          $set: getPageError(action.payload)
         }
       }
     });

--- a/client/app/intake/reducers/rampRefiling.js
+++ b/client/app/intake/reducers/rampRefiling.js
@@ -172,7 +172,7 @@ export const rampRefilingReducer = (state = mapDataToInitialRampRefiling(), acti
           $set: REQUEST_STATE.FAILED
         },
         reviewIntakeError: {
-          $set: getPageError(action.payload.responseErrorCodes)
+          $set: getPageError(action.payload)
         }
       }
     });

--- a/client/app/intake/reducers/supplementalClaim.js
+++ b/client/app/intake/reducers/supplementalClaim.js
@@ -199,7 +199,7 @@ export const supplementalClaimReducer = (state = mapDataToInitialSupplementalCla
           $set: REQUEST_STATE.FAILED
         },
         reviewIntakeError: {
-          $set: getPageError(action.payload.responseErrorCodes)
+          $set: getPageError(action.payload)
         },
         errorUUID: {
           $set: action.payload.errorUUID

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -13,9 +13,11 @@ export const getClaimantError = (responseErrorCodes) => {
   return CLAIMANT_ERRORS[errorCode];
 };
 
-export const getPageError = (responseErrorCodes) => (
-  _.get(responseErrorCodes.other, 0) === 'unknown_error' ? 'Unknown error.' : null
-);
+export const getPageError = (responseErrorPayload) => {
+  if (_.get(responseErrorPayload.responseErrorCodes.other, 0) === 'unknown_error') {
+    return { errorCode: 'default', errorUUID: responseErrorPayload.errorUUID };
+  }
+};
 
 // use this conversion to change between rails model and react radio input
 // otherwise we send over a string true/false and reloading turns it into a boolean

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -14,8 +14,8 @@ export const getClaimantError = (responseErrorCodes) => {
 };
 
 export const getPageError = (responseErrorPayload) => {
-  if (_.get(responseErrorPayload.responseErrorCodes.other, 0) === 'unknown_error') {
-    return { errorCode: 'default', errorUUID: responseErrorPayload.errorUUID };
+  if (responseErrorPayload.responseErrorCodes.other?.[0] === 'unknown_error') {
+    return { errorCode: null, errorUUID: responseErrorPayload.errorUUID };
   }
 };
 

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -133,9 +133,8 @@ RSpec.describe IntakesController, :postgres do
           intake = Intake.new(user_id: current_user.id, started_at: Time.zone.now)
           intake.save!
           allow_any_instance_of(Intake).to receive(:complete!).and_raise(unknown_error)
-          expect do
-            post :complete, params: { id: intake.id }
-          end.to raise_error(Caseflow::Error::EstablishClaimFailedInVBMS)
+          post :complete, params: { id: intake.id }
+          expect(response.status).to eq(500)
         end
       end
 

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -148,6 +148,7 @@ feature "Intake", :all_dbs do
 
     scenario "Search for a veteran but search throws an unhandled exception" do
       expect_any_instance_of(Intake).to receive(:start!).and_raise("random error")
+      allow(Raven).to receive(:last_event_id).and_return("sentry_event_id")
       visit "/intake"
       select_form(Constants.INTAKE_FORM_NAMES.higher_level_review)
       safe_click ".cf-submit.usa-button"
@@ -159,7 +160,7 @@ feature "Intake", :all_dbs do
 
       expect(page).to have_current_path("/intake/search")
       expect(page).to have_content("Something went wrong")
-      expect(page).to have_content(/Error code \w+-\w+-\w+-\w+/)
+      expect(page).to have_content("Error code sentry_event_id")
     end
 
     scenario "Search for a veteran with an incident flash" do

--- a/spec/feature/intake/intake_spec.rb
+++ b/spec/feature/intake/intake_spec.rb
@@ -148,7 +148,6 @@ feature "Intake", :all_dbs do
 
     scenario "Search for a veteran but search throws an unhandled exception" do
       expect_any_instance_of(Intake).to receive(:start!).and_raise("random error")
-      allow(Raven).to receive(:last_event_id).and_return("sentry_event_id")
       visit "/intake"
       select_form(Constants.INTAKE_FORM_NAMES.higher_level_review)
       safe_click ".cf-submit.usa-button"
@@ -160,7 +159,7 @@ feature "Intake", :all_dbs do
 
       expect(page).to have_current_path("/intake/search")
       expect(page).to have_content("Something went wrong")
-      expect(page).to have_content("Error code sentry_event_id")
+      expect(page).to have_content("Error code 00000000000000000123456789abcdef")
     end
 
     scenario "Search for a veteran with an incident flash" do


### PR DESCRIPTION
Connects #15261 

### Description
This PR updates the error reporting mechanisms in Intake so that Sentry event IDs are always displayed on the frontend (and logged by Rails) whenever unexpected exceptions are thrown and propagate up to the controller. Unlike Caseflow-originated UUIDs, event IDs are the primary key in Sentry, providing an easy and painless way to go from a Bat Team report to a stack trace.

A few recent incidents where unexpected exceptions in Intake resulted in unspecific Bat Team reports:
- when submitting an SSN: [Bat thread](https://dsva.slack.com/archives/CHX8FMP28/p1600810948046300) resulting in #15296 
- when performing the review step: [Bat thread](https://dsva.slack.com/archives/CHX8FMP28/p1600289624269300) resulting in #15259
- when attempting establishment: [Bat thread](https://dsva.slack.com/archives/CHX8FMP28/p1598295178042100) resulting in #15190 - subsequent [investigation](https://dsva.slack.com/archives/C54QCEHAL/p1600705176022200) shows relevance to #12967

Each of these situations has a before-and-after treatment in the User Facing Changes section below.

### Acceptance Criteria
- [x] more useful error message or URL to facilitate error reproduction and investigation

### Testing Plan
1. Tests updated!

### User Facing Changes

#### When submitting an SSN causes an unexpected error
Before:
<img width="871" src="https://user-images.githubusercontent.com/282869/94306303-ae91c500-ff40-11ea-8ef2-543849427ab2.png">

After:
<img width="871" src="https://user-images.githubusercontent.com/282869/94306316-b6ea0000-ff40-11ea-84cb-1f5b522c76f4.png">

#### When performing the review step causes an unexpected error
Before:
<img width="873" src="https://user-images.githubusercontent.com/282869/94306351-cc5f2a00-ff40-11ea-81c8-84660597e5a7.png">

After:
<img width="874" src="https://user-images.githubusercontent.com/282869/94306368-d41ece80-ff40-11ea-8ba0-3c8f8ed8f7f2.png">

#### When attempting establishment causes an unexpected error
Before:
<img width="878" src="https://user-images.githubusercontent.com/282869/94306420-eac52580-ff40-11ea-902f-6a250edc07a7.png">

After:
<img width="875" src="https://user-images.githubusercontent.com/282869/94306444-f6185100-ff40-11ea-8591-19daf937e749.png">

