### PR TITLE
Connect backend and frontend for convert hearing type page

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -106,6 +106,8 @@ class TasksController < ApplicationController
     render json: {
       tasks: tasks_hash
     }
+  rescue ActiveRecord::RecordInvalid => error
+    invalid_record_error(error.record)
   rescue AssignHearingDispositionTask::HearingAssociationMissing => error
     Raven.capture_exception(error)
     render json: {

--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -34,12 +34,7 @@ class HearingDay < CaseflowRecord
 
   class HearingDayHasChildrenRecords < StandardError; end
 
-  REQUEST_TYPES = {
-    virtual: "R",
-    video: "V",
-    travel: "T",
-    central: "C"
-  }.freeze
+  REQUEST_TYPES = Constants::HEARING_REQUEST_TYPES.with_indifferent_access.freeze
 
   SLOTS_BY_REQUEST_TYPE = { REQUEST_TYPES[:central] => 10 }.freeze
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -769,6 +769,8 @@
   "CONVERT_HEARING_TYPE_SUBTITLE": "The hearing request will appear in the scheduling queue for %s.",
   "CONVERT_HEARING_TYPE_SUBTITLE_2": "Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing.",
   "CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT": "the appropriate regional office",
+  "CONVERT_HEARING_TYPE_SUCCESS": "You have successfully converted %s's hearing to virtual",
+  "CONVERT_HEARING_TYPE_SUCCESS_DETAIL": "The hearing request is in the scheduling queue for the %s",
 
   "JUDGE_TEAM_REMOVE_JUDGE_ERROR": "Cannot remove a judge from their judge team.",
   "JUDGE_TEAM_ATTORNEY_RIGHTS_ERROR": "Cannot edit attorney rights on non-attorneys",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -770,7 +770,7 @@
   "CONVERT_HEARING_TYPE_SUBTITLE_2": "Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing.",
   "CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT": "the appropriate regional office",
   "CONVERT_HEARING_TYPE_SUCCESS": "You have successfully converted %s's hearing to virtual",
-  "CONVERT_HEARING_TYPE_SUCCESS_DETAIL": "The hearing request is in the scheduling queue for the %s",
+  "CONVERT_HEARING_TYPE_SUCCESS_DETAIL": "The hearing request is in the scheduling queue for %s",
 
   "JUDGE_TEAM_REMOVE_JUDGE_ERROR": "Cannot remove a judge from their judge team.",
   "JUDGE_TEAM_ATTORNEY_RIGHTS_ERROR": "Cannot edit attorney rights on non-attorneys",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -777,6 +777,9 @@
 
   "HEARING_UPDATE_SUCCESSFUL_TITLE": "You have successfully updated %s's hearing.",
 
+  "DEFAULT_UPDATE_ERROR_MESSAGE_TITLE": "Unable to save changes",
+  "DEFAULT_UPDATE_ERROR_MESSAGE_DETAIL": "An unknown error occurred",
+
   "VIRTUAL_HEARING_PROGRESS_ALERTS": {
     "CHANGED_TO_VIRTUAL": {
       "TITLE": "We're scheduling %s's virtual hearing",

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -8,6 +8,7 @@ import React, { useState } from 'react';
 
 import { HearingTypeConversionForm } from './HearingTypeConversionForm';
 import { appealWithDetailSelector, taskById } from '../../queue/selectors';
+import { deleteAppeal } from '../../queue/QueueActions';
 import {
   showErrorMessage,
   showSuccessMessage
@@ -61,6 +62,7 @@ export const HearingTypeConversion = ({
       await ApiUtil.patch(`/tasks/${task.taskId}`, { data });
 
       props.showSuccessMessage(getSuccessMsg());
+      props.deleteAppeal(task.externalAppealId);
     } catch (err) {
       const error = get(
         err,
@@ -95,6 +97,7 @@ export const HearingTypeConversion = ({
 HearingTypeConversion.propTypes = {
   appeal: PropTypes.object,
   appealId: PropTypes.string,
+  deleteAppeal: PropTypes.func,
   showErrorMessage: PropTypes.func,
   showSuccessMessage: PropTypes.func,
   task: PropTypes.object,
@@ -112,6 +115,7 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
+      deleteAppeal,
       showErrorMessage,
       showSuccessMessage
     },

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -1,6 +1,6 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { get }from 'lodash';
+import { get } from 'lodash';
 import { sprintf } from 'sprintf-js';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -16,7 +16,7 @@ import ApiUtil from '../../util/ApiUtil';
 import COPY from '../../../COPY';
 import HEARING_REQUEST_TYPES from
   '../../../constants/HEARING_REQUEST_TYPES';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 
 export const HearingTypeConversion = ({
   appeal,
@@ -71,7 +71,7 @@ export const HearingTypeConversion = ({
         }
       );
 
-      props.showErrorMessage(error)
+      props.showErrorMessage(error);
     } finally {
       setLoading(false);
 

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -31,7 +31,7 @@ const HearingTypeConversion = ({
     const title = sprintf(COPY.CONVERT_HEARING_TYPE_SUCCESS, appeal?.appellantFullName, type);
     const detail = sprintf(
       COPY.CONVERT_HEARING_TYPE_SUCCESS_DETAIL,
-      appeal?.closestRegionalOffice || 'appropriate regional office'
+      appeal?.closestRegionalOffice || COPY.CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT
     );
 
     return { title, detail };

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -1,3 +1,4 @@
+import { sprintf } from 'sprintf-js';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -11,18 +12,17 @@ import {
   showSuccessMessage
 } from '../../queue/uiReducer/uiActions';
 import ApiUtil from '../../util/ApiUtil';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 import HEARING_REQUEST_TYPES from
   '../../../constants/HEARING_REQUEST_TYPES';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 
 const HearingTypeConversion = ({
   appeal,
   history,
-  showErrorMessage,
-  showSuccessMessage,
   task,
-  type
+  type,
+  ...props
 }) => {
   // Create and manage the loading state
   const [loading, setLoading] = useState(false);
@@ -57,7 +57,7 @@ const HearingTypeConversion = ({
 
       setLoading(true);
 
-      await ApiUtil.patch(`/tasks/${task.taskId}`, { data });      
+      await ApiUtil.patch(`/tasks/${task.taskId}`, { data });
     } catch (err) {
       // What could this be?
       return;
@@ -67,7 +67,7 @@ const HearingTypeConversion = ({
       setLoading(false);
     }
 
-    showSuccessMessage(getSuccessMsg());
+    props.showSuccessMessage(getSuccessMsg());
 
     history.push(`/queue/appeals/${appeal.externalId}`);
   };

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -17,7 +17,7 @@ import HEARING_REQUEST_TYPES from
   '../../../constants/HEARING_REQUEST_TYPES';
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 
-const HearingTypeConversion = ({
+export const HearingTypeConversion = ({
   appeal,
   history,
   task,
@@ -58,6 +58,8 @@ const HearingTypeConversion = ({
       setLoading(true);
 
       await ApiUtil.patch(`/tasks/${task.taskId}`, { data });
+
+      props.showSuccessMessage(getSuccessMsg());
     } catch (err) {
       // What could this be?
       return;
@@ -66,8 +68,6 @@ const HearingTypeConversion = ({
       // appeals page.
       setLoading(false);
     }
-
-    props.showSuccessMessage(getSuccessMsg());
 
     history.push(`/queue/appeals/${appeal.externalId}`);
   };

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -1,0 +1,115 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+
+import { HearingTypeConversionForm } from './HearingTypeConversionForm';
+import { appealWithDetailSelector, taskById } from '../../queue/selectors';
+import {
+  showErrorMessage,
+  showSuccessMessage
+} from '../../queue/uiReducer/uiActions';
+import ApiUtil from '../../util/ApiUtil';
+import COPY from '../../../COPY.json';
+import HEARING_REQUEST_TYPES from
+  '../../../constants/HEARING_REQUEST_TYPES';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+
+const HearingTypeConversion = ({
+  appeal,
+  history,
+  showErrorMessage,
+  showSuccessMessage,
+  task,
+  type
+}) => {
+  // Create and manage the loading state
+  const [loading, setLoading] = useState(false);
+
+  const getSuccessMsg = () => {
+    const title = sprintf(COPY.CONVERT_HEARING_TYPE_SUCCESS, appeal?.appellantFullName, type);
+    const detail = sprintf(
+      COPY.CONVERT_HEARING_TYPE_SUCCESS_DETAIL,
+      appeal?.closestRegionalOffice || 'appropriate regional office'
+    );
+
+    return { title, detail };
+  };
+
+  const submit = async () => {
+    try {
+      const changedRequestType = type === 'Virtual' ? HEARING_REQUEST_TYPES.virtual : HEARING_REQUEST_TYPES.video;
+      const data = {
+        task: {
+          status: TASK_STATUSES.completed,
+          business_payloads: {
+            values: {
+              changed_request_type: changedRequestType
+            }
+          }
+        }
+      };
+
+      setLoading(true);
+
+      await ApiUtil.patch(`/tasks/${task.taskId}`, { data });      
+    } catch (err) {
+      // What could this be?
+      return;
+    } finally {
+      // Show that the action went through before redirecting the user back to the
+      // appeals page.
+      setLoading(false);
+    }
+
+    showSuccessMessage(getSuccessMsg());
+
+    history.push(`/queue/appeals/${appeal.externalId}`);
+  };
+
+  return (
+    <HearingTypeConversionForm
+      appeal={appeal}
+      history={history}
+      isLoading={loading}
+      onCancel={() => history.goBack()}
+      onSubmit={submit}
+      task={task}
+      type={type}
+    />
+  );
+};
+
+HearingTypeConversion.propTypes = {
+  appeal: PropTypes.object,
+  appealId: PropTypes.string,
+  showErrorMessage: PropTypes.func,
+  showSuccessMessage: PropTypes.func,
+  task: PropTypes.object,
+  taskId: PropTypes.string,
+  type: PropTypes.oneOf(['Virtual']),
+  // Router inherited props
+  history: PropTypes.object
+};
+
+const mapStateToProps = (state, ownProps) => ({
+  appeal: appealWithDetailSelector(state, ownProps),
+  task: taskById(state, { taskId: ownProps.taskId })
+});
+
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      showErrorMessage,
+      showSuccessMessage
+    },
+    dispatch
+  );
+
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(HearingTypeConversion)
+);

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -28,7 +28,11 @@ const HearingTypeConversion = ({
   const [loading, setLoading] = useState(false);
 
   const getSuccessMsg = () => {
-    const title = sprintf(COPY.CONVERT_HEARING_TYPE_SUCCESS, appeal?.appellantFullName, type);
+    const title = sprintf(
+      COPY.CONVERT_HEARING_TYPE_SUCCESS,
+      appeal?.appellantIsNotVeteran ? appeal?.appellantFullName : appeal?.veteranFullName,
+      type
+    );
     const detail = sprintf(
       COPY.CONVERT_HEARING_TYPE_SUCCESS_DETAIL,
       appeal?.closestRegionalOffice || COPY.CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -1,6 +1,7 @@
-import { sprintf } from 'sprintf-js';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { get }from 'lodash';
+import { sprintf } from 'sprintf-js';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
@@ -15,7 +16,7 @@ import ApiUtil from '../../util/ApiUtil';
 import COPY from '../../../COPY';
 import HEARING_REQUEST_TYPES from
   '../../../constants/HEARING_REQUEST_TYPES';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
 
 export const HearingTypeConversion = ({
   appeal,
@@ -61,15 +62,21 @@ export const HearingTypeConversion = ({
 
       props.showSuccessMessage(getSuccessMsg());
     } catch (err) {
-      // What could this be?
-      return;
-    } finally {
-      // Show that the action went through before redirecting the user back to the
-      // appeals page.
-      setLoading(false);
-    }
+      const error = get(
+        err,
+        'response.body.errors[0]',
+        {
+          title: COPY.DEFAULT_UPDATE_ERROR_MESSAGE_TITLE,
+          detail: COPY.DEFAULT_UPDATE_ERROR_MESSAGE_DETAIL
+        }
+      );
 
-    history.push(`/queue/appeals/${appeal.externalId}`);
+      props.showErrorMessage(error)
+    } finally {
+      setLoading(false);
+
+      history.push(`/queue/appeals/${appeal.externalId}`);
+    }
   };
 
   return (

--- a/client/app/hearings/components/HearingTypeConversion.stories.js
+++ b/client/app/hearings/components/HearingTypeConversion.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { HearingTypeConversion } from './HearingTypeConversion';
+import { legacyAppealForTravelBoard, veteranInfoWithoutEmail } from '../../../test/data/appeals';
+import { queueWrapper as Wrapper } from '../../../test/data/stores/queueStore';
+
+export default {
+  title: 'Hearings/Components/HearingTypeConversion',
+  component: HearingTypeConversion,
+  parameters: {
+    docs: {
+      inlineStories: false,
+      iframeHeight: 760,
+    },
+  }
+};
+
+const Template = (args) => {
+  const { storeArgs, componentArgs } = args;
+
+  return (
+    <Wrapper {...storeArgs}>
+      <HearingTypeConversion
+        {...componentArgs}
+      />
+    </Wrapper>
+  );
+};
+
+export const ToVirtual = Template.bind({});
+ToVirtual.args = {
+  componentArgs: {
+    appeal: legacyAppealForTravelBoard,
+    type: 'Virtual'
+  }
+};

--- a/client/app/hearings/components/HearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/HearingTypeConversionForm.jsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import PropTypes from 'prop-types';
 import { sprintf } from 'sprintf-js';
@@ -9,9 +11,15 @@ import COPY from '../../../COPY';
 import { getAppellantTitle } from '../utils';
 import { RepresentativeSection } from './VirtualHearings/RepresentativeSection';
 import { AppellantSection } from './VirtualHearings/AppellantSection';
+import { appealWithDetailSelector, taskById } from '../../queue/selectors';
+import ApiUtil from '../../util/ApiUtil';
 import Button from '../../components/Button';
+import HEARING_REQUEST_TYPES from
+  '../../../constants/HEARING_REQUEST_TYPES';
+import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
 
-export const HearingTypeConversionForm = ({
+const HearingTypeConversionForm = ({
+  task,
   type,
   appeal
 }) => {
@@ -59,6 +67,28 @@ export const HearingTypeConversionForm = ({
       COPY.CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT
   );
 
+  const submit = () => {
+    const changedRequestType = type === 'Virtual' ? HEARING_REQUEST_TYPES.virtual : HEARING_REQUEST_TYPES.video;
+    const data = {
+      task: {
+        status: TASK_STATUSES.completed,
+        business_payloads: {
+          values: {
+            changed_request_type: changedRequestType
+          }
+        }
+      }
+    };
+
+    return ApiUtil.
+      patch(`/tasks/${task.taskId}`, { data }).
+      then((response) => {
+      }).
+      catch(() => {
+
+      });
+  };
+
   return (
     <React.Fragment>
       <AppSegment filledBackground>
@@ -87,6 +117,7 @@ export const HearingTypeConversionForm = ({
             name={convertTitle}
             loading={loading}
             className="usa-button"
+            onClick={submit}
           >
             {convertTitle}
           </Button>
@@ -98,7 +129,17 @@ export const HearingTypeConversionForm = ({
 
 HearingTypeConversionForm.propTypes = {
   appeal: PropTypes.object,
+  appealId: PropTypes.string,
+  task: PropTypes.object,
+  taskId: PropTypes.string,
   // Router inherited props
   history: PropTypes.object,
-  type: PropTypes.string
+  type: PropTypes.oneOf(['Virtual'])
 };
+
+const mapStateToProps = (state, ownProps) => ({
+  appeal: appealWithDetailSelector(state, ownProps),
+  task: taskById(state, { taskId: ownProps.taskId })
+});
+
+export default withRouter(connect(mapStateToProps)(HearingTypeConversionForm));

--- a/client/app/hearings/components/HearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/HearingTypeConversionForm.jsx
@@ -26,7 +26,7 @@ export const HearingTypeConversionForm = ({
   const hearing = {
     representative: appeal?.powerOfAttorney?.representative_name,
     representativeType: appeal?.powerOfAttorney?.representative_type,
-    appellantFullName: appeal?.appellantFullName
+    appellantFullName: appeal?.appellantIsNotVeteran ? appeal?.appellantFullName : appeal?.veteranFullName,
   };
 
   // veteranInfo gets loaded into redux store when case details page loads

--- a/client/app/hearings/components/HearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/HearingTypeConversionForm.jsx
@@ -16,7 +16,6 @@ export const HearingTypeConversionForm = ({
   isLoading,
   onCancel,
   onSubmit,
-  task,
   type,
 }) => {
   // 'Appellant' or 'Veteran'
@@ -96,7 +95,6 @@ HearingTypeConversionForm.defaultProps = {
 
 HearingTypeConversionForm.propTypes = {
   appeal: PropTypes.object,
-  task: PropTypes.object,
   type: PropTypes.oneOf(['Virtual']),
   isLoading: PropTypes.bool,
   onCancel: PropTypes.func,

--- a/client/app/hearings/components/HearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/HearingTypeConversionForm.jsx
@@ -26,7 +26,9 @@ export const HearingTypeConversionForm = ({
   const hearing = {
     representative: appeal?.powerOfAttorney?.representative_name,
     representativeType: appeal?.powerOfAttorney?.representative_type,
-    appellantFullName: appeal?.appellantIsNotVeteran ? appeal?.appellantFullName : appeal?.veteranFullName,
+    appellantFullName: appeal?.appellantFullName,
+    appellantIsNotVeteran: appeal?.appellantIsNotVeteran,
+    veteranFullName: appeal?.veteranFullName,
   };
 
   // veteranInfo gets loaded into redux store when case details page loads

--- a/client/app/hearings/components/HearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/HearingTypeConversionForm.jsx
@@ -1,34 +1,24 @@
-import React, { useState } from 'react';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { sprintf } from 'sprintf-js';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import PropTypes from 'prop-types';
-import { sprintf } from 'sprintf-js';
+import React from 'react';
 
-import { marginTop, saveButton, cancelButton } from './details/style';
-import { HelperText } from './VirtualHearings/HelperText';
-import COPY from '../../../COPY';
-import { getAppellantTitle } from '../utils';
-import { RepresentativeSection } from './VirtualHearings/RepresentativeSection';
 import { AppellantSection } from './VirtualHearings/AppellantSection';
-import { appealWithDetailSelector, taskById } from '../../queue/selectors';
-import ApiUtil from '../../util/ApiUtil';
+import { HelperText } from './VirtualHearings/HelperText';
+import { RepresentativeSection } from './VirtualHearings/RepresentativeSection';
+import { getAppellantTitle } from '../utils';
+import { marginTop, saveButton, cancelButton } from './details/style';
 import Button from '../../components/Button';
-import HEARING_REQUEST_TYPES from
-  '../../../constants/HEARING_REQUEST_TYPES';
-import TASK_STATUSES from '../../../constants/TASK_STATUSES.json';
+import COPY from '../../../COPY';
 
-const HearingTypeConversionForm = ({
+export const HearingTypeConversionForm = ({
+  appeal,
+  isLoading,
+  onCancel,
+  onSubmit,
   task,
   type,
-  appeal
 }) => {
-  // Create and manage the loading state
-  const [loading, setLoading] = useState(false);
-
-  // reset any states
-  const reset = () => setLoading(false);
-
   // 'Appellant' or 'Veteran'
   const appellantTitle = getAppellantTitle(appeal?.appellantIsNotVeteran);
 
@@ -67,28 +57,6 @@ const HearingTypeConversionForm = ({
       COPY.CONVERT_HEARING_TYPE_DEFAULT_REGIONAL_OFFICE_TEXT
   );
 
-  const submit = () => {
-    const changedRequestType = type === 'Virtual' ? HEARING_REQUEST_TYPES.virtual : HEARING_REQUEST_TYPES.video;
-    const data = {
-      task: {
-        status: TASK_STATUSES.completed,
-        business_payloads: {
-          values: {
-            changed_request_type: changedRequestType
-          }
-        }
-      }
-    };
-
-    return ApiUtil.
-      patch(`/tasks/${task.taskId}`, { data }).
-      then((response) => {
-      }).
-      catch(() => {
-
-      });
-  };
-
   return (
     <React.Fragment>
       <AppSegment filledBackground>
@@ -102,12 +70,7 @@ const HearingTypeConversionForm = ({
         <Button
           name="Cancel"
           linkStyling
-          onClick={
-            () => {
-              reset();
-              history.goBack();
-            }
-          }
+          onClick={onCancel}
           styling={cancelButton}
         >
           Cancel
@@ -115,9 +78,9 @@ const HearingTypeConversionForm = ({
         <span {...saveButton}>
           <Button
             name={convertTitle}
-            loading={loading}
+            loading={isLoading}
             className="usa-button"
-            onClick={submit}
+            onClick={onSubmit}
           >
             {convertTitle}
           </Button>
@@ -127,19 +90,15 @@ const HearingTypeConversionForm = ({
   );
 };
 
-HearingTypeConversionForm.propTypes = {
-  appeal: PropTypes.object,
-  appealId: PropTypes.string,
-  task: PropTypes.object,
-  taskId: PropTypes.string,
-  // Router inherited props
-  history: PropTypes.object,
-  type: PropTypes.oneOf(['Virtual'])
+HearingTypeConversionForm.defaultProps = {
+  isLoading: false
 };
 
-const mapStateToProps = (state, ownProps) => ({
-  appeal: appealWithDetailSelector(state, ownProps),
-  task: taskById(state, { taskId: ownProps.taskId })
-});
-
-export default withRouter(connect(mapStateToProps)(HearingTypeConversionForm));
+HearingTypeConversionForm.propTypes = {
+  appeal: PropTypes.object,
+  task: PropTypes.object,
+  type: PropTypes.oneOf(['Virtual']),
+  isLoading: PropTypes.bool,
+  onCancel: PropTypes.func,
+  onSubmit: PropTypes.func
+};

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -10,7 +10,7 @@ import { sprintf } from 'sprintf-js';
 
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import COPY from '../../../COPY';
-import { CENTRAL_OFFICE_HEARING, VIRTUAL_HEARING } from '../constants';
+import { CENTRAL_OFFICE_HEARING, VIDEO_HEARING } from '../constants';
 import { appealWithDetailSelector, scheduleHearingTasksForAppeal } from '../../queue/selectors';
 import { showSuccessMessage, showErrorMessage, requestPatch } from '../../queue/uiReducer/uiActions';
 import { onReceiveAppealDetails } from '../../queue/QueueActions';
@@ -69,7 +69,7 @@ export const ScheduleVeteran = ({
   const virtual = assignHearingForm?.virtualHearing;
   const requestType = selectedHearingDay?.regionalOffice === 'C' ?
     CENTRAL_OFFICE_HEARING :
-    VIRTUAL_HEARING;
+    VIDEO_HEARING;
 
   // Determine whether we are rescheduling
   const reschedule = scheduledHearing?.disposition === 'reschedule';

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -26,9 +26,10 @@ import {
   startPollingHearing,
 } from '../../components/common/actions';
 import { ScheduleVeteranForm } from './ScheduleVeteranForm';
-import { HEARING_REQUEST_TYPES } from '../constants';
 import ApiUtil from '../../util/ApiUtil';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
+import HEARING_REQUEST_TYPES from
+  '../../../constants/HEARING_REQUEST_TYPES';
 
 export const ScheduleVeteran = ({
   scheduleHearingTask,
@@ -67,7 +68,9 @@ export const ScheduleVeteran = ({
 
   // Determine the Request Type for the hearing
   const virtual = assignHearingForm?.virtualHearing;
-  const requestType = selectedHearingDay?.regionalOffice === 'C' ? HEARING_REQUEST_TYPES.C : HEARING_REQUEST_TYPES.V;
+  const requestType = selectedHearingDay?.regionalOffice === 'C' ?
+    HEARING_REQUEST_TYPES.central :
+    HEARING_REQUEST_TYPES.virtual;
 
   // Determine whether we are rescheduling
   const reschedule = scheduledHearing?.disposition === 'reschedule';

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -10,6 +10,7 @@ import { sprintf } from 'sprintf-js';
 
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import COPY from '../../../COPY';
+import { CENTRAL_OFFICE_HEARING, VIRTUAL_HEARING } from '../constants';
 import { appealWithDetailSelector, scheduleHearingTasksForAppeal } from '../../queue/selectors';
 import { showSuccessMessage, showErrorMessage, requestPatch } from '../../queue/uiReducer/uiActions';
 import { onReceiveAppealDetails } from '../../queue/QueueActions';
@@ -28,8 +29,6 @@ import {
 import { ScheduleVeteranForm } from './ScheduleVeteranForm';
 import ApiUtil from '../../util/ApiUtil';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
-import HEARING_REQUEST_TYPES from
-  '../../../constants/HEARING_REQUEST_TYPES';
 
 export const ScheduleVeteran = ({
   scheduleHearingTask,
@@ -69,8 +68,8 @@ export const ScheduleVeteran = ({
   // Determine the Request Type for the hearing
   const virtual = assignHearingForm?.virtualHearing;
   const requestType = selectedHearingDay?.regionalOffice === 'C' ?
-    HEARING_REQUEST_TYPES.central :
-    HEARING_REQUEST_TYPES.virtual;
+    CENTRAL_OFFICE_HEARING :
+    VIRTUAL_HEARING;
 
   // Determine whether we are rescheduling
   const reschedule = scheduledHearing?.disposition === 'reschedule';

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -93,6 +93,7 @@ export const ScheduleVeteran = ({
     appellantCity: appeal?.appellantAddress?.city,
     appellantState: appeal?.appellantAddress?.state,
     appellantZip: appeal?.appellantAddress?.zip,
+    veteranFullName: appeal?.veteranFullName,
     requestType
   };
 

--- a/client/app/hearings/components/ScheduleVeteranForm.jsx
+++ b/client/app/hearings/components/ScheduleVeteranForm.jsx
@@ -12,9 +12,10 @@ import HearingTypeDropdown from './details/HearingTypeDropdown';
 import { HearingTime } from './modalForms/HearingTime';
 import { RepresentativeSection } from './VirtualHearings/RepresentativeSection';
 import { AppellantSection } from './VirtualHearings/AppellantSection';
-import { HEARING_CONVERSION_TYPES, HEARING_REQUEST_TYPES } from '../constants';
 import { marginTop } from './details/style';
 import { isEmpty, orderBy } from 'lodash';
+import HEARING_REQUEST_TYPES from
+  '../../../constants/HEARING_REQUEST_TYPES';
 
 export const ScheduleVeteranForm = ({
   virtual,
@@ -56,7 +57,7 @@ export const ScheduleVeteranForm = ({
         <React.Fragment>
 
           <div className="usa-width-one-half">
-            <ReadOnly spacing={0} label="Regional Office" text={HEARING_REQUEST_TYPES.C} />
+            <ReadOnly spacing={0} label="Regional Office" text={HEARING_REQUEST_TYPES.central} />
             <ReadOnly spacing={15} label="Hearing Location" text="Virtual" />
 
             <HearingDateDropdown

--- a/client/app/hearings/components/ScheduleVeteranForm.jsx
+++ b/client/app/hearings/components/ScheduleVeteranForm.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable camelcase */
 import React from 'react';
 import PropTypes from 'prop-types';
+import { CENTRAL_OFFICE_HEARING, HEARING_CONVERSION_TYPES } from '../constants';
 import {
   RegionalOfficeDropdown,
   AppealHearingLocationsDropdown,
   HearingDateDropdown
 } from '../../components/DataDropdowns';
-import { CENTRAL_OFFICE_HEARING } from '../constants';
 import { AddressLine } from './details/Address';
 import { ReadOnly } from './details/ReadOnly';
 import HearingTypeDropdown from './details/HearingTypeDropdown';

--- a/client/app/hearings/components/ScheduleVeteranForm.jsx
+++ b/client/app/hearings/components/ScheduleVeteranForm.jsx
@@ -6,6 +6,7 @@ import {
   AppealHearingLocationsDropdown,
   HearingDateDropdown
 } from '../../components/DataDropdowns';
+import { CENTRAL_OFFICE_HEARING } from '../constants';
 import { AddressLine } from './details/Address';
 import { ReadOnly } from './details/ReadOnly';
 import HearingTypeDropdown from './details/HearingTypeDropdown';
@@ -14,8 +15,6 @@ import { RepresentativeSection } from './VirtualHearings/RepresentativeSection';
 import { AppellantSection } from './VirtualHearings/AppellantSection';
 import { marginTop } from './details/style';
 import { isEmpty, orderBy } from 'lodash';
-import HEARING_REQUEST_TYPES from
-  '../../../constants/HEARING_REQUEST_TYPES';
 
 export const ScheduleVeteranForm = ({
   virtual,
@@ -57,7 +56,7 @@ export const ScheduleVeteranForm = ({
         <React.Fragment>
 
           <div className="usa-width-one-half">
-            <ReadOnly spacing={0} label="Regional Office" text={HEARING_REQUEST_TYPES.central} />
+            <ReadOnly spacing={0} label="Regional Office" text={CENTRAL_OFFICE_HEARING} />
             <ReadOnly spacing={15} label="Hearing Location" text="Virtual" />
 
             <HearingDateDropdown

--- a/client/app/hearings/components/VirtualHearings/AppellantSection.jsx
+++ b/client/app/hearings/components/VirtualHearings/AppellantSection.jsx
@@ -28,9 +28,7 @@ export const AppellantSection = ({
   showOnlyAppellantName,
   showMissingEmailAlert
 }) => {
-  const appellantName = hearing?.appellantFullName ? hearing?.appellantFullName :
-    `${hearing?.veteranFirstName} ${hearing?.veteranLastName}`;
-
+  const appellantName = hearing?.appellantFullName;
   const showTimezoneField = virtual && !video;
 
   // determine whether to show a missing email underneath readonly email
@@ -41,7 +39,8 @@ export const AppellantSection = ({
       {showOnlyAppellantName ? (
         <ReadOnly
           label={`${appellantTitle} Name`}
-          text={appellantName} />
+          text={appellantName}
+        />
       ) :
         (
           <AddressLine

--- a/client/app/hearings/components/VirtualHearings/AppellantSection.jsx
+++ b/client/app/hearings/components/VirtualHearings/AppellantSection.jsx
@@ -28,7 +28,11 @@ export const AppellantSection = ({
   showOnlyAppellantName,
   showMissingEmailAlert
 }) => {
-  const appellantName = hearing?.appellantFullName;
+  // Depending on where this component is used, the *FullName fields will be available.
+  // If they aren't, the *FirstName/*LastName fields should be available.
+  const appellantName = hearing?.appellantIsNotVeteran ?
+    (hearing?.appellantFullName || `${hearing?.appellantFirstName} ${hearing?.appellantLastName}`) :
+    (hearing?.veteranFullName || `${hearing?.veteranFirstName} ${hearing?.veteranLastName}`);
   const showTimezoneField = virtual && !video;
 
   // determine whether to show a missing email underneath readonly email

--- a/client/app/hearings/constants.js
+++ b/client/app/hearings/constants.js
@@ -126,9 +126,3 @@ export const HEARING_CONVERSION_TYPES = [
   'change_email_or_timezone',
   'change_hearing_time'
 ];
-
-export const HEARING_REQUEST_TYPES = {
-  V: VIDEO_HEARING,
-  C: CENTRAL_OFFICE_HEARING,
-  R: VIRTUAL_HEARING,
-};

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -675,7 +675,9 @@ class QueueApp extends React.PureComponent {
               />
               <PageRoute
                 exact
-                path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`}
+                path={
+                  `/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`
+                }
                 title="Change Hearing Request Type to Virtual | Caseflow"
                 render={this.routedChangeHearingRequestTypeToVirtual}
               />

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -273,7 +273,7 @@ class QueueApp extends React.PureComponent {
   routedChangeTaskTypeModal = (props) => <ChangeTaskTypeModal {...props.match.params} />;
 
   routedChangeHearingRequestTypeToVirtual = (props) => (
-    <HearingTypeConversionForm type='Virtual' {...props.match.params} />
+    <HearingTypeConversionForm type="Virtual" {...props.match.params} />
   );
 
   routedSetOvertimeStatusModal = (props) => <SetOvertimeStatusModal {...props.match.params} />;

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -85,6 +85,7 @@ import { FlashAlerts } from '../nonComp/components/Alerts';
 import { PulacCerulloReminderModal } from './pulacCerullo/PulacCerulloReminderModal';
 import { motionToVacateRoutes } from './mtv/motionToVacateRoutes';
 import ScheduleVeteran from '../hearings/components/ScheduleVeteran';
+import HearingTypeConversionForm from '../hearings/components/HearingTypeConversionForm';
 
 class QueueApp extends React.PureComponent {
   componentDidMount = () => {
@@ -270,6 +271,10 @@ class QueueApp extends React.PureComponent {
   )
 
   routedChangeTaskTypeModal = (props) => <ChangeTaskTypeModal {...props.match.params} />;
+
+  routedChangeHearingRequestTypeToVirtual = (props) => (
+    <HearingTypeConversionForm type='Virtual' {...props.match.params} />
+  );
 
   routedSetOvertimeStatusModal = (props) => <SetOvertimeStatusModal {...props.match.params} />;
 
@@ -667,6 +672,12 @@ class QueueApp extends React.PureComponent {
                 path="/queue/appeals/:appealId/tasks/:taskId/modal/change_task_type"
                 title="Change Task Type | Caseflow"
                 render={this.routedChangeTaskTypeModal}
+              />
+              <PageRoute
+                exact
+                path={`/queue/appeals/:appealId/tasks/:taskId/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`}
+                title="Change Hearing Request Type to Virtual | Caseflow"
+                render={this.routedChangeHearingRequestTypeToVirtual}
               />
 
               <Route

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -85,7 +85,7 @@ import { FlashAlerts } from '../nonComp/components/Alerts';
 import { PulacCerulloReminderModal } from './pulacCerullo/PulacCerulloReminderModal';
 import { motionToVacateRoutes } from './mtv/motionToVacateRoutes';
 import ScheduleVeteran from '../hearings/components/ScheduleVeteran';
-import HearingTypeConversionForm from '../hearings/components/HearingTypeConversionForm';
+import HearingTypeConversion from '../hearings/components/HearingTypeConversion';
 
 class QueueApp extends React.PureComponent {
   componentDidMount = () => {
@@ -273,7 +273,7 @@ class QueueApp extends React.PureComponent {
   routedChangeTaskTypeModal = (props) => <ChangeTaskTypeModal {...props.match.params} />;
 
   routedChangeHearingRequestTypeToVirtual = (props) => (
-    <HearingTypeConversionForm type="Virtual" {...props.match.params} />
+    <HearingTypeConversion type="Virtual" {...props.match.params} />
   );
 
   routedSetOvertimeStatusModal = (props) => <SetOvertimeStatusModal {...props.match.params} />;

--- a/client/constants/HEARING_REQUEST_TYPES.json
+++ b/client/constants/HEARING_REQUEST_TYPES.json
@@ -1,0 +1,6 @@
+{
+  "virtual": "R",
+  "video": "V",
+  "travel": "T",
+  "central": "C"
+}

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -15,7 +15,7 @@
   },
   "CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL": {
     "label": "Convert hearing to virtual",
-    "value": "<placeholder>page/change_hearing_request_type</placeholder>",
+    "value": "change_hearing_request_type_to_virtual",
     "func": "change_hearing_request_type_data"
   },
   "ASSIGN_OMO": {

--- a/client/test/app/hearings/components/HearingTypeConversion.test.js
+++ b/client/test/app/hearings/components/HearingTypeConversion.test.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { mount } from 'enzyme';
+
+import {
+  HearingTypeConversionForm,
+} from '../../../../app/hearings/components/HearingTypeConversionForm';
+import { legacyAppealForTravelBoard } from '../../../data/appeals';
+import { queueWrapper } from '../../../data/stores/queueStore';
+import HearingTypeConversion from
+  '../../../../app/hearings/components/HearingTypeConversion';
+
+describe('HearingTypeConversion', () => {
+  test('Matches snapshot with default props', () => {
+    const hearingTypeConversion = mount(
+      <HearingTypeConversion
+        appeal={legacyAppealForTravelBoard}
+        type={'Virtual'}
+      />,
+      {
+        wrappingComponent: queueWrapper,
+      }
+    );
+
+    expect(hearingTypeConversion.exists(HearingTypeConversionForm)).toBeTruthy();
+    expect(hearingTypeConversion).toMatchSnapshot();
+  });
+});

--- a/client/test/app/hearings/components/ScheduleVeteran.test.js
+++ b/client/test/app/hearings/components/ScheduleVeteran.test.js
@@ -19,7 +19,6 @@ import { queueWrapper, appealsData } from 'test/data/stores/queueStore';
 import Button from 'app/components/Button';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import { formatDateStr } from 'app/util/DateUtil';
-import { HEARING_REQUEST_TYPES } from 'app/hearings/constants';
 import Alert from 'app/components/Alert';
 import { AppellantSection } from 'app/hearings/components/VirtualHearings/AppellantSection';
 import { RepresentativeSection } from 'app/hearings/components/VirtualHearings/RepresentativeSection';
@@ -27,6 +26,8 @@ import { ScheduleVeteranForm } from 'app/hearings/components/ScheduleVeteranForm
 import ApiUtil from 'app/util/ApiUtil';
 
 import * as uiActions from 'app/queue/uiReducer/uiActions';
+
+import { VIDEO_HEARING } from '../../../../app/hearings/constants';
 
 jest.mock('app/queue/uiReducer/uiActions');
 import * as utils from 'app/hearings/utils';
@@ -409,7 +410,7 @@ describe('ScheduleVeteran', () => {
       ),
       title: `You have successfully assigned ${
         amaAppeal.appellantFullName
-      } to a ${HEARING_REQUEST_TYPES.V} hearing on ${formatDateStr(
+      } to a ${VIDEO_HEARING} hearing on ${formatDateStr(
         scheduleHearingDetails.hearingDay.hearingDate,
         'YYYY-MM-DD',
         'MM/DD/YYYY'

--- a/client/test/app/hearings/components/VirtualHearings/__snapshots__/AppellantSection.test.js.snap
+++ b/client/test/app/hearings/components/VirtualHearings/__snapshots__/AppellantSection.test.js.snap
@@ -127,10 +127,10 @@ exports[`Appellant Displays timezone when virtual 1`] = `
       addressLine1="9999 MISSION ST"
       addressState="CA"
       addressZip="94103"
-      name="John Smith"
+      name="Tom Brady"
     >
       <ReadOnly
-        text="John Smith
+        text="Tom Brady
 9999 MISSION ST
 SAN FRANCISCO, CA 94103"
       >
@@ -138,7 +138,7 @@ SAN FRANCISCO, CA 94103"
           data-css-1a5irm0=""
         >
           <pre>
-            John Smith
+            Tom Brady
 9999 MISSION ST
 SAN FRANCISCO, CA 94103
           </pre>
@@ -15448,10 +15448,10 @@ exports[`Appellant Does not allow editing emails when read-only 1`] = `
       addressLine1="9999 MISSION ST"
       addressState="CA"
       addressZip="94103"
-      name="John Smith"
+      name="Tom Brady"
     >
       <ReadOnly
-        text="John Smith
+        text="Tom Brady
 9999 MISSION ST
 SAN FRANCISCO, CA 94103"
       >
@@ -15459,7 +15459,7 @@ SAN FRANCISCO, CA 94103"
           data-css-1a5irm0=""
         >
           <pre>
-            John Smith
+            Tom Brady
 9999 MISSION ST
 SAN FRANCISCO, CA 94103
           </pre>
@@ -15630,10 +15630,10 @@ exports[`Appellant Matches snapshot with default props 1`] = `
       addressLine1="9999 MISSION ST"
       addressState="CA"
       addressZip="94103"
-      name="John Smith"
+      name="Tom Brady"
     >
       <ReadOnly
-        text="John Smith
+        text="Tom Brady
 9999 MISSION ST
 SAN FRANCISCO, CA 94103"
       >
@@ -15641,7 +15641,7 @@ SAN FRANCISCO, CA 94103"
           data-css-1a5irm0=""
         >
           <pre>
-            John Smith
+            Tom Brady
 9999 MISSION ST
 SAN FRANCISCO, CA 94103
           </pre>

--- a/client/test/app/hearings/components/__snapshots__/HearingTypeConversion.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingTypeConversion.test.js.snap
@@ -230,6 +230,7 @@ exports[`HearingTypeConversion Matches snapshot with default props 1`] = `
     type="Virtual"
   >
     <HearingTypeConversion
+      deleteAppeal={[Function]}
       history={
         Object {
           "action": "POP",

--- a/client/test/app/hearings/components/__snapshots__/HearingTypeConversion.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingTypeConversion.test.js.snap
@@ -1,0 +1,594 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HearingTypeConversion Matches snapshot with default props 1`] = `
+<withRouter(Connect(HearingTypeConversion))
+  appeal={
+    Object {
+      "appellantAddress": Object {
+        "address_line_1": "9999 MISSION ST",
+        "address_line_2": "UBER",
+        "address_line_3": "APT 2",
+        "city": "SAN FRANCISCO",
+        "country": "USA",
+        "state": "CA",
+        "zip": "94103",
+      },
+      "appellantFullName": "Abellona Valtas",
+      "appellantIsNotVeteran": false,
+      "appellantRelationship": "Spouse",
+      "assignedAttorney": null,
+      "assignedJudge": null,
+      "assignedToLocation": "Hearing Admin",
+      "attorneyCaseRewriteDetails": Object {
+        "note_from_attorney": null,
+        "untimely_evidence": null,
+      },
+      "availableHearingLocations": Array [],
+      "canEditDocumentId": false,
+      "canEditRequestIssues": false,
+      "caseReviewId": null,
+      "caseType": "Original",
+      "caseflowVeteranId": 541,
+      "certificationDate": null,
+      "closestRegionalOffice": null,
+      "closestRegionalOfficeLabel": "Nashville Regional office",
+      "completedHearingOnPreviousAppeal": false,
+      "decisionDate": null,
+      "decisionIssues": Array [],
+      "docketName": "Legacy",
+      "docketNumber": "200805-541",
+      "documentID": null,
+      "externalId": "1234456",
+      "hearings": Array [],
+      "id": "1",
+      "isAdvancedOnDocket": false,
+      "isLegacyAppeal": true,
+      "isPaperCase": false,
+      "issueCount": 0,
+      "issues": Array [],
+      "nodDate": "2020-08-05",
+      "overtime": false,
+      "powerOfAttorney": Object {
+        "representative_address": Object {
+          "address_line_1": "9999 MISSION ST",
+          "address_line_2": "UBER",
+          "address_line_3": "APT 2",
+          "city": "SAN FRANCISCO",
+          "country": "USA",
+          "state": "CA",
+          "zip": "94103",
+        },
+        "representative_email_address": "tom.brady@caseflow.gov",
+        "representative_name": "Attorney McAttorneyFace",
+        "representative_type": "Attorney",
+      },
+      "readableHearingRequestType": "Travel",
+      "regionalOffice": null,
+      "removed": false,
+      "status": "not_distributed",
+      "vacateType": null,
+      "veteranFileNumber": "123456789",
+      "veteranFullName": "Abellona Valtas",
+      "veteranInfo": Object {
+        "veteran": Object {
+          "address": Object {
+            "address_line_1": "1234 Main Street",
+            "address_line_2": null,
+            "address_line_3": null,
+            "city": "Orlando",
+            "country": "USA",
+            "state": "FL",
+            "zip": "12345",
+          },
+          "date_of_birth": "01/10/1935",
+          "date_of_death": null,
+          "email_address": "Abellona.Valtas@test.com",
+          "full_name": "Abellona Valtas",
+          "gender": "M",
+        },
+      },
+      "withdrawn": false,
+    }
+  }
+  type="Virtual"
+>
+  <Connect(HearingTypeConversion)
+    appeal={
+      Object {
+        "appellantAddress": Object {
+          "address_line_1": "9999 MISSION ST",
+          "address_line_2": "UBER",
+          "address_line_3": "APT 2",
+          "city": "SAN FRANCISCO",
+          "country": "USA",
+          "state": "CA",
+          "zip": "94103",
+        },
+        "appellantFullName": "Abellona Valtas",
+        "appellantIsNotVeteran": false,
+        "appellantRelationship": "Spouse",
+        "assignedAttorney": null,
+        "assignedJudge": null,
+        "assignedToLocation": "Hearing Admin",
+        "attorneyCaseRewriteDetails": Object {
+          "note_from_attorney": null,
+          "untimely_evidence": null,
+        },
+        "availableHearingLocations": Array [],
+        "canEditDocumentId": false,
+        "canEditRequestIssues": false,
+        "caseReviewId": null,
+        "caseType": "Original",
+        "caseflowVeteranId": 541,
+        "certificationDate": null,
+        "closestRegionalOffice": null,
+        "closestRegionalOfficeLabel": "Nashville Regional office",
+        "completedHearingOnPreviousAppeal": false,
+        "decisionDate": null,
+        "decisionIssues": Array [],
+        "docketName": "Legacy",
+        "docketNumber": "200805-541",
+        "documentID": null,
+        "externalId": "1234456",
+        "hearings": Array [],
+        "id": "1",
+        "isAdvancedOnDocket": false,
+        "isLegacyAppeal": true,
+        "isPaperCase": false,
+        "issueCount": 0,
+        "issues": Array [],
+        "nodDate": "2020-08-05",
+        "overtime": false,
+        "powerOfAttorney": Object {
+          "representative_address": Object {
+            "address_line_1": "9999 MISSION ST",
+            "address_line_2": "UBER",
+            "address_line_3": "APT 2",
+            "city": "SAN FRANCISCO",
+            "country": "USA",
+            "state": "CA",
+            "zip": "94103",
+          },
+          "representative_email_address": "tom.brady@caseflow.gov",
+          "representative_name": "Attorney McAttorneyFace",
+          "representative_type": "Attorney",
+        },
+        "readableHearingRequestType": "Travel",
+        "regionalOffice": null,
+        "removed": false,
+        "status": "not_distributed",
+        "vacateType": null,
+        "veteranFileNumber": "123456789",
+        "veteranFullName": "Abellona Valtas",
+        "veteranInfo": Object {
+          "veteran": Object {
+            "address": Object {
+              "address_line_1": "1234 Main Street",
+              "address_line_2": null,
+              "address_line_3": null,
+              "city": "Orlando",
+              "country": "USA",
+              "state": "FL",
+              "zip": "12345",
+            },
+            "date_of_birth": "01/10/1935",
+            "date_of_death": null,
+            "email_address": "Abellona.Valtas@test.com",
+            "full_name": "Abellona Valtas",
+            "gender": "M",
+          },
+        },
+        "withdrawn": false,
+      }
+    }
+    history={
+      Object {
+        "action": "POP",
+        "block": [Function],
+        "canGo": [Function],
+        "createHref": [Function],
+        "entries": Array [
+          Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+        ],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "index": 0,
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      }
+    }
+    location={
+      Object {
+        "hash": "",
+        "pathname": "/",
+        "search": "",
+        "state": undefined,
+      }
+    }
+    match={
+      Object {
+        "isExact": true,
+        "params": Object {},
+        "path": "/",
+        "url": "/",
+      }
+    }
+    type="Virtual"
+  >
+    <HearingTypeConversion
+      history={
+        Object {
+          "action": "POP",
+          "block": [Function],
+          "canGo": [Function],
+          "createHref": [Function],
+          "entries": Array [
+            Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+          ],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "index": 0,
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        }
+      }
+      location={
+        Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        }
+      }
+      match={
+        Object {
+          "isExact": true,
+          "params": Object {},
+          "path": "/",
+          "url": "/",
+        }
+      }
+      showErrorMessage={[Function]}
+      showSuccessMessage={[Function]}
+      type="Virtual"
+    >
+      <HearingTypeConversionForm
+        history={
+          Object {
+            "action": "POP",
+            "block": [Function],
+            "canGo": [Function],
+            "createHref": [Function],
+            "entries": Array [
+              Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+            ],
+            "go": [Function],
+            "goBack": [Function],
+            "goForward": [Function],
+            "index": 0,
+            "length": 1,
+            "listen": [Function],
+            "location": Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+            "push": [Function],
+            "replace": [Function],
+          }
+        }
+        isLoading={false}
+        onCancel={[Function]}
+        onSubmit={[Function]}
+        type="Virtual"
+      >
+        <AppSegment
+          filledBackground={true}
+        >
+          <section
+            className="cf-app-segment cf-app-segment--alt"
+            role="main"
+          >
+            <h1
+              className="cf-margin-bottom-0"
+            >
+              Convert Hearing To Virtual
+            </h1>
+            <p
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "The hearing request will appear in the scheduling queue for the appropriate regional office.",
+                }
+              }
+            />
+            <HelperText
+              label="Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing."
+            >
+              <span
+                data-css-tgxxqt=""
+              >
+                Review and update the following information in VBMS if needed. Caseflow won't send email notifications until you schedule the hearing.
+              </span>
+            </HelperText>
+            <AppellantSection
+              appellantTitle="Veteran"
+              hearing={
+                Object {
+                  "appellantFullName": undefined,
+                  "representative": undefined,
+                  "representativeType": undefined,
+                }
+              }
+              readOnly={true}
+              showDivider={false}
+              showMissingEmailAlert={true}
+              showOnlyAppellantName={true}
+              type="Virtual"
+              virtualHearing={
+                Object {
+                  "appellantEmail": undefined,
+                  "representativeEmail": undefined,
+                }
+              }
+            >
+              <VirtualHearingSection
+                hide={false}
+                label="Veteran"
+                showDivider={false}
+              >
+                <div
+                  data-css-1jfbwxw=""
+                />
+                <h2>
+                  Veteran
+                </h2>
+                <ReadOnly
+                  label="Veteran Name"
+                >
+                  <div
+                    data-css-1a5irm0=""
+                  >
+                    <strong>
+                      Veteran Name
+                    </strong>
+                  </div>
+                </ReadOnly>
+                <div
+                  className="usa-grid css-1jfbwxw"
+                  id="email-section"
+                >
+                  <div
+                    className="usa-width-one-half css-uplrl8"
+                  >
+                    <VirtualHearingEmail
+                      emailType="appellantEmail"
+                      label="Veteran Email"
+                      readOnly={true}
+                      required={true}
+                      type="Virtual"
+                    >
+                      <ReadOnly
+                        label="Veteran Email"
+                        text="None"
+                      >
+                        <div
+                          data-css-1a5irm0=""
+                        >
+                          <strong>
+                            Veteran Email
+                          </strong>
+                          <pre>
+                            None
+                          </pre>
+                        </div>
+                      </ReadOnly>
+                    </VirtualHearingEmail>
+                    <div>
+                      <Alert
+                        fixed={false}
+                        message="If you have the Veteran's email address, enter it in VBMS. The email will be required to send notifications when you schedule the hearing."
+                        scrollOnAlert={false}
+                        type="info"
+                      >
+                        <div
+                          className="usa-alert usa-alert-info usa-alert-slim"
+                          role="alert"
+                        >
+                          <div
+                            className="usa-alert-body"
+                          >
+                            <h2
+                              className="usa-alert-heading"
+                            />
+                            <div
+                              className="usa-alert-text"
+                            >
+                              If you have the Veteran's email address, enter it in VBMS. The email will be required to send notifications when you schedule the hearing.
+                            </div>
+                          </div>
+                        </div>
+                      </Alert>
+                    </div>
+                  </div>
+                </div>
+              </VirtualHearingSection>
+            </AppellantSection>
+            <RepresentativeSection
+              appellantTitle="Veteran"
+              hearing={
+                Object {
+                  "appellantFullName": undefined,
+                  "representative": undefined,
+                  "representativeType": undefined,
+                }
+              }
+              readOnly={true}
+              showDivider={false}
+              showMissingEmailAlert={true}
+              showOnlyAppellantName={true}
+              type="Virtual"
+              virtualHearing={
+                Object {
+                  "appellantEmail": undefined,
+                  "representativeEmail": undefined,
+                }
+              }
+            >
+              <VirtualHearingSection
+                hide={false}
+                label="Power of Attorney"
+                showDivider={true}
+              >
+                <div
+                  className="cf-help-divider"
+                />
+                <h2>
+                  Power of Attorney
+                </h2>
+                <ReadOnly
+                  text="The Veteran does not have a representative recorded in VBMS"
+                >
+                  <div
+                    data-css-1a5irm0=""
+                  >
+                    <pre>
+                      The Veteran does not have a representative recorded in VBMS
+                    </pre>
+                  </div>
+                </ReadOnly>
+                <div
+                  className="usa-grid css-1jfbwxw"
+                >
+                  <div
+                    className="usa-width-one-half css-uplrl8"
+                  >
+                    <VirtualHearingEmail
+                      emailType="representativeEmail"
+                      label="POA/Representative Email"
+                      readOnly={true}
+                      type="Virtual"
+                    >
+                      <ReadOnly
+                        label="POA/Representative Email"
+                        text="None"
+                      >
+                        <div
+                          data-css-1a5irm0=""
+                        >
+                          <strong>
+                            POA/Representative Email
+                          </strong>
+                          <pre>
+                            None
+                          </pre>
+                        </div>
+                      </ReadOnly>
+                    </VirtualHearingEmail>
+                  </div>
+                </div>
+              </VirtualHearingSection>
+            </RepresentativeSection>
+          </section>
+        </AppSegment>
+        <div
+          data-css-1jfbwxw=""
+        >
+          <Button
+            classNames={
+              Array [
+                "cf-submit",
+              ]
+            }
+            linkStyling={true}
+            loading={false}
+            name="Cancel"
+            onClick={[Function]}
+            styling={
+              Object {
+                "data-css-14x0t8z": "",
+              }
+            }
+            type="button"
+            willNeverBeLoading={false}
+          >
+            <span>
+              <button
+                className="cf-submit cf-btn-link usa-button"
+                data-css-14x0t8z=""
+                id="button-Cancel"
+                onClick={[Function]}
+                type="button"
+              >
+                Cancel
+              </button>
+            </span>
+          </Button>
+          <span
+            data-css-jf1dde=""
+          >
+            <Button
+              className="usa-button"
+              classNames={
+                Array [
+                  "cf-submit",
+                ]
+              }
+              linkStyling={false}
+              loading={false}
+              name="Convert Hearing To Virtual"
+              onClick={[Function]}
+              type="button"
+              willNeverBeLoading={false}
+            >
+              <span>
+                <button
+                  className="cf-submit usa-button"
+                  id="button-Convert-Hearing-To-Virtual"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  Convert Hearing To Virtual
+                </button>
+              </span>
+            </Button>
+          </span>
+        </div>
+      </HearingTypeConversionForm>
+    </HearingTypeConversion>
+  </Connect(HearingTypeConversion)>
+</withRouter(Connect(HearingTypeConversion))>
+`;

--- a/client/test/app/hearings/components/__snapshots__/HearingTypeConversion.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingTypeConversion.test.js.snap
@@ -349,8 +349,10 @@ exports[`HearingTypeConversion Matches snapshot with default props 1`] = `
               hearing={
                 Object {
                   "appellantFullName": undefined,
+                  "appellantIsNotVeteran": undefined,
                   "representative": undefined,
                   "representativeType": undefined,
+                  "veteranFullName": undefined,
                 }
               }
               readOnly={true}
@@ -378,6 +380,7 @@ exports[`HearingTypeConversion Matches snapshot with default props 1`] = `
                 </h2>
                 <ReadOnly
                   label="Veteran Name"
+                  text="undefined undefined"
                 >
                   <div
                     data-css-1a5irm0=""
@@ -385,6 +388,9 @@ exports[`HearingTypeConversion Matches snapshot with default props 1`] = `
                     <strong>
                       Veteran Name
                     </strong>
+                    <pre>
+                      undefined undefined
+                    </pre>
                   </div>
                 </ReadOnly>
                 <div
@@ -452,8 +458,10 @@ exports[`HearingTypeConversion Matches snapshot with default props 1`] = `
               hearing={
                 Object {
                   "appellantFullName": undefined,
+                  "appellantIsNotVeteran": undefined,
                   "representative": undefined,
                   "representativeType": undefined,
+                  "veteranFullName": undefined,
                 }
               }
               readOnly={true}

--- a/client/test/app/hearings/components/__snapshots__/HearingTypeConversionForm.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingTypeConversionForm.test.js.snap
@@ -128,8 +128,10 @@ exports[`HearingTypeConversionForm Display missing email alert 1`] = `
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -235,8 +237,10 @@ exports[`HearingTypeConversionForm Display missing email alert 1`] = `
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -507,8 +511,10 @@ exports[`HearingTypeConversionForm Displays "the appropriate regional office" wh
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -589,8 +595,10 @@ exports[`HearingTypeConversionForm Displays "the appropriate regional office" wh
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -861,8 +869,10 @@ exports[`HearingTypeConversionForm Does not show a divider on top of Appellant S
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -943,8 +953,10 @@ exports[`HearingTypeConversionForm Does not show a divider on top of Appellant S
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -1215,8 +1227,10 @@ exports[`HearingTypeConversionForm Matches snapshot with default props 1`] = `
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}
@@ -1297,8 +1311,10 @@ exports[`HearingTypeConversionForm Matches snapshot with default props 1`] = `
         hearing={
           Object {
             "appellantFullName": "Abellona Valtas",
+            "appellantIsNotVeteran": false,
             "representative": "Attorney McAttorneyFace",
             "representativeType": "Attorney",
+            "veteranFullName": "Abellona Valtas",
           }
         }
         readOnly={true}

--- a/client/test/app/hearings/components/__snapshots__/HearingTypeConversionForm.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingTypeConversionForm.test.js.snap
@@ -92,6 +92,7 @@ exports[`HearingTypeConversionForm Display missing email alert 1`] = `
       "withdrawn": false,
     }
   }
+  isLoading={false}
   type="Virtual"
 >
   <AppSegment
@@ -330,7 +331,6 @@ exports[`HearingTypeConversionForm Display missing email alert 1`] = `
       linkStyling={true}
       loading={false}
       name="Cancel"
-      onClick={[Function]}
       styling={
         Object {
           "data-css-14x0t8z": "",
@@ -344,7 +344,6 @@ exports[`HearingTypeConversionForm Display missing email alert 1`] = `
           className="cf-submit cf-btn-link usa-button"
           data-css-14x0t8z=""
           id="button-Cancel"
-          onClick={[Function]}
           type="button"
         >
           Cancel
@@ -472,6 +471,7 @@ exports[`HearingTypeConversionForm Displays "the appropriate regional office" wh
       "withdrawn": false,
     }
   }
+  isLoading={false}
   type="Virtual"
 >
   <AppSegment
@@ -685,7 +685,6 @@ exports[`HearingTypeConversionForm Displays "the appropriate regional office" wh
       linkStyling={true}
       loading={false}
       name="Cancel"
-      onClick={[Function]}
       styling={
         Object {
           "data-css-14x0t8z": "",
@@ -699,7 +698,6 @@ exports[`HearingTypeConversionForm Displays "the appropriate regional office" wh
           className="cf-submit cf-btn-link usa-button"
           data-css-14x0t8z=""
           id="button-Cancel"
-          onClick={[Function]}
           type="button"
         >
           Cancel
@@ -827,6 +825,7 @@ exports[`HearingTypeConversionForm Does not show a divider on top of Appellant S
       "withdrawn": false,
     }
   }
+  isLoading={false}
   type="Virtual"
 >
   <AppSegment
@@ -1040,7 +1039,6 @@ exports[`HearingTypeConversionForm Does not show a divider on top of Appellant S
       linkStyling={true}
       loading={false}
       name="Cancel"
-      onClick={[Function]}
       styling={
         Object {
           "data-css-14x0t8z": "",
@@ -1054,7 +1052,6 @@ exports[`HearingTypeConversionForm Does not show a divider on top of Appellant S
           className="cf-submit cf-btn-link usa-button"
           data-css-14x0t8z=""
           id="button-Cancel"
-          onClick={[Function]}
           type="button"
         >
           Cancel
@@ -1182,6 +1179,7 @@ exports[`HearingTypeConversionForm Matches snapshot with default props 1`] = `
       "withdrawn": false,
     }
   }
+  isLoading={false}
   type="Virtual"
 >
   <AppSegment
@@ -1395,7 +1393,6 @@ exports[`HearingTypeConversionForm Matches snapshot with default props 1`] = `
       linkStyling={true}
       loading={false}
       name="Cancel"
-      onClick={[Function]}
       styling={
         Object {
           "data-css-14x0t8z": "",
@@ -1409,7 +1406,6 @@ exports[`HearingTypeConversionForm Matches snapshot with default props 1`] = `
           className="cf-submit cf-btn-link usa-button"
           data-css-14x0t8z=""
           id="button-Cancel"
-          onClick={[Function]}
           type="button"
         >
           Cancel

--- a/spec/feature/hearings/convert_travel_board_hearing/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_travel_board_hearing/edit_hearsched_spec.rb
@@ -11,8 +11,13 @@ RSpec.feature "Convert travel board appeal for 'Edit HearSched' (Hearing Coordin
   let!(:legacy_appeal) do
     create(
       :legacy_appeal,
+      :with_veteran,
       vacols_case: vacols_case
     )
+  end
+
+  before do
+    HearingsManagement.singleton.add_user(current_user)
   end
 
   context "with FeatureToggle enabled" do
@@ -32,6 +37,36 @@ RSpec.feature "Convert travel board appeal for 'Edit HearSched' (Hearing Coordin
       click_dropdown(text: Constants.TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.label)
       expect(ChangeHearingRequestTypeTask.count).to eq(1)
       expect(ChangeHearingRequestTypeTask.first.appeal.vacols_id).to eq(legacy_appeal.vacols_id)
+    end
+
+    scenario "user can change a hearing from travel to virtual" do
+      visit "queue/appeals/#{legacy_appeal.vacols_id}"
+
+      step "select change hearing request type action" do
+        click_dropdown(text: Constants.TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.label)
+      end
+
+      step "ensure page has veteran and representative info" do
+        expect(page).to have_content(legacy_appeal.veteran_full_name)
+        expect(page).to have_content(legacy_appeal.representative_name)
+      end
+
+      step "submit conversion" do
+        click_button("Convert Hearing To Virtual")
+      end
+
+      step "confirm page has the correct success message" do
+        expect(page).to have_content(
+          "You have successfully converted #{legacy_appeal.veteran_full_name}'s hearing to virtual"
+        )
+        expect(page).to have_content(
+          "The hearing request is in the scheduling queue for the appropriate regional office"
+        )
+      end
+
+      step "cnofirm schedule veteran task is actionable" do
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.label)
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #15159

### Description

  * Create `HearingTypeConversion` component which wraps the `HearingTypeConversionForm`
  * Create new route that's connected to the convert hearing type task action
  * Small refactors
    * Made the logic to determine whether or not to display the veteran vs. appellant name consistent
    * Attempt to consolidate where hearing request type mappings are defined in a single location

### Acceptance Criteria

- [x] Selecting "Convert hearing type to virtual" on a `ChangeHearingRequestTypeTask` shows the non-modal "Convert Hearing to Virtual" form (created in #15217)
- [x] Submitting the "Convert hearing to virtual" form causes the new request type to be recorded correctly
- [x] The expected alert is shown when the conversion has successfully taken place
    - [x] If the appeal has been geomatched:
    ```
    The hearing request is in the scheduling queue for the [Regional office name] regional office.
    ```
    - [x] If the appeal has not been geomatched:
    ```
    The hearing request is in the scheduling queue for the appropriate regional office.
    ```

### Testing Plan

N/A

### User Facing Changes

_Note: The task tree is a bit messed up because I was reusing the same appeal over and over again. When I completed the task the first time, it unlocks the schedule hearing task. From there, I was able to schedule the appeal, which is why you see the select hearing disposition task in the screencap._

![Screen Recording 2020-09-28 at 10 52 01 AM mov](https://user-images.githubusercontent.com/1298274/94448611-1894af00-0179-11eb-952a-6ca964cf2eba.gif)


### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [x] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [x] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [x] Write a separate story (within the same file) for each discrete variation of the component

