### PR TITLE
Geomatch Travel Board Hearings

### DIFF
--- a/app/jobs/fetch_hearing_locations_for_veterans_job.rb
+++ b/app/jobs/fetch_hearing_locations_for_veterans_job.rb
@@ -104,9 +104,14 @@ class FetchHearingLocationsForVeteransJob < ApplicationJob
   def find_travel_board_appeals_ready_for_geomatching(exclude_ids)
     VACOLS::Case
       .where(
+        # Travle Board Hearing Request
         bfhr: VACOLS::Case::HEARING_PREFERENCE_TYPES_V2[:TRAVEL_BOARD][:vacols_value],
+        # Current Location
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+        # Video Hearing Request Indicator
         bfdocind: nil,
-        bfdocind: nil
+        # Datetime of Decision
+        bfddec: nil
       )
       .where.not(bfkey: exclude_ids)
       .map do |vacols_case|

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -509,12 +509,27 @@ class Appeal < DecisionReview
     false
   end
 
+  # Returns the hearing request type.
+  #
+  # @note See `LegacyAppeal#sanitized_hearing_request_type` for more information.
+  #   This method is provided for compatibility.
+  def sanitized_hearing_request_type
+    return nil if closest_regional_office.nil?
+
+    (closest_regional_office == "C") ? :central : :video
+  end
+
   # Determine type using cloesest_regional_office
   # "Central" if closest_regional_office office is "C", "Video" otherwise
   def readable_hearing_request_type
-    return nil if closest_regional_office.nil?
-
-    (closest_regional_office == "C") ? Hearing::HEARING_TYPES[:C] : Hearing::HEARING_TYPES[:V]
+    case sanitized_hearing_request_type
+    when nil
+      nil
+    when :central
+      Hearing::HEARING_TYPES[:C]
+    else
+      Hearing::HEARING_TYPES[:V]
+    end
   end
 
   private

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -761,8 +761,9 @@
   "VIRTUAL_HEARING_TIMEZONE_REQUIRED": "Timezone is required to send email notifications.",
   "MISSING_EMAIL_ALERT_MESSAGE": "If you have the %s's email address, enter it in VBMS. The email will be required to send notifications when you schedule the hearing.",
   "CONVERT_HEARING_TYPE_TITLE": "Convert Hearing To %s",
-  "CONVERT_HEARING_TYPE_SUBTITLE": "The hearing request will appear in the scheduling queue for <strong>%s</strong>.",
+  "CONVERT_HEARING_TYPE_SUBTITLE": "The hearing request will appear in the scheduling queue for %s.",
   "CONVERT_HEARING_TYPE_SUBTITLE_2": "Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing.",
+  "CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT": "the appropriate regional office",
 
   "JUDGE_TEAM_REMOVE_JUDGE_ERROR": "Cannot remove a judge from their judge team.",
   "JUDGE_TEAM_ATTORNEY_RIGHTS_ERROR": "Cannot edit attorney rights on non-attorneys",

--- a/client/app/hearings/components/HearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/HearingTypeConversionForm.jsx
@@ -52,15 +52,18 @@ export const HearingTypeConversionForm = ({
   };
 
   const convertTitle = sprintf(COPY.CONVERT_HEARING_TYPE_TITLE, type);
+  const convertSubtitle = sprintf(
+    COPY.CONVERT_HEARING_TYPE_SUBTITLE,
+    appeal?.closestRegionalOfficeLabel ?
+      `<strong>${appeal.closestRegionalOfficeLabel}</strong>` :
+      COPY.CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT
+  );
 
   return (
     <React.Fragment>
       <AppSegment filledBackground>
         <h1 className="cf-margin-bottom-0">{convertTitle}</h1>
-        <p dangerouslySetInnerHTML={
-          { __html: sprintf(COPY.CONVERT_HEARING_TYPE_SUBTITLE, appeal?.closestRegionalOfficeLabel ?? '') }
-        }
-        />
+        <p dangerouslySetInnerHTML={{ __html: convertSubtitle }} />
         <HelperText label={COPY.CONVERT_HEARING_TYPE_SUBTITLE_2} />
         <AppellantSection {...sectionProps} />
         <RepresentativeSection {...sectionProps} />

--- a/client/app/hearings/components/HearingTypeConversionForm.stories.js
+++ b/client/app/hearings/components/HearingTypeConversionForm.stories.js
@@ -55,3 +55,12 @@ MissingVeteranEmailAlert.args = {
     }
   }
 }
+
+export const AppealNotGeomatchedYet = Template.bind({});
+AppealNotGeomatchedYet.args = {
+  ...Basic.args,
+  appeal: {
+    ...legacyAppealForTravelBoard,
+    closestRegionalOfficeLabel: null
+  }
+};

--- a/client/test/app/hearings/components/HearingTypeConversionForm.test.js
+++ b/client/test/app/hearings/components/HearingTypeConversionForm.test.js
@@ -9,6 +9,8 @@ import { AddressLine } from 'app/hearings/components/details/Address';
 import { VirtualHearingEmail } from 'app/hearings/components/VirtualHearings/Emails';
 import { getAppellantTitle } from 'app/hearings/utils';
 
+import COPY from 'COPY';
+
 describe('HearingTypeConversionForm', () => {
   test('Matches snapshot with default props', () => {
     const hearingTypeConversionForm = mount(
@@ -57,9 +59,32 @@ describe('HearingTypeConversionForm', () => {
         appeal={appeal}
         type={'Virtual'}
       />
-    )
+    );
 
     expect(hearingTypeConversionForm.find('.usa-alert')).toHaveLength(1);
+    expect(hearingTypeConversionForm).toMatchSnapshot();
+  });
+
+  test('Displays "the appropriate regional office" when closest regional office has not been determined yet', () => {
+    const appeal = {
+      ...legacyAppealForTravelBoard,
+      closestRegionalOfficeLabel: null
+    };
+
+    const hearingTypeConversionForm = mount(
+      <HearingTypeConversionForm
+        appeal={appeal}
+        type={'Virtual'}
+      />
+    );
+
+    expect(
+      hearingTypeConversionForm
+        .find('p')
+        .first()
+        .text()
+        .includes(COPY.CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT)
+    ).toEqual(true);
     expect(hearingTypeConversionForm).toMatchSnapshot();
   });
 });

--- a/client/test/app/hearings/components/__snapshots__/HearingTypeConversionForm.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingTypeConversionForm.test.js.snap
@@ -382,6 +382,361 @@ exports[`HearingTypeConversionForm Display missing email alert 1`] = `
 </HearingTypeConversionForm>
 `;
 
+exports[`HearingTypeConversionForm Displays "the appropriate regional office" when closest regional office has not been determined yet 1`] = `
+<HearingTypeConversionForm
+  appeal={
+    Object {
+      "appellantAddress": Object {
+        "address_line_1": "9999 MISSION ST",
+        "address_line_2": "UBER",
+        "address_line_3": "APT 2",
+        "city": "SAN FRANCISCO",
+        "country": "USA",
+        "state": "CA",
+        "zip": "94103",
+      },
+      "appellantFullName": "Abellona Valtas",
+      "appellantIsNotVeteran": false,
+      "appellantRelationship": "Spouse",
+      "assignedAttorney": null,
+      "assignedJudge": null,
+      "assignedToLocation": "Hearing Admin",
+      "attorneyCaseRewriteDetails": Object {
+        "note_from_attorney": null,
+        "untimely_evidence": null,
+      },
+      "availableHearingLocations": Array [],
+      "canEditDocumentId": false,
+      "canEditRequestIssues": false,
+      "caseReviewId": null,
+      "caseType": "Original",
+      "caseflowVeteranId": 541,
+      "certificationDate": null,
+      "closestRegionalOffice": null,
+      "closestRegionalOfficeLabel": null,
+      "completedHearingOnPreviousAppeal": false,
+      "decisionDate": null,
+      "decisionIssues": Array [],
+      "docketName": "Legacy",
+      "docketNumber": "200805-541",
+      "documentID": null,
+      "externalId": "1234456",
+      "hearings": Array [],
+      "id": "1",
+      "isAdvancedOnDocket": false,
+      "isLegacyAppeal": true,
+      "isPaperCase": false,
+      "issueCount": 0,
+      "issues": Array [],
+      "nodDate": "2020-08-05",
+      "overtime": false,
+      "powerOfAttorney": Object {
+        "representative_address": Object {
+          "address_line_1": "9999 MISSION ST",
+          "address_line_2": "UBER",
+          "address_line_3": "APT 2",
+          "city": "SAN FRANCISCO",
+          "country": "USA",
+          "state": "CA",
+          "zip": "94103",
+        },
+        "representative_email_address": "tom.brady@caseflow.gov",
+        "representative_name": "Attorney McAttorneyFace",
+        "representative_type": "Attorney",
+      },
+      "readableHearingRequestType": "Travel",
+      "regionalOffice": null,
+      "removed": false,
+      "status": "not_distributed",
+      "vacateType": null,
+      "veteranFileNumber": "123456789",
+      "veteranFullName": "Abellona Valtas",
+      "veteranInfo": Object {
+        "veteran": Object {
+          "address": Object {
+            "address_line_1": "1234 Main Street",
+            "address_line_2": null,
+            "address_line_3": null,
+            "city": "Orlando",
+            "country": "USA",
+            "state": "FL",
+            "zip": "12345",
+          },
+          "date_of_birth": "01/10/1935",
+          "date_of_death": null,
+          "email_address": "Abellona.Valtas@test.com",
+          "full_name": "Abellona Valtas",
+          "gender": "M",
+        },
+      },
+      "withdrawn": false,
+    }
+  }
+  type="Virtual"
+>
+  <AppSegment
+    filledBackground={true}
+  >
+    <section
+      className="cf-app-segment cf-app-segment--alt"
+      role="main"
+    >
+      <h1
+        className="cf-margin-bottom-0"
+      >
+        Convert Hearing To Virtual
+      </h1>
+      <p
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "The hearing request will appear in the scheduling queue for the appropriate regional office.",
+          }
+        }
+      />
+      <HelperText
+        label="Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing."
+      >
+        <span
+          data-css-tgxxqt=""
+        >
+          Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing.
+        </span>
+      </HelperText>
+      <AppellantSection
+        appellantTitle="Veteran"
+        hearing={
+          Object {
+            "appellantFullName": "Abellona Valtas",
+            "representative": "Attorney McAttorneyFace",
+            "representativeType": "Attorney",
+          }
+        }
+        readOnly={true}
+        showDivider={false}
+        showMissingEmailAlert={true}
+        showOnlyAppellantName={true}
+        type="Virtual"
+        virtualHearing={
+          Object {
+            "appellantEmail": "Abellona.Valtas@test.com",
+            "representativeEmail": "tom.brady@caseflow.gov",
+          }
+        }
+      >
+        <VirtualHearingSection
+          hide={false}
+          label="Veteran"
+          showDivider={false}
+        >
+          <div
+            data-css-1jfbwxw=""
+          />
+          <h2>
+            Veteran
+          </h2>
+          <ReadOnly
+            label="Veteran Name"
+            text="Abellona Valtas"
+          >
+            <div
+              data-css-1a5irm0=""
+            >
+              <strong>
+                Veteran Name
+              </strong>
+              <pre>
+                Abellona Valtas
+              </pre>
+            </div>
+          </ReadOnly>
+          <div
+            className="usa-grid css-1jfbwxw"
+            id="email-section"
+          >
+            <div
+              className="usa-width-one-half css-uplrl8"
+            >
+              <VirtualHearingEmail
+                email="Abellona.Valtas@test.com"
+                emailType="appellantEmail"
+                label="Veteran Email"
+                readOnly={true}
+                required={true}
+                type="Virtual"
+              >
+                <ReadOnly
+                  label="Veteran Email"
+                  text="Abellona.Valtas@test.com"
+                >
+                  <div
+                    data-css-1a5irm0=""
+                  >
+                    <strong>
+                      Veteran Email
+                    </strong>
+                    <pre>
+                      Abellona.Valtas@test.com
+                    </pre>
+                  </div>
+                </ReadOnly>
+              </VirtualHearingEmail>
+            </div>
+          </div>
+        </VirtualHearingSection>
+      </AppellantSection>
+      <RepresentativeSection
+        appellantTitle="Veteran"
+        hearing={
+          Object {
+            "appellantFullName": "Abellona Valtas",
+            "representative": "Attorney McAttorneyFace",
+            "representativeType": "Attorney",
+          }
+        }
+        readOnly={true}
+        showDivider={false}
+        showMissingEmailAlert={true}
+        showOnlyAppellantName={true}
+        type="Virtual"
+        virtualHearing={
+          Object {
+            "appellantEmail": "Abellona.Valtas@test.com",
+            "representativeEmail": "tom.brady@caseflow.gov",
+          }
+        }
+      >
+        <VirtualHearingSection
+          hide={false}
+          label="Power of Attorney"
+          showDivider={true}
+        >
+          <div
+            className="cf-help-divider"
+          />
+          <h2>
+            Power of Attorney
+          </h2>
+          <AddressLine
+            label="Attorney"
+            name="Attorney McAttorneyFace"
+          >
+            <ReadOnly
+              label="Attorney"
+              text="Attorney McAttorneyFace
+"
+            >
+              <div
+                data-css-1a5irm0=""
+              >
+                <strong>
+                  Attorney
+                </strong>
+                <pre>
+                  Attorney McAttorneyFace
+
+                </pre>
+              </div>
+            </ReadOnly>
+          </AddressLine>
+          <div
+            className="usa-grid css-1jfbwxw"
+          >
+            <div
+              className="usa-width-one-half css-uplrl8"
+            >
+              <VirtualHearingEmail
+                email="tom.brady@caseflow.gov"
+                emailType="representativeEmail"
+                label="POA/Representative Email"
+                readOnly={true}
+                type="Virtual"
+              >
+                <ReadOnly
+                  label="POA/Representative Email"
+                  text="tom.brady@caseflow.gov"
+                >
+                  <div
+                    data-css-1a5irm0=""
+                  >
+                    <strong>
+                      POA/Representative Email
+                    </strong>
+                    <pre>
+                      tom.brady@caseflow.gov
+                    </pre>
+                  </div>
+                </ReadOnly>
+              </VirtualHearingEmail>
+            </div>
+          </div>
+        </VirtualHearingSection>
+      </RepresentativeSection>
+    </section>
+  </AppSegment>
+  <div
+    data-css-1jfbwxw=""
+  >
+    <Button
+      classNames={
+        Array [
+          "cf-submit",
+        ]
+      }
+      linkStyling={true}
+      loading={false}
+      name="Cancel"
+      onClick={[Function]}
+      styling={
+        Object {
+          "data-css-14x0t8z": "",
+        }
+      }
+      type="button"
+      willNeverBeLoading={false}
+    >
+      <span>
+        <button
+          className="cf-submit cf-btn-link usa-button"
+          data-css-14x0t8z=""
+          id="button-Cancel"
+          onClick={[Function]}
+          type="button"
+        >
+          Cancel
+        </button>
+      </span>
+    </Button>
+    <span
+      data-css-jf1dde=""
+    >
+      <Button
+        className="usa-button"
+        classNames={
+          Array [
+            "cf-submit",
+          ]
+        }
+        linkStyling={false}
+        loading={false}
+        name="Convert Hearing To Virtual"
+        type="button"
+        willNeverBeLoading={false}
+      >
+        <span>
+          <button
+            className="cf-submit usa-button"
+            id="button-Convert-Hearing-To-Virtual"
+            type="button"
+          >
+            Convert Hearing To Virtual
+          </button>
+        </span>
+      </Button>
+    </span>
+  </div>
+</HearingTypeConversionForm>
+`;
+
 exports[`HearingTypeConversionForm Does not show a divider on top of Appellant Section 1`] = `
 <HearingTypeConversionForm
   appeal={

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -51,6 +51,7 @@ describe FetchHearingLocationsForVeteransJob do
     end
   end
 
+  # Location Code 57 is "Schedule Hearing"
   context "when there is a case in location 57 *without* an associated veteran" do
     let!(:bfcorlid) { "123456789S" }
     let!(:bfcorlid_file_number) { "123456789" }

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -108,7 +108,7 @@ describe FetchHearingLocationsForVeteransJob do
       it "creates schedule hearing tasks for appeal and records a geomatched result" do
         expect(subject).to(
           receive(:record_geomatched_appeal)
-            .with(legacy_appeal.external_id, :matched_available_hearing_locations)
+            .with(legacy_appeal, :matched_available_hearing_locations)
         )
 
         subject.perform
@@ -176,7 +176,7 @@ describe FetchHearingLocationsForVeteransJob do
               allow(subject).to(receive(:job_running_past_expected_end_time?).and_return(false, false, true))
 
               expect(subject).to(
-                receive(:record_geomatched_appeal).with(legacy_appeal.external_id, "limit_error").once
+                receive(:record_geomatched_appeal).with(legacy_appeal, "limit_error").once
               )
 
               subject.perform
@@ -192,7 +192,7 @@ describe FetchHearingLocationsForVeteransJob do
 
             it "records multiple geomatch errors" do
               expect(subject).to(
-                receive(:record_geomatched_appeal).with(legacy_appeal.external_id, "limit_error").at_least(:once)
+                receive(:record_geomatched_appeal).with(legacy_appeal, "limit_error").at_least(:once)
               )
 
               subject.perform
@@ -205,10 +205,10 @@ describe FetchHearingLocationsForVeteransJob do
 
               it "retries the same appeal again" do
                 expect(subject).to(
-                  receive(:record_geomatched_appeal).with(legacy_appeal.external_id, "limit_error").at_least(:twice)
+                  receive(:record_geomatched_appeal).with(legacy_appeal, "limit_error").at_least(:twice)
                 )
                 expect(subject).not_to(
-                  receive(:record_geomatched_appeal).with(appeal.external_id, any_args)
+                  receive(:record_geomatched_appeal).with(appeal, any_args)
                 )
 
                 subject.perform
@@ -233,11 +233,11 @@ describe FetchHearingLocationsForVeteransJob do
 
           context "retries to geomatch" do
             it "retries geomatching hearing locations for appeal" do
-              expect(subject).to(receive(:record_geomatched_appeal).once.with(legacy_appeal.external_id, "limit_error"))
+              expect(subject).to(receive(:record_geomatched_appeal).once.with(legacy_appeal, "limit_error"))
               expect(subject).to(
                 receive(:record_geomatched_appeal)
                   .once
-                  .with(legacy_appeal.external_id, :matched_available_hearing_locations)
+                  .with(legacy_appeal, :matched_available_hearing_locations)
               )
 
               subject.perform
@@ -255,7 +255,7 @@ describe FetchHearingLocationsForVeteransJob do
 
         it "records a geomatch error" do
           expect(subject).to(
-            receive(:record_geomatched_appeal).with(legacy_appeal.external_id, "error")
+            receive(:record_geomatched_appeal).with(legacy_appeal, "error")
           )
           expect(Raven).to receive(:capture_exception)
 

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -265,6 +265,32 @@ describe FetchHearingLocationsForVeteransJob do
     end
   end
 
+  context "for a travel board appeal in VACOLS" do
+    let!(:vacols_case) do
+      create(
+        :case,
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+        bfhr: "2",
+        bfdocind: nil,
+        bfddec: nil
+      )
+    end
+
+    describe "#perform" do
+      subject { FetchHearingLocationsForVeteransJob.new }
+
+      it "geomatches for the travel board appeal" do
+        subject.perform
+
+        legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
+
+        expect(legacy_appeal).not_to be_nil
+        expect(legacy_appeal.closest_regional_office).not_to be_nil
+        expect(legacy_appeal.available_hearing_locations).not_to be_empty
+      end
+    end
+  end
+
   def veteran_record(file_number:, state: "MA", zip_code: "01002", country: "USA")
     {
       file_number: file_number,

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1163,32 +1163,52 @@ describe Appeal, :all_dbs do
     end
   end
 
+  describe "#sanitized_hearing_request_type" do
+    let(:appeal) { create(:appeal, closest_regional_office: closest_regional_office) }
+
+    subject { appeal.sanitized_hearing_request_type }
+
+    context "closest_regional_office is 'C'" do
+      let(:closest_regional_office) { "C" }
+
+      it { expect(subject).to eq(:central) }
+    end
+
+    context "closest_regional_office is a RO" do
+      let(:closest_regional_office) { "RO39" }
+
+      it { expect(subject).to eq(:video) }
+    end
+
+    context "closest_regional_office is a nil" do
+      let(:closest_regional_office) { nil }
+
+      it { expect(subject).to eq(nil) }
+    end
+  end
+
   describe "#readable_hearing_request_type" do
+    subject { appeal.readable_hearing_request_type }
+
     context "no hearings have been scheduled" do
       let(:appeal) { create(:appeal, closest_regional_office: closest_regional_office) }
 
       context "closest_regional_office is 'C'" do
         let(:closest_regional_office) { "C" }
 
-        it "returns 'Central'" do
-          expect(appeal.readable_hearing_request_type).to eq("Central")
-        end
+        it { expect(subject).to eq("Central") }
       end
 
       context "closest_regional_office is a RO" do
         let(:closest_regional_office) { "RO39" }
 
-        it "returns 'Video'" do
-          expect(appeal.readable_hearing_request_type).to eq("Video")
-        end
+        it { expect(subject).to eq("Video") }
       end
 
       context "closest_regional_office is a nil" do
         let(:closest_regional_office) { nil }
 
-        it "returns nil" do
-          expect(appeal.readable_hearing_request_type).to eq(nil)
-        end
+        it { expect(subject).to eq(nil) }
       end
     end
   end


### PR DESCRIPTION
Resolves #15264 

### Description

* Update `FetchHearingLocationsForVeteransJob` to geomatch appeals that need travel board hearings
  * Also update job to tag every event with the hearing request type associated with the appeal
* Implement `Appeal#sanitized_hearing_request_type` so both `LegacyAppeal` and `Appeal` respond to it
* Update subtitle on the hearing conversion screen to handle case where `closestRegionalOffice == null`
* Add jest tests and unit tests


### Acceptance Criteria
- [x]  Geomatch Travel Board hearings in fetch hearing locations job
- [x] Fallback language for conversion page if geomatch is not complete:
  - [x] convert page: The hearing request will appear in the scheduling queue for the appropriate regional office.
- [x] Add an additional attribute to the geomatched_appeals metric so we can track the number of appeals with travel board hearing requests that have been geomatched

### Testing Plan

N/A

### User Facing Changes

<img width="1176" alt="Screen Shot 2020-09-23 at 1 35 25 PM" src="https://user-images.githubusercontent.com/1298274/94048532-a51e2680-fda1-11ea-8937-3014c049db86.png">

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.
