### PR TITLE
Remove unnecessary router definition

### DIFF
--- a/client/app/reader/index.jsx
+++ b/client/app/reader/index.jsx
@@ -16,17 +16,16 @@ class Reader extends React.PureComponent {
   routedDecisionReviewer = () => <DecisionReviewer {...this.props} />;
 
   render = () => {
-    const Router = this.props.router || BrowserRouter;
 
     return (
       <ReduxBase reducer={rootReducer}>
-        <Router basename="/reader/appeal" {...this.props.routerTestProps}>
+        <BrowserRouter basename="/reader/appeal" {...this.props.routerTestProps}>
           <Switch>
             {/* We want access to React Router's match params, so we'll wrap all possible paths in a <Route>. */}
             <Route path="/:vacolsId/documents" render={this.routedDecisionReviewer} />
             <Route path="/" render={this.routedDecisionReviewer} />
           </Switch>
-        </Router>
+        </BrowserRouter>
       </ReduxBase>
     );
   };


### PR DESCRIPTION
Connects #15173

### Description
We had been setting the react router definition inside of the Reader component like so: 
`const Router = this.props.router || BrowserRouter;`

This was seemingly written this way in anticipation of a router prop being passed to this component which does not currently exist.  Moreover it is hypothesized that the fact that we are setting the router definition every time the component loads, this could be related to the undesired component reload behavior described in the linked ticket.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. go to `localhost:3000` and login as any user with Reader access e.g. `BVAAABSHIRE`
2. under `App Selector` select the `Reader` product and the bulleted `Document List` underneath 
3. Select any of the available documents
4. Ensure the document loads correctly and you are able to use the `Previous` and `Next` buttons in the view to select different documents
5. Use the `Back` button in the UI (not the browser's built in back button) to return to the list of documents
6. Ensure the documents load properly and that the page/component does not reload unnecessarily 
7. User the search bar to search for a particular `Document Type`, e.g. Correspondence
8. Utilize one of the `Categories` filters as well
9. Select one of the documents from the search results and repeat steps 4 - 6
10. When returning to the document list ensure that the search results and Categories filtering are preserved