### PR TITLE
Only consider genpop appeals when attempting to evenly distribute cases to judges

### DIFF
--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -88,7 +88,7 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
   # Because we cannot distribute fractional cases, there can be cases leftover after taking the priority target
   # into account. This number will always be less than the number of judges that need distribution because division
   def leftover_cases_count
-    ready_priority_appeals_count - target_distributions_for_eligible_judges.values.sum
+    ready_genpop_priority_appeals_count - target_distributions_for_eligible_judges.values.sum
   end
 
   # Calculate the number of cases a judge should receive based on the priority target. Don't toss out judges with 0 as
@@ -105,14 +105,14 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
   def priority_target
     @priority_target ||= begin
       distribution_counts = priority_distributions_this_month_for_eligible_judges.values
-      target = (distribution_counts.sum + ready_priority_appeals_count) / distribution_counts.count
+      target = (distribution_counts.sum + ready_genpop_priority_appeals_count) / distribution_counts.count
 
       # If there are any judges that have previous distributions that are MORE than the currently calculated priority
       # target, no target will be large enough to get all other judges up to their number of cases. Remove them from
       # consideration and recalculate the target for all other judges.
       while distribution_counts.any? { |distribution_count| distribution_count > target }
         distribution_counts = distribution_counts.reject { |distribution_count| distribution_count > target }
-        target = (distribution_counts.sum + ready_priority_appeals_count) / distribution_counts.count
+        target = (distribution_counts.sum + ready_genpop_priority_appeals_count) / distribution_counts.count
       end
 
       target
@@ -123,8 +123,8 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
     @docket_coordinator ||= DocketCoordinator.new
   end
 
-  def ready_priority_appeals_count
-    @ready_priority_appeals_count ||= docket_coordinator.priority_count
+  def ready_genpop_priority_appeals_count
+    @ready_genpop_priority_appeals_count ||= docket_coordinator.genpop_priority_count
   end
 
   # Number of priority distributions every eligible judge has received in the last month

--- a/app/models/concerns/proportion_hash.rb
+++ b/app/models/concerns/proportion_hash.rb
@@ -11,7 +11,7 @@
 
 module ProportionHash
   def normalize!(to: 1.0)
-    total = values.reduce(0, :+)
+    total = values.sum
     transform_values! { |proportion| proportion * (to / total) }
   end
 
@@ -24,7 +24,7 @@ module ProportionHash
 
   def add_fixed_proportions!(fixed)
     except!(*fixed.keys)
-      .normalize!(to: 1.0 - fixed.values.reduce(0, :+))
+      .normalize!(to: 1.0 - fixed.values.sum)
       .merge!(fixed)
   end
 
@@ -52,7 +52,7 @@ module ProportionHash
 
   def stochastic_allocation(num)
     result = transform_values { |proportion| (num * proportion).floor }
-    rem = num - result.values.reduce(0, :+)
+    rem = num - result.values.sum
 
     return result if rem == 0
 

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -30,6 +30,10 @@ class Docket
     appeals(priority: priority, ready: ready).ids.size
   end
 
+  def genpop_priority_count
+    count(priority: true, ready: true)
+  end
+
   def weight
     count
   end

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -30,6 +30,7 @@ class Docket
     appeals(priority: priority, ready: ready).ids.size
   end
 
+  # By default all cases are considered genpop. This can be overridden for specific dockets
   def genpop_priority_count
     count(priority: true, ready: true)
   end

--- a/app/models/docket_coordinator.rb
+++ b/app/models/docket_coordinator.rb
@@ -100,7 +100,11 @@ class DocketCoordinator
     @priority_count ||= dockets
       .values
       .map { |docket| docket.count(priority: true, ready: true) }
-      .reduce(0, :+)
+      .sum
+  end
+
+  def genpop_priority_count
+    @genpop_priority_count ||= dockets.values.map(&:genpop_priority_count).sum
   end
 
   def direct_review_due_count
@@ -140,6 +144,6 @@ class DocketCoordinator
   end
 
   def nonpriority_decisions_per_year
-    @nonpriority_decisions_per_year ||= [LegacyAppeal, Docket].map(&:nonpriority_decisions_per_year).reduce(0, :+)
+    @nonpriority_decisions_per_year ||= [LegacyAppeal, Docket].map(&:nonpriority_decisions_per_year).sum
   end
 end

--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -5,12 +5,18 @@ class HearingRequestDocket < Docket
     Constants.AMA_DOCKETS.hearing
   end
 
-  def age_of_n_oldest_priority_appeals(num)
-    relation = appeals(priority: true, ready: true).limit(num)
+  def ready_priority_appeals
+    appeals(priority: true, ready: true)
+  end
 
+  def age_of_n_oldest_priority_appeals(num)
     HearingRequestDistributionQuery.new(
-      base_relation: relation, genpop: "only_genpop"
+      base_relation: ready_priority_appeals.limit(num), genpop: "only_genpop"
     ).call.map(&:ready_for_distribution_at)
+  end
+
+  def genpop_priority_count
+    HearingRequestDistributionQuery.new(base_relation: ready_priority_appeals, genpop: "only_genpop").call.count
   end
 
   def distribute_appeals(distribution, priority: false, genpop: "any", limit: 1)

--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -15,6 +15,7 @@ class HearingRequestDocket < Docket
     ).call.map(&:ready_for_distribution_at)
   end
 
+  # Hearing cases distinguish genpop from cases tied to a judge
   def genpop_priority_count
     HearingRequestDistributionQuery.new(base_relation: ready_priority_appeals, genpop: "only_genpop").call.count
   end

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -31,7 +31,7 @@ class LegacyDocket
   end
 
   def ready_priority_appeal_ids
-    LegacyAppeal.repository.ready_priority_appeal_ids
+    LegacyAppeal.repository.priority_ready_appeal_vacols_ids
   end
 
   def oldest_priority_appeal_days_waiting

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -31,7 +31,7 @@ class LegacyDocket
   end
 
   def ready_priority_appeal_ids
-    LegacyAppeal.repository.priority_ready_appeal_vacols_ids
+    LegacyAppeal.repository.ready_priority_appeal_ids
   end
 
   def oldest_priority_appeal_days_waiting

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -22,12 +22,16 @@ class LegacyDocket
   end
   # rubocop:enable Metrics/CyclomaticComplexity
 
+  def genpop_priority_count
+    LegacyAppeal.repository.genpop_priority_count
+  end
+
   def weight
     count(priority: false) + nod_count * NOD_ADJUSTMENT
   end
 
   def ready_priority_appeal_ids
-    VACOLS::CaseDocket.priority_ready_appeal_vacols_ids
+    LegacyAppeal.repository.priority_ready_appeal_vacols_ids
   end
 
   def oldest_priority_appeal_days_waiting

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -168,11 +168,11 @@ class VACOLS::CaseDocket < VACOLS::Record
 
   def self.genpop_priority_count
     query = <<-SQL
-      #{VACOLS::CaseDocket::SELECT_PRIORITY_APPEALS}
+      #{SELECT_PRIORITY_APPEALS}
       where VLJ is null
     SQL
 
-    VACOLS::CaseDocket.connection.exec_query(query).to_hash.count
+    connection.exec_query(query).to_hash.count
   end
 
   def self.nod_count

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -166,6 +166,15 @@ class VACOLS::CaseDocket < VACOLS::Record
   end
   # rubocop:enable Metrics/MethodLength
 
+  def self.genpop_priority_count
+    query = <<-SQL
+      #{VACOLS::CaseDocket::SELECT_PRIORITY_APPEALS}
+      where VLJ is null
+    SQL
+
+    VACOLS::CaseDocket.connection.exec_query(query).to_hash.count
+  end
+
   def self.nod_count
     where("BFMPRO = 'ADV' and BFD19 is null").count
   end

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -713,11 +713,11 @@ class AppealRepository
       end
     end
 
-    def ready_priority_appeal_ids
-      MetricsService.record("VACOLS: ready_priority_appeal_ids",
-                            name: "ready_priority_appeal_ids",
+    def priority_ready_appeal_vacols_ids
+      MetricsService.record("VACOLS: priority_ready_appeal_vacols_ids",
+                            name: "priority_ready_appeal_vacols_ids",
                             service: :vacols) do
-        VACOLS::CaseDocket.ready_priority_appeal_ids
+        VACOLS::CaseDocket.priority_ready_appeal_vacols_ids
       end
     end
 

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -705,6 +705,22 @@ class AppealRepository
       end
     end
 
+    def genpop_priority_count
+      MetricsService.record("VACOLS: genpop_priority_count",
+                            name: "genpop_priority_count",
+                            service: :vacols) do
+        VACOLS::CaseDocket.genpop_priority_count
+      end
+    end
+
+    def ready_priority_appeal_ids
+      MetricsService.record("VACOLS: ready_priority_appeal_ids",
+                            name: "ready_priority_appeal_ids",
+                            service: :vacols) do
+        VACOLS::CaseDocket.ready_priority_appeal_ids
+      end
+    end
+
     def nod_count
       MetricsService.record("VACOLS: nod_count",
                             name: "nod_count",

--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -308,7 +308,7 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       job.instance_variable_set(:@genpop_distributions, distributed_cases)
       allow_any_instance_of(PushPriorityAppealsToJudgesJob)
         .to receive(:priority_distributions_this_month_for_eligible_judges).and_return(previous_distributions)
-      allow_any_instance_of(DocketCoordinator).to receive(:priority_count).and_return(20)
+      allow_any_instance_of(DocketCoordinator).to receive(:genpop_priority_count).and_return(20)
     end
 
     it "returns ids and age of ready priority appeals not distributed" do
@@ -344,7 +344,7 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)
           .to receive(:priority_distributions_this_month_for_eligible_judges)
           .and_return(to_judge_hash(distribution_counts))
-        allow_any_instance_of(DocketCoordinator).to receive(:priority_count).and_return(priority_count)
+        allow_any_instance_of(DocketCoordinator).to receive(:genpop_priority_count).and_return(priority_count)
       end
 
       subject { PushPriorityAppealsToJudgesJob.new.eligible_judge_target_distributions_with_leftovers }
@@ -474,7 +474,7 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
     before do
       allow_any_instance_of(PushPriorityAppealsToJudgesJob)
         .to receive(:target_distributions_for_eligible_judges).and_return(target_distributions)
-      allow_any_instance_of(DocketCoordinator).to receive(:priority_count).and_return(priority_count)
+      allow_any_instance_of(DocketCoordinator).to receive(:genpop_priority_count).and_return(priority_count)
     end
 
     subject { PushPriorityAppealsToJudgesJob.new.leftover_cases_count }
@@ -519,7 +519,7 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)
           .to receive(:priority_distributions_this_month_for_eligible_judges)
           .and_return(to_judge_hash(distribution_counts))
-        allow_any_instance_of(DocketCoordinator).to receive(:priority_count).and_return(priority_count)
+        allow_any_instance_of(DocketCoordinator).to receive(:genpop_priority_count).and_return(priority_count)
       end
 
       subject { PushPriorityAppealsToJudgesJob.new.target_distributions_for_eligible_judges }
@@ -637,7 +637,7 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)
           .to receive(:priority_distributions_this_month_for_eligible_judges)
           .and_return(to_judge_hash(distribution_counts))
-        allow_any_instance_of(DocketCoordinator).to receive(:priority_count).and_return(priority_count)
+        allow_any_instance_of(DocketCoordinator).to receive(:genpop_priority_count).and_return(priority_count)
       end
 
       subject { PushPriorityAppealsToJudgesJob.new.priority_target }

--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -453,7 +453,7 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)
           .to receive(:priority_distributions_this_month_for_eligible_judges).and_return(@distribution_counts)
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)
-          .to receive(:ready_priority_appeals_count).and_return(priority_count)
+          .to receive(:ready_genpop_priority_appeals_count).and_return(priority_count)
       end
 
       it "evens out over multiple calls" do

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -1,210 +1,283 @@
 # frozen_string_literal: true
 
 describe DocketCoordinator do
-  before do
-    FeatureToggle.enable!(:test_facols)
-    Timecop.freeze(Time.utc(2020, 4, 1, 12, 0, 0))
+  describe "direct review docket pace setting" do
+    before do
+      FeatureToggle.enable!(:test_facols)
+      Timecop.freeze(Time.utc(2020, 4, 1, 12, 0, 0))
 
-    4.times do
-      team = JudgeTeam.create_for_judge(create(:user))
-      create_list(:user, 5).each do |attorney|
-        team.add_user(attorney)
-      end
-    end
-
-    allow_any_instance_of(DirectReviewDocket)
-      .to receive(:nonpriority_receipts_per_year)
-      .and_return(nonpriority_receipts_per_year)
-
-    allow(Docket)
-      .to receive(:nonpriority_decisions_per_year)
-      .and_return(nonpriority_decisions_per_year)
-  end
-
-  after do
-    FeatureToggle.disable!(:test_facols)
-    Timecop.return
-  end
-
-  let(:nonpriority_receipts_per_year) { 100 }
-  let(:nonpriority_decisions_per_year) { 1000 }
-
-  let(:docket_coordinator) { DocketCoordinator.new }
-
-  let(:priority_case_count) { 10 }
-  let!(:priority_cases) do
-    (0...priority_case_count).map do |i|
-      create(
-        :case,
-        :aod,
-        bfd19: 2.years.ago,
-        bfac: "1",
-        bfmpro: "ACT",
-        bfcurloc: "81",
-        bfdloout: i.days.ago,
-        folder: build(
-          :folder,
-          tinum: "1801#{format('%<index>03d', index: i)}",
-          titrnum: "123456789S"
-        )
-      )
-    end
-  end
-
-  let(:nonpriority_legacy_count) { 10 }
-  let!(:nonpriority_legacy_cases) do
-    (0...nonpriority_legacy_count).map do |i|
-      create(
-        :case,
-        bfd19: 3.years.ago,
-        bfac: "1",
-        bfmpro: "ACT",
-        bfcurloc: "81",
-        bfdloout: i.days.ago,
-        folder: build(
-          :folder,
-          tinum: "1701#{format('%<index>03d', index: i)}",
-          titrnum: "123456789S"
-        )
-      )
-    end
-  end
-
-  let(:due_direct_review_count) { 10 }
-  let!(:due_direct_review_cases) do
-    (0...due_direct_review_count).map do
-      create(
-        :appeal,
-        :with_post_intake_tasks,
-        docket_type: Constants.AMA_DOCKETS.direct_review,
-        receipt_date: 11.months.ago,
-        target_decision_date: 1.month.from_now
-      )
-    end
-  end
-
-  let(:days_before_goal_due) { DirectReviewDocket::DAYS_BEFORE_GOAL_DUE_FOR_DISTRIBUTION }
-  let(:days_to_decision_goal) { DirectReviewDocket::DAYS_TO_DECISION_GOAL }
-
-  let!(:other_direct_review_cases) do
-    (0...10).map do
-      create(
-        :appeal,
-        :with_post_intake_tasks,
-        docket_type: Constants.AMA_DOCKETS.direct_review,
-        receipt_date: (days_before_goal_due + 1).days.ago,
-        target_decision_date: (days_to_decision_goal - days_before_goal_due + 35).days.from_now
-      )
-    end
-  end
-
-  let(:other_docket_count) { 5 }
-
-  let!(:evidence_submission_cases) do
-    (0...other_docket_count).map do
-      create(
-        :appeal,
-        :with_post_intake_tasks,
-        docket_type: Constants.AMA_DOCKETS.evidence_submission
-      )
-    end
-  end
-
-  let!(:hearing_cases) do
-    (0...other_docket_count).map do
-      create(
-        :appeal,
-        :with_post_intake_tasks,
-        docket_type: Constants.AMA_DOCKETS.hearing
-      )
-    end
-  end
-
-  context "when there are due direct reviews" do
-    it "uses the number of due direct reviews as a proportion of the docket margin net of priority" do
-      expect(docket_coordinator.docket_proportions).to eq(
-        legacy: 0.4,
-        direct_review: 0.2,
-        evidence_submission: 0.2,
-        hearing: 0.2
-      )
-      expect(docket_coordinator.pacesetting_direct_review_proportion).to eq(0.1)
-      expect(docket_coordinator.interpolated_minimum_direct_review_proportion).to eq(0.067)
-      expect(docket_coordinator.target_number_of_ama_hearings(2.years)).to eq(400)
-    end
-
-    context "with appeals that have already been marked in range" do
-      let(:appeals_count) { docket_coordinator.dockets[:hearing].appeals.count }
-      let(:number_of_appeals_in_range) { 2 }
-
-      before do
-        docket_coordinator.dockets[:hearing]
-          .appeals
-          .limit(number_of_appeals_in_range)
-          .update(docket_range_date: Time.utc(2019, 1, 1))
+      4.times do
+        team = JudgeTeam.create_for_judge(create(:user))
+        create_list(:user, 5).each do |attorney|
+          team.add_user(attorney)
+        end
       end
 
-      it "returns appeals that have not been marked in range" do
-        expect(
-          docket_coordinator
-            .upcoming_appeals_in_range(2.years, Time.utc(2019, 1, 1))
-            .pluck(:id)
-            .count
-        )
-          .to eq(other_docket_count)
-      end
+      allow_any_instance_of(DirectReviewDocket)
+        .to receive(:nonpriority_receipts_per_year)
+        .and_return(nonpriority_receipts_per_year)
+
+      allow(Docket)
+        .to receive(:nonpriority_decisions_per_year)
+        .and_return(nonpriority_decisions_per_year)
     end
 
-    context "when the direct review proportion would exceed 80%" do
-      let(:due_direct_review_count) { 170 }
+    after do
+      FeatureToggle.disable!(:test_facols)
+      Timecop.return
+    end
 
-      it "caps the percentage at 80%" do
-        expect(docket_coordinator.docket_proportions).to include(
-          legacy: 0.1,
-          direct_review: 0.8
+    let(:nonpriority_receipts_per_year) { 100 }
+    let(:nonpriority_decisions_per_year) { 1000 }
+
+    let(:docket_coordinator) { DocketCoordinator.new }
+
+    let(:priority_case_count) { 10 }
+    let!(:priority_cases) do
+      (0...priority_case_count).map do |i|
+        create(
+          :case,
+          :aod,
+          bfd19: 2.years.ago,
+          bfac: "1",
+          bfmpro: "ACT",
+          bfcurloc: "81",
+          bfdloout: i.days.ago,
+          folder: build(
+            :folder,
+            tinum: "1801#{format('%<index>03d', index: i)}",
+            titrnum: "123456789S"
+          )
         )
       end
     end
 
-    context "when the legacy proportion would dip below 10%" do
-      let(:priority_case_count) { 0 }
-      let(:due_direct_review_count) { 60 }
-      let(:nonpriority_legacy_count) { 12 }
-      let(:other_docket_count) { 12 }
-
-      it "ensures a minimum of 10%" do
-        expect(docket_coordinator.docket_proportions).to include(
-          legacy: 0.1,
-          direct_review: 0.8
+    let(:nonpriority_legacy_count) { 10 }
+    let!(:nonpriority_legacy_cases) do
+      (0...nonpriority_legacy_count).map do |i|
+        create(
+          :case,
+          bfd19: 3.years.ago,
+          bfac: "1",
+          bfmpro: "ACT",
+          bfcurloc: "81",
+          bfdloout: i.days.ago,
+          folder: build(
+            :folder,
+            tinum: "1701#{format('%<index>03d', index: i)}",
+            titrnum: "123456789S"
+          )
         )
       end
+    end
 
-      context "unless there aren't that many cases" do
-        let(:nonpriority_legacy_count) { 3 }
+    let(:due_direct_review_count) { 10 }
+    let!(:due_direct_review_cases) do
+      (0...due_direct_review_count).map do
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          docket_type: Constants.AMA_DOCKETS.direct_review,
+          receipt_date: 11.months.ago,
+          target_decision_date: 1.month.from_now
+        )
+      end
+    end
 
-        it "uses the maximum number possible" do
+    let(:days_before_goal_due) { DirectReviewDocket::DAYS_BEFORE_GOAL_DUE_FOR_DISTRIBUTION }
+    let(:days_to_decision_goal) { DirectReviewDocket::DAYS_TO_DECISION_GOAL }
+
+    let!(:other_direct_review_cases) do
+      (0...10).map do
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          docket_type: Constants.AMA_DOCKETS.direct_review,
+          receipt_date: (days_before_goal_due + 1).days.ago,
+          target_decision_date: (days_to_decision_goal - days_before_goal_due + 35).days.from_now
+        )
+      end
+    end
+
+    let(:other_docket_count) { 5 }
+
+    let!(:evidence_submission_cases) do
+      (0...other_docket_count).map do
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          docket_type: Constants.AMA_DOCKETS.evidence_submission
+        )
+      end
+    end
+
+    let!(:hearing_cases) do
+      (0...other_docket_count).map do
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          docket_type: Constants.AMA_DOCKETS.hearing
+        )
+      end
+    end
+
+    context "when there are due direct reviews" do
+      it "uses the number of due direct reviews as a proportion of the docket margin net of priority" do
+        expect(docket_coordinator.docket_proportions).to eq(
+          legacy: 0.4,
+          direct_review: 0.2,
+          evidence_submission: 0.2,
+          hearing: 0.2
+        )
+        expect(docket_coordinator.pacesetting_direct_review_proportion).to eq(0.1)
+        expect(docket_coordinator.interpolated_minimum_direct_review_proportion).to eq(0.067)
+        expect(docket_coordinator.target_number_of_ama_hearings(2.years)).to eq(400)
+      end
+
+      context "with appeals that have already been marked in range" do
+        let(:appeals_count) { docket_coordinator.dockets[:hearing].appeals.count }
+        let(:number_of_appeals_in_range) { 2 }
+
+        before do
+          docket_coordinator.dockets[:hearing]
+            .appeals
+            .limit(number_of_appeals_in_range)
+            .update(docket_range_date: Time.utc(2019, 1, 1))
+        end
+
+        it "returns appeals that have not been marked in range" do
+          expect(
+            docket_coordinator
+              .upcoming_appeals_in_range(2.years, Time.utc(2019, 1, 1))
+              .pluck(:id)
+              .count
+          )
+            .to eq(other_docket_count)
+        end
+      end
+
+      context "when the direct review proportion would exceed 80%" do
+        let(:due_direct_review_count) { 170 }
+
+        it "caps the percentage at 80%" do
           expect(docket_coordinator.docket_proportions).to include(
-            legacy: 0.05,
+            legacy: 0.1,
             direct_review: 0.8
           )
         end
       end
+
+      context "when the legacy proportion would dip below 10%" do
+        let(:priority_case_count) { 0 }
+        let(:due_direct_review_count) { 60 }
+        let(:nonpriority_legacy_count) { 12 }
+        let(:other_docket_count) { 12 }
+
+        it "ensures a minimum of 10%" do
+          expect(docket_coordinator.docket_proportions).to include(
+            legacy: 0.1,
+            direct_review: 0.8
+          )
+        end
+
+        context "unless there aren't that many cases" do
+          let(:nonpriority_legacy_count) { 3 }
+
+          it "uses the maximum number possible" do
+            expect(docket_coordinator.docket_proportions).to include(
+              legacy: 0.05,
+              direct_review: 0.8
+            )
+          end
+        end
+      end
+    end
+
+    context "when there are no due direct reviews" do
+      let(:due_direct_review_count) { 0 }
+      let(:nonpriority_receipts_per_year) { 1000 }
+      let(:nonpriority_decisions_per_year) { 1340 }
+      let(:nonpriority_legacy_count) { 80 }
+
+      it "uses the pacesetting direct review proportion" do
+        expect(docket_coordinator.docket_proportions).to include(
+          legacy: 0.8,
+          evidence_submission: 0.05,
+          hearing: 0.05
+        )
+        expect(docket_coordinator.interpolated_minimum_direct_review_proportion).to be_within(0.001).of(0.1)
+      end
     end
   end
 
-  context "when there are no due direct reviews" do
-    let(:due_direct_review_count) { 0 }
-    let(:nonpriority_receipts_per_year) { 1000 }
-    let(:nonpriority_decisions_per_year) { 1340 }
-    let(:nonpriority_legacy_count) { 80 }
+  shared_examples "correct priority count" do
+    let(:judge) { create(:user, :with_vacols_judge_record) }
 
-    it "uses the pacesetting direct review proportion" do
-      expect(docket_coordinator.docket_proportions).to include(
-        legacy: 0.8,
-        evidence_submission: 0.05,
-        hearing: 0.05
-      )
-      expect(docket_coordinator.interpolated_minimum_direct_review_proportion).to be_within(0.001).of(0.1)
+    let(:tied_legacy_case_count) { 5 }
+    let(:genpop_legacy_case_count) { 4 }
+    let(:tied_ama_hearing_case_count) { 3 }
+    let(:genpop_ama_hearing_case_count) { 2 }
+    let(:genpop_direct_case_count) { 2 }
+    let(:genpop_evidence_case_count) { 2 }
+
+    let(:genpop_priority_cases_count) do
+      genpop_legacy_case_count + genpop_ama_hearing_case_count + genpop_direct_case_count + genpop_evidence_case_count
     end
+    let(:all_priority_cases_count) do
+      genpop_priority_cases_count + tied_legacy_case_count + tied_ama_hearing_case_count
+    end
+
+    before do
+      tied_legacy_case_count.times { create(:case, :aod, :ready_for_distribution, :tied_to_judge, tied_judge: judge) }
+      genpop_legacy_case_count.times { create(:case, :aod, :ready_for_distribution) }
+      tied_ama_hearing_case_count.times do
+        create(
+          :appeal,
+          :hearing_docket,
+          :ready_for_distribution,
+          :advanced_on_docket_due_to_age,
+          :held_hearing,
+          :tied_to_judge,
+          tied_judge: judge,
+          adding_user: judge
+        )
+      end
+      genpop_ama_hearing_case_count.times do
+        create(
+          :appeal,
+          :hearing_docket,
+          :ready_for_distribution,
+          :advanced_on_docket_due_to_age,
+          :held_hearing,
+          adding_user: judge
+        )
+      end
+      genpop_direct_case_count.times do
+        create(:appeal, :direct_review_docket, :ready_for_distribution, :advanced_on_docket_due_to_age)
+      end
+      genpop_evidence_case_count.times do
+        create(:appeal, :evidence_submission_docket, :ready_for_distribution, :advanced_on_docket_due_to_age)
+      end
+    end
+
+    it "returns the count of all priority cases that are ready to be distributed" do
+      expect(subject).to eq expected_priority_count
+    end
+  end
+
+  fdescribe "#priority_count" do
+    subject { DocketCoordinator.new.priority_count }
+
+    let(:expected_priority_count) { all_priority_cases_count }
+
+    it_behaves_like "correct priority count"
+  end
+
+  fdescribe "#genpop_priority_count" do
+    subject { DocketCoordinator.new.genpop_priority_count }
+
+    let(:expected_priority_count) { genpop_priority_cases_count }
+
+    it_behaves_like "correct priority count"
   end
 end

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -265,7 +265,7 @@ describe DocketCoordinator do
     end
   end
 
-  fdescribe "#priority_count" do
+  describe "#priority_count" do
     subject { DocketCoordinator.new.priority_count }
 
     let(:expected_priority_count) { all_priority_cases_count }
@@ -273,7 +273,7 @@ describe DocketCoordinator do
     it_behaves_like "correct priority count"
   end
 
-  fdescribe "#genpop_priority_count" do
+  describe "#genpop_priority_count" do
     subject { DocketCoordinator.new.genpop_priority_count }
 
     let(:expected_priority_count) { genpop_priority_cases_count }


### PR DESCRIPTION
Resolves discrepancy found here: https://dsva.slack.com/archives/CN3FQR4A1/p1601297485008600

### Description
Our priority push job runs in 2 phases.
First, we distribute all cases that are tied to a judge through previous decision or a held hearing.
Second, we pull a count of all remaining priority cases ready to be distributed and calculate how to distribute them evenly across judges.
However, when we pull the count of remaining cases, we were previously including cases that are tied to judges but could not be distributed. This could happen for a number of reasons (judge case is tied to no longer works for the board, is not a user in caseflow, is an AVLJ, etc). The issue is that when we try evenly distribute remaining cases, we cannot distribute cases tied to judges to another judge.
This let to us only having 60 cases to distribute, but our calculations were done assuming there would be 350+ cases to distribute.

This PR ensures the calculations done on `ready_priority_appeals_count` do not consider cases we cannot distribute (cases tied to another judge)

### Acceptance Criteria
- [ ] When calculating priority target for the acd priority push job, only consider genpop cases

### Testing Plan
1. in prod
```ruby
PushPriorityAppealsToJudgesJob.new.ready_priority_appeals_count
=> 346
# Or some other 300+ number

# what should this be instead?
query = <<-SQL
  #{VACOLS::CaseDocket::SELECT_PRIORITY_APPEALS}
  where VLJ is null
SQL

VACOLS::CaseDocket.connection.exec_query(query).to_hash.count
=> 34
HearingRequestDistributionQuery.new(base_relation: HearingRequestDocket.new.appeals(ready: true, priority: true), genpop: "only_genpop").call.count
=> 0
DirectReviewDocket.new.count(ready: true, priority: true)
=> 0
EvidenceSubmissionDocket.new.count(ready: true, priority: true)
=> 0
# The sum of these numbers should be MUCH lower than the one returned from ready_priority_appeals_count
```