### PR TITLE
Revert total_batch_size to JudgeTeam query

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -125,6 +125,6 @@ class Distribution < CaseflowRecord
   end
 
   def total_batch_size
-    DecisionDraftingAttorney.users.size * CASES_PER_ATTORNEY
+    JudgeTeam.includes(:non_admin_users).flat_map(&:non_admin_users).size * CASES_PER_ATTORNEY
   end
 end


### PR DESCRIPTION
Resolves #15305 

### Description
The new call did 2 + (2 * NumAttys) calls. This one does _2_

Reverting to this call:
```ruby
[8] pry(main)> JudgeTeam.includes(:non_admin_users).flat_map(&:non_admin_users).size
[2020-09-24 11:14:42 -0400]   JudgeTeam Load (1.3ms)  SELECT "organizations".* FROM "organizations" WHERE "organizations"."type" IN ('JudgeTeam') AND "organizations"."status" = $1  [["status", "active"]]
[2020-09-24 11:14:42 -0400]   OrganizationsUser Load (0.7ms)  SELECT "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."admin" = $1 AND "organizations_users"."organization_id" IN ($2, $3, $4, $5, $6, $7, $8, $9, $10)  [["admin", false], ["organization_id", 19], ["organization_id", 20], ["organization_id", 21], ["organization_id", 22], ["organization_id", 23], ["organization_id", 26], ["organization_id", 27], ["organization_id", 28], ["organization_id", 29]]
=> 19
```

Instead of:
```ruby
[4] pry(main)> Distribution.new.send(:total_batch_size)
[2020-09-24 11:11:56 -0400]   DecisionDraftingAttorney Load (5.5ms)  SELECT "judge_team_roles".* FROM "judge_team_roles" WHERE "judge_team_roles"."type" IN ('DecisionDraftingAttorney')
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.4ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 35], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.5ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 71], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.4ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 36], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.4ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 72], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 37], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.4ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 73], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 39], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 75], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 40], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 76], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.4ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 41], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 77], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 43], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 78], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.2ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 44], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 79], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.2ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 45], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 80], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 47], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 2], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 48], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 81], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 49], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 82], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.2ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 51], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 1], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.4ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 52], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 84], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.2ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 53], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 85], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 60], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 90], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 62], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 93], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.3ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 64], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.2ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 96], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   OrganizationsUser Load (0.2ms)  SELECT  "organizations_users".* FROM "organizations_users" WHERE "organizations_users"."id" = $1 LIMIT $2  [["id", 66], ["LIMIT", 1]]
[2020-09-24 11:11:56 -0400]   User Load (0.3ms)  SELECT  "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 657], ["LIMIT", 1]]
=> 57
```

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass

### Testing Plan
1. Confirm `Distribution.new.send(:total_batch_size)` now triggers only two db calls.